### PR TITLE
fix: set submittedTime at pay publish hook start for accurate time-to-complete metrics

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add optional `atomic` property to `TransactionBatchRequest` to configure whether EIP-7702 batch calls revert together or can fail independently ([#8320](https://github.com/MetaMask/core/pull/8320))
 
+### Changed
+
+- Preserve `submittedTime` if already set by a publish hook instead of overwriting it ([#8439](https://github.com/MetaMask/core/pull/8439))
+
 ## [64.1.0]
 
 ### Added

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -2903,6 +2903,51 @@ describe('TransactionController', () => {
         });
       });
 
+      it('preserves submittedTime if already set by publish hook', async () => {
+        const presetSubmittedTime = 1000000;
+
+        const { controller } = setupController({
+          options: {
+            hooks: {
+              publish: async (txMeta) => {
+                const existing = controller.state.transactions.find(
+                  (transaction) => transaction.id === txMeta.id,
+                );
+
+                if (existing) {
+                  controller.updateTransaction(
+                    { ...existing, submittedTime: presetSubmittedTime },
+                    'Set submittedTime in publish hook',
+                  );
+                }
+                return { transactionHash: '0x123' };
+              },
+            },
+          },
+          messengerOptions: {
+            addTransactionApprovalRequest: {
+              state: 'approved',
+            },
+          },
+        });
+
+        const { result } = await controller.addTransaction(
+          {
+            from: ACCOUNT_MOCK,
+            to: ACCOUNT_MOCK,
+          },
+          {
+            networkClientId: NETWORK_CLIENT_ID_MOCK,
+          },
+        );
+
+        await result;
+
+        expect(controller.state.transactions[0].submittedTime).toBe(
+          presetSubmittedTime,
+        );
+      });
+
       it('throws with data message if publish fails', async () => {
         const { controller } = setupController({
           messengerOptions: {

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -3291,7 +3291,7 @@ export class TransactionController extends BaseController<
         (draftTxMeta) => {
           draftTxMeta.hash = hash;
           draftTxMeta.status = TransactionStatus.submitted;
-          draftTxMeta.submittedTime = new Date().getTime();
+          draftTxMeta.submittedTime ??= new Date().getTime();
           if (shouldUpdatePreTxBalance) {
             draftTxMeta.preTxBalance = preTxBalance;
             log('Updated pre-transaction balance', preTxBalance);

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/ramps-controller` from `^13.0.0` to `^13.1.0` ([#8407](https://github.com/MetaMask/core/pull/8407))
 - Bump `@metamask/transaction-controller` from `^64.0.0` to `^64.1.0` ([#8432](https://github.com/MetaMask/core/pull/8432))
 
+### Fixed
+
+- Set `submittedTime` at the start of `TransactionPayPublishHook` before strategy execution for accurate `mm_pay_time_to_complete_s` metrics in intent-based flows ([#8439](https://github.com/MetaMask/core/pull/8439))
+
 ## [19.1.0]
 
 ### Added

--- a/packages/transaction-pay-controller/src/helpers/TransactionPayPublishHook.test.ts
+++ b/packages/transaction-pay-controller/src/helpers/TransactionPayPublishHook.test.ts
@@ -30,7 +30,12 @@ describe('TransactionPayPublishHook', () => {
   const executeMock = jest.fn();
   const getStrategyByNameMock = jest.mocked(getStrategyByName);
 
-  const { messenger, getControllerStateMock } = getMessengerMock();
+  const {
+    messenger,
+    getControllerStateMock,
+    getTransactionControllerStateMock,
+    updateTransactionMock,
+  } = getMessengerMock();
 
   let hook: TransactionPayPublishHook;
 
@@ -65,6 +70,10 @@ describe('TransactionPayPublishHook', () => {
         },
       },
     } as TransactionPayControllerState);
+
+    getTransactionControllerStateMock.mockReturnValue({
+      transactions: [TRANSACTION_META_MOCK],
+    });
   });
 
   it('executes strategy with quotes', async () => {
@@ -91,6 +100,45 @@ describe('TransactionPayPublishHook', () => {
     await runHook();
 
     expect(executeMock).not.toHaveBeenCalled();
+  });
+
+  it('sets submittedTime on the transaction before executing strategy', async () => {
+    await runHook();
+
+    expect(updateTransactionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: TRANSACTION_META_MOCK.id,
+        submittedTime: expect.any(Number),
+      }),
+      'Set submittedTime at pay publish hook start',
+    );
+  });
+
+  it('sets submittedTime before strategy.execute is called', async () => {
+    const callOrder: string[] = [];
+
+    updateTransactionMock.mockImplementation(() => {
+      callOrder.push('updateTransaction');
+    });
+
+    executeMock.mockImplementation(() => {
+      callOrder.push('execute');
+      return { transactionHash: '0x123' };
+    });
+
+    await runHook();
+
+    expect(callOrder).toStrictEqual(['updateTransaction', 'execute']);
+  });
+
+  it('does not set submittedTime if no quotes', async () => {
+    getControllerStateMock.mockReturnValue({
+      transactionData: {},
+    });
+
+    await runHook();
+
+    expect(updateTransactionMock).not.toHaveBeenCalled();
   });
 
   it('throws errors from submit', async () => {

--- a/packages/transaction-pay-controller/src/helpers/TransactionPayPublishHook.ts
+++ b/packages/transaction-pay-controller/src/helpers/TransactionPayPublishHook.ts
@@ -10,6 +10,7 @@ import type {
   TransactionPayQuote,
 } from '../types';
 import { getStrategyByName } from '../utils/strategy';
+import { updateTransaction } from '../utils/transaction';
 
 const log = createModuleLogger(projectLogger, 'pay-publish-hook');
 
@@ -67,6 +68,17 @@ export class TransactionPayPublishHook {
       log('Skipping as no quotes found');
       return EMPTY_RESULT;
     }
+
+    updateTransaction(
+      {
+        transactionId,
+        messenger: this.#messenger,
+        note: 'Set submittedTime at pay publish hook start',
+      },
+      (tx) => {
+        tx.submittedTime = new Date().getTime();
+      },
+    );
 
     const strategy = getStrategyByName(quotes[0].strategy);
 


### PR DESCRIPTION
## Explanation

For intent-based flows (e.g., perps withdrawals via Hyperliquid + Relay), the entire Relay execution happens inside `TransactionPayPublishHook`. `TransactionController` only sets `submittedTime` **after** the publish hook returns, which means `submittedTime` is nearly identical to the finalization time. This causes `mm_pay_time_to_complete_s` to report ~0.5s instead of the actual seconds/minutes it takes.

**`transaction-pay-controller`**: `TransactionPayPublishHook` now sets `submittedTime` on the transaction at the start of the hook (before `strategy.execute`), capturing the moment the user initiates the action.

**`transaction-controller`**: `submittedTime` assignment in `#approveTransaction` changed from `=` to `??=` so it preserves a value pre-set by the publish hook. Normal flows where `submittedTime` is not pre-set are unaffected.

## References

- CONF-1158
- Related to MetaMask/metamask-mobile#27862

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk behavioral tweak to transaction metadata timestamping; main risk is subtle impact on metrics or downstream assumptions about when `submittedTime` is set.
> 
> **Overview**
> Improves intent-based MetaMask Pay timing metrics by setting `submittedTime` at the start of `TransactionPayPublishHook` (before `strategy.execute`) when quotes exist, rather than effectively at the end of the pay strategy.
> 
> Updates `TransactionController` to **preserve any pre-set `submittedTime`** (e.g., set by a publish hook) by using nullish assignment when marking a transaction as `submitted`, and adds targeted tests plus changelog entries to cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5907d59d0162b5daefde0368de2f1d90d546bcbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->