### PR TITLE
fix(transaction-pay-controller): resolve correct networkClientId for source chain in relay execute

### DIFF
--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Resolve correct `networkClientId` for source chain in Relay execute flow ([#8492](https://github.com/MetaMask/core/pull/8492))
+
 ## [19.2.0]
 
 ### Changed

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-submit.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-submit.test.ts
@@ -1272,6 +1272,7 @@ describe('Relay Submit Utils', () => {
         expect(getDelegationTransactionMock).toHaveBeenCalledWith({
           transaction: expect.objectContaining({
             chainId: CHAIN_ID_MOCK,
+            networkClientId: NETWORK_CLIENT_ID_MOCK,
             nestedTransactions: [
               {
                 data: '0x1234',
@@ -1281,6 +1282,14 @@ describe('Relay Submit Utils', () => {
             ],
           }),
         });
+      });
+
+      it('resolves networkClientId for source chain instead of inheriting from original transaction', async () => {
+        await submitRelayQuotes(request);
+
+        expect(findNetworkClientIdByChainIdMock).toHaveBeenCalledWith(
+          CHAIN_ID_MOCK,
+        );
       });
 
       it('submits to /execute with delegation data', async () => {

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-submit.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-submit.ts
@@ -400,9 +400,15 @@ async function submitViaRelayExecute(
   const { from, sourceChainId } = quote.request;
   const { requestId } = quote.original.steps[0];
 
+  const networkClientId = messenger.call(
+    'NetworkController:findNetworkClientIdByChainId',
+    sourceChainId,
+  );
+
   const sourceCallTransaction = {
     ...transaction,
     chainId: sourceChainId,
+    networkClientId,
     nestedTransactions: allParams.map((params) => ({
       data: (params.data ?? '0x') as Hex,
       to: params.to as Hex,


### PR DESCRIPTION
## Explanation

During cross-chain MetaMask Pay flows, the delegation transaction receives the wrong `networkClientId` — it gets the target chain's instead of the source chain's. This causes the EIP-7702 authorization nonce to be looked up on the wrong chain, breaking the gasless execute flow.

Resolves the correct `networkClientId` for the source chain before passing it to `getDelegationTransaction`, matching the pattern already used in `submitViaTransactionController`.

## References

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Relay execute submission logic used in gasless cross-chain Pay flows; a wrong `networkClientId` could break nonce/authorization handling, but the change is small and covered by targeted tests.
> 
> **Overview**
> Fixes the Relay `/execute` (EIP-7702) submission path to **resolve `networkClientId` from `sourceChainId`** via `NetworkController:findNetworkClientIdByChainId` before calling `TransactionPayController:getDelegationTransaction`, instead of implicitly inheriting the original transaction’s network context.
> 
> Updates Relay submit tests to assert `networkClientId` is passed on the delegation transaction and that the source-chain lookup is performed, and records the change in the package changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71e1067957ffd4fe502beb8e2f0877309d1554e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->