### PR TITLE
fix: link existing push token when notification accounts are added

### DIFF
--- a/packages/notification-services-controller/CHANGELOG.md
+++ b/packages/notification-services-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Add backend push token links for newly added notification accounts using the existing device token, so account additions trigger additive `POST /api/v2/token` registration for both primary and imported SRPs
+- Add backend push token links for newly added notification accounts using the existing device token, so account additions trigger additive `POST /api/v2/token` registration for both primary and imported SRPs ([#8449](https://github.com/MetaMask/core/pull/8449))
 
 ### Changed
 

--- a/packages/notification-services-controller/CHANGELOG.md
+++ b/packages/notification-services-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add backend push token links for newly added notification accounts using the existing device token, so account additions trigger additive `POST /api/v2/token` registration for both primary and imported SRPs
+
 ### Changed
 
 - Bump `@metamask/keyring-controller` from `^25.1.1` to `^25.2.0` ([#8363](https://github.com/MetaMask/core/pull/8363))

--- a/packages/notification-services-controller/CHANGELOG.md
+++ b/packages/notification-services-controller/CHANGELOG.md
@@ -7,16 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Add backend push token links for newly added notification accounts using the existing device token, so account additions trigger additive `POST /api/v2/token` registration for both primary and imported SRPs ([#8449](https://github.com/MetaMask/core/pull/8449))
-
 ### Changed
 
 - Bump `@metamask/keyring-controller` from `^25.1.1` to `^25.2.0` ([#8363](https://github.com/MetaMask/core/pull/8363))
 - Bump `@metamask/profile-sync-controller` from `^28.0.1` to `^28.0.2` ([#8325](https://github.com/MetaMask/core/pull/8325))
 - Bump `@metamask/controller-utils` from `^11.19.0` to `^11.20.0` ([#8344](https://github.com/MetaMask/core/pull/8344))
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
+
+### Fixed
+
+- Add backend push token links for newly added notification accounts using the existing device token, so account additions trigger additive `POST /api/v2/token` registration for both primary and imported SRPs ([#8449](https://github.com/MetaMask/core/pull/8449))
+  - Add the `NotificationServicesPushController:addPushNotificationLinks` messenger action and export the corresponding `NotificationServicesPushControllerAddPushNotificationLinksAction` type so clients can allow and type the new additive push-link flow.
 
 ## [23.0.1]
 

--- a/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.test.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.test.ts
@@ -16,6 +16,7 @@ import log from 'loglevel';
 import type nock from 'nock';
 
 import type {
+  NotificationServicesPushControllerAddPushNotificationLinksAction,
   NotificationServicesPushControllerDisablePushNotificationsAction,
   NotificationServicesPushControllerDeletePushNotificationLinksAction,
   NotificationServicesPushControllerEnablePushNotificationsAction,
@@ -819,7 +820,11 @@ describe('NotificationServicesController', () => {
     };
 
     it('enables notifications for given accounts', async () => {
-      const { messenger, mockUpdateNotifications } = arrangeMocks();
+      const {
+        messenger,
+        mockAddPushNotificationLinks,
+        mockUpdateNotifications,
+      } = arrangeMocks();
       const controller = new NotificationServicesController({
         messenger,
         env: { featureAnnouncements: featureAnnouncementsEnv },
@@ -828,6 +833,7 @@ describe('NotificationServicesController', () => {
       await controller.enableAccounts([ADDRESS_1]);
 
       expect(mockUpdateNotifications.isDone()).toBe(true);
+      expect(mockAddPushNotificationLinks).toHaveBeenCalledWith([ADDRESS_1]);
     });
 
     it('throws errors when invalid auth', async () => {
@@ -1712,6 +1718,7 @@ function mockNotificationMessenger(): {
   mockGetBearerToken: jest.Mock;
   mockIsSignedIn: jest.Mock;
   mockAuthPerformSignIn: jest.Mock;
+  mockAddPushNotificationLinks: jest.Mock;
   mockDisablePushNotifications: jest.Mock;
   mockDeletePushNotificationLinks: jest.Mock;
   mockEnablePushNotifications: jest.Mock;
@@ -1737,6 +1744,7 @@ function mockNotificationMessenger(): {
       'AuthenticationController:getBearerToken',
       'AuthenticationController:isSignedIn',
       'AuthenticationController:performSignIn',
+      'NotificationServicesPushController:addPushNotificationLinks',
       'NotificationServicesPushController:disablePushNotifications',
       'NotificationServicesPushController:deletePushNotificationLinks',
       'NotificationServicesPushController:enablePushNotifications',
@@ -1764,6 +1772,11 @@ function mockNotificationMessenger(): {
   const mockAuthPerformSignIn =
     typedMockAction<AuthenticationController.AuthenticationControllerPerformSignInAction>().mockResolvedValue(
       ['New Access Token'],
+    );
+
+  const mockAddPushNotificationLinks =
+    typedMockAction<NotificationServicesPushControllerAddPushNotificationLinksAction>().mockResolvedValue(
+      true,
     );
 
   const mockDisablePushNotifications =
@@ -1817,6 +1830,13 @@ function mockNotificationMessenger(): {
 
     if (
       actionType ===
+      'NotificationServicesPushController:addPushNotificationLinks'
+    ) {
+      return mockAddPushNotificationLinks(params[0]);
+    }
+
+    if (
+      actionType ===
       'NotificationServicesPushController:disablePushNotifications'
     ) {
       return mockDisablePushNotifications();
@@ -1854,6 +1874,7 @@ function mockNotificationMessenger(): {
     mockGetBearerToken,
     mockIsSignedIn,
     mockAuthPerformSignIn,
+    mockAddPushNotificationLinks,
     mockDisablePushNotifications,
     mockDeletePushNotificationLinks,
     mockEnablePushNotifications,

--- a/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.ts
@@ -342,6 +342,16 @@ export class NotificationServicesController extends BaseController<
         // Do nothing, failing silently.
       }
     },
+    addPushNotificationLinks: async (addresses: string[]): Promise<void> => {
+      try {
+        await this.messenger.call(
+          'NotificationServicesPushController:addPushNotificationLinks',
+          addresses,
+        );
+      } catch {
+        // Do nothing, failing silently.
+      }
+    },
     disablePushNotifications: async (): Promise<void> => {
       try {
         await this.messenger.call(
@@ -983,6 +993,8 @@ export class NotificationServicesController extends BaseController<
         accounts.map((address) => ({ address, enabled: true })),
         this.#env,
       );
+
+      await this.#pushNotifications.addPushNotificationLinks(accounts);
     } catch (error) {
       log.error('Failed to update OnChain triggers', error);
       throw new Error('Failed to update OnChain triggers');

--- a/packages/notification-services-controller/src/NotificationServicesPushController/NotificationServicesPushController-method-action-types.ts
+++ b/packages/notification-services-controller/src/NotificationServicesPushController/NotificationServicesPushController-method-action-types.ts
@@ -36,6 +36,19 @@ export type NotificationServicesPushControllerDisablePushNotificationsAction = {
 };
 
 /**
+ * Adds backend push notification links for the given addresses using the current FCM token.
+ * This is used when accounts are added after push notifications have already been enabled,
+ * so backend can link the existing device token to the newly added addresses.
+ *
+ * @param addresses - Addresses that should be linked to push notifications.
+ * @returns Whether the add request succeeded.
+ */
+export type NotificationServicesPushControllerAddPushNotificationLinksAction = {
+  type: `NotificationServicesPushController:addPushNotificationLinks`;
+  handler: NotificationServicesPushController['addPushNotificationLinks'];
+};
+
+/**
  * Deletes backend push notification links for the given addresses on the current platform.
  * This is used when accounts are removed (for example SRP removal), so backend can remove
  * all associated FCM tokens for those address/platform pairs.
@@ -70,5 +83,6 @@ export type NotificationServicesPushControllerMethodActions =
   | NotificationServicesPushControllerSubscribeToPushNotificationsAction
   | NotificationServicesPushControllerEnablePushNotificationsAction
   | NotificationServicesPushControllerDisablePushNotificationsAction
+  | NotificationServicesPushControllerAddPushNotificationLinksAction
   | NotificationServicesPushControllerDeletePushNotificationLinksAction
   | NotificationServicesPushControllerUpdateTriggerPushNotificationsAction;

--- a/packages/notification-services-controller/src/NotificationServicesPushController/NotificationServicesPushController.test.ts
+++ b/packages/notification-services-controller/src/NotificationServicesPushController/NotificationServicesPushController.test.ts
@@ -25,6 +25,7 @@ describe('NotificationServicesPushController', () => {
   ): {
     activatePushNotificationsMock: jest.SpyInstance;
     deactivatePushNotificationsMock: jest.SpyInstance;
+    updateLinksAPIMock: jest.SpyInstance;
     deleteLinksAPIMock: jest.SpyInstance;
   } => {
     const activatePushNotificationsMock = jest
@@ -35,6 +36,10 @@ describe('NotificationServicesPushController', () => {
       .spyOn(services, 'deactivatePushNotifications')
       .mockResolvedValue(true);
 
+    const updateLinksAPIMock = jest
+      .spyOn(services, 'updateLinksAPI')
+      .mockResolvedValue(true);
+
     const deleteLinksAPIMock = jest
       .spyOn(services, 'deleteLinksAPI')
       .mockResolvedValue(true);
@@ -42,6 +47,7 @@ describe('NotificationServicesPushController', () => {
     return {
       activatePushNotificationsMock,
       deactivatePushNotificationsMock,
+      updateLinksAPIMock,
       deleteLinksAPIMock,
     };
   };
@@ -343,6 +349,67 @@ describe('NotificationServicesPushController', () => {
         await controller.deletePushNotificationLinks(MOCK_ADDRESSES);
 
       expect(mocks.deleteLinksAPIMock).not.toHaveBeenCalled();
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('addPushNotificationLinks', () => {
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('should call updateLinksAPI with addresses and the existing token', async () => {
+      const mocks = arrangeServicesMocks();
+      const { controller, messenger } = arrangeMockMessenger({
+        state: {
+          fcmToken: MOCK_FCM_TOKEN,
+          isPushEnabled: true,
+          isUpdatingFCMToken: false,
+        },
+      });
+      mockAuthBearerTokenCall(messenger);
+
+      const result = await controller.addPushNotificationLinks(MOCK_ADDRESSES);
+
+      expect(mocks.updateLinksAPIMock).toHaveBeenCalledWith({
+        bearerToken: MOCK_JWT,
+        addresses: MOCK_ADDRESSES,
+        regToken: {
+          token: MOCK_FCM_TOKEN,
+          platform: 'extension',
+          locale: 'en',
+        },
+        env: 'prd',
+      });
+      expect(result).toBe(true);
+    });
+
+    it('should return false when push feature is disabled', async () => {
+      const mocks = arrangeServicesMocks();
+      const { controller } = arrangeMockMessenger({
+        isPushFeatureEnabled: false,
+      });
+
+      const result = await controller.addPushNotificationLinks(MOCK_ADDRESSES);
+
+      expect(mocks.updateLinksAPIMock).not.toHaveBeenCalled();
+      expect(result).toBe(false);
+    });
+
+    it('should return false when there is no token to add', async () => {
+      const mocks = arrangeServicesMocks();
+      const { controller, messenger } = arrangeMockMessenger({
+        state: {
+          fcmToken: '',
+          isPushEnabled: true,
+          isUpdatingFCMToken: false,
+        },
+      });
+      mockAuthBearerTokenCall(messenger);
+
+      const result = await controller.addPushNotificationLinks(MOCK_ADDRESSES);
+
+      expect(mocks.updateLinksAPIMock).not.toHaveBeenCalled();
       expect(result).toBe(false);
     });
   });

--- a/packages/notification-services-controller/src/NotificationServicesPushController/NotificationServicesPushController.ts
+++ b/packages/notification-services-controller/src/NotificationServicesPushController/NotificationServicesPushController.ts
@@ -15,6 +15,7 @@ import {
   activatePushNotifications,
   deleteLinksAPI,
   deactivatePushNotifications,
+  updateLinksAPI,
 } from './services/services';
 import type { PushNotificationEnv } from './types';
 import type { PushService } from './types/push-service-interface';
@@ -30,6 +31,7 @@ export type NotificationServicesPushControllerState = {
 const MESSENGER_EXPOSED_METHODS = [
   'subscribeToPushNotifications',
   'enablePushNotifications',
+  'addPushNotificationLinks',
   'disablePushNotifications',
   'updateTriggerPushNotifications',
   'deletePushNotificationLinks',
@@ -355,6 +357,40 @@ export class NotificationServicesPushController extends BaseController<
 
     // Update State
     this.#updatePushState({ type: 'disable' });
+  }
+
+  /**
+   * Adds backend push notification links for the given addresses using the current FCM token.
+   * This is used when accounts are added after push notifications have already been enabled,
+   * so backend can link the existing device token to the newly added addresses.
+   *
+   * @param addresses - Addresses that should be linked to push notifications.
+   * @returns Whether the add request succeeded.
+   */
+  public async addPushNotificationLinks(addresses: string[]): Promise<boolean> {
+    if (
+      !this.#config.isPushFeatureEnabled ||
+      addresses.length === 0 ||
+      !this.state.fcmToken
+    ) {
+      return false;
+    }
+
+    try {
+      const bearerToken = await this.#getAndAssertBearerToken();
+      return await updateLinksAPI({
+        bearerToken,
+        addresses,
+        regToken: {
+          token: this.state.fcmToken,
+          platform: this.#config.platform,
+          locale: this.#config.getLocale?.() ?? 'en',
+        },
+        env: this.#config.env ?? 'prd',
+      });
+    } catch {
+      return false;
+    }
   }
 
   /**

--- a/packages/notification-services-controller/src/NotificationServicesPushController/index.ts
+++ b/packages/notification-services-controller/src/NotificationServicesPushController/index.ts
@@ -12,6 +12,7 @@ export * as Mocks from './mocks';
 export type {
   NotificationServicesPushControllerSubscribeToPushNotificationsAction,
   NotificationServicesPushControllerEnablePushNotificationsAction,
+  NotificationServicesPushControllerAddPushNotificationLinksAction,
   NotificationServicesPushControllerDisablePushNotificationsAction,
   NotificationServicesPushControllerUpdateTriggerPushNotificationsAction,
   NotificationServicesPushControllerDeletePushNotificationLinksAction,


### PR DESCRIPTION
## Explanation
**Summary**

When notification accounts are added after push notifications have already been enabled, we were updating on-chain triggers, but not re-linking the existing Firebase token to the newly added addresses. As a result, the backend never received the additive `POST /api/v2/token` call for those new (address, token) pairs.

This change adds a dedicated additive push-link path that reuses the current `fcmToken` and links only the newly added
  addresses, without rotating the token or sending oldToken. 
Because notification account discovery already includes all keyrings, this now covers:
- adding accounts on the primary SRP
- adding accounts on imported/subsequent SRPs



**Code Changes**

- Add NotificationServicesPushController:addPushNotificationLinks
- Use the existing fcmToken to POST newly added addresses to the push registration endpoint
- Call that new method from NotificationServicesController.enableAccounts(...) after on-chain notifications are enabled
- Add focused tests for both the controller flow and the push-controller API call
- Update the package changelog



<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates push-notification registration flow to add backend token links when accounts are enabled, affecting server-side delivery for newly added addresses. Risk is moderate due to changes in notification subscription side effects and new messenger action surface, but behavior is guarded and tested.
> 
> **Overview**
> Fixes a gap where enabling notifications for newly added accounts updated on-chain triggers but **did not register the existing device push token** for those addresses.
> 
> Adds `NotificationServicesPushController:addPushNotificationLinks` (with exported action type) to POST additive `(address, token)` links using the current `fcmToken`, and wires `NotificationServicesController.enableAccounts()` to invoke it after enabling on-chain notifications (silent-fail like other push calls). Tests are updated to cover the new controller call and the push-controller API call/guard conditions, and the changelog documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a8eae82288306af3443b396faabc26e15ee2a40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->