### PR TITLE
feat(social-controllers): add followingProfileIds to controller state

### DIFF
--- a/packages/social-controllers/CHANGELOG.md
+++ b/packages/social-controllers/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `intent` and optional `category` fields to `Trade` type ([#8410](https://github.com/MetaMask/core/pull/8410))
 - Export `TradeStruct` superstruct schema; derive `Trade` type via `Infer` ([#8410](https://github.com/MetaMask/core/pull/8410))
 - Narrow `direction` to `'buy' | 'sell'` and `intent` to `'enter' | 'exit'` on `Trade` type ([#8410](https://github.com/MetaMask/core/pull/8410))
+- Add `followingProfileIds` to `SocialControllerState` — stores Clicker profile IDs alongside existing `followingAddresses` ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
 
 ### Changed
 

--- a/packages/social-controllers/CHANGELOG.md
+++ b/packages/social-controllers/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `intent` and optional `category` fields to `Trade` type ([#8410](https://github.com/MetaMask/core/pull/8410))
 - Export `TradeStruct` superstruct schema; derive `Trade` type via `Infer` ([#8410](https://github.com/MetaMask/core/pull/8410))
 - Narrow `direction` to `'buy' | 'sell'` and `intent` to `'enter' | 'exit'` on `Trade` type ([#8410](https://github.com/MetaMask/core/pull/8410))
-- Add `followingProfileIds` to `SocialControllerState` — stores Clicker profile IDs alongside existing `followingAddresses` ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
+- Add `followingProfileIds` to `SocialControllerState` — stores Clicker profile IDs alongside existing `followingAddresses` ([#8459](https://github.com/MetaMask/core/pull/8459))
 
 ### Changed
 

--- a/packages/social-controllers/src/SocialController.test.ts
+++ b/packages/social-controllers/src/SocialController.test.ts
@@ -98,6 +98,7 @@ describe('SocialController', () => {
       expect(getDefaultSocialControllerState()).toStrictEqual({
         leaderboardEntries: [],
         followingAddresses: [],
+        followingProfileIds: [],
       });
     });
   });
@@ -109,6 +110,7 @@ describe('SocialController', () => {
       expect(controller.state).toStrictEqual({
         leaderboardEntries: [],
         followingAddresses: [],
+        followingProfileIds: [],
       });
     });
 
@@ -120,6 +122,21 @@ describe('SocialController', () => {
       expect(controller.state).toStrictEqual({
         leaderboardEntries: [],
         followingAddresses: ['0xaaaa'],
+        followingProfileIds: [],
+      });
+    });
+
+    it('merges partial initial followingProfileIds with defaults', () => {
+      const { controller } = createController({
+        state: {
+          followingProfileIds: ['550e8400-e29b-41d4-a716-446655440000'],
+        },
+      });
+
+      expect(controller.state).toStrictEqual({
+        leaderboardEntries: [],
+        followingAddresses: [],
+        followingProfileIds: ['550e8400-e29b-41d4-a716-446655440000'],
       });
     });
   });
@@ -210,7 +227,7 @@ describe('SocialController', () => {
   });
 
   describe('followTrader', () => {
-    it('calls service via messenger and appends new addresses to state', async () => {
+    it('calls service via messenger and appends new addresses and profile IDs to state', async () => {
       const rootMessenger = getRootMessenger();
       const follow = jest
         .fn()
@@ -232,9 +249,12 @@ describe('SocialController', () => {
       expect(controller.state.followingAddresses).toStrictEqual([
         '0x1111111111111111111111111111111111111111',
       ]);
+      expect(controller.state.followingProfileIds).toStrictEqual([
+        '550e8400-e29b-41d4-a716-446655440000',
+      ]);
     });
 
-    it('appends multiple new addresses', async () => {
+    it('appends multiple new addresses and profile IDs', async () => {
       const rootMessenger = getRootMessenger();
       mockServiceAction(
         rootMessenger,
@@ -258,9 +278,13 @@ describe('SocialController', () => {
         '0x1111111111111111111111111111111111111111',
         '0x2222222222222222222222222222222222222222',
       ]);
+      expect(controller.state.followingProfileIds).toStrictEqual([
+        '550e8400-e29b-41d4-a716-446655440000',
+        '660e8400-e29b-41d4-a716-446655440001',
+      ]);
     });
 
-    it('deduplicates addresses within the same batch', async () => {
+    it('deduplicates addresses and profile IDs within the same batch', async () => {
       const rootMessenger = getRootMessenger();
       mockServiceAction(
         rootMessenger,
@@ -279,6 +303,36 @@ describe('SocialController', () => {
 
       expect(controller.state.followingAddresses).toStrictEqual([
         '0x1111111111111111111111111111111111111111',
+      ]);
+      expect(controller.state.followingProfileIds).toStrictEqual([
+        '550e8400-e29b-41d4-a716-446655440000',
+      ]);
+    });
+
+    it('does not duplicate existing addresses or profile IDs across calls', async () => {
+      const rootMessenger = getRootMessenger();
+      mockServiceAction(
+        rootMessenger,
+        'SocialService:follow',
+        jest.fn().mockResolvedValue({ followed: [mockProfileSummary] }),
+      );
+
+      const { controller } = createController({ rootMessenger });
+
+      await controller.followTrader({
+        addressOrUid: '0xuser',
+        targets: ['0x1111111111111111111111111111111111111111'],
+      });
+      await controller.followTrader({
+        addressOrUid: '0xuser',
+        targets: ['0x1111111111111111111111111111111111111111'],
+      });
+
+      expect(controller.state.followingAddresses).toStrictEqual([
+        '0x1111111111111111111111111111111111111111',
+      ]);
+      expect(controller.state.followingProfileIds).toStrictEqual([
+        '550e8400-e29b-41d4-a716-446655440000',
       ]);
     });
 
@@ -302,7 +356,7 @@ describe('SocialController', () => {
   });
 
   describe('unfollowTrader', () => {
-    it('calls service via messenger and removes addresses from state', async () => {
+    it('calls service via messenger and removes addresses and profile IDs from state', async () => {
       const rootMessenger = getRootMessenger();
       const unfollow = jest
         .fn()
@@ -315,6 +369,10 @@ describe('SocialController', () => {
           followingAddresses: [
             '0x1111111111111111111111111111111111111111',
             '0x2222222222222222222222222222222222222222',
+          ],
+          followingProfileIds: [
+            '550e8400-e29b-41d4-a716-446655440000',
+            '660e8400-e29b-41d4-a716-446655440001',
           ],
         },
       });
@@ -332,6 +390,9 @@ describe('SocialController', () => {
       expect(controller.state.followingAddresses).toStrictEqual([
         '0x2222222222222222222222222222222222222222',
       ]);
+      expect(controller.state.followingProfileIds).toStrictEqual([
+        '660e8400-e29b-41d4-a716-446655440001',
+      ]);
     });
 
     it('handles unfollowing an address not in state gracefully', async () => {
@@ -344,7 +405,7 @@ describe('SocialController', () => {
 
       const { controller } = createController({
         rootMessenger,
-        state: { followingAddresses: [] },
+        state: { followingAddresses: [], followingProfileIds: [] },
       });
 
       await controller.unfollowTrader({
@@ -353,6 +414,7 @@ describe('SocialController', () => {
       });
 
       expect(controller.state.followingAddresses).toStrictEqual([]);
+      expect(controller.state.followingProfileIds).toStrictEqual([]);
     });
 
     it('is callable via messenger action', async () => {
@@ -375,7 +437,7 @@ describe('SocialController', () => {
   });
 
   describe('updateFollowing', () => {
-    it('calls service via messenger and replaces followingAddresses in state', async () => {
+    it('calls service via messenger and replaces followingAddresses and followingProfileIds in state', async () => {
       const rootMessenger = getRootMessenger();
       const fetchFollowing = jest.fn().mockResolvedValue({
         following: [mockProfileSummary],
@@ -389,7 +451,10 @@ describe('SocialController', () => {
 
       const { controller } = createController({
         rootMessenger,
-        state: { followingAddresses: ['0xold'] },
+        state: {
+          followingAddresses: ['0xold'],
+          followingProfileIds: ['old-profile-id'],
+        },
       });
 
       const result = await controller.updateFollowing({
@@ -403,9 +468,12 @@ describe('SocialController', () => {
       expect(controller.state.followingAddresses).toStrictEqual([
         '0x1111111111111111111111111111111111111111',
       ]);
+      expect(controller.state.followingProfileIds).toStrictEqual([
+        '550e8400-e29b-41d4-a716-446655440000',
+      ]);
     });
 
-    it('clears followingAddresses when response is empty', async () => {
+    it('clears followingAddresses and followingProfileIds when response is empty', async () => {
       const rootMessenger = getRootMessenger();
       mockServiceAction(
         rootMessenger,
@@ -415,12 +483,16 @@ describe('SocialController', () => {
 
       const { controller } = createController({
         rootMessenger,
-        state: { followingAddresses: ['0xold'] },
+        state: {
+          followingAddresses: ['0xold'],
+          followingProfileIds: ['old-profile-id'],
+        },
       });
 
       await controller.updateFollowing({ addressOrUid: '0xuser' });
 
       expect(controller.state.followingAddresses).toStrictEqual([]);
+      expect(controller.state.followingProfileIds).toStrictEqual([]);
     });
 
     it('is callable via messenger action', async () => {

--- a/packages/social-controllers/src/SocialController.ts
+++ b/packages/social-controllers/src/SocialController.ts
@@ -91,6 +91,7 @@ export function getDefaultSocialControllerState(): SocialControllerState {
   return {
     leaderboardEntries: [],
     followingAddresses: [],
+    followingProfileIds: [],
   };
 }
 
@@ -104,6 +105,12 @@ const socialControllerMetadata: StateMetadata<SocialControllerState> = {
     usedInUi: true,
   },
   followingAddresses: {
+    persist: true,
+    includeInDebugSnapshot: false,
+    includeInStateLogs: false,
+    usedInUi: true,
+  },
+  followingProfileIds: {
     persist: true,
     includeInDebugSnapshot: false,
     includeInStateLogs: false,
@@ -181,6 +188,9 @@ export class SocialController extends BaseController<
     const newAddresses = [
       ...new Set(followResponse.followed.map((profile) => profile.address)),
     ];
+    const newProfileIds = [
+      ...new Set(followResponse.followed.map((profile) => profile.profileId)),
+    ];
 
     this.update((state) => {
       const existing = new Set(state.followingAddresses);
@@ -188,6 +198,10 @@ export class SocialController extends BaseController<
         (address) => !existing.has(address),
       );
       state.followingAddresses.push(...uniqueNewAddresses);
+
+      const existingIds = new Set(state.followingProfileIds);
+      const uniqueNewIds = newProfileIds.filter((id) => !existingIds.has(id));
+      state.followingProfileIds.push(...uniqueNewIds);
     });
 
     return followResponse;
@@ -210,10 +224,16 @@ export class SocialController extends BaseController<
     const removedAddresses = new Set(
       unfollowResponse.unfollowed.map((profile) => profile.address),
     );
+    const removedProfileIds = new Set(
+      unfollowResponse.unfollowed.map((profile) => profile.profileId),
+    );
 
     this.update((state) => {
       state.followingAddresses = state.followingAddresses.filter(
         (address) => !removedAddresses.has(address),
+      );
+      state.followingProfileIds = state.followingProfileIds.filter(
+        (id) => !removedProfileIds.has(id),
       );
     });
 
@@ -239,6 +259,9 @@ export class SocialController extends BaseController<
     this.update((state) => {
       state.followingAddresses = followingResponse.following.map(
         (profile) => profile.address,
+      );
+      state.followingProfileIds = followingResponse.following.map(
+        (profile) => profile.profileId,
       );
     });
 

--- a/packages/social-controllers/src/social-types.ts
+++ b/packages/social-controllers/src/social-types.ts
@@ -270,6 +270,8 @@ export type UnfollowOptions = {
 export type SocialControllerState = {
   /** Cached ranked trader list from the last `updateLeaderboard` call. */
   leaderboardEntries: LeaderboardEntry[];
-  /** Addresses the current user follows — drives Follow/Following button state. */
+  /** Wallet addresses the current user follows. */
   followingAddresses: string[];
+  /** Clicker profile IDs the current user follows — used by mobile UI. */
+  followingProfileIds: string[];
 };


### PR DESCRIPTION
## Explanation

**Adding `followingProfileIds` to controller state.**

Stores Clicker profile IDs alongside existing `followingAddresses` on follow, unfollow, and updateFollowing.  This enables the mobile UI to check follow status by trader profile ID without an extra API call.

[TSA-401](https://consensyssoftware.atlassian.net/browse/TSA-401)

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


[TSA-401]: https://consensyssoftware.atlassian.net/browse/TSA-401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new persisted state field and updates follow/unfollow/updateFollowing mutations, which could affect consumers that assume the previous state shape or rely on persistence/migrations.
> 
> **Overview**
> **Adds `followingProfileIds` to `SocialControllerState`** and persists it alongside `followingAddresses` so clients can track follows by Clicker profile ID.
> 
> Updates `getDefaultSocialControllerState` and controller metadata, and extends `followTrader`, `unfollowTrader`, and `updateFollowing` to populate/dedupe/remove/replace profile IDs in lockstep with addresses; tests and the package changelog are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38e27b9420d3d111c5235e84b661bf5bd59e11d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->