### PR TITLE
fix(transaction-pay-controller): poll Across status by deposit txn ref

### DIFF
--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix Across deposit status polling to query `/deposit/status` with `depositTxnRef=<source transaction hash>` and return `fillTxnRef` when Across omits the destination hash ([#8489](https://github.com/MetaMask/core/pull/8489))
+
 ## [19.2.0]
 
 ### Changed

--- a/packages/transaction-pay-controller/src/strategy/across/across-submit.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/across/across-submit.test.ts
@@ -139,7 +139,7 @@ describe('Across Submit', () => {
       transactionMeta: TRANSACTION_META_MOCK,
     });
     successfulFetchMock.mockResolvedValue({
-      json: async () => ({ status: 'pending' }),
+      json: async () => ({ status: 'success' }),
     } as Response);
   });
 
@@ -576,7 +576,7 @@ describe('Across Submit', () => {
       );
     });
 
-    it('polls Across status endpoint when quote includes a deposit id', async () => {
+    it('polls Across status endpoint with depositTxnRef from the source tx hash', async () => {
       const confirmedTransaction = {
         id: 'new-tx',
         chainId: '0x1',
@@ -633,7 +633,7 @@ describe('Across Submit', () => {
       });
 
       expect(successfulFetchMock).toHaveBeenCalledWith(
-        expect.stringContaining('/deposit/status?'),
+        expect.stringContaining('/deposit/status?depositTxnRef=0xconfirmed'),
         expect.objectContaining({ method: 'GET' }),
       );
       expect(result.transactionHash).toBe('0xtarget');
@@ -726,6 +726,25 @@ describe('Across Submit', () => {
       } finally {
         jest.useRealTimers();
       }
+    });
+
+    it('returns fill txn ref when destination hash is missing', async () => {
+      setupConfirmedSubmission();
+      successfulFetchMock.mockResolvedValueOnce({
+        json: async () => ({
+          fillTxnRef: '0xfillref',
+          status: 'filled',
+        }),
+      } as Response);
+
+      const result = await submitAcrossQuotes({
+        messenger,
+        quotes: [buildDepositQuote()],
+        transaction: TRANSACTION_META_MOCK,
+        isSmartTransaction: jest.fn(),
+      });
+
+      expect(result.transactionHash).toBe('0xfillref');
     });
 
     it('returns fill tx hash when destination hash is missing', async () => {

--- a/packages/transaction-pay-controller/src/strategy/across/across-submit.ts
+++ b/packages/transaction-pay-controller/src/strategy/across/across-submit.ts
@@ -242,34 +242,28 @@ async function submitTransactions(
     ? getTransaction(transactionIds.slice(-1)[0], messenger)?.hash
     : undefined;
 
-  return await waitForAcrossCompletion(
-    quote.original,
-    hash as Hex | undefined,
-    messenger,
-  );
+  return await waitForAcrossCompletion(hash as Hex | undefined, messenger);
 }
 
 type AcrossStatusResponse = {
   status?: string;
   destinationTxHash?: Hex;
+  fillTxnRef?: Hex;
   fillTxHash?: Hex;
   txHash?: Hex;
 };
 
 async function waitForAcrossCompletion(
-  quote: AcrossQuote,
   transactionHash: Hex | undefined,
   messenger: TransactionPayControllerMessenger,
 ): Promise<Hex | undefined> {
-  if (!transactionHash || !quote.quote.id) {
+  if (!transactionHash) {
     return transactionHash;
   }
 
   const config = getPayStrategiesConfig(messenger);
   const params = new URLSearchParams({
-    depositId: quote.quote.id,
-    originChainId: String(quote.quote.swapTx.chainId),
-    txHash: transactionHash,
+    depositTxnRef: transactionHash,
   });
   const url = `${config.across.apiBase}/deposit/status?${params.toString()}`;
 
@@ -313,6 +307,7 @@ async function waitForAcrossCompletion(
       ['completed', 'filled', 'success'].includes(normalizedStatus)
     ) {
       return (
+        status.fillTxnRef ??
         status.destinationTxHash ??
         status.fillTxHash ??
         status.txHash ??


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Fix Across deposit status polling to query /deposit/status with depositTxnRef=<source tx hash> instead of misusing the quote id as depositId.

Also handle fillTxnRef in the response so the status poller can return the fill transaction reference when Across provides it.

This resolves the repeated 400s seen after the source-chain tx finalized by aligning the request and response handling with Across' current status API shape.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the bridge completion polling request/response logic, which can affect whether intents resolve to the correct destination transaction hash; scope is small and covered by updated unit tests.
> 
> **Overview**
> Fixes Across completion polling by querying `/deposit/status` with `depositTxnRef=<source tx hash>` (instead of passing quote/deposit id params), aligning with Across’ current status API.
> 
> Updates the status response handling to prefer `fillTxnRef` when returning the destination/fill transaction reference (falling back to `destinationTxHash`, `fillTxHash`, `txHash`, then the source hash), with tests and changelog updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe98acc0d0c6f921d845758c59457ec0b8325346. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->