### PR TITLE
fix(perps): use live price for reverse position orders

### DIFF
--- a/packages/perps-controller/.sync-state.json
+++ b/packages/perps-controller/.sync-state.json
@@ -1,8 +1,8 @@
 {
-  "lastSyncedMobileCommit": "14dbdb4e3c7d218fe4f74984969c55142656fcf1",
-  "lastSyncedMobileBranch": "fix/perps/myx-webpack-ignore-restore",
-  "lastSyncedCoreCommit": "796d13b6e190fc481461bd268a1dd3820ca7b9a9",
-  "lastSyncedCoreBranch": "fix/perps/myx-webpack-ignore-restore-clean",
-  "lastSyncedDate": "2026-04-15T16:45:31Z",
-  "sourceChecksum": "5be7d584829db03e7449d06a8c329816966d2dd218a9fa42d57f07c22b00bc51"
+  "lastSyncedMobileCommit": "acda605cc580a77b425ef26d2e0c1d3cb7b5a972",
+  "lastSyncedMobileBranch": "main",
+  "lastSyncedCoreCommit": "360a80d1bde1c0a9ce19f3147bcc1383cc465eb9",
+  "lastSyncedCoreBranch": "feat/perps/reverse-position-live-price-sync",
+  "lastSyncedDate": "2026-04-16T06:21:43Z",
+  "sourceChecksum": "e85c1a9b4cf5beb0969a2d55da1da2e42d3cfb5b30a74438a7ee1570d178279a"
 }

--- a/packages/perps-controller/.sync-state.json
+++ b/packages/perps-controller/.sync-state.json
@@ -1,8 +1,8 @@
 {
-  "lastSyncedMobileCommit": "acda605cc580a77b425ef26d2e0c1d3cb7b5a972",
-  "lastSyncedMobileBranch": "main",
-  "lastSyncedCoreCommit": "360a80d1bde1c0a9ce19f3147bcc1383cc465eb9",
+  "lastSyncedMobileCommit": "f795eb2f5227f933e329ec61fdc804d3d95e0a73",
+  "lastSyncedMobileBranch": "perps/fix-reverse-order-price",
+  "lastSyncedCoreCommit": "ac29b054722c2c4667c801a64659a31c8effcd02",
   "lastSyncedCoreBranch": "feat/perps/reverse-position-live-price-sync",
-  "lastSyncedDate": "2026-04-16T06:21:43Z",
-  "sourceChecksum": "e85c1a9b4cf5beb0969a2d55da1da2e42d3cfb5b30a74438a7ee1570d178279a"
+  "lastSyncedDate": "2026-04-16T19:23:34Z",
+  "sourceChecksum": "b860a2f9b58ee470835f0efb0b076134225b0c3ccbd97df89b9055f3522c1f00"
 }

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Use live market pricing instead of stale entry pricing when flipping a perps position, preventing reverse-position orders from failing ([#0000](https://github.com/MetaMask/core/pull/0000))
+
 ## [3.1.1]
 
 ### Fixed

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Use live market pricing instead of stale entry pricing when flipping a perps position, preventing reverse-position orders from failing ([#0000](https://github.com/MetaMask/core/pull/0000))
+- Use live market pricing instead of stale entry pricing when flipping a perps position, preventing reverse-position orders from failing ([#8481](https://github.com/MetaMask/core/pull/8481))
 
 ## [3.1.1]
 

--- a/packages/perps-controller/src/PerpsController.ts
+++ b/packages/perps-controller/src/PerpsController.ts
@@ -1730,8 +1730,11 @@ export class PerpsController extends BaseController<
       // IMPORTANT: Must use import() — NOT require() — for core/extension tree-shaking.
       // require() is synchronous and bundlers include it in the main bundle.
       // import() enables true code splitting so MYX is excluded when not enabled.
+      // NOTE: Keep the path in a variable so ts-bridge does not rewrite the
+      // import argument and strip the webpackIgnore magic comment in core dist.
+      const myxModulePath = './providers/MYXProvider';
       this.#myxRegistrationPromise = import(
-        /* webpackIgnore: true */ './providers/MYXProvider'
+        /* webpackIgnore: true */ myxModulePath
       )
         .then(({ MYXProvider }) => {
           this.registerMYXProvider(MYXProvider);

--- a/packages/perps-controller/src/PerpsController.ts
+++ b/packages/perps-controller/src/PerpsController.ts
@@ -1730,11 +1730,8 @@ export class PerpsController extends BaseController<
       // IMPORTANT: Must use import() — NOT require() — for core/extension tree-shaking.
       // require() is synchronous and bundlers include it in the main bundle.
       // import() enables true code splitting so MYX is excluded when not enabled.
-      // NOTE: Keep the path in a variable so ts-bridge does not rewrite the
-      // import argument and strip the webpackIgnore magic comment in core dist.
-      const myxModulePath = './providers/MYXProvider';
       this.#myxRegistrationPromise = import(
-        /* webpackIgnore: true */ myxModulePath
+        /* webpackIgnore: true */ './providers/MYXProvider'
       )
         .then(({ MYXProvider }) => {
           this.registerMYXProvider(MYXProvider);

--- a/packages/perps-controller/src/services/TradingService.ts
+++ b/packages/perps-controller/src/services/TradingService.ts
@@ -4,7 +4,6 @@ import {
   PERPS_EVENT_PROPERTY,
   PERPS_EVENT_VALUE,
 } from '../constants/eventNames';
-import { ESTIMATED_FEE_RATE } from '../constants/hyperLiquidConfig';
 import { isTPSLOrder } from '../constants/orderTypes';
 import { PerpsMeasurementName } from '../constants/performanceMetrics';
 import { PERPS_CONSTANTS } from '../constants/perpsConfig';
@@ -1942,43 +1941,28 @@ export class TradingService {
       const isCurrentlyLong = parseFloat(position.size) > 0;
       const oppositeDirection = !isCurrentlyLong;
 
-      // Validate available balance for fees
-      const accountState = await provider.getAccountState?.();
-      if (!accountState) {
-        throw new Error('Failed to get account state');
-      }
-
-      const availableBalance = parseFloat(accountState.availableBalance);
-
-      // Estimate fees: ESTIMATED_FEE_RATE (0.09%) already accounts for both legs
-      // (close at 0.045% + open at 0.045% = 0.09% of position notional).
-      // Apply to 1x notional (positionSize * entryPrice), not 2x (flipSize * entryPrice).
-      const entryPrice = parseFloat(position.entryPrice);
       const flipSize = positionSize * 2;
-      const notionalValue = positionSize * entryPrice;
-      const estimatedFees = notionalValue * ESTIMATED_FEE_RATE;
-
-      if (estimatedFees > availableBalance) {
-        throw new Error(
-          `Insufficient balance for flip fees. Need $${estimatedFees.toFixed(2)}, have $${availableBalance.toFixed(2)}`,
-        );
-      }
 
       // Create order params for flip
-      // Use 2x position size: 1x to close current position + 1x to open opposite position
+      // Use 2x position size: 1x to close current position + 1x to open opposite position.
+      // Do not pass the position entry price as currentPrice: the provider must fetch
+      // live market data for validation and IOC pricing.
       const orderParams: OrderParams = {
         symbol: position.symbol,
         isBuy: oppositeDirection,
         size: flipSize.toString(),
         orderType: 'market',
         leverage: position.leverage?.value,
-        currentPrice: entryPrice,
       };
 
       // Place flip order (HyperLiquid handles margin transfer automatically)
       const result = await provider.placeOrder(orderParams);
 
       const completionDuration = this.#deps.performance.now() - startTime;
+
+      const executedPrice = parseFloat(
+        result.averagePrice ?? position.entryPrice,
+      );
 
       if (result.success) {
         // Update state on success
@@ -2006,8 +1990,7 @@ export class TradingService {
             [PERPS_EVENT_PROPERTY.ORDER_SIZE]: positionSize,
             [PERPS_EVENT_PROPERTY.COMPLETION_DURATION]: completionDuration,
             [PERPS_EVENT_PROPERTY.ACTION]: flipAction,
-            [PERPS_EVENT_PROPERTY.ORDER_VALUE]:
-              positionSize * parseFloat(position.entryPrice),
+            [PERPS_EVENT_PROPERTY.ORDER_VALUE]: positionSize * executedPrice,
           },
         );
 


### PR DESCRIPTION
## Explanation

  Sync the perps controller fix from mobile so reverse-position orders no longer use a stale entry price during flip order placement.

  The issue was in `TradingService.flipPosition()`: it passed `position.entryPrice` as `currentPrice` for the market flip order. That value could be stale relative to the live market, which meant provider side validation and IOC pricing could use the wrong price and cause reverse position failures. This change removes that stale price from the flip order params so the provider uses live market pricing instead, and it updates the order value analytics fallback accordingly.

  This PR also updates the perps controller changelog entry and sync state as part of the standard mobile-to-core sync flow.

  ## References

  - Synced from MetaMask Mobile perps controller changes
  - Related to mobile branch: `perps/fix-reverse-order-price`
  - Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2946

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes perps position-flip order submission by removing fee/balance prechecks and no longer sending a potentially stale `currentPrice`, which could affect provider-side validation and analytics values if assumptions differ.
> 
> **Overview**
> Fixes reverse-position (flip) market orders by **stopping `flipPosition()` from passing `position.entryPrice` as `currentPrice`**, forcing providers to validate/price against live market data.
> 
> Removes the flip fee/balance prevalidation based on `ESTIMATED_FEE_RATE`, and updates flip analytics `ORDER_VALUE` to use the executed `averagePrice` (falling back to entry price) instead. Changelog and `.sync-state.json` are updated to reflect the synced fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a12f5dd9308f4623322fdf76a0f12e81ca22f4b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->