### PR TITLE
Revert "Release 912.0.0 (#8451)"

### DIFF
--- a/packages/account-tree-controller/CHANGELOG.md
+++ b/packages/account-tree-controller/CHANGELOG.md
@@ -18,7 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/accounts-controller` from `^37.1.1` to `^37.2.0` ([#8363](https://github.com/MetaMask/core/pull/8363))
 - Bump `@metamask/keyring-controller` from `^25.1.1` to `^25.2.0` ([#8363](https://github.com/MetaMask/core/pull/8363))
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [7.0.0]
 

--- a/packages/account-tree-controller/package.json
+++ b/packages/account-tree-controller/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@metamask/accounts-controller": "^37.2.0",
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/keyring-api": "^21.6.0",
     "@metamask/keyring-controller": "^25.2.0",
     "@metamask/messenger": "^1.1.1",

--- a/packages/accounts-controller/CHANGELOG.md
+++ b/packages/accounts-controller/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [37.2.0]
 

--- a/packages/accounts-controller/package.json
+++ b/packages/accounts-controller/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@ethereumjs/util": "^9.1.0",
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/eth-snap-keyring": "^19.0.0",
     "@metamask/keyring-api": "^21.6.0",
     "@metamask/keyring-controller": "^25.2.0",

--- a/packages/address-book-controller/CHANGELOG.md
+++ b/packages/address-book-controller/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/controller-utils` from `^11.19.0` to `^11.20.0` ([#8344](https://github.com/MetaMask/core/pull/8344))
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [7.1.1]
 

--- a/packages/address-book-controller/package.json
+++ b/packages/address-book-controller/package.json
@@ -53,7 +53,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/controller-utils": "^11.20.0",
     "@metamask/messenger": "^1.1.1",
     "@metamask/utils": "^11.9.0"

--- a/packages/ai-controllers/CHANGELOG.md
+++ b/packages/ai-controllers/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [0.6.3]
 

--- a/packages/ai-controllers/package.json
+++ b/packages/ai-controllers/package.json
@@ -53,7 +53,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/messenger": "^1.1.1",
     "@metamask/superstruct": "^3.1.0",
     "@metamask/utils": "^11.9.0"

--- a/packages/analytics-controller/CHANGELOG.md
+++ b/packages/analytics-controller/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [1.0.1]
 

--- a/packages/analytics-controller/package.json
+++ b/packages/analytics-controller/package.json
@@ -53,7 +53,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/messenger": "^1.1.1",
     "@metamask/utils": "^11.9.0"
   },

--- a/packages/analytics-data-regulation-controller/CHANGELOG.md
+++ b/packages/analytics-data-regulation-controller/CHANGELOG.md
@@ -11,6 +11,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/messenger` from `^1.1.0` to `^1.1.1` ([#8373](https://github.com/MetaMask/core/pull/8373))
 - Bump `@metamask/controller-utils` from `^11.19.0` to `^11.20.0` ([#8344](https://github.com/MetaMask/core/pull/8344))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 [Unreleased]: https://github.com/MetaMask/core/

--- a/packages/analytics-data-regulation-controller/package.json
+++ b/packages/analytics-data-regulation-controller/package.json
@@ -53,7 +53,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/controller-utils": "^11.20.0",
     "@metamask/messenger": "^1.1.1",
     "@metamask/utils": "^11.9.0"

--- a/packages/announcement-controller/CHANGELOG.md
+++ b/packages/announcement-controller/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [8.1.0]
 

--- a/packages/announcement-controller/package.json
+++ b/packages/announcement-controller/package.json
@@ -53,7 +53,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/messenger": "^1.1.1"
   },
   "devDependencies": {

--- a/packages/app-metadata-controller/CHANGELOG.md
+++ b/packages/app-metadata-controller/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [2.0.1]
 

--- a/packages/app-metadata-controller/package.json
+++ b/packages/app-metadata-controller/package.json
@@ -51,7 +51,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/messenger": "^1.1.1"
   },
   "devDependencies": {

--- a/packages/approval-controller/CHANGELOG.md
+++ b/packages/approval-controller/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [9.0.1]
 

--- a/packages/approval-controller/package.json
+++ b/packages/approval-controller/package.json
@@ -53,7 +53,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/messenger": "^1.1.1",
     "@metamask/rpc-errors": "^7.0.2",
     "@metamask/utils": "^11.9.0",

--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `@metamask/transaction-controller` from `^64.0.0` to `^64.2.0` ([#8432](https://github.com/MetaMask/core/pull/8432), [#8447](https://github.com/MetaMask/core/pull/8447))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ### Fixed
 

--- a/packages/assets-controller/package.json
+++ b/packages/assets-controller/package.json
@@ -58,7 +58,7 @@
     "@ethersproject/providers": "^5.7.0",
     "@metamask/account-tree-controller": "^7.0.0",
     "@metamask/assets-controllers": "^103.1.1",
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/client-controller": "^1.0.1",
     "@metamask/controller-utils": "^11.20.0",
     "@metamask/core-backend": "^6.2.1",

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -20,7 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/keyring-controller` from `^25.1.1` to `^25.2.0` ([#8363](https://github.com/MetaMask/core/pull/8363))
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
 - Bump `@metamask/transaction-controller` from `^64.0.0` to `^64.2.0` ([#8432](https://github.com/MetaMask/core/pull/8432), [#8447](https://github.com/MetaMask/core/pull/8447))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ### Fixed
 

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -63,7 +63,7 @@
     "@metamask/account-tree-controller": "^7.0.0",
     "@metamask/accounts-controller": "^37.2.0",
     "@metamask/approval-controller": "^9.0.1",
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/contract-metadata": "^2.4.0",
     "@metamask/controller-utils": "^11.20.0",
     "@metamask/core-backend": "^6.2.1",

--- a/packages/base-controller/CHANGELOG.md
+++ b/packages/base-controller/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [9.1.0]
-
 ### Added
 
 - Add `${ControllerName}:stateChanged` as alternative to `${ControllerName}:stateChange` ([#8187](https://github.com/MetaMask/core/pull/8187))
@@ -434,8 +432,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/base-controller@9.1.0...HEAD
-[9.1.0]: https://github.com/MetaMask/core/compare/@metamask/base-controller@9.0.1...@metamask/base-controller@9.1.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/base-controller@9.0.1...HEAD
 [9.0.1]: https://github.com/MetaMask/core/compare/@metamask/base-controller@9.0.0...@metamask/base-controller@9.0.1
 [9.0.0]: https://github.com/MetaMask/core/compare/@metamask/base-controller@8.4.2...@metamask/base-controller@9.0.0
 [8.4.2]: https://github.com/MetaMask/core/compare/@metamask/base-controller@8.4.1...@metamask/base-controller@8.4.2

--- a/packages/base-controller/package.json
+++ b/packages/base-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/base-controller",
-  "version": "9.1.0",
+  "version": "9.0.1",
   "description": "Provides scaffolding for controllers as well a communication system for all controllers",
   "keywords": [
     "Ethereum",

--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -25,7 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/accounts-controller` from `^37.1.1` to `^37.2.0` ([#8363](https://github.com/MetaMask/core/pull/8363))
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
 - Bump `@metamask/transaction-controller` from `^64.0.0` to `^64.2.0` ([#8432](https://github.com/MetaMask/core/pull/8432), [#8447](https://github.com/MetaMask/core/pull/8447))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ### Deprecated
 

--- a/packages/bridge-controller/package.json
+++ b/packages/bridge-controller/package.json
@@ -60,7 +60,7 @@
     "@metamask/accounts-controller": "^37.2.0",
     "@metamask/assets-controller": "^5.0.0",
     "@metamask/assets-controllers": "^103.1.1",
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/controller-utils": "^11.20.0",
     "@metamask/gas-fee-controller": "^26.1.1",
     "@metamask/keyring-api": "^21.6.0",

--- a/packages/bridge-status-controller/CHANGELOG.md
+++ b/packages/bridge-status-controller/CHANGELOG.md
@@ -21,7 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/keyring-controller` from `^25.1.1` to `^25.2.0` ([#8363](https://github.com/MetaMask/core/pull/8363))
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
 - Bump `@metamask/transaction-controller` from `^64.0.0` to `^64.2.0` ([#8432](https://github.com/MetaMask/core/pull/8432), [#8447](https://github.com/MetaMask/core/pull/8447))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [70.0.5]
 

--- a/packages/bridge-status-controller/package.json
+++ b/packages/bridge-status-controller/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@metamask/accounts-controller": "^37.2.0",
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/bridge-controller": "^70.0.1",
     "@metamask/controller-utils": "^11.20.0",
     "@metamask/gas-fee-controller": "^26.1.1",

--- a/packages/claims-controller/CHANGELOG.md
+++ b/packages/claims-controller/CHANGELOG.md
@@ -13,7 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/profile-sync-controller` from `^28.0.1` to `^28.0.2` ([#8325](https://github.com/MetaMask/core/pull/8325))
 - Bump `@metamask/controller-utils` from `^11.19.0` to `^11.20.0` ([#8344](https://github.com/MetaMask/core/pull/8344))
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [0.5.0]
 

--- a/packages/claims-controller/package.json
+++ b/packages/claims-controller/package.json
@@ -53,7 +53,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/controller-utils": "^11.20.0",
     "@metamask/keyring-controller": "^25.2.0",
     "@metamask/messenger": "^1.1.1",

--- a/packages/client-controller/CHANGELOG.md
+++ b/packages/client-controller/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [1.0.1]
 

--- a/packages/client-controller/package.json
+++ b/packages/client-controller/package.json
@@ -53,7 +53,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/messenger": "^1.1.1"
   },
   "devDependencies": {

--- a/packages/compliance-controller/CHANGELOG.md
+++ b/packages/compliance-controller/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `@metamask/messenger` from `^1.1.0` to `^1.1.1` ([#8373](https://github.com/MetaMask/core/pull/8373))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [2.0.0]
 

--- a/packages/compliance-controller/package.json
+++ b/packages/compliance-controller/package.json
@@ -53,7 +53,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/controller-utils": "^11.20.0",
     "@metamask/messenger": "^1.1.1",
     "@metamask/superstruct": "^3.1.0",

--- a/packages/composable-controller/CHANGELOG.md
+++ b/packages/composable-controller/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [12.0.1]
 

--- a/packages/composable-controller/package.json
+++ b/packages/composable-controller/package.json
@@ -51,7 +51,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/messenger": "^1.1.1"
   },
   "devDependencies": {

--- a/packages/config-registry-controller/CHANGELOG.md
+++ b/packages/config-registry-controller/CHANGELOG.md
@@ -13,7 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/profile-sync-controller` from `^28.0.1` to `^28.0.2` ([#8325](https://github.com/MetaMask/core/pull/8325))
 - Bump `@metamask/controller-utils` from `^11.19.0` to `^11.20.0` ([#8344](https://github.com/MetaMask/core/pull/8344))
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [0.2.0]
 

--- a/packages/config-registry-controller/package.json
+++ b/packages/config-registry-controller/package.json
@@ -54,7 +54,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/controller-utils": "^11.20.0",
     "@metamask/keyring-controller": "^25.2.0",
     "@metamask/messenger": "^1.1.1",

--- a/packages/connectivity-controller/CHANGELOG.md
+++ b/packages/connectivity-controller/CHANGELOG.md
@@ -16,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [0.2.0]
 

--- a/packages/connectivity-controller/package.json
+++ b/packages/connectivity-controller/package.json
@@ -53,7 +53,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/messenger": "^1.1.1",
     "reselect": "^5.1.1"
   },

--- a/packages/delegation-controller/CHANGELOG.md
+++ b/packages/delegation-controller/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
-
 ## [3.0.0]
 
 ### Changed

--- a/packages/delegation-controller/package.json
+++ b/packages/delegation-controller/package.json
@@ -53,7 +53,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/keyring-controller": "^25.2.0",
     "@metamask/messenger": "^1.1.1",
     "@metamask/utils": "^11.9.0"

--- a/packages/earn-controller/CHANGELOG.md
+++ b/packages/earn-controller/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
-
 ## [12.0.0]
 
 ### Added

--- a/packages/earn-controller/package.json
+++ b/packages/earn-controller/package.json
@@ -56,7 +56,7 @@
     "@ethersproject/bignumber": "^5.7.0",
     "@ethersproject/providers": "^5.7.0",
     "@metamask/account-tree-controller": "^7.0.0",
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/controller-utils": "^11.20.0",
     "@metamask/keyring-api": "^21.6.0",
     "@metamask/messenger": "^1.1.1",

--- a/packages/ens-controller/CHANGELOG.md
+++ b/packages/ens-controller/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/controller-utils` from `^11.19.0` to `^11.20.0` ([#8344](https://github.com/MetaMask/core/pull/8344))
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [19.1.1]
 

--- a/packages/ens-controller/package.json
+++ b/packages/ens-controller/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@ethersproject/providers": "^5.7.0",
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/controller-utils": "^11.20.0",
     "@metamask/messenger": "^1.1.1",
     "@metamask/network-controller": "^30.0.1",

--- a/packages/gas-fee-controller/CHANGELOG.md
+++ b/packages/gas-fee-controller/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/messenger` from `^1.1.0` to `^1.1.1` ([#8373](https://github.com/MetaMask/core/pull/8373))
 - Add missing `@metamask/messenger` dependency ([#8318](https://github.com/MetaMask/core/pull/8318), [#8364](https://github.com/MetaMask/core/pull/8364))
 - Bump `@metamask/controller-utils` from `^11.19.0` to `^11.20.0` ([#8344](https://github.com/MetaMask/core/pull/8344))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [26.1.1]
 

--- a/packages/gas-fee-controller/package.json
+++ b/packages/gas-fee-controller/package.json
@@ -53,7 +53,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/controller-utils": "^11.20.0",
     "@metamask/eth-query": "^4.0.0",
     "@metamask/ethjs-unit": "^0.3.0",

--- a/packages/gator-permissions-controller/CHANGELOG.md
+++ b/packages/gator-permissions-controller/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
 - Bump `@metamask/transaction-controller` from `^64.0.0` to `^64.2.0` ([#8432](https://github.com/MetaMask/core/pull/8432), [#8447](https://github.com/MetaMask/core/pull/8447))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [3.0.1]
 

--- a/packages/gator-permissions-controller/package.json
+++ b/packages/gator-permissions-controller/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@metamask/7715-permission-types": "^0.5.0",
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/delegation-core": "^0.2.0",
     "@metamask/delegation-deployments": "^0.12.0",
     "@metamask/messenger": "^1.1.1",

--- a/packages/geolocation-controller/CHANGELOG.md
+++ b/packages/geolocation-controller/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/controller-utils` from `^11.19.0` to `^11.20.0` ([#8344](https://github.com/MetaMask/core/pull/8344))
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [0.1.2]
 

--- a/packages/geolocation-controller/package.json
+++ b/packages/geolocation-controller/package.json
@@ -53,7 +53,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/controller-utils": "^11.20.0",
     "@metamask/messenger": "^1.1.1"
   },

--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -26,7 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [25.2.0]
 

--- a/packages/keyring-controller/package.json
+++ b/packages/keyring-controller/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@ethereumjs/util": "^9.1.0",
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/browser-passworder": "^6.0.0",
     "@metamask/eth-hd-keyring": "^13.1.1",
     "@metamask/eth-sig-util": "^8.2.0",

--- a/packages/logging-controller/CHANGELOG.md
+++ b/packages/logging-controller/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/controller-utils` from `^11.19.0` to `^11.20.0` ([#8344](https://github.com/MetaMask/core/pull/8344))
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [8.0.1]
 

--- a/packages/logging-controller/package.json
+++ b/packages/logging-controller/package.json
@@ -53,7 +53,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/controller-utils": "^11.20.0",
     "@metamask/messenger": "^1.1.1",
     "uuid": "^8.3.2"

--- a/packages/message-manager/CHANGELOG.md
+++ b/packages/message-manager/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/controller-utils` from `^11.19.0` to `^11.20.0` ([#8344](https://github.com/MetaMask/core/pull/8344))
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [14.1.1]
 

--- a/packages/message-manager/package.json
+++ b/packages/message-manager/package.json
@@ -51,7 +51,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/controller-utils": "^11.20.0",
     "@metamask/eth-sig-util": "^8.2.0",
     "@metamask/messenger": "^1.1.1",

--- a/packages/money-account-controller/CHANGELOG.md
+++ b/packages/money-account-controller/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `@metamask/messenger` from `^1.1.0` to `^1.1.1` ([#8373](https://github.com/MetaMask/core/pull/8373))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [0.1.0]
 

--- a/packages/money-account-controller/package.json
+++ b/packages/money-account-controller/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@metamask/accounts-controller": "^37.2.0",
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/eth-money-keyring": "^2.0.0",
     "@metamask/keyring-api": "^21.6.0",
     "@metamask/keyring-controller": "^25.2.0",

--- a/packages/multichain-account-service/CHANGELOG.md
+++ b/packages/multichain-account-service/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/accounts-controller` from `^37.1.1` to `^37.2.0` ([#8363](https://github.com/MetaMask/core/pull/8363))
 - Bump `@metamask/keyring-controller` from `^25.1.1` to `^25.2.0` ([#8363](https://github.com/MetaMask/core/pull/8363))
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [8.0.1]
 

--- a/packages/multichain-account-service/package.json
+++ b/packages/multichain-account-service/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "@ethereumjs/util": "^9.1.0",
     "@metamask/accounts-controller": "^37.2.0",
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/eth-snap-keyring": "^19.0.0",
     "@metamask/key-tree": "^10.1.1",
     "@metamask/keyring-api": "^21.6.0",

--- a/packages/multichain-network-controller/CHANGELOG.md
+++ b/packages/multichain-network-controller/CHANGELOG.md
@@ -16,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/accounts-controller` from `^37.1.0` to `^37.2.0` ([#8325](https://github.com/MetaMask/core/pull/8325), [#8363](https://github.com/MetaMask/core/pull/8363))
 - Bump `@metamask/controller-utils` from `^11.19.0` to `^11.20.0` ([#8344](https://github.com/MetaMask/core/pull/8344))
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [3.0.6]
 

--- a/packages/multichain-network-controller/package.json
+++ b/packages/multichain-network-controller/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@metamask/accounts-controller": "^37.2.0",
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/controller-utils": "^11.20.0",
     "@metamask/keyring-api": "^21.6.0",
     "@metamask/keyring-internal-api": "^10.0.0",

--- a/packages/multichain-transactions-controller/CHANGELOG.md
+++ b/packages/multichain-transactions-controller/CHANGELOG.md
@@ -18,7 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/accounts-controller` from `^37.1.1` to `^37.2.0` ([#8363](https://github.com/MetaMask/core/pull/8363))
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [7.0.4]
 

--- a/packages/multichain-transactions-controller/package.json
+++ b/packages/multichain-transactions-controller/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@metamask/accounts-controller": "^37.2.0",
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/keyring-api": "^21.6.0",
     "@metamask/keyring-internal-api": "^10.0.0",
     "@metamask/keyring-snap-client": "^8.2.0",

--- a/packages/name-controller/CHANGELOG.md
+++ b/packages/name-controller/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/controller-utils` from `^11.19.0` to `^11.20.0` ([#8344](https://github.com/MetaMask/core/pull/8344))
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [9.1.1]
 

--- a/packages/name-controller/package.json
+++ b/packages/name-controller/package.json
@@ -54,7 +54,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/controller-utils": "^11.20.0",
     "@metamask/messenger": "^1.1.1",
     "@metamask/utils": "^11.9.0",

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -29,7 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/controller-utils` from `^11.19.0` to `^11.20.0` ([#8344](https://github.com/MetaMask/core/pull/8344))
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ### Deprecated
 

--- a/packages/network-controller/package.json
+++ b/packages/network-controller/package.json
@@ -53,7 +53,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/connectivity-controller": "^0.2.0",
     "@metamask/controller-utils": "^11.20.0",
     "@metamask/eth-block-tracker": "^15.0.1",

--- a/packages/network-enablement-controller/CHANGELOG.md
+++ b/packages/network-enablement-controller/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
 - Bump `@metamask/transaction-controller` from `^64.0.0` to `^64.2.0` ([#8432](https://github.com/MetaMask/core/pull/8432), [#8447](https://github.com/MetaMask/core/pull/8447))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [5.0.2]
 

--- a/packages/network-enablement-controller/package.json
+++ b/packages/network-enablement-controller/package.json
@@ -53,7 +53,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/controller-utils": "^11.20.0",
     "@metamask/keyring-api": "^21.6.0",
     "@metamask/messenger": "^1.1.1",

--- a/packages/notification-services-controller/CHANGELOG.md
+++ b/packages/notification-services-controller/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
-
 ## [23.1.0]
 
 ### Added

--- a/packages/notification-services-controller/package.json
+++ b/packages/notification-services-controller/package.json
@@ -106,7 +106,7 @@
   },
   "dependencies": {
     "@contentful/rich-text-html-renderer": "^16.5.2",
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/controller-utils": "^11.20.0",
     "@metamask/keyring-controller": "^25.2.0",
     "@metamask/messenger": "^1.1.1",

--- a/packages/permission-controller/CHANGELOG.md
+++ b/packages/permission-controller/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/controller-utils` from `^11.19.0` to `^11.20.0` ([#8344](https://github.com/MetaMask/core/pull/8344))
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [12.3.0]
 

--- a/packages/permission-controller/package.json
+++ b/packages/permission-controller/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@metamask/approval-controller": "^9.0.1",
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/controller-utils": "^11.20.0",
     "@metamask/json-rpc-engine": "^10.2.4",
     "@metamask/messenger": "^1.1.1",

--- a/packages/permission-log-controller/CHANGELOG.md
+++ b/packages/permission-log-controller/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [5.1.0]
 

--- a/packages/permission-log-controller/package.json
+++ b/packages/permission-log-controller/package.json
@@ -53,7 +53,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/json-rpc-engine": "^10.2.4",
     "@metamask/messenger": "^1.1.1",
     "@metamask/utils": "^11.9.0"

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `@metamask/transaction-controller` from `^64.0.0` to `^64.1.0` ([#8432](https://github.com/MetaMask/core/pull/8432))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [3.0.0]
 

--- a/packages/perps-controller/package.json
+++ b/packages/perps-controller/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@metamask/abi-utils": "^2.0.3",
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/controller-utils": "^11.20.0",
     "@metamask/messenger": "^1.1.1",
     "@metamask/utils": "^11.9.0",

--- a/packages/phishing-controller/CHANGELOG.md
+++ b/packages/phishing-controller/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
 - Bump `@metamask/transaction-controller` from `^64.0.0` to `^64.2.0` ([#8432](https://github.com/MetaMask/core/pull/8432), [#8447](https://github.com/MetaMask/core/pull/8447))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [17.1.1]
 

--- a/packages/phishing-controller/package.json
+++ b/packages/phishing-controller/package.json
@@ -53,7 +53,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/controller-utils": "^11.20.0",
     "@metamask/messenger": "^1.1.1",
     "@metamask/transaction-controller": "^64.2.0",

--- a/packages/polling-controller/CHANGELOG.md
+++ b/packages/polling-controller/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `@metamask/controller-utils` from `^11.19.0` to `^11.20.0` ([#8344](https://github.com/MetaMask/core/pull/8344))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [16.0.4]
 

--- a/packages/polling-controller/package.json
+++ b/packages/polling-controller/package.json
@@ -51,7 +51,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/controller-utils": "^11.20.0",
     "@metamask/network-controller": "^30.0.1",
     "@metamask/utils": "^11.9.0",

--- a/packages/preferences-controller/CHANGELOG.md
+++ b/packages/preferences-controller/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [23.1.0]
 

--- a/packages/preferences-controller/package.json
+++ b/packages/preferences-controller/package.json
@@ -53,7 +53,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/messenger": "^1.1.1"
   },
   "devDependencies": {

--- a/packages/profile-metrics-controller/CHANGELOG.md
+++ b/packages/profile-metrics-controller/CHANGELOG.md
@@ -13,7 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/keyring-controller` from `^25.1.1` to `^25.2.0` ([#8363](https://github.com/MetaMask/core/pull/8363))
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
 - Bump `@metamask/transaction-controller` from `^64.0.0` to `^64.2.0` ([#8432](https://github.com/MetaMask/core/pull/8432), [#8447](https://github.com/MetaMask/core/pull/8447))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [3.1.3]
 

--- a/packages/profile-metrics-controller/package.json
+++ b/packages/profile-metrics-controller/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@metamask/accounts-controller": "^37.2.0",
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/controller-utils": "^11.20.0",
     "@metamask/keyring-controller": "^25.2.0",
     "@metamask/messenger": "^1.1.1",

--- a/packages/profile-sync-controller/CHANGELOG.md
+++ b/packages/profile-sync-controller/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/keyring-controller` from `^25.1.1` to `^25.2.0` ([#8363](https://github.com/MetaMask/core/pull/8363))
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [28.0.2]
 

--- a/packages/profile-sync-controller/package.json
+++ b/packages/profile-sync-controller/package.json
@@ -107,7 +107,7 @@
   },
   "dependencies": {
     "@metamask/address-book-controller": "^7.1.1",
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/keyring-controller": "^25.2.0",
     "@metamask/messenger": "^1.1.1",
     "@metamask/snaps-controllers": "^19.0.0",

--- a/packages/ramps-controller/CHANGELOG.md
+++ b/packages/ramps-controller/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
-
 ## [13.1.0]
 
 ### Added

--- a/packages/ramps-controller/package.json
+++ b/packages/ramps-controller/package.json
@@ -54,7 +54,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/controller-utils": "^11.20.0",
     "@metamask/messenger": "^1.1.1"
   },

--- a/packages/rate-limit-controller/CHANGELOG.md
+++ b/packages/rate-limit-controller/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [7.0.1]
 

--- a/packages/rate-limit-controller/package.json
+++ b/packages/rate-limit-controller/package.json
@@ -51,7 +51,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/messenger": "^1.1.1",
     "@metamask/rpc-errors": "^7.0.2",
     "@metamask/utils": "^11.9.0"

--- a/packages/remote-feature-flag-controller/CHANGELOG.md
+++ b/packages/remote-feature-flag-controller/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/controller-utils` from `^11.19.0` to `^11.20.0` ([#8344](https://github.com/MetaMask/core/pull/8344))
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [4.2.0]
 

--- a/packages/remote-feature-flag-controller/package.json
+++ b/packages/remote-feature-flag-controller/package.json
@@ -53,7 +53,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/controller-utils": "^11.20.0",
     "@metamask/messenger": "^1.1.1",
     "@metamask/utils": "^11.9.0",

--- a/packages/sample-controllers/CHANGELOG.md
+++ b/packages/sample-controllers/CHANGELOG.md
@@ -27,7 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add `@tanstack/query-core` ^4.43.0
   - Add `@metamask/superstruct` ^3.2.1
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ### Removed
 

--- a/packages/sample-controllers/package.json
+++ b/packages/sample-controllers/package.json
@@ -53,7 +53,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/base-data-service": "^0.1.1",
     "@metamask/messenger": "^1.1.1",
     "@metamask/network-controller": "^30.0.1",

--- a/packages/seedless-onboarding-controller/CHANGELOG.md
+++ b/packages/seedless-onboarding-controller/CHANGELOG.md
@@ -32,7 +32,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Use `SecretMetadata.matchesType` for filtering
 - **BREAKING:** Change `SecretMetadata.fromRawMetadata` signature to require `storageMetadata` parameter ([#7284](https://github.com/MetaMask/core/pull/7284))
 - **BREAKING:** Remove `version` getter from `SecretMetadata`; use `storageVersion` instead ([#7284](https://github.com/MetaMask/core/pull/7284))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ### Fixed
 

--- a/packages/seedless-onboarding-controller/package.json
+++ b/packages/seedless-onboarding-controller/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@metamask/auth-network-utils": "^0.3.0",
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/browser-passworder": "^6.0.0",
     "@metamask/keyring-controller": "^25.2.0",
     "@metamask/messenger": "^1.1.1",

--- a/packages/selected-network-controller/CHANGELOG.md
+++ b/packages/selected-network-controller/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [26.1.0]
 

--- a/packages/selected-network-controller/package.json
+++ b/packages/selected-network-controller/package.json
@@ -53,7 +53,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/json-rpc-engine": "^10.2.4",
     "@metamask/messenger": "^1.1.1",
     "@metamask/network-controller": "^30.0.1",

--- a/packages/shield-controller/CHANGELOG.md
+++ b/packages/shield-controller/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
 - Bump `@metamask/transaction-controller` from `^64.0.0` to `^64.2.0` ([#8432](https://github.com/MetaMask/core/pull/8432), [#8447](https://github.com/MetaMask/core/pull/8447))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [5.1.1]
 

--- a/packages/shield-controller/package.json
+++ b/packages/shield-controller/package.json
@@ -53,7 +53,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/controller-utils": "^11.20.0",
     "@metamask/messenger": "^1.1.1",
     "@metamask/signature-controller": "^39.1.2",

--- a/packages/signature-controller/CHANGELOG.md
+++ b/packages/signature-controller/CHANGELOG.md
@@ -14,7 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/keyring-controller` from `^25.1.1` to `^25.2.0` ([#8363](https://github.com/MetaMask/core/pull/8363))
 - Bump `@metamask/controller-utils` from `^11.19.0` to `^11.20.0` ([#8344](https://github.com/MetaMask/core/pull/8344))
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [39.1.2]
 

--- a/packages/signature-controller/package.json
+++ b/packages/signature-controller/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "@metamask/accounts-controller": "^37.2.0",
     "@metamask/approval-controller": "^9.0.1",
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/controller-utils": "^11.20.0",
     "@metamask/eth-sig-util": "^8.2.0",
     "@metamask/gator-permissions-controller": "^3.0.1",

--- a/packages/social-controllers/CHANGELOG.md
+++ b/packages/social-controllers/CHANGELOG.md
@@ -16,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `@metamask/messenger` from `^1.1.0` to `^1.1.1` ([#8373](https://github.com/MetaMask/core/pull/8373))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [0.1.0]
 

--- a/packages/social-controllers/package.json
+++ b/packages/social-controllers/package.json
@@ -53,7 +53,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/base-data-service": "^0.1.1",
     "@metamask/controller-utils": "^11.20.0",
     "@metamask/messenger": "^1.1.1",

--- a/packages/subscription-controller/CHANGELOG.md
+++ b/packages/subscription-controller/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
 - Bump `@metamask/transaction-controller` from `^64.0.0` to `^64.2.0` ([#8432](https://github.com/MetaMask/core/pull/8432), [#8447](https://github.com/MetaMask/core/pull/8447))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [6.1.2]
 

--- a/packages/subscription-controller/package.json
+++ b/packages/subscription-controller/package.json
@@ -53,7 +53,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/controller-utils": "^11.20.0",
     "@metamask/messenger": "^1.1.1",
     "@metamask/polling-controller": "^16.0.4",

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -14,7 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Skip simulation when transaction `containerTypes` includes `EnforcedSimulations` ([#8431](https://github.com/MetaMask/core/pull/8431))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [64.2.0]
 

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -62,7 +62,7 @@
     "@ethersproject/wallet": "^5.7.0",
     "@metamask/accounts-controller": "^37.2.0",
     "@metamask/approval-controller": "^9.0.1",
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/controller-utils": "^11.20.0",
     "@metamask/core-backend": "^6.2.1",
     "@metamask/gas-fee-controller": "^26.1.1",

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
-
 ## [19.1.1]
 
 ### Changed

--- a/packages/transaction-pay-controller/package.json
+++ b/packages/transaction-pay-controller/package.json
@@ -59,7 +59,7 @@
     "@ethersproject/providers": "^5.7.0",
     "@metamask/assets-controller": "^5.0.0",
     "@metamask/assets-controllers": "^103.1.1",
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/bridge-controller": "^70.0.1",
     "@metamask/bridge-status-controller": "^70.0.5",
     "@metamask/controller-utils": "^11.20.0",

--- a/packages/user-operation-controller/CHANGELOG.md
+++ b/packages/user-operation-controller/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/keyring-controller` from `^25.1.1` to `^25.2.0` ([#8363](https://github.com/MetaMask/core/pull/8363))
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
 - Bump `@metamask/transaction-controller` from `^64.0.0` to `^64.2.0` ([#8432](https://github.com/MetaMask/core/pull/8432), [#8447](https://github.com/MetaMask/core/pull/8447))
-- Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8451](https://github.com/MetaMask/core/pull/8451))
 
 ## [41.2.0]
 

--- a/packages/user-operation-controller/package.json
+++ b/packages/user-operation-controller/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@metamask/approval-controller": "^9.0.1",
-    "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-controller": "^9.0.1",
     "@metamask/controller-utils": "^11.20.0",
     "@metamask/eth-query": "^4.0.0",
     "@metamask/gas-fee-controller": "^26.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2530,7 +2530,7 @@ __metadata:
     "@metamask/account-api": "npm:^1.0.0"
     "@metamask/accounts-controller": "npm:^37.2.0"
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/keyring-api": "npm:^21.6.0"
     "@metamask/keyring-controller": "npm:^25.2.0"
     "@metamask/messenger": "npm:^1.1.1"
@@ -2566,7 +2566,7 @@ __metadata:
   dependencies:
     "@ethereumjs/util": "npm:^9.1.0"
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/controller-utils": "npm:^11.20.0"
     "@metamask/eth-snap-keyring": "npm:^19.0.0"
     "@metamask/keyring-api": "npm:^21.6.0"
@@ -2618,7 +2618,7 @@ __metadata:
   resolution: "@metamask/address-book-controller@workspace:packages/address-book-controller"
   dependencies:
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/controller-utils": "npm:^11.20.0"
     "@metamask/messenger": "npm:^1.1.1"
     "@metamask/utils": "npm:^11.9.0"
@@ -2639,7 +2639,7 @@ __metadata:
   resolution: "@metamask/ai-controllers@workspace:packages/ai-controllers"
   dependencies:
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/messenger": "npm:^1.1.1"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^11.9.0"
@@ -2660,7 +2660,7 @@ __metadata:
   resolution: "@metamask/analytics-controller@workspace:packages/analytics-controller"
   dependencies:
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/messenger": "npm:^1.1.1"
     "@metamask/utils": "npm:^11.9.0"
     "@ts-bridge/cli": "npm:^0.6.4"
@@ -2680,7 +2680,7 @@ __metadata:
   resolution: "@metamask/analytics-data-regulation-controller@workspace:packages/analytics-data-regulation-controller"
   dependencies:
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/controller-utils": "npm:^11.20.0"
     "@metamask/messenger": "npm:^1.1.1"
     "@metamask/utils": "npm:^11.9.0"
@@ -2702,7 +2702,7 @@ __metadata:
   resolution: "@metamask/announcement-controller@workspace:packages/announcement-controller"
   dependencies:
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/messenger": "npm:^1.1.1"
     "@ts-bridge/cli": "npm:^0.6.4"
     "@types/jest": "npm:^29.5.14"
@@ -2728,7 +2728,7 @@ __metadata:
   resolution: "@metamask/app-metadata-controller@workspace:packages/app-metadata-controller"
   dependencies:
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/messenger": "npm:^1.1.1"
     "@ts-bridge/cli": "npm:^0.6.4"
     "@types/jest": "npm:^29.5.14"
@@ -2746,7 +2746,7 @@ __metadata:
   resolution: "@metamask/approval-controller@workspace:packages/approval-controller"
   dependencies:
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/messenger": "npm:^1.1.1"
     "@metamask/rpc-errors": "npm:^7.0.2"
     "@metamask/utils": "npm:^11.9.0"
@@ -2773,7 +2773,7 @@ __metadata:
     "@metamask/account-tree-controller": "npm:^7.0.0"
     "@metamask/assets-controllers": "npm:^103.1.1"
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/client-controller": "npm:^1.0.1"
     "@metamask/controller-utils": "npm:^11.20.0"
     "@metamask/core-backend": "npm:^6.2.1"
@@ -2826,7 +2826,7 @@ __metadata:
     "@metamask/accounts-controller": "npm:^37.2.0"
     "@metamask/approval-controller": "npm:^9.0.1"
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/contract-metadata": "npm:^2.4.0"
     "@metamask/controller-utils": "npm:^11.20.0"
     "@metamask/core-backend": "npm:^6.2.1"
@@ -2952,7 +2952,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/base-controller@npm:^9.0.0, @metamask/base-controller@npm:^9.1.0, @metamask/base-controller@workspace:packages/base-controller":
+"@metamask/base-controller@npm:^9.0.0, @metamask/base-controller@npm:^9.0.1, @metamask/base-controller@workspace:packages/base-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/base-controller@workspace:packages/base-controller"
   dependencies:
@@ -3008,7 +3008,7 @@ __metadata:
     "@metamask/assets-controller": "npm:^5.0.0"
     "@metamask/assets-controllers": "npm:^103.1.1"
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/controller-utils": "npm:^11.20.0"
     "@metamask/eth-json-rpc-provider": "npm:^6.0.1"
     "@metamask/gas-fee-controller": "npm:^26.1.1"
@@ -3048,7 +3048,7 @@ __metadata:
   dependencies:
     "@metamask/accounts-controller": "npm:^37.2.0"
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/bridge-controller": "npm:^70.0.1"
     "@metamask/controller-utils": "npm:^11.20.0"
     "@metamask/gas-fee-controller": "npm:^26.1.1"
@@ -3133,7 +3133,7 @@ __metadata:
   resolution: "@metamask/claims-controller@workspace:packages/claims-controller"
   dependencies:
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/controller-utils": "npm:^11.20.0"
     "@metamask/keyring-controller": "npm:^25.2.0"
     "@metamask/messenger": "npm:^1.1.1"
@@ -3156,7 +3156,7 @@ __metadata:
   resolution: "@metamask/client-controller@workspace:packages/client-controller"
   dependencies:
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/messenger": "npm:^1.1.1"
     "@ts-bridge/cli": "npm:^0.6.4"
     "@types/jest": "npm:^29.5.14"
@@ -3176,7 +3176,7 @@ __metadata:
   resolution: "@metamask/compliance-controller@workspace:packages/compliance-controller"
   dependencies:
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/controller-utils": "npm:^11.20.0"
     "@metamask/messenger": "npm:^1.1.1"
     "@metamask/superstruct": "npm:^3.1.0"
@@ -3200,7 +3200,7 @@ __metadata:
   resolution: "@metamask/composable-controller@workspace:packages/composable-controller"
   dependencies:
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/json-rpc-engine": "npm:^10.2.4"
     "@metamask/messenger": "npm:^1.1.1"
     "@ts-bridge/cli": "npm:^0.6.4"
@@ -3221,7 +3221,7 @@ __metadata:
   dependencies:
     "@lavamoat/allow-scripts": "npm:^3.0.4"
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/controller-utils": "npm:^11.20.0"
     "@metamask/keyring-controller": "npm:^25.2.0"
     "@metamask/messenger": "npm:^1.1.1"
@@ -3249,7 +3249,7 @@ __metadata:
   resolution: "@metamask/connectivity-controller@workspace:packages/connectivity-controller"
   dependencies:
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/messenger": "npm:^1.1.1"
     "@ts-bridge/cli": "npm:^0.6.4"
     "@types/jest": "npm:^29.5.14"
@@ -3415,7 +3415,7 @@ __metadata:
   resolution: "@metamask/delegation-controller@workspace:packages/delegation-controller"
   dependencies:
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/keyring-controller": "npm:^25.2.0"
     "@metamask/messenger": "npm:^1.1.1"
     "@metamask/utils": "npm:^11.9.0"
@@ -3457,7 +3457,7 @@ __metadata:
     "@ethersproject/providers": "npm:^5.7.0"
     "@metamask/account-tree-controller": "npm:^7.0.0"
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/controller-utils": "npm:^11.20.0"
     "@metamask/keyring-api": "npm:^21.6.0"
     "@metamask/messenger": "npm:^1.1.1"
@@ -3551,7 +3551,7 @@ __metadata:
   dependencies:
     "@ethersproject/providers": "npm:^5.7.0"
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/controller-utils": "npm:^11.20.0"
     "@metamask/messenger": "npm:^1.1.1"
     "@metamask/network-controller": "npm:^30.0.1"
@@ -4019,7 +4019,7 @@ __metadata:
   dependencies:
     "@babel/runtime": "npm:^7.23.9"
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/controller-utils": "npm:^11.20.0"
     "@metamask/eth-query": "npm:^4.0.0"
     "@metamask/ethjs-unit": "npm:^0.3.0"
@@ -4056,7 +4056,7 @@ __metadata:
     "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
     "@metamask/7715-permission-types": "npm:^0.5.0"
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/delegation-core": "npm:^0.2.0"
     "@metamask/delegation-deployments": "npm:^0.12.0"
     "@metamask/messenger": "npm:^1.1.1"
@@ -4082,7 +4082,7 @@ __metadata:
   resolution: "@metamask/geolocation-controller@workspace:packages/geolocation-controller"
   dependencies:
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/controller-utils": "npm:^11.20.0"
     "@metamask/messenger": "npm:^1.1.1"
     "@ts-bridge/cli": "npm:^0.6.4"
@@ -4197,7 +4197,7 @@ __metadata:
     "@lavamoat/allow-scripts": "npm:^3.0.4"
     "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/browser-passworder": "npm:^6.0.0"
     "@metamask/eth-hd-keyring": "npm:^13.1.1"
     "@metamask/eth-sig-util": "npm:^8.2.0"
@@ -4318,7 +4318,7 @@ __metadata:
   resolution: "@metamask/logging-controller@workspace:packages/logging-controller"
   dependencies:
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/controller-utils": "npm:^11.20.0"
     "@metamask/messenger": "npm:^1.1.1"
     "@ts-bridge/cli": "npm:^0.6.4"
@@ -4339,7 +4339,7 @@ __metadata:
   resolution: "@metamask/message-manager@workspace:packages/message-manager"
   dependencies:
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/controller-utils": "npm:^11.20.0"
     "@metamask/eth-sig-util": "npm:^8.2.0"
     "@metamask/messenger": "npm:^1.1.1"
@@ -4431,7 +4431,7 @@ __metadata:
   dependencies:
     "@metamask/accounts-controller": "npm:^37.2.0"
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/eth-money-keyring": "npm:^2.0.0"
     "@metamask/keyring-api": "npm:^21.6.0"
     "@metamask/keyring-controller": "npm:^25.2.0"
@@ -4459,7 +4459,7 @@ __metadata:
     "@metamask/account-api": "npm:^1.0.0"
     "@metamask/accounts-controller": "npm:^37.2.0"
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/controller-utils": "npm:^11.20.0"
     "@metamask/eth-hd-keyring": "npm:^13.1.1"
     "@metamask/eth-snap-keyring": "npm:^19.0.0"
@@ -4533,7 +4533,7 @@ __metadata:
   dependencies:
     "@metamask/accounts-controller": "npm:^37.2.0"
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/controller-utils": "npm:^11.20.0"
     "@metamask/keyring-api": "npm:^21.6.0"
     "@metamask/keyring-controller": "npm:^25.2.0"
@@ -4566,7 +4566,7 @@ __metadata:
   dependencies:
     "@metamask/accounts-controller": "npm:^37.2.0"
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/keyring-api": "npm:^21.6.0"
     "@metamask/keyring-controller": "npm:^25.2.0"
     "@metamask/keyring-internal-api": "npm:^10.0.0"
@@ -4597,7 +4597,7 @@ __metadata:
   resolution: "@metamask/name-controller@workspace:packages/name-controller"
   dependencies:
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/controller-utils": "npm:^11.20.0"
     "@metamask/messenger": "npm:^1.1.1"
     "@metamask/utils": "npm:^11.9.0"
@@ -4620,7 +4620,7 @@ __metadata:
   dependencies:
     "@json-rpc-specification/meta-schema": "npm:^1.0.6"
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/connectivity-controller": "npm:^0.2.0"
     "@metamask/controller-utils": "npm:^11.20.0"
     "@metamask/eth-block-tracker": "npm:^15.0.1"
@@ -4668,7 +4668,7 @@ __metadata:
   resolution: "@metamask/network-enablement-controller@workspace:packages/network-enablement-controller"
   dependencies:
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/controller-utils": "npm:^11.20.0"
     "@metamask/keyring-api": "npm:^21.6.0"
     "@metamask/messenger": "npm:^1.1.1"
@@ -4710,7 +4710,7 @@ __metadata:
     "@lavamoat/allow-scripts": "npm:^3.0.4"
     "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/controller-utils": "npm:^11.20.0"
     "@metamask/keyring-controller": "npm:^25.2.0"
     "@metamask/messenger": "npm:^1.1.1"
@@ -4766,7 +4766,7 @@ __metadata:
   dependencies:
     "@metamask/approval-controller": "npm:^9.0.1"
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/controller-utils": "npm:^11.20.0"
     "@metamask/json-rpc-engine": "npm:^10.2.4"
     "@metamask/messenger": "npm:^1.1.1"
@@ -4793,7 +4793,7 @@ __metadata:
   resolution: "@metamask/permission-log-controller@workspace:packages/permission-log-controller"
   dependencies:
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/json-rpc-engine": "npm:^10.2.4"
     "@metamask/messenger": "npm:^1.1.1"
     "@metamask/utils": "npm:^11.9.0"
@@ -4819,7 +4819,7 @@ __metadata:
     "@metamask/abi-utils": "npm:^2.0.3"
     "@metamask/account-tree-controller": "npm:^7.0.0"
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/controller-utils": "npm:^11.20.0"
     "@metamask/geolocation-controller": "npm:^0.1.2"
     "@metamask/keyring-controller": "npm:^25.2.0"
@@ -4856,7 +4856,7 @@ __metadata:
   resolution: "@metamask/phishing-controller@workspace:packages/phishing-controller"
   dependencies:
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/controller-utils": "npm:^11.20.0"
     "@metamask/messenger": "npm:^1.1.1"
     "@metamask/transaction-controller": "npm:^64.2.0"
@@ -4883,7 +4883,7 @@ __metadata:
   resolution: "@metamask/polling-controller@workspace:packages/polling-controller"
   dependencies:
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/controller-utils": "npm:^11.20.0"
     "@metamask/messenger": "npm:^1.1.1"
     "@metamask/network-controller": "npm:^30.0.1"
@@ -4917,7 +4917,7 @@ __metadata:
   resolution: "@metamask/preferences-controller@workspace:packages/preferences-controller"
   dependencies:
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/messenger": "npm:^1.1.1"
     "@metamask/utils": "npm:^11.9.0"
     "@ts-bridge/cli": "npm:^0.6.4"
@@ -4938,7 +4938,7 @@ __metadata:
   dependencies:
     "@metamask/accounts-controller": "npm:^37.2.0"
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/controller-utils": "npm:^11.20.0"
     "@metamask/keyring-controller": "npm:^25.2.0"
     "@metamask/keyring-internal-api": "npm:^10.0.0"
@@ -4969,7 +4969,7 @@ __metadata:
     "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
     "@metamask/address-book-controller": "npm:^7.1.1"
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/keyring-api": "npm:^21.6.0"
     "@metamask/keyring-controller": "npm:^25.2.0"
     "@metamask/keyring-internal-api": "npm:^10.0.0"
@@ -5029,7 +5029,7 @@ __metadata:
   resolution: "@metamask/ramps-controller@workspace:packages/ramps-controller"
   dependencies:
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/controller-utils": "npm:^11.20.0"
     "@metamask/messenger": "npm:^1.1.1"
     "@ts-bridge/cli": "npm:^0.6.4"
@@ -5050,7 +5050,7 @@ __metadata:
   resolution: "@metamask/rate-limit-controller@workspace:packages/rate-limit-controller"
   dependencies:
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/messenger": "npm:^1.1.1"
     "@metamask/rpc-errors": "npm:^7.0.2"
     "@metamask/utils": "npm:^11.9.0"
@@ -5095,7 +5095,7 @@ __metadata:
   dependencies:
     "@lavamoat/allow-scripts": "npm:^3.0.4"
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/controller-utils": "npm:^11.20.0"
     "@metamask/messenger": "npm:^1.1.1"
     "@metamask/utils": "npm:^11.9.0"
@@ -5135,7 +5135,7 @@ __metadata:
   resolution: "@metamask/sample-controllers@workspace:packages/sample-controllers"
   dependencies:
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/base-data-service": "npm:^0.1.1"
     "@metamask/controller-utils": "npm:^11.20.0"
     "@metamask/messenger": "npm:^1.1.1"
@@ -5174,7 +5174,7 @@ __metadata:
     "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
     "@metamask/auth-network-utils": "npm:^0.3.0"
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/browser-passworder": "npm:^6.0.0"
     "@metamask/keyring-controller": "npm:^25.2.0"
     "@metamask/messenger": "npm:^1.1.1"
@@ -5205,7 +5205,7 @@ __metadata:
   resolution: "@metamask/selected-network-controller@workspace:packages/selected-network-controller"
   dependencies:
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/json-rpc-engine": "npm:^10.2.4"
     "@metamask/messenger": "npm:^1.1.1"
     "@metamask/network-controller": "npm:^30.0.1"
@@ -5236,7 +5236,7 @@ __metadata:
     "@lavamoat/allow-scripts": "npm:^3.0.4"
     "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/controller-utils": "npm:^11.20.0"
     "@metamask/messenger": "npm:^1.1.1"
     "@metamask/signature-controller": "npm:^39.1.2"
@@ -5264,7 +5264,7 @@ __metadata:
     "@metamask/accounts-controller": "npm:^37.2.0"
     "@metamask/approval-controller": "npm:^9.0.1"
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/controller-utils": "npm:^11.20.0"
     "@metamask/eth-sig-util": "npm:^8.2.0"
     "@metamask/gator-permissions-controller": "npm:^3.0.1"
@@ -5431,7 +5431,7 @@ __metadata:
   resolution: "@metamask/social-controllers@workspace:packages/social-controllers"
   dependencies:
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/base-data-service": "npm:^0.1.1"
     "@metamask/controller-utils": "npm:^11.20.0"
     "@metamask/messenger": "npm:^1.1.1"
@@ -5479,7 +5479,7 @@ __metadata:
   resolution: "@metamask/subscription-controller@workspace:packages/subscription-controller"
   dependencies:
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/controller-utils": "npm:^11.20.0"
     "@metamask/messenger": "npm:^1.1.1"
     "@metamask/polling-controller": "npm:^16.0.4"
@@ -5546,7 +5546,7 @@ __metadata:
     "@metamask/accounts-controller": "npm:^37.2.0"
     "@metamask/approval-controller": "npm:^9.0.1"
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/connectivity-controller": "npm:^0.2.0"
     "@metamask/controller-utils": "npm:^11.20.0"
     "@metamask/core-backend": "npm:^6.2.1"
@@ -5598,7 +5598,7 @@ __metadata:
     "@metamask/assets-controller": "npm:^5.0.0"
     "@metamask/assets-controllers": "npm:^103.1.1"
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/bridge-controller": "npm:^70.0.1"
     "@metamask/bridge-status-controller": "npm:^70.0.5"
     "@metamask/controller-utils": "npm:^11.20.0"
@@ -5632,7 +5632,7 @@ __metadata:
   dependencies:
     "@metamask/approval-controller": "npm:^9.0.1"
     "@metamask/auto-changelog": "npm:^6.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-controller": "npm:^9.0.1"
     "@metamask/controller-utils": "npm:^11.20.0"
     "@metamask/eth-block-tracker": "npm:^15.0.0"
     "@metamask/eth-query": "npm:^4.0.0"


### PR DESCRIPTION
This reverts commit e00fdbf63c3237f95d8d6682899f022da8950747. The root `package.json` was never bumped, so deployment was not initiated.

## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only revert that downgrades `@metamask/base-controller` from `9.1.0` to `9.0.1` across many packages; risk is limited to potential build/behavior differences for any consumers expecting `9.1.0` APIs.
> 
> **Overview**
> Reverts the prior `@metamask/base-controller@9.1.0` release by resetting `@metamask/base-controller` back to `9.0.1` and updating all affected packages to depend on `^9.0.1` again.
> 
> Corresponding changelog entries referencing the `9.1.0` bump are removed/rolled back, and `yarn.lock` is updated to reflect the downgraded dependency graph.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0910e51cca7442c9e8b5d5b25f832a1644e6546d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->