### PR TITLE
feat: add Injective Mainnet to Price API supported chains

### DIFF
--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `MultichainAssetsController`: periodic Blockaid re-scan of stored SPL-style `token:` assets (default once per day) so tokens that become malicious after a prior scan are dropped; use constructor option `blockaidTokenRescanInterval` (ms), or `0` to disable. ([#8400](https://github.com/MetaMask/core/pull/8400))
+- Added Injective Mainnet native token to Price API supported chains ([#8487](https://github.com/MetaMask/core/pull/8487))
 
 ### Changed
 

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `MultichainAssetsController`: periodic Blockaid re-scan of stored SPL-style `token:` assets (default once per day) so tokens that become malicious after a prior scan are dropped; use constructor option `blockaidTokenRescanInterval` (ms), or `0` to disable. ([#8400](https://github.com/MetaMask/core/pull/8400))
+- Added Injective Mainnet native token to Price API supported chains ([#8487](https://github.com/MetaMask/core/pull/8487))
 
 ### Changed
 

--- a/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
+++ b/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
@@ -285,6 +285,7 @@ export const SPOT_PRICES_SUPPORT_INFO = {
   '0x504': 'eip155:1284/slip44:1284', // Moonbeam - Native symbol: GLMR
   '0x505': 'eip155:1285/slip44:1285', // Moonriver - Native symbol: MOVR
   '0x531': 'eip155:1329/slip44:19000118', // Sei Mainnet - Native symbol: SEI
+  '0x6f0': 'eip155:1776/slip44:22000119', // Injective Mainnet - Native symbol: INJ
   '0x74c': 'eip155:1868/erc20:0x0000000000000000000000000000000000000000', // Soneium - Native symbol: ETH
   '0xa729': 'eip155:42793/erc20:0x0000000000000000000000000000000000000000', // Etherlink - Native symbol: XTZ (Tezos L2)
   '0xab5': 'eip155:2741/erc20:0x0000000000000000000000000000000000000000', // Abstract - Native symbol: ETH


### PR DESCRIPTION
## Explanation

Injective Mainnet (chain `0x6f0` / 1776) is missing from `SPOT_PRICES_SUPPORT_INFO` in `assets-controllers`. `validateChainIdSupported('0x6f0')` therefore returns `false`, so Extension and Mobile never call the Price API for any Injective token (native or ERC20). The wallet UI shows "no conversion rate available" for INJ and every Injective ERC20 (USDT, wETH, USDC, ATOM, TIA, stINJ).

This PR adds `'0x6f0': 'eip155:1776/slip44:22000119'` to `SPOT_PRICES_SUPPORT_INFO` — INJ's CAIP-19 asset identifier already exists in [`va-mmcx-price-api`'s slip44 map](https://github.com/consensys-vertical-apps/va-mmcx-price-api/blob/main/src/constants/slip44.ts). Same one-line pattern as #7939 (Chiliz, Plasma).

The `it.each(SUPPORTED_CHAIN_IDS)` test at `src/token-prices-service/codefi-v2.test.ts:1762` automatically covers the new entry.

The Injective EVM ERC20 contracts must also be wired up server-side in the Price API — that work lives in the companion PR (link below). Without it, this change unblocks native INJ but ERC20 prices still come back empty.

## References

- NEB-549 — "Price Issues — Injective, Chiliz, Plasma, Rootstock"
- Pattern reference: #7939 ("add chiliz and fix plasma for price api supported chains")
- Companion Price API PR: <link to be added>

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single Injective chainId-to-CAIP-19 mapping and a changelog entry, with no behavior changes beyond enabling Price API lookups for that chain.
> 
> **Overview**
> Enables Price API spot-price support for Injective Mainnet by adding chain `0x6f0` → `eip155:1776/slip44:22000119` to `SPOT_PRICES_SUPPORT_INFO`, allowing native INJ (and price requests on that chain) to pass support validation.
> 
> Updates the `assets-controllers` changelog to announce the new Injective native token Price API support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfc10f2b3907afa01af9ae5824580519849761a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->