### PR TITLE
fix(transaction-controller): broaden gas estimation for type-4 transactions with non-self target

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Gas estimation for EIP-7702 transactions now supports any upgrade-with-data transaction, not only self-targeted ones ([#8467](https://github.com/MetaMask/core/pull/8467))
+
 ## [64.3.0]
 
 ### Added

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -1393,7 +1393,7 @@ describe('TransactionController', () => {
         estimatedGas: gasMock,
         blockGasLimit: blockGasLimitMock,
         simulationFails: simulationFailsMock,
-        isUpgradeWithDataToSelf: false,
+        isUpgradeWithData: false,
       });
 
       addGasBufferMock.mockReturnValue(expectedEstimatedGas);

--- a/packages/transaction-controller/src/utils/feature-flags.test.ts
+++ b/packages/transaction-controller/src/utils/feature-flags.test.ts
@@ -658,7 +658,7 @@ describe('Feature Flags Utils', () => {
         getGasEstimateBuffer({
           chainId: CHAIN_ID_MOCK,
           isCustomRPC: false,
-          isUpgradeWithDataToSelf: false,
+          isUpgradeWithData: false,
           messenger: controllerMessenger,
         }),
       ).toBe(1.0);
@@ -675,7 +675,7 @@ describe('Feature Flags Utils', () => {
         getGasEstimateBuffer({
           chainId: CHAIN_ID_MOCK,
           isCustomRPC: false,
-          isUpgradeWithDataToSelf: false,
+          isUpgradeWithData: false,
           messenger: controllerMessenger,
         }),
       ).toBe(GAS_BUFFER_MOCK);
@@ -693,7 +693,7 @@ describe('Feature Flags Utils', () => {
         getGasEstimateBuffer({
           chainId: CHAIN_ID_MOCK,
           isCustomRPC: false,
-          isUpgradeWithDataToSelf: false,
+          isUpgradeWithData: false,
           messenger: controllerMessenger,
         }),
       ).toBe(GAS_BUFFER_2_MOCK);
@@ -716,7 +716,7 @@ describe('Feature Flags Utils', () => {
         getGasEstimateBuffer({
           chainId: CHAIN_ID_MOCK,
           isCustomRPC: false,
-          isUpgradeWithDataToSelf: false,
+          isUpgradeWithData: false,
           messenger: controllerMessenger,
         }),
       ).toBe(GAS_BUFFER_3_MOCK);
@@ -740,7 +740,7 @@ describe('Feature Flags Utils', () => {
         getGasEstimateBuffer({
           chainId: CHAIN_ID_MOCK,
           isCustomRPC: false,
-          isUpgradeWithDataToSelf: false,
+          isUpgradeWithData: false,
           messenger: controllerMessenger,
         }),
       ).toBe(GAS_BUFFER_4_MOCK);
@@ -765,7 +765,7 @@ describe('Feature Flags Utils', () => {
         getGasEstimateBuffer({
           chainId: CHAIN_ID_MOCK,
           isCustomRPC: false,
-          isUpgradeWithDataToSelf: true,
+          isUpgradeWithData: true,
           messenger: controllerMessenger,
         }),
       ).toBe(GAS_BUFFER_5_MOCK);

--- a/packages/transaction-controller/src/utils/feature-flags.ts
+++ b/packages/transaction-controller/src/utils/feature-flags.ts
@@ -399,19 +399,19 @@ export function getGasEstimateFallback(
  * @param request - The request object.
  * @param request.chainId - The chain ID.
  * @param request.isCustomRPC - Whether the network RPC is added by the user.
- * @param request.isUpgradeWithDataToSelf - Whether the transaction is an EIP-7702 upgrade with data to self.
+ * @param request.isUpgradeWithData - Whether the transaction is an EIP-7702 upgrade combined with a call.
  * @param request.messenger - The controller messenger instance.
  * @returns The gas buffers.
  */
 export function getGasEstimateBuffer({
   chainId,
   isCustomRPC,
-  isUpgradeWithDataToSelf,
+  isUpgradeWithData,
   messenger,
 }: {
   chainId: Hex;
   isCustomRPC: boolean;
-  isUpgradeWithDataToSelf: boolean;
+  isUpgradeWithData: boolean;
   messenger: TransactionControllerMessenger;
 }): number {
   const featureFlags = getFeatureFlags(messenger);
@@ -423,9 +423,7 @@ export function getGasEstimateBuffer({
     ? undefined
     : gasBufferFlags?.included;
 
-  const upgradeBuffer = isUpgradeWithDataToSelf
-    ? chainFlags?.eip7702
-    : undefined;
+  const upgradeBuffer = isUpgradeWithData ? chainFlags?.eip7702 : undefined;
 
   return (
     upgradeBuffer ??

--- a/packages/transaction-controller/src/utils/gas.test.ts
+++ b/packages/transaction-controller/src/utils/gas.test.ts
@@ -1124,6 +1124,14 @@ describe('gas', () => {
         estimateGasResponse: toHex(GAS_MOCK),
       });
 
+      simulateTransactionsMock.mockResolvedValueOnce({
+        transactions: [
+          {
+            gasLimit: toHex(INTRINSIC_GAS),
+          },
+        ],
+      } as SimulationResponse);
+
       const result = await estimateGasBatch({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         from: FROM_MOCK,
@@ -1143,14 +1151,15 @@ describe('gas', () => {
         BATCH_TX_PARAMS_MOCK,
       );
 
+      // Upgrade-only estimation via eth_estimateGas (step 1 of split path)
       expect(rpcRequestMock).toHaveBeenCalledWith({
         messenger: MESSENGER_MOCK,
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         method: 'eth_estimateGas',
         params: [
           expect.objectContaining({
-            to: TO_MOCK,
-            data: DATA_MOCK,
+            to: FROM_MOCK,
+            data: '0x',
             from: FROM_MOCK,
             authorizationList: [
               expect.objectContaining({

--- a/packages/transaction-controller/src/utils/gas.test.ts
+++ b/packages/transaction-controller/src/utils/gas.test.ts
@@ -536,7 +536,7 @@ describe('gas', () => {
         estimatedGas: toHex(GAS_MOCK),
         blockGasLimit: toHex(BLOCK_GAS_LIMIT_MOCK),
         simulationFails: undefined,
-        isUpgradeWithDataToSelf: false,
+        isUpgradeWithData: false,
       });
     });
 
@@ -560,7 +560,7 @@ describe('gas', () => {
       expect(result).toStrictEqual({
         estimatedGas: expect.any(String),
         blockGasLimit: toHex(BLOCK_GAS_LIMIT_MOCK),
-        isUpgradeWithDataToSelf: false,
+        isUpgradeWithData: false,
         simulationFails: {
           reason: 'TestError',
           errorKey: 'TestKey',
@@ -596,7 +596,7 @@ describe('gas', () => {
         estimatedGas: toHex(fallbackGas),
         blockGasLimit: toHex(BLOCK_GAS_LIMIT_MOCK),
         simulationFails: expect.any(Object),
-        isUpgradeWithDataToSelf: false,
+        isUpgradeWithData: false,
       });
     });
 
@@ -621,7 +621,7 @@ describe('gas', () => {
         estimatedGas: toHex(FIXED_ESTIMATE_GAS_MOCK),
         blockGasLimit: toHex(BLOCK_GAS_LIMIT_MOCK),
         simulationFails: expect.any(Object),
-        isUpgradeWithDataToSelf: false,
+        isUpgradeWithData: false,
       });
     });
 
@@ -786,7 +786,7 @@ describe('gas', () => {
           estimatedGas: toHex(SIMULATE_GAS_MOCK),
           blockGasLimit: toHex(BLOCK_GAS_LIMIT_MOCK),
           simulationFails: undefined,
-          isUpgradeWithDataToSelf: false,
+          isUpgradeWithData: false,
         });
       });
 
@@ -838,7 +838,7 @@ describe('gas', () => {
           estimatedGas: toHex(GAS_2_MOCK + SIMULATE_GAS_MOCK - INTRINSIC_GAS),
           blockGasLimit: toHex(BLOCK_GAS_LIMIT_MOCK),
           simulationFails: undefined,
-          isUpgradeWithDataToSelf: true,
+          isUpgradeWithData: true,
         });
       });
 
@@ -971,7 +971,7 @@ describe('gas', () => {
           estimatedGas: toHex(GAS_2_MOCK),
           blockGasLimit: toHex(BLOCK_GAS_LIMIT_MOCK),
           simulationFails: undefined,
-          isUpgradeWithDataToSelf: true,
+          isUpgradeWithData: true,
         });
       });
 
@@ -1006,7 +1006,7 @@ describe('gas', () => {
         expect(result).toStrictEqual({
           estimatedGas: toHex(GAS_2_MOCK + SIMULATE_GAS_MOCK - INTRINSIC_GAS),
           blockGasLimit: toHex(BLOCK_GAS_LIMIT_MOCK),
-          isUpgradeWithDataToSelf: true,
+          isUpgradeWithData: true,
           simulationFails: undefined,
         });
       });
@@ -1042,7 +1042,7 @@ describe('gas', () => {
         expect(result).toStrictEqual({
           estimatedGas: expect.any(String),
           blockGasLimit: toHex(BLOCK_GAS_LIMIT_MOCK),
-          isUpgradeWithDataToSelf: true,
+          isUpgradeWithData: true,
           simulationFails: {
             debug: {
               blockGasLimit: toHex(BLOCK_GAS_LIMIT_MOCK),

--- a/packages/transaction-controller/src/utils/gas.ts
+++ b/packages/transaction-controller/src/utils/gas.ts
@@ -102,7 +102,7 @@ export async function estimateGas({
   simulationFails: TransactionMeta['simulationFails'];
 }> {
   const request = { ...txParams };
-  const { authorizationList, data, from, value, to } = request;
+  const { authorizationList, data, value } = request;
   const chainId = getChainId({ messenger, networkClientId });
 
   if (ignoreDelegationSignatures && !isSimulationEnabled) {
@@ -146,9 +146,6 @@ export async function estimateGas({
     Boolean(data) &&
     data !== '0x';
 
-  const isUpgradeWithDataToSelf = isUpgradeWithData &&
-    from?.toLowerCase() === to?.toLowerCase();
-
   try {
     if (isSimulationEnabled && isUpgradeWithData) {
       estimatedGas = await estimateGasUpgradeWithDataToSelf(
@@ -184,7 +181,7 @@ export async function estimateGas({
   return {
     blockGasLimit,
     estimatedGas,
-    isUpgradeWithDataToSelf,
+    isUpgradeWithDataToSelf: isUpgradeWithData,
     simulationFails,
   };
 }

--- a/packages/transaction-controller/src/utils/gas.ts
+++ b/packages/transaction-controller/src/utils/gas.ts
@@ -98,7 +98,7 @@ export async function estimateGas({
 }): Promise<{
   blockGasLimit: string;
   estimatedGas: string;
-  isUpgradeWithDataToSelf: boolean;
+  isUpgradeWithData: boolean;
   simulationFails: TransactionMeta['simulationFails'];
 }> {
   const request = { ...txParams };
@@ -181,7 +181,7 @@ export async function estimateGas({
   return {
     blockGasLimit,
     estimatedGas,
-    isUpgradeWithDataToSelf: isUpgradeWithData,
+    isUpgradeWithData,
     simulationFails,
   };
 }
@@ -425,18 +425,14 @@ async function getGas(
     return [FIXED_GAS, undefined, FIXED_GAS];
   }
 
-  const {
-    blockGasLimit,
-    estimatedGas,
-    isUpgradeWithDataToSelf,
-    simulationFails,
-  } = await estimateGas({
-    isSimulationEnabled,
-    getSimulationConfig,
-    messenger,
-    networkClientId,
-    txParams: txMeta.txParams,
-  });
+  const { blockGasLimit, estimatedGas, isUpgradeWithData, simulationFails } =
+    await estimateGas({
+      isSimulationEnabled,
+      getSimulationConfig,
+      messenger,
+      networkClientId,
+      txParams: txMeta.txParams,
+    });
 
   log('Original estimated gas', estimatedGas);
 
@@ -455,7 +451,7 @@ async function getGas(
   const bufferMultiplier = getGasEstimateBuffer({
     chainId,
     isCustomRPC: isCustomNetwork,
-    isUpgradeWithDataToSelf,
+    isUpgradeWithData,
     messenger,
   });
 

--- a/packages/transaction-controller/src/utils/gas.ts
+++ b/packages/transaction-controller/src/utils/gas.ts
@@ -140,15 +140,17 @@ export async function estimateGas({
   let estimatedGas = fallback;
   let simulationFails: TransactionMeta['simulationFails'];
 
-  const isUpgradeWithDataToSelf =
+  const isUpgradeWithData =
     txParams.type === TransactionEnvelopeType.setCode &&
     Boolean(authorizationList?.length) &&
     Boolean(data) &&
-    data !== '0x' &&
+    data !== '0x';
+
+  const isUpgradeWithDataToSelf = isUpgradeWithData &&
     from?.toLowerCase() === to?.toLowerCase();
 
   try {
-    if (isSimulationEnabled && isUpgradeWithDataToSelf) {
+    if (isSimulationEnabled && isUpgradeWithData) {
       estimatedGas = await estimateGasUpgradeWithDataToSelf(
         request,
         messenger,
@@ -570,6 +572,7 @@ async function estimateGasUpgradeWithDataToSelf(
     params: [
       {
         ...txParams,
+        to: txParams.from,
         data: '0x',
       },
     ],


### PR DESCRIPTION
## Explanation

Gas estimation for EIP-7702 transactions was previously limited to self-targeted upgrades (where `from === to`). This blocked reliable gas estimation for transactions that combine a 7702 authorization upgrade with a call to a different contract — notably enforced simulations, which target the delegation manager.

Broadening this path enables accurate gas estimation for the general case of "upgrade + execute in one transaction", correctly applies the EIP-7702 gas buffer to all such transactions, and fixes the upgrade-only step to always send to the account itself (since a bare 7702 authorization is always a self-transaction regardless of the full transaction's target).

## References

Companion to MetaMask/metamask-extension#41775

## Changelog

### `@metamask/transaction-controller`

#### Changed

- Gas estimation for EIP-7702 transactions now supports any upgrade-with-data transaction (not only self-targeted). The EIP-7702 gas buffer multiplier applies to this broader set.
- Upgrade-only estimation step now targets the sender's address, matching the semantics of a 7702 authorization.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes gas estimation and buffer selection for EIP-7702 `setCode` transactions, which can affect gas limits (and thus transaction success/cost) across supported networks. Scope is contained to estimation paths and is covered by updated unit tests, but incorrect detection could impact type-4 transactions.
> 
> **Overview**
> Gas estimation now treats **any** EIP-7702 `setCode` transaction that includes non-empty `data` as an *upgrade+execute* flow (not just `from === to`), returning `isUpgradeWithData` and applying the per-chain `eip7702` gas buffer multiplier to this broader set.
> 
> The upgrade-only step in the split estimation path is fixed to always call `eth_estimateGas` with `to` set to the sender address (and `data: 0x`), aligning with 7702 authorization semantics. Tests and the changelog are updated to reflect the renamed flag and expanded behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81bca261693274b7189dc549f218361dc132729b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->