### PR TITLE
Deprecate AbstractRpcService and RpcServiceRequestable

### DIFF
--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 - `NetworkControllerGetNetworkConfigurationByNetworkClientId` type is deprecated in favor of `NetworkControllerGetNetworkConfigurationByNetworkClientIdAction` ([#8350](https://github.com/MetaMask/core/pull/8350))
-- Deprecate `AbstractRpcService` and `RpcServiceRequestable`
+- Deprecate `AbstractRpcService` and `RpcServiceRequestable` ([#8475](https://github.com/MetaMask/core/pull/8475))
   - There are no equivalents to these interfaces. If you need to take an "RPC-service-like" argument, it's best to declare which properties you're interested in rather than accepting the entire RPC service interface.
 
 ## [30.0.1]

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 - `NetworkControllerGetNetworkConfigurationByNetworkClientId` type is deprecated in favor of `NetworkControllerGetNetworkConfigurationByNetworkClientIdAction` ([#8350](https://github.com/MetaMask/core/pull/8350))
+- Deprecate `AbstractRpcService` and `RpcServiceRequestable`
+  - There are no equivalents to these interfaces. If you need to take an "RPC-service-like" argument, it's best to declare which properties you're interested in rather than accepting the entire RPC service interface.
 
 ## [30.0.1]
 

--- a/packages/network-controller/src/rpc-service/abstract-rpc-service.ts
+++ b/packages/network-controller/src/rpc-service/abstract-rpc-service.ts
@@ -3,6 +3,11 @@ import type { RpcServiceRequestable } from './rpc-service-requestable';
 /**
  * The interface for a service class responsible for making a request to an RPC
  * endpoint or a group of RPC endpoints.
+ *
+ * @deprecated Don't use this interface (it will be removed in an upcoming major
+ * version). If you need to take an "RPC-service-like" argument, it's best to
+ * declare which properties you're interested in rather than accepting the
+ * entire RPC service interface.
  */
 export type AbstractRpcService = RpcServiceRequestable & {
   /**

--- a/packages/network-controller/src/rpc-service/rpc-service-requestable.ts
+++ b/packages/network-controller/src/rpc-service/rpc-service-requestable.ts
@@ -18,6 +18,11 @@ import type {
  * The interface for a service class responsible for making a request to a
  * target, whether that is a single RPC endpoint or an RPC endpoint in an RPC
  * service chain.
+ *
+ * @deprecated Don't use this interface (it will be removed in an upcoming major
+ * version). If you need to take an "RPC-service-like" argument, it's best to
+ * declare which properties you're interested in rather than accepting the
+ * entire RPC service interface.
  */
 export type RpcServiceRequestable = {
   /**

--- a/packages/network-controller/src/rpc-service/rpc-service.ts
+++ b/packages/network-controller/src/rpc-service/rpc-service.ts
@@ -274,7 +274,7 @@ function stripCredentialsFromUrl(url: URL): URL {
  * failures, retrying requests using exponential backoff. It also offers a hook
  * which can used to respond to slow requests.
  */
-export class RpcService implements AbstractRpcService {
+export class RpcService {
   /**
    * The URL of the RPC endpoint.
    */

--- a/packages/network-controller/src/rpc-service/rpc-service.ts
+++ b/packages/network-controller/src/rpc-service/rpc-service.ts
@@ -16,13 +16,18 @@ import type {
   JsonRpcRequest,
   JsonRpcResponse,
 } from '@metamask/utils';
-import { CircuitState, IDisposable } from 'cockatiel';
+import { CircuitState } from 'cockatiel';
 import deepmerge from 'deepmerge';
 import type { Logger } from 'loglevel';
 
 import { projectLogger, createModuleLogger } from '../logger';
-import type { AbstractRpcService } from './abstract-rpc-service';
-import type { FetchOptions } from './shared';
+import type {
+  CockatielEventToEventListenerWithData,
+  ExcludeCockatielEventData,
+  ExtendCockatielEventData,
+  ExtractCockatielEventData,
+  FetchOptions,
+} from './shared';
 
 /**
  * Options for the RpcService constructor.
@@ -395,7 +400,12 @@ export class RpcService {
    * @returns What {@link ServicePolicy.onRetry} returns.
    * @see {@link createServicePolicy}
    */
-  onRetry(listener: Parameters<AbstractRpcService['onRetry']>[0]): IDisposable {
+  onRetry(
+    listener: CockatielEventToEventListenerWithData<
+      ServicePolicy['onRetry'],
+      { endpointUrl: string }
+    >,
+  ): ReturnType<ServicePolicy['onRetry']> {
     return this.#policy.onRetry((data) => {
       listener({ ...data, endpointUrl: this.endpointUrl.toString() });
     });
@@ -409,7 +419,17 @@ export class RpcService {
    * @returns What {@link ServicePolicy.onBreak} returns.
    * @see {@link createServicePolicy}
    */
-  onBreak(listener: Parameters<AbstractRpcService['onBreak']>[0]): IDisposable {
+  onBreak(
+    listener: (
+      data: ExcludeCockatielEventData<
+        ExtendCockatielEventData<
+          ExtractCockatielEventData<ServicePolicy['onBreak']>,
+          { endpointUrl: string }
+        >,
+        'isolated'
+      >,
+    ) => void,
+  ): ReturnType<ServicePolicy['onBreak']> {
     return this.#policy.onBreak((data) => {
       // `{ isolated: true }` is a special object that shows up when `isolate`
       // is called on the circuit breaker. Usually `isolate` is used to hold the
@@ -440,8 +460,11 @@ export class RpcService {
    * @see {@link createServicePolicy}
    */
   onDegraded(
-    listener: Parameters<AbstractRpcService['onDegraded']>[0],
-  ): IDisposable {
+    listener: CockatielEventToEventListenerWithData<
+      ServicePolicy['onDegraded'],
+      { endpointUrl: string; rpcMethodName: string }
+    >,
+  ): ReturnType<ServicePolicy['onDegraded']> {
     return this.#policy.onDegraded((data) => {
       if (data === undefined) {
         listener({
@@ -466,8 +489,11 @@ export class RpcService {
    * @see {@link createServicePolicy}
    */
   onAvailable(
-    listener: Parameters<AbstractRpcService['onAvailable']>[0],
-  ): IDisposable {
+    listener: CockatielEventToEventListenerWithData<
+      ServicePolicy['onAvailable'],
+      { endpointUrl: string }
+    >,
+  ): ReturnType<ServicePolicy['onAvailable']> {
     return this.#policy.onAvailable(() => {
       listener({ endpointUrl: this.endpointUrl.toString() });
     });


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

In the past, `AbstractRpcService` and `RpcServiceRequestable` were added so that we could express that the fetch and Infura middleware supported either an `RpcService` or `RpcServiceChain`. However, since then, these middleware have been changed so that they do not care about a _complete_ RPC service-like interface, just the `request` method. Hence, it is no longer necessary for the two interfaces to exist.

In fact, the existence of these interfaces create impediments for development. `RpcService` is not public itself, but `AbstractRpcService` and `RpcServiceRequestable` are. So each time we make incompatible changes to `RpcService` we have to remember to keep `AbstractRpcService` and `RpcServiceRequestable` updated as well, and this results in more major releases for `network-controller` than we would like.

To address these issues, we update `RpcService` so that it no longer implements `AbstractRpcService`, and we deprecate both interfaces so that we do not have to update them whenever we make changes to `RpcService` or `RpcServiceChain`. We will remove both interfaces in a future major version. 

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public TypeScript surface changes deprecate exported RPC service interfaces and stop `RpcService` from implementing them, which may affect downstream typing even though runtime behavior is unchanged.
> 
> **Overview**
> Marks the exported `AbstractRpcService` and `RpcServiceRequestable` types as **deprecated** (with guidance to accept narrower “RPC-like” shapes), and records this deprecation in the `network-controller` changelog.
> 
> Updates `RpcService` to no longer implement `AbstractRpcService` and replaces interface-derived listener typings/return types with explicit `ServicePolicy`-based types from `./shared`, removing the `cockatiel` `IDisposable` dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 609adf89f721d38dee849620e8dbe9c117ee681b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->