### PR TITLE
chore: Use Oxfmt for import sorting instead of `import-x/order`

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -3,6 +3,14 @@
   "printWidth": 80,
   "quoteProps": "as-needed",
   "singleQuote": true,
+  "sortImports": {
+    "newlinesBetween": false,
+    "groups": [
+      ["builtin", "external"],
+      { "newlinesBetween": true },
+      ["internal", "parent", "sibling", "index", "unknown"]
+    ]
+  },
   "tabWidth": 2,
   "trailingComma": "all",
   "ignorePatterns": [

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -91,6 +91,7 @@ const config = createConfig([
     rules: {
       // Handled by Oxfmt.
       'prettier/prettier': 'off',
+      'import-x/order': 'off',
     },
   },
   {

--- a/packages/account-tree-controller/src/AccountTreeController.test.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.test.ts
@@ -32,6 +32,10 @@ import type { InternalAccount } from '@metamask/keyring-internal-api';
 import type { GetSnap as SnapControllerGetSnap } from '@metamask/snaps-controllers';
 
 import {
+  getAccountTreeControllerMessenger,
+  getRootMessenger,
+} from '../tests/mockMessenger';
+import {
   AccountTreeController,
   getDefaultAccountTreeControllerState,
 } from './AccountTreeController';
@@ -40,10 +44,6 @@ import { BackupAndSyncService } from './backup-and-sync/service';
 import { isAccountGroupNameUnique } from './group';
 import { getAccountWalletNameFromKeyringType } from './rules/keyring';
 import type { AccountTreeControllerState } from './types';
-import {
-  getAccountTreeControllerMessenger,
-  getRootMessenger,
-} from '../tests/mockMessenger';
 
 // Local mock of EMPTY_ACCOUNT to avoid circular dependency
 const EMPTY_ACCOUNT_MOCK: InternalAccount = {

--- a/packages/account-tree-controller/src/backup-and-sync/authentication/utils.test.ts
+++ b/packages/account-tree-controller/src/backup-and-sync/authentication/utils.test.ts
@@ -1,6 +1,6 @@
-import { getProfileId } from './utils';
 import type { AccountTreeController } from '../../AccountTreeController';
 import type { BackupAndSyncContext } from '../types';
+import { getProfileId } from './utils';
 
 describe('BackupAndSyncAuthentication - Utils', () => {
   describe('getProfileId', () => {

--- a/packages/account-tree-controller/src/backup-and-sync/service/atomic-sync-queue.test.ts
+++ b/packages/account-tree-controller/src/backup-and-sync/service/atomic-sync-queue.test.ts
@@ -1,5 +1,5 @@
-import { backupAndSyncLogger } from '../../logger';
 /* eslint-disable no-void */
+import { backupAndSyncLogger } from '../../logger';
 import { AtomicSyncQueue } from './atomic-sync-queue';
 
 jest.mock('../../logger', () => ({

--- a/packages/account-tree-controller/src/backup-and-sync/service/atomic-sync-queue.test.ts
+++ b/packages/account-tree-controller/src/backup-and-sync/service/atomic-sync-queue.test.ts
@@ -1,6 +1,6 @@
+import { backupAndSyncLogger } from '../../logger';
 /* eslint-disable no-void */
 import { AtomicSyncQueue } from './atomic-sync-queue';
-import { backupAndSyncLogger } from '../../logger';
 
 jest.mock('../../logger', () => ({
   backupAndSyncLogger: jest.fn(),

--- a/packages/account-tree-controller/src/backup-and-sync/service/index.ts
+++ b/packages/account-tree-controller/src/backup-and-sync/service/index.ts
@@ -2,7 +2,6 @@ import type { AccountGroupId, AccountWalletId } from '@metamask/account-api';
 import { AccountWalletType } from '@metamask/account-api';
 import type { UserStorageController } from '@metamask/profile-sync-controller';
 
-import { AtomicSyncQueue } from './atomic-sync-queue';
 import { backupAndSyncLogger } from '../../logger';
 import type { AccountTreeControllerState } from '../../types';
 import type { AccountWalletEntropyObject } from '../../wallet';
@@ -35,6 +34,7 @@ import {
   toErrorMessage,
 } from '../utils';
 import type { StateSnapshot } from '../utils';
+import { AtomicSyncQueue } from './atomic-sync-queue';
 
 /**
  * Service responsible for managing all backup and sync operations.

--- a/packages/account-tree-controller/src/backup-and-sync/syncing/group.test.ts
+++ b/packages/account-tree-controller/src/backup-and-sync/syncing/group.test.ts
@@ -1,9 +1,3 @@
-import {
-  createLocalGroupsFromUserStorage,
-  syncGroupMetadata,
-  syncGroupsMetadata,
-} from './group';
-import * as metadataExports from './metadata';
 import type { AccountGroupMultichainAccountObject } from '../../group';
 import type { AccountWalletEntropyObject } from '../../wallet';
 import { BackupAndSyncAnalyticsEvent } from '../analytics';
@@ -16,6 +10,12 @@ import {
   pushGroupToUserStorageBatch,
 } from '../user-storage/network-operations';
 import { getLocalGroupsForEntropyWallet } from '../utils';
+import {
+  createLocalGroupsFromUserStorage,
+  syncGroupMetadata,
+  syncGroupsMetadata,
+} from './group';
+import * as metadataExports from './metadata';
 
 jest.mock('./metadata');
 jest.mock('../user-storage/network-operations');

--- a/packages/account-tree-controller/src/backup-and-sync/syncing/group.ts
+++ b/packages/account-tree-controller/src/backup-and-sync/syncing/group.ts
@@ -1,6 +1,5 @@
 import { toMultichainAccountWalletId } from '@metamask/account-api';
 
-import { compareAndSyncMetadata } from './metadata';
 import type { AccountGroupMultichainAccountObject } from '../../group';
 import { backupAndSyncLogger } from '../../logger';
 import type { AccountWalletEntropyObject } from '../../wallet';
@@ -18,6 +17,7 @@ import {
 } from '../user-storage/network-operations';
 import { getLocalGroupsForEntropyWallet } from '../utils';
 import { toErrorMessage } from '../utils/errors';
+import { compareAndSyncMetadata } from './metadata';
 
 /**
  * Creates multiple multichain account groups in batch (from 0 to maxGroupIndex).

--- a/packages/account-tree-controller/src/backup-and-sync/syncing/legacy.test.ts
+++ b/packages/account-tree-controller/src/backup-and-sync/syncing/legacy.test.ts
@@ -1,13 +1,13 @@
 import { AccountGroupType } from '@metamask/account-api';
 import { getUUIDFromAddressOfNormalAccount } from '@metamask/accounts-controller';
 
-import { createMultichainAccountGroupsBatch } from './group';
-import { performLegacyAccountSyncing } from './legacy';
 import type { AccountGroupMultichainAccountObject } from '../../group';
 import { BackupAndSyncAnalyticsEvent } from '../analytics';
 import type { BackupAndSyncContext } from '../types';
 import { getAllLegacyUserStorageAccounts } from '../user-storage';
 import { getLocalGroupsForEntropyWallet } from '../utils';
+import { createMultichainAccountGroupsBatch } from './group';
+import { performLegacyAccountSyncing } from './legacy';
 
 jest.mock('@metamask/accounts-controller');
 jest.mock('../user-storage');

--- a/packages/account-tree-controller/src/backup-and-sync/syncing/legacy.ts
+++ b/packages/account-tree-controller/src/backup-and-sync/syncing/legacy.ts
@@ -1,13 +1,13 @@
 import { toMultichainAccountWalletId } from '@metamask/account-api';
 import { getUUIDFromAddressOfNormalAccount } from '@metamask/accounts-controller';
 
-import { createMultichainAccountGroupsBatch } from './group';
 import { backupAndSyncLogger } from '../../logger';
 import { BackupAndSyncAnalyticsEvent } from '../analytics';
 import type { ProfileId } from '../authentication';
 import type { BackupAndSyncContext } from '../types';
 import { getAllLegacyUserStorageAccounts } from '../user-storage';
 import { getLocalGroupsForEntropyWallet } from '../utils';
+import { createMultichainAccountGroupsBatch } from './group';
 
 /**
  * Performs a stripped down version of legacy account syncing, replacing the current

--- a/packages/account-tree-controller/src/backup-and-sync/syncing/metadata.test.ts
+++ b/packages/account-tree-controller/src/backup-and-sync/syncing/metadata.test.ts
@@ -1,6 +1,6 @@
-import { compareAndSyncMetadata } from './metadata';
 import { BackupAndSyncAnalyticsEvent } from '../analytics';
 import type { BackupAndSyncContext } from '../types';
+import { compareAndSyncMetadata } from './metadata';
 
 describe('BackupAndSync - Syncing - Metadata', () => {
   let mockContext: BackupAndSyncContext;

--- a/packages/account-tree-controller/src/backup-and-sync/syncing/wallet.test.ts
+++ b/packages/account-tree-controller/src/backup-and-sync/syncing/wallet.test.ts
@@ -1,12 +1,12 @@
+import type { AccountWalletEntropyObject } from '../../wallet';
+import { BackupAndSyncAnalyticsEvent } from '../analytics';
+import type { BackupAndSyncContext, UserStorageSyncedWallet } from '../types';
+import { pushWalletToUserStorage } from '../user-storage/network-operations';
 import { compareAndSyncMetadata } from './metadata';
 import {
   syncWalletMetadataAndCheckIfPushNeeded,
   syncWalletMetadata,
 } from './wallet';
-import type { AccountWalletEntropyObject } from '../../wallet';
-import { BackupAndSyncAnalyticsEvent } from '../analytics';
-import type { BackupAndSyncContext, UserStorageSyncedWallet } from '../types';
-import { pushWalletToUserStorage } from '../user-storage/network-operations';
 
 jest.mock('./metadata');
 jest.mock('../user-storage/network-operations');

--- a/packages/account-tree-controller/src/backup-and-sync/syncing/wallet.ts
+++ b/packages/account-tree-controller/src/backup-and-sync/syncing/wallet.ts
@@ -1,4 +1,3 @@
-import { compareAndSyncMetadata } from './metadata';
 import { backupAndSyncLogger } from '../../logger';
 import type { AccountWalletEntropyObject } from '../../wallet';
 import { BackupAndSyncAnalyticsEvent } from '../analytics';
@@ -6,6 +5,7 @@ import type { ProfileId } from '../authentication';
 import { UserStorageSyncedWalletSchema } from '../types';
 import type { BackupAndSyncContext, UserStorageSyncedWallet } from '../types';
 import { pushWalletToUserStorage } from '../user-storage/network-operations';
+import { compareAndSyncMetadata } from './metadata';
 
 /**
  * Syncs wallet metadata fields and determines if the wallet needs to be pushed to user storage.

--- a/packages/account-tree-controller/src/backup-and-sync/types.ts
+++ b/packages/account-tree-controller/src/backup-and-sync/types.ts
@@ -15,7 +15,6 @@ import {
 } from '@metamask/superstruct';
 import type { Infer, Struct } from '@metamask/superstruct';
 
-import type { BackupAndSyncEmitAnalyticsEventParams } from './analytics';
 import type { AccountTreeController } from '../AccountTreeController';
 import type {
   AccountGroupMultichainAccountObject,
@@ -24,6 +23,7 @@ import type {
 import type { RuleResult } from '../rule';
 import type { AccountTreeControllerMessenger } from '../types';
 import type { AccountTreeWalletPersistedMetadata } from '../wallet';
+import type { BackupAndSyncEmitAnalyticsEventParams } from './analytics';
 
 /**
  * Schema for an updatable field with value and timestamp.

--- a/packages/account-tree-controller/src/backup-and-sync/user-storage/format-utils.test.ts
+++ b/packages/account-tree-controller/src/backup-and-sync/user-storage/format-utils.test.ts
@@ -1,3 +1,7 @@
+import type { AccountGroupMultichainAccountObject } from '../../group';
+import { backupAndSyncLogger } from '../../logger';
+import type { AccountWalletEntropyObject } from '../../wallet';
+import type { BackupAndSyncContext, UserStorageSyncedWallet } from '../types';
 import {
   formatWalletForUserStorageUsage,
   formatGroupForUserStorageUsage,
@@ -10,10 +14,6 @@ import {
   assertValidUserStorageGroup,
   assertValidLegacyUserStorageAccount,
 } from './validation';
-import type { AccountGroupMultichainAccountObject } from '../../group';
-import { backupAndSyncLogger } from '../../logger';
-import type { AccountWalletEntropyObject } from '../../wallet';
-import type { BackupAndSyncContext, UserStorageSyncedWallet } from '../types';
 
 jest.mock('./validation');
 jest.mock('../../logger');

--- a/packages/account-tree-controller/src/backup-and-sync/user-storage/format-utils.ts
+++ b/packages/account-tree-controller/src/backup-and-sync/user-storage/format-utils.ts
@@ -1,10 +1,5 @@
 import { mask } from '@metamask/superstruct';
 
-import {
-  assertValidUserStorageWallet,
-  assertValidUserStorageGroup,
-  assertValidLegacyUserStorageAccount,
-} from './validation';
 import type { AccountGroupMultichainAccountObject } from '../../group';
 import { backupAndSyncLogger } from '../../logger';
 import type { AccountWalletEntropyObject } from '../../wallet';
@@ -16,6 +11,11 @@ import type {
 } from '../types';
 import { UserStorageSyncedWalletGroupSchema } from '../types';
 import { toErrorMessage } from '../utils/errors';
+import {
+  assertValidUserStorageWallet,
+  assertValidUserStorageGroup,
+  assertValidLegacyUserStorageAccount,
+} from './validation';
 
 /**
  * Formats the wallet for user storage usage.

--- a/packages/account-tree-controller/src/backup-and-sync/user-storage/network-operations.test.ts
+++ b/packages/account-tree-controller/src/backup-and-sync/user-storage/network-operations.test.ts
@@ -1,5 +1,12 @@
 import { SDK } from '@metamask/profile-sync-controller';
 
+import type { AccountGroupMultichainAccountObject } from '../../group';
+import type { AccountWalletEntropyObject } from '../../wallet';
+import type {
+  BackupAndSyncContext,
+  UserStorageSyncedWallet,
+  UserStorageSyncedWalletGroup,
+} from '../types';
 import {
   USER_STORAGE_WALLETS_FEATURE_KEY,
   USER_STORAGE_WALLETS_FEATURE_ENTRY_KEY,
@@ -22,13 +29,6 @@ import {
   getAllLegacyUserStorageAccounts,
 } from './network-operations';
 import { executeWithRetry } from './network-utils';
-import type { AccountGroupMultichainAccountObject } from '../../group';
-import type { AccountWalletEntropyObject } from '../../wallet';
-import type {
-  BackupAndSyncContext,
-  UserStorageSyncedWallet,
-  UserStorageSyncedWalletGroup,
-} from '../types';
 
 jest.mock('./format-utils');
 jest.mock('./network-utils');

--- a/packages/account-tree-controller/src/backup-and-sync/user-storage/network-operations.ts
+++ b/packages/account-tree-controller/src/backup-and-sync/user-storage/network-operations.ts
@@ -1,5 +1,15 @@
 import { SDK } from '@metamask/profile-sync-controller';
 
+import type { AccountGroupMultichainAccountObject } from '../../group';
+import { backupAndSyncLogger } from '../../logger';
+import type { AccountWalletEntropyObject } from '../../wallet';
+import type {
+  BackupAndSyncContext,
+  LegacyUserStorageSyncedAccount,
+  UserStorageSyncedWallet,
+  UserStorageSyncedWalletGroup,
+} from '../types';
+import { toErrorMessage } from '../utils/errors';
 import {
   USER_STORAGE_GROUPS_FEATURE_KEY,
   USER_STORAGE_WALLETS_FEATURE_ENTRY_KEY,
@@ -13,16 +23,6 @@ import {
   parseLegacyAccountFromUserStorageResponse,
 } from './format-utils';
 import { executeWithRetry } from './network-utils';
-import type { AccountGroupMultichainAccountObject } from '../../group';
-import { backupAndSyncLogger } from '../../logger';
-import type { AccountWalletEntropyObject } from '../../wallet';
-import type {
-  BackupAndSyncContext,
-  LegacyUserStorageSyncedAccount,
-  UserStorageSyncedWallet,
-  UserStorageSyncedWalletGroup,
-} from '../types';
-import { toErrorMessage } from '../utils/errors';
 
 /**
  * Retrieves the wallet from user storage.

--- a/packages/account-tree-controller/src/backup-and-sync/utils/controller.test.ts
+++ b/packages/account-tree-controller/src/backup-and-sync/utils/controller.test.ts
@@ -1,5 +1,11 @@
 import { AccountWalletType, AccountGroupType } from '@metamask/account-api';
 
+import type { AccountTreeController } from '../../AccountTreeController';
+import type {
+  AccountWalletEntropyObject,
+  AccountWalletKeyringObject,
+} from '../../wallet';
+import type { BackupAndSyncContext } from '../types';
 import {
   getLocalEntropyWallets,
   getLocalGroupsForEntropyWallet,
@@ -8,12 +14,6 @@ import {
   getLocalGroupForEntropyWallet,
 } from './controller';
 import type { StateSnapshot } from './controller';
-import type { AccountTreeController } from '../../AccountTreeController';
-import type {
-  AccountWalletEntropyObject,
-  AccountWalletKeyringObject,
-} from '../../wallet';
-import type { BackupAndSyncContext } from '../types';
 
 describe('BackupAndSyncUtils - Controller', () => {
   let mockContext: BackupAndSyncContext;

--- a/packages/account-tree-controller/src/rule.test.ts
+++ b/packages/account-tree-controller/src/rule.test.ts
@@ -13,13 +13,13 @@ import {
 import { KeyringTypes } from '@metamask/keyring-controller';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 
-import type { AccountGroupObject } from './group';
-import { BaseRule } from './rule';
-import type { AccountWalletObject } from './wallet';
 import {
   getAccountTreeControllerMessenger,
   getRootMessenger,
 } from '../tests/mockMessenger';
+import type { AccountGroupObject } from './group';
+import { BaseRule } from './rule';
+import type { AccountWalletObject } from './wallet';
 
 const ETH_EOA_METHODS = [
   EthMethod.PersonalSign,

--- a/packages/account-tree-controller/src/rules/entropy.test.ts
+++ b/packages/account-tree-controller/src/rules/entropy.test.ts
@@ -15,12 +15,12 @@ import { KeyringTypes } from '@metamask/keyring-controller';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 import type { AccountWalletEntropyObject } from 'src/wallet';
 
-import { EntropyRule } from './entropy';
 import {
   getAccountTreeControllerMessenger,
   getRootMessenger,
 } from '../../tests/mockMessenger';
 import type { AccountGroupObjectOf } from '../group';
+import { EntropyRule } from './entropy';
 
 const ETH_EOA_METHODS = [
   EthMethod.PersonalSign,

--- a/packages/account-tree-controller/src/rules/keyring.test.ts
+++ b/packages/account-tree-controller/src/rules/keyring.test.ts
@@ -8,7 +8,6 @@ import { EthAccountType, EthMethod, EthScope } from '@metamask/keyring-api';
 import { KeyringTypes } from '@metamask/keyring-controller';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 
-import { KeyringRule, getAccountWalletNameFromKeyringType } from './keyring';
 import {
   getAccountTreeControllerMessenger,
   getRootMessenger,
@@ -18,6 +17,7 @@ import type {
   AccountWalletKeyringObject,
   AccountWalletObjectOf,
 } from '../wallet';
+import { KeyringRule, getAccountWalletNameFromKeyringType } from './keyring';
 
 describe('keyring', () => {
   describe('getAccountWalletNameFromKeyringType', () => {

--- a/packages/account-tree-controller/src/rules/snap.test.ts
+++ b/packages/account-tree-controller/src/rules/snap.test.ts
@@ -10,13 +10,13 @@ import type { InternalAccount } from '@metamask/keyring-internal-api';
 import type { SnapId } from '@metamask/snaps-sdk';
 import type { Snap } from '@metamask/snaps-utils';
 
-import { SnapRule } from './snap';
 import {
   getAccountTreeControllerMessenger,
   getRootMessenger,
 } from '../../tests/mockMessenger';
 import type { AccountGroupObjectOf } from '../group';
 import type { AccountWalletObjectOf, AccountWalletSnapObject } from '../wallet';
+import { SnapRule } from './snap';
 
 const ETH_EOA_METHODS = [
   EthMethod.PersonalSign,

--- a/packages/account-tree-controller/src/rules/snap.ts
+++ b/packages/account-tree-controller/src/rules/snap.ts
@@ -5,10 +5,10 @@ import type { InternalAccount } from '@metamask/keyring-internal-api';
 import type { SnapId } from '@metamask/snaps-sdk';
 import { stripSnapPrefix } from '@metamask/snaps-utils';
 
-import { getAccountGroupPrefixFromKeyringType } from './keyring';
 import { BaseRule } from '../rule';
 import type { Rule, RuleResult } from '../rule';
 import type { AccountWalletObjectOf } from '../wallet';
+import { getAccountGroupPrefixFromKeyringType } from './keyring';
 
 /**
  * Snap account type.

--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -34,6 +34,12 @@ import type { CaipChainId } from '@metamask/utils';
 import type { V4Options } from 'uuid';
 import { v4 as uuidV4 } from 'uuid';
 
+import {
+  createExpectedInternalAccount,
+  createMockInternalAccount,
+  createMockInternalAccountOptions,
+  ETH_EOA_METHODS,
+} from '../tests/mocks';
 import type {
   AccountsControllerMessenger,
   AccountsControllerState,
@@ -43,12 +49,6 @@ import {
   getUUIDOptionsFromAddressOfNormalAccount,
   keyringTypeToName,
 } from './utils';
-import {
-  createExpectedInternalAccount,
-  createMockInternalAccount,
-  createMockInternalAccountOptions,
-  ETH_EOA_METHODS,
-} from '../tests/mocks';
 
 type AllAccountsControllerActions =
   MessengerActions<AccountsControllerMessenger>;

--- a/packages/accounts-controller/src/utils.test.ts
+++ b/packages/accounts-controller/src/utils.test.ts
@@ -2,6 +2,7 @@ import { toChecksumAddress } from '@ethereumjs/util';
 import type { KeyringObject } from '@metamask/keyring-controller';
 import { KeyringTypes } from '@metamask/keyring-controller';
 
+import { createMockInternalAccount } from '../tests/mocks';
 import {
   constructAccountIdByAddress,
   getEvmGroupIndexFromAddressIndex,
@@ -10,7 +11,6 @@ import {
   isSimpleKeyringType,
   keyringTypeToName,
 } from './utils';
-import { createMockInternalAccount } from '../tests/mocks';
 
 describe('utils', () => {
   describe('keyringTypeToName', () => {

--- a/packages/approval-controller/src/ApprovalController.test.ts
+++ b/packages/approval-controller/src/ApprovalController.test.ts
@@ -10,6 +10,7 @@ import type {
 import { errorCodes, JsonRpcError } from '@metamask/rpc-errors';
 import { nanoid } from 'nanoid';
 
+import { flushPromises } from '../../../tests/helpers';
 import type {
   AddApprovalOptions,
   ApprovalControllerActions,
@@ -31,7 +32,6 @@ import {
   MissingApprovalFlowError,
   NoApprovalFlowsError,
 } from './errors';
-import { flushPromises } from '../../../tests/helpers';
 
 jest.mock('nanoid');
 

--- a/packages/assets-controller/src/data-sources/AbstractDataSource.test.ts
+++ b/packages/assets-controller/src/data-sources/AbstractDataSource.test.ts
@@ -1,10 +1,10 @@
+import type { ChainId } from '../types';
 import type {
   ActiveSubscription,
   DataSourceState,
   SubscriptionRequest,
 } from './AbstractDataSource';
 import { AbstractDataSource } from './AbstractDataSource';
-import type { ChainId } from '../types';
 
 const CHAIN_MAINNET = 'eip155:1' as ChainId;
 const CHAIN_POLYGON = 'eip155:137' as ChainId;

--- a/packages/assets-controller/src/data-sources/AccountsApiDataSource.test.ts
+++ b/packages/assets-controller/src/data-sources/AccountsApiDataSource.test.ts
@@ -5,6 +5,12 @@ import { Messenger, MOCK_ANY_NAMESPACE } from '@metamask/messenger';
 import type { MockAnyNamespace } from '@metamask/messenger';
 
 import type {
+  ChainId,
+  DataRequest,
+  Context,
+  AssetsControllerStateInternal,
+} from '../types';
+import type {
   AccountsApiDataSourceOptions,
   AccountsApiDataSourceAllowedActions,
 } from './AccountsApiDataSource';
@@ -12,12 +18,6 @@ import {
   AccountsApiDataSource,
   filterResponseToKnownAssets,
 } from './AccountsApiDataSource';
-import type {
-  ChainId,
-  DataRequest,
-  Context,
-  AssetsControllerStateInternal,
-} from '../types';
 
 type AllActions = AccountsApiDataSourceAllowedActions;
 type AllEvents = never;

--- a/packages/assets-controller/src/data-sources/AccountsApiDataSource.ts
+++ b/packages/assets-controller/src/data-sources/AccountsApiDataSource.ts
@@ -6,11 +6,6 @@ import {
   toCaipChainId,
 } from '@metamask/utils';
 
-import type {
-  DataSourceState,
-  SubscriptionRequest,
-} from './AbstractDataSource';
-import { AbstractDataSource } from './AbstractDataSource';
 import { projectLogger, createModuleLogger } from '../logger';
 import type {
   ChainId,
@@ -22,6 +17,11 @@ import type {
   AssetsControllerStateInternal,
 } from '../types';
 import { normalizeAssetId } from '../utils';
+import type {
+  DataSourceState,
+  SubscriptionRequest,
+} from './AbstractDataSource';
+import { AbstractDataSource } from './AbstractDataSource';
 
 // ============================================================================
 // CONSTANTS

--- a/packages/assets-controller/src/data-sources/BackendWebsocketDataSource.test.ts
+++ b/packages/assets-controller/src/data-sources/BackendWebsocketDataSource.test.ts
@@ -9,6 +9,8 @@ import type { InternalAccount } from '@metamask/keyring-internal-api';
 import { Messenger, MOCK_ANY_NAMESPACE } from '@metamask/messenger';
 import type { MockAnyNamespace } from '@metamask/messenger';
 
+import type { AssetsControllerMessenger } from '../AssetsController';
+import type { ChainId, DataRequest } from '../types';
 import {
   BackendWebsocketDataSource,
   createBackendWebsocketDataSource,
@@ -17,8 +19,6 @@ import type {
   BackendWebsocketDataSourceAllowedActions,
   BackendWebsocketDataSourceAllowedEvents,
 } from './BackendWebsocketDataSource';
-import type { AssetsControllerMessenger } from '../AssetsController';
-import type { ChainId, DataRequest } from '../types';
 
 type AllActions = BackendWebsocketDataSourceAllowedActions;
 type AllEvents = BackendWebsocketDataSourceAllowedEvents;

--- a/packages/assets-controller/src/data-sources/BackendWebsocketDataSource.ts
+++ b/packages/assets-controller/src/data-sources/BackendWebsocketDataSource.ts
@@ -15,11 +15,6 @@ import {
 } from '@metamask/utils';
 import BigNumberJS from 'bignumber.js';
 
-import { AbstractDataSource } from './AbstractDataSource';
-import type {
-  DataSourceState,
-  SubscriptionRequest,
-} from './AbstractDataSource';
 import type { AssetsControllerMessenger } from '../AssetsController';
 import { projectLogger, createModuleLogger } from '../logger';
 import type {
@@ -29,6 +24,11 @@ import type {
   AssetBalance,
   DataResponse,
 } from '../types';
+import { AbstractDataSource } from './AbstractDataSource';
+import type {
+  DataSourceState,
+  SubscriptionRequest,
+} from './AbstractDataSource';
 
 // ============================================================================
 // CONSTANTS

--- a/packages/assets-controller/src/data-sources/PriceDataSource.test.ts
+++ b/packages/assets-controller/src/data-sources/PriceDataSource.test.ts
@@ -1,8 +1,6 @@
 import type { SupportedCurrency } from '@metamask/core-backend';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 
-import type { PriceDataSourceOptions } from './PriceDataSource';
-import { PriceDataSource } from './PriceDataSource';
 import type {
   ChainId,
   DataRequest,
@@ -10,6 +8,8 @@ import type {
   Caip19AssetId,
   AssetsControllerStateInternal,
 } from '../types';
+import type { PriceDataSourceOptions } from './PriceDataSource';
+import { PriceDataSource } from './PriceDataSource';
 
 jest.useFakeTimers();
 

--- a/packages/assets-controller/src/data-sources/PriceDataSource.ts
+++ b/packages/assets-controller/src/data-sources/PriceDataSource.ts
@@ -5,8 +5,6 @@ import type {
 import { ApiPlatformClient } from '@metamask/core-backend';
 import { parseCaipAssetType } from '@metamask/utils';
 
-import type { SubscriptionRequest } from './AbstractDataSource';
-import { reduceInBatchesSerially } from './evm-rpc-services';
 import { projectLogger, createModuleLogger } from '../logger';
 import { forDataTypes } from '../types';
 import type {
@@ -17,6 +15,8 @@ import type {
   Middleware,
   AssetsControllerStateInternal,
 } from '../types';
+import type { SubscriptionRequest } from './AbstractDataSource';
+import { reduceInBatchesSerially } from './evm-rpc-services';
 
 // ============================================================================
 // CONSTANTS

--- a/packages/assets-controller/src/data-sources/RpcDataSource.test.ts
+++ b/packages/assets-controller/src/data-sources/RpcDataSource.test.ts
@@ -4,6 +4,15 @@ import type { NetworkState } from '@metamask/network-controller';
 import { NetworkStatus, RpcEndpointType } from '@metamask/network-controller';
 import type { TransactionMeta } from '@metamask/transaction-controller';
 
+import {
+  createMockAssetControllerMessenger,
+  MockRootMessenger,
+  registerRpcDataSourceActions,
+} from '../__fixtures__/MockAssetControllerMessenger';
+import { getDefaultAssetsControllerState } from '../AssetsController';
+import type { AssetsControllerMessenger } from '../AssetsController';
+import type { Caip19AssetId, ChainId, DataRequest, Context } from '../types';
+import { normalizeAssetId } from '../utils';
 import { BalanceFetcher, TokenDetector } from './evm-rpc-services';
 import type {
   Address,
@@ -16,15 +25,6 @@ import {
   caipChainIdToHex,
   createRpcDataSource,
 } from './RpcDataSource';
-import {
-  createMockAssetControllerMessenger,
-  MockRootMessenger,
-  registerRpcDataSourceActions,
-} from '../__fixtures__/MockAssetControllerMessenger';
-import { getDefaultAssetsControllerState } from '../AssetsController';
-import type { AssetsControllerMessenger } from '../AssetsController';
-import type { Caip19AssetId, ChainId, DataRequest, Context } from '../types';
-import { normalizeAssetId } from '../utils';
 
 const MOCK_CHAIN_ID_HEX = '0x1';
 const MOCK_CHAIN_ID_CAIP = 'eip155:1' as ChainId;

--- a/packages/assets-controller/src/data-sources/RpcDataSource.ts
+++ b/packages/assets-controller/src/data-sources/RpcDataSource.ts
@@ -23,6 +23,22 @@ import {
 import type { Hex } from '@metamask/utils';
 import BigNumberJS from 'bignumber.js';
 
+import type {
+  AssetsControllerGetStateAction,
+  AssetsControllerMessenger,
+} from '../AssetsController';
+import { projectLogger, createModuleLogger } from '../logger';
+import type {
+  ChainId,
+  Caip19AssetId,
+  AssetBalance,
+  AssetMetadata,
+  DataRequest,
+  DataResponse,
+  Middleware,
+} from '../types';
+import { normalizeAssetId } from '../utils';
+import { ZERO_ADDRESS } from '../utils/constants';
 import { AbstractDataSource } from './AbstractDataSource';
 import type {
   DataSourceState,
@@ -45,22 +61,6 @@ import type {
   BalanceFetchResult,
   TokenDetectionResult,
 } from './evm-rpc-services/types';
-import type {
-  AssetsControllerGetStateAction,
-  AssetsControllerMessenger,
-} from '../AssetsController';
-import { projectLogger, createModuleLogger } from '../logger';
-import type {
-  ChainId,
-  Caip19AssetId,
-  AssetBalance,
-  AssetMetadata,
-  DataRequest,
-  DataResponse,
-  Middleware,
-} from '../types';
-import { normalizeAssetId } from '../utils';
-import { ZERO_ADDRESS } from '../utils/constants';
 
 const CONTROLLER_NAME = 'RpcDataSource';
 const DEFAULT_BALANCE_INTERVAL = 30_000; // 30 seconds

--- a/packages/assets-controller/src/data-sources/SnapDataSource.test.ts
+++ b/packages/assets-controller/src/data-sources/SnapDataSource.test.ts
@@ -7,6 +7,8 @@ import type {
   SubjectPermissions,
 } from '@metamask/permission-controller';
 
+import type { AssetsControllerMessenger } from '../AssetsController';
+import type { ChainId, DataRequest, Context, Caip19AssetId } from '../types';
 import type {
   SnapDataSourceOptions,
   AccountBalancesUpdatedEventPayload,
@@ -21,8 +23,6 @@ import {
   KEYRING_PERMISSION,
   ASSETS_PERMISSION,
 } from './SnapDataSource';
-import type { AssetsControllerMessenger } from '../AssetsController';
-import type { ChainId, DataRequest, Context, Caip19AssetId } from '../types';
 
 // Test chain IDs
 const SOLANA_MAINNET = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp' as ChainId;

--- a/packages/assets-controller/src/data-sources/SnapDataSource.ts
+++ b/packages/assets-controller/src/data-sources/SnapDataSource.ts
@@ -16,11 +16,6 @@ import { HandlerType, SnapCaveatType } from '@metamask/snaps-utils';
 import { parseCaipAssetType } from '@metamask/utils';
 import type { Json, JsonRpcRequest } from '@metamask/utils';
 
-import { AbstractDataSource } from './AbstractDataSource';
-import type {
-  DataSourceState,
-  SubscriptionRequest,
-} from './AbstractDataSource';
 import type { AssetsControllerMessenger } from '../AssetsController';
 import { projectLogger, createModuleLogger } from '../logger';
 import type {
@@ -31,6 +26,11 @@ import type {
   DataResponse,
   Middleware,
 } from '../types';
+import { AbstractDataSource } from './AbstractDataSource';
+import type {
+  DataSourceState,
+  SubscriptionRequest,
+} from './AbstractDataSource';
 
 // ============================================================================
 // SNAP KEYRING EVENT TYPES

--- a/packages/assets-controller/src/data-sources/StakedBalanceDataSource.test.ts
+++ b/packages/assets-controller/src/data-sources/StakedBalanceDataSource.test.ts
@@ -1,8 +1,6 @@
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 import { TransactionStatus } from '@metamask/transaction-controller';
 
-import type { StakedBalanceDataSourceOptions } from './StakedBalanceDataSource';
-import { StakedBalanceDataSource } from './StakedBalanceDataSource';
 import {
   MockRootMessenger,
   createMockAssetControllerMessenger,
@@ -16,6 +14,8 @@ import type {
   Context,
   DataRequest,
 } from '../types';
+import type { StakedBalanceDataSourceOptions } from './StakedBalanceDataSource';
+import { StakedBalanceDataSource } from './StakedBalanceDataSource';
 
 const MAINNET_CHAIN_ID_HEX = '0x1';
 const MAINNET_CHAIN_ID_CAIP = 'eip155:1' as ChainId;

--- a/packages/assets-controller/src/data-sources/StakedBalanceDataSource.ts
+++ b/packages/assets-controller/src/data-sources/StakedBalanceDataSource.ts
@@ -10,6 +10,18 @@ import {
 } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
 
+import type { AssetsControllerMessenger } from '../AssetsController';
+import { projectLogger, createModuleLogger } from '../logger';
+import type {
+  AccountId,
+  ChainId,
+  Caip19AssetId,
+  AssetBalance,
+  AssetMetadata,
+  DataRequest,
+  DataResponse,
+  Middleware,
+} from '../types';
 import type {
   DataSourceState,
   SubscriptionRequest,
@@ -24,18 +36,6 @@ import {
   getStakingContractAddress,
   getSupportedStakingChainIds,
 } from './evm-rpc-services';
-import type { AssetsControllerMessenger } from '../AssetsController';
-import { projectLogger, createModuleLogger } from '../logger';
-import type {
-  AccountId,
-  ChainId,
-  Caip19AssetId,
-  AssetBalance,
-  AssetMetadata,
-  DataRequest,
-  DataResponse,
-  Middleware,
-} from '../types';
 
 const CONTROLLER_NAME = 'StakedBalanceDataSource';
 const DEFAULT_POLL_INTERVAL = 180_000; // 3 minutes

--- a/packages/assets-controller/src/data-sources/TokenDataSource.test.ts
+++ b/packages/assets-controller/src/data-sources/TokenDataSource.test.ts
@@ -7,10 +7,10 @@ import type {
 } from '@metamask/phishing-controller';
 import { TokenScanResultType } from '@metamask/phishing-controller';
 
-import type { TokenDataSourceOptions } from './TokenDataSource';
-import { TokenDataSource } from './TokenDataSource';
 import type { AssetsControllerMessenger } from '../AssetsController';
 import type { Context, DataRequest, Caip19AssetId, ChainId } from '../types';
+import type { TokenDataSourceOptions } from './TokenDataSource';
+import { TokenDataSource } from './TokenDataSource';
 
 type AllActions = PhishingControllerBulkScanTokensAction;
 type AllEvents = never;

--- a/packages/assets-controller/src/data-sources/TokenDataSource.ts
+++ b/packages/assets-controller/src/data-sources/TokenDataSource.ts
@@ -8,10 +8,6 @@ import { TokenScanResultType } from '@metamask/phishing-controller';
 import { KnownCaipNamespace, parseCaipAssetType } from '@metamask/utils';
 import type { CaipAssetType } from '@metamask/utils';
 
-import {
-  isStakingContractAssetId,
-  reduceInBatchesSerially,
-} from './evm-rpc-services';
 import type { AssetsControllerMessenger } from '../AssetsController';
 import { projectLogger, createModuleLogger } from '../logger';
 import { forDataTypes } from '../types';
@@ -21,6 +17,10 @@ import type {
   Middleware,
   FungibleAssetMetadata,
 } from '../types';
+import {
+  isStakingContractAssetId,
+  reduceInBatchesSerially,
+} from './evm-rpc-services';
 
 // ============================================================================
 // CONSTANTS

--- a/packages/assets-controller/src/data-sources/evm-rpc-services/clients/MulticallClient.test.ts
+++ b/packages/assets-controller/src/data-sources/evm-rpc-services/clients/MulticallClient.test.ts
@@ -1,12 +1,12 @@
 import { defaultAbiCoder, Interface } from '@ethersproject/abi';
 import type { Hex } from '@metamask/utils';
 
+import type { Address, BalanceOfRequest, ChainId, Provider } from '../types';
 import {
   decodeAggregate3Response,
   encodeAggregate3,
   MulticallClient,
 } from './MulticallClient';
-import type { Address, BalanceOfRequest, ChainId, Provider } from '../types';
 
 // =============================================================================
 // MOCK PROVIDER

--- a/packages/assets-controller/src/data-sources/evm-rpc-services/clients/TokensApiClient.test.ts
+++ b/packages/assets-controller/src/data-sources/evm-rpc-services/clients/TokensApiClient.test.ts
@@ -1,6 +1,6 @@
+import type { ChainId } from '../types';
 import { TokensApiClient } from './TokensApiClient';
 import type { TokensApiClientConfig } from './TokensApiClient';
-import type { ChainId } from '../types';
 
 // =============================================================================
 // CONSTANTS

--- a/packages/assets-controller/src/data-sources/evm-rpc-services/services/BalanceFetcher.test.ts
+++ b/packages/assets-controller/src/data-sources/evm-rpc-services/services/BalanceFetcher.test.ts
@@ -1,11 +1,5 @@
 import type { CaipAssetType } from '@metamask/utils';
 
-import { BalanceFetcher } from './BalanceFetcher';
-import type {
-  BalanceFetcherConfig,
-  BalanceFetcherMessenger,
-  BalancePollingInput,
-} from './BalanceFetcher';
 import type { MulticallClient } from '../clients';
 import type {
   Address,
@@ -14,6 +8,12 @@ import type {
   BalanceOfResponse,
   ChainId,
 } from '../types';
+import { BalanceFetcher } from './BalanceFetcher';
+import type {
+  BalanceFetcherConfig,
+  BalanceFetcherMessenger,
+  BalancePollingInput,
+} from './BalanceFetcher';
 
 // =============================================================================
 // CONSTANTS

--- a/packages/assets-controller/src/data-sources/evm-rpc-services/services/TokenDetector.test.ts
+++ b/packages/assets-controller/src/data-sources/evm-rpc-services/services/TokenDetector.test.ts
@@ -1,8 +1,3 @@
-import { TokenDetector } from './TokenDetector';
-import type {
-  TokenDetectorConfig,
-  DetectionPollingInput,
-} from './TokenDetector';
 import type { MulticallClient } from '../clients';
 import type { TokensApiClient } from '../clients/TokensApiClient';
 import type {
@@ -11,6 +6,11 @@ import type {
   ChainId,
   TokenListEntry,
 } from '../types';
+import { TokenDetector } from './TokenDetector';
+import type {
+  TokenDetectorConfig,
+  DetectionPollingInput,
+} from './TokenDetector';
 
 // =============================================================================
 // CONSTANTS

--- a/packages/assets-controller/src/middlewares/DetectionMiddleware.test.ts
+++ b/packages/assets-controller/src/middlewares/DetectionMiddleware.test.ts
@@ -1,13 +1,13 @@
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 import { Messenger } from '@metamask/messenger';
 
-import { DetectionMiddleware } from './DetectionMiddleware';
 import type {
   Context,
   DataRequest,
   Caip19AssetId,
   AssetsControllerStateInternal,
 } from '../types';
+import { DetectionMiddleware } from './DetectionMiddleware';
 
 const MOCK_ADDRESS = '0x1234567890123456789012345678901234567890';
 const MOCK_ACCOUNT_ID = 'mock-account-id';

--- a/packages/assets-controller/src/middlewares/ParallelMiddleware.test.ts
+++ b/packages/assets-controller/src/middlewares/ParallelMiddleware.test.ts
@@ -1,6 +1,6 @@
-import { createParallelMiddleware } from './ParallelMiddleware';
 import type { AssetsDataSource } from '../types';
 import type { Context, DataResponse } from '../types';
+import { createParallelMiddleware } from './ParallelMiddleware';
 
 const MOCK_ASSET = 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
 

--- a/packages/assets-controller/src/selectors/balance.test.ts
+++ b/packages/assets-controller/src/selectors/balance.test.ts
@@ -1,14 +1,14 @@
 import type { AccountTreeControllerState } from '@metamask/account-tree-controller';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 
+import type { AssetsControllerState } from '../AssetsController';
+import type { Caip19AssetId } from '../types';
 import type { AccountsById, EnabledNetworkMap } from './balance';
 import {
   getAggregatedBalanceForAccount,
   getGroupIdForAccount,
   getInternalAccountsForGroup,
 } from './balance';
-import type { AssetsControllerState } from '../AssetsController';
-import type { Caip19AssetId } from '../types';
 
 describe('balance selectors', () => {
   const accountId1 = 'account-id-1';

--- a/packages/assets-controller/src/utils/formatExchangeRatesForBridge.test.ts
+++ b/packages/assets-controller/src/utils/formatExchangeRatesForBridge.test.ts
@@ -1,5 +1,5 @@
-import { formatExchangeRatesForBridge } from './formatExchangeRatesForBridge';
 import type { FungibleAssetPrice } from '../types';
+import { formatExchangeRatesForBridge } from './formatExchangeRatesForBridge';
 
 /**
  * Builds minimal AssetPrice for tests. Defaults usdPrice to the same

--- a/packages/assets-controller/src/utils/formatStateForTransactionPay.test.ts
+++ b/packages/assets-controller/src/utils/formatStateForTransactionPay.test.ts
@@ -1,8 +1,8 @@
+import type { AssetBalance, AssetMetadata, FungibleAssetPrice } from '../types';
 import {
   formatStateForTransactionPay,
   AccountForLegacyFormat,
 } from './formatStateForTransactionPay';
-import type { AssetBalance, AssetMetadata, FungibleAssetPrice } from '../types';
 
 function price(
   overrides: Partial<FungibleAssetPrice> & { price: number },

--- a/packages/assets-controller/src/utils/formatStateForTransactionPay.ts
+++ b/packages/assets-controller/src/utils/formatStateForTransactionPay.ts
@@ -2,14 +2,14 @@ import { toChecksumAddress } from '@ethereumjs/util';
 import { numberToHex } from '@metamask/utils';
 import { parseCaipAssetType, parseCaipChainId } from '@metamask/utils';
 
-import { formatExchangeRatesForBridge } from './formatExchangeRatesForBridge';
-import type { BridgeExchangeRatesFormat } from './formatExchangeRatesForBridge';
 import type {
   AssetBalance,
   AssetMetadata,
   AssetPrice,
   Caip19AssetId,
 } from '../types';
+import { formatExchangeRatesForBridge } from './formatExchangeRatesForBridge';
+import type { BridgeExchangeRatesFormat } from './formatExchangeRatesForBridge';
 
 /** Account with id and address for mapping state to legacy format. */
 export type AccountForLegacyFormat = { id: string; address: string };

--- a/packages/assets-controllers/src/AccountTrackerController.test.ts
+++ b/packages/assets-controllers/src/AccountTrackerController.test.ts
@@ -19,10 +19,6 @@ import type { TransactionMeta } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 import BN from 'bn.js';
 
-import type { AccountTrackerControllerMessenger } from './AccountTrackerController';
-import { AccountTrackerController } from './AccountTrackerController';
-import { AccountsApiBalanceFetcher } from './multi-chain-accounts-service/api-balance-fetcher';
-import { getTokenBalancesForMultipleAddresses } from './multicall';
 import { FakeProvider } from '../../../tests/fake-provider';
 import { jestAdvanceTime } from '../../../tests/helpers';
 import { createMockInternalAccount } from '../../accounts-controller/tests/mocks';
@@ -30,6 +26,10 @@ import {
   buildCustomNetworkClientConfiguration,
   buildMockGetNetworkClientById,
 } from '../../network-controller/tests/helpers';
+import type { AccountTrackerControllerMessenger } from './AccountTrackerController';
+import { AccountTrackerController } from './AccountTrackerController';
+import { AccountsApiBalanceFetcher } from './multi-chain-accounts-service/api-balance-fetcher';
+import { getTokenBalancesForMultipleAddresses } from './multicall';
 
 type AllAccountTrackerControllerActions =
   MessengerActions<AccountTrackerControllerMessenger>;

--- a/packages/assets-controllers/src/AssetsContractController.test.ts
+++ b/packages/assets-controllers/src/AssetsContractController.test.ts
@@ -27,15 +27,15 @@ import type { PreferencesState } from '@metamask/preferences-controller';
 import { getDefaultPreferencesState } from '@metamask/preferences-controller';
 import assert from 'assert';
 
+import { SECONDS } from '../../../tests/constants';
+import { mockNetwork } from '../../../tests/mock-network';
+import { buildInfuraNetworkClientConfiguration } from '../../network-controller/tests/helpers';
 import type { AssetsContractControllerMessenger } from './AssetsContractController';
 import {
   AssetsContractController,
   MISSING_PROVIDER_ERROR,
 } from './AssetsContractController';
 import { SupportedTokenDetectionNetworks } from './assetsUtil';
-import { SECONDS } from '../../../tests/constants';
-import { mockNetwork } from '../../../tests/mock-network';
-import { buildInfuraNetworkClientConfiguration } from '../../network-controller/tests/helpers';
 
 type AllAssetsContractControllerActions =
   MessengerActions<AssetsContractControllerMessenger>;

--- a/packages/assets-controllers/src/AssetsContractController.ts
+++ b/packages/assets-controllers/src/AssetsContractController.ts
@@ -26,8 +26,8 @@ import {
 import type { Call } from './multicall';
 import { multicallOrFallback } from './multicall';
 import { ERC20Standard } from './Standards/ERC20Standard';
-import { ERC1155Standard } from './Standards/NftStandards/ERC1155/ERC1155Standard';
 import { ERC721Standard } from './Standards/NftStandards/ERC721/ERC721Standard';
+import { ERC1155Standard } from './Standards/NftStandards/ERC1155/ERC1155Standard';
 
 /**
  * Check if token detection is enabled for certain networks

--- a/packages/assets-controllers/src/AssetsContractControllerWithNetworkClientId.test.ts
+++ b/packages/assets-controllers/src/AssetsContractControllerWithNetworkClientId.test.ts
@@ -2,11 +2,11 @@ import { BigNumber } from '@ethersproject/bignumber';
 import { BUILT_IN_NETWORKS } from '@metamask/controller-utils';
 import { NetworkClientType } from '@metamask/network-controller';
 
+import { SECONDS } from '../../../tests/constants';
 import {
   setupAssetContractControllers,
   mockNetworkWithDefaultChainId,
 } from './AssetsContractController.test';
-import { SECONDS } from '../../../tests/constants';
 
 const ERC20_UNI_ADDRESS = '0x1f9840a85d5af5bf1d1762f925bdaddc4201f984';
 const ERC20_SAI_ADDRESS = '0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359';

--- a/packages/assets-controllers/src/CurrencyRateController.test.ts
+++ b/packages/assets-controllers/src/CurrencyRateController.test.ts
@@ -13,10 +13,10 @@ import type {
 import type { NetworkConfiguration } from '@metamask/network-controller';
 import type { Hex } from '@metamask/utils';
 
+import { jestAdvanceTime } from '../../../tests/helpers';
 import type { CurrencyRateMessenger } from './CurrencyRateController';
 import { CurrencyRateController } from './CurrencyRateController';
 import type { AbstractTokenPricesService } from './token-prices-service';
-import { jestAdvanceTime } from '../../../tests/helpers';
 
 const namespace = 'CurrencyRateController';
 

--- a/packages/assets-controllers/src/DeFiPositionsController/DeFiPositionsController.test.ts
+++ b/packages/assets-controllers/src/DeFiPositionsController/DeFiPositionsController.test.ts
@@ -7,6 +7,12 @@ import type {
   MockAnyNamespace,
 } from '@metamask/messenger';
 
+import { flushPromises } from '../../../../tests/helpers';
+import { createMockInternalAccount } from '../../../accounts-controller/tests/mocks';
+import type {
+  InternalAccount,
+  TransactionMeta,
+} from '../../../transaction-controller/src/types';
 import * as calculateDefiMetrics from './calculate-defi-metrics';
 import type { DeFiPositionsControllerMessenger } from './DeFiPositionsController';
 import {
@@ -15,12 +21,6 @@ import {
 } from './DeFiPositionsController';
 import * as fetchPositions from './fetch-positions';
 import * as groupDeFiPositions from './group-defi-positions';
-import { flushPromises } from '../../../../tests/helpers';
-import { createMockInternalAccount } from '../../../accounts-controller/tests/mocks';
-import type {
-  InternalAccount,
-  TransactionMeta,
-} from '../../../transaction-controller/src/types';
 
 const GROUP_ACCOUNTS = [
   createMockInternalAccount({

--- a/packages/assets-controllers/src/MultichainAssetsController/MultichainAssetsController.test.ts
+++ b/packages/assets-controllers/src/MultichainAssetsController/MultichainAssetsController.test.ts
@@ -29,12 +29,12 @@ import {
   getDefaultMultichainAssetsControllerState,
   MultichainAssetsController,
 } from '.';
+import { jestAdvanceTime } from '../../../../tests/helpers';
 import type {
   AssetMetadataResponse,
   MultichainAssetsControllerMessenger,
   MultichainAssetsControllerState,
 } from './MultichainAssetsController';
-import { jestAdvanceTime } from '../../../../tests/helpers';
 
 const mockSolanaAccount: InternalAccount = {
   type: 'solana:data-account',

--- a/packages/assets-controllers/src/MultichainAssetsRatesController/MultichainAssetsRatesController.test.ts
+++ b/packages/assets-controllers/src/MultichainAssetsRatesController/MultichainAssetsRatesController.test.ts
@@ -16,8 +16,8 @@ import type { OnAssetHistoricalPriceResponse } from '@metamask/snaps-sdk';
 import { v4 as uuidv4 } from 'uuid';
 
 import { MultichainAssetsRatesController } from '.';
-import type { MultichainAssetsRatesControllerMessenger } from './MultichainAssetsRatesController';
 import { jestAdvanceTime } from '../../../../tests/helpers';
+import type { MultichainAssetsRatesControllerMessenger } from './MultichainAssetsRatesController';
 
 type AllMultichainAssetsRateControllerActions =
   MessengerActions<MultichainAssetsRatesControllerMessenger>;

--- a/packages/assets-controllers/src/MultichainAssetsRatesController/MultichainAssetsRatesController.ts
+++ b/packages/assets-controllers/src/MultichainAssetsRatesController/MultichainAssetsRatesController.ts
@@ -34,8 +34,6 @@ import { HandlerType } from '@metamask/snaps-utils';
 import { Mutex } from 'async-mutex';
 import type { Draft } from 'immer';
 
-import { MAP_CAIP_CURRENCIES } from './constant';
-import type { MultichainAssetsRatesControllerMethodActions } from './MultichainAssetsRatesController-method-action-types';
 import type {
   CurrencyRateState,
   CurrencyRateStateChange,
@@ -45,6 +43,8 @@ import type {
   MultichainAssetsControllerGetStateAction,
   MultichainAssetsControllerAccountAssetListUpdatedEvent,
 } from '../MultichainAssetsController';
+import { MAP_CAIP_CURRENCIES } from './constant';
+import type { MultichainAssetsRatesControllerMethodActions } from './MultichainAssetsRatesController-method-action-types';
 
 /**
  * The name of the MultichainAssetsRatesController.

--- a/packages/assets-controllers/src/NftController.test.ts
+++ b/packages/assets-controllers/src/NftController.test.ts
@@ -40,6 +40,12 @@ import type { Hex } from '@metamask/utils';
 import nock from 'nock';
 import { v4 } from 'uuid';
 
+import { createMockInternalAccount } from '../../accounts-controller/tests/mocks';
+import {
+  buildCustomNetworkClientConfiguration,
+  buildMockFindNetworkClientIdByChainId,
+  buildMockGetNetworkClientById,
+} from '../../network-controller/tests/helpers';
 import type {
   AssetsContractControllerGetERC1155TokenURIAction,
   AssetsContractControllerGetERC721AssetNameAction,
@@ -59,12 +65,6 @@ import type {
 } from './NftController';
 import { NftController } from './NftController';
 import type { Collection } from './NftDetectionController';
-import { createMockInternalAccount } from '../../accounts-controller/tests/mocks';
-import {
-  buildCustomNetworkClientConfiguration,
-  buildMockFindNetworkClientIdByChainId,
-  buildMockGetNetworkClientById,
-} from '../../network-controller/tests/helpers';
 
 type AllActions =
   | MessengerActions<NftControllerMessenger>

--- a/packages/assets-controllers/src/NftDetectionController.test.ts
+++ b/packages/assets-controllers/src/NftDetectionController.test.ts
@@ -25,13 +25,6 @@ import { getDefaultPreferencesState } from '@metamask/preferences-controller';
 import type { PreferencesState } from '@metamask/preferences-controller';
 import nock from 'nock';
 
-import { Source } from './constants';
-import { getDefaultNftControllerState } from './NftController';
-import {
-  NftDetectionController,
-  BlockaidResultType,
-} from './NftDetectionController';
-import type { NftDetectionControllerMessenger } from './NftDetectionController';
 import { FakeBlockTracker } from '../../../tests/fake-block-tracker';
 import { FakeProvider } from '../../../tests/fake-provider';
 import { jestAdvanceTime } from '../../../tests/helpers';
@@ -40,6 +33,13 @@ import {
   buildMockFindNetworkClientIdByChainId,
   buildMockGetNetworkClientById,
 } from '../../network-controller/tests/helpers';
+import { Source } from './constants';
+import { getDefaultNftControllerState } from './NftController';
+import {
+  NftDetectionController,
+  BlockaidResultType,
+} from './NftDetectionController';
+import type { NftDetectionControllerMessenger } from './NftDetectionController';
 
 type AllActions = MessengerActions<NftDetectionControllerMessenger>;
 

--- a/packages/assets-controllers/src/RatesController/RatesController.test.ts
+++ b/packages/assets-controllers/src/RatesController/RatesController.test.ts
@@ -6,14 +6,14 @@ import type {
   MockAnyNamespace,
 } from '@metamask/messenger';
 
+import { jestAdvanceTime } from '../../../../tests/helpers';
+import type { fetchMultiExchangeRate as defaultFetchExchangeRate } from '../crypto-compare-service';
 import {
   Cryptocurrency,
   RatesController,
   name as ratesControllerName,
 } from './RatesController';
 import type { RatesControllerMessenger, RatesControllerState } from './types';
-import { jestAdvanceTime } from '../../../../tests/helpers';
-import type { fetchMultiExchangeRate as defaultFetchExchangeRate } from '../crypto-compare-service';
 
 type AllActions = MessengerActions<RatesControllerMessenger>;
 

--- a/packages/assets-controllers/src/RatesController/RatesController.ts
+++ b/packages/assets-controllers/src/RatesController/RatesController.ts
@@ -3,13 +3,13 @@ import type { StateMetadata } from '@metamask/base-controller';
 import { Mutex } from 'async-mutex';
 import type { Draft } from 'immer';
 
+import { fetchMultiExchangeRate as defaultFetchExchangeRate } from '../crypto-compare-service';
 import type {
   ConversionRates,
   RatesControllerState,
   RatesControllerOptions,
   RatesControllerMessenger,
 } from './types';
-import { fetchMultiExchangeRate as defaultFetchExchangeRate } from '../crypto-compare-service';
 
 export const name = 'RatesController';
 

--- a/packages/assets-controllers/src/RatesController/types.ts
+++ b/packages/assets-controllers/src/RatesController/types.ts
@@ -4,11 +4,11 @@ import type {
 } from '@metamask/base-controller';
 import type { Messenger } from '@metamask/messenger';
 
+import type { fetchMultiExchangeRate as defaultFetchExchangeRate } from '../crypto-compare-service';
 import type {
   name as ratesControllerName,
   Cryptocurrency,
 } from './RatesController';
-import type { fetchMultiExchangeRate as defaultFetchExchangeRate } from '../crypto-compare-service';
 
 /**
  * Represents the conversion rates from one currency to others, including the conversion date.

--- a/packages/assets-controllers/src/TokenBalancesController.test.ts
+++ b/packages/assets-controllers/src/TokenBalancesController.test.ts
@@ -16,6 +16,9 @@ import type { Hex } from '@metamask/utils';
 import BN from 'bn.js';
 import type nock from 'nock';
 
+import { jestAdvanceTime, flushPromises } from '../../../tests/helpers';
+import { createMockInternalAccount } from '../../accounts-controller/tests/mocks';
+import type { RpcEndpoint } from '../../network-controller/src/NetworkController';
 import { mockAPI_accountsAPI_MultichainAccountBalances as mockAPIAccountsAPIMultichainAccountBalancesCamelCase } from './__fixtures__/account-api-v4-mocks';
 import { waitFor } from './__fixtures__/test-utils';
 import { AccountsApiBalanceFetcher } from './multi-chain-accounts-service/api-balance-fetcher';
@@ -37,9 +40,6 @@ import {
   parseAssetType,
 } from './TokenBalancesController';
 import type { TokensControllerState } from './TokensController';
-import { jestAdvanceTime, flushPromises } from '../../../tests/helpers';
-import { createMockInternalAccount } from '../../accounts-controller/tests/mocks';
-import type { RpcEndpoint } from '../../network-controller/src/NetworkController';
 
 type AllTokenBalancesControllerActions =
   MessengerActions<TokenBalancesControllerMessenger>;

--- a/packages/assets-controllers/src/TokenDetectionController.test.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.test.ts
@@ -30,6 +30,12 @@ import type { Hex } from '@metamask/utils';
 import BN from 'bn.js';
 import nock from 'nock';
 
+import { jestAdvanceTime } from '../../../tests/helpers';
+import { createMockInternalAccount } from '../../accounts-controller/tests/mocks';
+import {
+  buildCustomRpcEndpoint,
+  buildInfuraNetworkConfiguration,
+} from '../../network-controller/tests/helpers';
 import { formatAggregatorNames } from './assetsUtil';
 import { TOKEN_END_POINT_API } from './token-service';
 import type { TokenDetectionControllerMessenger } from './TokenDetectionController';
@@ -46,12 +52,6 @@ import type {
   TokensControllerState,
 } from './TokensController';
 import { getDefaultTokensState } from './TokensController';
-import { jestAdvanceTime } from '../../../tests/helpers';
-import { createMockInternalAccount } from '../../accounts-controller/tests/mocks';
-import {
-  buildCustomRpcEndpoint,
-  buildInfuraNetworkConfiguration,
-} from '../../network-controller/tests/helpers';
 
 const DEFAULT_INTERVAL = 180000;
 

--- a/packages/assets-controllers/src/TokenListController.test.ts
+++ b/packages/assets-controllers/src/TokenListController.test.ts
@@ -17,6 +17,12 @@ import { StorageGetResult } from '@metamask/storage-service';
 import type { Hex } from '@metamask/utils';
 import nock from 'nock';
 
+import { jestAdvanceTime } from '../../../tests/helpers';
+import {
+  buildCustomNetworkClientConfiguration,
+  buildInfuraNetworkClientConfiguration,
+  buildMockGetNetworkClientById,
+} from '../../network-controller/tests/helpers';
 import * as tokenService from './token-service';
 import type {
   TokenListMap,
@@ -25,12 +31,6 @@ import type {
   DataCache,
 } from './TokenListController';
 import { TokenListController } from './TokenListController';
-import { jestAdvanceTime } from '../../../tests/helpers';
-import {
-  buildCustomNetworkClientConfiguration,
-  buildInfuraNetworkClientConfiguration,
-  buildMockGetNetworkClientById,
-} from '../../network-controller/tests/helpers';
 
 const namespace = 'TokenListController';
 const timestamp = Date.now();

--- a/packages/assets-controllers/src/TokenRatesController.test.ts
+++ b/packages/assets-controllers/src/TokenRatesController.test.ts
@@ -17,6 +17,7 @@ import type { CaipAssetType, Hex } from '@metamask/utils';
 import { add0x, KnownCaipNamespace } from '@metamask/utils';
 import type { Patch } from 'immer';
 
+import { flushPromises } from '../../../tests/helpers';
 import { TOKEN_PRICES_BATCH_SIZE } from './assetsUtil';
 import type {
   AbstractTokenPricesService,
@@ -32,7 +33,6 @@ import type {
 } from './TokenRatesController';
 import { getDefaultTokensState } from './TokensController';
 import type { TokensControllerState } from './TokensController';
-import { flushPromises } from '../../../tests/helpers';
 
 const defaultSelectedAddress = '0x1111111111111111111111111111111111111111';
 

--- a/packages/assets-controllers/src/TokenSearchDiscoveryDataController/TokenSearchDiscoveryDataController.test.ts
+++ b/packages/assets-controllers/src/TokenSearchDiscoveryDataController/TokenSearchDiscoveryDataController.test.ts
@@ -9,6 +9,12 @@ import type {
 import type { Hex } from '@metamask/utils';
 import assert from 'assert';
 
+import type {
+  AbstractTokenPricesService,
+  EvmAssetWithMarketData,
+} from '../token-prices-service/abstract-token-prices-service';
+import { fetchTokenMetadata } from '../token-service';
+import type { Token } from '../TokenRatesController';
 import {
   getDefaultTokenSearchDiscoveryDataControllerState,
   TokenSearchDiscoveryDataController,
@@ -20,12 +26,6 @@ import type {
   TokenSearchDiscoveryDataControllerState,
 } from './TokenSearchDiscoveryDataController';
 import type { NotFoundTokenDisplayData, FoundTokenDisplayData } from './types';
-import type {
-  AbstractTokenPricesService,
-  EvmAssetWithMarketData,
-} from '../token-prices-service/abstract-token-prices-service';
-import { fetchTokenMetadata } from '../token-service';
-import type { Token } from '../TokenRatesController';
 
 jest.mock('../token-service', () => {
   const mockFetchTokenMetadata = jest.fn();

--- a/packages/assets-controllers/src/TokenSearchDiscoveryDataController/TokenSearchDiscoveryDataController.ts
+++ b/packages/assets-controllers/src/TokenSearchDiscoveryDataController/TokenSearchDiscoveryDataController.ts
@@ -7,7 +7,6 @@ import type {
 import type { Messenger } from '@metamask/messenger';
 import type { Hex } from '@metamask/utils';
 
-import type { TokenDisplayData } from './types';
 import { formatIconUrlWithProxy } from '../assetsUtil';
 import type { GetCurrencyRateState } from '../CurrencyRateController';
 import type { AbstractTokenPricesService } from '../token-prices-service';
@@ -16,6 +15,7 @@ import {
   TOKEN_METADATA_NO_SUPPORT_ERROR,
 } from '../token-service';
 import type { TokenListToken } from '../TokenListController';
+import type { TokenDisplayData } from './types';
 
 // === GENERAL ===
 

--- a/packages/assets-controllers/src/TokensController.test.ts
+++ b/packages/assets-controllers/src/TokensController.test.ts
@@ -30,6 +30,12 @@ import type { Patch } from 'immer';
 import nock from 'nock';
 import { v1 as uuidV1 } from 'uuid';
 
+import { FakeProvider } from '../../../tests/fake-provider';
+import { createMockInternalAccount } from '../../accounts-controller/tests/mocks';
+import {
+  buildCustomNetworkClientConfiguration,
+  buildMockGetNetworkClientById,
+} from '../../network-controller/tests/helpers';
 import { ERC20Standard } from './Standards/ERC20Standard';
 import { ERC1155Standard } from './Standards/NftStandards/ERC1155/ERC1155Standard';
 import { TOKEN_END_POINT_API } from './token-service';
@@ -40,12 +46,6 @@ import type {
   TokensControllerMessenger,
   TokensControllerState,
 } from './TokensController';
-import { FakeProvider } from '../../../tests/fake-provider';
-import { createMockInternalAccount } from '../../accounts-controller/tests/mocks';
-import {
-  buildCustomNetworkClientConfiguration,
-  buildMockGetNetworkClientById,
-} from '../../network-controller/tests/helpers';
 
 jest.mock('@ethersproject/contracts');
 jest.mock('uuid', () => ({

--- a/packages/assets-controllers/src/multi-chain-accounts-service/api-balance-fetcher.test.ts
+++ b/packages/assets-controllers/src/multi-chain-accounts-service/api-balance-fetcher.test.ts
@@ -1,12 +1,12 @@
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 import BN from 'bn.js';
 
-import { AccountsApiBalanceFetcher } from './api-balance-fetcher';
-import type { ChainIdHex, ChecksumAddress } from './api-balance-fetcher';
-import type { GetBalancesResponse } from './types';
 import { createMockInternalAccount } from '../../../accounts-controller/tests/mocks';
 import { SUPPORTED_NETWORKS_ACCOUNTS_API_V4 } from '../constants';
 import * as ConstantsModule from '../constants';
+import { AccountsApiBalanceFetcher } from './api-balance-fetcher';
+import type { ChainIdHex, ChecksumAddress } from './api-balance-fetcher';
+import type { GetBalancesResponse } from './types';
 
 // Mock dependencies that cause import issues
 jest.mock('../AssetsContractController', () => ({

--- a/packages/assets-controllers/src/multi-chain-accounts-service/api-balance-fetcher.ts
+++ b/packages/assets-controllers/src/multi-chain-accounts-service/api-balance-fetcher.ts
@@ -12,8 +12,6 @@ import type { CaipAccountAddress, CaipChainId, Hex } from '@metamask/utils';
 import { parseCaipChainId } from '@metamask/utils';
 import BN from 'bn.js';
 
-import { fetchMultiChainBalancesV4 } from './multi-chain-accounts';
-import type { GetBalancesResponse } from './types';
 import { STAKING_CONTRACT_ADDRESS_BY_CHAINID } from '../AssetsContractController';
 import {
   accountAddressToCaipReference,
@@ -21,6 +19,8 @@ import {
   SupportedStakedBalanceNetworks,
 } from '../assetsUtil';
 import { SUPPORTED_NETWORKS_ACCOUNTS_API_V4 } from '../constants';
+import { fetchMultiChainBalancesV4 } from './multi-chain-accounts';
+import type { GetBalancesResponse } from './types';
 
 // Maximum number of account addresses that can be sent to the accounts API in a single request
 const ACCOUNTS_API_BATCH_SIZE = 20;

--- a/packages/assets-controllers/src/rpc-service/rpc-balance-fetcher.test.ts
+++ b/packages/assets-controllers/src/rpc-service/rpc-balance-fetcher.test.ts
@@ -3,10 +3,10 @@ import type { InternalAccount } from '@metamask/keyring-internal-api';
 import type { NetworkClient } from '@metamask/network-controller';
 import BN from 'bn.js';
 
-import { RpcBalanceFetcher } from './rpc-balance-fetcher';
-import type { ChainIdHex, ChecksumAddress } from './rpc-balance-fetcher';
 import type { UnprocessedTokens } from '../multi-chain-accounts-service/api-balance-fetcher';
 import type { TokensControllerState } from '../TokensController';
+import { RpcBalanceFetcher } from './rpc-balance-fetcher';
+import type { ChainIdHex, ChecksumAddress } from './rpc-balance-fetcher';
 
 const MOCK_ADDRESS_1 = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
 const MOCK_ADDRESS_2 = '0x742d35cc6675c4f17f41140100aa83a4b1fa4c82';

--- a/packages/assets-controllers/src/selectors/token-selectors.test.ts
+++ b/packages/assets-controllers/src/selectors/token-selectors.test.ts
@@ -10,8 +10,6 @@ import type { NetworkState } from '@metamask/network-controller';
 import type { Hex } from '@metamask/utils';
 import { cloneDeep } from 'lodash';
 
-import { MOCK_TRON_TOKENS } from './__fixtures__/arrange-tron-state';
-import { selectAssetsBySelectedAccountGroup } from './token-selectors';
 import type { AccountGroupMultichainAccountObject } from '../../../account-tree-controller/src/group';
 import type { CurrencyRateState } from '../CurrencyRateController';
 import type { MultichainAssetsControllerState } from '../MultichainAssetsController';
@@ -20,6 +18,8 @@ import type { MultichainBalancesControllerState } from '../MultichainBalancesCon
 import type { TokenBalancesControllerState } from '../TokenBalancesController';
 import type { TokenRatesControllerState } from '../TokenRatesController';
 import type { TokensControllerState } from '../TokensController';
+import { MOCK_TRON_TOKENS } from './__fixtures__/arrange-tron-state';
+import { selectAssetsBySelectedAccountGroup } from './token-selectors';
 
 const mockTokensControllerState: TokensControllerState = {
   allTokens: {

--- a/packages/assets-controllers/src/selectors/token-selectors.ts
+++ b/packages/assets-controllers/src/selectors/token-selectors.ts
@@ -10,10 +10,6 @@ import type { Hex } from '@metamask/utils';
 import { createSelector, weakMapMemoize } from 'reselect';
 import { TokenRwaData } from 'src/token-service';
 
-import {
-  parseBalanceWithDecimals,
-  stringifyBalanceWithDecimals,
-} from './stringify-balance';
 import { shouldIncludeNativeToken } from '../constants';
 import type { CurrencyRateState } from '../CurrencyRateController';
 import type { MultichainAssetsControllerState } from '../MultichainAssetsController';
@@ -23,6 +19,10 @@ import { getNativeTokenAddress } from '../token-prices-service/codefi-v2';
 import type { TokenBalancesControllerState } from '../TokenBalancesController';
 import type { Token, TokenRatesControllerState } from '../TokenRatesController';
 import type { TokensControllerState } from '../TokensController';
+import {
+  parseBalanceWithDecimals,
+  stringifyBalanceWithDecimals,
+} from './stringify-balance';
 
 // Asset Tron Filters
 export const TRON_RESOURCE = {

--- a/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
+++ b/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
@@ -15,6 +15,7 @@ import {
   toCaipChainId,
 } from '@metamask/utils';
 
+import type { MarketDataDetails } from '../TokenRatesController';
 import type {
   AbstractTokenPricesService,
   EvmAssetAddressWithChain,
@@ -23,7 +24,6 @@ import type {
   ExchangeRatesByCurrency,
   NativeAssetIdentifiersMap,
 } from './abstract-token-prices-service';
-import type { MarketDataDetails } from '../TokenRatesController';
 
 /**
  * The list of currencies that can be supplied as the `vsCurrency` parameter to

--- a/packages/assets-controllers/src/utils/timeout-with-retry.test.ts
+++ b/packages/assets-controllers/src/utils/timeout-with-retry.test.ts
@@ -1,5 +1,5 @@
-import { timeoutWithRetry } from './timeout-with-retry';
 import { flushPromises } from '../../../../tests/helpers';
+import { timeoutWithRetry } from './timeout-with-retry';
 
 describe('timeoutWithRetry', () => {
   const timeout = 1000;

--- a/packages/base-data-service/tests/ExampleDataService.ts
+++ b/packages/base-data-service/tests/ExampleDataService.ts
@@ -2,13 +2,13 @@ import { ConstantBackoff } from '@metamask/controller-utils';
 import { Messenger } from '@metamask/messenger';
 import { CaipAssetId, Duration, inMilliseconds, Json } from '@metamask/utils';
 
-import { ExampleDataServiceMethodActions } from './ExampleDataService-method-action-types';
 import {
   BaseDataService,
   DataServiceInvalidateQueriesAction,
   DataServiceCacheUpdatedEvent,
   DataServiceGranularCacheUpdatedEvent,
 } from '../src/BaseDataService';
+import { ExampleDataServiceMethodActions } from './ExampleDataService-method-action-types';
 
 export const serviceName = 'ExampleDataService';
 

--- a/packages/bridge-controller/src/bridge-controller.sse.test.ts
+++ b/packages/bridge-controller/src/bridge-controller.sse.test.ts
@@ -9,6 +9,19 @@ import type {
 } from '@metamask/messenger';
 import { abiERC20 } from '@metamask/metamask-eth-abis';
 
+import { flushPromises } from '../../../tests/helpers';
+import mockBridgeQuotesErc20Erc20 from '../tests/mock-quotes-erc20-erc20.json';
+import mockBridgeQuotesNativeErc20Eth from '../tests/mock-quotes-native-erc20-eth.json';
+import mockBridgeQuotesNativeErc20 from '../tests/mock-quotes-native-erc20.json';
+import {
+  advanceToNthTimer,
+  advanceToNthTimerThenFlush,
+  mockSseEventSource,
+  mockSseEventSourceWithComplete,
+  mockSseEventSourceWithMultipleDelays,
+  mockSseEventSourceWithWarnings,
+  mockSseServerError,
+} from '../tests/mock-sse';
 import { BridgeController } from './bridge-controller';
 import {
   BridgeClientId,
@@ -26,19 +39,6 @@ import {
   TokenFeatureType,
   QuoteStreamCompleteReason,
 } from './utils/validators';
-import { flushPromises } from '../../../tests/helpers';
-import mockBridgeQuotesErc20Erc20 from '../tests/mock-quotes-erc20-erc20.json';
-import mockBridgeQuotesNativeErc20Eth from '../tests/mock-quotes-native-erc20-eth.json';
-import mockBridgeQuotesNativeErc20 from '../tests/mock-quotes-native-erc20.json';
-import {
-  advanceToNthTimer,
-  advanceToNthTimerThenFlush,
-  mockSseEventSource,
-  mockSseEventSourceWithComplete,
-  mockSseEventSourceWithMultipleDelays,
-  mockSseEventSourceWithWarnings,
-  mockSseServerError,
-} from '../tests/mock-sse';
 
 type RootMessenger = Messenger<
   MockAnyNamespace,

--- a/packages/bridge-controller/src/bridge-controller.test.ts
+++ b/packages/bridge-controller/src/bridge-controller.test.ts
@@ -15,6 +15,13 @@ import type {
 } from '@metamask/messenger';
 import nock from 'nock';
 
+import { flushPromises } from '../../../tests/helpers';
+import { handleFetch } from '../../controller-utils/src';
+import mockBridgeQuotesErc20Native from '../tests/mock-quotes-erc20-native.json';
+import mockBridgeQuotesNativeErc20Eth from '../tests/mock-quotes-native-erc20-eth.json';
+import mockBridgeQuotesNativeErc20 from '../tests/mock-quotes-native-erc20.json';
+import mockBridgeQuotesSolErc20 from '../tests/mock-quotes-sol-erc20.json';
+import { advanceToNthTimerThenFlush } from '../tests/mock-sse';
 import { BridgeController } from './bridge-controller';
 import {
   BridgeClientId,
@@ -42,13 +49,6 @@ import {
   UnifiedSwapBridgeEventName,
 } from './utils/metrics/constants';
 import { FeatureId } from './utils/validators';
-import { flushPromises } from '../../../tests/helpers';
-import { handleFetch } from '../../controller-utils/src';
-import mockBridgeQuotesErc20Native from '../tests/mock-quotes-erc20-native.json';
-import mockBridgeQuotesNativeErc20Eth from '../tests/mock-quotes-native-erc20-eth.json';
-import mockBridgeQuotesNativeErc20 from '../tests/mock-quotes-native-erc20.json';
-import mockBridgeQuotesSolErc20 from '../tests/mock-quotes-sol-erc20.json';
-import { advanceToNthTimerThenFlush } from '../tests/mock-sse';
 
 const EMPTY_INIT_STATE = DEFAULT_BRIDGE_CONTROLLER_STATE;
 

--- a/packages/bridge-controller/src/constants/bridge.ts
+++ b/packages/bridge-controller/src/constants/bridge.ts
@@ -2,11 +2,11 @@ import { AddressZero } from '@ethersproject/constants';
 import { BtcScope, SolScope, TrxScope } from '@metamask/keyring-api';
 import type { Hex } from '@metamask/utils';
 
-import { CHAIN_IDS } from './chains';
 import type {
   BridgeControllerState,
   FeatureFlagsPlatformConfig,
 } from '../types';
+import { CHAIN_IDS } from './chains';
 
 export const ALLOWED_BRIDGE_CHAIN_IDS = [
   CHAIN_IDS.MAINNET,

--- a/packages/bridge-controller/src/utils/assets.ts
+++ b/packages/bridge-controller/src/utils/assets.ts
@@ -1,8 +1,8 @@
 import type { CaipAssetType } from '@metamask/utils';
 
+import type { ExchangeRate, GenericQuoteRequest } from '../types';
 import { getNativeAssetForChainId } from './bridge';
 import { formatAddressToAssetId } from './caip-formatters';
-import type { ExchangeRate, GenericQuoteRequest } from '../types';
 
 export const getAssetIdsForToken = (
   tokenAddress: GenericQuoteRequest['srcTokenAddress'],

--- a/packages/bridge-controller/src/utils/balance.test.ts
+++ b/packages/bridge-controller/src/utils/balance.test.ts
@@ -5,9 +5,9 @@ import { Web3Provider } from '@ethersproject/providers';
 import { abiERC20 } from '@metamask/metamask-eth-abis';
 import type { Provider } from '@metamask/network-controller';
 
+import { FakeProvider } from '../../../../tests/fake-provider';
 import * as balanceUtils from './balance';
 import { fetchTokenBalance } from './balance';
-import { FakeProvider } from '../../../../tests/fake-provider';
 
 declare global {
   var ethereumProvider: Provider;

--- a/packages/bridge-controller/src/utils/bridge.test.ts
+++ b/packages/bridge-controller/src/utils/bridge.test.ts
@@ -2,6 +2,13 @@ import { BtcScope, SolScope } from '@metamask/keyring-api';
 import type { Hex } from '@metamask/utils';
 
 import {
+  ETH_USDT_ADDRESS,
+  METABRIDGE_ETHEREUM_ADDRESS,
+} from '../constants/bridge';
+import { CHAIN_IDS } from '../constants/chains';
+import { SWAPS_CHAINID_DEFAULT_TOKEN_MAP } from '../constants/tokens';
+import { ChainId } from '../types';
+import {
   getNativeAssetForChainId,
   isBitcoinChainId,
   isCrossChain,
@@ -12,13 +19,6 @@ import {
   isSwapsDefaultTokenSymbol,
   sumHexes,
 } from './bridge';
-import {
-  ETH_USDT_ADDRESS,
-  METABRIDGE_ETHEREUM_ADDRESS,
-} from '../constants/bridge';
-import { CHAIN_IDS } from '../constants/chains';
-import { SWAPS_CHAINID_DEFAULT_TOKEN_MAP } from '../constants/tokens';
-import { ChainId } from '../types';
 
 describe('Bridge utils', () => {
   beforeEach(() => {

--- a/packages/bridge-controller/src/utils/bridge.ts
+++ b/packages/bridge-controller/src/utils/bridge.ts
@@ -6,11 +6,6 @@ import { isCaipChainId, isStrictHexString } from '@metamask/utils';
 import type { CaipAssetType, CaipChainId, Hex } from '@metamask/utils';
 
 import {
-  formatChainIdToCaip,
-  formatChainIdToDec,
-  formatChainIdToHex,
-} from './caip-formatters';
-import {
   DEFAULT_BRIDGE_CONTROLLER_STATE,
   ETH_USDT_ADDRESS,
   METABRIDGE_ETHEREUM_ADDRESS,
@@ -30,6 +25,11 @@ import type {
   TxData,
 } from '../types';
 import { ChainId } from '../types';
+import {
+  formatChainIdToCaip,
+  formatChainIdToDec,
+  formatChainIdToHex,
+} from './caip-formatters';
 
 /**
  * Checks whether the transaction is a cross-chain transaction by comparing the source and destination chainIds

--- a/packages/bridge-controller/src/utils/caip-formatters.test.ts
+++ b/packages/bridge-controller/src/utils/caip-formatters.test.ts
@@ -1,6 +1,8 @@
 import { AddressZero } from '@ethersproject/constants';
 import { BtcScope, SolScope, TrxScope } from '@metamask/keyring-api';
 
+import { CHAIN_IDS } from '../constants/chains';
+import { ChainId } from '../types';
 import {
   formatChainIdToCaip,
   formatChainIdToDec,
@@ -8,8 +10,6 @@ import {
   formatAddressToCaipReference,
   formatAddressToAssetId,
 } from './caip-formatters';
-import { CHAIN_IDS } from '../constants/chains';
-import { ChainId } from '../types';
 
 describe('CAIP Formatters', () => {
   describe('formatChainIdToCaip', () => {

--- a/packages/bridge-controller/src/utils/caip-formatters.ts
+++ b/packages/bridge-controller/src/utils/caip-formatters.ts
@@ -18,6 +18,8 @@ import {
 } from '@metamask/utils';
 import type { CaipAssetType, CaipChainId, Hex } from '@metamask/utils';
 
+import type { GenericQuoteRequest } from '../types';
+import { ChainId } from '../types';
 import {
   getNativeAssetForChainId,
   isBitcoinChainId,
@@ -25,8 +27,6 @@ import {
   isSolanaChainId,
   isTronChainId,
 } from './bridge';
-import type { GenericQuoteRequest } from '../types';
-import { ChainId } from '../types';
 
 /**
  * Converts a chainId to a CaipChainId

--- a/packages/bridge-controller/src/utils/feature-flags.test.ts
+++ b/packages/bridge-controller/src/utils/feature-flags.test.ts
@@ -1,13 +1,13 @@
-import {
-  formatFeatureFlags,
-  getBridgeFeatureFlags,
-  hasMinimumRequiredVersion,
-} from './feature-flags';
 import { DEFAULT_CHAIN_RANKING } from '../constants/bridge';
 import type {
   FeatureFlagsPlatformConfig,
   BridgeControllerMessenger,
 } from '../types';
+import {
+  formatFeatureFlags,
+  getBridgeFeatureFlags,
+  hasMinimumRequiredVersion,
+} from './feature-flags';
 
 describe('feature-flags', () => {
   describe('formatFeatureFlags', () => {

--- a/packages/bridge-controller/src/utils/feature-flags.ts
+++ b/packages/bridge-controller/src/utils/feature-flags.ts
@@ -1,12 +1,12 @@
 import type { RemoteFeatureFlagControllerState } from '@metamask/remote-feature-flag-controller';
 
-import { formatChainIdToCaip } from './caip-formatters';
-import { validateFeatureFlagsResponse } from './validators';
 import {
   DEFAULT_CHAIN_RANKING,
   DEFAULT_FEATURE_FLAG_CONFIG,
 } from '../constants/bridge';
 import type { FeatureFlagsPlatformConfig, ChainConfiguration } from '../types';
+import { formatChainIdToCaip } from './caip-formatters';
+import { validateFeatureFlagsResponse } from './validators';
 
 export const formatFeatureFlags = (
   bridgeFeatureFlags: FeatureFlagsPlatformConfig,

--- a/packages/bridge-controller/src/utils/fetch.test.ts
+++ b/packages/bridge-controller/src/utils/fetch.test.ts
@@ -1,15 +1,15 @@
 import { AddressZero } from '@ethersproject/constants';
 import type { CaipAssetType } from '@metamask/utils';
 
+import mockBridgeQuotesErc20Erc20 from '../../tests/mock-quotes-erc20-erc20.json';
+import mockBridgeQuotesNativeErc20 from '../../tests/mock-quotes-native-erc20.json';
+import { BridgeClientId, BRIDGE_PROD_API_BASE_URL } from '../constants/bridge';
 import {
   fetchBridgeQuotes,
   fetchBridgeTokens,
   fetchAssetPrices,
 } from './fetch';
 import { FeatureId } from './validators';
-import mockBridgeQuotesErc20Erc20 from '../../tests/mock-quotes-erc20-erc20.json';
-import mockBridgeQuotesNativeErc20 from '../../tests/mock-quotes-native-erc20.json';
-import { BridgeClientId, BRIDGE_PROD_API_BASE_URL } from '../constants/bridge';
 
 const mockFetchFn = jest.fn();
 

--- a/packages/bridge-controller/src/utils/fetch.ts
+++ b/packages/bridge-controller/src/utils/fetch.ts
@@ -2,6 +2,15 @@
 import { StructError } from '@metamask/superstruct';
 import type { CaipAssetType, CaipChainId, Hex } from '@metamask/utils';
 
+import type {
+  QuoteResponse,
+  FetchFunction,
+  GenericQuoteRequest,
+  QuoteRequest,
+  BridgeAsset,
+  TokenFeature,
+  QuoteStreamCompleteData,
+} from '../types';
 import { getEthUsdtResetData } from './bridge';
 import {
   formatAddressToCaipReference,
@@ -16,15 +25,6 @@ import {
   validateTokenFeature,
   validateQuoteStreamComplete,
 } from './validators';
-import type {
-  QuoteResponse,
-  FetchFunction,
-  GenericQuoteRequest,
-  QuoteRequest,
-  BridgeAsset,
-  TokenFeature,
-  QuoteStreamCompleteData,
-} from '../types';
 
 export const getClientHeaders = ({
   clientId,

--- a/packages/bridge-controller/src/utils/metrics/properties.test.ts
+++ b/packages/bridge-controller/src/utils/metrics/properties.test.ts
@@ -1,6 +1,9 @@
 import { SolScope } from '@metamask/keyring-api';
 import type { CaipChainId } from '@metamask/utils';
 
+import type { QuoteResponse } from '../../types';
+import { getNativeAssetForChainId } from '../bridge';
+import { formatChainIdToCaip } from '../caip-formatters';
 import { MetricsSwapType } from './constants';
 import {
   toInputChangedPropertyKey,
@@ -10,9 +13,6 @@ import {
   getRequestParams,
   getQuotesReceivedProperties,
 } from './properties';
-import type { QuoteResponse } from '../../types';
-import { getNativeAssetForChainId } from '../bridge';
-import { formatChainIdToCaip } from '../caip-formatters';
 
 describe('properties', () => {
   beforeEach(() => {

--- a/packages/bridge-controller/src/utils/metrics/properties.ts
+++ b/packages/bridge-controller/src/utils/metrics/properties.ts
@@ -1,12 +1,5 @@
 import type { AccountsControllerState } from '@metamask/accounts-controller';
 
-import { MetricsSwapType } from './constants';
-import type {
-  InputKeys,
-  InputValues,
-  QuoteWarning,
-  RequestParams,
-} from './types';
 import { DEFAULT_BRIDGE_CONTROLLER_STATE } from '../../constants/bridge';
 import { ChainId } from '../../types';
 import type {
@@ -21,6 +14,13 @@ import {
   formatAddressToAssetId,
   formatChainIdToCaip,
 } from '../caip-formatters';
+import { MetricsSwapType } from './constants';
+import type {
+  InputKeys,
+  InputValues,
+  QuoteWarning,
+  RequestParams,
+} from './types';
 
 export const toInputChangedPropertyKey: Partial<
   Record<keyof QuoteRequest, InputKeys>

--- a/packages/bridge-controller/src/utils/metrics/types.ts
+++ b/packages/bridge-controller/src/utils/metrics/types.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import type { CaipAssetType, CaipChainId } from '@metamask/utils';
 
+import type { SortOrder, StatusTypes } from '../../types';
 import type {
   UnifiedSwapBridgeEventName,
   MetaMetricsSwapsEventSource,
@@ -8,7 +9,6 @@ import type {
   MetricsSwapType,
   PollingStatus,
 } from './constants';
-import type { SortOrder, StatusTypes } from '../../types';
 
 /**
  * These properties map to properties required by the segment-schema. For example: https://github.com/Consensys/segment-schema/blob/main/libraries/properties/cross-chain-swaps-action.yaml

--- a/packages/bridge-controller/src/utils/quote-fees.ts
+++ b/packages/bridge-controller/src/utils/quote-fees.ts
@@ -2,10 +2,6 @@ import type { InternalAccount } from '@metamask/keyring-internal-api';
 import type { TransactionController } from '@metamask/transaction-controller';
 import { numberToHex } from '@metamask/utils';
 
-import { isNonEvmChainId, sumHexes } from './bridge';
-import { formatChainIdToCaip } from './caip-formatters';
-import { computeFeeRequest } from './snaps';
-import { extractTradeData, isTronTrade } from './trade-utils';
 import { CHAIN_IDS } from '../constants/chains';
 import type {
   QuoteResponse,
@@ -14,6 +10,10 @@ import type {
   TxData,
   BridgeControllerMessenger,
 } from '../types';
+import { isNonEvmChainId, sumHexes } from './bridge';
+import { formatChainIdToCaip } from './caip-formatters';
+import { computeFeeRequest } from './snaps';
+import { extractTradeData, isTronTrade } from './trade-utils';
 
 /**
  * Appends transaction fees for EVM chains to quotes

--- a/packages/bridge-controller/src/utils/quote.test.ts
+++ b/packages/bridge-controller/src/utils/quote.test.ts
@@ -2,6 +2,14 @@ import { AddressZero } from '@ethersproject/constants';
 import { convertHexToDecimal } from '@metamask/controller-utils';
 import { BigNumber } from 'bignumber.js';
 
+import type {
+  GenericQuoteRequest,
+  QuoteResponse,
+  Quote,
+  NonEvmFees,
+  L1GasFees,
+  TxData,
+} from '../types';
 import {
   isValidQuoteRequest,
   getQuoteIdentifier,
@@ -18,14 +26,6 @@ import {
   formatEtaInMinutes,
   calcSlippagePercentage,
 } from './quote';
-import type {
-  GenericQuoteRequest,
-  QuoteResponse,
-  Quote,
-  NonEvmFees,
-  L1GasFees,
-  TxData,
-} from '../types';
 
 describe('Quote Utils', () => {
   describe('isValidQuoteRequest', () => {

--- a/packages/bridge-controller/src/utils/quote.ts
+++ b/packages/bridge-controller/src/utils/quote.ts
@@ -6,8 +6,6 @@ import {
 } from '@metamask/controller-utils';
 import { BigNumber } from 'bignumber.js';
 
-import { isNativeAddress, isNonEvmChainId } from './bridge';
-import { FeatureId } from './validators';
 import type {
   BridgeAsset,
   ExchangeRate,
@@ -19,6 +17,8 @@ import type {
   NonEvmFees,
   TxData,
 } from '../types';
+import { isNativeAddress, isNonEvmChainId } from './bridge';
+import { FeatureId } from './validators';
 
 export const isValidQuoteRequest = (
   partialRequest: Partial<GenericQuoteRequest>,

--- a/packages/bridge-controller/src/utils/slippage.ts
+++ b/packages/bridge-controller/src/utils/slippage.ts
@@ -1,5 +1,5 @@
-import { isCrossChain, isSolanaChainId } from './bridge';
 import type { GenericQuoteRequest } from '../types';
+import { isCrossChain, isSolanaChainId } from './bridge';
 
 export const BRIDGE_DEFAULT_SLIPPAGE = 0.5;
 const SWAP_SOLANA_SLIPPAGE = undefined;

--- a/packages/bridge-controller/src/utils/swaps.test.ts
+++ b/packages/bridge-controller/src/utils/swaps.test.ts
@@ -1,12 +1,5 @@
 import type { Hex } from '@metamask/utils';
 
-import {
-  API_BASE_URL,
-  fetchTokens,
-  getSwapsContractAddress,
-  isValidSwapsContractAddress,
-} from './swaps';
-import type { SwapsToken } from './swaps';
 import { CHAIN_IDS } from '../constants/chains';
 import {
   ALLOWED_CONTRACT_ADDRESSES,
@@ -17,6 +10,13 @@ import {
   SWAPS_CHAINID_DEFAULT_TOKEN_MAP,
 } from '../constants/tokens';
 import type { FetchFunction } from '../types';
+import {
+  API_BASE_URL,
+  fetchTokens,
+  getSwapsContractAddress,
+  isValidSwapsContractAddress,
+} from './swaps';
+import type { SwapsToken } from './swaps';
 
 describe('Swaps utils', () => {
   beforeEach(() => {

--- a/packages/bridge-controller/src/utils/swaps.ts
+++ b/packages/bridge-controller/src/utils/swaps.ts
@@ -1,6 +1,5 @@
 import type { Hex } from '@metamask/utils';
 
-import { formatChainIdToDec } from './caip-formatters';
 import { CHAIN_IDS } from '../constants/chains';
 import {
   ALLOWED_CONTRACT_ADDRESSES,
@@ -11,6 +10,7 @@ import {
   SWAPS_CHAINID_DEFAULT_TOKEN_MAP,
 } from '../constants/tokens';
 import type { FetchFunction } from '../types';
+import { formatChainIdToDec } from './caip-formatters';
 
 /**
  * Checks if the given contract address is valid for the given chain ID.

--- a/packages/bridge-controller/src/utils/trade-utils.test.ts
+++ b/packages/bridge-controller/src/utils/trade-utils.test.ts
@@ -1,3 +1,4 @@
+import type { BitcoinTradeData, TronTradeData, TxData } from '../types';
 import {
   extractTradeData,
   isEvmTxData,
@@ -5,7 +6,6 @@ import {
   isTronTrade,
 } from './trade-utils';
 import type { Trade } from './trade-utils';
-import type { BitcoinTradeData, TronTradeData, TxData } from '../types';
 
 describe('Trade utils', () => {
   describe('isEvmTxData', () => {

--- a/packages/bridge-status-controller/src/bridge-status-controller.test.ts
+++ b/packages/bridge-status-controller/src/bridge-status-controller.test.ts
@@ -36,6 +36,7 @@ import type {
 import type { CaipAssetType } from '@metamask/utils';
 import { numberToHex } from '@metamask/utils';
 
+import { flushPromises } from '../../../tests/helpers';
 import { BridgeStatusController } from './bridge-status-controller';
 import {
   BRIDGE_STATUS_CONTROLLER_NAME,
@@ -53,7 +54,6 @@ import type {
 } from './types';
 import * as bridgeStatusUtils from './utils/bridge-status';
 import * as transactionUtils from './utils/transaction';
-import { flushPromises } from '../../../tests/helpers';
 
 type AllBridgeStatusControllerActions =
   MessengerActions<BridgeStatusControllerMessenger>;

--- a/packages/bridge-status-controller/src/utils/bridge-status.test.ts
+++ b/packages/bridge-status-controller/src/utils/bridge-status.test.ts
@@ -1,12 +1,12 @@
+import { BRIDGE_PROD_API_BASE_URL, REFRESH_INTERVAL_MS } from '../constants';
+import { BridgeClientId } from '../types';
+import type { StatusRequestWithSrcTxHash, FetchFunction } from '../types';
 import {
   fetchBridgeTxStatus,
   getBridgeStatusUrl,
   getStatusRequestDto,
   shouldSkipFetchDueToFetchFailures,
 } from './bridge-status';
-import { BRIDGE_PROD_API_BASE_URL, REFRESH_INTERVAL_MS } from '../constants';
-import { BridgeClientId } from '../types';
-import type { StatusRequestWithSrcTxHash, FetchFunction } from '../types';
 
 describe('utils', () => {
   const mockStatusRequest: StatusRequestWithSrcTxHash = {

--- a/packages/bridge-status-controller/src/utils/bridge-status.ts
+++ b/packages/bridge-status-controller/src/utils/bridge-status.ts
@@ -2,7 +2,6 @@ import { getClientHeaders } from '@metamask/bridge-controller';
 import type { Quote, QuoteResponse } from '@metamask/bridge-controller';
 import { StructError } from '@metamask/superstruct';
 
-import { validateBridgeStatusResponse } from './validators';
 import { REFRESH_INTERVAL_MS } from '../constants';
 import type {
   StatusResponse,
@@ -12,6 +11,7 @@ import type {
   BridgeHistoryItem,
   StatusRequest,
 } from '../types';
+import { validateBridgeStatusResponse } from './validators';
 
 export const getBridgeStatusUrl = (bridgeApiBaseUrl: string): string =>
   `${bridgeApiBaseUrl}/getTxStatus`;

--- a/packages/bridge-status-controller/src/utils/history.test.ts
+++ b/packages/bridge-status-controller/src/utils/history.test.ts
@@ -1,12 +1,12 @@
 import { StatusTypes } from '@metamask/bridge-controller';
 import type { Quote } from '@metamask/bridge-controller';
 
-import { getHistoryKey, rekeyHistoryItemInState } from './history';
 import type {
   BridgeStatusControllerState,
   BridgeHistoryItem,
   StatusResponse,
 } from '../types';
+import { getHistoryKey, rekeyHistoryItemInState } from './history';
 
 describe('History Utils', () => {
   describe('rekeyHistoryItemInState', () => {

--- a/packages/bridge-status-controller/src/utils/intent-api.test.ts
+++ b/packages/bridge-status-controller/src/utils/intent-api.test.ts
@@ -2,6 +2,7 @@
 import { BridgeClientId, StatusTypes } from '@metamask/bridge-controller';
 import { TransactionStatus } from '@metamask/transaction-controller';
 
+import type { FetchFunction } from '../types';
 import {
   getIntentFromQuote,
   IntentApiImpl,
@@ -11,7 +12,6 @@ import {
 } from './intent-api';
 import type { IntentSubmissionParams } from './intent-api';
 import { IntentOrderStatus } from './validators';
-import type { FetchFunction } from '../types';
 
 describe('IntentApiImpl', () => {
   const baseUrl = 'https://example.com/api';

--- a/packages/bridge-status-controller/src/utils/intent-api.ts
+++ b/packages/bridge-status-controller/src/utils/intent-api.ts
@@ -8,12 +8,12 @@ import {
 } from '@metamask/bridge-controller';
 import { TransactionStatus } from '@metamask/transaction-controller';
 
+import type { FetchFunction, StatusResponse } from '../types';
 import {
   IntentStatusResponse,
   IntentOrderStatus,
   validateIntentStatusResponse,
 } from './validators';
-import type { FetchFunction, StatusResponse } from '../types';
 
 export type IntentSubmissionParams = {
   srcChainId: ChainId;

--- a/packages/bridge-status-controller/src/utils/metrics.test.ts
+++ b/packages/bridge-status-controller/src/utils/metrics.test.ts
@@ -15,6 +15,7 @@ import type {
 import { TransactionType } from '@metamask/transaction-controller';
 import { TransactionStatus } from '@metamask/transaction-controller';
 
+import type { BridgeHistoryItem } from '../types';
 import {
   getTxStatusesFromHistory,
   getFinalizedTxProperties,
@@ -24,7 +25,6 @@ import {
   getEVMTxPropertiesFromTransactionMeta,
   getPreConfirmationPropertiesFromQuote,
 } from './metrics';
-import type { BridgeHistoryItem } from '../types';
 
 describe('metrics utils', () => {
   const mockHistoryItem: BridgeHistoryItem = {

--- a/packages/bridge-status-controller/src/utils/metrics.ts
+++ b/packages/bridge-status-controller/src/utils/metrics.ts
@@ -33,12 +33,12 @@ import type { TransactionMeta } from '@metamask/transaction-controller';
 import type { CaipAssetType } from '@metamask/utils';
 import { BigNumber } from 'bignumber.js';
 
+import type { BridgeHistoryItem } from '../types';
 import { calcActualGasUsed } from './gas';
 import {
   getActualBridgeReceivedAmount,
   getActualSwapReceivedAmount,
 } from './swap-received-amount';
-import type { BridgeHistoryItem } from '../types';
 
 export const getTxStatusesFromHistory = ({
   status,

--- a/packages/bridge-status-controller/src/utils/snaps.test.ts
+++ b/packages/bridge-status-controller/src/utils/snaps.test.ts
@@ -1,9 +1,9 @@
 /* eslint-disable consistent-return */
 import { v4 as uuid } from 'uuid';
 
-import { createClientTransactionRequest, handleNonEvmTx } from './snaps';
 import { ChainId } from '../../../bridge-controller/src/types';
 import { BridgeStatusControllerMessenger } from '../types';
+import { createClientTransactionRequest, handleNonEvmTx } from './snaps';
 
 jest.mock('uuid', () => ({
   v4: jest.fn(),

--- a/packages/bridge-status-controller/src/utils/transaction.test.ts
+++ b/packages/bridge-status-controller/src/utils/transaction.test.ts
@@ -16,6 +16,8 @@ import {
 } from '@metamask/transaction-controller';
 import type { TransactionMeta } from '@metamask/transaction-controller';
 
+import { APPROVAL_DELAY_MS } from '../constants';
+import type { BridgeStatusControllerMessenger } from '../types';
 import { getStatusRequestParams } from './bridge-status';
 import * as snaps from './snaps';
 import {
@@ -26,8 +28,6 @@ import {
   waitForTxConfirmation,
   toBatchTxParams,
 } from './transaction';
-import { APPROVAL_DELAY_MS } from '../constants';
-import type { BridgeStatusControllerMessenger } from '../types';
 
 describe('Bridge Status Controller Transaction Utils', () => {
   describe('waitForTxConfirmation', () => {

--- a/packages/bridge-status-controller/src/utils/transaction.ts
+++ b/packages/bridge-status-controller/src/utils/transaction.ts
@@ -25,10 +25,10 @@ import type {
 import { createProjectLogger, Hex } from '@metamask/utils';
 import { BigNumber } from 'bignumber.js';
 
-import { getAccountByAddress } from './accounts';
-import { getNetworkClientIdByChainId } from './network';
 import { APPROVAL_DELAY_MS } from '../constants';
 import type { BridgeStatusControllerMessenger } from '../types';
+import { getAccountByAddress } from './accounts';
+import { getNetworkClientIdByChainId } from './network';
 
 export const getGasFeeEstimates = async (
   messenger: BridgeStatusControllerMessenger,

--- a/packages/build-utils/src/transforms/remove-fenced-code.test.ts
+++ b/packages/build-utils/src/transforms/remove-fenced-code.test.ts
@@ -1,10 +1,10 @@
+import { removeFencedCode } from '..';
+import type { FeatureLabels } from '..';
 import {
   DirectiveCommand,
   multiSplice,
   validateCommand,
 } from './remove-fenced-code';
-import { removeFencedCode } from '..';
-import type { FeatureLabels } from '..';
 
 const FEATURE_A = 'feature-a';
 const FEATURE_B = 'feature-b';

--- a/packages/chain-agnostic-permission/src/operators/caip-permission-operator-accounts.test.ts
+++ b/packages/chain-agnostic-permission/src/operators/caip-permission-operator-accounts.test.ts
@@ -1,5 +1,7 @@
 import type { CaipAccountId } from '@metamask/utils';
 
+import type { Caip25CaveatValue } from '../caip25Permission';
+import type { InternalScopesObject } from '../scope/types';
 import {
   getEthAccounts,
   setEthAccounts,
@@ -9,8 +11,6 @@ import {
   isCaipAccountIdInPermittedAccountIds,
   isInternalAccountInPermittedAccountIds,
 } from './caip-permission-operator-accounts';
-import type { Caip25CaveatValue } from '../caip25Permission';
-import type { InternalScopesObject } from '../scope/types';
 
 describe('CAIP-25 eth_accounts adapters', () => {
   describe('getEthAccounts', () => {

--- a/packages/chain-agnostic-permission/src/operators/caip-permission-operator-permittedChains.test.ts
+++ b/packages/chain-agnostic-permission/src/operators/caip-permission-operator-permittedChains.test.ts
@@ -1,3 +1,5 @@
+import type { Caip25CaveatValue } from '../caip25Permission';
+import { Caip25CaveatType } from '../caip25Permission';
 import {
   addPermittedEthChainId,
   getPermittedEthChainIds,
@@ -9,8 +11,6 @@ import {
   getAllNamespacesFromCaip25CaveatValue,
   getAllScopesFromPermission,
 } from './caip-permission-operator-permittedChains';
-import type { Caip25CaveatValue } from '../caip25Permission';
-import { Caip25CaveatType } from '../caip25Permission';
 
 describe('CAIP-25 permittedChains adapters', () => {
   describe('getPermittedEthChainIds', () => {

--- a/packages/chain-agnostic-permission/src/operators/caip-permission-operator-session-scopes.test.ts
+++ b/packages/chain-agnostic-permission/src/operators/caip-permission-operator-session-scopes.test.ts
@@ -1,16 +1,16 @@
 import type { CaipAccountId } from '@metamask/utils';
 
 import {
-  getInternalScopesObject,
-  getPermittedAccountsForScopes,
-  getSessionScopes,
-} from './caip-permission-operator-session-scopes';
-import {
   KnownNotifications,
   KnownRpcMethods,
   KnownWalletNamespaceRpcMethods,
   KnownWalletRpcMethods,
 } from '../scope/constants';
+import {
+  getInternalScopesObject,
+  getPermittedAccountsForScopes,
+  getSessionScopes,
+} from './caip-permission-operator-session-scopes';
 
 describe('CAIP-25 session scopes adapters', () => {
   describe('getInternalScopesObject', () => {

--- a/packages/claims-controller/src/ClaimsController.test.ts
+++ b/packages/claims-controller/src/ClaimsController.test.ts
@@ -1,5 +1,7 @@
 import { toHex } from '@metamask/controller-utils';
 
+import { createMockClaimsControllerMessenger } from '../tests/mocks/messenger';
+import type { WithControllerArgs } from '../tests/types';
 import {
   ClaimsController,
   getDefaultClaimsControllerState,
@@ -11,8 +13,6 @@ import type {
   ClaimsConfigurationsResponse,
   CreateClaimRequest,
 } from './types';
-import { createMockClaimsControllerMessenger } from '../tests/mocks/messenger';
-import type { WithControllerArgs } from '../tests/types';
 
 const mockClaimServiceRequestHeaders = jest.fn();
 const mockClaimServiceGetClaimsApiUrl = jest.fn();

--- a/packages/claims-controller/src/ClaimsService.test.ts
+++ b/packages/claims-controller/src/ClaimsService.test.ts
@@ -1,3 +1,4 @@
+import { createMockClaimsServiceMessenger } from '../tests/mocks/messenger';
 import { ClaimsService } from './ClaimsService';
 import {
   CLAIMS_API_URL_MAP,
@@ -11,7 +12,6 @@ import type {
   GenerateSignatureMessageResponse,
 } from './types';
 import { createSentryError } from './utils';
-import { createMockClaimsServiceMessenger } from '../tests/mocks/messenger';
 
 const mockAuthenticationControllerGetBearerToken = jest.fn();
 const mockFetchFunction = jest.fn();

--- a/packages/claims-controller/tests/types.ts
+++ b/packages/claims-controller/tests/types.ts
@@ -1,10 +1,10 @@
-import type { RootControllerMessenger } from './mocks/messenger';
 import type {
   ClaimsController,
   ClaimsControllerMessenger,
   ClaimsControllerOptions,
 } from '../src/ClaimsController';
 import type { ClaimsControllerState } from '../src/types';
+import type { RootControllerMessenger } from './mocks/messenger';
 
 /**
  * Helper function to create controller with options.

--- a/packages/config-registry-controller/src/ConfigRegistryController.test.ts
+++ b/packages/config-registry-controller/src/ConfigRegistryController.test.ts
@@ -5,6 +5,7 @@ import type {
 } from '@metamask/messenger';
 import { Messenger, MOCK_ANY_NAMESPACE } from '@metamask/messenger';
 
+import { createMockNetworkConfig } from '../tests/helpers';
 import type { RegistryNetworkConfig } from './config-registry-api-service/types';
 import type { FetchConfigResult } from './config-registry-api-service/types';
 import type { ConfigRegistryControllerMessenger } from './ConfigRegistryController';
@@ -13,7 +14,6 @@ import {
   DEFAULT_POLLING_INTERVAL,
 } from './ConfigRegistryController';
 import { selectFeaturedNetworks, selectNetworks } from './selectors';
-import { createMockNetworkConfig } from '../tests/helpers';
 
 const namespace = 'ConfigRegistryController' as const;
 

--- a/packages/config-registry-controller/src/config-registry-api-service/config-registry-api-service.test.ts
+++ b/packages/config-registry-controller/src/config-registry-api-service/config-registry-api-service.test.ts
@@ -1,13 +1,13 @@
 import { SDK } from '@metamask/profile-sync-controller';
 import nock from 'nock';
 
+import { createMockNetworkConfig } from '../../tests/helpers';
 import { ConfigRegistryApiService } from './config-registry-api-service';
 import type {
   ConfigRegistryApiServiceMessenger,
   ConfigRegistryApiServiceOptions,
 } from './config-registry-api-service';
 import type { RegistryConfigApiResponse } from './types';
-import { createMockNetworkConfig } from '../../tests/helpers';
 
 function createMockServiceMessenger(): ConfigRegistryApiServiceMessenger {
   return {

--- a/packages/config-registry-controller/src/config-registry-api-service/filters.test.ts
+++ b/packages/config-registry-controller/src/config-registry-api-service/filters.test.ts
@@ -1,6 +1,6 @@
+import { createMockNetworkConfig } from '../../tests/helpers';
 import { filterNetworks } from './filters';
 import type { RegistryNetworkConfig } from './types';
-import { createMockNetworkConfig } from '../../tests/helpers';
 
 describe('filters', () => {
   describe('filterNetworks', () => {

--- a/packages/config-registry-controller/src/selectors.test.ts
+++ b/packages/config-registry-controller/src/selectors.test.ts
@@ -1,5 +1,5 @@
-import { selectFeaturedNetworks, selectNetworks } from './selectors';
 import { createMockNetworkConfig } from '../tests/helpers';
+import { selectFeaturedNetworks, selectNetworks } from './selectors';
 
 describe('selectors', () => {
   describe('selectNetworks', () => {

--- a/packages/controller-utils/src/util.test.ts
+++ b/packages/controller-utils/src/util.test.ts
@@ -4,9 +4,9 @@ import { BigNumber } from 'bignumber.js';
 import BN from 'bn.js';
 import nock from 'nock';
 
+import { FakeProvider } from '../../../tests/fake-provider';
 import { MAX_SAFE_CHAIN_ID } from './constants';
 import * as util from './util';
-import { FakeProvider } from '../../../tests/fake-provider';
 
 type EverythingButNull =
   | string

--- a/packages/core-backend/src/AccountActivityService.test.ts
+++ b/packages/core-backend/src/AccountActivityService.test.ts
@@ -7,6 +7,7 @@ import type {
 } from '@metamask/messenger';
 import type { Hex } from '@metamask/utils';
 
+import { flushPromises } from '../../../tests/helpers';
 import { AccountActivityService } from './AccountActivityService';
 import type {
   AccountActivityServiceMessenger,
@@ -16,7 +17,6 @@ import type { ServerNotificationMessage } from './BackendWebSocketService';
 import { WebSocketState } from './BackendWebSocketService';
 import type { Transaction, BalanceUpdate } from './types';
 import type { AccountActivityMessage } from './types';
-import { flushPromises } from '../../../tests/helpers';
 
 type AllAccountActivityServiceActions =
   MessengerActions<AccountActivityServiceMessenger>;

--- a/packages/core-backend/src/BackendWebSocketService.test.ts
+++ b/packages/core-backend/src/BackendWebSocketService.test.ts
@@ -5,6 +5,7 @@ import type {
   MockAnyNamespace,
 } from '@metamask/messenger';
 
+import { flushPromises } from '../../../tests/helpers';
 import {
   BackendWebSocketService,
   getCloseReason,
@@ -15,7 +16,6 @@ import type {
   BackendWebSocketServiceOptions,
   BackendWebSocketServiceMessenger,
 } from './BackendWebSocketService';
-import { flushPromises } from '../../../tests/helpers';
 
 // =====================================================
 // TYPES

--- a/packages/core-backend/src/api/accounts/client.test.ts
+++ b/packages/core-backend/src/api/accounts/client.test.ts
@@ -2,12 +2,6 @@
  * Accounts API Client Tests - accounts.api.cx.metamask.io
  */
 
-import type {
-  V1SupportedNetworksResponse,
-  V2SupportedNetworksResponse,
-  V2BalancesResponse,
-  V5BalancesResponse,
-} from './types';
 import type { ApiPlatformClient } from '../ApiPlatformClient';
 import { API_URLS, HttpError } from '../shared-types';
 import {
@@ -15,6 +9,12 @@ import {
   createMockResponse,
   setupTestEnvironment,
 } from '../test-utils';
+import type {
+  V1SupportedNetworksResponse,
+  V2SupportedNetworksResponse,
+  V2BalancesResponse,
+  V5BalancesResponse,
+} from './types';
 
 describe('AccountsApiClient', () => {
   let client: ApiPlatformClient;

--- a/packages/core-backend/src/api/accounts/client.ts
+++ b/packages/core-backend/src/api/accounts/client.ts
@@ -17,6 +17,9 @@ import type {
   QueryFunctionContext,
 } from '@tanstack/query-core';
 
+import { BaseApiClient, API_URLS, STALE_TIMES, GC_TIMES } from '../base-client';
+import { getQueryOptionsOverrides } from '../shared-types';
+import type { FetchOptions } from '../shared-types';
 import type {
   V1SupportedNetworksResponse,
   V2SupportedNetworksResponse,
@@ -31,9 +34,6 @@ import type {
   V2NftsResponse,
   V2TokensResponse,
 } from './types';
-import { BaseApiClient, API_URLS, STALE_TIMES, GC_TIMES } from '../base-client';
-import { getQueryOptionsOverrides } from '../shared-types';
-import type { FetchOptions } from '../shared-types';
 
 /**
  * Accounts API Client.

--- a/packages/core-backend/src/api/prices/client.test.ts
+++ b/packages/core-backend/src/api/prices/client.test.ts
@@ -2,11 +2,6 @@
  * Prices API Client Tests - price.api.cx.metamask.io
  */
 
-import type {
-  PriceSupportedNetworksResponse,
-  V1ExchangeRatesResponse,
-  V3SpotPricesResponse,
-} from './types';
 import type { ApiPlatformClient } from '../ApiPlatformClient';
 import { API_URLS } from '../shared-types';
 import type { FetchOptions } from '../shared-types';
@@ -15,6 +10,11 @@ import {
   mockFetch,
   setupTestEnvironment,
 } from '../test-utils';
+import type {
+  PriceSupportedNetworksResponse,
+  V1ExchangeRatesResponse,
+  V3SpotPricesResponse,
+} from './types';
 
 describe('PricesApiClient', () => {
   let client: ApiPlatformClient;

--- a/packages/core-backend/src/api/prices/client.ts
+++ b/packages/core-backend/src/api/prices/client.ts
@@ -14,6 +14,13 @@ import type {
   QueryFunctionContext,
 } from '@tanstack/query-core';
 
+import { BaseApiClient, API_URLS, STALE_TIMES, GC_TIMES } from '../base-client';
+import { getQueryOptionsOverrides } from '../shared-types';
+import type {
+  FetchOptions,
+  MarketDataDetails,
+  SupportedCurrency,
+} from '../shared-types';
 import type {
   CoinGeckoSpotPrice,
   V1ExchangeRatesResponse,
@@ -22,13 +29,6 @@ import type {
   V3SpotPricesResponse,
   V3HistoricalPricesResponse,
 } from './types';
-import { BaseApiClient, API_URLS, STALE_TIMES, GC_TIMES } from '../base-client';
-import { getQueryOptionsOverrides } from '../shared-types';
-import type {
-  FetchOptions,
-  MarketDataDetails,
-  SupportedCurrency,
-} from '../shared-types';
 
 /**
  * Prices API Client.

--- a/packages/core-backend/src/api/token/client.test.ts
+++ b/packages/core-backend/src/api/token/client.test.ts
@@ -2,7 +2,6 @@
  * Token API Client Tests - token.api.cx.metamask.io
  */
 
-import type { NetworkInfo, TokenMetadata } from './types';
 import type { ApiPlatformClient } from '../ApiPlatformClient';
 import { API_URLS } from '../shared-types';
 import {
@@ -10,6 +9,7 @@ import {
   createMockResponse,
   setupTestEnvironment,
 } from '../test-utils';
+import type { NetworkInfo, TokenMetadata } from './types';
 
 describe('TokenApiClient', () => {
   let client: ApiPlatformClient;

--- a/packages/core-backend/src/api/token/client.ts
+++ b/packages/core-backend/src/api/token/client.ts
@@ -17,6 +17,9 @@ import type {
   QueryFunctionContext,
 } from '@tanstack/query-core';
 
+import { BaseApiClient, API_URLS, STALE_TIMES, GC_TIMES } from '../base-client';
+import { getQueryOptionsOverrides } from '../shared-types';
+import type { FetchOptions } from '../shared-types';
 import type {
   TokenMetadata,
   V1TokenDescriptionResponse,
@@ -27,9 +30,6 @@ import type {
   TopGainersSortOption,
   V1SuggestedOccurrenceFloorsResponse,
 } from './types';
-import { BaseApiClient, API_URLS, STALE_TIMES, GC_TIMES } from '../base-client';
-import { getQueryOptionsOverrides } from '../shared-types';
-import type { FetchOptions } from '../shared-types';
 
 /**
  * Token API Client.

--- a/packages/core-backend/src/api/tokens/client.ts
+++ b/packages/core-backend/src/api/tokens/client.ts
@@ -11,15 +11,15 @@ import type {
   QueryFunctionContext,
 } from '@tanstack/query-core';
 
+import { BaseApiClient, API_URLS, STALE_TIMES, GC_TIMES } from '../base-client';
+import { getQueryOptionsOverrides } from '../shared-types';
+import type { FetchOptions } from '../shared-types';
 import type {
   V1TokenSupportedNetworksResponse,
   V2TokenSupportedNetworksResponse,
   V3AssetResponse,
   V3AssetsQueryOptions,
 } from './types';
-import { BaseApiClient, API_URLS, STALE_TIMES, GC_TIMES } from '../base-client';
-import { getQueryOptionsOverrides } from '../shared-types';
-import type { FetchOptions } from '../shared-types';
 
 /**
  * Tokens API Client.

--- a/packages/earn-controller/src/EarnController.test.ts
+++ b/packages/earn-controller/src/EarnController.test.ts
@@ -20,6 +20,11 @@ import type {
   LendingMarket,
 } from '@metamask/stake-sdk';
 
+import type { TransactionMeta } from '../../transaction-controller/src';
+import {
+  TransactionStatus,
+  TransactionType,
+} from '../../transaction-controller/src';
 import {
   EarnController,
   DEFAULT_POOLED_STAKING_CHAIN_STATE,
@@ -28,11 +33,6 @@ import type {
   EarnControllerState,
   EarnControllerMessenger,
 } from './EarnController';
-import type { TransactionMeta } from '../../transaction-controller/src';
-import {
-  TransactionStatus,
-  TransactionType,
-} from '../../transaction-controller/src';
 
 type AllEarnControllerActions = MessengerActions<EarnControllerMessenger>;
 

--- a/packages/eip-5792-middleware/src/hooks/getCallsStatus.test.ts
+++ b/packages/eip-5792-middleware/src/hooks/getCallsStatus.test.ts
@@ -6,9 +6,9 @@ import type {
   TransactionControllerState,
 } from '@metamask/transaction-controller';
 
-import { getCallsStatus } from './getCallsStatus';
 import { GetCallsStatusCode } from '../constants';
 import type { EIP5792Messenger } from '../types';
+import { getCallsStatus } from './getCallsStatus';
 
 const CHAIN_ID_MOCK = '0x123';
 const BATCH_ID_MOCK = '0xf3472db2a4134607a17213b7e9ca26e3';

--- a/packages/eip-5792-middleware/src/hooks/getCapabilities.test.ts
+++ b/packages/eip-5792-middleware/src/hooks/getCapabilities.test.ts
@@ -12,8 +12,8 @@ import type {
 import type { TransactionController } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 
-import { getCapabilities } from './getCapabilities';
 import type { EIP5792Messenger } from '../types';
+import { getCapabilities } from './getCapabilities';
 
 const CHAIN_ID_MOCK = '0x123';
 const FROM_MOCK = '0xabc123';

--- a/packages/eip-5792-middleware/src/hooks/processSendCalls.test.ts
+++ b/packages/eip-5792-middleware/src/hooks/processSendCalls.test.ts
@@ -16,13 +16,13 @@ import { providerErrors } from '@metamask/rpc-errors';
 import type { TransactionController } from '@metamask/transaction-controller';
 import type { Hex, JsonRpcRequest } from '@metamask/utils';
 
-import { processSendCalls } from './processSendCalls';
 import { SupportedCapabilities } from '../constants';
 import type {
   SendCallsPayload,
   SendCallsParams,
   EIP5792Messenger,
 } from '../types';
+import { processSendCalls } from './processSendCalls';
 
 const CHAIN_ID_MOCK = '0x123';
 const CHAIN_ID_2_MOCK = '0xabc';

--- a/packages/eip-5792-middleware/src/methods/wallet_getCallsStatus.test.ts
+++ b/packages/eip-5792-middleware/src/methods/wallet_getCallsStatus.test.ts
@@ -5,12 +5,12 @@ import type {
 } from '@metamask/utils';
 import { klona } from 'klona';
 
-import { walletGetCallsStatus } from './wallet_getCallsStatus';
 import type {
   GetCallsStatusHook,
   GetCallsStatusParams,
   GetCallsStatusResult,
 } from '../types';
+import { walletGetCallsStatus } from './wallet_getCallsStatus';
 
 const ID_MOCK = '0x12345678';
 

--- a/packages/eip-5792-middleware/src/methods/wallet_getCapabilities.test.ts
+++ b/packages/eip-5792-middleware/src/methods/wallet_getCapabilities.test.ts
@@ -1,12 +1,12 @@
 import type { JsonRpcRequest, PendingJsonRpcResponse } from '@metamask/utils';
 import { klona } from 'klona';
 
-import { walletGetCapabilities } from './wallet_getCapabilities';
 import type {
   GetCapabilitiesHook,
   GetCapabilitiesParams,
   GetCapabilitiesResult,
 } from '../types';
+import { walletGetCapabilities } from './wallet_getCapabilities';
 
 type GetPermittedAccountsForOrigin = () => Promise<string[]>;
 

--- a/packages/eip-5792-middleware/src/methods/wallet_sendCalls.test.ts
+++ b/packages/eip-5792-middleware/src/methods/wallet_sendCalls.test.ts
@@ -1,12 +1,12 @@
 import type { JsonRpcRequest, PendingJsonRpcResponse } from '@metamask/utils';
 import { klona } from 'klona';
 
-import { walletSendCalls } from './wallet_sendCalls';
 import type {
   ProcessSendCallsHook,
   SendCallsPayload,
   SendCallsParams,
 } from '../types';
+import { walletSendCalls } from './wallet_sendCalls';
 
 type GetPermittedAccountsForOrigin = () => Promise<string[]>;
 

--- a/packages/ens-controller/src/EnsController.test.ts
+++ b/packages/ens-controller/src/EnsController.test.ts
@@ -17,15 +17,15 @@ import type {
   NetworkState,
 } from '@metamask/network-controller';
 
+import {
+  buildMockGetNetworkClientById,
+  buildCustomNetworkClientConfiguration,
+} from '../../network-controller/tests/helpers';
 import { EnsController, DEFAULT_ENS_NETWORK_MAP } from './EnsController';
 import type {
   EnsControllerState,
   EnsControllerMessenger,
 } from './EnsController';
-import {
-  buildMockGetNetworkClientById,
-  buildCustomNetworkClientConfiguration,
-} from '../../network-controller/tests/helpers';
 
 const defaultState: EnsControllerState = {
   ensEntries: {},

--- a/packages/eth-json-rpc-middleware/src/block-ref-rewrite.test.ts
+++ b/packages/eth-json-rpc-middleware/src/block-ref-rewrite.test.ts
@@ -2,11 +2,11 @@ import type { PollingBlockTracker } from '@metamask/eth-block-tracker';
 import { JsonRpcEngineV2 } from '@metamask/json-rpc-engine/v2';
 import type { Json, JsonRpcRequest } from '@metamask/utils';
 
-import { createBlockRefRewriteMiddleware } from './block-ref-rewrite';
 import {
   createFinalMiddlewareWithDefaultResult,
   createRequest,
 } from '../test/util/helpers';
+import { createBlockRefRewriteMiddleware } from './block-ref-rewrite';
 
 const createMockBlockTracker = (): PollingBlockTracker => {
   return {

--- a/packages/eth-json-rpc-middleware/src/block-tracker-inspector.test.ts
+++ b/packages/eth-json-rpc-middleware/src/block-tracker-inspector.test.ts
@@ -3,11 +3,11 @@ import { JsonRpcEngineV2 } from '@metamask/json-rpc-engine/v2';
 import { rpcErrors } from '@metamask/rpc-errors';
 import { Hex, Json } from '@metamask/utils';
 
-import { createBlockTrackerInspectorMiddleware } from './block-tracker-inspector';
 import {
   createFinalMiddlewareWithDefaultResult,
   createRequest,
 } from '../test/util/helpers';
+import { createBlockTrackerInspectorMiddleware } from './block-tracker-inspector';
 
 const createMockBlockTracker = (): PollingBlockTracker => {
   return {

--- a/packages/eth-json-rpc-middleware/src/fetch.test.ts
+++ b/packages/eth-json-rpc-middleware/src/fetch.test.ts
@@ -10,9 +10,9 @@ import type {
   JsonRpcResponse,
 } from '@metamask/utils';
 
+import { createRequest } from '../test/util/helpers';
 import { createFetchMiddleware } from './fetch';
 import type { AbstractRpcServiceLike } from './types';
-import { createRequest } from '../test/util/helpers';
 
 describe('createFetchMiddleware', () => {
   it.each([

--- a/packages/eth-json-rpc-middleware/src/methods/wallet-get-granted-execution-permissions.test.ts
+++ b/packages/eth-json-rpc-middleware/src/methods/wallet-get-granted-execution-permissions.test.ts
@@ -1,11 +1,11 @@
 import type { Hex, Json, JsonRpcRequest } from '@metamask/utils';
 
+import type { WalletMiddlewareParams } from '../wallet';
 import type {
   GetGrantedExecutionPermissionsResult,
   ProcessGetGrantedExecutionPermissionsHook,
 } from './wallet-get-granted-execution-permissions';
 import { createWalletGetGrantedExecutionPermissionsHandler } from './wallet-get-granted-execution-permissions';
-import type { WalletMiddlewareParams } from '../wallet';
 
 const RESULT_MOCK: GetGrantedExecutionPermissionsResult = [
   {

--- a/packages/eth-json-rpc-middleware/src/methods/wallet-get-supported-execution-permissions.test.ts
+++ b/packages/eth-json-rpc-middleware/src/methods/wallet-get-supported-execution-permissions.test.ts
@@ -1,11 +1,11 @@
 import type { Hex, Json, JsonRpcRequest } from '@metamask/utils';
 
+import type { WalletMiddlewareParams } from '../wallet';
 import type {
   GetSupportedExecutionPermissionsResult,
   ProcessGetSupportedExecutionPermissionsHook,
 } from './wallet-get-supported-execution-permissions';
 import { createWalletGetSupportedExecutionPermissionsHandler } from './wallet-get-supported-execution-permissions';
-import type { WalletMiddlewareParams } from '../wallet';
 
 const RESULT_MOCK: GetSupportedExecutionPermissionsResult = {
   'native-token-allowance': {

--- a/packages/eth-json-rpc-middleware/src/methods/wallet-request-execution-permissions.test.ts
+++ b/packages/eth-json-rpc-middleware/src/methods/wallet-request-execution-permissions.test.ts
@@ -1,13 +1,13 @@
 import type { Json, JsonRpcRequest } from '@metamask/utils';
 import { klona } from 'klona';
 
+import type { WalletMiddlewareParams } from '../wallet';
 import type {
   ProcessRequestExecutionPermissionsHook,
   RequestExecutionPermissionsRequestParams,
   RequestExecutionPermissionsResult,
 } from './wallet-request-execution-permissions';
 import { createWalletRequestExecutionPermissionsHandler } from './wallet-request-execution-permissions';
-import type { WalletMiddlewareParams } from '../wallet';
 
 const FROM_ADDRESS_MOCK = '0x123abc123abc123abc123abc123abc123abc123A';
 const TO_ADDRESS_MOCK = '0x016562aA41A8697720ce0943F003141f5dEAe006';

--- a/packages/eth-json-rpc-middleware/src/methods/wallet-revoke-execution-permission.test.ts
+++ b/packages/eth-json-rpc-middleware/src/methods/wallet-revoke-execution-permission.test.ts
@@ -1,12 +1,12 @@
 import type { Json, JsonRpcRequest } from '@metamask/utils';
 import { klona } from 'klona';
 
+import type { WalletMiddlewareParams } from '../wallet';
 import type {
   ProcessRevokeExecutionPermissionHook,
   RevokeExecutionPermissionRequestParams,
 } from './wallet-revoke-execution-permission';
 import { createWalletRevokeExecutionPermissionHandler } from './wallet-revoke-execution-permission';
-import type { WalletMiddlewareParams } from '../wallet';
 
 const HEX_MOCK = '0x123abc';
 

--- a/packages/eth-json-rpc-middleware/src/providerAsMiddleware.test.ts
+++ b/packages/eth-json-rpc-middleware/src/providerAsMiddleware.test.ts
@@ -7,11 +7,11 @@ import {
   assertIsJsonRpcSuccess,
 } from '@metamask/utils';
 
+import { createRequest } from '../test/util/helpers';
 import {
   providerAsMiddleware,
   providerAsMiddlewareV2,
 } from './providerAsMiddleware';
-import { createRequest } from '../test/util/helpers';
 
 const createMockProvider = (resultOrError: Json | Error): InternalProvider =>
   ({

--- a/packages/eth-json-rpc-middleware/src/utils/validation.test.ts
+++ b/packages/eth-json-rpc-middleware/src/utils/validation.test.ts
@@ -3,12 +3,12 @@ import { providerErrors } from '@metamask/rpc-errors';
 import type { StructError } from '@metamask/superstruct';
 import { any, validate } from '@metamask/superstruct';
 
+import type { WalletMiddlewareKeyValues } from '../wallet';
 import {
   resemblesAddress,
   validateAndNormalizeKeyholder,
   validateParams,
 } from './validation';
-import type { WalletMiddlewareKeyValues } from '../wallet';
 
 jest.mock('@metamask/superstruct', () => ({
   ...jest.requireActual('@metamask/superstruct'),

--- a/packages/eth-json-rpc-middleware/src/utils/validation.ts
+++ b/packages/eth-json-rpc-middleware/src/utils/validation.ts
@@ -3,8 +3,8 @@ import type { Struct, StructError } from '@metamask/superstruct';
 import { validate } from '@metamask/superstruct';
 import type { Hex } from '@metamask/utils';
 
-import { parseTypedMessage } from './normalize';
 import type { WalletMiddlewareContext } from '../wallet';
+import { parseTypedMessage } from './normalize';
 
 /**
  * Validates and normalizes a keyholder address for transaction- and

--- a/packages/eth-json-rpc-middleware/src/wallet.test.ts
+++ b/packages/eth-json-rpc-middleware/src/wallet.test.ts
@@ -8,8 +8,8 @@ import type {
   TypedMessageV1Params,
 } from '.';
 import { createWalletMiddleware } from '.';
-import { DANGEROUS_PROTOTYPE_PROPERTIES } from './utils/validation';
 import { createHandleParams, createRequest } from '../test/util/helpers';
+import { DANGEROUS_PROTOTYPE_PROPERTIES } from './utils/validation';
 
 const testAddresses = [
   '0xbe93f9bacbcffc8ee6663f2647917ed7a20a57bb',

--- a/packages/gas-fee-controller/src/GasFeeController.test.ts
+++ b/packages/gas-fee-controller/src/GasFeeController.test.ts
@@ -19,6 +19,10 @@ import type {
 import type { Hex } from '@metamask/utils';
 import nock from 'nock';
 
+import {
+  buildCustomNetworkConfiguration,
+  buildCustomRpcEndpoint,
+} from '../../network-controller/tests/helpers';
 import determineGasFeeCalculations from './determineGasFeeCalculations';
 import {
   fetchGasEstimates,
@@ -34,10 +38,6 @@ import type {
   GasFeeStateFeeMarket,
   GasFeeStateLegacy,
 } from './GasFeeController';
-import {
-  buildCustomNetworkConfiguration,
-  buildCustomRpcEndpoint,
-} from '../../network-controller/tests/helpers';
 
 jest.mock('./determineGasFeeCalculations');
 

--- a/packages/gator-permissions-controller/src/GatorPermissionsController.test.ts
+++ b/packages/gator-permissions-controller/src/GatorPermissionsController.test.ts
@@ -24,6 +24,11 @@ import { TransactionStatus } from '@metamask/transaction-controller';
 import { hexToBigInt, numberToHex } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
 
+import { flushPromises } from '../../../tests/helpers';
+import {
+  mockGatorPermissionsStorageEntriesFactory,
+  mockNativeTokenStreamStorageEntry,
+} from '../tests/mocks';
 import { DELEGATION_FRAMEWORK_VERSION } from './constants';
 import { GatorPermissionsFetchError } from './errors';
 import type { GatorPermissionsControllerMessenger } from './GatorPermissionsController';
@@ -34,11 +39,6 @@ import type {
   RevocationParams,
   SupportedPermissionType,
 } from './types';
-import { flushPromises } from '../../../tests/helpers';
-import {
-  mockGatorPermissionsStorageEntriesFactory,
-  mockNativeTokenStreamStorageEntry,
-} from '../tests/mocks';
 
 const MOCK_CHAIN_ID_1: Hex = '0xaa36a7';
 const MOCK_CHAIN_ID_2: Hex = '0x1';

--- a/packages/gator-permissions-controller/src/decodePermission/rules/erc20TokenPeriodic.ts
+++ b/packages/gator-permissions-controller/src/decodePermission/rules/erc20TokenPeriodic.ts
@@ -1,6 +1,5 @@
 import { hexToBigInt, hexToNumber } from '@metamask/utils';
 
-import { makePermissionRule } from './makePermissionRule';
 import type {
   ChecksumCaveat,
   ChecksumEnforcersByChainId,
@@ -13,6 +12,7 @@ import {
   splitHex,
   ZERO_32_BYTES,
 } from '../utils';
+import { makePermissionRule } from './makePermissionRule';
 
 /**
  * Creates the erc20-token-periodic permission rule.

--- a/packages/gator-permissions-controller/src/decodePermission/rules/erc20TokenRevocation.ts
+++ b/packages/gator-permissions-controller/src/decodePermission/rules/erc20TokenRevocation.ts
@@ -1,4 +1,3 @@
-import { makePermissionRule } from './makePermissionRule';
 import type {
   ChecksumCaveat,
   ChecksumEnforcersByChainId,
@@ -11,6 +10,7 @@ import {
   getTermsByEnforcer,
   ZERO_32_BYTES,
 } from '../utils';
+import { makePermissionRule } from './makePermissionRule';
 
 /**
  * Creates the erc20-token-revocation permission rule.

--- a/packages/gator-permissions-controller/src/decodePermission/rules/erc20TokenStream.ts
+++ b/packages/gator-permissions-controller/src/decodePermission/rules/erc20TokenStream.ts
@@ -1,6 +1,5 @@
 import { hexToBigInt, hexToNumber } from '@metamask/utils';
 
-import { makePermissionRule } from './makePermissionRule';
 import type {
   ChecksumCaveat,
   ChecksumEnforcersByChainId,
@@ -13,6 +12,7 @@ import {
   splitHex,
   ZERO_32_BYTES,
 } from '../utils';
+import { makePermissionRule } from './makePermissionRule';
 
 /**
  * Creates the erc20-token-stream permission rule.

--- a/packages/gator-permissions-controller/src/decodePermission/rules/index.ts
+++ b/packages/gator-permissions-controller/src/decodePermission/rules/index.ts
@@ -1,10 +1,10 @@
+import type { DeployedContractsByName, PermissionRule } from '../types';
+import { getChecksumEnforcersByChainId } from '../utils';
 import { makeErc20TokenPeriodicRule } from './erc20TokenPeriodic';
 import { makeErc20TokenRevocationRule } from './erc20TokenRevocation';
 import { makeErc20TokenStreamRule } from './erc20TokenStream';
 import { makeNativeTokenPeriodicRule } from './nativeTokenPeriodic';
 import { makeNativeTokenStreamRule } from './nativeTokenStream';
-import type { DeployedContractsByName, PermissionRule } from '../types';
-import { getChecksumEnforcersByChainId } from '../utils';
 
 /**
  * Builds the canonical set of permission matching rules for a chain.

--- a/packages/gator-permissions-controller/src/decodePermission/rules/nativeTokenPeriodic.ts
+++ b/packages/gator-permissions-controller/src/decodePermission/rules/nativeTokenPeriodic.ts
@@ -1,6 +1,5 @@
 import { hexToBigInt, hexToNumber } from '@metamask/utils';
 
-import { makePermissionRule } from './makePermissionRule';
 import type {
   ChecksumCaveat,
   ChecksumEnforcersByChainId,
@@ -8,6 +7,7 @@ import type {
   PermissionRule,
 } from '../types';
 import { getByteLength, getTermsByEnforcer, splitHex } from '../utils';
+import { makePermissionRule } from './makePermissionRule';
 
 /**
  * Creates the native-token-periodic permission rule.

--- a/packages/gator-permissions-controller/src/decodePermission/rules/nativeTokenStream.ts
+++ b/packages/gator-permissions-controller/src/decodePermission/rules/nativeTokenStream.ts
@@ -1,6 +1,5 @@
 import { hexToBigInt, hexToNumber } from '@metamask/utils';
 
-import { makePermissionRule } from './makePermissionRule';
 import type {
   ChecksumCaveat,
   ChecksumEnforcersByChainId,
@@ -8,6 +7,7 @@ import type {
   PermissionRule,
 } from '../types';
 import { getByteLength, getTermsByEnforcer, splitHex } from '../utils';
+import { makePermissionRule } from './makePermissionRule';
 
 /**
  * Creates the native-token-stream permission rule.

--- a/packages/geolocation-controller/src/geolocation-api-service/geolocation-api-service.test.ts
+++ b/packages/geolocation-controller/src/geolocation-api-service/geolocation-api-service.test.ts
@@ -6,12 +6,12 @@ import type {
   MessengerEvents,
 } from '@metamask/messenger';
 
+import { Env } from '../types';
 import type { GeolocationApiServiceMessenger } from './geolocation-api-service';
 import {
   GeolocationApiService,
   UNKNOWN_LOCATION,
 } from './geolocation-api-service';
-import { Env } from '../types';
 
 describe('GeolocationApiService', () => {
   beforeEach(() => {

--- a/packages/geolocation-controller/src/geolocation-api-service/geolocation-api-service.ts
+++ b/packages/geolocation-controller/src/geolocation-api-service/geolocation-api-service.ts
@@ -6,8 +6,8 @@ import { createServicePolicy, HttpError } from '@metamask/controller-utils';
 import type { Messenger } from '@metamask/messenger';
 import type { IDisposable } from 'cockatiel';
 
-import type { GeolocationApiServiceMethodActions } from './geolocation-api-service-method-action-types';
 import { Env } from '../types';
+import type { GeolocationApiServiceMethodActions } from './geolocation-api-service-method-action-types';
 
 const DEFAULT_TTL_MS = 5 * 60 * 1000;
 

--- a/packages/json-rpc-engine/src/asV2Middleware.test.ts
+++ b/packages/json-rpc-engine/src/asV2Middleware.test.ts
@@ -2,15 +2,15 @@ import { rpcErrors } from '@metamask/rpc-errors';
 import type { Json, JsonRpcRequest } from '@metamask/utils';
 
 import { JsonRpcEngine } from '.';
-import { asV2Middleware } from './asV2Middleware';
-import { JsonRpcEngineV2 } from './v2/JsonRpcEngineV2';
-import type { JsonRpcMiddleware as V2Middleware } from './v2/JsonRpcEngineV2';
-import type { MiddlewareContext } from './v2/MiddlewareContext';
 import {
   getExtraneousKeys,
   makeNullMiddleware,
   makeRequest,
 } from '../tests/utils';
+import { asV2Middleware } from './asV2Middleware';
+import { JsonRpcEngineV2 } from './v2/JsonRpcEngineV2';
+import type { JsonRpcMiddleware as V2Middleware } from './v2/JsonRpcEngineV2';
+import type { MiddlewareContext } from './v2/MiddlewareContext';
 
 describe('asV2Middleware', () => {
   it('converts a legacy engine to a v2 middleware', () => {

--- a/packages/json-rpc-engine/src/v2/JsonRpcEngineV2.test.ts
+++ b/packages/json-rpc-engine/src/v2/JsonRpcEngineV2.test.ts
@@ -2,12 +2,6 @@
 import type { Json, JsonRpcId } from '@metamask/utils';
 import { createDeferredPromise } from '@metamask/utils';
 
-import type { JsonRpcMiddleware, ResultConstraint } from './JsonRpcEngineV2';
-import { JsonRpcEngineV2 } from './JsonRpcEngineV2';
-import type { EmptyContext } from './MiddlewareContext';
-import { MiddlewareContext } from './MiddlewareContext';
-import { isRequest, JsonRpcEngineError, stringify } from './utils';
-import type { JsonRpcCall, JsonRpcNotification, JsonRpcRequest } from './utils';
 import {
   makeNotification,
   makeNotificationMiddleware,
@@ -15,6 +9,12 @@ import {
   makeRequest,
   makeRequestMiddleware,
 } from '../../tests/utils';
+import type { JsonRpcMiddleware, ResultConstraint } from './JsonRpcEngineV2';
+import { JsonRpcEngineV2 } from './JsonRpcEngineV2';
+import type { EmptyContext } from './MiddlewareContext';
+import { MiddlewareContext } from './MiddlewareContext';
+import { isRequest, JsonRpcEngineError, stringify } from './utils';
+import type { JsonRpcCall, JsonRpcNotification, JsonRpcRequest } from './utils';
 
 const jsonrpc = '2.0' as const;
 

--- a/packages/json-rpc-engine/src/v2/JsonRpcServer.ts
+++ b/packages/json-rpc-engine/src/v2/JsonRpcServer.ts
@@ -8,6 +8,7 @@ import type {
 } from '@metamask/utils';
 import { hasProperty, isObject } from '@metamask/utils';
 
+import { getUniqueId } from '../getUniqueId';
 import type {
   HandleOptions,
   JsonRpcMiddleware,
@@ -17,7 +18,6 @@ import type {
 } from './JsonRpcEngineV2';
 import { JsonRpcEngineV2 } from './JsonRpcEngineV2';
 import type { JsonRpcCall } from './utils';
-import { getUniqueId } from '../getUniqueId';
 
 type OnError = (error: unknown) => void;
 

--- a/packages/json-rpc-engine/src/v2/asLegacyMiddleware.test.ts
+++ b/packages/json-rpc-engine/src/v2/asLegacyMiddleware.test.ts
@@ -5,15 +5,15 @@ import type {
   JsonRpcSuccess,
 } from '@metamask/utils';
 
-import { asLegacyMiddleware } from './asLegacyMiddleware';
-import type { JsonRpcMiddleware, ResultConstraint } from './JsonRpcEngineV2';
-import { JsonRpcEngineV2 } from './JsonRpcEngineV2';
 import {
   getExtraneousKeys,
   makeRequest,
   makeRequestMiddleware,
 } from '../../tests/utils';
 import { JsonRpcEngine } from '../JsonRpcEngine';
+import { asLegacyMiddleware } from './asLegacyMiddleware';
+import type { JsonRpcMiddleware, ResultConstraint } from './JsonRpcEngineV2';
+import { JsonRpcEngineV2 } from './JsonRpcEngineV2';
 
 describe('asLegacyMiddleware', () => {
   it('converts a v2 engine to a legacy middleware', () => {

--- a/packages/json-rpc-engine/src/v2/asLegacyMiddleware.ts
+++ b/packages/json-rpc-engine/src/v2/asLegacyMiddleware.ts
@@ -1,5 +1,7 @@
 import type { JsonRpcParams, JsonRpcRequest } from '@metamask/utils';
 
+import { createAsyncMiddleware } from '..';
+import type { JsonRpcMiddleware as LegacyMiddleware } from '..';
 import {
   deepClone,
   fromLegacyRequest,
@@ -8,8 +10,6 @@ import {
 } from './compatibility-utils';
 import type { JsonRpcMiddleware, ResultConstraint } from './JsonRpcEngineV2';
 import { JsonRpcEngineV2 } from './JsonRpcEngineV2';
-import { createAsyncMiddleware } from '..';
-import type { JsonRpcMiddleware as LegacyMiddleware } from '..';
 
 /**
  * Convert a {@link JsonRpcEngineV2} into a legacy middleware.

--- a/packages/json-rpc-engine/src/v2/createScaffoldMiddleware.test.ts
+++ b/packages/json-rpc-engine/src/v2/createScaffoldMiddleware.test.ts
@@ -1,9 +1,9 @@
 import { rpcErrors } from '@metamask/rpc-errors';
 
+import { makeRequest } from '../../tests/utils';
 import type { MiddlewareScaffold } from './createScaffoldMiddleware';
 import { createScaffoldMiddleware } from './createScaffoldMiddleware';
 import { JsonRpcEngineV2 } from './JsonRpcEngineV2';
-import { makeRequest } from '../../tests/utils';
 
 describe('createScaffoldMiddleware', () => {
   it('basic middleware test', async () => {

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -26,6 +26,19 @@ import { bytesToHex, isValidHexAddress } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
 import { Mutex } from 'async-mutex';
 
+import MockEncryptor, {
+  DECRYPTION_ERROR,
+  MOCK_ENCRYPTION_KEY,
+  SALT,
+} from '../tests/mocks/mockEncryptor';
+import { MockErc4337Keyring } from '../tests/mocks/mockErc4337Keyring';
+import {
+  HardwareWalletError,
+  MockHardwareKeyring,
+} from '../tests/mocks/mockHardwareKeyring';
+import { MockKeyring } from '../tests/mocks/mockKeyring';
+import MockShallowKeyring from '../tests/mocks/mockShallowKeyring';
+import { buildMockTransaction } from '../tests/mocks/mockTransaction';
 import { KeyringControllerErrorMessage } from './constants';
 import { KeyringControllerError } from './errors';
 import type {
@@ -46,19 +59,6 @@ import {
   isCustodyKeyring,
   keyringBuilderFactory,
 } from './KeyringController';
-import MockEncryptor, {
-  DECRYPTION_ERROR,
-  MOCK_ENCRYPTION_KEY,
-  SALT,
-} from '../tests/mocks/mockEncryptor';
-import { MockErc4337Keyring } from '../tests/mocks/mockErc4337Keyring';
-import {
-  HardwareWalletError,
-  MockHardwareKeyring,
-} from '../tests/mocks/mockHardwareKeyring';
-import { MockKeyring } from '../tests/mocks/mockKeyring';
-import MockShallowKeyring from '../tests/mocks/mockShallowKeyring';
-import { buildMockTransaction } from '../tests/mocks/mockTransaction';
 
 type AllKeyringControllerActions = MessengerActions<KeyringControllerMessenger>;
 

--- a/packages/multichain-account-service/src/analytics/perf.test.ts
+++ b/packages/multichain-account-service/src/analytics/perf.test.ts
@@ -1,5 +1,6 @@
 import type { TraceCallback, TraceRequest } from '@metamask/controller-utils';
 
+import { projectLogger } from '../logger';
 import {
   isPerfEnabled,
   log as perfLog,
@@ -7,7 +8,6 @@ import {
   withLocalPerfTrace,
 } from './perf';
 import { now } from './timer';
-import { projectLogger } from '../logger';
 
 jest.mock('./timer', () => ({
   now: jest.fn(),

--- a/packages/multichain-account-service/src/analytics/perf.ts
+++ b/packages/multichain-account-service/src/analytics/perf.ts
@@ -4,8 +4,8 @@ import type {
   TraceRequest,
 } from '@metamask/controller-utils';
 
-import { now } from './timer';
 import { createModuleLogger, projectLogger } from '../logger';
+import { now } from './timer';
 
 export const log = createModuleLogger(projectLogger, 'perf');
 

--- a/packages/multichain-account-service/src/analytics/traces.test.ts
+++ b/packages/multichain-account-service/src/analytics/traces.test.ts
@@ -2,13 +2,13 @@ import type { TraceRequest } from '@metamask/controller-utils';
 import { AccountCreationType } from '@metamask/keyring-api';
 import type { CreateAccountOptions } from '@metamask/keyring-api';
 
+import type { Bip44AccountProvider } from '../providers';
 import {
   toCreateAccountsV2DataTraces,
   toProviderDataTraces,
   traceFallback,
   TraceName,
 } from './traces';
-import type { Bip44AccountProvider } from '../providers';
 
 describe('MultichainAccountService - Traces', () => {
   describe('traceFallback', () => {

--- a/packages/multichain-account-service/src/providers/AccountProviderWrapper.ts
+++ b/packages/multichain-account-service/src/providers/AccountProviderWrapper.ts
@@ -7,8 +7,8 @@ import type {
 } from '@metamask/keyring-api';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 
-import { BaseBip44AccountProvider } from './BaseBip44AccountProvider';
 import type { MultichainAccountServiceMessenger } from '../types';
+import { BaseBip44AccountProvider } from './BaseBip44AccountProvider';
 
 /**
  * A simple wrapper that adds disable functionality to any BaseBip44AccountProvider.

--- a/packages/multichain-account-service/src/providers/BtcAccountProvider.test.ts
+++ b/packages/multichain-account-service/src/providers/BtcAccountProvider.test.ts
@@ -9,13 +9,6 @@ import type {
 import { SnapControllerState } from '@metamask/snaps-controllers';
 import deepmerge from 'deepmerge';
 
-import { AccountProviderWrapper } from './AccountProviderWrapper';
-import {
-  BTC_ACCOUNT_PROVIDER_DEFAULT_CONFIG,
-  BTC_ACCOUNT_PROVIDER_NAME,
-  BtcAccountProvider,
-} from './BtcAccountProvider';
-import type { SnapAccountProviderConfig } from './SnapAccountProvider';
 import { TraceName } from '../analytics/traces';
 import {
   getMultichainAccountServiceMessenger,
@@ -29,6 +22,13 @@ import {
   toGroupIndexRangeArray,
 } from '../tests';
 import type { RootMessenger, DeepPartial } from '../tests';
+import { AccountProviderWrapper } from './AccountProviderWrapper';
+import {
+  BTC_ACCOUNT_PROVIDER_DEFAULT_CONFIG,
+  BTC_ACCOUNT_PROVIDER_NAME,
+  BtcAccountProvider,
+} from './BtcAccountProvider';
+import type { SnapAccountProviderConfig } from './SnapAccountProvider';
 
 function asConfig(
   partial: DeepPartial<SnapAccountProviderConfig>,

--- a/packages/multichain-account-service/src/providers/BtcAccountProvider.ts
+++ b/packages/multichain-account-service/src/providers/BtcAccountProvider.ts
@@ -13,15 +13,15 @@ import {
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 import type { SnapId } from '@metamask/snaps-sdk';
 
+import { traceFallback } from '../analytics';
+import { TraceName } from '../analytics/traces';
+import type { MultichainAccountServiceMessenger } from '../types';
 import { SnapAccountProvider } from './SnapAccountProvider';
 import type {
   RestrictedSnapKeyring,
   SnapAccountProviderConfig,
 } from './SnapAccountProvider';
 import { withRetry, withTimeout } from './utils';
-import { traceFallback } from '../analytics';
-import { TraceName } from '../analytics/traces';
-import type { MultichainAccountServiceMessenger } from '../types';
 
 export type BtcAccountProviderConfig = SnapAccountProviderConfig;
 

--- a/packages/multichain-account-service/src/providers/EvmAccountProvider.test.ts
+++ b/packages/multichain-account-service/src/providers/EvmAccountProvider.test.ts
@@ -14,13 +14,6 @@ import type {
 import type { Hex } from '@metamask/utils';
 import { createBytes } from '@metamask/utils';
 
-import {
-  EVM_ACCOUNT_PROVIDER_DEFAULT_CONFIG,
-  EVM_ACCOUNT_PROVIDER_NAME,
-  EvmAccountProvider,
-  EvmAccountProviderConfig,
-} from './EvmAccountProvider';
-import { TimeoutError } from './utils';
 import { TraceName } from '../analytics/traces';
 import {
   getMultichainAccountServiceMessenger,
@@ -33,6 +26,13 @@ import {
   mockAsInternalAccount,
   RootMessenger,
 } from '../tests';
+import {
+  EVM_ACCOUNT_PROVIDER_DEFAULT_CONFIG,
+  EVM_ACCOUNT_PROVIDER_NAME,
+  EvmAccountProvider,
+  EvmAccountProviderConfig,
+} from './EvmAccountProvider';
+import { TimeoutError } from './utils';
 
 jest.mock('@ethereumjs/util', () => {
   const actual = jest.requireActual('@ethereumjs/util');

--- a/packages/multichain-account-service/src/providers/EvmAccountProvider.ts
+++ b/packages/multichain-account-service/src/providers/EvmAccountProvider.ts
@@ -25,16 +25,16 @@ import type { Provider } from '@metamask/network-controller';
 import { add0x, assert, bytesToHex, isStrictHexString } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
 
+import { traceFallback } from '../analytics';
+import { TraceName } from '../analytics/traces';
+import { projectLogger as log, WARNING_PREFIX } from '../logger';
+import type { MultichainAccountServiceMessenger } from '../types';
 import {
   assertAreBip44Accounts,
   assertIsBip44Account,
   BaseBip44AccountProvider,
 } from './BaseBip44AccountProvider';
 import { withRetry, withTimeout } from './utils';
-import { traceFallback } from '../analytics';
-import { TraceName } from '../analytics/traces';
-import { projectLogger as log, WARNING_PREFIX } from '../logger';
-import type { MultichainAccountServiceMessenger } from '../types';
 
 const ETH_MAINNET_CHAIN_ID = '0x1';
 

--- a/packages/multichain-account-service/src/providers/SnapAccountProvider.test.ts
+++ b/packages/multichain-account-service/src/providers/SnapAccountProvider.test.ts
@@ -20,15 +20,6 @@ import type { InternalAccount } from '@metamask/keyring-internal-api';
 import type { JsonRpcRequest, SnapId } from '@metamask/snaps-sdk';
 import deepmerge from 'deepmerge';
 
-import { BtcAccountProvider } from './BtcAccountProvider';
-import type { SnapAccountProviderConfig } from './SnapAccountProvider';
-import {
-  isSnapAccountProvider,
-  SnapAccountProvider,
-} from './SnapAccountProvider';
-import { SolAccountProvider } from './SolAccountProvider';
-import { TrxAccountProvider } from './TrxAccountProvider';
-import { TimeoutError } from './utils';
 import { traceFallback } from '../analytics';
 import type { DeepPartial, RootMessenger } from '../tests';
 import {
@@ -40,6 +31,15 @@ import {
   MockAccountBuilder,
 } from '../tests';
 import type { MultichainAccountServiceMessenger } from '../types';
+import { BtcAccountProvider } from './BtcAccountProvider';
+import type { SnapAccountProviderConfig } from './SnapAccountProvider';
+import {
+  isSnapAccountProvider,
+  SnapAccountProvider,
+} from './SnapAccountProvider';
+import { SolAccountProvider } from './SolAccountProvider';
+import { TrxAccountProvider } from './TrxAccountProvider';
+import { TimeoutError } from './utils';
 
 jest.mock('../analytics', () => {
   const actual = jest.requireActual('../analytics');

--- a/packages/multichain-account-service/src/providers/SnapAccountProvider.ts
+++ b/packages/multichain-account-service/src/providers/SnapAccountProvider.ts
@@ -21,8 +21,6 @@ import type { Json, JsonRpcRequest, SnapId } from '@metamask/snaps-sdk';
 import { HandlerType } from '@metamask/snaps-utils';
 import { Semaphore } from 'async-mutex';
 
-import { BaseBip44AccountProvider } from './BaseBip44AccountProvider';
-import { withTimeout } from './utils';
 import {
   toCreateAccountsV2DataTraces,
   traceFallback,
@@ -31,6 +29,8 @@ import {
 import { reportError } from '../errors';
 import { projectLogger as log, WARNING_PREFIX } from '../logger';
 import type { MultichainAccountServiceMessenger } from '../types';
+import { BaseBip44AccountProvider } from './BaseBip44AccountProvider';
+import { withTimeout } from './utils';
 
 export type RestrictedSnapKeyring = {
   createAccount: (options: Record<string, Json>) => Promise<KeyringAccount>;

--- a/packages/multichain-account-service/src/providers/SolAccountProvider.test.ts
+++ b/packages/multichain-account-service/src/providers/SolAccountProvider.test.ts
@@ -9,13 +9,6 @@ import type {
 import { SnapControllerState } from '@metamask/snaps-controllers';
 import deepmerge from 'deepmerge';
 
-import { AccountProviderWrapper } from './AccountProviderWrapper';
-import type { SnapAccountProviderConfig } from './SnapAccountProvider';
-import {
-  SOL_ACCOUNT_PROVIDER_DEFAULT_CONFIG,
-  SOL_ACCOUNT_PROVIDER_NAME,
-  SolAccountProvider,
-} from './SolAccountProvider';
 import { TraceName } from '../analytics/traces';
 import {
   getMultichainAccountServiceMessenger,
@@ -28,6 +21,13 @@ import {
   MockAccountBuilder,
 } from '../tests';
 import type { RootMessenger, DeepPartial } from '../tests';
+import { AccountProviderWrapper } from './AccountProviderWrapper';
+import type { SnapAccountProviderConfig } from './SnapAccountProvider';
+import {
+  SOL_ACCOUNT_PROVIDER_DEFAULT_CONFIG,
+  SOL_ACCOUNT_PROVIDER_NAME,
+  SolAccountProvider,
+} from './SolAccountProvider';
 
 function asConfig(
   partial: DeepPartial<SnapAccountProviderConfig>,

--- a/packages/multichain-account-service/src/providers/SolAccountProvider.ts
+++ b/packages/multichain-account-service/src/providers/SolAccountProvider.ts
@@ -16,15 +16,15 @@ import { KeyringTypes } from '@metamask/keyring-controller';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 import type { SnapId } from '@metamask/snaps-sdk';
 
+import { traceFallback } from '../analytics';
+import { TraceName } from '../analytics/traces';
+import type { MultichainAccountServiceMessenger } from '../types';
 import { SnapAccountProvider } from './SnapAccountProvider';
 import type {
   RestrictedSnapKeyring,
   SnapAccountProviderConfig,
 } from './SnapAccountProvider';
 import { withRetry, withTimeout } from './utils';
-import { traceFallback } from '../analytics';
-import { TraceName } from '../analytics/traces';
-import type { MultichainAccountServiceMessenger } from '../types';
 
 export type SolAccountProviderConfig = SnapAccountProviderConfig;
 

--- a/packages/multichain-account-service/src/providers/TrxAccountProvider.test.ts
+++ b/packages/multichain-account-service/src/providers/TrxAccountProvider.test.ts
@@ -9,13 +9,6 @@ import type {
 import { SnapControllerState } from '@metamask/snaps-controllers';
 import deepmerge from 'deepmerge';
 
-import { AccountProviderWrapper } from './AccountProviderWrapper';
-import type { SnapAccountProviderConfig } from './SnapAccountProvider';
-import {
-  TRX_ACCOUNT_PROVIDER_DEFAULT_CONFIG,
-  TRX_ACCOUNT_PROVIDER_NAME,
-  TrxAccountProvider,
-} from './TrxAccountProvider';
 import { TraceName } from '../analytics/traces';
 import {
   getMultichainAccountServiceMessenger,
@@ -28,6 +21,13 @@ import {
   toGroupIndexRangeArray,
 } from '../tests';
 import type { RootMessenger, DeepPartial } from '../tests';
+import { AccountProviderWrapper } from './AccountProviderWrapper';
+import type { SnapAccountProviderConfig } from './SnapAccountProvider';
+import {
+  TRX_ACCOUNT_PROVIDER_DEFAULT_CONFIG,
+  TRX_ACCOUNT_PROVIDER_NAME,
+  TrxAccountProvider,
+} from './TrxAccountProvider';
 
 function asConfig(
   partial: DeepPartial<SnapAccountProviderConfig>,

--- a/packages/multichain-account-service/src/providers/TrxAccountProvider.ts
+++ b/packages/multichain-account-service/src/providers/TrxAccountProvider.ts
@@ -14,15 +14,15 @@ import { KeyringTypes } from '@metamask/keyring-controller';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 import type { SnapId } from '@metamask/snaps-sdk';
 
+import { traceFallback } from '../analytics';
+import { TraceName } from '../analytics/traces';
+import type { MultichainAccountServiceMessenger } from '../types';
 import { SnapAccountProvider } from './SnapAccountProvider';
 import type {
   RestrictedSnapKeyring,
   SnapAccountProviderConfig,
 } from './SnapAccountProvider';
 import { withRetry, withTimeout } from './utils';
-import { traceFallback } from '../analytics';
-import { TraceName } from '../analytics/traces';
-import type { MultichainAccountServiceMessenger } from '../types';
 
 export type TrxAccountProviderConfig = SnapAccountProviderConfig;
 

--- a/packages/multichain-account-service/src/snaps/SnapPlatformWatcher.test.ts
+++ b/packages/multichain-account-service/src/snaps/SnapPlatformWatcher.test.ts
@@ -4,15 +4,15 @@ import { SnapControllerState } from '@metamask/snaps-controllers';
 import { createDeferredPromise } from '@metamask/utils';
 
 import {
-  DEFAULT_SNAP_KEYRING_WAIT_TIMEOUT_MS,
-  SnapPlatformWatcher,
-} from './SnapPlatformWatcher';
-import {
   getMultichainAccountServiceMessenger,
   getRootMessenger,
 } from '../tests';
 import type { RootMessenger } from '../tests';
 import { MultichainAccountServiceMessenger } from '../types';
+import {
+  DEFAULT_SNAP_KEYRING_WAIT_TIMEOUT_MS,
+  SnapPlatformWatcher,
+} from './SnapPlatformWatcher';
 
 function setup(
   {

--- a/packages/multichain-api-middleware/src/middlewares/MultichainSubscriptionManager.test.ts
+++ b/packages/multichain-api-middleware/src/middlewares/MultichainSubscriptionManager.test.ts
@@ -1,8 +1,8 @@
 import createSubscriptionManager from '@metamask/eth-json-rpc-filters/subscriptionManager';
 import type SafeEventEmitter from '@metamask/safe-event-emitter';
 
-import { MultichainSubscriptionManager } from './MultichainSubscriptionManager';
 import { MultichainApiNotifications } from '../handlers/types';
+import { MultichainSubscriptionManager } from './MultichainSubscriptionManager';
 
 jest.mock('@metamask/eth-json-rpc-filters/subscriptionManager', () =>
   jest.fn(),

--- a/packages/multichain-api-middleware/src/middlewares/MultichainSubscriptionManager.ts
+++ b/packages/multichain-api-middleware/src/middlewares/MultichainSubscriptionManager.ts
@@ -6,8 +6,8 @@ import SafeEventEmitter from '@metamask/safe-event-emitter';
 import type { CaipChainId, Hex } from '@metamask/utils';
 import { parseCaipChainId } from '@metamask/utils';
 
-import type { ExtendedJsonRpcMiddleware } from './MultichainMiddlewareManager';
 import { MultichainApiNotifications } from '../handlers/types';
+import type { ExtendedJsonRpcMiddleware } from './MultichainMiddlewareManager';
 
 export type SubscriptionManager = {
   events: SafeEventEmitter;

--- a/packages/multichain-api-middleware/src/middlewares/multichainMethodCallValidatorMiddleware.test.ts
+++ b/packages/multichain-api-middleware/src/middlewares/multichainMethodCallValidatorMiddleware.test.ts
@@ -4,8 +4,8 @@ import type {
   JsonRpcResponse,
 } from '@metamask/utils';
 
-import { multichainMethodCallValidatorMiddleware } from './multichainMethodCallValidatorMiddleware';
 import { MultichainApiNotifications } from '../handlers/types';
+import { multichainMethodCallValidatorMiddleware } from './multichainMethodCallValidatorMiddleware';
 
 describe('multichainMethodCallValidatorMiddleware', () => {
   const mockNext = jest.fn();

--- a/packages/multichain-network-controller/src/MultichainNetworkController/MultichainNetworkController.test.ts
+++ b/packages/multichain-network-controller/src/MultichainNetworkController/MultichainNetworkController.test.ts
@@ -31,12 +31,12 @@ import type {
 import { KnownCaipNamespace } from '@metamask/utils';
 import type { CaipAccountId } from '@metamask/utils';
 
-import { MultichainNetworkController } from './MultichainNetworkController';
 import { createMockInternalAccount } from '../../tests/utils';
 import type { ActiveNetworksResponse } from '../api/accounts-api';
 import { getDefaultMultichainNetworkControllerState } from '../constants';
 import type { AbstractMultichainNetworkService } from '../MultichainNetworkService/AbstractMultichainNetworkService';
 import type { MultichainNetworkControllerMessenger } from '../types';
+import { MultichainNetworkController } from './MultichainNetworkController';
 
 // We exclude the generic account type, since it's used for testing purposes.
 type TestKeyringAccountType = Exclude<

--- a/packages/multichain-network-controller/src/MultichainNetworkService/MultichainNetworkService.test.ts
+++ b/packages/multichain-network-controller/src/MultichainNetworkService/MultichainNetworkService.test.ts
@@ -2,13 +2,13 @@ import { KnownCaipNamespace } from '@metamask/utils';
 import type { CaipAccountId } from '@metamask/utils';
 import { chunk } from 'lodash';
 
-import { MultichainNetworkService } from './MultichainNetworkService';
 import {
   MULTICHAIN_ACCOUNTS_CLIENT_HEADER,
   MULTICHAIN_ACCOUNTS_CLIENT_ID,
   MULTICHAIN_ACCOUNTS_BASE_URL,
 } from '../api/accounts-api';
 import type { ActiveNetworksResponse } from '../api/accounts-api';
+import { MultichainNetworkService } from './MultichainNetworkService';
 
 describe('MultichainNetworkService', () => {
   beforeEach(() => {

--- a/packages/name-controller/src/providers/ens.test.ts
+++ b/packages/name-controller/src/providers/ens.test.ts
@@ -1,5 +1,5 @@
-import { ENSNameProvider } from './ens';
 import { NameType } from '../types';
+import { ENSNameProvider } from './ens';
 
 jest.mock('../util');
 

--- a/packages/name-controller/src/providers/etherscan.test.ts
+++ b/packages/name-controller/src/providers/etherscan.test.ts
@@ -1,7 +1,7 @@
-import { EtherscanNameProvider } from './etherscan';
 import { CHAIN_IDS } from '../constants';
 import { NameType } from '../types';
 import { handleFetch } from '../util';
+import { EtherscanNameProvider } from './etherscan';
 
 jest.mock('../util');
 

--- a/packages/name-controller/src/providers/lens.test.ts
+++ b/packages/name-controller/src/providers/lens.test.ts
@@ -1,6 +1,6 @@
-import { LensNameProvider } from './lens';
 import { NameType } from '../types';
 import { graphQL } from '../util';
+import { LensNameProvider } from './lens';
 
 jest.mock('../util');
 

--- a/packages/name-controller/src/providers/token.test.ts
+++ b/packages/name-controller/src/providers/token.test.ts
@@ -1,6 +1,6 @@
-import { TokenNameProvider } from './token';
 import { NameType } from '../types';
 import { handleFetch } from '../util';
+import { TokenNameProvider } from './token';
 
 jest.mock('../util');
 

--- a/packages/network-controller/src/create-auto-managed-network-client.test.ts
+++ b/packages/network-controller/src/create-auto-managed-network-client.test.ts
@@ -1,6 +1,8 @@
 import { BUILT_IN_NETWORKS, NetworkType } from '@metamask/controller-utils';
 import { PollingBlockTrackerOptions } from '@metamask/eth-block-tracker';
 
+import { mockNetwork } from '../../../tests/mock-network';
+import { buildNetworkControllerMessenger } from '../tests/helpers';
 import { createAutoManagedNetworkClient } from './create-auto-managed-network-client';
 import * as createNetworkClientModule from './create-network-client';
 import { RpcServiceOptions } from './rpc-service/rpc-service';
@@ -9,8 +11,6 @@ import type {
   InfuraNetworkClientConfiguration,
 } from './types';
 import { NetworkClientType } from './types';
-import { mockNetwork } from '../../../tests/mock-network';
-import { buildNetworkControllerMessenger } from '../tests/helpers';
 
 describe('createAutoManagedNetworkClient', () => {
   const networkClientConfigurations: [

--- a/packages/network-controller/src/rpc-service/rpc-service-chain.ts
+++ b/packages/network-controller/src/rpc-service/rpc-service-chain.ts
@@ -10,6 +10,7 @@ import type {
 } from '@metamask/utils';
 import { IDisposable } from 'cockatiel';
 
+import { projectLogger, createModuleLogger } from '../logger';
 import { RpcService } from './rpc-service';
 import type { RpcServiceOptions } from './rpc-service';
 import type {
@@ -18,7 +19,6 @@ import type {
   ExtractCockatielEventData,
   FetchOptions,
 } from './shared';
-import { projectLogger, createModuleLogger } from '../logger';
 
 const log = createModuleLogger(projectLogger, 'RpcServiceChain');
 

--- a/packages/network-controller/src/rpc-service/rpc-service.ts
+++ b/packages/network-controller/src/rpc-service/rpc-service.ts
@@ -20,9 +20,9 @@ import { CircuitState, IDisposable } from 'cockatiel';
 import deepmerge from 'deepmerge';
 import type { Logger } from 'loglevel';
 
+import { projectLogger, createModuleLogger } from '../logger';
 import type { AbstractRpcService } from './abstract-rpc-service';
 import type { FetchOptions } from './shared';
-import { projectLogger, createModuleLogger } from '../logger';
 
 /**
  * Options for the RpcService constructor.

--- a/packages/network-controller/tests/NetworkController.provider.test.ts
+++ b/packages/network-controller/tests/NetworkController.provider.test.ts
@@ -4,12 +4,12 @@ import {
 } from '@metamask/controller-utils';
 import nock from 'nock';
 
+import { NetworkStatus } from '../src/constants';
 import {
   buildCustomNetworkConfiguration,
   buildCustomRpcEndpoint,
   withController,
 } from './helpers';
-import { NetworkStatus } from '../src/constants';
 
 describe('NetworkController provider tests', () => {
   beforeEach(() => {

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -19,24 +19,6 @@ import { when, resetAllWhenMocks, WhenMock } from 'jest-when';
 import { inspect, isDeepStrictEqual, promisify } from 'util';
 import { v4 as uuidV4 } from 'uuid';
 
-import {
-  buildAddNetworkCustomRpcEndpointFields,
-  buildAddNetworkFields,
-  buildCustomNetworkClientConfiguration,
-  buildCustomNetworkConfiguration,
-  buildCustomRpcEndpoint,
-  buildInfuraNetworkClientConfiguration,
-  buildInfuraNetworkConfiguration,
-  buildInfuraRpcEndpoint,
-  buildNetworkConfiguration,
-  buildNetworkControllerMessenger,
-  buildRootMessenger,
-  buildUpdateNetworkCustomRpcEndpointFields,
-  INFURA_NETWORKS,
-  TESTNET,
-  withController,
-} from './helpers';
-import type { RootMessenger } from './helpers';
 import { FakeBlockTracker } from '../../../tests/fake-block-tracker';
 import type { FakeProviderStub } from '../../../tests/fake-provider';
 import { FakeProvider } from '../../../tests/fake-provider';
@@ -67,6 +49,24 @@ import {
 import type { RpcServiceOptions } from '../src/rpc-service/rpc-service';
 import type { NetworkClientConfiguration, Provider } from '../src/types';
 import { NetworkClientType } from '../src/types';
+import {
+  buildAddNetworkCustomRpcEndpointFields,
+  buildAddNetworkFields,
+  buildCustomNetworkClientConfiguration,
+  buildCustomNetworkConfiguration,
+  buildCustomRpcEndpoint,
+  buildInfuraNetworkClientConfiguration,
+  buildInfuraNetworkConfiguration,
+  buildInfuraRpcEndpoint,
+  buildNetworkConfiguration,
+  buildNetworkControllerMessenger,
+  buildRootMessenger,
+  buildUpdateNetworkCustomRpcEndpointFields,
+  INFURA_NETWORKS,
+  TESTNET,
+  withController,
+} from './helpers';
+import type { RootMessenger } from './helpers';
 
 jest.mock('../src/create-network-client');
 

--- a/packages/network-controller/tests/network-client/block-hash-in-response.ts
+++ b/packages/network-controller/tests/network-client/block-hash-in-response.ts
@@ -1,5 +1,7 @@
 import { errorCodes, rpcErrors } from '@metamask/rpc-errors';
 
+import { CUSTOM_RPC_ERRORS } from '../../src/rpc-service/rpc-service';
+import { NetworkClientType } from '../../src/types';
 import type { ProviderType } from './helpers';
 import {
   waitForPromiseToBeFulfilledAfterRunningAllTimers,
@@ -7,8 +9,6 @@ import {
   withNetworkClient,
 } from './helpers';
 import { testsForRpcFailoverBehavior } from './rpc-failover';
-import { CUSTOM_RPC_ERRORS } from '../../src/rpc-service/rpc-service';
-import { NetworkClientType } from '../../src/types';
 
 type TestsForRpcMethodThatCheckForBlockHashInResponseOptions = {
   providerType: ProviderType;

--- a/packages/network-controller/tests/network-client/block-param.ts
+++ b/packages/network-controller/tests/network-client/block-param.ts
@@ -1,6 +1,8 @@
 import { errorCodes, rpcErrors } from '@metamask/rpc-errors';
 import type { Hex } from '@metamask/utils';
 
+import { CUSTOM_RPC_ERRORS } from '../../src/rpc-service/rpc-service';
+import { NetworkClientType } from '../../src/types';
 import type { MockRequest, ProviderType } from './helpers';
 import {
   buildMockParams,
@@ -10,8 +12,6 @@ import {
   withNetworkClient,
 } from './helpers';
 import { testsForRpcFailoverBehavior } from './rpc-failover';
-import { CUSTOM_RPC_ERRORS } from '../../src/rpc-service/rpc-service';
-import { NetworkClientType } from '../../src/types';
 
 type TestsForRpcMethodSupportingBlockParam = {
   providerType: ProviderType;

--- a/packages/network-controller/tests/network-client/no-block-param.ts
+++ b/packages/network-controller/tests/network-client/no-block-param.ts
@@ -1,5 +1,7 @@
 import { errorCodes, rpcErrors } from '@metamask/rpc-errors';
 
+import { CUSTOM_RPC_ERRORS } from '../../src/rpc-service/rpc-service';
+import { NetworkClientType } from '../../src/types';
 import type { ProviderType } from './helpers';
 import {
   waitForPromiseToBeFulfilledAfterRunningAllTimers,
@@ -7,8 +9,6 @@ import {
   withNetworkClient,
 } from './helpers';
 import { testsForRpcFailoverBehavior } from './rpc-failover';
-import { CUSTOM_RPC_ERRORS } from '../../src/rpc-service/rpc-service';
-import { NetworkClientType } from '../../src/types';
 
 type TestsForRpcMethodAssumingNoBlockParamOptions = {
   providerType: ProviderType;

--- a/packages/network-controller/tests/network-client/rpc-failover.ts
+++ b/packages/network-controller/tests/network-client/rpc-failover.ts
@@ -1,10 +1,10 @@
 import { ConstantBackoff } from '@metamask/controller-utils';
 import type { Hex } from '@metamask/utils';
 
-import type { MockRequest, MockResponse, ProviderType } from './helpers';
-import { withMockedCommunications, withNetworkClient } from './helpers';
 import { ignoreRejection } from '../../../../tests/helpers';
 import { buildRootMessenger } from '../helpers';
+import type { MockRequest, MockResponse, ProviderType } from './helpers';
+import { withMockedCommunications, withNetworkClient } from './helpers';
 
 /**
  * Tests for RPC failover behavior.

--- a/packages/network-enablement-controller/src/NetworkEnablementController.test.ts
+++ b/packages/network-enablement-controller/src/NetworkEnablementController.test.ts
@@ -14,6 +14,7 @@ import type { TransactionMeta } from '@metamask/transaction-controller';
 import { KnownCaipNamespace } from '@metamask/utils';
 import type { CaipChainId, CaipNamespace, Hex } from '@metamask/utils';
 
+import { jestAdvanceTime } from '../../../tests/helpers';
 import { POPULAR_NETWORKS } from './constants';
 import { NetworkEnablementController } from './NetworkEnablementController';
 import type {
@@ -21,7 +22,6 @@ import type {
   NativeAssetIdentifiersMap,
 } from './NetworkEnablementController';
 import { Slip44Service } from './services';
-import { jestAdvanceTime } from '../../../tests/helpers';
 
 // Known chainId mappings from chainid.network for mocking
 const chainIdToSlip44: Record<number, number> = {

--- a/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.test.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.test.ts
@@ -15,6 +15,12 @@ import { AuthenticationController } from '@metamask/profile-sync-controller';
 import log from 'loglevel';
 import type nock from 'nock';
 
+import type {
+  NotificationServicesPushControllerDisablePushNotificationsAction,
+  NotificationServicesPushControllerDeletePushNotificationLinksAction,
+  NotificationServicesPushControllerEnablePushNotificationsAction,
+  NotificationServicesPushControllerSubscribeToPushNotificationsAction,
+} from '../NotificationServicesPushController';
 import { ADDRESS_1, ADDRESS_2, ADDRESS_3 } from './__fixtures__/mockAddresses';
 import {
   mockGetOnChainNotificationsConfig,
@@ -46,12 +52,6 @@ import { processNotification } from './processors/process-notifications';
 import { processSnapNotification } from './processors/process-snap-notifications';
 import { notificationsConfigCache } from './services/notification-config-cache';
 import type { INotification, OrderInput } from './types';
-import type {
-  NotificationServicesPushControllerDisablePushNotificationsAction,
-  NotificationServicesPushControllerDeletePushNotificationLinksAction,
-  NotificationServicesPushControllerEnablePushNotificationsAction,
-  NotificationServicesPushControllerSubscribeToPushNotificationsAction,
-} from '../NotificationServicesPushController';
 
 // Mock type used for testing purposes
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.ts
@@ -22,6 +22,11 @@ import { debounce } from 'lodash';
 import log from 'loglevel';
 
 import type { NormalisedAPINotification } from '.';
+import type {
+  NotificationServicesPushControllerStateChangeEvent,
+  NotificationServicesPushControllerOnNewNotificationEvent,
+} from '../NotificationServicesPushController';
+import type { NotificationServicesPushControllerMethodActions } from '../NotificationServicesPushController/NotificationServicesPushController-method-action-types';
 import { TRIGGER_TYPES } from './constants/notification-schema';
 import type { NotificationServicesControllerMethodActions } from './NotificationServicesController-method-action-types';
 import {
@@ -42,11 +47,6 @@ import type {
   MarkAsReadNotificationsParam,
 } from './types/notification/notification';
 import type { OrderInput } from './types/perps';
-import type {
-  NotificationServicesPushControllerStateChangeEvent,
-  NotificationServicesPushControllerOnNewNotificationEvent,
-} from '../NotificationServicesPushController';
-import type { NotificationServicesPushControllerMethodActions } from '../NotificationServicesPushController/NotificationServicesPushController-method-action-types';
 
 // Unique name for the controller
 const controllerName = 'NotificationServicesController';

--- a/packages/notification-services-controller/src/NotificationServicesController/mocks/mockResponses.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/mocks/mockResponses.ts
@@ -1,5 +1,3 @@
-import { createMockFeatureAnnouncementAPIResult } from './mock-feature-announcements';
-import { createMockRawOnChainNotifications } from './mock-raw-notifications';
 import {
   NOTIFICATION_API_LIST_ENDPOINT,
   NOTIFICATION_API_MARK_ALL_AS_READ_ENDPOINT,
@@ -8,6 +6,8 @@ import {
 } from '../services/api-notifications';
 import { FEATURE_ANNOUNCEMENT_API } from '../services/feature-announcements';
 import { PERPS_API_CREATE_ORDERS } from '../services/perp-notifications';
+import { createMockFeatureAnnouncementAPIResult } from './mock-feature-announcements';
+import { createMockRawOnChainNotifications } from './mock-raw-notifications';
 
 type MockResponse = {
   url: string;

--- a/packages/notification-services-controller/src/NotificationServicesController/processors/process-api-notifications.test.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/processors/process-api-notifications.test.ts
@@ -1,4 +1,3 @@
-import { processAPINotifications } from './process-api-notifications';
 import {
   createMockNotificationEthSent,
   createMockNotificationEthReceived,
@@ -17,6 +16,7 @@ import {
   createMockNotificationLidoReadyToBeWithdrawn,
   createMockPlatformNotification,
 } from '../mocks/mock-raw-notifications';
+import { processAPINotifications } from './process-api-notifications';
 
 const rawNotifications = [
   createMockNotificationEthSent(),

--- a/packages/notification-services-controller/src/NotificationServicesController/processors/process-api-notifications.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/processors/process-api-notifications.ts
@@ -1,5 +1,5 @@
-import type { INotification } from '../types/notification/notification';
 import type { NormalisedAPINotification } from '../types/notification-api/notification-api';
+import type { INotification } from '../types/notification/notification';
 import { shouldAutoExpire } from '../utils/should-auto-expire';
 
 /**

--- a/packages/notification-services-controller/src/NotificationServicesController/processors/process-feature-announcement.test.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/processors/process-feature-announcement.test.ts
@@ -1,10 +1,10 @@
+import type { INotification } from '..';
+import { TRIGGER_TYPES } from '../constants/notification-schema';
+import { createMockFeatureAnnouncementRaw } from '../mocks/mock-feature-announcements';
 import {
   isFeatureAnnouncementRead,
   processFeatureAnnouncement,
 } from './process-feature-announcement';
-import type { INotification } from '..';
-import { TRIGGER_TYPES } from '../constants/notification-schema';
-import { createMockFeatureAnnouncementRaw } from '../mocks/mock-feature-announcements';
 
 describe('process-feature-announcement - isFeatureAnnouncementRead()', () => {
   const MOCK_NOTIFICATION_ID = 'MOCK_NOTIFICATION_ID';

--- a/packages/notification-services-controller/src/NotificationServicesController/processors/process-notifications.test.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/processors/process-notifications.test.ts
@@ -1,7 +1,3 @@
-import {
-  processNotification,
-  safeProcessNotification,
-} from './process-notifications';
 import type { TRIGGER_TYPES } from '../constants/notification-schema';
 import { createMockFeatureAnnouncementRaw } from '../mocks/mock-feature-announcements';
 import {
@@ -9,6 +5,10 @@ import {
   createMockPlatformNotification,
 } from '../mocks/mock-raw-notifications';
 import { createMockSnapNotification } from '../mocks/mock-snap-notification';
+import {
+  processNotification,
+  safeProcessNotification,
+} from './process-notifications';
 
 describe('process-notifications - processNotification()', () => {
   // More thorough tests are found in the specific process

--- a/packages/notification-services-controller/src/NotificationServicesController/processors/process-notifications.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/processors/process-notifications.ts
@@ -1,20 +1,20 @@
+import {
+  TRIGGER_TYPES,
+  NOTIFICATION_API_TRIGGER_TYPES_SET,
+} from '../constants/notification-schema';
+import type { FeatureAnnouncementRawNotification } from '../types/feature-announcement/feature-announcement';
+import type { NormalisedAPINotification } from '../types/notification-api/notification-api';
+import type {
+  INotification,
+  RawNotificationUnion,
+} from '../types/notification/notification';
+import type { RawSnapNotification } from '../types/snaps';
 import { processAPINotifications } from './process-api-notifications';
 import {
   isFeatureAnnouncementRead,
   processFeatureAnnouncement,
 } from './process-feature-announcement';
 import { processSnapNotification } from './process-snap-notifications';
-import {
-  TRIGGER_TYPES,
-  NOTIFICATION_API_TRIGGER_TYPES_SET,
-} from '../constants/notification-schema';
-import type { FeatureAnnouncementRawNotification } from '../types/feature-announcement/feature-announcement';
-import type {
-  INotification,
-  RawNotificationUnion,
-} from '../types/notification/notification';
-import type { NormalisedAPINotification } from '../types/notification-api/notification-api';
-import type { RawSnapNotification } from '../types/snaps';
 
 const isOnChainNotification = (
   notification: RawNotificationUnion,

--- a/packages/notification-services-controller/src/NotificationServicesController/processors/process-snap-notifications.test.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/processors/process-snap-notifications.test.ts
@@ -1,7 +1,7 @@
-import { processSnapNotification } from './process-snap-notifications';
 import type { INotification } from '..';
 import { TRIGGER_TYPES } from '../constants';
 import { createMockSnapNotification } from '../mocks';
+import { processSnapNotification } from './process-snap-notifications';
 
 describe('process-snap-notifications - processSnapNotification()', () => {
   it('processes a Raw Snap Notification to a shared Notification Type', () => {

--- a/packages/notification-services-controller/src/NotificationServicesController/services/api-notifications.test.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/services/api-notifications.test.ts
@@ -1,4 +1,3 @@
-import * as OnChainNotifications from './api-notifications';
 import {
   mockGetOnChainNotificationsConfig,
   mockUpdateOnChainNotifications,
@@ -9,6 +8,7 @@ import {
   createMockNotificationERC20Sent,
   createMockPlatformNotification,
 } from '../mocks';
+import * as OnChainNotifications from './api-notifications';
 
 const MOCK_BEARER_TOKEN = 'MOCK_BEARER_TOKEN';
 const MOCK_ADDRESSES = ['0x123', '0x456', '0x789'];

--- a/packages/notification-services-controller/src/NotificationServicesController/services/api-notifications.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/services/api-notifications.ts
@@ -1,6 +1,5 @@
 import log from 'loglevel';
 
-import { notificationsConfigCache } from './notification-config-cache';
 import { toRawAPINotification } from '../../shared/to-raw-notification';
 import type {
   NormalisedAPINotification,
@@ -8,6 +7,7 @@ import type {
   UnprocessedRawNotification,
 } from '../types/notification-api';
 import { makeApiCall } from '../utils/utils';
+import { notificationsConfigCache } from './notification-config-cache';
 
 export type NotificationTrigger = {
   id: string;

--- a/packages/notification-services-controller/src/NotificationServicesController/services/feature-announcements.test.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/services/feature-announcements.test.ts
@@ -1,12 +1,12 @@
+import type { INotification } from '..';
+import { mockFetchFeatureAnnouncementNotifications } from '../__fixtures__/mockServices';
+import { TRIGGER_TYPES } from '../constants/notification-schema';
+import { createMockFeatureAnnouncementAPIResult } from '../mocks/mock-feature-announcements';
 import {
   ContentfulResult,
   getFeatureAnnouncementNotifications,
   getFeatureAnnouncementUrl,
 } from './feature-announcements';
-import type { INotification } from '..';
-import { mockFetchFeatureAnnouncementNotifications } from '../__fixtures__/mockServices';
-import { TRIGGER_TYPES } from '../constants/notification-schema';
-import { createMockFeatureAnnouncementAPIResult } from '../mocks/mock-feature-announcements';
 
 // Mocked type for testing, allows overwriting TS to test erroneous values
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/notification-services-controller/src/NotificationServicesController/services/perp-notifications.test.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/services/perp-notifications.test.ts
@@ -1,6 +1,6 @@
-import { createPerpOrderNotification } from './perp-notifications';
 import { mockCreatePerpNotification } from '../__fixtures__/mockServices';
 import type { OrderInput } from '../types/perps';
+import { createPerpOrderNotification } from './perp-notifications';
 
 const mockOrderInput = (): OrderInput => ({
   user_id: '0x111', // User Address

--- a/packages/notification-services-controller/src/NotificationServicesController/types/feature-announcement/feature-announcement.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/types/feature-announcement/feature-announcement.ts
@@ -1,5 +1,5 @@
-import type { TypeFeatureAnnouncement } from './type-feature-announcement';
 import type { TRIGGER_TYPES } from '../../constants/notification-schema';
+import type { TypeFeatureAnnouncement } from './type-feature-announcement';
 
 export type FeatureAnnouncementRawNotificationData = Omit<
   TypeFeatureAnnouncement['fields'],

--- a/packages/notification-services-controller/src/NotificationServicesController/types/notification-api/notification-api.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/types/notification-api/notification-api.ts
@@ -1,8 +1,8 @@
+import type { TRIGGER_TYPES } from '../../constants/notification-schema';
+import type { Compute } from '../type-utils';
 // Types derived from external Notification API schema - naming follows API conventions
 /* eslint-disable @typescript-eslint/naming-convention */
 import type { components } from './schema';
-import type { TRIGGER_TYPES } from '../../constants/notification-schema';
-import type { Compute } from '../type-utils';
 
 export type Data_MetamaskSwapCompleted =
   components['schemas']['Data_MetamaskSwapCompleted'];

--- a/packages/notification-services-controller/src/NotificationServicesPushController/NotificationServicesPushController.ts
+++ b/packages/notification-services-controller/src/NotificationServicesPushController/NotificationServicesPushController.ts
@@ -8,6 +8,7 @@ import type { Messenger } from '@metamask/messenger';
 import type { AuthenticationController } from '@metamask/profile-sync-controller';
 import log from 'loglevel';
 
+import type { Types } from '../NotificationServicesController';
 import type { NotificationServicesPushControllerMethodActions } from './NotificationServicesPushController-method-action-types';
 import type { ENV } from './services/endpoints';
 import {
@@ -17,7 +18,6 @@ import {
 } from './services/services';
 import type { PushNotificationEnv } from './types';
 import type { PushService } from './types/push-service-interface';
-import type { Types } from '../NotificationServicesController';
 
 const controllerName = 'NotificationServicesPushController';
 

--- a/packages/notification-services-controller/src/NotificationServicesPushController/services/services.test.ts
+++ b/packages/notification-services-controller/src/NotificationServicesPushController/services/services.test.ts
@@ -1,16 +1,16 @@
 import log from 'loglevel';
 
 import {
+  mockEndpointDeletePushNotificationLinks,
+  mockEndpointUpdatePushNotificationLinks,
+} from '../__fixtures__/mockServices';
+import type { PushNotificationEnv } from '../types/firebase';
+import {
   activatePushNotifications,
   deactivatePushNotifications,
   deleteLinksAPI,
   updateLinksAPI,
 } from './services';
-import {
-  mockEndpointDeletePushNotificationLinks,
-  mockEndpointUpdatePushNotificationLinks,
-} from '../__fixtures__/mockServices';
-import type { PushNotificationEnv } from '../types/firebase';
 
 // Testing util to clean up verbose logs when testing errors
 const mockErrorLog = (): jest.SpyInstance =>

--- a/packages/notification-services-controller/src/NotificationServicesPushController/services/services.ts
+++ b/packages/notification-services-controller/src/NotificationServicesPushController/services/services.ts
@@ -1,10 +1,10 @@
-import type { ENV } from './endpoints';
-import * as endpoints from './endpoints';
 import type { PushNotificationEnv } from '../types';
 import type {
   CreateRegToken,
   DeleteRegToken,
 } from '../types/push-service-interface';
+import type { ENV } from './endpoints';
+import * as endpoints from './endpoints';
 
 export type RegToken = {
   token: string;

--- a/packages/notification-services-controller/src/NotificationServicesPushController/utils/get-notification-message.test.ts
+++ b/packages/notification-services-controller/src/NotificationServicesPushController/utils/get-notification-message.test.ts
@@ -1,5 +1,3 @@
-import type { TranslationKeys } from './get-notification-message';
-import { createOnChainPushNotificationMessage } from './get-notification-message';
 import { Processors } from '../../NotificationServicesController';
 import {
   createMockNotificationERC1155Received,
@@ -18,6 +16,8 @@ import {
   createMockNotificationRocketPoolStakeCompleted,
   createMockNotificationRocketPoolUnStakeCompleted,
 } from '../../NotificationServicesController/mocks';
+import type { TranslationKeys } from './get-notification-message';
+import { createOnChainPushNotificationMessage } from './get-notification-message';
 
 const mockTranslations: TranslationKeys = {
   pushPlatformNotificationsFundsSentTitle: () => 'Funds sent',

--- a/packages/notification-services-controller/src/NotificationServicesPushController/utils/get-notification-message.ts
+++ b/packages/notification-services-controller/src/NotificationServicesPushController/utils/get-notification-message.ts
@@ -1,6 +1,6 @@
-import { getAmount, formatAmount } from './get-notification-data';
 import type { Types } from '../../NotificationServicesController';
 import type { Constants } from '../../NotificationServicesController';
+import { getAmount, formatAmount } from './get-notification-data';
 
 export type TranslationKeys = {
   pushPlatformNotificationsFundsSentTitle: () => string;

--- a/packages/notification-services-controller/src/NotificationServicesPushController/web/push-utils.test.ts
+++ b/packages/notification-services-controller/src/NotificationServicesPushController/web/push-utils.test.ts
@@ -2,15 +2,15 @@ import * as FirebaseAppModule from 'firebase/app';
 import * as FirebaseMessagingModule from 'firebase/messaging';
 import * as FirebaseMessagingSWModule from 'firebase/messaging/sw';
 
+import { processNotification } from '../../NotificationServicesController';
+import { createMockNotificationEthSent } from '../../NotificationServicesController/mocks/mock-raw-notifications';
+import { buildPushPlatformNotificationsControllerMessenger } from '../__fixtures__/mockMessenger';
 import {
   createRegToken,
   deleteRegToken,
   createSubscribeToPushNotifications,
 } from './push-utils';
 import * as PushWebModule from './push-utils';
-import { processNotification } from '../../NotificationServicesController';
-import { createMockNotificationEthSent } from '../../NotificationServicesController/mocks/mock-raw-notifications';
-import { buildPushPlatformNotificationsControllerMessenger } from '../__fixtures__/mockMessenger';
 
 jest.mock('firebase/app');
 jest.mock('firebase/messaging');

--- a/packages/permission-controller/src/rpc-methods/getPermissions.test.ts
+++ b/packages/permission-controller/src/rpc-methods/getPermissions.test.ts
@@ -2,8 +2,8 @@ import { JsonRpcEngine } from '@metamask/json-rpc-engine';
 import type { JsonRpcRequest, PendingJsonRpcResponse } from '@metamask/utils';
 import { assertIsJsonRpcSuccess } from '@metamask/utils';
 
-import { getPermissionsHandler } from './getPermissions';
 import type { PermissionConstraint } from '../Permission';
+import { getPermissionsHandler } from './getPermissions';
 
 describe('getPermissions RPC method', () => {
   it('returns the values of the object returned by getPermissionsForOrigin', async () => {

--- a/packages/permission-log-controller/tests/PermissionLogController.test.ts
+++ b/packages/permission-log-controller/tests/PermissionLogController.test.ts
@@ -13,7 +13,6 @@ import { PendingJsonRpcResponseStruct } from '@metamask/utils';
 import type { PendingJsonRpcResponse, JsonRpcRequest } from '@metamask/utils';
 import { nanoid } from 'nanoid';
 
-import { constants, getters, noop } from './helpers';
 import { LOG_LIMIT, LOG_METHOD_TYPES } from '../src/enums';
 import { PermissionLogController } from '../src/PermissionLogController';
 import type {
@@ -21,6 +20,7 @@ import type {
   PermissionLogControllerState,
   PermissionLogControllerMessenger,
 } from '../src/PermissionLogController';
+import { constants, getters, noop } from './helpers';
 
 const { PERMS, RPC_REQUESTS } = getters;
 const { ACCOUNTS, EXPECTED_HISTORIES, SUBJECTS, PERM_NAMES, REQUEST_IDS } =

--- a/packages/perps-controller/src/services/AccountService.ts
+++ b/packages/perps-controller/src/services/AccountService.ts
@@ -1,6 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
 
-import type { ServiceContext } from './ServiceContext';
 import {
   PERPS_EVENT_PROPERTY,
   PERPS_EVENT_VALUE,
@@ -26,6 +25,7 @@ import type { PerpsControllerMessengerBase } from '../types/messenger';
 import type { TransactionStatus } from '../types/transactionTypes';
 import { getSelectedEvmAccount } from '../utils/accountUtils';
 import { ensureError } from '../utils/errorUtils';
+import type { ServiceContext } from './ServiceContext';
 
 /**
  * AccountService

--- a/packages/perps-controller/src/services/DataLakeService.ts
+++ b/packages/perps-controller/src/services/DataLakeService.ts
@@ -1,6 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
 
-import type { ServiceContext } from './ServiceContext';
 import { PerpsMeasurementName } from '../constants/performanceMetrics';
 import {
   DATA_LAKE_API_CONFIG,
@@ -11,6 +10,7 @@ import type { PerpsPlatformDependencies } from '../types';
 import type { PerpsControllerMessengerBase } from '../types/messenger';
 import { getSelectedEvmAccount } from '../utils/accountUtils';
 import { ensureError } from '../utils/errorUtils';
+import type { ServiceContext } from './ServiceContext';
 
 /**
  * DataLakeService

--- a/packages/perps-controller/src/services/FeatureFlagConfigurationService.ts
+++ b/packages/perps-controller/src/services/FeatureFlagConfigurationService.ts
@@ -1,6 +1,5 @@
 import { hasProperty } from '@metamask/utils';
 
-import type { ServiceContext } from './ServiceContext';
 import { PERPS_CONSTANTS } from '../constants/perpsConfig';
 import { isVersionGatedFeatureFlag } from '../types';
 import type {
@@ -13,6 +12,7 @@ import {
   parseCommaSeparatedString,
   stripQuotes,
 } from '../utils/stringParseUtils';
+import type { ServiceContext } from './ServiceContext';
 
 /**
  * FeatureFlagConfigurationService

--- a/packages/perps-controller/src/services/HyperLiquidSubscriptionService.ts
+++ b/packages/perps-controller/src/services/HyperLiquidSubscriptionService.ts
@@ -16,8 +16,6 @@ import type {
   OpenOrdersWsEvent,
 } from '@nktkas/hyperliquid';
 
-import type { HyperLiquidClientService } from './HyperLiquidClientService';
-import type { HyperLiquidWalletService } from './HyperLiquidWalletService';
 import { TP_SL_CONFIG, PERPS_CONSTANTS } from '../constants/perpsConfig';
 import { WebSocketConnectionState } from '../types';
 import type {
@@ -48,6 +46,8 @@ import {
 } from '../utils/hyperLiquidAdapter';
 import { processBboData } from '../utils/hyperLiquidOrderBookProcessor';
 import { calculateOpenInterestUSD } from '../utils/marketDataTransform';
+import type { HyperLiquidClientService } from './HyperLiquidClientService';
+import type { HyperLiquidWalletService } from './HyperLiquidWalletService';
 
 /**
  * Service for managing HyperLiquid WebSocket subscriptions

--- a/packages/perps-controller/src/services/MarketDataService.ts
+++ b/packages/perps-controller/src/services/MarketDataService.ts
@@ -1,6 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
 
-import type { ServiceContext } from './ServiceContext';
 import type { CandlePeriod } from '../constants/chartConfig';
 import { PerpsMeasurementName } from '../constants/performanceMetrics';
 import { PERPS_CONSTANTS } from '../constants/perpsConfig';
@@ -34,6 +33,7 @@ import type {
 } from '../types';
 import type { CandleData } from '../types/perps-types';
 import { ensureError } from '../utils/errorUtils';
+import type { ServiceContext } from './ServiceContext';
 
 /**
  * MarketDataService

--- a/packages/perps-controller/src/services/TradingService.ts
+++ b/packages/perps-controller/src/services/TradingService.ts
@@ -1,7 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
 
-import type { RewardsIntegrationService } from './RewardsIntegrationService';
-import type { ServiceContext } from './ServiceContext';
 import {
   PERPS_EVENT_PROPERTY,
   PERPS_EVENT_VALUE,
@@ -33,6 +31,8 @@ import type {
   PerpsPlatformDependencies,
 } from '../types';
 import { ensureError } from '../utils/errorUtils';
+import type { RewardsIntegrationService } from './RewardsIntegrationService';
+import type { ServiceContext } from './ServiceContext';
 
 /**
  * Controller-level dependencies for TradingService.

--- a/packages/perps-controller/src/types/index.ts
+++ b/packages/perps-controller/src/types/index.ts
@@ -6,8 +6,8 @@ import type {
   Hex,
 } from '@metamask/utils';
 
-import type { CandleData, OrderType } from './perps-types';
 import type { CandlePeriod, TimeDuration } from '../constants/chartConfig';
+import type { CandleData, OrderType } from './perps-types';
 
 /**
  * Connection states for WebSocket management.

--- a/packages/perps-controller/src/utils/hyperLiquidAdapter.ts
+++ b/packages/perps-controller/src/utils/hyperLiquidAdapter.ts
@@ -1,9 +1,5 @@
 import { hasProperty, Hex, isHexString } from '@metamask/utils';
 
-import {
-  countSignificantFigures,
-  roundToSignificantFigures,
-} from './significantFigures';
 import { HIP3_ASSET_ID_CONFIG } from '../constants/hyperLiquidConfig';
 import { DECIMAL_PRECISION_CONFIG } from '../constants/perpsConfig';
 import type {
@@ -23,6 +19,10 @@ import type {
   MetaResponse,
   SDKOrderParams,
 } from '../types/hyperliquid-types';
+import {
+  countSignificantFigures,
+  roundToSignificantFigures,
+} from './significantFigures';
 
 type FrontendOrderWithParentTpsl = FrontendOrder & {
   takeProfitPrice?: unknown;

--- a/packages/perps-controller/src/utils/marketDataTransform.ts
+++ b/packages/perps-controller/src/utils/marketDataTransform.ts
@@ -6,7 +6,6 @@
  */
 import { hasProperty } from '@metamask/utils';
 
-import { parseAssetName } from './hyperLiquidAdapter';
 import { HYPERLIQUID_CONFIG } from '../constants/hyperLiquidConfig';
 import { PERPS_CONSTANTS } from '../constants/perpsConfig';
 import type {
@@ -20,6 +19,7 @@ import type {
   PerpsAssetCtx,
   PredictedFunding,
 } from '../types/hyperliquid-types';
+import { parseAssetName } from './hyperLiquidAdapter';
 
 /**
  * Calculate open interest in USD

--- a/packages/perps-controller/src/utils/orderCalculations.ts
+++ b/packages/perps-controller/src/utils/orderCalculations.ts
@@ -1,16 +1,16 @@
 import type { Hex } from '@metamask/utils';
 
 import {
-  formatHyperLiquidPrice,
-  formatHyperLiquidSize,
-} from './hyperLiquidAdapter';
-import {
   MAX_ORDER_MARGIN_BUFFER,
   ORDER_SLIPPAGE_CONFIG,
 } from '../constants/perpsConfig';
 import { PERPS_ERROR_CODES } from '../perpsErrorCodes';
 import type { PerpsDebugLogger } from '../types';
 import type { SDKOrderParams } from '../types/hyperliquid-types';
+import {
+  formatHyperLiquidPrice,
+  formatHyperLiquidSize,
+} from './hyperLiquidAdapter';
 
 /**
  * Optional debug logger for order calculation functions.

--- a/packages/perps-controller/src/utils/rewardsUtils.ts
+++ b/packages/perps-controller/src/utils/rewardsUtils.ts
@@ -12,8 +12,8 @@ import {
   parseCaipChainId,
 } from '@metamask/utils';
 
-import { ensureError } from './errorUtils';
 import type { PerpsLogger } from '../types';
+import { ensureError } from './errorUtils';
 
 /**
  * Converts a numeric or hex chain ID to a CAIP-2 chain ID string.

--- a/packages/polling-controller/src/StaticIntervalPollingController.test.ts
+++ b/packages/polling-controller/src/StaticIntervalPollingController.test.ts
@@ -2,8 +2,8 @@ import { MOCK_ANY_NAMESPACE, Messenger } from '@metamask/messenger';
 import type { MockAnyNamespace } from '@metamask/messenger';
 import { createDeferredPromise } from '@metamask/utils';
 
-import { StaticIntervalPollingController } from './StaticIntervalPollingController';
 import { jestAdvanceTime } from '../../../tests/helpers';
+import { StaticIntervalPollingController } from './StaticIntervalPollingController';
 
 const TICK_TIME = 5;
 

--- a/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.test.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.test.ts
@@ -6,6 +6,10 @@ import type {
   MockAnyNamespace,
 } from '@metamask/messenger';
 
+import type { LoginResponse } from '../../sdk';
+import { Platform } from '../../sdk';
+import { arrangeAuthAPIs } from '../../sdk/__fixtures__/auth';
+import { MOCK_USER_PROFILE_LINEAGE_RESPONSE } from '../../sdk/mocks/auth';
 import { AuthenticationController } from './AuthenticationController';
 import type {
   AuthenticationControllerMessenger,
@@ -15,10 +19,6 @@ import {
   MOCK_LOGIN_RESPONSE,
   MOCK_OATH_TOKEN_RESPONSE,
 } from './mocks/mockResponses';
-import type { LoginResponse } from '../../sdk';
-import { Platform } from '../../sdk';
-import { arrangeAuthAPIs } from '../../sdk/__fixtures__/auth';
-import { MOCK_USER_PROFILE_LINEAGE_RESPONSE } from '../../sdk/mocks/auth';
 
 const MOCK_ENTROPY_SOURCE_IDS = [
   'MOCK_ENTROPY_SOURCE_ID',

--- a/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.ts
@@ -13,12 +13,6 @@ import type { Messenger } from '@metamask/messenger';
 import type { SnapControllerHandleRequestAction } from '@metamask/snaps-controllers';
 import type { Json } from '@metamask/utils';
 
-import {
-  createSnapPublicKeyRequest,
-  createSnapAllPublicKeysRequest,
-  createSnapSignMessageRequest,
-} from './auth-snap-requests';
-import { AuthenticationControllerMethodActions } from './AuthenticationController-method-action-types';
 import type {
   LoginResponse,
   SRPInterface,
@@ -32,6 +26,12 @@ import {
   JwtBearerAuth,
 } from '../../sdk';
 import type { MetaMetricsAuth } from '../../shared/types/services';
+import {
+  createSnapPublicKeyRequest,
+  createSnapAllPublicKeysRequest,
+  createSnapSignMessageRequest,
+} from './auth-snap-requests';
+import { AuthenticationControllerMethodActions } from './AuthenticationController-method-action-types';
 
 const controllerName = 'AuthenticationController';
 

--- a/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.test.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.test.ts
@@ -1,6 +1,7 @@
 import { deriveStateFromMetadata } from '@metamask/base-controller';
 import type nock from 'nock';
 
+import { USER_STORAGE_FEATURE_NAMES } from '../../shared/storage-schema';
 import { mockUserStorageMessenger } from './__fixtures__/mockMessenger';
 import {
   mockEndpointBatchUpsertUserStorage,
@@ -14,7 +15,6 @@ import {
 import { BACKUPANDSYNC_FEATURES } from './constants';
 import { MOCK_STORAGE_DATA, MOCK_STORAGE_KEY } from './mocks/mockStorage';
 import { UserStorageController, defaultState } from './UserStorageController';
-import { USER_STORAGE_FEATURE_NAMES } from '../../shared/storage-schema';
 
 describe('UserStorageController', () => {
   describe('constructor', () => {

--- a/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/UserStorageController.ts
@@ -26,10 +26,6 @@ import type {
 import type { Messenger } from '@metamask/messenger';
 import type { SnapControllerHandleRequestAction } from '@metamask/snaps-controllers';
 
-import { BACKUPANDSYNC_FEATURES } from './constants';
-import { syncContactsWithUserStorage } from './contact-syncing/controller-integration';
-import { setupContactSyncingSubscriptions } from './contact-syncing/setup-subscriptions';
-import type { UserStorageControllerMethodActions } from './UserStorageController-method-action-types';
 import type {
   UserStorageGenericFeatureKey,
   UserStorageGenericPathWithFeatureAndKey,
@@ -45,6 +41,10 @@ import type {
   AuthenticationControllerIsSignedInAction,
   AuthenticationControllerPerformSignInAction,
 } from '../authentication/AuthenticationController-method-action-types';
+import { BACKUPANDSYNC_FEATURES } from './constants';
+import { syncContactsWithUserStorage } from './contact-syncing/controller-integration';
+import { setupContactSyncingSubscriptions } from './contact-syncing/setup-subscriptions';
+import type { UserStorageControllerMethodActions } from './UserStorageController-method-action-types';
 
 const controllerName = 'UserStorageController';
 

--- a/packages/profile-sync-controller/src/controllers/user-storage/contact-syncing/controller-integration.test.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/contact-syncing/controller-integration.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { AddressBookEntry } from '@metamask/address-book-controller';
 
+import { USER_STORAGE_FEATURE_NAMES } from '../../../shared/storage-schema';
 import {
   MOCK_LOCAL_CONTACTS,
   MOCK_REMOTE_CONTACTS,
@@ -12,7 +13,6 @@ import {
 import * as ContactSyncingControllerIntegrationModule from './controller-integration';
 import * as ContactSyncingUtils from './sync-utils';
 import type { ContactSyncingOptions } from './types';
-import { USER_STORAGE_FEATURE_NAMES } from '../../../shared/storage-schema';
 
 // Mock UserStorageController to avoid json-rpc-engine dependency issues
 class MockUserStorageController {

--- a/packages/profile-sync-controller/src/controllers/user-storage/contact-syncing/controller-integration.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/contact-syncing/controller-integration.ts
@@ -1,5 +1,7 @@
 import type { AddressBookEntry } from '@metamask/address-book-controller';
 
+import { USER_STORAGE_FEATURE_NAMES } from '../../../shared/storage-schema';
+import { TraceName } from '../constants';
 import { canPerformContactSyncing } from './sync-utils';
 import type { ContactSyncingOptions } from './types';
 import type { UserStorageContactEntry } from './types';
@@ -9,8 +11,6 @@ import {
   mapUserStorageEntryToAddressBookEntry,
 } from './utils';
 import { isContactBridgedFromAccounts } from './utils';
-import { USER_STORAGE_FEATURE_NAMES } from '../../../shared/storage-schema';
-import { TraceName } from '../constants';
 
 export type SyncContactsWithUserStorageConfig = {
   onContactSyncErroneousSituation?: (

--- a/packages/profile-sync-controller/src/controllers/user-storage/contact-syncing/types.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/contact-syncing/types.ts
@@ -1,12 +1,12 @@
 import type { TraceCallback } from '@metamask/controller-utils';
 import type { Hex } from '@metamask/utils';
 
+import type { UserStorageControllerMessenger } from '../UserStorageController';
+import type { UserStorageController } from '../UserStorageController';
 import type {
   USER_STORAGE_VERSION_KEY,
   USER_STORAGE_VERSION,
 } from './constants';
-import type { UserStorageControllerMessenger } from '../UserStorageController';
-import type { UserStorageController } from '../UserStorageController';
 
 export type UserStorageContactEntry = {
   /**

--- a/packages/profile-sync-controller/src/controllers/user-storage/mocks/mockResponses.ts
+++ b/packages/profile-sync-controller/src/controllers/user-storage/mocks/mockResponses.ts
@@ -1,8 +1,3 @@
-import {
-  MOCK_ENCRYPTED_STORAGE_DATA,
-  MOCK_STORAGE_DATA,
-  MOCK_STORAGE_KEY,
-} from './mockStorage';
 import { Env, getEnvUrls } from '../../../sdk';
 import type {
   UserStorageGenericPathWithFeatureAndKey,
@@ -16,6 +11,11 @@ import type {
   GetUserStorageAllFeatureEntriesResponse,
   GetUserStorageResponse,
 } from '../types';
+import {
+  MOCK_ENCRYPTED_STORAGE_DATA,
+  MOCK_STORAGE_DATA,
+  MOCK_STORAGE_KEY,
+} from './mockStorage';
 
 type MockResponse = {
   url: string;

--- a/packages/profile-sync-controller/src/sdk/authentication-jwt-bearer/flow-siwe.ts
+++ b/packages/profile-sync-controller/src/sdk/authentication-jwt-bearer/flow-siwe.ts
@@ -1,5 +1,7 @@
 import { SiweMessage } from 'siwe';
 
+import { ValidationError } from '../errors';
+import { validateLoginResponse } from '../utils/validate-login-response';
 import {
   SIWE_LOGIN_URL,
   authenticate,
@@ -16,8 +18,6 @@ import type {
   UserProfile,
   UserProfileLineage,
 } from './types';
-import { ValidationError } from '../errors';
-import { validateLoginResponse } from '../utils/validate-login-response';
 
 type JwtBearerAuth_SIWE_Options = {
   storage: AuthStorageOptions;

--- a/packages/profile-sync-controller/src/sdk/authentication-jwt-bearer/flow-srp.test.ts
+++ b/packages/profile-sync-controller/src/sdk/authentication-jwt-bearer/flow-srp.test.ts
@@ -1,9 +1,9 @@
+import { Env, Platform } from '../../shared/env';
+import { RateLimitedError } from '../errors';
 import { SRPJwtBearerAuth } from './flow-srp';
 import { AuthType } from './types';
 import type { AuthConfig, LoginResponse, UserProfile } from './types';
 import * as timeUtils from './utils/time';
-import { Env, Platform } from '../../shared/env';
-import { RateLimitedError } from '../errors';
 
 jest.setTimeout(15000);
 

--- a/packages/profile-sync-controller/src/sdk/authentication-jwt-bearer/flow-srp.ts
+++ b/packages/profile-sync-controller/src/sdk/authentication-jwt-bearer/flow-srp.ts
@@ -1,5 +1,15 @@
 import type { Eip1193Provider } from 'ethers';
 
+import type { MetaMetricsAuth } from '../../shared/types/services';
+import { ValidationError, RateLimitedError } from '../errors';
+import { getMetaMaskProviderEIP6963 } from '../utils/eip-6963-metamask-provider';
+import {
+  MESSAGE_SIGNING_SNAP,
+  assertMessageStartsWithMetamask,
+  connectSnap,
+  isSnapConnected,
+} from '../utils/messaging-signing-snap-requests';
+import { validateLoginResponse } from '../utils/validate-login-response';
 import {
   authenticate,
   authorizeOIDC,
@@ -17,16 +27,6 @@ import type {
   UserProfileLineage,
 } from './types';
 import * as timeUtils from './utils/time';
-import type { MetaMetricsAuth } from '../../shared/types/services';
-import { ValidationError, RateLimitedError } from '../errors';
-import { getMetaMaskProviderEIP6963 } from '../utils/eip-6963-metamask-provider';
-import {
-  MESSAGE_SIGNING_SNAP,
-  assertMessageStartsWithMetamask,
-  connectSnap,
-  isSnapConnected,
-} from '../utils/messaging-signing-snap-requests';
-import { validateLoginResponse } from '../utils/validate-login-response';
 
 type JwtBearerAuth_SRP_Options = {
   storage: AuthStorageOptions;

--- a/packages/profile-sync-controller/src/sdk/authentication-jwt-bearer/services.test.ts
+++ b/packages/profile-sync-controller/src/sdk/authentication-jwt-bearer/services.test.ts
@@ -1,3 +1,10 @@
+import { Env, Platform } from '../../shared/env';
+import {
+  NonceRetrievalError,
+  SignInError,
+  PairError,
+  RateLimitedError,
+} from '../errors';
 import {
   getNonce,
   authenticate,
@@ -12,13 +19,6 @@ import {
   PROFILE_LINEAGE_URL,
 } from './services';
 import { AuthType } from './types';
-import { Env, Platform } from '../../shared/env';
-import {
-  NonceRetrievalError,
-  SignInError,
-  PairError,
-  RateLimitedError,
-} from '../errors';
 
 // Mock global fetch
 const mockFetch = jest.fn();

--- a/packages/profile-sync-controller/src/sdk/authentication-jwt-bearer/services.ts
+++ b/packages/profile-sync-controller/src/sdk/authentication-jwt-bearer/services.ts
@@ -1,10 +1,3 @@
-import type {
-  AccessToken,
-  ErrorMessage,
-  UserProfile,
-  UserProfileLineage,
-} from './types';
-import { AuthType } from './types';
 import type { Env, Platform } from '../../shared/env';
 import { getEnvUrls, getOidcClientId } from '../../shared/env';
 import type { MetaMetricsAuth } from '../../shared/types/services';
@@ -16,6 +9,13 @@ import {
   ValidationError,
   RateLimitedError,
 } from '../errors';
+import type {
+  AccessToken,
+  ErrorMessage,
+  UserProfile,
+  UserProfileLineage,
+} from './types';
+import { AuthType } from './types';
 
 /**
  * Parse Retry-After header into milliseconds if possible.

--- a/packages/profile-sync-controller/src/sdk/authentication.test.ts
+++ b/packages/profile-sync-controller/src/sdk/authentication.test.ts
@@ -1,5 +1,6 @@
 import type { Eip1193Provider } from 'ethers';
 
+import { Env, Platform } from '../shared/env';
 import { arrangeAuthAPIs } from './__fixtures__/auth';
 import type { MockVariable } from './__fixtures__/test-utils';
 import { arrangeAuth, arrangeMockProvider } from './__fixtures__/test-utils';
@@ -15,7 +16,6 @@ import {
 } from './errors';
 import { MOCK_ACCESS_JWT, MOCK_SRP_LOGIN_RESPONSE } from './mocks/auth';
 import * as Eip6963MetamaskProvider from './utils/eip-6963-metamask-provider';
-import { Env, Platform } from '../shared/env';
 
 const MOCK_SRP = '0x6265617665726275696c642e6f7267';
 const MOCK_ADDRESS = '0x68757d15a4d8d1421c17003512AFce15D3f3FaDa';

--- a/packages/profile-sync-controller/src/sdk/authentication.ts
+++ b/packages/profile-sync-controller/src/sdk/authentication.ts
@@ -1,5 +1,6 @@
 import type { Eip1193Provider } from 'ethers';
 
+import type { Env } from '../shared/env';
 import { SIWEJwtBearerAuth } from './authentication-jwt-bearer/flow-siwe';
 import { SRPJwtBearerAuth } from './authentication-jwt-bearer/flow-srp';
 import {
@@ -13,7 +14,6 @@ import type {
 } from './authentication-jwt-bearer/types';
 import { AuthType } from './authentication-jwt-bearer/types';
 import { PairError, UnsupportedAuthTypeError } from './errors';
-import type { Env } from '../shared/env';
 
 // Computing the Classes, so we only get back the public methods for the interface.
 

--- a/packages/profile-sync-controller/src/sdk/user-storage.test.ts
+++ b/packages/profile-sync-controller/src/sdk/user-storage.test.ts
@@ -1,5 +1,9 @@
 import type { UserStorageGenericFeatureKey } from 'src/shared/storage-schema';
 
+import encryption, { createSHA256Hash } from '../shared/encryption';
+import { SHARED_SALT } from '../shared/encryption/constants';
+import { Env } from '../shared/env';
+import { USER_STORAGE_FEATURE_NAMES } from '../shared/storage-schema';
 import { arrangeAuthAPIs } from './__fixtures__/auth';
 import { arrangeAuth, typedMockFn } from './__fixtures__/test-utils';
 import {
@@ -19,10 +23,6 @@ import {
 } from './mocks/userstorage';
 import type { StorageOptions } from './user-storage';
 import { STORAGE_URL, UserStorage } from './user-storage';
-import encryption, { createSHA256Hash } from '../shared/encryption';
-import { SHARED_SALT } from '../shared/encryption/constants';
-import { Env } from '../shared/env';
-import { USER_STORAGE_FEATURE_NAMES } from '../shared/storage-schema';
 
 const MOCK_SRP = '0x6265617665726275696c642e6f7267';
 const MOCK_ADDRESS = '0x68757d15a4d8d1421c17003512AFce15D3f3FaDa';

--- a/packages/profile-sync-controller/src/sdk/user-storage.ts
+++ b/packages/profile-sync-controller/src/sdk/user-storage.ts
@@ -1,5 +1,3 @@
-import type { IBaseAuth } from './authentication-jwt-bearer/types';
-import { NotFoundError, UserStorageError } from './errors';
 import encryption, { createSHA256Hash } from '../shared/encryption';
 import { SHARED_SALT } from '../shared/encryption/constants';
 import type { Env } from '../shared/env';
@@ -12,6 +10,8 @@ import type {
 } from '../shared/storage-schema';
 import { createEntryPath } from '../shared/storage-schema';
 import type { NativeScrypt } from '../shared/types/encryption';
+import type { IBaseAuth } from './authentication-jwt-bearer/types';
+import { NotFoundError, UserStorageError } from './errors';
 
 export const STORAGE_URL = (env: Env, encryptedPath: string) =>
   `${getEnvUrls(env).userStorageApiUrl}/api/v1/userstorage/${encryptedPath}`;

--- a/packages/profile-sync-controller/src/sdk/utils/eip-6963-metamask-provider.test.ts
+++ b/packages/profile-sync-controller/src/sdk/utils/eip-6963-metamask-provider.test.ts
@@ -1,11 +1,11 @@
 import type { Eip1193Provider } from 'ethers';
 
+import type { MockVariable } from '../__fixtures__/test-utils';
 import type { AnnounceProviderEvent } from './eip-6963-metamask-provider';
 import {
   getMetaMaskProviderEIP6963,
   metamaskClientsRdns,
 } from './eip-6963-metamask-provider';
-import type { MockVariable } from '../__fixtures__/test-utils';
 
 describe('getMetaMaskProviderEIP6963() tests', () => {
   let unsubscribe: undefined | (() => void);

--- a/packages/profile-sync-controller/src/sdk/utils/messaging-signing-snap-requests.test.ts
+++ b/packages/profile-sync-controller/src/sdk/utils/messaging-signing-snap-requests.test.ts
@@ -1,3 +1,5 @@
+import { arrangeMockProvider } from '../__fixtures__/test-utils';
+import type { MockVariable } from '../__fixtures__/test-utils';
 import type { Snap } from './messaging-signing-snap-requests';
 import {
   MESSAGE_SIGNING_SNAP,
@@ -6,8 +8,6 @@ import {
   getSnaps,
   isSnapConnected,
 } from './messaging-signing-snap-requests';
-import { arrangeMockProvider } from '../__fixtures__/test-utils';
-import type { MockVariable } from '../__fixtures__/test-utils';
 
 /**
  * Most of these utilities are wrappers around making wallet requests,

--- a/packages/profile-sync-controller/src/sdk/utils/validate-login-response.test.ts
+++ b/packages/profile-sync-controller/src/sdk/utils/validate-login-response.test.ts
@@ -1,5 +1,5 @@
-import { validateLoginResponse } from './validate-login-response';
 import type { LoginResponse } from '../authentication';
+import { validateLoginResponse } from './validate-login-response';
 
 /**
  * Creates a minimal JWT string with the given payload claims.

--- a/packages/profile-sync-controller/src/shared/encryption/encryption.ts
+++ b/packages/profile-sync-controller/src/shared/encryption/encryption.ts
@@ -4,6 +4,7 @@ import { scryptAsync } from '@noble/hashes/scrypt';
 import { sha256 } from '@noble/hashes/sha256';
 import { utf8ToBytes, concatBytes, bytesToHex } from '@noble/hashes/utils';
 
+import type { NativeScrypt } from '../types/encryption';
 import {
   getCachedKeyBySalt,
   getCachedKeyGeneratedWithSharedSalt,
@@ -25,7 +26,6 @@ import {
   bytesToUtf8,
   stringToByteArray,
 } from './utils';
-import type { NativeScrypt } from '../types/encryption';
 
 export type EncryptedPayload = {
   // version

--- a/packages/profile-sync-controller/src/shared/env.test.ts
+++ b/packages/profile-sync-controller/src/shared/env.test.ts
@@ -1,5 +1,5 @@
-import { getEnvUrls, Env, Platform, getOidcClientId } from './env';
 import type { MockVariable } from '../sdk/__fixtures__/test-utils';
+import { getEnvUrls, Env, Platform, getOidcClientId } from './env';
 
 describe('getEnvUrls', () => {
   it('should return URLs if given a valid environment', () => {

--- a/packages/ramps-controller/src/RampsService.test.ts
+++ b/packages/ramps-controller/src/RampsService.test.ts
@@ -6,10 +6,10 @@ import type {
 } from '@metamask/messenger';
 import nock from 'nock';
 
-import type { RampsServiceMessenger } from './RampsService';
-import { RampsService, RampsEnvironment } from './RampsService';
 import { flushPromises } from '../../../tests/helpers';
 import packageJson from '../package.json';
+import type { RampsServiceMessenger } from './RampsService';
+import { RampsService, RampsEnvironment } from './RampsService';
 
 const CONTROLLER_VERSION = packageJson.version;
 

--- a/packages/ramps-controller/src/RampsService.ts
+++ b/packages/ramps-controller/src/RampsService.ts
@@ -5,8 +5,8 @@ import type {
 import { createServicePolicy, HttpError } from '@metamask/controller-utils';
 import type { Messenger } from '@metamask/messenger';
 
-import type { RampsServiceMethodActions } from './RampsService-method-action-types';
 import packageJson from '../package.json';
+import type { RampsServiceMethodActions } from './RampsService-method-action-types';
 
 /**
  * Represents phone number information for a country.

--- a/packages/ramps-controller/src/TransakService.test.ts
+++ b/packages/ramps-controller/src/TransakService.test.ts
@@ -6,6 +6,7 @@ import type {
 } from '@metamask/messenger';
 import nock, { cleanAll, isDone } from 'nock';
 
+import { flushPromises } from '../../../tests/helpers';
 import type {
   TransakServiceMessenger,
   TransakAccessToken,
@@ -16,7 +17,6 @@ import {
   TransakOrderIdTransformer,
   TransakApiError,
 } from './TransakService';
-import { flushPromises } from '../../../tests/helpers';
 
 // === Test Constants ===
 

--- a/packages/react-data-query/src/createUIQueryClient.test.ts
+++ b/packages/react-data-query/src/createUIQueryClient.test.ts
@@ -7,7 +7,6 @@ import {
   QueryObserver,
 } from '@tanstack/query-core';
 
-import { createUIQueryClient } from './createUIQueryClient';
 import {
   ExampleDataService,
   ExampleDataServiceActions,
@@ -20,6 +19,7 @@ import {
   mockTransactionsPage1,
   mockTransactionsPage2,
 } from '../../base-data-service/tests/mocks';
+import { createUIQueryClient } from './createUIQueryClient';
 
 const DATA_SERVICES = ['ExampleDataService'];
 

--- a/packages/remote-feature-flag-controller/src/client-config-api-service/client-config-api-service.test.ts
+++ b/packages/remote-feature-flag-controller/src/client-config-api-service/client-config-api-service.test.ts
@@ -1,4 +1,3 @@
-import { ClientConfigApiService } from './client-config-api-service';
 import { BASE_URL } from '../constants';
 import type {
   ApiDataResponse,
@@ -9,6 +8,7 @@ import {
   DistributionType,
   EnvironmentType,
 } from '../remote-feature-flag-controller-types';
+import { ClientConfigApiService } from './client-config-api-service';
 
 import Mock = jest.Mock;
 

--- a/packages/remote-feature-flag-controller/src/client-config-api-service/client-config-api-service.ts
+++ b/packages/remote-feature-flag-controller/src/client-config-api-service/client-config-api-service.ts
@@ -7,7 +7,6 @@ import {
 import type { ServicePolicy } from '@metamask/controller-utils';
 import type { IDisposable } from 'cockatiel';
 
-import type { AbstractClientConfigApiService } from './abstract-client-config-api-service';
 import { BASE_URL } from '../constants';
 import type {
   FeatureFlags,
@@ -17,6 +16,7 @@ import type {
   ServiceResponse,
   ApiDataResponse,
 } from '../remote-feature-flag-controller-types';
+import type { AbstractClientConfigApiService } from './abstract-client-config-api-service';
 
 /**
  * This service is responsible for fetching feature flags from the ClientConfig API.

--- a/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.test.ts
+++ b/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.test.ts
@@ -6,6 +6,7 @@ import type {
   MockAnyNamespace,
 } from '@metamask/messenger';
 
+import { flushPromises } from '../../../tests/helpers';
 import type { AbstractClientConfigApiService } from './client-config-api-service/abstract-client-config-api-service';
 import {
   RemoteFeatureFlagController,
@@ -18,7 +19,6 @@ import type {
   RemoteFeatureFlagControllerState,
 } from './remote-feature-flag-controller';
 import type { FeatureFlags } from './remote-feature-flag-controller-types';
-import { flushPromises } from '../../../tests/helpers';
 
 const MOCK_FLAGS: FeatureFlags = {
   feature1: true,

--- a/packages/sample-controllers/src/sample-petnames-controller.test.ts
+++ b/packages/sample-controllers/src/sample-petnames-controller.test.ts
@@ -6,9 +6,9 @@ import type {
   MessengerEvents,
 } from '@metamask/messenger';
 
+import { PROTOTYPE_POLLUTION_BLOCKLIST } from '../../controller-utils/src/util';
 import type { SamplePetnamesControllerMessenger } from './sample-petnames-controller';
 import { SamplePetnamesController } from './sample-petnames-controller';
-import { PROTOTYPE_POLLUTION_BLOCKLIST } from '../../controller-utils/src/util';
 
 describe('SamplePetnamesController', () => {
   describe('constructor', () => {

--- a/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.test.ts
+++ b/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.test.ts
@@ -42,6 +42,24 @@ import { managedNonce } from '@noble/ciphers/webcrypto';
 import { Mutex } from 'async-mutex';
 import type { webcrypto } from 'node:crypto';
 
+import type {
+  MockKeyringControllerMessenger,
+  RootMessenger,
+} from '../tests/__fixtures__/mockMessenger';
+import { mockSeedlessOnboardingMessenger } from '../tests/__fixtures__/mockMessenger';
+import {
+  handleMockSecretDataGet,
+  handleMockSecretDataAdd,
+  handleMockCommitment,
+  handleMockAuthenticate,
+} from '../tests/__fixtures__/topfClient';
+import {
+  createMockSecretDataGetResponse,
+  MULTIPLE_MOCK_SECRET_METADATA,
+} from '../tests/mocks/toprf';
+import { MockToprfEncryptorDecryptor } from '../tests/mocks/toprfEncryptor';
+import { createMockJWTToken } from '../tests/mocks/utils';
+import MockVaultEncryptor from '../tests/mocks/vaultEncryptor';
 import {
   Web3AuthNetwork,
   SeedlessOnboardingControllerErrorMessage,
@@ -63,24 +81,6 @@ import type {
   SeedlessOnboardingControllerState,
   VaultEncryptor,
 } from './types';
-import type {
-  MockKeyringControllerMessenger,
-  RootMessenger,
-} from '../tests/__fixtures__/mockMessenger';
-import { mockSeedlessOnboardingMessenger } from '../tests/__fixtures__/mockMessenger';
-import {
-  handleMockSecretDataGet,
-  handleMockSecretDataAdd,
-  handleMockCommitment,
-  handleMockAuthenticate,
-} from '../tests/__fixtures__/topfClient';
-import {
-  createMockSecretDataGetResponse,
-  MULTIPLE_MOCK_SECRET_METADATA,
-} from '../tests/mocks/toprf';
-import { MockToprfEncryptorDecryptor } from '../tests/mocks/toprfEncryptor';
-import { createMockJWTToken } from '../tests/mocks/utils';
-import MockVaultEncryptor from '../tests/mocks/vaultEncryptor';
 
 const authConnection = AuthConnection.Google;
 const socialLoginEmail = 'user-test@gmail.com';

--- a/packages/seedless-onboarding-controller/src/utils.test.ts
+++ b/packages/seedless-onboarding-controller/src/utils.test.ts
@@ -2,6 +2,7 @@ import { EncAccountDataType } from '@metamask/toprf-secure-backup';
 import { bytesToBase64 } from '@metamask/utils';
 import { utf8ToBytes } from '@noble/ciphers/utils';
 
+import { createMockJWTToken } from '../tests/mocks/utils';
 import type { DecodedNodeAuthToken } from './types';
 import {
   compareTimeuuid,
@@ -11,7 +12,6 @@ import {
   getSecretTypeFromDataType,
   getTimestampFromTimeuuid,
 } from './utils';
-import { createMockJWTToken } from '../tests/mocks/utils';
 
 describe('utils', () => {
   describe('decodeNodeAuthToken', () => {

--- a/packages/seedless-onboarding-controller/tests/mocks/toprf.ts
+++ b/packages/seedless-onboarding-controller/tests/mocks/toprf.ts
@@ -1,7 +1,7 @@
 import { EncAccountDataType } from '@metamask/toprf-secure-backup';
 
-import { MockToprfEncryptorDecryptor } from './toprfEncryptor';
 import { SecretType } from '../../src/constants';
+import { MockToprfEncryptorDecryptor } from './toprfEncryptor';
 
 export const TOPRF_BASE_URL = /https:\/\/node-[1-5]\.dev-node\.web3auth\.io/u;
 

--- a/packages/shield-controller/src/ShieldController.test.ts
+++ b/packages/shield-controller/src/ShieldController.test.ts
@@ -6,13 +6,6 @@ import { TransactionStatus } from '@metamask/transaction-controller';
 import type { TransactionMeta } from '@metamask/transaction-controller';
 import type { TransactionControllerState } from '@metamask/transaction-controller';
 
-import {
-  getDefaultShieldControllerState,
-  ShieldController,
-  ShieldControllerMessenger,
-} from './ShieldController';
-import type { ShieldControllerState } from './ShieldController';
-import type { NormalizeSignatureRequestFn, ShieldBackend } from './types';
 import { TX_META_SIMULATION_DATA_MOCKS } from '../tests/data';
 import { createMockBackend, MOCK_COVERAGE_ID } from '../tests/mocks/backend';
 import { createMockMessenger, RootMessenger } from '../tests/mocks/messenger';
@@ -21,6 +14,13 @@ import {
   generateMockTxMeta,
   setupCoverageResultReceived,
 } from '../tests/utils';
+import {
+  getDefaultShieldControllerState,
+  ShieldController,
+  ShieldControllerMessenger,
+} from './ShieldController';
+import type { ShieldControllerState } from './ShieldController';
+import type { NormalizeSignatureRequestFn, ShieldBackend } from './types';
 
 /**
  * Sets up a ShieldController for testing.

--- a/packages/shield-controller/src/backend.test.ts
+++ b/packages/shield-controller/src/backend.test.ts
@@ -4,16 +4,16 @@ import {
 } from '@metamask/signature-controller';
 
 import {
+  generateMockSignatureRequest,
+  generateMockTxMeta,
+  getRandomCoverageResult,
+} from '../tests/utils';
+import {
   makeInitCoverageCheckBody,
   parseSignatureRequestMethod,
   ShieldRemoteBackend,
 } from './backend';
 import { SignTypedDataVersion } from './constants';
-import {
-  generateMockSignatureRequest,
-  generateMockTxMeta,
-  getRandomCoverageResult,
-} from '../tests/utils';
 
 const mockCaptureException = jest.fn();
 

--- a/packages/shield-controller/src/polling-with-policy.test.ts
+++ b/packages/shield-controller/src/polling-with-policy.test.ts
@@ -1,7 +1,7 @@
 import { HttpError } from '@metamask/controller-utils';
 
-import { PollingWithCockatielPolicy } from './polling-with-policy';
 import { delay } from '../tests/utils';
+import { PollingWithCockatielPolicy } from './polling-with-policy';
 
 describe('PollingWithCockatielPolicy', () => {
   it('should return the success result', async () => {

--- a/packages/shield-controller/tests/utils.ts
+++ b/packages/shield-controller/tests/utils.ts
@@ -11,9 +11,9 @@ import type { TransactionMeta } from '@metamask/transaction-controller';
 import type { SignTypedDataVersion } from 'src/constants';
 import { v1 as random } from 'uuid';
 
-import type { createMockMessenger } from './mocks/messenger';
 import { coverageStatuses } from '../src/types';
 import type { CoverageResult, CoverageStatus } from '../src/types';
+import type { createMockMessenger } from './mocks/messenger';
 
 /**
  * Generate a mock transaction meta.

--- a/packages/signature-controller/src/SignatureController.test.ts
+++ b/packages/signature-controller/src/SignatureController.test.ts
@@ -5,6 +5,7 @@ import { SignTypedDataVersion } from '@metamask/keyring-controller';
 import { LogType, SigningStage } from '@metamask/logging-controller';
 import { v1 } from 'uuid';
 
+import { flushPromises } from '../../../tests/helpers';
 import type {
   SignatureControllerMessenger,
   SignatureControllerOptions,
@@ -24,7 +25,6 @@ import {
   normalizeTypedMessageParams,
 } from './utils/normalize';
 import { validateTypedSignatureRequest } from './utils/validation';
-import { flushPromises } from '../../../tests/helpers';
 
 jest.mock('uuid');
 jest.mock('./utils/validation');

--- a/packages/signature-controller/src/utils/decoding-api.test.ts
+++ b/packages/signature-controller/src/utils/decoding-api.test.ts
@@ -1,6 +1,6 @@
-import { decodeSignature } from './decoding-api';
 import { EthMethod } from '../types';
 import type { OriginalRequest } from '../types';
+import { decodeSignature } from './decoding-api';
 
 const PERMIT_REQUEST_MOCK = {
   method: EthMethod.SignTypedDataV4,

--- a/packages/signature-controller/src/utils/decoding-api.ts
+++ b/packages/signature-controller/src/utils/decoding-api.ts
@@ -1,6 +1,6 @@
-import { normalizeParam } from './normalize';
 import { EthMethod } from '../types';
 import type { OriginalRequest } from '../types';
+import { normalizeParam } from './normalize';
 
 export const DECODING_API_ERRORS = {
   UNSUPPORTED_SIGNATURE: 'UNSUPPORTED_SIGNATURE',

--- a/packages/signature-controller/src/utils/delegations.test.ts
+++ b/packages/signature-controller/src/utils/delegations.test.ts
@@ -1,13 +1,13 @@
 import type { DecodedPermission } from '@metamask/gator-permissions-controller';
 import type { Json } from '@metamask/utils';
 
+import type { SignatureControllerMessenger } from '../SignatureController';
+import type { MessageParamsTyped, MessageParamsTypedData } from '../types';
 import {
   decodePermissionFromRequest,
   isDelegationRequest,
   validateExecutionPermissionMetadata,
 } from './delegations';
-import type { SignatureControllerMessenger } from '../SignatureController';
-import type { MessageParamsTyped, MessageParamsTypedData } from '../types';
 
 describe('delegations utils', () => {
   describe('isDelegationRequest', () => {

--- a/packages/signature-controller/src/utils/normalize.test.ts
+++ b/packages/signature-controller/src/utils/normalize.test.ts
@@ -1,11 +1,11 @@
 import { SignTypedDataVersion } from '@metamask/keyring-controller';
 
+import type { MessageParamsPersonal, MessageParamsTyped } from '../types';
 import {
   normalizeParam,
   normalizePersonalMessageParams,
   normalizeTypedMessageParams,
 } from './normalize';
-import type { MessageParamsPersonal, MessageParamsTyped } from '../types';
 
 describe('Normalize Utils', () => {
   describe('normalizePersonalMessageParams', () => {

--- a/packages/signature-controller/src/utils/validation.test.ts
+++ b/packages/signature-controller/src/utils/validation.test.ts
@@ -3,17 +3,17 @@ import { convertHexToDecimal, toHex } from '@metamask/controller-utils';
 import { SignTypedDataVersion } from '@metamask/keyring-controller';
 import type { Hex } from '@metamask/utils';
 
-import {
-  PRIMARY_TYPE_DELEGATION,
-  validatePersonalSignatureRequest,
-  validateTypedSignatureRequest,
-} from './validation';
 import type {
   MessageParams,
   MessageParamsPersonal,
   MessageParamsTyped,
   OriginalRequest,
 } from '../types';
+import {
+  PRIMARY_TYPE_DELEGATION,
+  validatePersonalSignatureRequest,
+  validateTypedSignatureRequest,
+} from './validation';
 
 const CHAIN_ID_MOCK = '0x1';
 const ORIGIN_MOCK = 'test.com';

--- a/packages/signature-controller/src/utils/validation.ts
+++ b/packages/signature-controller/src/utils/validation.ts
@@ -10,13 +10,13 @@ import type { Json } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
 import { validate } from 'jsonschema';
 
-import { isDelegationRequest } from './delegations';
 import type {
   MessageParamsPersonal,
   MessageParamsTyped,
   MessageParamsTypedData,
   OriginalRequest,
 } from '../types';
+import { isDelegationRequest } from './delegations';
 
 export const PRIMARY_TYPE_DELEGATION = 'Delegation';
 export const DELEGATOR_FIELD = 'delegator';

--- a/packages/subscription-controller/src/SubscriptionController.test.ts
+++ b/packages/subscription-controller/src/SubscriptionController.test.ts
@@ -11,6 +11,8 @@ import {
 } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 
+import { jestAdvanceTime } from '../../../tests/helpers';
+import { generateMockTxMeta } from '../tests/utils';
 import {
   controllerName,
   SubscriptionControllerErrorMessage,
@@ -51,8 +53,6 @@ import {
   SUBSCRIPTION_STATUSES,
   SubscriptionUserEvent,
 } from './types';
-import { jestAdvanceTime } from '../../../tests/helpers';
-import { generateMockTxMeta } from '../tests/utils';
 
 type AllActions = MessengerActions<SubscriptionControllerMessenger>;
 

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -43,6 +43,14 @@ import assert from 'assert';
 // eslint-disable-next-line import-x/namespace
 import * as uuidModule from 'uuid';
 
+import { FakeBlockTracker } from '../../../tests/fake-block-tracker';
+import { FakeProvider } from '../../../tests/fake-provider';
+import { flushPromises } from '../../../tests/helpers';
+import {
+  buildCustomNetworkClientConfiguration,
+  buildMockFindNetworkClientIdByChainId,
+  buildMockGetNetworkClientById,
+} from '../../network-controller/tests/helpers';
 import { CHAIN_IDS } from './constants';
 import { DefaultGasFeeFlow } from './gas-flows/DefaultGasFeeFlow';
 import { LineaGasFeeFlow } from './gas-flows/LineaGasFeeFlow';
@@ -118,14 +126,6 @@ import {
 } from './utils/swaps';
 import * as transactionTypeUtils from './utils/transaction-type';
 import { ErrorCode } from './utils/validation';
-import { FakeBlockTracker } from '../../../tests/fake-block-tracker';
-import { FakeProvider } from '../../../tests/fake-provider';
-import { flushPromises } from '../../../tests/helpers';
-import {
-  buildCustomNetworkClientConfiguration,
-  buildMockFindNetworkClientIdByChainId,
-  buildMockGetNetworkClientById,
-} from '../../network-controller/tests/helpers';
 
 type AllTransactionControllerActions =
   MessengerActions<TransactionControllerMessenger>;

--- a/packages/transaction-controller/src/TransactionControllerIntegration.test.ts
+++ b/packages/transaction-controller/src/TransactionControllerIntegration.test.ts
@@ -35,13 +35,6 @@ import type { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote
 import assert from 'assert';
 import { v4 as uuidV4 } from 'uuid';
 
-import type {
-  TransactionControllerMessenger,
-  TransactionControllerOptions,
-} from './TransactionController';
-import { TransactionController } from './TransactionController';
-import type { InternalAccount } from './types';
-import { TransactionStatus, TransactionType } from './types';
 import { jestAdvanceTime } from '../../../tests/helpers';
 import { mockNetwork } from '../../../tests/mock-network';
 import {
@@ -61,6 +54,13 @@ import {
   buildEthSendRawTransactionRequestMock,
   buildEthGetTransactionReceiptRequestMock,
 } from '../tests/JsonRpcRequestMocks';
+import type {
+  TransactionControllerMessenger,
+  TransactionControllerOptions,
+} from './TransactionController';
+import { TransactionController } from './TransactionController';
+import type { InternalAccount } from './types';
+import { TransactionStatus, TransactionType } from './types';
 
 jest.mock('uuid', () => {
   const actual = jest.requireActual('uuid');

--- a/packages/transaction-controller/src/api/accounts-api.test.ts
+++ b/packages/transaction-controller/src/api/accounts-api.test.ts
@@ -1,6 +1,7 @@
 import { successfulFetch } from '@metamask/controller-utils';
 import type { Hex } from '@metamask/utils';
 
+import { FirstTimeInteractionError } from '../errors';
 import type {
   GetAccountAddressRelationshipRequest,
   GetAccountTransactionsResponse,
@@ -9,7 +10,6 @@ import {
   getAccountAddressRelationship,
   getAccountTransactions,
 } from './accounts-api';
-import { FirstTimeInteractionError } from '../errors';
 
 jest.mock('@metamask/controller-utils', () => ({
   ...jest.requireActual('@metamask/controller-utils'),

--- a/packages/transaction-controller/src/api/simulation-api.test.ts
+++ b/packages/transaction-controller/src/api/simulation-api.test.ts
@@ -2,9 +2,9 @@ import type { Hex } from '@metamask/utils';
 import { cloneDeep } from 'lodash';
 import type { GetSimulationConfig } from 'src';
 
+import { CHAIN_IDS, DELEGATION_MANAGER_ADDRESSES } from '../constants';
 import type { SimulationRequest, SimulationResponse } from './simulation-api';
 import { simulateTransactions } from './simulation-api';
-import { CHAIN_IDS, DELEGATION_MANAGER_ADDRESSES } from '../constants';
 
 const CHAIN_ID_MOCK = '0x1';
 const CHAIN_ID_MOCK_DECIMAL = 1;

--- a/packages/transaction-controller/src/gas-flows/DefaultGasFeeFlow.test.ts
+++ b/packages/transaction-controller/src/gas-flows/DefaultGasFeeFlow.test.ts
@@ -6,7 +6,6 @@ import type {
 } from '@metamask/gas-fee-controller';
 import { GAS_ESTIMATE_TYPES } from '@metamask/gas-fee-controller';
 
-import { DefaultGasFeeFlow } from './DefaultGasFeeFlow';
 import type { TransactionControllerMessenger } from '../TransactionController';
 import type {
   FeeMarketGasFeeEstimates,
@@ -15,6 +14,7 @@ import type {
   TransactionMeta,
 } from '../types';
 import { GasFeeEstimateType, TransactionStatus } from '../types';
+import { DefaultGasFeeFlow } from './DefaultGasFeeFlow';
 
 const TRANSACTION_META_MOCK: TransactionMeta = {
   id: '1',

--- a/packages/transaction-controller/src/gas-flows/LineaGasFeeFlow.test.ts
+++ b/packages/transaction-controller/src/gas-flows/LineaGasFeeFlow.test.ts
@@ -1,8 +1,6 @@
 import type { GasFeeState } from '@metamask/gas-fee-controller';
 import { GAS_ESTIMATE_TYPES } from '@metamask/gas-fee-controller';
 
-import { DefaultGasFeeFlow } from './DefaultGasFeeFlow';
-import { LineaGasFeeFlow } from './LineaGasFeeFlow';
 import { CHAIN_IDS } from '../constants';
 import type { TransactionControllerMessenger } from '../TransactionController';
 import type {
@@ -17,6 +15,8 @@ import {
   TransactionStatus,
 } from '../types';
 import { rpcRequest } from '../utils/provider';
+import { DefaultGasFeeFlow } from './DefaultGasFeeFlow';
+import { LineaGasFeeFlow } from './LineaGasFeeFlow';
 
 jest.mock('../utils/provider', () => ({
   rpcRequest: jest.fn(),

--- a/packages/transaction-controller/src/gas-flows/LineaGasFeeFlow.ts
+++ b/packages/transaction-controller/src/gas-flows/LineaGasFeeFlow.ts
@@ -4,7 +4,6 @@ import { createModuleLogger } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
 import type BN from 'bn.js';
 
-import { DefaultGasFeeFlow } from './DefaultGasFeeFlow';
 import { projectLogger } from '../logger';
 import type { TransactionControllerMessenger } from '../TransactionController';
 import type {
@@ -16,6 +15,7 @@ import type {
 } from '../types';
 import { GasFeeEstimateLevel, GasFeeEstimateType } from '../types';
 import { rpcRequest } from '../utils/provider';
+import { DefaultGasFeeFlow } from './DefaultGasFeeFlow';
 
 type LineaEstimateGasResponse = {
   baseFeePerGas: Hex;

--- a/packages/transaction-controller/src/gas-flows/OptimismLayer1GasFeeFlow.test.ts
+++ b/packages/transaction-controller/src/gas-flows/OptimismLayer1GasFeeFlow.test.ts
@@ -2,11 +2,11 @@ import * as ControllerUtils from '@metamask/controller-utils';
 import { hexToNumber } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
 
-import { OptimismLayer1GasFeeFlow } from './OptimismLayer1GasFeeFlow';
 import { CHAIN_IDS } from '../constants';
 import type { TransactionControllerMessenger } from '../TransactionController';
 import type { TransactionMeta } from '../types';
 import { TransactionStatus } from '../types';
+import { OptimismLayer1GasFeeFlow } from './OptimismLayer1GasFeeFlow';
 
 jest.mock('@metamask/controller-utils', () => {
   const actual = jest.requireActual('@metamask/controller-utils');

--- a/packages/transaction-controller/src/gas-flows/OptimismLayer1GasFeeFlow.ts
+++ b/packages/transaction-controller/src/gas-flows/OptimismLayer1GasFeeFlow.ts
@@ -2,10 +2,10 @@ import { handleFetch } from '@metamask/controller-utils';
 import { hexToNumber } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
 
-import { OracleLayer1GasFeeFlow } from './OracleLayer1GasFeeFlow';
 import { CHAIN_IDS } from '../constants';
 import type { TransactionControllerMessenger } from '../TransactionController';
 import type { TransactionMeta } from '../types';
+import { OracleLayer1GasFeeFlow } from './OracleLayer1GasFeeFlow';
 
 const FALLBACK_OPTIMISM_STACK_CHAIN_IDS: Hex[] = [
   CHAIN_IDS.OPTIMISM,

--- a/packages/transaction-controller/src/gas-flows/OracleLayer1GasFeeFlow.test.ts
+++ b/packages/transaction-controller/src/gas-flows/OracleLayer1GasFeeFlow.test.ts
@@ -6,12 +6,12 @@ import { add0x } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
 import BN from 'bn.js';
 
-import { OracleLayer1GasFeeFlow } from './OracleLayer1GasFeeFlow';
 import { CHAIN_IDS } from '../constants';
 import type { TransactionControllerMessenger } from '../TransactionController';
 import { TransactionStatus } from '../types';
 import type { Layer1GasFeeFlowRequest, TransactionMeta } from '../types';
 import { bnFromHex, padHexToEvenLength } from '../utils/utils';
+import { OracleLayer1GasFeeFlow } from './OracleLayer1GasFeeFlow';
 
 jest.mock('@ethersproject/contracts', () => ({
   Contract: jest.fn(),

--- a/packages/transaction-controller/src/gas-flows/RandomisedEstimationsGasFeeFlow.test.ts
+++ b/packages/transaction-controller/src/gas-flows/RandomisedEstimationsGasFeeFlow.test.ts
@@ -2,11 +2,6 @@ import { toHex } from '@metamask/controller-utils';
 import { GAS_ESTIMATE_TYPES } from '@metamask/gas-fee-controller';
 import type { GasFeeState } from '@metamask/gas-fee-controller';
 
-import { DefaultGasFeeFlow } from './DefaultGasFeeFlow';
-import {
-  RandomisedEstimationsGasFeeFlow,
-  randomiseDecimalGWEIAndConvertToHex,
-} from './RandomisedEstimationsGasFeeFlow';
 import type { TransactionControllerMessenger } from '../TransactionController';
 import type {
   FeeMarketGasFeeEstimates,
@@ -20,6 +15,11 @@ import {
   TransactionStatus,
 } from '../types';
 import { getGasFeeRandomisation } from '../utils/feature-flags';
+import { DefaultGasFeeFlow } from './DefaultGasFeeFlow';
+import {
+  RandomisedEstimationsGasFeeFlow,
+  randomiseDecimalGWEIAndConvertToHex,
+} from './RandomisedEstimationsGasFeeFlow';
 
 jest.mock('./DefaultGasFeeFlow');
 jest.mock('../utils/feature-flags');

--- a/packages/transaction-controller/src/gas-flows/RandomisedEstimationsGasFeeFlow.ts
+++ b/packages/transaction-controller/src/gas-flows/RandomisedEstimationsGasFeeFlow.ts
@@ -3,7 +3,6 @@ import { GAS_ESTIMATE_TYPES } from '@metamask/gas-fee-controller';
 import { add0x, createModuleLogger } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
 
-import { DefaultGasFeeFlow } from './DefaultGasFeeFlow';
 import { projectLogger } from '../logger';
 import type { TransactionControllerMessenger } from '../TransactionController';
 import type {
@@ -20,6 +19,7 @@ import {
   gweiDecimalToWeiDecimal,
   gweiDecimalToWeiHex,
 } from '../utils/gas-fees';
+import { DefaultGasFeeFlow } from './DefaultGasFeeFlow';
 
 const log = createModuleLogger(
   projectLogger,

--- a/packages/transaction-controller/src/gas-flows/ScrollLayer1GasFeeFlow.test.ts
+++ b/packages/transaction-controller/src/gas-flows/ScrollLayer1GasFeeFlow.test.ts
@@ -1,10 +1,10 @@
 import type { Hex } from '@metamask/utils';
 
-import { ScrollLayer1GasFeeFlow } from './ScrollLayer1GasFeeFlow';
 import { CHAIN_IDS } from '../constants';
 import type { TransactionControllerMessenger } from '../TransactionController';
 import type { TransactionMeta } from '../types';
 import { TransactionStatus } from '../types';
+import { ScrollLayer1GasFeeFlow } from './ScrollLayer1GasFeeFlow';
 
 const TRANSACTION_META_MOCK: TransactionMeta = {
   id: '1',

--- a/packages/transaction-controller/src/gas-flows/ScrollLayer1GasFeeFlow.ts
+++ b/packages/transaction-controller/src/gas-flows/ScrollLayer1GasFeeFlow.ts
@@ -1,9 +1,9 @@
 import type { Hex } from '@metamask/utils';
 
-import { OracleLayer1GasFeeFlow } from './OracleLayer1GasFeeFlow';
 import { CHAIN_IDS } from '../constants';
 import type { TransactionControllerMessenger } from '../TransactionController';
 import type { TransactionMeta } from '../types';
+import { OracleLayer1GasFeeFlow } from './OracleLayer1GasFeeFlow';
 
 const SCROLL_CHAIN_IDS: Hex[] = [CHAIN_IDS.SCROLL, CHAIN_IDS.SCROLL_SEPOLIA];
 

--- a/packages/transaction-controller/src/gas-flows/TestGasFeeFlow.test.ts
+++ b/packages/transaction-controller/src/gas-flows/TestGasFeeFlow.test.ts
@@ -1,6 +1,6 @@
-import { TestGasFeeFlow } from './TestGasFeeFlow';
 import { GasFeeEstimateType } from '../types';
 import type { GasFeeFlowRequest } from '../types';
+import { TestGasFeeFlow } from './TestGasFeeFlow';
 
 describe('TestGasFeeFlow', () => {
   describe('matchesTransaction', () => {

--- a/packages/transaction-controller/src/helpers/AccountsApiRemoteTransactionSource.test.ts
+++ b/packages/transaction-controller/src/helpers/AccountsApiRemoteTransactionSource.test.ts
@@ -1,7 +1,3 @@
-import {
-  AccountsApiRemoteTransactionSource,
-  SUPPORTED_CHAIN_IDS,
-} from './AccountsApiRemoteTransactionSource';
 import type {
   GetAccountTransactionsResponse,
   TransactionResponse,
@@ -10,6 +6,10 @@ import { getAccountTransactions } from '../api/accounts-api';
 import { TransactionType } from '../types';
 import type { RemoteTransactionSourceRequest } from '../types';
 import { determineTransactionType } from '../utils/transaction-type';
+import {
+  AccountsApiRemoteTransactionSource,
+  SUPPORTED_CHAIN_IDS,
+} from './AccountsApiRemoteTransactionSource';
 
 jest.mock('../api/accounts-api');
 jest.mock('../utils/transaction-type');

--- a/packages/transaction-controller/src/helpers/GasFeePoller.test.ts
+++ b/packages/transaction-controller/src/helpers/GasFeePoller.test.ts
@@ -1,11 +1,6 @@
 /* eslint-disable no-new */
 import type { Hex } from '@metamask/utils';
 
-import {
-  GasFeePoller,
-  updateTransactionGasProperties,
-  updateTransactionGasEstimates,
-} from './GasFeePoller';
 import { flushPromises } from '../../../../tests/helpers';
 import { DefaultGasFeeFlow } from '../gas-flows/DefaultGasFeeFlow';
 import type { TransactionControllerMessenger } from '../TransactionController';
@@ -23,6 +18,11 @@ import type {
 } from '../types';
 import type { GasFeeFlow, GasFeeEstimates, TransactionMeta } from '../types';
 import { getTransactionLayer1GasFee } from '../utils/layer1-gas-fee-flow';
+import {
+  GasFeePoller,
+  updateTransactionGasProperties,
+  updateTransactionGasEstimates,
+} from './GasFeePoller';
 
 jest.mock('../utils/feature-flags');
 jest.mock('../utils/layer1-gas-fee-flow', () => ({

--- a/packages/transaction-controller/src/helpers/IncomingTransactionHelper.test.ts
+++ b/packages/transaction-controller/src/helpers/IncomingTransactionHelper.test.ts
@@ -4,11 +4,6 @@ import type {
 } from '@metamask/core-backend';
 import type { Hex } from '@metamask/utils';
 
-import { SUPPORTED_CHAIN_IDS } from './AccountsApiRemoteTransactionSource';
-import {
-  IncomingTransactionHelper,
-  WebSocketState,
-} from './IncomingTransactionHelper';
 import type { TransactionControllerMessenger } from '..';
 import { flushPromises } from '../../../../tests/helpers';
 import { TransactionStatus, TransactionType } from '../types';
@@ -17,6 +12,11 @@ import {
   getIncomingTransactionsPollingInterval,
   isIncomingTransactionsUseBackendWebSocketServiceEnabled,
 } from '../utils/feature-flags';
+import { SUPPORTED_CHAIN_IDS } from './AccountsApiRemoteTransactionSource';
+import {
+  IncomingTransactionHelper,
+  WebSocketState,
+} from './IncomingTransactionHelper';
 
 jest.useFakeTimers();
 

--- a/packages/transaction-controller/src/helpers/IncomingTransactionHelper.ts
+++ b/packages/transaction-controller/src/helpers/IncomingTransactionHelper.ts
@@ -8,7 +8,6 @@ import type { Hex } from '@metamask/utils';
 // eslint-disable-next-line import-x/no-nodejs-modules
 import EventEmitter from 'events';
 
-import { SUPPORTED_CHAIN_IDS } from './AccountsApiRemoteTransactionSource';
 import type { TransactionControllerMessenger } from '..';
 import { incomingTransactionsLogger as log } from '../logger';
 import type { RemoteTransactionSource, TransactionMeta } from '../types';
@@ -17,6 +16,7 @@ import {
   isIncomingTransactionsUseBackendWebSocketServiceEnabled,
 } from '../utils/feature-flags';
 import { caip2ToHex } from '../utils/utils';
+import { SUPPORTED_CHAIN_IDS } from './AccountsApiRemoteTransactionSource';
 
 export enum WebSocketState {
   CONNECTED = 'connected',

--- a/packages/transaction-controller/src/helpers/MethodDataHelper.test.ts
+++ b/packages/transaction-controller/src/helpers/MethodDataHelper.test.ts
@@ -1,11 +1,11 @@
 import { MethodRegistry } from 'eth-method-registry';
 
-import { MethodDataHelper } from './MethodDataHelper';
 import type {
   MethodData,
   TransactionControllerMessenger,
 } from '../TransactionController';
 import { getProvider } from '../utils/provider';
+import { MethodDataHelper } from './MethodDataHelper';
 
 jest.mock('eth-method-registry');
 

--- a/packages/transaction-controller/src/helpers/MultichainTrackingHelper.test.ts
+++ b/packages/transaction-controller/src/helpers/MultichainTrackingHelper.test.ts
@@ -7,12 +7,12 @@ import type {
 import type { NonceTracker } from '@metamask/nonce-tracker';
 import type { Hex } from '@metamask/utils';
 
+import { jestAdvanceTime } from '../../../../tests/helpers';
 import {
   MultichainTrackingHelper,
   MultichainTrackingHelperOptions,
 } from './MultichainTrackingHelper';
 import type { PendingTransactionTracker } from './PendingTransactionTracker';
-import { jestAdvanceTime } from '../../../../tests/helpers';
 
 jest.mock(
   '@metamask/eth-query',

--- a/packages/transaction-controller/src/helpers/MultichainTrackingHelper.ts
+++ b/packages/transaction-controller/src/helpers/MultichainTrackingHelper.ts
@@ -10,8 +10,8 @@ import type { NonceLock, NonceTracker } from '@metamask/nonce-tracker';
 import type { Hex } from '@metamask/utils';
 import { Mutex } from 'async-mutex';
 
-import type { PendingTransactionTracker } from './PendingTransactionTracker';
 import { createModuleLogger, projectLogger } from '../logger';
+import type { PendingTransactionTracker } from './PendingTransactionTracker';
 
 /**
  * Registry of network clients provided by the NetworkController

--- a/packages/transaction-controller/src/helpers/PendingTransactionTracker.test.ts
+++ b/packages/transaction-controller/src/helpers/PendingTransactionTracker.test.ts
@@ -2,12 +2,12 @@ import type { BlockTracker } from '@metamask/network-controller';
 import { Json } from '@metamask/utils';
 import { freeze } from 'immer';
 
-import { PendingTransactionTracker } from './PendingTransactionTracker';
-import { TransactionPoller } from './TransactionPoller';
 import type { TransactionControllerMessenger } from '../TransactionController';
 import type { TransactionMeta } from '../types';
 import { TransactionStatus } from '../types';
 import { rpcRequest } from '../utils/provider';
+import { PendingTransactionTracker } from './PendingTransactionTracker';
+import { TransactionPoller } from './TransactionPoller';
 
 const ID_MOCK = 'testId';
 const CHAIN_ID_MOCK = '0x1';

--- a/packages/transaction-controller/src/helpers/PendingTransactionTracker.ts
+++ b/packages/transaction-controller/src/helpers/PendingTransactionTracker.ts
@@ -8,7 +8,6 @@ import type { Json } from '@metamask/utils';
 import EventEmitter from 'events';
 import { cloneDeep, merge } from 'lodash';
 
-import { TransactionPoller } from './TransactionPoller';
 import { createModuleLogger, projectLogger } from '../logger';
 import type { TransactionControllerMessenger } from '../TransactionController';
 import type { TransactionMeta, TransactionReceipt } from '../types';
@@ -18,6 +17,7 @@ import {
   getTimeoutAttempts,
 } from '../utils/feature-flags';
 import { getChainId, rpcRequest } from '../utils/provider';
+import { TransactionPoller } from './TransactionPoller';
 
 /**
  * We wait this many blocks before emitting a 'transaction-dropped' event

--- a/packages/transaction-controller/src/helpers/ResimulateHelper.test.ts
+++ b/packages/transaction-controller/src/helpers/ResimulateHelper.test.ts
@@ -2,6 +2,15 @@ import { NetworkType } from '@metamask/controller-utils';
 import type { NetworkClientId } from '@metamask/network-controller';
 import { BN } from 'bn.js';
 
+import { CHAIN_IDS } from '../constants';
+import type {
+  TransactionMeta,
+  SecurityAlertResponse,
+  SimulationData,
+  SimulationTokenBalanceChange,
+} from '../types';
+import { TransactionStatus, SimulationTokenStandard } from '../types';
+import { getPercentageChange } from '../utils/utils';
 import {
   ResimulateHelper,
   BLOCK_TIME_ADDITIONAL_SECONDS,
@@ -13,15 +22,6 @@ import {
   RESIMULATE_INTERVAL_MS,
 } from './ResimulateHelper';
 import type { ResimulateHelperOptions } from './ResimulateHelper';
-import { CHAIN_IDS } from '../constants';
-import type {
-  TransactionMeta,
-  SecurityAlertResponse,
-  SimulationData,
-  SimulationTokenBalanceChange,
-} from '../types';
-import { TransactionStatus, SimulationTokenStandard } from '../types';
-import { getPercentageChange } from '../utils/utils';
 
 const CURRENT_TIME_MOCK = 1234567890;
 const CURRENT_TIME_SECONDS_MOCK = 1234567;

--- a/packages/transaction-controller/src/helpers/TransactionPoller.test.ts
+++ b/packages/transaction-controller/src/helpers/TransactionPoller.test.ts
@@ -1,10 +1,10 @@
 import type { Transaction } from '@metamask/core-backend';
 import type { BlockTracker } from '@metamask/network-controller';
 
-import { TransactionPoller } from './TransactionPoller';
 import { flushPromises } from '../../../../tests/helpers';
 import type { TransactionControllerMessenger } from '../TransactionController';
 import type { TransactionMeta } from '../types';
+import { TransactionPoller } from './TransactionPoller';
 
 jest.useFakeTimers();
 

--- a/packages/transaction-controller/src/hooks/CollectPublishHook.test.ts
+++ b/packages/transaction-controller/src/hooks/CollectPublishHook.test.ts
@@ -1,8 +1,8 @@
 import { noop } from 'lodash';
 
-import { CollectPublishHook } from './CollectPublishHook';
 import type { TransactionMeta } from '..';
 import { flushPromises } from '../../../../tests/helpers';
+import { CollectPublishHook } from './CollectPublishHook';
 
 const SIGNED_TX_MOCK = '0x123';
 const SIGNED_TX_2_MOCK = '0x456';

--- a/packages/transaction-controller/src/hooks/ExtraTransactionsPublishHook.test.ts
+++ b/packages/transaction-controller/src/hooks/ExtraTransactionsPublishHook.test.ts
@@ -1,6 +1,5 @@
 import type { Hex } from '@metamask/utils';
 
-import { ExtraTransactionsPublishHook } from './ExtraTransactionsPublishHook';
 import type {
   BatchTransactionParams,
   TransactionController,
@@ -8,6 +7,7 @@ import type {
 } from '..';
 import type { BatchTransaction } from '../types';
 import { TransactionType } from '../types';
+import { ExtraTransactionsPublishHook } from './ExtraTransactionsPublishHook';
 
 const SIGNED_TRANSACTION_MOCK = '0xffe';
 const SIGNED_TRANSACTION_2_MOCK = '0xfff' as Hex;

--- a/packages/transaction-controller/src/hooks/SequentialPublishBatchHook.test.ts
+++ b/packages/transaction-controller/src/hooks/SequentialPublishBatchHook.test.ts
@@ -1,9 +1,9 @@
 import type { Hex } from '@metamask/utils';
 
-import { SequentialPublishBatchHook } from './SequentialPublishBatchHook';
 import { flushPromises } from '../../../../tests/helpers';
 import type { PendingTransactionTracker } from '../helpers/PendingTransactionTracker';
 import type { PublishBatchHookTransaction, TransactionMeta } from '../types';
+import { SequentialPublishBatchHook } from './SequentialPublishBatchHook';
 
 const TRANSACTION_HASH_MOCK = '0x123';
 const TRANSACTION_HASH_2_MOCK = '0x456';

--- a/packages/transaction-controller/src/utils/balance-changes.test.ts
+++ b/packages/transaction-controller/src/utils/balance-changes.test.ts
@@ -3,9 +3,6 @@ import { Interface } from '@ethersproject/abi';
 import type { NetworkClientId } from '@metamask/network-controller';
 import type { Hex } from '@metamask/utils';
 
-import type { GetBalanceChangesRequest } from './balance-changes';
-import { getBalanceChanges, SupportedToken } from './balance-changes';
-import { rpcRequest } from './provider';
 import { simulateTransactions } from '../api/simulation-api';
 import type {
   SimulationResponseLog,
@@ -19,6 +16,9 @@ import {
 import type { TransactionControllerMessenger } from '../TransactionController';
 import type { GetSimulationConfig } from '../types';
 import { SimulationErrorCode, SimulationTokenStandard } from '../types';
+import type { GetBalanceChangesRequest } from './balance-changes';
+import { getBalanceChanges, SupportedToken } from './balance-changes';
+import { rpcRequest } from './provider';
 
 jest.mock('../api/simulation-api');
 

--- a/packages/transaction-controller/src/utils/balance-changes.ts
+++ b/packages/transaction-controller/src/utils/balance-changes.ts
@@ -7,7 +7,6 @@ import { createModuleLogger } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
 import BN from 'bn.js';
 
-import { getNativeBalance } from './balance';
 import { simulateTransactions } from '../api/simulation-api';
 import type {
   SimulationResponseLog,
@@ -38,6 +37,7 @@ import type {
   GetSimulationConfig,
 } from '../types';
 import { SimulationTokenStandard } from '../types';
+import { getNativeBalance } from './balance';
 
 export enum SupportedToken {
   ERC20 = 'erc20',

--- a/packages/transaction-controller/src/utils/balance.test.ts
+++ b/packages/transaction-controller/src/utils/balance.test.ts
@@ -1,10 +1,10 @@
 import { toHex } from '@metamask/controller-utils';
 import type { NetworkClientId } from '@metamask/network-controller';
 
-import { getNativeBalance, isNativeBalanceSufficientForGas } from './balance';
-import { rpcRequest } from './provider';
 import type { TransactionMeta } from '..';
 import type { TransactionControllerMessenger } from '../TransactionController';
+import { getNativeBalance, isNativeBalanceSufficientForGas } from './balance';
+import { rpcRequest } from './provider';
 
 jest.mock('./provider', () => ({
   rpcRequest: jest.fn(),

--- a/packages/transaction-controller/src/utils/balance.ts
+++ b/packages/transaction-controller/src/utils/balance.ts
@@ -2,9 +2,9 @@ import type { NetworkClientId } from '@metamask/network-controller';
 import type { Hex } from '@metamask/utils';
 import { BigNumber } from 'bignumber.js';
 
-import { rpcRequest } from './provider';
 import type { TransactionMeta } from '..';
 import type { TransactionControllerMessenger } from '../TransactionController';
+import { rpcRequest } from './provider';
 
 /**
  * Get the native balance for an address.

--- a/packages/transaction-controller/src/utils/batch.test.ts
+++ b/packages/transaction-controller/src/utils/batch.test.ts
@@ -5,24 +5,6 @@ import { rpcErrors, errorCodes } from '@metamask/rpc-errors';
 import { cloneDeep } from 'lodash';
 
 import {
-  ERROR_MESSAGE_NO_UPGRADE_CONTRACT,
-  addTransactionBatch,
-  isAtomicBatchSupported,
-} from './batch';
-import {
-  ERROR_MESSGE_PUBLIC_KEY,
-  doesChainSupportEIP7702,
-  generateEIP7702BatchTransaction,
-  isAccountUpgradedToEIP7702,
-} from './eip7702';
-import {
-  getEIP7702SupportedChains,
-  getEIP7702UpgradeContractAddress,
-} from './feature-flags';
-import { simulateGasBatch } from './gas';
-import { determineTransactionType } from './transaction-type';
-import { validateBatchRequest } from './validation';
-import {
   TransactionEnvelopeType,
   TransactionType,
   GasFeeEstimateLevel,
@@ -43,6 +25,24 @@ import type {
   RequiredAsset,
   TransactionBatchSingleRequest,
 } from '../types';
+import {
+  ERROR_MESSAGE_NO_UPGRADE_CONTRACT,
+  addTransactionBatch,
+  isAtomicBatchSupported,
+} from './batch';
+import {
+  ERROR_MESSGE_PUBLIC_KEY,
+  doesChainSupportEIP7702,
+  generateEIP7702BatchTransaction,
+  isAccountUpgradedToEIP7702,
+} from './eip7702';
+import {
+  getEIP7702SupportedChains,
+  getEIP7702UpgradeContractAddress,
+} from './feature-flags';
+import { simulateGasBatch } from './gas';
+import { determineTransactionType } from './transaction-type';
+import { validateBatchRequest } from './validation';
 
 jest.mock('./eip7702');
 jest.mock('./feature-flags');

--- a/packages/transaction-controller/src/utils/batch.ts
+++ b/packages/transaction-controller/src/utils/batch.ts
@@ -18,21 +18,6 @@ import { bytesToHex, createModuleLogger } from '@metamask/utils';
 import type { WritableDraft } from 'immer/dist/internal.js';
 import { parse, v4 } from 'uuid';
 
-import {
-  ERROR_MESSGE_PUBLIC_KEY,
-  doesChainSupportEIP7702,
-  generateEIP7702BatchTransaction,
-  isAccountUpgradedToEIP7702,
-} from './eip7702';
-import {
-  getBatchSizeLimit,
-  getEIP7702SupportedChains,
-  getEIP7702UpgradeContractAddress,
-} from './feature-flags';
-import { simulateGasBatch } from './gas';
-import { getChainId } from './provider';
-import { determineTransactionType } from './transaction-type';
-import { validateBatchRequest } from './validation';
 import { GasFeeEstimateLevel, TransactionStatus } from '..';
 import type {
   BatchTransactionParams,
@@ -64,6 +49,21 @@ import type {
   TransactionBatchMeta,
 } from '../types';
 import type { TransactionBatchResult, TransactionParams } from '../types';
+import {
+  ERROR_MESSGE_PUBLIC_KEY,
+  doesChainSupportEIP7702,
+  generateEIP7702BatchTransaction,
+  isAccountUpgradedToEIP7702,
+} from './eip7702';
+import {
+  getBatchSizeLimit,
+  getEIP7702SupportedChains,
+  getEIP7702UpgradeContractAddress,
+} from './feature-flags';
+import { simulateGasBatch } from './gas';
+import { getChainId } from './provider';
+import { determineTransactionType } from './transaction-type';
+import { validateBatchRequest } from './validation';
 
 type UpdateStateCallback = (
   callback: (

--- a/packages/transaction-controller/src/utils/eip7702.test.ts
+++ b/packages/transaction-controller/src/utils/eip7702.test.ts
@@ -8,6 +8,11 @@ import type { NetworkClientId } from '@metamask/network-controller';
 import type { Hex } from '@metamask/utils';
 import { remove0x } from '@metamask/utils';
 
+import type { KeyringControllerSignEip7702AuthorizationAction } from '../../../keyring-controller/src';
+import type { TransactionControllerMessenger } from '../TransactionController';
+import { TransactionStatus } from '../types';
+import type { AuthorizationList } from '../types';
+import type { TransactionMeta } from '../types';
 import {
   DELEGATION_PREFIX,
   doesChainSupportEIP7702,
@@ -21,11 +26,6 @@ import {
   getEIP7702SupportedChains,
 } from './feature-flags';
 import { rpcRequest } from './provider';
-import type { KeyringControllerSignEip7702AuthorizationAction } from '../../../keyring-controller/src';
-import type { TransactionControllerMessenger } from '../TransactionController';
-import { TransactionStatus } from '../types';
-import type { AuthorizationList } from '../types';
-import type { TransactionMeta } from '../types';
 
 jest.mock('../utils/feature-flags');
 

--- a/packages/transaction-controller/src/utils/eip7702.ts
+++ b/packages/transaction-controller/src/utils/eip7702.ts
@@ -5,11 +5,6 @@ import type { NetworkClientId } from '@metamask/network-controller';
 import { createModuleLogger, add0x } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
 
-import {
-  getEIP7702ContractAddresses,
-  getEIP7702SupportedChains,
-} from './feature-flags';
-import { rpcRequest } from './provider';
 import { ABI_IERC7821 } from '../constants';
 import { projectLogger } from '../logger';
 import type { TransactionControllerMessenger } from '../TransactionController';
@@ -19,6 +14,11 @@ import type {
   AuthorizationList,
   TransactionMeta,
 } from '../types';
+import {
+  getEIP7702ContractAddresses,
+  getEIP7702SupportedChains,
+} from './feature-flags';
+import { rpcRequest } from './provider';
 
 export const DELEGATION_PREFIX = '0xef0100';
 export const BATCH_FUNCTION_NAME = 'execute';

--- a/packages/transaction-controller/src/utils/external-transactions.test.ts
+++ b/packages/transaction-controller/src/utils/external-transactions.test.ts
@@ -1,8 +1,8 @@
 import { rpcErrors } from '@metamask/rpc-errors';
 
-import { validateConfirmedExternalTransaction } from './external-transactions';
 import type { TransactionMeta } from '../types';
 import { TransactionStatus } from '../types';
+import { validateConfirmedExternalTransaction } from './external-transactions';
 
 describe('validateConfirmedExternalTransaction', () => {
   const mockTransactionMeta = (

--- a/packages/transaction-controller/src/utils/feature-flags.test.ts
+++ b/packages/transaction-controller/src/utils/feature-flags.test.ts
@@ -7,6 +7,7 @@ import type {
 import type { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
 import type { Hex } from '@metamask/utils';
 
+import type { TransactionControllerMessenger } from '..';
 import type { TransactionControllerFeatureFlags } from './feature-flags';
 import {
   getAcceleratedPollingParams,
@@ -25,7 +26,6 @@ import {
   isIncomingTransactionsUseBackendWebSocketServiceEnabled,
 } from './feature-flags';
 import { isValidSignature } from './signature';
-import type { TransactionControllerMessenger } from '..';
 
 jest.mock('./signature');
 

--- a/packages/transaction-controller/src/utils/feature-flags.ts
+++ b/packages/transaction-controller/src/utils/feature-flags.ts
@@ -1,10 +1,10 @@
 import { createModuleLogger } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
 
-import { isValidSignature } from './signature';
-import { padHexToEvenLength } from './utils';
 import { projectLogger } from '../logger';
 import type { TransactionControllerMessenger } from '../TransactionController';
+import { isValidSignature } from './signature';
+import { padHexToEvenLength } from './utils';
 
 const DEFAULT_BATCH_SIZE_LIMIT = 10;
 const DEFAULT_ACCELERATED_POLLING_COUNT_MAX = 10;

--- a/packages/transaction-controller/src/utils/first-time-interaction.test.ts
+++ b/packages/transaction-controller/src/utils/first-time-interaction.test.ts
@@ -1,11 +1,11 @@
 import type { TraceContext } from '@metamask/controller-utils';
 
-import { updateFirstTimeInteraction } from './first-time-interaction';
-import { decodeTransactionData } from './transaction-type';
-import { validateParamTo } from './validation';
 import { getAccountAddressRelationship } from '../api/accounts-api';
 import type { TransactionMeta } from '../types';
 import { TransactionStatus, TransactionType } from '../types';
+import { updateFirstTimeInteraction } from './first-time-interaction';
+import { decodeTransactionData } from './transaction-type';
+import { validateParamTo } from './validation';
 
 jest.mock('./transaction-type');
 jest.mock('./validation');

--- a/packages/transaction-controller/src/utils/first-time-interaction.ts
+++ b/packages/transaction-controller/src/utils/first-time-interaction.ts
@@ -2,13 +2,13 @@ import type { TransactionDescription } from '@ethersproject/abi';
 import type { TraceContext, TraceCallback } from '@metamask/controller-utils';
 import { hexToNumber } from '@metamask/utils';
 
-import { decodeTransactionData } from './transaction-type';
-import { validateParamTo } from './validation';
 import { getAccountAddressRelationship } from '../api/accounts-api';
 import type { GetAccountAddressRelationshipRequest } from '../api/accounts-api';
 import { projectLogger as log } from '../logger';
 import { TransactionType } from '../types';
 import type { TransactionMeta } from '../types';
+import { decodeTransactionData } from './transaction-type';
+import { validateParamTo } from './validation';
 
 const TOKEN_TRANSFER_TYPES = [
   TransactionType.tokenMethodTransfer,

--- a/packages/transaction-controller/src/utils/gas-fee-tokens.test.ts
+++ b/packages/transaction-controller/src/utils/gas-fee-tokens.test.ts
@@ -1,6 +1,13 @@
 import type { Hex } from '@metamask/utils';
 import { cloneDeep } from 'lodash';
 
+import type {
+  GasFeeToken,
+  GetSimulationConfig,
+  TransactionControllerMessenger,
+  TransactionMeta,
+} from '..';
+import { simulateTransactions } from '../api/simulation-api';
 import { isNativeBalanceSufficientForGas } from './balance';
 import { doesChainSupportEIP7702 } from './eip7702';
 import { getEIP7702UpgradeContractAddress } from './feature-flags';
@@ -9,13 +16,6 @@ import {
   checkGasFeeTokenBeforePublish,
   getGasFeeTokens,
 } from './gas-fee-tokens';
-import type {
-  GasFeeToken,
-  GetSimulationConfig,
-  TransactionControllerMessenger,
-  TransactionMeta,
-} from '..';
-import { simulateTransactions } from '../api/simulation-api';
 
 jest.mock('../api/simulation-api');
 jest.mock('./eip7702');

--- a/packages/transaction-controller/src/utils/gas-fee-tokens.ts
+++ b/packages/transaction-controller/src/utils/gas-fee-tokens.ts
@@ -3,10 +3,6 @@ import { rpcErrors } from '@metamask/rpc-errors';
 import type { Hex } from '@metamask/utils';
 import { createModuleLogger } from '@metamask/utils';
 
-import { isNativeBalanceSufficientForGas } from './balance';
-import { ERROR_MESSAGE_NO_UPGRADE_CONTRACT } from './batch';
-import { ERROR_MESSGE_PUBLIC_KEY, doesChainSupportEIP7702 } from './eip7702';
-import { getEIP7702UpgradeContractAddress } from './feature-flags';
 import type {
   GasFeeToken,
   TransactionControllerMessenger,
@@ -20,6 +16,10 @@ import type {
 } from '../api/simulation-api';
 import { projectLogger } from '../logger';
 import type { GetSimulationConfig } from '../types';
+import { isNativeBalanceSufficientForGas } from './balance';
+import { ERROR_MESSAGE_NO_UPGRADE_CONTRACT } from './batch';
+import { ERROR_MESSGE_PUBLIC_KEY, doesChainSupportEIP7702 } from './eip7702';
+import { getEIP7702UpgradeContractAddress } from './feature-flags';
 
 const log = createModuleLogger(projectLogger, 'gas-fee-tokens');
 

--- a/packages/transaction-controller/src/utils/gas-fees.test.ts
+++ b/packages/transaction-controller/src/utils/gas-fees.test.ts
@@ -1,12 +1,12 @@
 import { ORIGIN_METAMASK } from '@metamask/controller-utils';
 import type { NetworkClientId } from '@metamask/network-controller';
 
-import type { UpdateGasFeesRequest } from './gas-fees';
-import { gweiDecimalToWeiDecimal, updateGasFees } from './gas-fees';
-import { rpcRequest } from './provider';
 import type { TransactionControllerMessenger } from '../TransactionController';
 import type { GasFeeFlow, GasFeeFlowResponse } from '../types';
 import { GasFeeEstimateType, TransactionType, UserFeeLevel } from '../types';
+import type { UpdateGasFeesRequest } from './gas-fees';
+import { gweiDecimalToWeiDecimal, updateGasFees } from './gas-fees';
+import { rpcRequest } from './provider';
 
 jest.mock('./provider', () => ({
   rpcRequest: jest.fn(),

--- a/packages/transaction-controller/src/utils/gas-fees.ts
+++ b/packages/transaction-controller/src/utils/gas-fees.ts
@@ -10,9 +10,6 @@ import type {
 import type { Hex } from '@metamask/utils';
 import { add0x, createModuleLogger } from '@metamask/utils';
 
-import { getGasFeeFlow } from './gas-flow';
-import { rpcRequest } from './provider';
-import { SWAP_TRANSACTION_TYPES } from './swaps';
 import { projectLogger } from '../logger';
 import type { TransactionControllerMessenger } from '../TransactionController';
 import type {
@@ -23,6 +20,9 @@ import type {
   GasFeeFlow,
 } from '../types';
 import { GasFeeEstimateType, UserFeeLevel } from '../types';
+import { getGasFeeFlow } from './gas-flow';
+import { rpcRequest } from './provider';
+import { SWAP_TRANSACTION_TYPES } from './swaps';
 
 export type UpdateGasFeesRequest = {
   eip1559: boolean;

--- a/packages/transaction-controller/src/utils/gas-flow.test.ts
+++ b/packages/transaction-controller/src/utils/gas-flow.test.ts
@@ -1,6 +1,5 @@
 import type { GasFeeEstimates as GasFeeControllerEstimates } from '@metamask/gas-fee-controller';
 
-import { getGasFeeFlow, mergeGasFeeEstimates } from './gas-flow';
 import type { TransactionControllerMessenger } from '../TransactionController';
 import type {
   FeeMarketGasFeeEstimates,
@@ -10,6 +9,7 @@ import type {
   TransactionMeta,
 } from '../types';
 import { GasFeeEstimateType, TransactionStatus } from '../types';
+import { getGasFeeFlow, mergeGasFeeEstimates } from './gas-flow';
 
 const TRANSACTION_META_MOCK: TransactionMeta = {
   id: '1',

--- a/packages/transaction-controller/src/utils/gas.test.ts
+++ b/packages/transaction-controller/src/utils/gas.test.ts
@@ -3,6 +3,19 @@ import { remove0x } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
 import { cloneDeep } from 'lodash';
 
+import type {
+  SimulationResponse,
+  SimulationResponseTransaction,
+} from '../api/simulation-api';
+import { simulateTransactions } from '../api/simulation-api';
+import type { TransactionControllerMessenger } from '../TransactionController';
+import { TransactionEnvelopeType } from '../types';
+import type { TransactionMeta } from '../types';
+import type {
+  AuthorizationList,
+  BatchTransactionParams,
+  TransactionBatchSingleRequest,
+} from '../types';
 import { DELEGATION_PREFIX, generateEIP7702BatchTransaction } from './eip7702';
 import { getGasEstimateBuffer, getGasEstimateFallback } from './feature-flags';
 import type { UpdateGasRequest } from './gas';
@@ -19,19 +32,6 @@ import {
   simulateGasBatch,
 } from './gas';
 import { rpcRequest } from './provider';
-import type {
-  SimulationResponse,
-  SimulationResponseTransaction,
-} from '../api/simulation-api';
-import { simulateTransactions } from '../api/simulation-api';
-import type { TransactionControllerMessenger } from '../TransactionController';
-import { TransactionEnvelopeType } from '../types';
-import type { TransactionMeta } from '../types';
-import type {
-  AuthorizationList,
-  BatchTransactionParams,
-  TransactionBatchSingleRequest,
-} from '../types';
 
 jest.mock('./provider', () => ({
   ...jest.requireActual('./provider'),

--- a/packages/transaction-controller/src/utils/gas.ts
+++ b/packages/transaction-controller/src/utils/gas.ts
@@ -9,9 +9,6 @@ import type { Hex, Json } from '@metamask/utils';
 import { add0x, createModuleLogger, remove0x } from '@metamask/utils';
 import { BigNumber } from 'bignumber.js';
 
-import { DELEGATION_PREFIX, generateEIP7702BatchTransaction } from './eip7702';
-import { getGasEstimateBuffer, getGasEstimateFallback } from './feature-flags';
-import { getChainId, rpcRequest } from './provider';
 import { simulateTransactions } from '../api/simulation-api';
 import { projectLogger } from '../logger';
 import type { TransactionControllerMessenger } from '../TransactionController';
@@ -26,6 +23,9 @@ import type {
   TransactionMeta,
   TransactionParams,
 } from '../types';
+import { DELEGATION_PREFIX, generateEIP7702BatchTransaction } from './eip7702';
+import { getGasEstimateBuffer, getGasEstimateFallback } from './feature-flags';
+import { getChainId, rpcRequest } from './provider';
 
 export type UpdateGasRequest = {
   isCustomNetwork: boolean;

--- a/packages/transaction-controller/src/utils/layer1-gas-fee-flow.test.ts
+++ b/packages/transaction-controller/src/utils/layer1-gas-fee-flow.test.ts
@@ -1,11 +1,11 @@
 import type { Provider } from '@metamask/network-controller';
 import type { Hex } from '@metamask/utils';
 
-import { updateTransactionLayer1GasFee } from './layer1-gas-fee-flow';
-import { getProvider } from './provider';
 import type { TransactionControllerMessenger } from '../TransactionController';
 import { TransactionStatus } from '../types';
 import type { Layer1GasFeeFlow, TransactionMeta } from '../types';
+import { updateTransactionLayer1GasFee } from './layer1-gas-fee-flow';
+import { getProvider } from './provider';
 
 jest.mock('@metamask/controller-utils', () => ({
   ...jest.requireActual('@metamask/controller-utils'),

--- a/packages/transaction-controller/src/utils/layer1-gas-fee-flow.ts
+++ b/packages/transaction-controller/src/utils/layer1-gas-fee-flow.ts
@@ -1,10 +1,10 @@
 import { createModuleLogger } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
 
-import { getProvider } from './provider';
 import { projectLogger } from '../logger';
 import type { TransactionControllerMessenger } from '../TransactionController';
 import type { Layer1GasFeeFlow, TransactionMeta } from '../types';
+import { getProvider } from './provider';
 
 const log = createModuleLogger(projectLogger, 'layer-1-gas-fee-flow');
 

--- a/packages/transaction-controller/src/utils/nonce.test.ts
+++ b/packages/transaction-controller/src/utils/nonce.test.ts
@@ -3,9 +3,9 @@ import type {
   Transaction as NonceTrackerTransaction,
 } from '@metamask/nonce-tracker';
 
-import { getAndFormatTransactionsForNonceTracker, getNextNonce } from './nonce';
 import type { TransactionMeta } from '../types';
 import { TransactionStatus } from '../types';
+import { getAndFormatTransactionsForNonceTracker, getNextNonce } from './nonce';
 
 const TRANSACTION_META_MOCK: TransactionMeta = {
   chainId: '0x1',

--- a/packages/transaction-controller/src/utils/prepare.test.ts
+++ b/packages/transaction-controller/src/utils/prepare.test.ts
@@ -4,9 +4,9 @@ import {
   EOACodeEIP7702Transaction,
 } from '@ethereumjs/tx';
 
-import { prepareTransaction, serializeTransaction } from './prepare';
 import { TransactionEnvelopeType } from '../types';
 import type { Authorization, TransactionParams } from '../types';
+import { prepareTransaction, serializeTransaction } from './prepare';
 
 const CHAIN_ID_MOCK = '0x123';
 

--- a/packages/transaction-controller/src/utils/provider.test.ts
+++ b/packages/transaction-controller/src/utils/provider.test.ts
@@ -1,8 +1,8 @@
 import type { NetworkClientId, Provider } from '@metamask/network-controller';
 import type { Hex } from '@metamask/utils';
 
-import { getProvider, rpcRequest } from './provider';
 import type { TransactionControllerMessenger } from '../TransactionController';
+import { getProvider, rpcRequest } from './provider';
 
 describe('provider utils', () => {
   const requestMock = jest.fn();

--- a/packages/transaction-controller/src/utils/retry.test.ts
+++ b/packages/transaction-controller/src/utils/retry.test.ts
@@ -1,5 +1,5 @@
-import { getTransactionParamsWithIncreasedGasFee } from './retry';
 import type { TransactionParams } from '../types';
+import { getTransactionParamsWithIncreasedGasFee } from './retry';
 
 const RATE_MOCK = 16;
 const VALUE_MOCK = '0x111';

--- a/packages/transaction-controller/src/utils/swaps.test.ts
+++ b/packages/transaction-controller/src/utils/swaps.test.ts
@@ -6,6 +6,11 @@ import type {
 } from '@metamask/messenger';
 import type { NetworkClientId } from '@metamask/network-controller';
 
+import { flushPromises } from '../../../../tests/helpers';
+import { CHAIN_IDS } from '../constants';
+import type { TransactionControllerMessenger } from '../TransactionController';
+import type { TransactionMeta } from '../types';
+import { TransactionType, TransactionStatus } from '../types';
 import { rpcRequest } from './provider';
 import {
   updateSwapsTransaction,
@@ -13,11 +18,6 @@ import {
   UPDATE_POST_TX_BALANCE_ATTEMPTS,
   SWAPS_CHAINID_DEFAULT_TOKEN_MAP,
 } from './swaps';
-import { flushPromises } from '../../../../tests/helpers';
-import { CHAIN_IDS } from '../constants';
-import type { TransactionControllerMessenger } from '../TransactionController';
-import type { TransactionMeta } from '../types';
-import { TransactionType, TransactionStatus } from '../types';
 
 jest.mock('./provider', () => ({
   rpcRequest: jest.fn(),

--- a/packages/transaction-controller/src/utils/swaps.ts
+++ b/packages/transaction-controller/src/utils/swaps.ts
@@ -1,13 +1,13 @@
 import type { NetworkClientId } from '@metamask/network-controller';
 import { merge, pickBy } from 'lodash';
 
-import { rpcRequest } from './provider';
-import { validateIfTransactionUnapproved } from './utils';
 import { CHAIN_IDS } from '../constants';
 import { createModuleLogger, projectLogger } from '../logger';
 import type { TransactionControllerMessenger } from '../TransactionController';
 import type { TransactionMeta } from '../types';
 import { TransactionType } from '../types';
+import { rpcRequest } from './provider';
+import { validateIfTransactionUnapproved } from './utils';
 
 const log = createModuleLogger(projectLogger, 'swaps');
 

--- a/packages/transaction-controller/src/utils/transaction-type.test.ts
+++ b/packages/transaction-controller/src/utils/transaction-type.test.ts
@@ -8,14 +8,14 @@ import {
 } from '@metamask/metamask-eth-abis';
 import type { NetworkClientId } from '@metamask/network-controller';
 
+import type { TransactionControllerMessenger } from '../TransactionController';
+import { TransactionType } from '../types';
 import { DELEGATION_PREFIX } from './eip7702';
 import { rpcRequest } from './provider';
 import {
   decodeTransactionData,
   determineTransactionType,
 } from './transaction-type';
-import type { TransactionControllerMessenger } from '../TransactionController';
-import { TransactionType } from '../types';
 
 jest.mock('./provider', () => ({
   rpcRequest: jest.fn(),

--- a/packages/transaction-controller/src/utils/transaction-type.ts
+++ b/packages/transaction-controller/src/utils/transaction-type.ts
@@ -8,11 +8,11 @@ import {
 } from '@metamask/metamask-eth-abis';
 import type { NetworkClientId } from '@metamask/network-controller';
 
-import { DELEGATION_PREFIX } from './eip7702';
-import { rpcRequest } from './provider';
 import type { TransactionControllerMessenger } from '../TransactionController';
 import type { InferTransactionTypeResult, TransactionParams } from '../types';
 import { TransactionType } from '../types';
+import { DELEGATION_PREFIX } from './eip7702';
+import { rpcRequest } from './provider';
 
 export const ESTIMATE_GAS_ERROR = 'eth_estimateGas rpc method error';
 

--- a/packages/transaction-controller/src/utils/utils.test.ts
+++ b/packages/transaction-controller/src/utils/utils.test.ts
@@ -1,13 +1,13 @@
 import { Hex } from '@metamask/utils';
 import BN from 'bn.js';
 
-import * as util from './utils';
 import type {
   FeeMarketEIP1559Values,
   GasPriceValue,
   TransactionParams,
 } from '../types';
 import { TransactionStatus } from '../types';
+import * as util from './utils';
 
 const MAX_FEE_PER_GAS = 'maxFeePerGas';
 const MAX_PRIORITY_FEE_PER_GAS = 'maxPriorityFeePerGas';

--- a/packages/transaction-controller/src/utils/validation.test.ts
+++ b/packages/transaction-controller/src/utils/validation.test.ts
@@ -2,14 +2,14 @@ import { ORIGIN_METAMASK } from '@metamask/controller-utils';
 import { rpcErrors } from '@metamask/rpc-errors';
 import type { Hex } from '@metamask/utils';
 
+import { TransactionEnvelopeType, TransactionType } from '../types';
+import type { TransactionParams } from '../types';
 import {
   validateBatchRequest,
   validateParamTo,
   validateTransactionOrigin,
   validateTxParams,
 } from './validation';
-import { TransactionEnvelopeType, TransactionType } from '../types';
-import type { TransactionParams } from '../types';
 
 const DATA_MOCK = '0x12345678';
 const FROM_MOCK: Hex = '0x1678a085c290ebd122dc42cba69373b5953b831d';

--- a/packages/transaction-controller/src/utils/validation.ts
+++ b/packages/transaction-controller/src/utils/validation.ts
@@ -5,13 +5,13 @@ import { JsonRpcError, providerErrors, rpcErrors } from '@metamask/rpc-errors';
 import type { Hex } from '@metamask/utils';
 import { isStrictHexString, remove0x } from '@metamask/utils';
 
-import { isEIP1559Transaction } from './utils';
 import { TransactionEnvelopeType, TransactionType } from '../types';
 import type {
   Authorization,
   TransactionBatchRequest,
   TransactionParams,
 } from '../types';
+import { isEIP1559Transaction } from './utils';
 
 export enum ErrorCode {
   DuplicateBundleId = 5720,

--- a/packages/transaction-pay-controller/src/actions/update-fiat-payment.test.ts
+++ b/packages/transaction-pay-controller/src/actions/update-fiat-payment.test.ts
@@ -1,9 +1,9 @@
 import type { TransactionMeta } from '@metamask/transaction-controller';
 import { noop } from 'lodash';
 
-import { updateFiatPayment } from './update-fiat-payment';
 import type { TransactionData, TransactionFiatPayment } from '../types';
 import { getTransaction } from '../utils/transaction';
+import { updateFiatPayment } from './update-fiat-payment';
 
 jest.mock('../utils/transaction');
 

--- a/packages/transaction-pay-controller/src/actions/update-payment-token.test.ts
+++ b/packages/transaction-pay-controller/src/actions/update-payment-token.test.ts
@@ -1,7 +1,6 @@
 import type { TransactionMeta } from '@metamask/transaction-controller';
 import { noop } from 'lodash';
 
-import { updatePaymentToken } from './update-payment-token';
 import type { TransactionData, TransactionPaymentToken } from '../types';
 import {
   getTokenBalance,
@@ -9,6 +8,7 @@ import {
   getTokenInfo,
 } from '../utils/token';
 import { getTransaction } from '../utils/transaction';
+import { updatePaymentToken } from './update-payment-token';
 
 jest.mock('../utils/token', () => ({
   ...jest.createMockFromModule<typeof import('../utils/token')>(

--- a/packages/transaction-pay-controller/src/helpers/QuoteRefresher.test.ts
+++ b/packages/transaction-pay-controller/src/helpers/QuoteRefresher.test.ts
@@ -2,7 +2,6 @@
 
 import { createDeferredPromise } from '@metamask/utils';
 
-import { QuoteRefresher } from './QuoteRefresher';
 import { flushPromises } from '../../../../tests/helpers';
 import { TransactionPayStrategy } from '../constants';
 import { getMessengerMock } from '../tests/messenger-mock';
@@ -11,6 +10,7 @@ import type {
   TransactionPayControllerMessenger,
 } from '../types';
 import { refreshQuotes } from '../utils/quotes';
+import { QuoteRefresher } from './QuoteRefresher';
 
 jest.mock('../utils/quotes');
 

--- a/packages/transaction-pay-controller/src/helpers/TransactionPayPublishHook.test.ts
+++ b/packages/transaction-pay-controller/src/helpers/TransactionPayPublishHook.test.ts
@@ -3,7 +3,6 @@ import type {
   TransactionMeta,
 } from '@metamask/transaction-controller';
 
-import { TransactionPayPublishHook } from './TransactionPayPublishHook';
 import { TransactionPayStrategy } from '..';
 import { getMessengerMock } from '../tests/messenger-mock';
 import type {
@@ -11,6 +10,7 @@ import type {
   TransactionPayQuote,
 } from '../types';
 import { getStrategyByName } from '../utils/strategy';
+import { TransactionPayPublishHook } from './TransactionPayPublishHook';
 
 jest.mock('../utils/strategy');
 

--- a/packages/transaction-pay-controller/src/strategy/across/AcrossStrategy.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/across/AcrossStrategy.test.ts
@@ -5,10 +5,6 @@ import {
 } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 
-import { getAcrossQuotes } from './across-quotes';
-import { submitAcrossQuotes } from './across-submit';
-import { AcrossStrategy } from './AcrossStrategy';
-import type { AcrossQuote } from './types';
 import { ARBITRUM_USDC_ADDRESS, CHAIN_ID_ARBITRUM } from '../../constants';
 import type {
   PayStrategyExecuteRequest,
@@ -16,6 +12,10 @@ import type {
   TransactionPayQuote,
 } from '../../types';
 import { getPayStrategiesConfig } from '../../utils/feature-flags';
+import { getAcrossQuotes } from './across-quotes';
+import { submitAcrossQuotes } from './across-submit';
+import { AcrossStrategy } from './AcrossStrategy';
+import type { AcrossQuote } from './types';
 
 jest.mock('./across-quotes');
 jest.mock('./across-submit');

--- a/packages/transaction-pay-controller/src/strategy/across/AcrossStrategy.ts
+++ b/packages/transaction-pay-controller/src/strategy/across/AcrossStrategy.ts
@@ -1,9 +1,5 @@
 import { TransactionType } from '@metamask/transaction-controller';
 
-import { getAcrossQuotes } from './across-quotes';
-import { submitAcrossQuotes } from './across-submit';
-import { isSupportedAcrossPerpsDepositRequest } from './perps';
-import type { AcrossQuote } from './types';
 import type {
   PayStrategy,
   PayStrategyExecuteRequest,
@@ -11,6 +7,10 @@ import type {
   TransactionPayQuote,
 } from '../../types';
 import { getPayStrategiesConfig } from '../../utils/feature-flags';
+import { getAcrossQuotes } from './across-quotes';
+import { submitAcrossQuotes } from './across-submit';
+import { isSupportedAcrossPerpsDepositRequest } from './perps';
+import type { AcrossQuote } from './types';
 
 export class AcrossStrategy implements PayStrategy<AcrossQuote> {
   supports(request: PayStrategyGetQuotesRequest): boolean {

--- a/packages/transaction-pay-controller/src/strategy/across/across-actions.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/across/across-actions.test.ts
@@ -2,6 +2,7 @@ import { Interface } from '@ethersproject/abi';
 import type { TransactionMeta } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 
+import type { QuoteRequest } from '../../types';
 import {
   buildAcrossActionFromCall,
   CREATE_PROXY_SIGNATURE,
@@ -11,7 +12,6 @@ import {
   SAFE_EXEC_TRANSACTION_SIGNATURE,
   TOKEN_TRANSFER_SIGNATURE,
 } from './across-actions';
-import type { QuoteRequest } from '../../types';
 
 const TOKEN_TRANSFER_INTERFACE = new Interface([TOKEN_TRANSFER_SIGNATURE]);
 const CREATE_PROXY_INTERFACE = new Interface([CREATE_PROXY_SIGNATURE]);

--- a/packages/transaction-pay-controller/src/strategy/across/across-actions.ts
+++ b/packages/transaction-pay-controller/src/strategy/across/across-actions.ts
@@ -3,9 +3,9 @@ import type { TransactionDescription } from '@ethersproject/abi';
 import type { TransactionMeta } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 
+import type { QuoteRequest } from '../../types';
 import { isSupportedAcrossPerpsDepositRequest } from './perps';
 import type { AcrossAction, AcrossActionArg } from './types';
-import type { QuoteRequest } from '../../types';
 
 export const TOKEN_TRANSFER_SIGNATURE =
   'function transfer(address to, uint256 value)';

--- a/packages/transaction-pay-controller/src/strategy/across/across-quotes.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/across/across-quotes.test.ts
@@ -4,10 +4,6 @@ import { TransactionType } from '@metamask/transaction-controller';
 import type { TransactionMeta } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 
-import { getAcrossQuotes } from './across-quotes';
-import { ACROSS_HYPERCORE_USDC_PERPS_ADDRESS } from './perps';
-import * as acrossTransactions from './transactions';
-import type { AcrossSwapApprovalResponse } from './types';
 import { getDefaultRemoteFeatureFlagControllerState } from '../../../../remote-feature-flag-controller/src/remote-feature-flag-controller';
 import {
   ARBITRUM_USDC_ADDRESS,
@@ -21,6 +17,10 @@ import { getGasBuffer, getSlippage } from '../../utils/feature-flags';
 import { calculateGasCost } from '../../utils/gas';
 import * as quoteGasUtils from '../../utils/quote-gas';
 import { getTokenFiatRate } from '../../utils/token';
+import { getAcrossQuotes } from './across-quotes';
+import { ACROSS_HYPERCORE_USDC_PERPS_ADDRESS } from './perps';
+import * as acrossTransactions from './transactions';
+import type { AcrossSwapApprovalResponse } from './types';
 
 jest.mock('../../utils/token');
 jest.mock('../../utils/gas', () => ({

--- a/packages/transaction-pay-controller/src/strategy/across/across-quotes.ts
+++ b/packages/transaction-pay-controller/src/strategy/across/across-quotes.ts
@@ -3,16 +3,6 @@ import type { Hex } from '@metamask/utils';
 import { createModuleLogger } from '@metamask/utils';
 import { BigNumber } from 'bignumber.js';
 
-import { getAcrossDestination } from './across-actions';
-import { normalizeAcrossRequest } from './perps';
-import { getAcrossOrderedTransactions } from './transactions';
-import type {
-  AcrossAction,
-  AcrossActionRequestBody,
-  AcrossGasLimits,
-  AcrossQuote,
-  AcrossSwapApprovalResponse,
-} from './types';
 import { TransactionPayStrategy } from '../../constants';
 import { projectLogger } from '../../logger';
 import type {
@@ -28,6 +18,16 @@ import { getPayStrategiesConfig, getSlippage } from '../../utils/feature-flags';
 import { calculateGasCost } from '../../utils/gas';
 import { estimateQuoteGasLimits } from '../../utils/quote-gas';
 import { getTokenFiatRate } from '../../utils/token';
+import { getAcrossDestination } from './across-actions';
+import { normalizeAcrossRequest } from './perps';
+import { getAcrossOrderedTransactions } from './transactions';
+import type {
+  AcrossAction,
+  AcrossActionRequestBody,
+  AcrossGasLimits,
+  AcrossQuote,
+  AcrossSwapApprovalResponse,
+} from './types';
 
 const log = createModuleLogger(projectLogger, 'across-strategy');
 

--- a/packages/transaction-pay-controller/src/strategy/across/across-submit.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/across/across-submit.test.ts
@@ -9,13 +9,13 @@ import type {
 } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 
-import { submitAcrossQuotes } from './across-submit';
-import * as acrossTransactions from './transactions';
-import type { AcrossQuote } from './types';
 import { getDefaultRemoteFeatureFlagControllerState } from '../../../../remote-feature-flag-controller/src/remote-feature-flag-controller';
 import { TransactionPayStrategy } from '../../constants';
 import { getMessengerMock } from '../../tests/messenger-mock';
 import type { TransactionPayQuote } from '../../types';
+import { submitAcrossQuotes } from './across-submit';
+import * as acrossTransactions from './transactions';
+import type { AcrossQuote } from './types';
 
 jest.mock('@metamask/controller-utils', () => ({
   ...jest.requireActual('@metamask/controller-utils'),

--- a/packages/transaction-pay-controller/src/strategy/across/across-submit.ts
+++ b/packages/transaction-pay-controller/src/strategy/across/across-submit.ts
@@ -12,8 +12,6 @@ import type {
 import type { Hex } from '@metamask/utils';
 import { createModuleLogger } from '@metamask/utils';
 
-import { getAcrossOrderedTransactions } from './transactions';
-import type { AcrossQuote } from './types';
 import { projectLogger } from '../../logger';
 import type {
   PayStrategyExecuteRequest,
@@ -27,6 +25,8 @@ import {
   updateTransaction,
   waitForTransactionConfirmed,
 } from '../../utils/transaction';
+import { getAcrossOrderedTransactions } from './transactions';
+import type { AcrossQuote } from './types';
 
 const log = createModuleLogger(projectLogger, 'across-strategy');
 const ACROSS_STATUS_POLL_INTERVAL = 1000;

--- a/packages/transaction-pay-controller/src/strategy/bridge/BridgeStrategy.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/bridge/BridgeStrategy.test.ts
@@ -2,6 +2,11 @@ import type { TransactionMeta } from '@metamask/transaction-controller';
 import type { BatchTransaction } from '@metamask/transaction-controller';
 import { TransactionType } from '@metamask/transaction-controller';
 
+import type { TransactionPayControllerMessenger } from '../..';
+import type {
+  PayStrategyGetBatchRequest,
+  TransactionPayQuote,
+} from '../../types';
 import {
   getBridgeBatchTransactions,
   getBridgeQuotes,
@@ -10,11 +15,6 @@ import {
 import { submitBridgeQuotes } from './bridge-submit';
 import { BridgeStrategy } from './BridgeStrategy';
 import type { TransactionPayBridgeQuote } from './types';
-import type { TransactionPayControllerMessenger } from '../..';
-import type {
-  PayStrategyGetBatchRequest,
-  TransactionPayQuote,
-} from '../../types';
 
 jest.mock('./bridge-quotes');
 jest.mock('./bridge-submit');

--- a/packages/transaction-pay-controller/src/strategy/bridge/BridgeStrategy.ts
+++ b/packages/transaction-pay-controller/src/strategy/bridge/BridgeStrategy.ts
@@ -1,13 +1,6 @@
 import { BatchTransaction } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 
-import {
-  getBridgeBatchTransactions,
-  getBridgeQuotes,
-  getBridgeRefreshInterval,
-} from './bridge-quotes';
-import { submitBridgeQuotes } from './bridge-submit';
-import type { TransactionPayBridgeQuote } from './types';
 import type {
   PayStrategy,
   PayStrategyExecuteRequest,
@@ -16,6 +9,13 @@ import type {
   PayStrategyGetRefreshIntervalRequest,
   TransactionPayQuote,
 } from '../../types';
+import {
+  getBridgeBatchTransactions,
+  getBridgeQuotes,
+  getBridgeRefreshInterval,
+} from './bridge-quotes';
+import { submitBridgeQuotes } from './bridge-submit';
+import type { TransactionPayBridgeQuote } from './types';
 
 export class BridgeStrategy implements PayStrategy<TransactionPayBridgeQuote> {
   async getQuotes(

--- a/packages/transaction-pay-controller/src/strategy/bridge/bridge-quotes.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/bridge/bridge-quotes.test.ts
@@ -4,13 +4,6 @@ import type { TxData } from '@metamask/bridge-controller';
 import { TransactionType } from '@metamask/transaction-controller';
 import type { TransactionMeta } from '@metamask/transaction-controller';
 
-import {
-  getBridgeBatchTransactions,
-  getBridgeQuotes,
-  getBridgeRefreshInterval,
-  refreshQuote,
-} from './bridge-quotes';
-import type { TransactionPayBridgeQuote } from './types';
 import { getDefaultRemoteFeatureFlagControllerState } from '../../../../remote-feature-flag-controller/src/remote-feature-flag-controller';
 import { getMessengerMock } from '../../tests/messenger-mock';
 import type {
@@ -21,6 +14,13 @@ import type {
 import type { QuoteRequest } from '../../types';
 import { calculateGasCost, calculateTransactionGasCost } from '../../utils/gas';
 import { getTokenFiatRate } from '../../utils/token';
+import {
+  getBridgeBatchTransactions,
+  getBridgeQuotes,
+  getBridgeRefreshInterval,
+  refreshQuote,
+} from './bridge-quotes';
+import type { TransactionPayBridgeQuote } from './types';
 
 jest.mock('../../utils/token');
 jest.mock('../../utils/gas');

--- a/packages/transaction-pay-controller/src/strategy/bridge/bridge-quotes.ts
+++ b/packages/transaction-pay-controller/src/strategy/bridge/bridge-quotes.ts
@@ -11,11 +11,6 @@ import { createModuleLogger } from '@metamask/utils';
 import { BigNumber } from 'bignumber.js';
 import { orderBy } from 'lodash';
 
-import type {
-  BridgeFeatureFlags,
-  TransactionPayBridgeQuote,
-  BridgeQuoteRequest,
-} from './types';
 import { TransactionPayStrategy } from '../..';
 import { projectLogger } from '../../logger';
 import type {
@@ -29,6 +24,11 @@ import type {
 } from '../../types';
 import { calculateGasCost, calculateTransactionGasCost } from '../../utils/gas';
 import { getTokenFiatRate } from '../../utils/token';
+import type {
+  BridgeFeatureFlags,
+  TransactionPayBridgeQuote,
+  BridgeQuoteRequest,
+} from './types';
 
 const ERROR_MESSAGE_NO_QUOTES = 'No quotes found';
 const ERROR_MESSAGE_ALL_QUOTES_UNDER_MINIMUM = 'All quotes under minimum';

--- a/packages/transaction-pay-controller/src/strategy/bridge/bridge-submit.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/bridge/bridge-submit.test.ts
@@ -5,16 +5,16 @@ import type { TransactionMeta } from '@metamask/transaction-controller';
 import { createDeferredPromise } from '@metamask/utils';
 import { cloneDeep } from 'lodash';
 
-import { refreshQuote } from './bridge-quotes';
-import type { SubmitBridgeQuotesRequest } from './bridge-submit';
-import { submitBridgeQuotes } from './bridge-submit';
-import type { TransactionPayBridgeQuote } from './types';
 import { getMessengerMock } from '../../tests/messenger-mock';
 import type { TransactionPayQuote } from '../../types';
 import {
   updateTransaction,
   waitForTransactionConfirmed,
 } from '../../utils/transaction';
+import { refreshQuote } from './bridge-quotes';
+import type { SubmitBridgeQuotesRequest } from './bridge-submit';
+import { submitBridgeQuotes } from './bridge-submit';
+import type { TransactionPayBridgeQuote } from './types';
 
 jest.mock('./bridge-quotes');
 

--- a/packages/transaction-pay-controller/src/strategy/bridge/bridge-submit.ts
+++ b/packages/transaction-pay-controller/src/strategy/bridge/bridge-submit.ts
@@ -8,8 +8,6 @@ import type { Hex } from '@metamask/utils';
 import { createModuleLogger } from '@metamask/utils';
 import { cloneDeep } from 'lodash';
 
-import { refreshQuote } from './bridge-quotes';
-import type { TransactionPayBridgeQuote } from './types';
 import { projectLogger } from '../../logger';
 import type {
   TransactionPayControllerMessenger,
@@ -20,6 +18,8 @@ import {
   updateTransaction,
   waitForTransactionConfirmed,
 } from '../../utils/transaction';
+import { refreshQuote } from './bridge-quotes';
+import type { TransactionPayBridgeQuote } from './types';
 
 const log = createModuleLogger(projectLogger, 'bridge-strategy');
 

--- a/packages/transaction-pay-controller/src/strategy/fiat/FiatStrategy.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/FiatStrategy.test.ts
@@ -1,11 +1,11 @@
 import type { TransactionMeta } from '@metamask/transaction-controller';
 
+import type { TransactionPayControllerMessenger } from '../..';
+import type { TransactionPayQuote } from '../../types';
 import { getFiatQuotes } from './fiat-quotes';
 import { submitFiatQuotes } from './fiat-submit';
 import { FiatStrategy } from './FiatStrategy';
 import type { FiatQuote } from './types';
-import type { TransactionPayControllerMessenger } from '../..';
-import type { TransactionPayQuote } from '../../types';
 
 jest.mock('./fiat-quotes');
 jest.mock('./fiat-submit');

--- a/packages/transaction-pay-controller/src/strategy/fiat/FiatStrategy.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/FiatStrategy.ts
@@ -1,12 +1,12 @@
-import { getFiatQuotes } from './fiat-quotes';
-import { submitFiatQuotes } from './fiat-submit';
-import type { FiatQuote } from './types';
 import type {
   PayStrategy,
   PayStrategyExecuteRequest,
   PayStrategyGetQuotesRequest,
   TransactionPayQuote,
 } from '../../types';
+import { getFiatQuotes } from './fiat-quotes';
+import { submitFiatQuotes } from './fiat-submit';
+import type { FiatQuote } from './types';
 
 export class FiatStrategy implements PayStrategy<FiatQuote> {
   async getQuotes(

--- a/packages/transaction-pay-controller/src/strategy/fiat/fiat-quotes.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/fiat-quotes.test.ts
@@ -6,9 +6,6 @@ import type { TransactionMeta } from '@metamask/transaction-controller';
 import { TransactionType } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 
-import type { TransactionPayFiatAsset } from './constants';
-import { getFiatQuotes } from './fiat-quotes';
-import { deriveFiatAssetForFiatPayment, pickBestFiatQuote } from './utils';
 import { TransactionPayStrategy } from '../../constants';
 import type {
   PayStrategyGetQuotesRequest,
@@ -18,6 +15,9 @@ import type {
 import { computeRawFromFiatAmount, getTokenFiatRate } from '../../utils/token';
 import { getRelayQuotes } from '../relay/relay-quotes';
 import type { RelayQuote } from '../relay/types';
+import type { TransactionPayFiatAsset } from './constants';
+import { getFiatQuotes } from './fiat-quotes';
+import { deriveFiatAssetForFiatPayment, pickBestFiatQuote } from './utils';
 
 jest.mock('../relay/relay-quotes');
 jest.mock('../../utils/token');

--- a/packages/transaction-pay-controller/src/strategy/fiat/fiat-quotes.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/fiat-quotes.ts
@@ -3,8 +3,6 @@ import type { Hex } from '@metamask/utils';
 import { createModuleLogger } from '@metamask/utils';
 import { BigNumber } from 'bignumber.js';
 
-import type { FiatQuote } from './types';
-import { deriveFiatAssetForFiatPayment, pickBestFiatQuote } from './utils';
 import { TransactionPayStrategy } from '../../constants';
 import { projectLogger } from '../../logger';
 import type {
@@ -16,6 +14,8 @@ import type {
 import { computeRawFromFiatAmount, getTokenFiatRate } from '../../utils/token';
 import { getRelayQuotes } from '../relay/relay-quotes';
 import type { RelayQuote } from '../relay/types';
+import type { FiatQuote } from './types';
+import { deriveFiatAssetForFiatPayment, pickBestFiatQuote } from './utils';
 
 const log = createModuleLogger(projectLogger, 'fiat-strategy');
 

--- a/packages/transaction-pay-controller/src/strategy/fiat/fiat-submit.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/fiat-submit.test.ts
@@ -1,9 +1,9 @@
 import type { TransactionMeta } from '@metamask/transaction-controller';
 
-import { submitFiatQuotes } from './fiat-submit';
-import type { FiatQuote } from './types';
 import type { TransactionPayControllerMessenger } from '../..';
 import type { TransactionPayQuote } from '../../types';
+import { submitFiatQuotes } from './fiat-submit';
+import type { FiatQuote } from './types';
 
 describe('submitFiatQuotes', () => {
   it('returns empty transaction hash placeholder', async () => {

--- a/packages/transaction-pay-controller/src/strategy/fiat/fiat-submit.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/fiat-submit.ts
@@ -1,5 +1,5 @@
-import type { FiatQuote } from './types';
 import type { PayStrategy, PayStrategyExecuteRequest } from '../../types';
+import type { FiatQuote } from './types';
 
 /**
  * Submit Fiat quotes.

--- a/packages/transaction-pay-controller/src/strategy/relay/RelayBridge.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/RelayBridge.test.ts
@@ -1,11 +1,11 @@
 import type { TransactionMeta } from '@metamask/transaction-controller';
 
+import type { TransactionPayControllerMessenger } from '../..';
+import type { TransactionPayQuote } from '../../types';
 import { getRelayQuotes } from './relay-quotes';
 import { submitRelayQuotes } from './relay-submit';
 import { RelayStrategy } from './RelayStrategy';
 import type { RelayQuote } from './types';
-import type { TransactionPayControllerMessenger } from '../..';
-import type { TransactionPayQuote } from '../../types';
 
 jest.mock('./relay-quotes');
 jest.mock('./relay-submit');

--- a/packages/transaction-pay-controller/src/strategy/relay/RelayStrategy.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/RelayStrategy.test.ts
@@ -1,15 +1,15 @@
 import type { Hex } from '@metamask/utils';
 
-import { getRelayQuotes } from './relay-quotes';
-import { submitRelayQuotes } from './relay-submit';
-import { RelayStrategy } from './RelayStrategy';
-import type { RelayQuote } from './types';
 import type {
   PayStrategyExecuteRequest,
   PayStrategyGetQuotesRequest,
   TransactionPayQuote,
 } from '../../types';
 import { getPayStrategiesConfig } from '../../utils/feature-flags';
+import { getRelayQuotes } from './relay-quotes';
+import { submitRelayQuotes } from './relay-submit';
+import { RelayStrategy } from './RelayStrategy';
+import type { RelayQuote } from './types';
 
 jest.mock('./relay-quotes');
 jest.mock('./relay-submit');

--- a/packages/transaction-pay-controller/src/strategy/relay/RelayStrategy.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/RelayStrategy.ts
@@ -1,6 +1,3 @@
-import { getRelayQuotes } from './relay-quotes';
-import { submitRelayQuotes } from './relay-submit';
-import type { RelayQuote } from './types';
 import type {
   PayStrategy,
   PayStrategyExecuteRequest,
@@ -8,6 +5,9 @@ import type {
   TransactionPayQuote,
 } from '../../types';
 import { getPayStrategiesConfig } from '../../utils/feature-flags';
+import { getRelayQuotes } from './relay-quotes';
+import { submitRelayQuotes } from './relay-submit';
+import type { RelayQuote } from './types';
 
 export class RelayStrategy implements PayStrategy<RelayQuote> {
   supports(request: PayStrategyGetQuotesRequest): boolean {

--- a/packages/transaction-pay-controller/src/strategy/relay/gas-station.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/gas-station.test.ts
@@ -1,13 +1,13 @@
 import type { GasFeeToken } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 
+import { getDefaultRemoteFeatureFlagControllerState } from '../../../../remote-feature-flag-controller/src/remote-feature-flag-controller';
+import { getMessengerMock } from '../../tests/messenger-mock';
+import { calculateGasFeeTokenCost } from '../../utils/gas';
 import {
   getGasStationEligibility,
   getGasStationCostInSourceTokenRaw,
 } from './gas-station';
-import { getDefaultRemoteFeatureFlagControllerState } from '../../../../remote-feature-flag-controller/src/remote-feature-flag-controller';
-import { getMessengerMock } from '../../tests/messenger-mock';
-import { calculateGasFeeTokenCost } from '../../utils/gas';
 
 jest.mock('../../utils/gas');
 

--- a/packages/transaction-pay-controller/src/strategy/relay/hyperliquid-withdraw.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/hyperliquid-withdraw.test.ts
@@ -2,11 +2,11 @@ import { successfulFetch } from '@metamask/controller-utils';
 import { SignTypedDataVersion } from '@metamask/keyring-controller';
 import type { Hex } from '@metamask/utils';
 
+import { getMessengerMock } from '../../tests/messenger-mock';
+import type { TransactionPayQuote } from '../../types';
 import { RELAY_AUTHORIZE_URL, HYPERLIQUID_EXCHANGE_URL } from './constants';
 import { submitHyperliquidWithdraw } from './hyperliquid-withdraw';
 import type { RelayQuote, RelaySignatureStep } from './types';
-import { getMessengerMock } from '../../tests/messenger-mock';
-import type { TransactionPayQuote } from '../../types';
 
 jest.mock('@metamask/controller-utils', () => ({
   ...jest.requireActual('@metamask/controller-utils'),

--- a/packages/transaction-pay-controller/src/strategy/relay/hyperliquid-withdraw.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/hyperliquid-withdraw.ts
@@ -3,14 +3,14 @@ import { SignTypedDataVersion } from '@metamask/keyring-controller';
 import type { Hex } from '@metamask/utils';
 import { createModuleLogger } from '@metamask/utils';
 
-import { RELAY_AUTHORIZE_URL, HYPERLIQUID_EXCHANGE_URL } from './constants';
-import type { RelayQuote, RelaySignatureStep } from './types';
 import { CHAIN_ID_ARBITRUM } from '../../constants';
 import { projectLogger } from '../../logger';
 import type {
   TransactionPayControllerMessenger,
   TransactionPayQuote,
 } from '../../types';
+import { RELAY_AUTHORIZE_URL, HYPERLIQUID_EXCHANGE_URL } from './constants';
+import type { RelayQuote, RelaySignatureStep } from './types';
 
 const log = createModuleLogger(projectLogger, 'hyperliquid-withdraw');
 

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-api.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-api.test.ts
@@ -1,5 +1,7 @@
 import { successfulFetch } from '@metamask/controller-utils';
 
+import type { FeatureFlags } from '../../utils/feature-flags';
+import { getFeatureFlags } from '../../utils/feature-flags';
 import { RELAY_STATUS_URL } from './constants';
 import {
   fetchRelayQuote,
@@ -7,8 +9,6 @@ import {
   submitRelayExecute,
 } from './relay-api';
 import type { RelayQuoteRequest } from './types';
-import type { FeatureFlags } from '../../utils/feature-flags';
-import { getFeatureFlags } from '../../utils/feature-flags';
 
 jest.mock('../../utils/feature-flags');
 

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-api.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-api.ts
@@ -1,5 +1,7 @@
 import { successfulFetch } from '@metamask/controller-utils';
 
+import type { TransactionPayControllerMessenger } from '../../types';
+import { getFeatureFlags } from '../../utils/feature-flags';
 import { RELAY_STATUS_URL } from './constants';
 import type {
   RelayExecuteRequest,
@@ -8,8 +10,6 @@ import type {
   RelayQuoteRequest,
   RelayStatusResponse,
 } from './types';
-import type { TransactionPayControllerMessenger } from '../../types';
-import { getFeatureFlags } from '../../utils/feature-flags';
 
 /**
  * Fetch a quote from the Relay API.

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-max-gas-station.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-max-gas-station.test.ts
@@ -4,8 +4,6 @@ import type {
 } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 
-import { getRelayMaxGasStationQuote } from './relay-max-gas-station';
-import type { RelayQuote } from './types';
 import { TransactionPayStrategy } from '../..';
 import { getDefaultRemoteFeatureFlagControllerState } from '../../../../remote-feature-flag-controller/src/remote-feature-flag-controller';
 import { getMessengerMock } from '../../tests/messenger-mock';
@@ -22,6 +20,8 @@ import {
   getTokenBalance,
   getTokenInfo,
 } from '../../utils/token';
+import { getRelayMaxGasStationQuote } from './relay-max-gas-station';
+import type { RelayQuote } from './types';
 
 jest.mock('../../utils/token');
 jest.mock('../../utils/gas');

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-max-gas-station.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-max-gas-station.ts
@@ -1,11 +1,6 @@
 import { createModuleLogger } from '@metamask/utils';
 import { BigNumber } from 'bignumber.js';
 
-import {
-  getGasStationEligibility,
-  getGasStationCostInSourceTokenRaw,
-} from './gas-station';
-import type { RelayQuote, RelayTransactionStep } from './types';
 import { projectLogger } from '../../logger';
 import type {
   PayStrategyGetQuotesRequest,
@@ -18,6 +13,11 @@ import {
   getTokenBalance,
   getTokenInfo,
 } from '../../utils/token';
+import {
+  getGasStationEligibility,
+  getGasStationCostInSourceTokenRaw,
+} from './gas-station';
+import type { RelayQuote, RelayTransactionStep } from './types';
 
 const log = createModuleLogger(projectLogger, 'relay-max-gas-station');
 

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.test.ts
@@ -7,8 +7,6 @@ import type {
 import type { Hex } from '@metamask/utils';
 import { cloneDeep } from 'lodash';
 
-import { getRelayQuotes } from './relay-quotes';
-import type { RelayQuote, RelayTransactionStep } from './types';
 import { getDefaultRemoteFeatureFlagControllerState } from '../../../../remote-feature-flag-controller/src/remote-feature-flag-controller';
 import {
   ARBITRUM_USDC_ADDRESS,
@@ -37,6 +35,8 @@ import {
   getTokenBalance,
   getTokenFiatRate,
 } from '../../utils/token';
+import { getRelayQuotes } from './relay-quotes';
+import type { RelayQuote, RelayTransactionStep } from './types';
 
 jest.mock('../../utils/token', () => ({
   ...jest.createMockFromModule<typeof import('../../utils/token')>(

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.ts
@@ -7,19 +7,6 @@ import type { Hex } from '@metamask/utils';
 import { createModuleLogger } from '@metamask/utils';
 import { BigNumber } from 'bignumber.js';
 
-import { TOKEN_TRANSFER_FOUR_BYTE } from './constants';
-import {
-  getGasStationCostInSourceTokenRaw,
-  getGasStationEligibility,
-} from './gas-station';
-import { fetchRelayQuote } from './relay-api';
-import { getRelayMaxGasStationQuote } from './relay-max-gas-station';
-import type {
-  RelayQuote,
-  RelayQuoteMetamask,
-  RelayQuoteRequest,
-  RelayTransactionStep,
-} from './types';
 import { TransactionPayStrategy } from '../..';
 import {
   ARBITRUM_USDC_ADDRESS,
@@ -60,6 +47,19 @@ import {
   TokenAddressTarget,
 } from '../../utils/token';
 import { isPredictWithdrawTransaction } from '../../utils/transaction';
+import { TOKEN_TRANSFER_FOUR_BYTE } from './constants';
+import {
+  getGasStationCostInSourceTokenRaw,
+  getGasStationEligibility,
+} from './gas-station';
+import { fetchRelayQuote } from './relay-api';
+import { getRelayMaxGasStationQuote } from './relay-max-gas-station';
+import type {
+  RelayQuote,
+  RelayQuoteMetamask,
+  RelayQuoteRequest,
+  RelayTransactionStep,
+} from './types';
 
 const log = createModuleLogger(projectLogger, 'relay-strategy');
 

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-submit.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-submit.test.ts
@@ -4,9 +4,6 @@ import type { TransactionMeta } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 import { cloneDeep } from 'lodash';
 
-import { RELAY_STATUS_URL } from './constants';
-import { submitRelayQuotes } from './relay-submit';
-import type { RelayQuote } from './types';
 import { getMessengerMock } from '../../tests/messenger-mock';
 import type {
   PayStrategyExecuteRequest,
@@ -26,6 +23,9 @@ import {
   updateTransaction,
   waitForTransactionConfirmed,
 } from '../../utils/transaction';
+import { RELAY_STATUS_URL } from './constants';
+import { submitRelayQuotes } from './relay-submit';
+import type { RelayQuote } from './types';
 
 jest.mock('../../utils/token');
 jest.mock('../../utils/transaction');

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-submit.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-submit.ts
@@ -9,19 +9,6 @@ import type { Hex } from '@metamask/utils';
 import { createModuleLogger } from '@metamask/utils';
 import { BigNumber } from 'bignumber.js';
 
-import {
-  RELAY_DEPOSIT_TYPES,
-  RELAY_FAILURE_STATUSES,
-  RELAY_PENDING_STATUSES,
-} from './constants';
-import { submitHyperliquidWithdraw } from './hyperliquid-withdraw';
-import { getRelayStatus, submitRelayExecute } from './relay-api';
-import type {
-  RelayExecuteRequest,
-  RelayQuote,
-  RelayStatusResponse,
-  RelayTransactionStep,
-} from './types';
 import { projectLogger } from '../../logger';
 import type {
   PayStrategyExecuteRequest,
@@ -44,6 +31,19 @@ import {
   updateTransaction,
   waitForTransactionConfirmed,
 } from '../../utils/transaction';
+import {
+  RELAY_DEPOSIT_TYPES,
+  RELAY_FAILURE_STATUSES,
+  RELAY_PENDING_STATUSES,
+} from './constants';
+import { submitHyperliquidWithdraw } from './hyperliquid-withdraw';
+import { getRelayStatus, submitRelayExecute } from './relay-api';
+import type {
+  RelayExecuteRequest,
+  RelayQuote,
+  RelayStatusResponse,
+  RelayTransactionStep,
+} from './types';
 
 const FALLBACK_HASH = '0x0' as Hex;
 

--- a/packages/transaction-pay-controller/src/strategy/test/TestStrategy.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/test/TestStrategy.test.ts
@@ -1,12 +1,12 @@
 import type { TransactionMeta } from '@metamask/transaction-controller';
 
-import { TestStrategy } from './TestStrategy';
 import { TransactionPayStrategy } from '../..';
 import type {
   QuoteRequest,
   TransactionPayControllerMessenger,
   TransactionPayQuote,
 } from '../../types';
+import { TestStrategy } from './TestStrategy';
 
 jest.useFakeTimers();
 

--- a/packages/transaction-pay-controller/src/utils/feature-flags.test.ts
+++ b/packages/transaction-pay-controller/src/utils/feature-flags.test.ts
@@ -1,5 +1,8 @@
 import type { Hex } from '@metamask/utils';
 
+import { getDefaultRemoteFeatureFlagControllerState } from '../../../remote-feature-flag-controller/src/remote-feature-flag-controller';
+import { TransactionPayStrategy } from '../constants';
+import { getMessengerMock } from '../tests/messenger-mock';
 import {
   DEFAULT_ACROSS_API_BASE,
   DEFAULT_FALLBACK_GAS_ESTIMATE,
@@ -24,9 +27,6 @@ import {
   getStrategyOrder,
 } from './feature-flags';
 import * as featureFlagsModule from './feature-flags';
-import { getDefaultRemoteFeatureFlagControllerState } from '../../../remote-feature-flag-controller/src/remote-feature-flag-controller';
-import { TransactionPayStrategy } from '../constants';
-import { getMessengerMock } from '../tests/messenger-mock';
 
 const GAS_FALLBACK_ESTIMATE_MOCK = 123;
 const GAS_FALLBACK_MAX_MOCK = 456;

--- a/packages/transaction-pay-controller/src/utils/gas.test.ts
+++ b/packages/transaction-pay-controller/src/utils/gas.test.ts
@@ -2,6 +2,12 @@ import { toHex } from '@metamask/controller-utils';
 import type { Hex } from '@metamask/utils';
 import { clone, cloneDeep } from 'lodash';
 
+import type { GasFeeEstimates } from '../../../gas-fee-controller/src';
+import type {
+  GasFeeToken,
+  TransactionMeta,
+} from '../../../transaction-controller/src';
+import { getMessengerMock } from '../tests/messenger-mock';
 import { getFallbackGas, getGasBuffer } from './feature-flags';
 import {
   calculateGasCost,
@@ -10,12 +16,6 @@ import {
   estimateGasLimit,
 } from './gas';
 import { getTokenBalance, getTokenFiatRate } from './token';
-import type { GasFeeEstimates } from '../../../gas-fee-controller/src';
-import type {
-  GasFeeToken,
-  TransactionMeta,
-} from '../../../transaction-controller/src';
-import { getMessengerMock } from '../tests/messenger-mock';
 
 jest.mock('./token');
 jest.mock('./feature-flags', () => ({

--- a/packages/transaction-pay-controller/src/utils/gas.ts
+++ b/packages/transaction-pay-controller/src/utils/gas.ts
@@ -7,11 +7,11 @@ import type {
 import type { Hex } from '@metamask/utils';
 import { BigNumber } from 'bignumber.js';
 
-import { getFallbackGas, getGasBuffer } from './feature-flags';
-import { getNativeToken, getTokenBalance, getTokenFiatRate } from './token';
 import type { TransactionPayControllerMessenger } from '..';
 import { createModuleLogger, projectLogger } from '../logger';
 import type { Amount } from '../types';
+import { getFallbackGas, getGasBuffer } from './feature-flags';
+import { getNativeToken, getTokenBalance, getTokenFiatRate } from './token';
 
 const log = createModuleLogger(projectLogger, 'gas');
 

--- a/packages/transaction-pay-controller/src/utils/quote-gas.test.ts
+++ b/packages/transaction-pay-controller/src/utils/quote-gas.test.ts
@@ -1,9 +1,9 @@
 import type { Hex } from '@metamask/utils';
 
+import { getMessengerMock } from '../tests/messenger-mock';
 import { getGasBuffer } from './feature-flags';
 import { estimateGasLimit } from './gas';
 import { estimateQuoteGasLimits } from './quote-gas';
-import { getMessengerMock } from '../tests/messenger-mock';
 
 jest.mock('./feature-flags', () => ({
   ...jest.requireActual('./feature-flags'),

--- a/packages/transaction-pay-controller/src/utils/quote-gas.ts
+++ b/packages/transaction-pay-controller/src/utils/quote-gas.ts
@@ -4,10 +4,10 @@ import type { Hex } from '@metamask/utils';
 import { createModuleLogger } from '@metamask/utils';
 import { BigNumber } from 'bignumber.js';
 
-import { getGasBuffer } from './feature-flags';
-import { estimateGasLimit } from './gas';
 import type { TransactionPayControllerMessenger } from '..';
 import { projectLogger } from '../logger';
+import { getGasBuffer } from './feature-flags';
+import { estimateGasLimit } from './gas';
 
 const log = createModuleLogger(projectLogger, 'quote-gas');
 

--- a/packages/transaction-pay-controller/src/utils/quotes.test.ts
+++ b/packages/transaction-pay-controller/src/utils/quotes.test.ts
@@ -4,12 +4,6 @@ import type { BatchTransaction } from '@metamask/transaction-controller';
 import type { Hex, Json } from '@metamask/utils';
 import { cloneDeep } from 'lodash';
 
-import type { UpdateQuotesRequest } from './quotes';
-import { refreshQuotes, updateQuotes } from './quotes';
-import { getStrategiesByName, getStrategyByName } from './strategy';
-import { getLiveTokenBalance, getTokenFiatRate } from './token';
-import { calculateTotals } from './totals';
-import { getTransaction, updateTransaction } from './transaction';
 import { TransactionPayStrategy } from '../constants';
 import { getMessengerMock } from '../tests/messenger-mock';
 import type {
@@ -20,6 +14,12 @@ import type {
   TransactionPaymentToken,
   TransactionPayRequiredToken,
 } from '../types';
+import type { UpdateQuotesRequest } from './quotes';
+import { refreshQuotes, updateQuotes } from './quotes';
+import { getStrategiesByName, getStrategyByName } from './strategy';
+import { getLiveTokenBalance, getTokenFiatRate } from './token';
+import { calculateTotals } from './totals';
+import { getTransaction, updateTransaction } from './transaction';
 
 jest.mock('./strategy');
 jest.mock('./transaction');

--- a/packages/transaction-pay-controller/src/utils/quotes.ts
+++ b/packages/transaction-pay-controller/src/utils/quotes.ts
@@ -4,14 +4,6 @@ import type { TransactionMeta } from '@metamask/transaction-controller';
 import type { Hex, Json } from '@metamask/utils';
 import { createModuleLogger } from '@metamask/utils';
 
-import { getStrategiesByName, getStrategyByName } from './strategy';
-import {
-  computeTokenAmounts,
-  getLiveTokenBalance,
-  getTokenFiatRate,
-} from './token';
-import { calculateTotals } from './totals';
-import { getTransaction, updateTransaction } from './transaction';
 import { TransactionPayStrategy } from '../constants';
 import { projectLogger } from '../logger';
 import type {
@@ -25,6 +17,14 @@ import type {
   TransactionPaymentToken,
   UpdateTransactionDataCallback,
 } from '../types';
+import { getStrategiesByName, getStrategyByName } from './strategy';
+import {
+  computeTokenAmounts,
+  getLiveTokenBalance,
+  getTokenFiatRate,
+} from './token';
+import { calculateTotals } from './totals';
+import { getTransaction, updateTransaction } from './transaction';
 
 const DEFAULT_REFRESH_INTERVAL = 30 * 1000; // 30 Seconds
 

--- a/packages/transaction-pay-controller/src/utils/required-tokens.test.ts
+++ b/packages/transaction-pay-controller/src/utils/required-tokens.test.ts
@@ -1,11 +1,11 @@
 import type { TransactionMeta } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 
-import { parseRequiredTokens } from './required-tokens';
-import { getTokenBalance, getTokenFiatRate, getTokenInfo } from './token';
 import { toHex } from '../../../controller-utils/src';
 import { NATIVE_TOKEN_ADDRESS } from '../constants';
 import type { TransactionPayControllerMessenger } from '../types';
+import { parseRequiredTokens } from './required-tokens';
+import { getTokenBalance, getTokenFiatRate, getTokenInfo } from './token';
 
 jest.mock('./token', () => ({
   ...jest.requireActual('./token'),

--- a/packages/transaction-pay-controller/src/utils/required-tokens.ts
+++ b/packages/transaction-pay-controller/src/utils/required-tokens.ts
@@ -6,6 +6,11 @@ import { add0x } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
 import { BigNumber } from 'bignumber.js';
 
+import type {
+  FiatRates,
+  TransactionPayControllerMessenger,
+  TransactionPayRequiredToken,
+} from '../types';
 import {
   computeTokenAmounts,
   getNativeToken,
@@ -13,11 +18,6 @@ import {
   getTokenFiatRate,
   getTokenInfo,
 } from './token';
-import type {
-  FiatRates,
-  TransactionPayControllerMessenger,
-  TransactionPayRequiredToken,
-} from '../types';
 
 const FOUR_BYTE_TOKEN_TRANSFER = '0xa9059cbb';
 

--- a/packages/transaction-pay-controller/src/utils/source-amounts.test.ts
+++ b/packages/transaction-pay-controller/src/utils/source-amounts.test.ts
@@ -1,13 +1,13 @@
 import { TransactionType } from '@metamask/transaction-controller';
 
-import { updateSourceAmounts } from './source-amounts';
-import { getTokenFiatRate } from './token';
-import { getTransaction } from './transaction';
 import { TransactionPayStrategy } from '..';
 import type { TransactionPaymentToken } from '..';
 import { ARBITRUM_USDC_ADDRESS, CHAIN_ID_ARBITRUM } from '../constants';
 import { getMessengerMock } from '../tests/messenger-mock';
 import type { TransactionData, TransactionPayRequiredToken } from '../types';
+import { updateSourceAmounts } from './source-amounts';
+import { getTokenFiatRate } from './token';
+import { getTransaction } from './transaction';
 
 jest.mock('./token', () => ({
   ...jest.requireActual('./token'),

--- a/packages/transaction-pay-controller/src/utils/source-amounts.ts
+++ b/packages/transaction-pay-controller/src/utils/source-amounts.ts
@@ -2,8 +2,6 @@ import { TransactionType } from '@metamask/transaction-controller';
 import { createModuleLogger } from '@metamask/utils';
 import { BigNumber } from 'bignumber.js';
 
-import { getTokenFiatRate, isSameToken } from './token';
-import { getTransaction } from './transaction';
 import type {
   TransactionPayControllerMessenger,
   TransactionPaymentToken,
@@ -17,6 +15,8 @@ import type {
   TransactionData,
   TransactionPayRequiredToken,
 } from '../types';
+import { getTokenFiatRate, isSameToken } from './token';
+import { getTransaction } from './transaction';
 
 const log = createModuleLogger(projectLogger, 'source-amounts');
 

--- a/packages/transaction-pay-controller/src/utils/strategy.test.ts
+++ b/packages/transaction-pay-controller/src/utils/strategy.test.ts
@@ -1,10 +1,10 @@
-import { getStrategiesByName, getStrategyByName } from './strategy';
 import { TransactionPayStrategy } from '../constants';
 import { AcrossStrategy } from '../strategy/across/AcrossStrategy';
 import { BridgeStrategy } from '../strategy/bridge/BridgeStrategy';
 import { FiatStrategy } from '../strategy/fiat/FiatStrategy';
 import { RelayStrategy } from '../strategy/relay/RelayStrategy';
 import { TestStrategy } from '../strategy/test/TestStrategy';
+import { getStrategiesByName, getStrategyByName } from './strategy';
 
 describe('Strategy Utils', () => {
   describe('getStrategyByName', () => {

--- a/packages/transaction-pay-controller/src/utils/token.test.ts
+++ b/packages/transaction-pay-controller/src/utils/token.test.ts
@@ -5,6 +5,13 @@ import type { AccountTrackerControllerState } from '@metamask/assets-controllers
 import type { TokenRatesControllerState } from '@metamask/assets-controllers';
 import type { Hex } from '@metamask/utils';
 
+import { getDefaultRemoteFeatureFlagControllerState } from '../../../remote-feature-flag-controller/src/remote-feature-flag-controller';
+import {
+  CHAIN_ID_POLYGON,
+  NATIVE_TOKEN_ADDRESS,
+  POLYGON_USDCE_ADDRESS,
+} from '../constants';
+import { getMessengerMock } from '../tests/messenger-mock';
 import {
   computeRawFromFiatAmount,
   computeTokenAmounts,
@@ -17,13 +24,6 @@ import {
   normalizeTokenAddress,
   TokenAddressTarget,
 } from './token';
-import { getDefaultRemoteFeatureFlagControllerState } from '../../../remote-feature-flag-controller/src/remote-feature-flag-controller';
-import {
-  CHAIN_ID_POLYGON,
-  NATIVE_TOKEN_ADDRESS,
-  POLYGON_USDCE_ADDRESS,
-} from '../constants';
-import { getMessengerMock } from '../tests/messenger-mock';
 
 jest.mock('@ethersproject/contracts', () => ({
   ...jest.requireActual('@ethersproject/contracts'),

--- a/packages/transaction-pay-controller/src/utils/token.ts
+++ b/packages/transaction-pay-controller/src/utils/token.ts
@@ -6,13 +6,13 @@ import { abiERC20 } from '@metamask/metamask-eth-abis';
 import type { Hex } from '@metamask/utils';
 import { BigNumber } from 'bignumber.js';
 
-import { getAssetsUnifyStateFeature } from './feature-flags';
 import {
   CHAIN_ID_POLYGON,
   NATIVE_TOKEN_ADDRESS,
   STABLECOINS,
 } from '../constants';
 import type { FiatRates, TransactionPayControllerMessenger } from '../types';
+import { getAssetsUnifyStateFeature } from './feature-flags';
 
 /**
  * Check if two tokens are the same (same address and chain).

--- a/packages/transaction-pay-controller/src/utils/totals.test.ts
+++ b/packages/transaction-pay-controller/src/utils/totals.test.ts
@@ -1,7 +1,5 @@
 import type { TransactionMeta } from '@metamask/transaction-controller';
 
-import { calculateTransactionGasCost } from './gas';
-import { calculateTotals } from './totals';
 import { TransactionPayStrategy } from '..';
 import type { TransactionPayControllerMessenger } from '..';
 import type {
@@ -9,6 +7,8 @@ import type {
   TransactionPayQuote,
   TransactionPayRequiredToken,
 } from '../types';
+import { calculateTransactionGasCost } from './gas';
+import { calculateTotals } from './totals';
 
 jest.mock('./gas');
 

--- a/packages/transaction-pay-controller/src/utils/totals.ts
+++ b/packages/transaction-pay-controller/src/utils/totals.ts
@@ -1,8 +1,6 @@
 import type { TransactionMeta } from '@metamask/transaction-controller';
 import { BigNumber } from 'bignumber.js';
 
-import { sumAmounts } from './amounts';
-import { calculateTransactionGasCost } from './gas';
 import type {
   FiatValue,
   TransactionPayControllerMessenger,
@@ -10,6 +8,8 @@ import type {
   TransactionPayRequiredToken,
   TransactionPayTotals,
 } from '../types';
+import { sumAmounts } from './amounts';
+import { calculateTransactionGasCost } from './gas';
 
 /**
  * Calculate totals for a list of quotes and tokens.

--- a/packages/transaction-pay-controller/src/utils/transaction.test.ts
+++ b/packages/transaction-pay-controller/src/utils/transaction.test.ts
@@ -7,6 +7,8 @@ import type { TransactionControllerState } from '@metamask/transaction-controlle
 import type { Hex } from '@metamask/utils';
 import { noop } from 'lodash';
 
+import { getMessengerMock } from '../tests/messenger-mock';
+import type { TransactionData, TransactionPayRequiredToken } from '../types';
 import { parseRequiredTokens } from './required-tokens';
 import {
   FINALIZED_STATUSES,
@@ -17,8 +19,6 @@ import {
   updateTransaction,
   waitForTransactionConfirmed,
 } from './transaction';
-import { getMessengerMock } from '../tests/messenger-mock';
-import type { TransactionData, TransactionPayRequiredToken } from '../types';
 
 jest.mock('./required-tokens');
 

--- a/packages/transaction-pay-controller/src/utils/transaction.ts
+++ b/packages/transaction-pay-controller/src/utils/transaction.ts
@@ -7,12 +7,12 @@ import type { Hex } from '@metamask/utils';
 import { createModuleLogger } from '@metamask/utils';
 import { cloneDeep } from 'lodash';
 
-import { parseRequiredTokens } from './required-tokens';
 import { projectLogger } from '../logger';
 import type {
   TransactionPayControllerMessenger,
   UpdateTransactionDataCallback,
 } from '../types';
+import { parseRequiredTokens } from './required-tokens';
 
 const log = createModuleLogger(projectLogger, 'transaction');
 

--- a/packages/user-operation-controller/src/helpers/Bundler.test.ts
+++ b/packages/user-operation-controller/src/helpers/Bundler.test.ts
@@ -1,5 +1,5 @@
-import { Bundler } from './Bundler';
 import type { UserOperation } from '../types';
+import { Bundler } from './Bundler';
 
 const URL_MOCK = 'http://test.com';
 const ENTRYPOINT_MOCK = '0x123';

--- a/packages/user-operation-controller/src/helpers/PendingUserOperationTracker.test.ts
+++ b/packages/user-operation-controller/src/helpers/PendingUserOperationTracker.test.ts
@@ -1,11 +1,11 @@
 import { query } from '@metamask/controller-utils';
 import type { NetworkControllerGetNetworkClientByIdAction } from '@metamask/network-controller';
 
-import * as BundlerHelper from './Bundler';
-import { PendingUserOperationTracker } from './PendingUserOperationTracker';
 import type { UserOperationMetadata, UserOperationReceipt } from '../types';
 import { UserOperationStatus } from '../types';
 import type { UserOperationControllerMessenger } from '../UserOperationController';
+import * as BundlerHelper from './Bundler';
+import { PendingUserOperationTracker } from './PendingUserOperationTracker';
 
 const CHAIN_ID_MOCK = '0x5';
 const NETWORK_CLIENT_ID_MOCK = 'testNetworkClientId';

--- a/packages/user-operation-controller/src/helpers/PendingUserOperationTracker.ts
+++ b/packages/user-operation-controller/src/helpers/PendingUserOperationTracker.ts
@@ -12,11 +12,11 @@ import type { Hex } from '@metamask/utils';
 // eslint-disable-next-line import-x/no-nodejs-modules
 import EventEmitter from 'events';
 
-import { Bundler } from './Bundler';
 import { projectLogger } from '../logger';
 import type { UserOperationMetadata, UserOperationReceipt } from '../types';
 import { UserOperationStatus } from '../types';
 import type { UserOperationControllerMessenger } from '../UserOperationController';
+import { Bundler } from './Bundler';
 
 const log = createModuleLogger(projectLogger, 'pending-user-operations');
 

--- a/packages/user-operation-controller/src/helpers/SnapSmartContractAccount.test.ts
+++ b/packages/user-operation-controller/src/helpers/SnapSmartContractAccount.test.ts
@@ -1,6 +1,5 @@
 import type { KeyringController } from '@metamask/keyring-controller';
 
-import { SnapSmartContractAccount } from './SnapSmartContractAccount';
 import { ADDRESS_ZERO, EMPTY_BYTES, VALUE_ZERO } from '../constants';
 import type {
   PrepareUserOperationResponse,
@@ -12,6 +11,7 @@ import type {
 import type { PrepareUserOperationRequest } from '../types';
 import type { UserOperationControllerMessenger } from '../UserOperationController';
 import { toEip155ChainId } from '../utils/chain-id';
+import { SnapSmartContractAccount } from './SnapSmartContractAccount';
 
 const PREPARE_USER_OPERATION_REQUEST_MOCK: PrepareUserOperationRequest = {
   chainId: '0x1',

--- a/packages/user-operation-controller/src/utils/gas.test.ts
+++ b/packages/user-operation-controller/src/utils/gas.test.ts
@@ -1,6 +1,5 @@
 import { cloneDeep } from 'lodash';
 
-import { updateGas } from './gas';
 import { VALUE_ZERO } from '../constants';
 import type { BundlerEstimateUserOperationGasResponse } from '../helpers/Bundler';
 import { Bundler } from '../helpers/Bundler';
@@ -8,6 +7,7 @@ import type {
   PrepareUserOperationResponse,
   UserOperationMetadata,
 } from '../types';
+import { updateGas } from './gas';
 
 jest.mock('../helpers/Bundler', () => ({
   Bundler: jest.fn(),

--- a/packages/user-operation-controller/src/utils/transaction.test.ts
+++ b/packages/user-operation-controller/src/utils/transaction.test.ts
@@ -1,4 +1,3 @@
-import { getTransactionMetadata } from './transaction';
 import type { TransactionParams } from '../../../transaction-controller/src';
 import {
   TransactionStatus,
@@ -9,6 +8,7 @@ import { EMPTY_BYTES, VALUE_ZERO } from '../constants';
 import { UserOperationStatus } from '../types';
 import type { UserOperation } from '../types';
 import type { UserOperationMetadata } from '../types';
+import { getTransactionMetadata } from './transaction';
 
 const USER_OPERATION_METADATA_MOCK: UserOperationMetadata = {
   id: 'testUserOperationId',

--- a/packages/user-operation-controller/src/utils/validation.test.ts
+++ b/packages/user-operation-controller/src/utils/validation.test.ts
@@ -3,13 +3,6 @@
 import { TransactionType } from '@metamask/transaction-controller';
 import { cloneDeep } from 'lodash';
 
-import {
-  validateAddUserOperationOptions,
-  validateAddUserOperationRequest,
-  validatePrepareUserOperationResponse,
-  validateSignUserOperationResponse,
-  validateUpdateUserOperationResponse,
-} from './validation';
 import type {
   PrepareUserOperationResponse,
   SignUserOperationResponse,
@@ -19,6 +12,13 @@ import type {
   AddUserOperationOptions,
   AddUserOperationRequest,
 } from '../UserOperationController';
+import {
+  validateAddUserOperationOptions,
+  validateAddUserOperationRequest,
+  validatePrepareUserOperationResponse,
+  validateSignUserOperationResponse,
+  validateUpdateUserOperationResponse,
+} from './validation';
 
 const ADD_USER_OPERATION_REQUEST_MOCK: AddUserOperationRequest = {
   data: '0x1',


### PR DESCRIPTION
## Explanation

This replaces `import-x/order` (ESLint rule) with Oxfmt for sorting imports, which solves a regression `eslint-plugin-import(-x)` introduced some time ago, where relative imports closer to the source file would be sorted higher up.

Blocked by:
- #8434.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to formatting/tooling (import sorting) plus mechanical import reordering across many files, with no intended runtime logic changes.
> 
> **Overview**
> Switches import sorting responsibility to **Oxfmt** by adding `sortImports` configuration in `.oxfmtrc.json` and disabling ESLint’s `import-x/order` rule.
> 
> Applies the new import ordering across many packages by mechanically reordering and regrouping import statements (including tests), without changing runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af8e66164d89d5ca48f97c4fbd142d2c7532fc46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->