### PR TITLE
feat: implement no-retry policy for TransakService verify OTP

### DIFF
--- a/packages/ramps-controller/CHANGELOG.md
+++ b/packages/ramps-controller/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8457](https://github.com/MetaMask/core/pull/8457))
 
+### Fixed
+
+- `TransakService.verifyUserOtp` no longer retries on failure, preventing single-use OTP attempts from being silently consumed when consumers configure a non-zero `maxRetries` in `policyOptions`
+
 ## [13.1.0]
 
 ### Added

--- a/packages/ramps-controller/CHANGELOG.md
+++ b/packages/ramps-controller/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `TransakService.verifyUserOtp` no longer retries on failure, preventing single-use OTP attempts from being silently consumed when consumers configure a non-zero `maxRetries` in `policyOptions`
+- `TransakService.verifyUserOtp` no longer retries on failure, preventing single-use OTP attempts from being silently consumed when consumers configure a non-zero `maxRetries` in `policyOptions` ([#8468](https://github.com/MetaMask/core/pull/8468))
 
 ## [13.1.0]
 

--- a/packages/ramps-controller/src/TransakService.test.ts
+++ b/packages/ramps-controller/src/TransakService.test.ts
@@ -658,6 +658,32 @@ describe('TransakService', () => {
 
       await expect(promise).rejects.toThrow("failed with status '401'");
     });
+
+    it('does not retry on failure even when retries are enabled', async () => {
+      nock(STAGING_TRANSAK_BASE)
+        .post('/api/v2/auth/verify')
+        .reply(500)
+        .post('/api/v2/auth/verify')
+        .reply(200, {
+          data: {
+            accessToken: 'should-not-be-used',
+            ttl: 3600,
+            created: '2025-01-01T00:00:00.000Z',
+          },
+        });
+
+      const { service } = getService({
+        options: { policyOptions: { maxRetries: 3 } },
+      });
+
+      const promise = service.verifyUserOtp('a@b.com', '000000', 'st');
+      promise.catch(() => undefined);
+      await jest.runAllTimersAsync();
+      await flushPromises();
+
+      await expect(promise).rejects.toThrow("failed with status '500'");
+      expect(service.getAccessToken()).toBeNull();
+    });
   });
 
   describe('logout', () => {

--- a/packages/ramps-controller/src/TransakService.ts
+++ b/packages/ramps-controller/src/TransakService.ts
@@ -448,6 +448,8 @@ export class TransakService {
 
   readonly #policy: ServicePolicy;
 
+  readonly #noRetryPolicy: ServicePolicy;
+
   readonly #environment: TransakEnvironment;
 
   readonly #context: string;
@@ -479,6 +481,7 @@ export class TransakService {
     this.#messenger = messenger;
     this.#fetch = fetchFunction;
     this.#policy = createServicePolicy(policyOptions);
+    this.#noRetryPolicy = createServicePolicy({ ...policyOptions, maxRetries: 0 });
     this.#environment = environment;
     this.#context = context;
     this.#apiKey = apiKey ?? null;
@@ -619,6 +622,7 @@ export class TransakService {
   async #transakPost<ResponseType>(
     path: string,
     body?: Record<string, unknown>,
+    options: { policy?: ServicePolicy } = { },
   ): Promise<ResponseType> {
     const apiKey = this.#ensureApiKey();
     const baseUrl = getTransakApiBaseUrl(this.#environment);
@@ -629,7 +633,9 @@ export class TransakService {
       apiKey,
     };
 
-    const response = await this.#policy.execute(async () => {
+    const policy = options.policy ?? this.#policy;
+
+    const response = await policy.execute(async () => {
       const fetchResponse = await this.#fetch(url.toString(), {
         method: 'POST',
         headers: this.#getHeaders(),
@@ -762,7 +768,7 @@ export class TransakService {
       email,
       otp: verificationCode,
       stateToken,
-    });
+    }, { policy: this.#noRetryPolicy });
 
     const accessToken: TransakAccessToken = {
       accessToken: responseData.accessToken,

--- a/packages/ramps-controller/src/TransakService.ts
+++ b/packages/ramps-controller/src/TransakService.ts
@@ -481,7 +481,10 @@ export class TransakService {
     this.#messenger = messenger;
     this.#fetch = fetchFunction;
     this.#policy = createServicePolicy(policyOptions);
-    this.#noRetryPolicy = createServicePolicy({ ...policyOptions, maxRetries: 0 });
+    this.#noRetryPolicy = createServicePolicy({
+      ...policyOptions,
+      maxRetries: 0,
+    });
     this.#environment = environment;
     this.#context = context;
     this.#apiKey = apiKey ?? null;
@@ -622,7 +625,7 @@ export class TransakService {
   async #transakPost<ResponseType>(
     path: string,
     body?: Record<string, unknown>,
-    options: { policy?: ServicePolicy } = { },
+    options: { policy?: ServicePolicy } = {},
   ): Promise<ResponseType> {
     const apiKey = this.#ensureApiKey();
     const baseUrl = getTransakApiBaseUrl(this.#environment);
@@ -764,11 +767,15 @@ export class TransakService {
       accessToken: string;
       ttl: number;
       created: string;
-    }>('/api/v2/auth/verify', {
-      email,
-      otp: verificationCode,
-      stateToken,
-    }, { policy: this.#noRetryPolicy });
+    }>(
+      '/api/v2/auth/verify',
+      {
+        email,
+        otp: verificationCode,
+        stateToken,
+      },
+      { policy: this.#noRetryPolicy },
+    );
 
     const accessToken: TransakAccessToken = {
       accessToken: responseData.accessToken,


### PR DESCRIPTION
## Explanation

Previously, `TransakService` wrapped every POST request (including `verifyUserOtp`) in the shared `ServicePolicy` created from the consumer-provided `policyOptions`. When consumers configure a non-zero `maxRetries`, a failed `/api/v2/auth/verify` call would be retried automatically. This is incorrect behavior for OTP verification: the `stateToken` and `otp` pair are single-use, and Transak rate-limits repeated verify attempts — retrying a failed verify silently burns the user's OTP attempts and can lock them out, and it prevents the client from surfacing the real failure to the user promptly.

This PR introduces a second, no-retry `ServicePolicy` on `TransakService` (`#noRetryPolicy`), built from the same `policyOptions` but with `maxRetries` forced to `0`. The private `#transakPost` helper now accepts an optional `{ policy }` override so individual endpoints can opt out of the default retry policy. `verifyUserOtp` is updated to pass `#noRetryPolicy`, ensuring that a failing verify call fails fast without consuming additional OTP attempts. All other POST endpoints continue to use the default `#policy` and are unaffected.

A new test, `verifyUserOtp > does not retry on failure even when retries are enabled`, constructs the service with `policyOptions: { maxRetries: 3 }` and registers two sequential interceptors for `/api/v2/auth/verify` (500 followed by 200). The test asserts the promise rejects with the 500 response and the access token remains null, proving that the no-retry policy short-circuits before the second interceptor would be hit.

## References

Fixes [TRAM-3442](https://consensyssoftware.atlassian.net/browse/TRAM-3442)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


[TRAM-3442]: https://consensyssoftware.atlassian.net/browse/TRAM-3442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request retry behavior for OTP verification, which can affect login reliability and error handling paths. Scope is limited to `verifyUserOtp` and is covered by a new regression test.
> 
> **Overview**
> Prevents `TransakService.verifyUserOtp` from being retried by introducing a dedicated `#noRetryPolicy` (forced `maxRetries: 0`) and allowing `#transakPost` to accept an optional policy override.
> 
> Adds a regression test ensuring OTP verification does **not** retry even when `policyOptions.maxRetries` is non-zero, and updates the package changelog to document the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98ecb9ffc9138ce1227cdbb7adf5ee043d11c9ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->