### PR TITLE
fix(transaction-pay-controller): allow Across perps ETH gas top-up quotes

### DIFF
--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Route Across status polling through the configured Across API base and support `depositTxnRef`/`fillTxnRef` for Across status responses ([#8512](https://github.com/MetaMask/core/pull/8512))
+- Support Across quotes for the Arbitrum native-token gas top-up leg of perps deposits ([#8493](https://github.com/MetaMask/core/pull/8493))
 
 ## [19.2.1]
 

--- a/packages/transaction-pay-controller/src/strategy/across/perps.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/across/perps.test.ts
@@ -1,0 +1,116 @@
+import { TransactionType } from '@metamask/transaction-controller';
+import type { Hex } from '@metamask/utils';
+
+import {
+  ARBITRUM_USDC_ADDRESS,
+  CHAIN_ID_ARBITRUM,
+  NATIVE_TOKEN_ADDRESS,
+} from '../../constants';
+import type { QuoteRequest } from '../../types';
+import {
+  ACROSS_HYPERCORE_USDC_PERPS_ADDRESS,
+  isSupportedAcrossPerpsDepositRequest,
+  normalizeAcrossRequest,
+} from './perps';
+
+const REQUEST_MOCK: QuoteRequest = {
+  from: '0x1234567890123456789012345678901234567890' as Hex,
+  sourceBalanceRaw: '1000000',
+  sourceChainId: '0x1' as Hex,
+  sourceTokenAddress: '0x1111111111111111111111111111111111111111' as Hex,
+  sourceTokenAmount: '1000000',
+  targetAmountMinimum: '1000000',
+  targetChainId: CHAIN_ID_ARBITRUM,
+  targetTokenAddress: ARBITRUM_USDC_ADDRESS,
+};
+
+describe('perps', () => {
+  describe('isSupportedAcrossPerpsDepositRequest', () => {
+    it('returns true for direct deposit requests on Arbitrum USDC', () => {
+      expect(
+        isSupportedAcrossPerpsDepositRequest(
+          {
+            ...REQUEST_MOCK,
+            targetTokenAddress: ARBITRUM_USDC_ADDRESS.toUpperCase() as Hex,
+          },
+          TransactionType.perpsDeposit,
+        ),
+      ).toBe(true);
+    });
+
+    it('returns true for Arbitrum native-token gas top-up requests', () => {
+      expect(
+        isSupportedAcrossPerpsDepositRequest(
+          {
+            ...REQUEST_MOCK,
+            targetTokenAddress: NATIVE_TOKEN_ADDRESS,
+          },
+          TransactionType.perpsDeposit,
+        ),
+      ).toBe(true);
+    });
+
+    it('returns false for post-quote requests', () => {
+      expect(
+        isSupportedAcrossPerpsDepositRequest(
+          {
+            ...REQUEST_MOCK,
+            isPostQuote: true,
+          },
+          TransactionType.perpsDeposit,
+        ),
+      ).toBe(false);
+    });
+
+    it('returns false for unsupported transaction types and tokens', () => {
+      expect(
+        isSupportedAcrossPerpsDepositRequest(
+          REQUEST_MOCK,
+          TransactionType.bridge,
+        ),
+      ).toBe(false);
+
+      expect(
+        isSupportedAcrossPerpsDepositRequest(
+          {
+            ...REQUEST_MOCK,
+            targetChainId: '0x1' as Hex,
+            targetTokenAddress:
+              '0x2222222222222222222222222222222222222222' as Hex,
+          },
+          TransactionType.perpsDeposit,
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe('normalizeAcrossRequest', () => {
+    it('normalizes direct perps deposits to the Across HyperCore route', () => {
+      expect(
+        normalizeAcrossRequest(REQUEST_MOCK, TransactionType.perpsDeposit),
+      ).toStrictEqual({
+        ...REQUEST_MOCK,
+        targetAmountMinimum: '100000000',
+        targetChainId: '0x539',
+        targetTokenAddress: ACROSS_HYPERCORE_USDC_PERPS_ADDRESS,
+      });
+    });
+
+    it('does not normalize gas top-up requests', () => {
+      const request = {
+        ...REQUEST_MOCK,
+        targetTokenAddress: NATIVE_TOKEN_ADDRESS,
+      };
+
+      expect(
+        normalizeAcrossRequest(request, TransactionType.perpsDeposit),
+      ).toBe(request);
+    });
+
+    it('does not normalize non-perps requests', () => {
+      expect(normalizeAcrossRequest(REQUEST_MOCK, TransactionType.bridge)).toBe(
+        REQUEST_MOCK,
+      );
+    });
+  });
+});

--- a/packages/transaction-pay-controller/src/strategy/across/perps.ts
+++ b/packages/transaction-pay-controller/src/strategy/across/perps.ts
@@ -7,6 +7,7 @@ import {
   CHAIN_ID_ARBITRUM,
   CHAIN_ID_HYPERCORE,
   HYPERCORE_USDC_DECIMALS,
+  NATIVE_TOKEN_ADDRESS,
   USDC_DECIMALS,
 } from '../../constants';
 import type { QuoteRequest } from '../../types';
@@ -14,18 +15,40 @@ import type { QuoteRequest } from '../../types';
 export const ACROSS_HYPERCORE_USDC_PERPS_ADDRESS =
   '0x2100000000000000000000000000000000000000' as Hex;
 
+function isAcrossPerpsDirectDepositRequest(
+  request: Pick<QuoteRequest, 'targetChainId' | 'targetTokenAddress'>,
+): boolean {
+  return (
+    request.targetChainId === CHAIN_ID_ARBITRUM &&
+    request.targetTokenAddress.toLowerCase() ===
+      ARBITRUM_USDC_ADDRESS.toLowerCase()
+  );
+}
+
+function isAcrossPerpsGasTopUpRequest(
+  request: Pick<QuoteRequest, 'targetChainId' | 'targetTokenAddress'>,
+): boolean {
+  return (
+    request.targetChainId === CHAIN_ID_ARBITRUM &&
+    request.targetTokenAddress.toLowerCase() ===
+      NATIVE_TOKEN_ADDRESS.toLowerCase()
+  );
+}
+
 /**
- * Detect the quote-time parent transaction shape that Across can map to the
- * new HyperCore USDC-PERPS direct-deposit route.
+ * Detect the quote-time parent transaction shape that Across can support for
+ * HyperCore perps deposits.
  *
  * The parent transaction remains `perpsDeposit` while quotes are being
  * selected. `perpsAcrossDeposit` is only assigned later to the generated
- * Across submission transaction(s).
+ * Across submission transaction(s). At quote time Across can support:
+ * - the direct HyperCore USDC deposit leg
+ * - the destination-chain native gas top-up leg
  *
  * @param request - Transaction pay quote request.
  * @param parentTransactionType - Parent transaction type before Across
  * execution.
- * @returns Whether the request matches the supported direct-deposit path.
+ * @returns Whether the request matches a supported perps deposit leg.
  */
 export function isSupportedAcrossPerpsDepositRequest(
   request: Pick<
@@ -37,9 +60,8 @@ export function isSupportedAcrossPerpsDepositRequest(
   return (
     parentTransactionType === TransactionType.perpsDeposit &&
     request.isPostQuote !== true &&
-    request.targetChainId === CHAIN_ID_ARBITRUM &&
-    request.targetTokenAddress.toLowerCase() ===
-      ARBITRUM_USDC_ADDRESS.toLowerCase()
+    (isAcrossPerpsDirectDepositRequest(request) ||
+      isAcrossPerpsGasTopUpRequest(request))
   );
 }
 
@@ -48,8 +70,8 @@ export function isSupportedAcrossPerpsDepositRequest(
  * direct perps deposits.
  *
  * Transaction pay starts from the required on-chain asset identity
- * (Arbitrum USDC, 6 decimals), while Across now expects the HyperCore
- * USDC-PERPS destination token (8 decimals).
+ * (Arbitrum USDC, 6 decimals), while Across expects the HyperCore
+ * USDC-PERPS destination token (8 decimals) for the USDC deposit leg.
  *
  * @param request - Transaction pay quote request.
  * @param parentTransactionType - Parent transaction type before Across
@@ -60,7 +82,10 @@ export function normalizeAcrossRequest(
   request: QuoteRequest,
   parentTransactionType?: TransactionType,
 ): QuoteRequest {
-  if (!isSupportedAcrossPerpsDepositRequest(request, parentTransactionType)) {
+  if (
+    parentTransactionType !== TransactionType.perpsDeposit ||
+    !isAcrossPerpsDirectDepositRequest(request)
+  ) {
     return request;
   }
 


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Across perps deposits originating from the PerpsController were being rejected before any quote call when the route included both the USDC deposit leg and the destination-chain ETH gas top-up leg.

The existing Across perps support check only allowed the Arbitrum USDC leg, so the ETH leg triggered quotes-strategy-unsupported and the whole route was rejected locally before reaching Across.

Widen the perps support gate to allow the native ETH top-up leg while still only normalizing the USDC leg into the HyperCore direct-deposit path. This preserves mixed USDC + ETH perps bundles and adds regression coverage for that route shape.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes strategy support gating for perps deposit quotes, which could alter which requests are considered eligible for Across quoting. Scope is limited to `perpsDeposit` on Arbitrum (USDC vs native token) and is covered by new unit tests.
> 
> **Overview**
> Enables Across quoting for *mixed perps deposit bundles* by expanding the perps support check to accept both the Arbitrum USDC deposit leg and the Arbitrum native-token (gas top-up) leg.
> 
> Keeps normalization to the HyperCore direct-deposit route **only** for the USDC deposit leg (leaving native-token top-up requests untouched), and adds a focused regression test suite for the new support/normalization behavior. Updates the package changelog to document the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fb59414c906b236935df93adbbb1d3e800c012e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->