### PR TITLE
fix(transaction-pay-controller): stop adding subsidized fee to target amount

### DIFF
--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Resolve correct `networkClientId` for source chain in Relay execute flow ([#8492](https://github.com/MetaMask/core/pull/8492))
+- Stop double-counting subsidized fees in Relay quote target amounts ([#8488](https://github.com/MetaMask/core/pull/8488))
 
 ## [19.2.0]
 

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.test.ts
@@ -1779,6 +1779,36 @@ describe('Relay Quotes Utils', () => {
       });
     });
 
+    it('uses amountFormatted for subsidized fee when fee token is a stablecoin', async () => {
+      const quoteMock = cloneDeep(QUOTE_MOCK);
+      quoteMock.fees.subsidized = {
+        amount: '500000',
+        amountFormatted: '0.50',
+        amountUsd: '0.49',
+        currency: {
+          address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as Hex,
+          chainId: 1,
+          decimals: 6,
+        },
+        minimumAmount: '500000',
+      };
+
+      successfulFetchMock.mockResolvedValue({
+        json: async () => quoteMock,
+      } as never);
+
+      const result = await getRelayQuotes({
+        messenger,
+        requests: [QUOTE_REQUEST_MOCK],
+        transaction: TRANSACTION_META_MOCK,
+      });
+
+      expect(result[0].fees.provider).toStrictEqual({
+        usd: '0',
+        fiat: '0',
+      });
+    });
+
     it('includes dust in quote', async () => {
       successfulFetchMock.mockResolvedValue({
         json: async () => QUOTE_MOCK,

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.test.ts
@@ -2402,7 +2402,7 @@ describe('Relay Quotes Utils', () => {
       });
     });
 
-    it('adds subsidized fee to target amount fiat values when trade type is EXACT_INPUT', async () => {
+    it('does not add subsidized fee to target amount', async () => {
       const quoteMock = cloneDeep(QUOTE_MOCK);
       quoteMock.fees.subsidized = {
         amount: '500000000000000',
@@ -2423,66 +2423,6 @@ describe('Relay Quotes Utils', () => {
       const result = await getRelayQuotes({
         messenger,
         requests: [{ ...QUOTE_REQUEST_MOCK, isMaxAmount: true }],
-        transaction: TRANSACTION_META_MOCK,
-      });
-
-      expect(result[0].targetAmount).toStrictEqual({
-        usd: '1.73',
-        fiat: '3.46',
-      });
-    });
-
-    it('uses amountFormatted for subsidized fee when fee token is a stablecoin', async () => {
-      const quoteMock = cloneDeep(QUOTE_MOCK);
-      quoteMock.fees.subsidized = {
-        amount: '500000',
-        amountFormatted: '0.50',
-        amountUsd: '0.49',
-        currency: {
-          address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as Hex,
-          chainId: 1,
-          decimals: 6,
-        },
-        minimumAmount: '500000',
-      };
-
-      successfulFetchMock.mockResolvedValue({
-        json: async () => quoteMock,
-      } as never);
-
-      const result = await getRelayQuotes({
-        messenger,
-        requests: [{ ...QUOTE_REQUEST_MOCK, isMaxAmount: true }],
-        transaction: TRANSACTION_META_MOCK,
-      });
-
-      expect(result[0].targetAmount).toStrictEqual({
-        usd: '1.73',
-        fiat: '3.46',
-      });
-    });
-
-    it('does not add subsidized fee to target amount when trade type is not EXACT_INPUT', async () => {
-      const quoteMock = cloneDeep(QUOTE_MOCK);
-      quoteMock.fees.subsidized = {
-        amount: '500000000000000',
-        amountFormatted: '0.0005',
-        amountUsd: '0.50',
-        currency: {
-          address: '0xdef' as Hex,
-          chainId: 1,
-          decimals: 18,
-        },
-        minimumAmount: '500000000000000',
-      };
-
-      successfulFetchMock.mockResolvedValue({
-        json: async () => quoteMock,
-      } as never);
-
-      const result = await getRelayQuotes({
-        messenger,
-        requests: [QUOTE_REQUEST_MOCK],
         transaction: TRANSACTION_META_MOCK,
       });
 

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.ts
@@ -471,23 +471,9 @@ async function normalizeQuote(
     request.targetTokenAddress,
   );
 
-  const additionalTargetAmountUsd =
-    quote.request.tradeType === 'EXACT_INPUT'
-      ? subsidizedFeeUsd
-      : new BigNumber(0);
-
-  if (additionalTargetAmountUsd.gt(0)) {
-    log(
-      'Including subsidized fee in target amount',
-      additionalTargetAmountUsd.toString(10),
-    );
-  }
-
-  const baseTargetAmountUsd = isTargetStablecoin
+  const targetAmountUsd = isTargetStablecoin
     ? new BigNumber(currencyOut.amountFormatted)
     : new BigNumber(currencyOut.amountUsd);
-
-  const targetAmountUsd = baseTargetAmountUsd.plus(additionalTargetAmountUsd);
 
   const targetAmount = getFiatValueFromUsd(targetAmountUsd, usdToFiatRate);
 


### PR DESCRIPTION
## Explanation

Relay now returns `currencyOut` as the full amount the user receives — subsidized fees are no longer deducted from the output. This was verified across all trade types (`EXACT_INPUT`, `EXPECTED_OUTPUT`), protocol versions (v2 — v1 is effectively dead), and execute/non-execute modes.

Our `normalizeQuote` code was adding the subsidized fee USD amount back to the target amount for `EXACT_INPUT` trades, which now **double-counts** the fee. For example, on a 0.032 USDC → mUSD swap with ~$2.10 in subsidized fees, the target amount was being inflated to ~$2.13 instead of the correct ~$0.032.

## Changes

- Remove `additionalTargetAmountUsd` logic from `normalizeQuote` in `relay-quotes.ts`
- Remove two tests that validated the old fee-addition behavior
- Consolidate remaining subsidized fee test into a single "does not add subsidized fee to target amount" test
- `subsidizedFeeUsd` is still used for zeroing the provider fee when fees are subsidized (unchanged)

## References

Verified via live API calls to `https://intents.dev-api.cx.metamask.io/relay/quote`:

| Config | `currencyOut.amount` | `subsidized.amountUsd` | Protocol |
|---|---|---|---|
| EXACT_INPUT + overhead | 32507 | ~2.15 | v2 |
| EXACT_INPUT, no overhead | 32507 | ~0.035 | v2 |
| EXPECTED_OUTPUT + overhead | 32507 | ~2.17 | v2 |
| EXPECTED_OUTPUT, no overhead | 32507 | ~0.035 | v2 |
| protocolVersion=v1 (any) | 32507 | varies | **v2** (v1 ignored) |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Relay `targetAmount` fiat/USD values are computed, which can affect user-visible quote/totals for max-amount flows. Risk is limited to quote presentation/math and is covered by updated unit tests.
> 
> **Overview**
> Prevents Relay quote normalization (`relay-quotes.ts`) from **adding subsidized fee USD back into the target amount**, avoiding double-counting now that Relay returns `currencyOut` as the full user-received amount.
> 
> Updates Relay quote tests to assert subsidized fees **do not change `targetAmount`** (including stablecoin-fee cases) and records the fix in the `CHANGELOG`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a08f64aa0bcb50fbf38e22abf5391eb36005682. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->