### PR TITLE
feat(perps): sync controller from mobile

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1601,6 +1601,9 @@
     }
   },
   "packages/perps-controller/src/PerpsController.ts": {
+    "@typescript-eslint/no-unused-vars": {
+      "count": 1
+    },
     "no-restricted-syntax": {
       "count": 3
     }

--- a/packages/perps-controller/.sync-state.json
+++ b/packages/perps-controller/.sync-state.json
@@ -1,8 +1,8 @@
 {
-  "lastSyncedMobileCommit": "1f90a9b7a957356c02dcd201ea650c9a779a0bda",
-  "lastSyncedMobileBranch": "feat/tat-2863-sync-controller-code-extension",
-  "lastSyncedCoreCommit": "c275531d934cb592fe27c545a73b08c11f50dfa3",
-  "lastSyncedCoreBranch": "feat/perps/another-sync",
-  "lastSyncedDate": "2026-04-08T11:07:13Z",
-  "sourceChecksum": "5eea712091624d82e569300f9679e6595f2e77aa9e1ced15db14d3d8cce15746"
+  "lastSyncedMobileCommit": "c8f5e5aa6470a017c5165e6525bb2396bf9b7070",
+  "lastSyncedMobileBranch": "feat/tat-2956-create-a-sync-skill-to-migrate",
+  "lastSyncedCoreCommit": "59412376fb3eb4972b6c7a11f45eece5d96a40f2",
+  "lastSyncedCoreBranch": "feat/perps/new-sync",
+  "lastSyncedDate": "2026-04-15T09:32:27Z",
+  "sourceChecksum": "32ada16094f0fdd1b1bf29863518fb222210479fa03bcaa41cf8d5f41f3474b4"
 }

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -7,10 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add disk-backed cold-start cache for instant data display on launch ([#8460](https://github.com/MetaMask/core/pull/8460))
+- Add `skipTTL` option to `getCachedMarketDataForActiveProvider` and `getCachedUserDataForActiveProvider` ([#8460](https://github.com/MetaMask/core/pull/8460))
+- Add perps decimal formatters (`perpsFormatters`) for shared formatting utilities ([#8460](https://github.com/MetaMask/core/pull/8460))
+- Add `FUNDING_RATE_CONFIG` constants for funding rate display formatting ([#8460](https://github.com/MetaMask/core/pull/8460))
+- Add `buildProviderCacheKey` and `getProviderNetworkKey` helper exports ([#8460](https://github.com/MetaMask/core/pull/8460))
+
 ### Changed
 
 - Bump `@metamask/transaction-controller` from `^64.0.0` to `^64.1.0` ([#8432](https://github.com/MetaMask/core/pull/8432))
 - Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8457](https://github.com/MetaMask/core/pull/8457))
+
+### Fixed
+
+- Fix TP/SL orders disappearing after creating a market order by filtering on `isPositionTpsl` ([#8460](https://github.com/MetaMask/core/pull/8460))
+- Fix missing latest funding payments by using paginated fetch with auto-split ([#8460](https://github.com/MetaMask/core/pull/8460))
+- Fix WebSocket reconnection on foreground return when socket is still alive ([#8460](https://github.com/MetaMask/core/pull/8460))
 
 ## [3.0.0]
 

--- a/packages/perps-controller/src/PerpsController-method-action-types.ts
+++ b/packages/perps-controller/src/PerpsController-method-action-types.ts
@@ -9,6 +9,10 @@ import type { PerpsController } from './PerpsController';
  * Read cached market data for the currently active provider (or aggregated).
  * Returns null when no valid cache exists or when cache has expired.
  *
+ * @param options - Optional settings.
+ * @param options.skipTTL - When true, bypass the 5-minute TTL check.
+ * Used during initial render so disk-hydrated structural data (with
+ * placeholder prices) is returned regardless of age.
  * @returns The cached market data array, or null if no valid cache.
  */
 export type PerpsControllerGetCachedMarketDataForActiveProviderAction = {
@@ -21,6 +25,10 @@ export type PerpsControllerGetCachedMarketDataForActiveProviderAction = {
  * Returns null when no valid cache exists, cache has expired, or address
  * does not match the currently selected EVM account.
  *
+ * @param options - Optional settings.
+ * @param options.skipTTL - When true, bypass the 60s staleness check.
+ * Used during initial render so disk-hydrated user data (positions/orders)
+ * is returned regardless of age, avoiding a skeleton flash.
  * @returns The cached user data, or null if no valid cache.
  */
 export type PerpsControllerGetCachedUserDataForActiveProviderAction = {

--- a/packages/perps-controller/src/PerpsController.ts
+++ b/packages/perps-controller/src/PerpsController.ts
@@ -21,6 +21,9 @@ import {
   PERPS_CONSTANTS,
   MARKET_SORTING_CONFIG,
   PROVIDER_CONFIG,
+  PERPS_DISK_CACHE_MARKETS,
+  PERPS_DISK_CACHE_USER_DATA,
+  buildProviderCacheKey,
 } from './constants/perpsConfig';
 import type { SortOptionId } from './constants/perpsConfig';
 import type { PerpsControllerMethodActions } from './PerpsController-method-action-types';
@@ -119,6 +122,11 @@ import {
 } from './types/transactionTypes';
 import { getSelectedEvmAccount } from './utils/accountUtils';
 import { ensureError } from './utils/errorUtils';
+import {
+  hydrateFromDiskSync,
+  persistMarketEntriesToDisk,
+  persistUserEntriesToDisk,
+} from './utils/perpsDiskPersistence';
 import type { SortDirection } from './utils/sortMarkets';
 import { wait } from './utils/wait';
 
@@ -992,6 +1000,10 @@ export class PerpsController extends BaseController<
 
     // Migrate old persisted data without accountAddress
     this.#migrateRequestsIfNeeded();
+
+    // Eagerly hydrate in-memory caches from disk so hooks see data on first render.
+    // Must happen at construction time — before any React component mounts.
+    this.#hydrateCacheFromDiskSync();
   }
 
   // ============================================================================
@@ -1022,38 +1034,58 @@ export class PerpsController extends BaseController<
   }
 
   /**
-   * Build a cache key for per-provider market data.
-   * Format: "providerId:network" (e.g. 'hyperliquid:mainnet', 'myx:testnet')
+   * Resolve the provider ids that should participate in aggregated cache reads.
    *
-   * @param providerId - The provider identifier.
-   * @param isTestnet - Whether the provider is on testnet.
-   * @returns The cache key string.
+   * Providers can still be registering when the first render happens, so we
+   * also look at cache keys to recover disk-hydrated provider snapshots before
+   * `init()` finishes populating `this.providers`.
+   *
+   * @param cacheKeys - Cache keys currently present in the relevant cache map.
+   * @returns Provider ids that should be included in aggregated reads.
    */
-  #marketCacheKey(providerId: string, isTestnet: boolean): string {
-    return `${providerId}:${isTestnet ? 'testnet' : 'mainnet'}`;
-  }
+  #getAggregatedCacheProviderIds(cacheKeys: string[]): string[] {
+    const providerIds = new Set<string>();
+    const currentNetwork = this.state.isTestnet ? 'testnet' : 'mainnet';
 
-  /**
-   * Determine the effective testnet flag for a given provider.
-   * MYX may be forced to testnet via PROVIDER_CONFIG.MYX_TESTNET_ONLY.
-   *
-   * @param providerId - The provider identifier.
-   * @returns Whether this provider should use testnet.
-   */
-  #providerIsTestnet(providerId: string): boolean {
-    if (providerId === 'myx') {
-      return PROVIDER_CONFIG.MYX_TESTNET_ONLY || this.state.isTestnet;
+    for (const [providerId] of this.providers) {
+      providerIds.add(providerId);
     }
-    return this.state.isTestnet;
+
+    for (const key of cacheKeys) {
+      const [providerId, network] = key.split(':');
+      if (
+        !providerId ||
+        network !== currentNetwork ||
+        providerId === 'aggregated'
+      ) {
+        continue;
+      }
+
+      if (
+        providerId === 'hyperliquid' ||
+        (providerId === 'myx' && this.#isMYXProviderEnabled()) ||
+        this.providers.has(providerId as PerpsProviderType)
+      ) {
+        providerIds.add(providerId);
+      }
+    }
+
+    return Array.from(providerIds);
   }
 
   /**
    * Read cached market data for the currently active provider (or aggregated).
    * Returns null when no valid cache exists or when cache has expired.
    *
+   * @param options - Optional settings.
+   * @param options.skipTTL - When true, bypass the 5-minute TTL check.
+   * Used during initial render so disk-hydrated structural data (with
+   * placeholder prices) is returned regardless of age.
    * @returns The cached market data array, or null if no valid cache.
    */
-  getCachedMarketDataForActiveProvider(): PerpsMarketData[] | null {
+  getCachedMarketDataForActiveProvider(options?: {
+    skipTTL?: boolean;
+  }): PerpsMarketData[] | null {
     const { activeProvider } = this.state;
     const cache = this.state.cachedMarketDataByProvider;
 
@@ -1061,11 +1093,10 @@ export class PerpsController extends BaseController<
       // Assemble from all registered provider entries
       const assembled: PerpsMarketData[] = [];
       let oldestTimestamp = Infinity;
-      for (const [providerId] of this.providers) {
-        const key = this.#marketCacheKey(
-          providerId,
-          this.#providerIsTestnet(providerId),
-        );
+      for (const providerId of this.#getAggregatedCacheProviderIds(
+        Object.keys(cache),
+      )) {
+        const key = buildProviderCacheKey(providerId, this.state.isTestnet);
         const entry = cache[key];
         if (!entry || entry.data.length === 0) {
           continue;
@@ -1077,22 +1108,25 @@ export class PerpsController extends BaseController<
         return null;
       }
       // Check TTL against the oldest entry
-      if (Date.now() - oldestTimestamp > PerpsController.#preloadGuardMs * 10) {
+      if (
+        !options?.skipTTL &&
+        Date.now() - oldestTimestamp > PerpsController.#preloadGuardMs * 10
+      ) {
         return null;
       }
       return assembled;
     }
 
     // Single provider mode
-    const key = this.#marketCacheKey(
-      activeProvider,
-      this.#providerIsTestnet(activeProvider),
-    );
+    const key = buildProviderCacheKey(activeProvider, this.state.isTestnet);
     const entry = cache[key];
     if (!entry || entry.data.length === 0) {
       return null;
     }
-    if (Date.now() - entry.timestamp > PerpsController.#preloadGuardMs * 10) {
+    if (
+      !options?.skipTTL &&
+      Date.now() - entry.timestamp > PerpsController.#preloadGuardMs * 10
+    ) {
       return null;
     }
     return entry.data;
@@ -1103,9 +1137,13 @@ export class PerpsController extends BaseController<
    * Returns null when no valid cache exists, cache has expired, or address
    * does not match the currently selected EVM account.
    *
+   * @param options - Optional settings.
+   * @param options.skipTTL - When true, bypass the 60s staleness check.
+   * Used during initial render so disk-hydrated user data (positions/orders)
+   * is returned regardless of age, avoiding a skeleton flash.
    * @returns The cached user data, or null if no valid cache.
    */
-  getCachedUserDataForActiveProvider(): {
+  getCachedUserDataForActiveProvider(options?: { skipTTL?: boolean }): {
     positions: Position[];
     orders: Order[];
     accountState: AccountState | null;
@@ -1127,13 +1165,15 @@ export class PerpsController extends BaseController<
       // Can't determine current account — trust the cache
     }
 
+    const skipTTL = options?.skipTTL ?? false;
+
     const isValidEntry = (
       entry: { timestamp: number; address: string } | undefined,
     ): entry is { timestamp: number; address: string } => {
       if (!entry) {
         return false;
       }
-      if (Date.now() - entry.timestamp >= staleCutoff) {
+      if (!skipTTL && Date.now() - entry.timestamp >= staleCutoff) {
         return false;
       }
       if (
@@ -1152,11 +1192,10 @@ export class PerpsController extends BaseController<
       let defaultAccountState: AccountState | null = null;
       let hasValidEntry = false;
 
-      for (const [providerId] of this.providers) {
-        const key = this.#marketCacheKey(
-          providerId,
-          this.#providerIsTestnet(providerId),
-        );
+      for (const providerId of this.#getAggregatedCacheProviderIds(
+        Object.keys(cache),
+      )) {
+        const key = buildProviderCacheKey(providerId, this.state.isTestnet);
         const entry = cache[key];
         if (!isValidEntry(entry)) {
           continue;
@@ -1182,10 +1221,7 @@ export class PerpsController extends BaseController<
     }
 
     // Single provider mode
-    const key = this.#marketCacheKey(
-      activeProvider,
-      this.#providerIsTestnet(activeProvider),
-    );
+    const key = buildProviderCacheKey(activeProvider, this.state.isTestnet);
     const entry = cache[key];
     if (!entry || !isValidEntry(entry)) {
       return null;
@@ -1694,11 +1730,8 @@ export class PerpsController extends BaseController<
       // IMPORTANT: Must use import() — NOT require() — for core/extension tree-shaking.
       // require() is synchronous and bundlers include it in the main bundle.
       // import() enables true code splitting so MYX is excluded when not enabled.
-      // NOTE: Uses a variable so ts-bridge does not rewrite the import
-      // specifier (which would strip the webpackIgnore magic comment).
-      const myxModulePath = './providers/MYXProvider';
       this.#myxRegistrationPromise = import(
-        /* webpackIgnore: true */ myxModulePath
+        /* webpackIgnore: true */ './providers/MYXProvider'
       )
         .then(({ MYXProvider }) => {
           this.registerMYXProvider(MYXProvider);
@@ -2924,6 +2957,42 @@ export class PerpsController extends BaseController<
   static readonly #preloadGuardMs = 30_000; // 30s debounce
 
   /**
+   * Synchronously hydrate in-memory caches from disk-persisted snapshots.
+   * Uses the sync MMKV API (~1ms) so data is available before any hook reads.
+   * Falls back to no-op when getItemSync is not available (e.g. E2E).
+   * All computed updates are applied in a single this.update() call to avoid
+   * triggering state subscribers once per provider entry.
+   */
+  #hydrateCacheFromDiskSync(): void {
+    const { marketUpdates, userUpdates, stats } = hydrateFromDiskSync(
+      this.#options.infrastructure.diskCache,
+      this.state.cachedMarketDataByProvider,
+      this.state.cachedUserDataByProvider,
+      PerpsController.#preloadGuardMs,
+    );
+
+    const hasMarketUpdates = Object.keys(marketUpdates).length > 0;
+    const hasUserUpdates = Object.keys(userUpdates).length > 0;
+    if (hasMarketUpdates || hasUserUpdates) {
+      this.update((state) => {
+        if (hasMarketUpdates) {
+          Object.assign(state.cachedMarketDataByProvider, marketUpdates);
+        }
+        if (hasUserUpdates) {
+          Object.assign(state.cachedUserDataByProvider, userUpdates);
+        }
+      });
+    }
+
+    this.#debugLog('PerpsController: Disk cache hydrated (sync)', {
+      markets: stats.marketCount,
+      positions: stats.userPositions,
+      orders: stats.userOrders,
+      duration_ms: stats.durationMs,
+    });
+  }
+
+  /**
    * Start background market data preloading.
    * Fetches market data immediately and refreshes every 5 minutes.
    * Watches for isTestnet and hip3ConfigVersion changes to re-preload.
@@ -3027,6 +3096,12 @@ export class PerpsController extends BaseController<
         this.update((state) => {
           state.cachedUserDataByProvider = {};
         });
+        // Invalidate disk-cached user data for the old account
+        this.#options.infrastructure.diskCache
+          .removeItem(PERPS_DISK_CACHE_USER_DATA)
+          .catch(() => {
+            /* fire-and-forget */
+          });
         // Only preload if the new account is an EVM account
         if (currentAddress) {
           this.#performUserDataPreload().catch(() => {
@@ -3091,9 +3166,9 @@ export class PerpsController extends BaseController<
     const actualProviderId = this.activeProviderInstance
       ? this.state.activeProvider // includes 'aggregated'
       : 'hyperliquid';
-    const cacheKey = this.#marketCacheKey(
+    const cacheKey = buildProviderCacheKey(
       actualProviderId,
-      this.#providerIsTestnet(actualProviderId),
+      this.state.isTestnet,
     );
 
     const now = Date.now();
@@ -3124,10 +3199,20 @@ export class PerpsController extends BaseController<
       });
 
       this.#debugLog('PerpsController: Fetching market data in background');
+      this.#debugLog('PerpsController: rest_preload_start');
       const data = await this.getMarketDataWithPrices({ standalone: true });
+      this.#debugLog('PerpsController: rest_preload_end', {
+        duration_ms: Math.round(performance.now() - preloadStart),
+        markets: data.length,
+      });
 
       // Store under per-provider key(s)
       const ts = Date.now();
+      const marketDiskEntries: {
+        providerNetworkKey: string;
+        data: PerpsMarketData[];
+        timestamp: number;
+      }[] = [];
       if (
         this.state.activeProvider === 'aggregated' &&
         this.activeProviderInstance
@@ -3146,7 +3231,12 @@ export class PerpsController extends BaseController<
         }
         this.update((state) => {
           for (const [pid, slice] of byProvider) {
-            const key = this.#marketCacheKey(pid, this.#providerIsTestnet(pid));
+            const key = buildProviderCacheKey(pid, this.state.isTestnet);
+            marketDiskEntries.push({
+              providerNetworkKey: key,
+              data: slice,
+              timestamp: ts,
+            });
             state.cachedMarketDataByProvider[key] = {
               data: slice,
               timestamp: ts,
@@ -3159,6 +3249,11 @@ export class PerpsController extends BaseController<
           };
         });
       } else {
+        marketDiskEntries.push({
+          providerNetworkKey: cacheKey,
+          data,
+          timestamp: ts,
+        });
         this.update((state) => {
           state.cachedMarketDataByProvider[cacheKey] = {
             data,
@@ -3166,6 +3261,11 @@ export class PerpsController extends BaseController<
           };
         });
       }
+
+      persistMarketEntriesToDisk(
+        this.#options.infrastructure.diskCache,
+        marketDiskEntries,
+      );
 
       this.#debugLog('PerpsController: Market data preloaded', {
         marketCount: data.length,
@@ -3230,9 +3330,9 @@ export class PerpsController extends BaseController<
     const actualProviderId = this.activeProviderInstance
       ? this.state.activeProvider // includes 'aggregated'
       : 'hyperliquid';
-    const userCacheKey = this.#marketCacheKey(
+    const userCacheKey = buildProviderCacheKey(
       actualProviderId,
-      this.#providerIsTestnet(actualProviderId),
+      this.state.isTestnet,
     );
 
     // Skip if cache is fresh and for same account
@@ -3330,9 +3430,25 @@ export class PerpsController extends BaseController<
           accountState.providerId ?? fallbackProviderId,
         ).accountState = accountState;
 
+        const diskEntries: {
+          providerNetworkKey: string;
+          address: string;
+          positions: Position[];
+          orders: Order[];
+          accountState: AccountState | null;
+          timestamp: number;
+        }[] = [];
         this.update((state) => {
           for (const [pid, data] of byProvider) {
-            const key = this.#marketCacheKey(pid, this.#providerIsTestnet(pid));
+            const key = buildProviderCacheKey(pid, this.state.isTestnet);
+            diskEntries.push({
+              providerNetworkKey: key,
+              address: userAddress,
+              positions: data.positions,
+              orders: data.orders,
+              accountState: data.accountState,
+              timestamp: ts,
+            });
             state.cachedUserDataByProvider[key] = {
               ...data,
               timestamp: ts,
@@ -3348,17 +3464,34 @@ export class PerpsController extends BaseController<
             address: userAddress,
           };
         });
+
+        persistUserEntriesToDisk(
+          this.#options.infrastructure.diskCache,
+          diskEntries,
+        );
       } else {
         // Single provider — store directly under its key
+        const ts = Date.now();
         this.update((state) => {
           state.cachedUserDataByProvider[userCacheKey] = {
             positions,
             orders,
             accountState,
-            timestamp: Date.now(),
+            timestamp: ts,
             address: userAddress,
           };
         });
+
+        persistUserEntriesToDisk(this.#options.infrastructure.diskCache, [
+          {
+            providerNetworkKey: userCacheKey,
+            address: userAddress,
+            positions,
+            orders,
+            accountState,
+            timestamp: ts,
+          },
+        ]);
       }
 
       this.#debugLog('PerpsController: User data preloaded', {

--- a/packages/perps-controller/src/constants/eventNames.ts
+++ b/packages/perps-controller/src/constants/eventNames.ts
@@ -234,6 +234,7 @@ export const PERPS_EVENT_VALUE = {
     ADD_FUNDS_ACTION: 'add_funds_action',
     CANCEL_ORDER: 'cancel_order',
     ASSET_DETAIL_SCREEN: 'asset_detail_screen',
+    MARKET_INSIGHTS: 'market_insights',
     // TAT-2449: Geo-block sources for close/modify actions
     CLOSE_POSITION_ACTION: 'close_position_action',
     MODIFY_POSITION_ACTION: 'modify_position_action',

--- a/packages/perps-controller/src/constants/perpsConfig.ts
+++ b/packages/perps-controller/src/constants/perpsConfig.ts
@@ -29,6 +29,7 @@ export const PERPS_CONSTANTS = {
   ConnectionAttemptTimeoutMs: 30_000, // 30 seconds timeout for connection attempts to prevent indefinite hanging
   WebsocketPingTimeoutMs: 5_000, // 5 seconds timeout for WebSocket health check ping
   ConnectRetryDelayMs: 200, // Delay before retrying connect() when connection isn't ready yet
+  ForegroundPingRetryDelayMs: 500, // Delay before retrying ping in resumeFromForeground — JS thread may be sluggish right after foregrounding
   ReconnectionCleanupDelayMs: 500, // Platform-agnostic delay to ensure WebSocket is ready
   ReconnectionDelayAndroidMs: 300, // Android-specific reconnection delay for better reliability on slower devices
   ReconnectionDelayIosMs: 100, // iOS-specific reconnection delay for optimal performance
@@ -350,6 +351,19 @@ export type SortOptionId =
   (typeof MARKET_SORTING_CONFIG.SortOptions)[number]['id'];
 
 /**
+ * Funding rate display configuration
+ * Controls how funding rates are formatted and displayed
+ */
+export const FUNDING_RATE_CONFIG = {
+  // Number of decimal places to display for funding rates
+  Decimals: 4,
+  // Default display value when funding rate is zero or unavailable
+  ZeroDisplay: '0.0000%',
+  // Multiplier to convert decimal funding rate to percentage
+  PercentageMultiplier: 100,
+} as const;
+
+/**
  * Provider configuration for multi-provider support
  */
 export const PROVIDER_CONFIG = {
@@ -358,3 +372,43 @@ export const PROVIDER_CONFIG = {
   /** Force MYX to testnet only (mainnet credentials not yet available) */
   MYX_TESTNET_ONLY: false,
 } as const;
+
+// Disk-backed cold-start cache keys and throttle interval
+export const PERPS_DISK_CACHE_MARKETS = 'PERPS_DISK_CACHE_MARKETS';
+export const PERPS_DISK_CACHE_USER_DATA = 'PERPS_DISK_CACHE_USER_DATA';
+export const PERPS_DISK_CACHE_THROTTLE_MS = 30_000;
+
+/**
+ * Build the standard provider:network cache key from controller state.
+ *
+ * @param state - Controller state containing provider and network info.
+ * @param state.activeProvider - Active perps provider name.
+ * @param state.isTestnet - Whether testnet mode is active.
+ * @returns Cache key in the format "provider:mainnet" or "provider:testnet".
+ */
+export function getProviderNetworkKey(state: {
+  activeProvider?: string;
+  isTestnet?: boolean;
+}): string {
+  return `${state.activeProvider ?? PROVIDER_CONFIG.DefaultProvider}:${state.isTestnet ? 'testnet' : 'mainnet'}`;
+}
+
+/**
+ * Build a provider:network cache key for a specific provider id.
+ * Accounts for MYX_TESTNET_ONLY: MYX is always on testnet regardless of the
+ * global network flag.
+ *
+ * @param providerId - The provider identifier (e.g. "hyperliquid", "myx").
+ * @param isTestnet - Global testnet flag from controller state.
+ * @returns Cache key in the format "provider:mainnet" or "provider:testnet".
+ */
+export function buildProviderCacheKey(
+  providerId: string,
+  isTestnet: boolean,
+): string {
+  const effectiveTestnet =
+    providerId === 'myx'
+      ? PROVIDER_CONFIG.MYX_TESTNET_ONLY || isTestnet
+      : isTestnet;
+  return `${providerId}:${effectiveTestnet ? 'testnet' : 'mainnet'}`;
+}

--- a/packages/perps-controller/src/constants/transactionsHistoryConfig.ts
+++ b/packages/perps-controller/src/constants/transactionsHistoryConfig.ts
@@ -6,10 +6,29 @@ export const PERPS_TRANSACTIONS_HISTORY_CONSTANTS = {
   FLASH_LIST_SCROLL_EVENT_THROTTLE: 16,
   LIST_ITEM_SELECTOR_OPACITY: 0.7,
   /**
-   * Default number of days to look back for funding history.
-   * HyperLiquid API requires a startTime and returns max 500 records.
-   * Using 365 days ensures most users see their complete recent history.
-   * Can be increased if users need older funding data.
+   * Maximum number of days to look back for funding history.
+   * Only the most recent 30-day window is fetched on initial load;
+   * older windows are fetched on-demand as the user scrolls.
+   * Empty windows (gaps in activity) are skipped automatically.
    */
   DEFAULT_FUNDING_HISTORY_DAYS: 365,
+  /**
+   * Number of days per pagination window when fetching funding history.
+   * Each window is fetched via fetchWindowWithAutoSplit, which recursively
+   * halves any window that hits FUNDING_HISTORY_API_LIMIT, guaranteeing
+   * complete results regardless of position count or trading activity.
+   */
+  FUNDING_HISTORY_PAGE_WINDOW_DAYS: 30,
+  /**
+   * HyperLiquid API returns at most this many records per userFunding call.
+   * When a single window exceeds this, only the oldest records are returned —
+   * the pagination strategy avoids this by using small enough windows.
+   */
+  FUNDING_HISTORY_API_LIMIT: 500,
+  /**
+   * Minimum window size (ms) for the auto-split recursion in getFunding.
+   * HyperLiquid's funding interval is 8 h, so a 1-hour window holds at most
+   * a fraction of one event per position — well under the 500-record cap.
+   */
+  MIN_SPLIT_WINDOW_MS: 60 * 60 * 1000,
 } as const;

--- a/packages/perps-controller/src/index.ts
+++ b/packages/perps-controller/src/index.ts
@@ -418,6 +418,7 @@ export {
   DECIMAL_PRECISION_CONFIG,
   MARKET_SORTING_CONFIG,
   PROVIDER_CONFIG,
+  FUNDING_RATE_CONFIG,
 } from './constants';
 export type { SortOptionId } from './constants';
 
@@ -534,6 +535,18 @@ export {
   adaptHyperLiquidLedgerUpdateToUserHistoryItem,
 } from './utils';
 export { getEnvironment } from './utils';
+export type { FiatRangeConfig } from './utils';
+export {
+  PRICE_THRESHOLD,
+  formatWithSignificantDigits,
+  PRICE_RANGES_MINIMAL_VIEW,
+  PRICE_RANGES_UNIVERSAL,
+  formatPerpsFiat,
+  formatPositionSize,
+  formatPnl,
+  formatPercentage,
+  formatFundingRate,
+} from './utils';
 
 // Error codes (explicit named exports)
 export { PERPS_ERROR_CODES } from './perpsErrorCodes';

--- a/packages/perps-controller/src/providers/HyperLiquidProvider.ts
+++ b/packages/perps-controller/src/providers/HyperLiquidProvider.ts
@@ -4350,21 +4350,24 @@ export class HyperLiquidProvider implements PerpsProvider {
           { cachedOrdersCount: cachedOrders.length },
         );
 
-        // Filter using normalized Order type properties
-        // Note: Cached orders don't have isPositionTpsl, but we identify TP/SL orders by:
+        // Filter using normalized Order type properties, matching the REST fallback criteria:
+        // - symbol matches
         // - isTrigger === true
         // - reduceOnly === true
+        // - isPositionTpsl matches the configured mode (only cancel position-bound TP/SL,
+        //   not normalTpsl children that belong to pending limit orders)
         // - detailedOrderType contains 'Take Profit' or 'Stop'
         const tpslOrders = cachedOrders.filter(
           (order) =>
             order.symbol === symbol &&
             order.reduceOnly === true &&
             order.isTrigger === true &&
+            order.isPositionTpsl ===
+              Boolean(TP_SL_CONFIG.UsePositionBoundTpsl) &&
             order.detailedOrderType &&
             (order.detailedOrderType.includes('Take Profit') ||
               order.detailedOrderType.includes('Stop')),
         );
-
         cancelRequests = tpslOrders.map((order) => ({
           a: assetId,
           o: parseInt(order.orderId, 10),
@@ -4953,11 +4956,15 @@ export class HyperLiquidProvider implements PerpsProvider {
 
             // Find TP/SL orders for this position
             // First check direct trigger orders (raw SDK uses 'coin', adapted position uses 'symbol')
+            // Only match position-bound TP/SL orders when UsePositionBoundTpsl is enabled,
+            // to avoid picking up normalTpsl children from pending limit orders
             const positionOrders = allOrders.filter(
               (order) =>
                 order.coin === position.symbol &&
                 order.isTrigger &&
-                order.reduceOnly,
+                order.reduceOnly &&
+                order.isPositionTpsl ===
+                  Boolean(TP_SL_CONFIG.UsePositionBoundTpsl),
             );
 
             // Also check for parent orders that might have TP/SL children
@@ -5422,38 +5429,99 @@ export class HyperLiquidProvider implements PerpsProvider {
         params?.accountId,
       );
 
-      // HyperLiquid API requires startTime to be a number (not undefined)
-      // Default to configured days ago to get recent funding payments
-      // Using 0 (epoch) would return oldest 500 records, missing latest payments
-      const defaultStartTime =
-        Date.now() -
-        PERPS_TRANSACTIONS_HISTORY_CONSTANTS.DEFAULT_FUNDING_HISTORY_DAYS *
-          24 *
-          60 *
-          60 *
-          1000;
-      const rawFunding = await infoClient.userFunding({
-        user: userAddress,
-        startTime: params?.startTime ?? defaultStartTime,
-        endTime: params?.endTime,
+      // On-demand loading: the default window is one 30-day page so the
+      // initial fetch costs exactly 1 API call (~24 weight vs 312 previously).
+      // When loadMoreFunding in usePerpsTransactionHistory passes explicit
+      // startTime/endTime for an older 30-day page the while-loop below still
+      // produces exactly 1 chunk. The 365-day max lookback is enforced by the
+      // caller.
+      //
+      // Each chunk is fetched via fetchWindowWithAutoSplit: if a call returns
+      // FUNDING_HISTORY_API_LIMIT records the window has hit the API cap and
+      // the oldest records would be silently dropped. The function splits the
+      // window in half and recurses until every sub-window is under the cap,
+      // guaranteeing complete results regardless of position count or activity.
+      const finalEndTime = params?.endTime ?? Date.now();
+      const pageWindowMs =
+        PERPS_TRANSACTIONS_HISTORY_CONSTANTS.FUNDING_HISTORY_PAGE_WINDOW_DAYS *
+        24 *
+        60 *
+        60 *
+        1000;
+      const finalStartTime = params?.startTime ?? finalEndTime - pageWindowMs; // Default: most recent 30-day window only
+
+      const minSplitWindowMs =
+        PERPS_TRANSACTIONS_HISTORY_CONSTANTS.MIN_SPLIT_WINDOW_MS;
+      const apiLimit =
+        PERPS_TRANSACTIONS_HISTORY_CONSTANTS.FUNDING_HISTORY_API_LIMIT;
+
+      // Fetches a single window. If the result hits the API cap the window is
+      // split in half and both halves are fetched in parallel, recursively,
+      // until every sub-window is under the cap.
+      const fetchWindowWithAutoSplit = async (
+        windowStart: number,
+        windowEnd: number,
+      ): Promise<Awaited<ReturnType<typeof infoClient.userFunding>>> => {
+        const result = await infoClient.userFunding({
+          user: userAddress,
+          startTime: windowStart,
+          endTime: windowEnd,
+        });
+        const records = result ?? [];
+        if (
+          records.length >= apiLimit &&
+          windowEnd - windowStart > minSplitWindowMs
+        ) {
+          const mid = windowStart + Math.floor((windowEnd - windowStart) / 2);
+          const [left, right] = await Promise.all([
+            fetchWindowWithAutoSplit(windowStart, mid),
+            fetchWindowWithAutoSplit(mid, windowEnd),
+          ]);
+          return [...(left ?? []), ...(right ?? [])];
+        }
+        return records;
+      };
+
+      const chunks: { start: number; end: number }[] = [];
+      let chunkEnd = finalEndTime;
+      while (chunkEnd > finalStartTime) {
+        const chunkStart = Math.max(finalStartTime, chunkEnd - pageWindowMs);
+        chunks.push({ start: chunkStart, end: chunkEnd });
+        chunkEnd = chunkStart;
+      }
+
+      const pages = await Promise.all(
+        chunks.map((chunk) => fetchWindowWithAutoSplit(chunk.start, chunk.end)),
+      );
+
+      // Deduplicate at chunk boundaries — adjacent windows share their boundary
+      // timestamp (chunkEnd of N === chunkStart of N+1) and the API is
+      // inclusive on both sides, so a record can appear in both adjacent calls.
+      // Funding records share a zero hash, so we key on time + coin instead.
+      const seen = new Set<string>();
+      const allRaw = pages.flat().filter((record) => {
+        const key = `${record.time}-${record.delta.coin}`;
+        if (seen.has(key)) {
+          return false;
+        }
+        seen.add(key);
+        return true;
       });
+      allRaw.sort((a, b) => a.time - b.time);
 
       this.#deps.debugLogger.log('User funding received:', {
-        count: rawFunding?.length ?? 0,
+        count: allRaw.length,
+        chunks: chunks.length,
       });
 
       // Transform HyperLiquid funding to abstract Funding type
-      const funding: Funding[] = (rawFunding || []).map((rawFundingItem) => {
-        const { delta, hash, time } = rawFundingItem;
-
-        return {
-          symbol: delta.coin,
-          amountUsd: delta.usdc,
-          rate: delta.fundingRate,
-          timestamp: time,
-          transactionHash: hash,
-        };
-      });
+      const funding: Funding[] = allRaw.map(({ delta, hash, time }) => ({
+        symbol: delta.coin,
+        amountUsd: delta.usdc,
+        rate: delta.fundingRate,
+        timestamp: time,
+        transactionHash: hash,
+      }));
 
       return funding;
     } catch (error) {

--- a/packages/perps-controller/src/services/HyperLiquidSubscriptionService.ts
+++ b/packages/perps-controller/src/services/HyperLiquidSubscriptionService.ts
@@ -732,6 +732,15 @@ export class HyperLiquidSubscriptionService {
         // This ensures consistency with raw SDK order processing which uses triggerPx
         const tpslPrice = order.triggerPrice ?? order.price;
         if (order.isTrigger && tpslPrice) {
+          // When UsePositionBoundTpsl is enabled, only position-bound TP/SL orders
+          // should be shown on positions — skip normalTpsl children of limit orders
+          if (
+            TP_SL_CONFIG.UsePositionBoundTpsl &&
+            order.isPositionTpsl !== true
+          ) {
+            return;
+          }
+
           const isTakeProfit = order.detailedOrderType?.includes('Take Profit');
           const isStop = order.detailedOrderType?.includes('Stop');
 

--- a/packages/perps-controller/src/types/index.ts
+++ b/packages/perps-controller/src/types/index.ts
@@ -1524,6 +1524,14 @@ export type PerpsPlatformDependencies = {
   // === Cache Invalidation (for standalone query caches) ===
   cacheInvalidator: PerpsCacheInvalidator;
 
+  // === Disk Cache (cold-start persistence) ===
+  diskCache: {
+    getItem(key: string): Promise<string | null>;
+    getItemSync?(key: string): string | null;
+    setItem(key: string, value: string): Promise<void>;
+    removeItem(key: string): Promise<void>;
+  };
+
   // === Rewards (DI — no RewardsController in Core yet) ===
   rewards: {
     /**

--- a/packages/perps-controller/src/utils/index.ts
+++ b/packages/perps-controller/src/utils/index.ts
@@ -26,6 +26,7 @@ export * from './idUtils';
 export * from './marketDataTransform';
 export * from './marketUtils';
 export * from './orderCalculations';
+export * from './perpsDiskPersistence';
 export * from './rewardsUtils';
 export * from './significantFigures';
 export * from './sortMarkets';
@@ -39,3 +40,4 @@ export const getEnvironment = (): 'DEV' | 'PROD' => {
   const env = globalThis.process?.env?.NODE_ENV ?? 'production';
   return env === 'production' ? 'PROD' : 'DEV';
 };
+export * from './perpsFormatters';

--- a/packages/perps-controller/src/utils/perpsDiskPersistence.ts
+++ b/packages/perps-controller/src/utils/perpsDiskPersistence.ts
@@ -1,0 +1,360 @@
+import {
+  buildProviderCacheKey,
+  PERPS_CONSTANTS,
+  PERPS_DISK_CACHE_MARKETS,
+  PERPS_DISK_CACHE_USER_DATA,
+  PROVIDER_CONFIG,
+} from '../constants/perpsConfig';
+import type { AccountState, Order, PerpsMarketData, Position } from '../types';
+
+/**
+ * Multiplier applied to staleGuardMs (preloadGuardMs, currently 30s) to compute
+ * the staleness cap for disk-hydrated timestamps. A factor of 10 ensures hydrated
+ * data is always TTL-expired so the stream manager overwrites it with live data,
+ * while still being recent enough for a useful first paint.
+ */
+const DISK_HYDRATION_STALENESS_FACTOR = 10;
+
+/** Minimal disk cache interface required by persistence utilities. */
+export type PerpsDiskCache = {
+  getItem(key: string): Promise<string | null>;
+  getItemSync?(key: string): string | null;
+  setItem(key: string, value: string): Promise<void>;
+};
+
+/** Shape of a single market entry persisted to disk cache. */
+export type DiskCacheMarketEntry = {
+  providerNetworkKey: string;
+  data: PerpsMarketData[];
+  timestamp: number;
+};
+
+/** Shape of a single user-data entry persisted to disk cache. */
+export type DiskCacheUserEntry = {
+  providerNetworkKey: string;
+  address: string;
+  positions: Position[];
+  orders: Order[];
+  accountState: AccountState | null;
+  timestamp: number;
+};
+
+/** Disk payload shape — either a single entry or a multi-provider wrapper. */
+export type DiskCacheMarketPayload =
+  | DiskCacheMarketEntry
+  | { entries: DiskCacheMarketEntry[] };
+
+export type DiskCacheUserPayload =
+  | DiskCacheUserEntry
+  | { entries: DiskCacheUserEntry[] };
+
+/**
+ * Build the disk-cache payload for market data.
+ * In aggregated mode, groups markets by provider into separate entries.
+ *
+ * @param markets - Current market data snapshot.
+ * @param activeProvider - The active provider id (may be "aggregated").
+ * @param isTestnet - Global testnet flag.
+ * @param now - Timestamp to stamp entries with.
+ * @returns Payload ready for JSON serialization.
+ */
+export function buildMarketDataPayload(
+  markets: PerpsMarketData[],
+  activeProvider: string,
+  isTestnet: boolean,
+  now: number,
+): DiskCacheMarketPayload {
+  if (activeProvider === 'aggregated') {
+    const entriesByKey = new Map<string, DiskCacheMarketEntry>();
+    for (const market of markets) {
+      const providerId = market.providerId ?? PROVIDER_CONFIG.DefaultProvider;
+      const key = buildProviderCacheKey(providerId, isTestnet);
+      const existing = entriesByKey.get(key);
+      if (existing) {
+        existing.data.push(market);
+      } else {
+        entriesByKey.set(key, {
+          providerNetworkKey: key,
+          data: [market],
+          timestamp: now,
+        });
+      }
+    }
+    const entries = Array.from(entriesByKey.values());
+    return entries.length === 1 ? entries[0] : { entries };
+  }
+  return {
+    providerNetworkKey: buildProviderCacheKey(
+      activeProvider ?? PROVIDER_CONFIG.DefaultProvider,
+      isTestnet,
+    ),
+    data: markets,
+    timestamp: now,
+  };
+}
+
+/**
+ * Build the disk-cache payload for user data (positions, orders, account).
+ * In aggregated mode, groups entries by provider.
+ *
+ * @param positions - Current positions snapshot.
+ * @param orders - Current orders snapshot.
+ * @param accountState - Current account state snapshot.
+ * @param address - EVM account address.
+ * @param activeProvider - The active provider id (may be "aggregated").
+ * @param isTestnet - Global testnet flag.
+ * @param now - Timestamp to stamp entries with.
+ * @returns Payload ready for JSON serialization.
+ */
+export function buildUserDataPayload(
+  positions: Position[],
+  orders: Order[],
+  accountState: AccountState | null,
+  address: string,
+  activeProvider: string,
+  isTestnet: boolean,
+  now: number,
+): DiskCacheUserPayload {
+  if (activeProvider === 'aggregated') {
+    const entriesByKey = new Map<string, DiskCacheUserEntry>();
+    const ensureEntry = (providerId: string): DiskCacheUserEntry => {
+      const key = buildProviderCacheKey(providerId, isTestnet);
+      let entry = entriesByKey.get(key);
+      if (!entry) {
+        entry = {
+          providerNetworkKey: key,
+          address,
+          positions: [],
+          orders: [],
+          accountState: null,
+          timestamp: now,
+        };
+        entriesByKey.set(key, entry);
+      }
+      return entry;
+    };
+
+    for (const position of positions) {
+      ensureEntry(
+        position.providerId ?? PROVIDER_CONFIG.DefaultProvider,
+      ).positions.push(position);
+    }
+    for (const order of orders) {
+      ensureEntry(
+        order.providerId ?? PROVIDER_CONFIG.DefaultProvider,
+      ).orders.push(order);
+    }
+    if (accountState) {
+      ensureEntry(
+        accountState.providerId ?? PROVIDER_CONFIG.DefaultProvider,
+      ).accountState = accountState;
+    }
+
+    const entries = Array.from(entriesByKey.values()).filter(
+      (entry) =>
+        entry.positions.length > 0 ||
+        entry.orders.length > 0 ||
+        entry.accountState !== null,
+    );
+    return entries.length === 1 ? entries[0] : { entries };
+  }
+  return {
+    providerNetworkKey: buildProviderCacheKey(
+      activeProvider ?? PROVIDER_CONFIG.DefaultProvider,
+      isTestnet,
+    ),
+    address,
+    positions,
+    orders,
+    accountState,
+    timestamp: now,
+  };
+}
+
+/**
+ * Write market entries to disk (best-effort, non-blocking).
+ *
+ * @param diskCache - Disk cache instance from controller infrastructure.
+ * @param entries - Pre-assembled market cache entries to persist.
+ */
+export function persistMarketEntriesToDisk(
+  diskCache: PerpsDiskCache,
+  entries: DiskCacheMarketEntry[],
+): void {
+  if (entries.length === 0) {
+    return;
+  }
+  const payload = entries.length === 1 ? entries[0] : { entries };
+  diskCache
+    .setItem(PERPS_DISK_CACHE_MARKETS, JSON.stringify(payload))
+    .catch(() => {
+      // Disk persistence is best-effort and must never block preload.
+    });
+}
+
+/**
+ * Write user data entries to disk (best-effort, non-blocking).
+ *
+ * @param diskCache - Disk cache instance from controller infrastructure.
+ * @param entries - Pre-assembled user cache entries to persist.
+ */
+export function persistUserEntriesToDisk(
+  diskCache: PerpsDiskCache,
+  entries: DiskCacheUserEntry[],
+): void {
+  if (entries.length === 0) {
+    return;
+  }
+  const payload = entries.length === 1 ? entries[0] : { entries };
+  diskCache
+    .setItem(PERPS_DISK_CACHE_USER_DATA, JSON.stringify(payload))
+    .catch(() => {
+      // Disk persistence is best-effort and must never block preload.
+    });
+}
+
+/** Computed updates returned by hydrateFromDiskSync. */
+export type HydrateFromDiskResult = {
+  marketUpdates: Record<string, { data: PerpsMarketData[]; timestamp: number }>;
+  userUpdates: Record<
+    string,
+    {
+      positions: Position[];
+      orders: Order[];
+      accountState: AccountState | null;
+      timestamp: number;
+      address: string;
+    }
+  >;
+  stats: {
+    marketCount: number;
+    userPositions: number;
+    userOrders: number;
+    durationMs: number;
+  };
+};
+
+/**
+ * Read disk-persisted cache snapshots and compute the state updates to apply.
+ * Returns plain objects rather than mutating state directly, so the caller
+ * can apply all changes in a single batched this.update() call.
+ *
+ * All returned timestamps are capped at DISK_HYDRATION_STALENESS_FACTOR * staleGuardMs
+ * in the past so the stream manager always overwrites disk data with fresh live data.
+ *
+ * @param diskCache - Disk cache instance from controller infrastructure.
+ * @param currentMarketCache - Current cachedMarketDataByProvider state.
+ * @param currentUserCache - Current cachedUserDataByProvider state.
+ * @param staleGuardMs - preloadGuardMs constant from the controller.
+ * @returns Updates to apply plus stats for debug logging.
+ */
+export function hydrateFromDiskSync(
+  diskCache: PerpsDiskCache,
+  currentMarketCache: Record<string, { timestamp: number }>,
+  currentUserCache: Record<string, { timestamp: number }>,
+  staleGuardMs: number,
+): HydrateFromDiskResult {
+  const hydrateT0 = Date.now();
+  const marketUpdates: HydrateFromDiskResult['marketUpdates'] = {};
+  const userUpdates: HydrateFromDiskResult['userUpdates'] = {};
+  let marketCount = 0;
+  let userPositions = 0;
+  let userOrders = 0;
+
+  if (!diskCache.getItemSync) {
+    return {
+      marketUpdates,
+      userUpdates,
+      stats: { marketCount, userPositions, userOrders, durationMs: 0 },
+    };
+  }
+
+  const staleHydratedTimestamp =
+    Date.now() - staleGuardMs * DISK_HYDRATION_STALENESS_FACTOR - 1;
+
+  try {
+    const marketsRaw = diskCache.getItemSync(PERPS_DISK_CACHE_MARKETS);
+    const userRaw = diskCache.getItemSync(PERPS_DISK_CACHE_USER_DATA);
+
+    if (marketsRaw) {
+      try {
+        const parsed = JSON.parse(marketsRaw) as
+          | DiskCacheMarketEntry
+          | { entries: DiskCacheMarketEntry[] };
+        const entries = Array.isArray((parsed as { entries?: unknown }).entries)
+          ? (parsed as { entries: DiskCacheMarketEntry[] }).entries
+          : [parsed as DiskCacheMarketEntry];
+
+        for (const entry of entries) {
+          if (entry.providerNetworkKey && Array.isArray(entry.data)) {
+            const existing = currentMarketCache[entry.providerNetworkKey];
+            if (!existing || existing.timestamp < entry.timestamp) {
+              const strippedData = entry.data.map((market) => ({
+                ...market,
+                price: PERPS_CONSTANTS.FallbackPriceDisplay,
+                change24h: PERPS_CONSTANTS.FallbackDataDisplay,
+                change24hPercent: PERPS_CONSTANTS.FallbackPercentageDisplay,
+              }));
+              marketUpdates[entry.providerNetworkKey] = {
+                data: strippedData,
+                // Disk-hydrated market snapshots are only for structural
+                // first paint. Keep them TTL-stale so the stream manager
+                // still fetches fresh prices on connect.
+                timestamp: Math.min(entry.timestamp, staleHydratedTimestamp),
+              };
+              marketCount += strippedData.length;
+            }
+          }
+        }
+      } catch {
+        // Corrupt JSON — silently ignore
+      }
+    }
+
+    if (userRaw) {
+      try {
+        const parsed = JSON.parse(userRaw) as
+          | DiskCacheUserEntry
+          | { entries: DiskCacheUserEntry[] };
+        const entries = Array.isArray((parsed as { entries?: unknown }).entries)
+          ? (parsed as { entries: DiskCacheUserEntry[] }).entries
+          : [parsed as DiskCacheUserEntry];
+
+        for (const entry of entries) {
+          if (entry.providerNetworkKey && entry.address) {
+            // Skip address check here — accounts may not be loaded yet at
+            // constructor time. getCachedUserDataForActiveProvider validates
+            // the address at read time, so stale-account data is never served.
+            const existing = currentUserCache[entry.providerNetworkKey];
+            if (!existing || existing.timestamp < entry.timestamp) {
+              userUpdates[entry.providerNetworkKey] = {
+                positions: entry.positions,
+                orders: entry.orders,
+                accountState: entry.accountState,
+                timestamp: Math.min(entry.timestamp, staleHydratedTimestamp),
+                address: entry.address,
+              };
+              userPositions += entry.positions.length;
+              userOrders += entry.orders.length;
+            }
+          }
+        }
+      } catch {
+        // Corrupt JSON — silently ignore
+      }
+    }
+  } catch {
+    // Disk read failure — non-critical
+  }
+
+  return {
+    marketUpdates,
+    userUpdates,
+    stats: {
+      marketCount,
+      userPositions,
+      userOrders,
+      durationMs: Date.now() - hydrateT0,
+    },
+  };
+}

--- a/packages/perps-controller/src/utils/perpsFormatters.ts
+++ b/packages/perps-controller/src/utils/perpsFormatters.ts
@@ -1,0 +1,624 @@
+/**
+ * Portable perps decimal formatters.
+ *
+ * These are the canonical implementations, exported from the controller so
+ * extension and any future consumer can import them directly.
+ * No mobile-specific imports — safe to sync to Core.
+ *
+ * Intl.NumberFormat instances are cached in a module-level Map keyed by
+ * serialized options, avoiding repeated construction costs.
+ */
+import {
+  DECIMAL_PRECISION_CONFIG,
+  FUNDING_RATE_CONFIG,
+  PERPS_CONSTANTS,
+} from '../constants/perpsConfig';
+
+// Module-level Intl.NumberFormat cache (keyed by serialized options).
+const _fmtCache = new Map<string, Intl.NumberFormat>();
+
+function _formatCurrency(
+  value: number,
+  currency: string,
+  opts: { minimumFractionDigits: number; maximumFractionDigits: number },
+): string {
+  const key = `${currency}:${opts.minimumFractionDigits}:${opts.maximumFractionDigits}`;
+  let formatter = _fmtCache.get(key);
+  if (!formatter) {
+    formatter = new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency,
+      currencyDisplay: 'narrowSymbol',
+      minimumFractionDigits: opts.minimumFractionDigits,
+      maximumFractionDigits: opts.maximumFractionDigits,
+    });
+    _fmtCache.set(key, formatter);
+  }
+  return formatter.format(value);
+}
+
+/**
+ * Internal equivalent of the mobile formatWithThreshold utility.
+ * Formats a currency value, returning "<$X.XX" for values below threshold.
+ *
+ * @param amount - The numeric amount to format.
+ * @param threshold - The threshold below which the "<" prefix is shown.
+ * @param options - Intl formatting options.
+ * @param options.currency - ISO 4217 currency code.
+ * @param options.minimumFractionDigits - Minimum decimal digits.
+ * @param options.maximumFractionDigits - Maximum decimal digits.
+ * @returns Formatted currency string.
+ */
+function _formatWithThreshold(
+  amount: number,
+  threshold: number,
+  options: {
+    currency: string;
+    minimumFractionDigits: number;
+    maximumFractionDigits: number;
+  },
+): string {
+  const formatOpts = {
+    minimumFractionDigits: options.minimumFractionDigits,
+    maximumFractionDigits: options.maximumFractionDigits,
+    currencyDisplay: 'narrowSymbol' as const,
+  };
+  if (amount === 0) {
+    return _formatCurrency(0, options.currency, formatOpts);
+  }
+  return Math.abs(amount) < threshold
+    ? `<${_formatCurrency(threshold, options.currency, formatOpts)}`
+    : _formatCurrency(amount, options.currency, formatOpts);
+}
+
+/**
+ * Price threshold constants for PRICE_RANGES_UNIVERSAL
+ * These define the boundaries between different formatting ranges
+ */
+export const PRICE_THRESHOLD = {
+  /** Very high values boundary (> $100k) */
+  VERY_HIGH: 100_000,
+  /** High values boundary (> $10k) */
+  HIGH: 10_000,
+  /** Large values boundary (> $1k) */
+  LARGE: 1_000,
+  /** Medium values boundary (> $100) */
+  MEDIUM: 100,
+  /** Medium-low values boundary (> $10) */
+  MEDIUM_LOW: 10,
+  /** Low values boundary (>= $0.01) */
+  LOW: 0.01,
+  /**
+   * Very small values threshold (< $0.01)
+   * This is the minimum value for formatWithThreshold and should align with
+   * the 6 decimal maximum (0.000001 is the smallest representable value)
+   */
+  VERY_SMALL: 0.000001,
+} as const;
+
+/**
+ * Configuration for a specific number range formatting
+ */
+export type FiatRangeConfig = {
+  /**
+   * The condition to match for this range (e.g., < 0.0001, < 1, >= 1000)
+   * Function should return true if this config should be applied
+   */
+  condition: (value: number) => boolean;
+  /** Minimum decimal places for this range */
+  minimumDecimals: number;
+  /** Maximum decimal places for this range */
+  maximumDecimals: number;
+  /** Optional threshold for formatWithThreshold (defaults to the range boundary) */
+  threshold?: number;
+  /** Optional significant digits for this range (overrides decimal places when set) */
+  significantDigits?: number;
+  /** Optional custom formatting logic for this range */
+  customFormat?: (value: number, locale: string, currency: string) => string;
+  /** Optional flag to strip trailing zeros for this range (overrides global stripTrailingZeros option) */
+  stripTrailingZeros?: boolean;
+  /**
+   * Optional flag for fiat-style stripping (only strips .00, preserves meaningful decimals like .10, .40)
+   * When true, "$1,250.00" → "$1,250" but "$1,250.10" stays "$1,250.10"
+   * When false (default), strips all trailing zeros: "$1,250.10" → "$1,250.1"
+   */
+  fiatStyleStripping?: boolean;
+};
+
+/**
+ * Formats a number to a specific number of significant digits
+ * Strips trailing zeros unless minDecimals requires them
+ *
+ * @param value - The numeric value to format
+ * @param significantDigits - Number of significant digits to maintain
+ * @param minDecimals - Minimum decimal places to show (may add zeros)
+ * @param maxDecimals - Maximum decimal places allowed
+ * @returns Formatted number with appropriate precision, trailing zeros removed
+ */
+export function formatWithSignificantDigits(
+  value: number,
+  significantDigits: number,
+  minDecimals?: number,
+  maxDecimals?: number,
+): { value: number; decimals: number } {
+  // Handle special cases
+  if (value === 0) {
+    // Return zero with no trailing decimals by default (matches stripTrailingZeros behavior)
+    // Can be overridden by explicit minDecimals if needed
+    return { value: 0, decimals: minDecimals ?? 0 };
+  }
+
+  const absValue = Math.abs(value);
+
+  // For numbers >= 1, calculate decimals based on magnitude to achieve target significant figures
+  // This ensures consistent precision across different price ranges:
+  // Examples with 4 significant figures:
+  //   $123,456.78 → $123,456.78 (≥$1000: 2 decimals minimum, 8 sig figs)
+  //   $456.12 → $456.12 (≥$10: 2 decimals minimum, 5 sig figs)
+  //   $56.123 → $56.123 (≥$10: 2 decimals minimum, 5 sig figs)
+  //   $5.123 → $5.123 ($1-$10: 3 decimals = 4 sig figs)
+  //   $2.801 → $2.801 ($1-$10: 3 decimals = 4 sig figs)
+  //   $1.234 → $1.234 ($1-$10: 3 decimals = 4 sig figs)
+  if (absValue >= 1) {
+    let targetDecimals: number;
+
+    // Calculate decimals needed based on integer digits to achieve target significant figures
+    // For $38.388 with 5 sig figs: 2 integer digits, need 3 decimals (3,8,3,8,8)
+    // For $123.45 with 5 sig figs: 3 integer digits, need 2 decimals (1,2,3,4,5)
+    const integerDigits = Math.floor(Math.log10(absValue)) + 1;
+    const decimalsNeeded = significantDigits - integerDigits;
+    targetDecimals = Math.max(decimalsNeeded, 0); // Can't have negative decimals
+
+    // Apply explicit minimum decimals constraint if provided (for special cases)
+    if (minDecimals !== undefined && targetDecimals < minDecimals) {
+      targetDecimals = minDecimals;
+    }
+
+    // Apply maximum decimals constraint if specified
+    const finalDecimals =
+      maxDecimals === undefined
+        ? targetDecimals
+        : Math.min(targetDecimals, maxDecimals);
+
+    // Round to prevent floating-point artifacts (e.g., 2.820000000000003 → 2.82)
+    const roundedValue = Number(value.toFixed(finalDecimals));
+
+    return {
+      value: roundedValue,
+      decimals: finalDecimals,
+    };
+  }
+
+  // For numbers < 1, use toPrecision to limit to significantDigits
+  // Examples: 0.1234, 0.01234 should show exactly 4 sig figs
+  const precisionStr = absValue.toPrecision(significantDigits);
+  const precisionNum = parseFloat(precisionStr);
+
+  // Convert to string to count actual decimals after trailing zeros are removed
+  const valueStr = precisionNum.toString();
+  const [, decPart = ''] = valueStr.split('.');
+  let actualDecimals = decPart.length;
+
+  // Apply min/max decimal constraints
+  if (minDecimals !== undefined && actualDecimals < minDecimals) {
+    actualDecimals = minDecimals; // Will add zeros if needed
+  }
+  if (maxDecimals !== undefined && actualDecimals > maxDecimals) {
+    actualDecimals = maxDecimals;
+  }
+
+  // Return the value with sign restored and decimal count
+  return {
+    value: value < 0 ? -precisionNum : precisionNum,
+    decimals: actualDecimals,
+  };
+}
+
+/**
+ * Minimal view fiat range configuration
+ * Uses fiat-style stripping for clean currency display
+ * Strips only .00 to avoid partial decimals like $1,250.1
+ */
+export const PRICE_RANGES_MINIMAL_VIEW: FiatRangeConfig[] = [
+  {
+    // Large values (>= $1000): Strip .00 only ($5,000 not $5,000.00, but $5,000.10 stays)
+    condition: (val: number) => Math.abs(val) >= PRICE_THRESHOLD.LARGE,
+    minimumDecimals: 2,
+    maximumDecimals: 2,
+    threshold: PRICE_THRESHOLD.LARGE,
+    stripTrailingZeros: true,
+    fiatStyleStripping: true,
+  },
+  {
+    // Small values (< $1000): Also use fiat-style stripping ($100 not $100.00, but $13.40 stays)
+    condition: () => true,
+    minimumDecimals: 2,
+    maximumDecimals: 2,
+    threshold: PRICE_THRESHOLD.LOW,
+    stripTrailingZeros: true,
+    fiatStyleStripping: true,
+  },
+];
+
+/**
+ * Universal price range configuration following comprehensive rules from rules-decimals.md
+ *
+ * Rules:
+ * - Max 6 decimals across all ranges (Hyperliquid limit)
+ * - Strip trailing zeros by default
+ * - Use |v| (absolute value) for conditions
+ *
+ * Significant digits by range:
+ * - > $100,000: 6 sig digs
+ * - $100,000 > x > $0.01: 5 sig digs
+ * - < $0.01: 4 sig digs
+ *
+ * Decimal limits by price range:
+ * - |v| > 10,000: min 0, max 0 decimals; 5 sig digs (6 if >100k)
+ * - |v| > 1,000: min 0, max 1 decimal; 5 sig digs
+ * - |v| > 100: min 0, max 2 decimals; 5 sig digs
+ * - |v| > 10: min 0, max 4 decimals; 5 sig digs
+ * - |v| ≥ 0.01: 5 sig digs, min 2, max 6 decimals
+ * - |v| < 0.01: 4 sig digs, min 2, max 6 decimals
+ *
+ * Examples:
+ * - $123,456.78 → $123,457 (>$10k: 0 decimals, 6 sig figs)
+ * - $12,345.67 → $12,346 (>$10k: 0 decimals, 5 sig figs)
+ * - $1,234.56 → $1,234.6 ($1k-$10k: 1 decimal, 5 sig figs)
+ * - $123.456 → $123.46 ($100-$1k: 2 decimals, 5 sig figs)
+ * - $12.34567 → $12.346 ($10-$100: 4 decimals, 5 sig figs)
+ * - $1.3445555 → $1.3446 (≥$0.01: 5 sig figs)
+ * - $0.333333 → $0.33333 (≥$0.01: 5 sig figs)
+ * - $0.004236 → $0.004236 (<$0.01: 4 sig figs, max 6 decimals)
+ * - $0.0000006 → $0.000001 (<$0.01: 4 sig figs, rounds with max 6 decimals)
+ */
+export const PRICE_RANGES_UNIVERSAL: FiatRangeConfig[] = [
+  {
+    // Very high values (> $100,000): No decimals, 6 significant figures
+    // Ex: $123,456.78 → $123,457
+    condition: (val) => Math.abs(val) > PRICE_THRESHOLD.VERY_HIGH,
+    minimumDecimals: 0,
+    maximumDecimals: 0,
+    significantDigits: 6,
+    threshold: PRICE_THRESHOLD.VERY_HIGH,
+  },
+  {
+    // High values ($10,000-$100,000]: No decimals, 5 significant figures
+    // Ex: $12,345.67 → $12,346
+    condition: (val) => Math.abs(val) > PRICE_THRESHOLD.HIGH,
+    minimumDecimals: 0,
+    maximumDecimals: 0,
+    significantDigits: 5,
+    threshold: PRICE_THRESHOLD.HIGH,
+  },
+  {
+    // Large values ($1,000-$10,000]: Max 1 decimal, 5 significant figures
+    // Ex: $1,234.56 → $1,234.6
+    condition: (val) => Math.abs(val) > PRICE_THRESHOLD.LARGE,
+    minimumDecimals: 0,
+    maximumDecimals: 1,
+    significantDigits: 5,
+    threshold: PRICE_THRESHOLD.LARGE,
+  },
+  {
+    // Medium values ($100-$1,000]: Max 2 decimals, 5 significant figures
+    // Ex: $123.456 → $123.46
+    condition: (val) => Math.abs(val) > PRICE_THRESHOLD.MEDIUM,
+    minimumDecimals: 0,
+    maximumDecimals: 2,
+    significantDigits: 5,
+    threshold: PRICE_THRESHOLD.MEDIUM,
+  },
+  {
+    // Medium-low values ($10-$100]: Max 4 decimals, 5 significant figures
+    // Ex: $12.34567 → $12.346
+    condition: (val) => Math.abs(val) > PRICE_THRESHOLD.MEDIUM_LOW,
+    minimumDecimals: 0,
+    maximumDecimals: 4,
+    significantDigits: 5,
+    threshold: PRICE_THRESHOLD.MEDIUM_LOW,
+  },
+  {
+    // Low values ($0.01-$10]: 5 significant figures, min 2 max MAX_PRICE_DECIMALS decimals
+    // Ex: $1.3445555 → $1.3446 | $0.333333 → $0.33333
+    condition: (val) => Math.abs(val) >= PRICE_THRESHOLD.LOW,
+    significantDigits: 5,
+    minimumDecimals: 2,
+    maximumDecimals: DECIMAL_PRECISION_CONFIG.MaxPriceDecimals,
+    threshold: PRICE_THRESHOLD.LOW,
+  },
+  {
+    // Very small values (< $0.01): 4 significant figures, min 2 max MAX_PRICE_DECIMALS decimals
+    // Ex: $0.004236 → $0.004236 | $0.0000006 → $0.000001
+    condition: () => true,
+    significantDigits: 4,
+    minimumDecimals: 2,
+    maximumDecimals: DECIMAL_PRECISION_CONFIG.MaxPriceDecimals,
+    threshold: PRICE_THRESHOLD.VERY_SMALL,
+  },
+];
+
+/**
+ * Formats a balance value as USD currency with appropriate decimal places
+ *
+ * @param balance - Raw numeric balance value (e.g., 1234.56, not token minimal denomination)
+ * @param options - Optional formatting options
+ * @param options.minimumDecimals - Global minimum decimal places (overrides range configs)
+ * @param options.maximumDecimals - Global maximum decimal places (overrides range configs)
+ * @param options.significantDigits - Global significant digits (overrides decimal settings when set)
+ * @param options.ranges - Custom range configurations (defaults to PRICE_RANGES_MINIMAL_VIEW)
+ * @param options.currency - Currency code (default: 'USD')
+ * @param options.locale - Locale for formatting (default: 'en-US')
+ * @param options.stripTrailingZeros - Strip trailing zeros from output (default: false via PRICE_RANGES_MINIMAL_VIEW). When true, overrides minimumDecimals constraint.
+ * @returns Formatted currency string with variable decimals based on configured ranges
+ * @example
+ * // Using defaults (preserves trailing zeros for fiat)
+ * formatPerpsFiat(1234.56) => "$1,234.56"
+ * formatPerpsFiat(1250.00) => "$1,250.00"  // Trailing zeros preserved
+ * formatPerpsFiat(50000) => "$50,000.00"   // Trailing zeros preserved
+ *
+ * // Stripping trailing zeros when needed (e.g., for crypto)
+ * formatPerpsFiat(1250, { stripTrailingZeros: true }) => "$1,250"
+ *
+ * // With custom ranges
+ * formatPerpsFiat(0.00001, {
+ *   ranges: [
+ *     { condition: (v) => v < 0.001, minimumDecimals: 6, maximumDecimals: 8 },
+ *     { condition: () => true, minimumDecimals: 2, maximumDecimals: 2 }
+ *   ]
+ * }) => "$0.00001"  // Trailing zero stripped
+ *
+ * // With significant digits
+ * formatPerpsFiat(1234.56789, { significantDigits: 5 }) => "$1,234.6"
+ * formatPerpsFiat(0.0001234, { significantDigits: 3 }) => "$0.000123"
+ */
+export const formatPerpsFiat = (
+  balance: string | number,
+  options?: {
+    minimumDecimals?: number;
+    maximumDecimals?: number;
+    significantDigits?: number;
+    ranges?: FiatRangeConfig[];
+    currency?: string;
+    locale?: string;
+    stripTrailingZeros?: boolean;
+  },
+): string => {
+  const value = typeof balance === 'string' ? parseFloat(balance) : balance;
+  const currency = options?.currency ?? 'USD';
+
+  let formatted: string;
+
+  if (isNaN(value)) {
+    // Return placeholder for invalid values to avoid confusion with actual $0 values
+    return PERPS_CONSTANTS.FallbackPriceDisplay;
+  }
+
+  // Use custom ranges or defaults
+  const ranges = options?.ranges ?? PRICE_RANGES_MINIMAL_VIEW;
+
+  // Find the first matching range configuration
+  const rangeConfig = ranges.find((range) => range.condition(value));
+
+  if (rangeConfig) {
+    // Check for significant digits (global or range-specific)
+    const sigDigits =
+      options?.significantDigits ?? rangeConfig.significantDigits;
+
+    // If significant digits are specified, use them
+    if (sigDigits) {
+      // Get min/max decimals (global overrides range, range overrides default)
+      const minDecimals =
+        options?.minimumDecimals ?? rangeConfig.minimumDecimals;
+      const maxDecimals =
+        options?.maximumDecimals ?? rangeConfig.maximumDecimals;
+
+      // Calculate appropriate formatting based on significant digits
+      const { value: formattedValue, decimals } = formatWithSignificantDigits(
+        value,
+        sigDigits,
+        minDecimals,
+        maxDecimals,
+      );
+
+      // Format with the calculated decimal places
+      formatted = _formatWithThreshold(
+        formattedValue,
+        rangeConfig.threshold ?? 0.01,
+        {
+          currency,
+          minimumFractionDigits: decimals,
+          maximumFractionDigits: decimals,
+        },
+      );
+    } else {
+      // Standard decimal-based formatting (existing logic)
+      const minDecimals =
+        options?.minimumDecimals ?? rangeConfig.minimumDecimals;
+      const maxDecimals =
+        options?.maximumDecimals ?? rangeConfig.maximumDecimals;
+
+      // Use custom formatting if provided
+      if (rangeConfig.customFormat) {
+        formatted = rangeConfig.customFormat(
+          value,
+          options?.locale ?? 'en-US',
+          currency,
+        );
+      } else {
+        // Use standard formatting with threshold
+        formatted = _formatWithThreshold(value, rangeConfig.threshold ?? 0.01, {
+          currency,
+          minimumFractionDigits: minDecimals,
+          maximumFractionDigits: maxDecimals,
+        });
+      }
+    }
+  } else {
+    // Fallback if no range matches (shouldn't happen with proper default config)
+    const fallbackMin = options?.minimumDecimals ?? 2;
+    const fallbackMax = options?.maximumDecimals ?? 2;
+    formatted = _formatWithThreshold(value, 0.01, {
+      currency,
+      minimumFractionDigits: fallbackMin,
+      maximumFractionDigits: fallbackMax,
+    });
+  }
+
+  // Post-process: strip trailing zeros unless explicitly disabled
+  // Priority: explicit options.stripTrailingZeros false > rangeConfig > options default > true
+  // If options.stripTrailingZeros is explicitly false, skip stripping entirely
+  if (options?.stripTrailingZeros === false) {
+    return formatted;
+  }
+
+  // Otherwise check range config or default to true
+  const shouldStrip =
+    rangeConfig?.stripTrailingZeros ?? options?.stripTrailingZeros ?? true;
+
+  if (shouldStrip) {
+    // Check if fiat-style stripping is enabled (only strips .00)
+    const useFiatStyle = rangeConfig?.fiatStyleStripping ?? false;
+
+    if (useFiatStyle) {
+      // Fiat-style: Only strip .00 (no meaningful decimals), preserve 2-decimal format
+      // Examples: $1,250.00 → $1,250 | $1,000.10 → $1,000.10 | $13.40 → $13.40
+      return formatted.replace(/\.00$/u, '');
+    }
+    // Standard: Strip all trailing zeros after decimal point
+    // Examples: $1,250.00 → $1,250 | $100.0 → $100 | $10.5 → $10.5 | $1.234 → $1.234
+    return formatted.replace(/(\.\d*?)0+$/u, '$1').replace(/\.$/u, '');
+  }
+
+  return formatted;
+};
+
+/**
+ * Formats position size with variable decimal precision based on magnitude or asset-specific decimals
+ * Removes trailing zeros to match task requirements
+ *
+ * @param size - Raw position size value
+ * @param szDecimals - Optional asset-specific decimal precision from Hyperliquid metadata (e.g., BTC=5, ETH=4, DOGE=1)
+ * @returns Format varies by size or uses asset-specific decimals, with trailing zeros removed:
+ * If szDecimals provided: Uses exact decimals (e.g., 0.00009 BTC with szDecimals=5 => "0.00009")
+ * Otherwise falls back to magnitude-based logic:
+ * - Size < 0.01: Up to 6 decimals (e.g., "0.00009" not "0.000090")
+ * - Size < 1: Up to 4 decimals (e.g., "0.0024" not "0.002400")
+ * - Size >= 1: Up to 2 decimals (e.g., "44" not "44.00")
+ * @example formatPositionSize(0.00009, 5) => "0.00009" (uses szDecimals)
+ * @example formatPositionSize(44.00, 1) => "44" (uses szDecimals, trailing zeros removed)
+ * @example formatPositionSize(0.0024) => "0.0024" (no szDecimals, uses magnitude logic)
+ * @example formatPositionSize(44.00) => "44" (no szDecimals, uses magnitude logic)
+ */
+export const formatPositionSize = (
+  size: string | number,
+  szDecimals?: number,
+): string => {
+  const value = typeof size === 'string' ? parseFloat(size) : size;
+
+  if (isNaN(value) || value === 0) {
+    return '0';
+  }
+
+  // Use asset-specific decimals if provided (Hyperliquid metadata)
+  if (szDecimals !== undefined) {
+    return value.toFixed(szDecimals).replace(/\.?0+$/u, '');
+  }
+
+  // Fallback: magnitude-based decimal logic for backwards compatibility
+  const abs = Math.abs(value);
+  let formatted: string;
+
+  if (abs < 0.01) {
+    // For very small numbers, use more decimal places
+    formatted = value.toFixed(6);
+  } else if (abs < 1) {
+    // For small numbers, use 4 decimal places
+    formatted = value.toFixed(4);
+  } else {
+    // For normal numbers, use 2 decimal places
+    formatted = value.toFixed(2);
+  }
+
+  // Remove trailing zeros and unnecessary decimal point
+  return formatted.replace(/\.?0+$/u, '');
+};
+
+/**
+ * Formats a PnL (Profit and Loss) value with sign prefix
+ *
+ * @param pnl - Raw numeric PnL value (positive for profit, negative for loss)
+ * @returns Format: "+$X,XXX.XX" or "-$X,XXX.XX" (always shows sign, 2 decimals)
+ * @example formatPnl(1234.56) => "+$1,234.56"
+ * @example formatPnl(-500) => "-$500.00"
+ * @example formatPnl(0) => "+$0.00"
+ */
+export const formatPnl = (pnl: string | number): string => {
+  const value = typeof pnl === 'string' ? parseFloat(pnl) : pnl;
+
+  if (isNaN(value)) {
+    return PERPS_CONSTANTS.ZeroAmountDetailedDisplay;
+  }
+
+  const formatted = _formatCurrency(Math.abs(value), 'USD', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+
+  return value >= 0 ? `+${formatted}` : `-${formatted}`;
+};
+
+/**
+ * Formats a percentage value with sign prefix
+ *
+ * @param value - Raw percentage value (e.g., 5.25 for 5.25%, not 0.0525)
+ * @param decimals - Number of decimal places to show (default: 2)
+ * @returns Format: "+X.XX%" or "-X.XX%" (always shows sign, 2 decimals)
+ * @example formatPercentage(5.25) => "+5.25%"
+ * @example formatPercentage(-2.75) => "-2.75%"
+ * @example formatPercentage(0) => "+0.00%"
+ */
+export const formatPercentage = (
+  value: string | number,
+  decimals: number = 2,
+): string => {
+  const parsed = typeof value === 'string' ? parseFloat(value) : value;
+
+  if (isNaN(parsed)) {
+    return '0.00%';
+  }
+
+  return `${parsed >= 0 ? '+' : ''}${parsed.toFixed(decimals)}%`;
+};
+
+/**
+ * Formats funding rate for display
+ *
+ * @param value - Raw funding rate value (decimal, not percentage)
+ * @param options - Optional formatting options
+ * @param options.showZero - Whether to return zero display value for zero/undefined (default: true)
+ * @returns Formatted funding rate as percentage string
+ * @example formatFundingRate(0.0005) => "0.0500%"
+ * @example formatFundingRate(-0.0001) => "-0.0100%"
+ * @example formatFundingRate(undefined) => "0.0000%"
+ */
+export const formatFundingRate = (
+  value?: number | null,
+  options?: { showZero?: boolean },
+): string => {
+  const showZero = options?.showZero ?? true;
+
+  if (value === undefined || value === null) {
+    return showZero ? FUNDING_RATE_CONFIG.ZeroDisplay : '';
+  }
+
+  const percentage = value * FUNDING_RATE_CONFIG.PercentageMultiplier;
+  const formatted = percentage.toFixed(FUNDING_RATE_CONFIG.Decimals);
+
+  // Check if the result is effectively zero
+  if (showZero && parseFloat(formatted) === 0) {
+    return FUNDING_RATE_CONFIG.ZeroDisplay;
+  }
+
+  return `${formatted}%`;
+};

--- a/packages/perps-controller/tests/defer-eligibility.test.ts
+++ b/packages/perps-controller/tests/defer-eligibility.test.ts
@@ -58,6 +58,12 @@ function buildMockInfrastructure(): PerpsPlatformDependencies {
     cacheInvalidator: {
       invalidate: jest.fn(),
     } as unknown as PerpsPlatformDependencies['cacheInvalidator'],
+    diskCache: {
+      getItem: jest.fn().mockResolvedValue(null),
+      getItemSync: jest.fn().mockReturnValue(null),
+      setItem: jest.fn().mockResolvedValue(undefined),
+      removeItem: jest.fn().mockResolvedValue(undefined),
+    },
     rewards: { getPerpsDiscountForAccount: jest.fn().mockResolvedValue(0) },
   };
 }


### PR DESCRIPTION
## Explanation

Syncs `app/controllers/perps/` from MetaMask Mobile (commit `87ad5e48`) to `packages/perps-controller/src/` using the automated `validate-core-sync.sh` pipeline. All 9 sync steps passed with 0 suppressions.

Key changes:

- **Disk-backed cold-start cache** — new `perpsDiskPersistence.ts` enables instant data display on launch by hydrating in-memory caches from MMKV synchronously at construction time. Adds `skipTTL` option to `getCachedMarketDataForActiveProvider` and `getCachedUserDataForActiveProvider` so disk-hydrated data is returned regardless of age on first render.
- **Perps decimal formatters** — new `perpsFormatters.ts` exports shared formatting utilities (price, size, leverage, PnL, funding rate) from the controller for use by extension consumers.
- **TP/SL order fix** — filters TP/SL orders by `isPositionTpsl` to prevent position-bound orders from disappearing after creating a market order. Distinguishes position TP/SL from normalTpsl children on pending limit orders.
- **WebSocket reconnection fix** — avoids full reconnection on foreground return when the WebSocket is still alive within the grace period. Adds `ForegroundPingRetryDelayMs` constant.
- **Geo-block compliance** — enforces compliance gate on Market Insights Long/Short actions.
- **Funding payments fix** — replaces single API call with paginated fetch using `fetchWindowWithAutoSplit` that recursively splits windows hitting the API cap, ensuring complete results. Deduplicates at chunk boundaries.
- **Funding rate config** — adds `FUNDING_RATE_CONFIG` constants for display formatting.
- **Cache key refactoring** — extracts `buildProviderCacheKey` and `getProviderNetworkKey` helpers. Replaces private `#marketCacheKey`/`#providerIsTestnet` with shared utilities. Adds `#getAggregatedCacheProviderIds` to recover disk-hydrated provider snapshots before `init()` finishes.
- **MYX dynamic import fix** — removes variable indirection for `ts-bridge` compatibility.

New files:
- `packages/perps-controller/src/utils/perpsDiskPersistence.ts` (360 lines)
- `packages/perps-controller/src/utils/perpsFormatters.ts` (624 lines)

## References

- Mobile PR chain: disk cache (#27898), formatters (#28538), TP/SL fix (#28073), WS fix (#28592), geo-block (#28678), funding fix (#28671)

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `PerpsController` caching/preload behavior (including new disk persistence and cache-key refactors) plus funding history fetching logic; regressions could impact cold-start UI correctness or data freshness across networks/accounts.
> 
> **Overview**
> **Adds a disk-backed cold-start cache for perps market/user data.** `PerpsController` now hydrates in-memory caches synchronously at construction, persists preload snapshots back to disk, and clears disk user data on account changes; cache reads gain an optional `skipTTL` to allow first-render usage of disk-hydrated data.
> 
> **Refactors cache keying and aggregated cache reads.** Introduces `buildProviderCacheKey`/`getProviderNetworkKey` helpers and updates aggregated reads to include provider ids inferred from disk-hydrated keys before `init()` completes.
> 
> **Fixes and shared utilities.** TP/SL lookup now filters by `isPositionTpsl` to avoid hiding position-bound TP/SL orders, funding history fetching switches to paginated windowed requests with recursive auto-splitting/deduping to avoid API caps, and new `perpsFormatters`/`FUNDING_RATE_CONFIG` are exported for consistent formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b36f51034516d2366a8438dc669759cf762c5034. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->