### PR TITLE
ci: Run some jobs on Node.js 24

### DIFF
--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x, 22.x, 24.x]
     outputs:
       child-workspace-package-names: ${{ steps.workspace-package-names.outputs.child-workspace-package-names }}
     steps:

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -31,7 +31,7 @@ jobs:
     needs: prepare
     strategy:
       matrix:
-        node-version: [22.x]
+        node-version: [24.x]
         script:
           - lint:eslint
           - lint:misc:check
@@ -64,7 +64,7 @@ jobs:
     needs: prepare
     strategy:
       matrix:
-        node-version: [22.x]
+        node-version: [24.x]
         package-name: ${{ fromJson(needs.prepare.outputs.child-workspace-package-names) }}
     steps:
       - name: Checkout and setup environment
@@ -97,7 +97,7 @@ jobs:
     needs: prepare
     strategy:
       matrix:
-        node-version: [22.x]
+        node-version: [24.x]
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v2
@@ -119,7 +119,7 @@ jobs:
     needs: prepare
     strategy:
       matrix:
-        node-version: [22.x]
+        node-version: [24.x]
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v2


### PR DESCRIPTION
## Explanation

ESLint consistently runs 40-50 seconds faster on Node.js 24 compared to Node.js 22. I've updated CI to run all jobs that are currently running on Node.js 22 to run on Node.js 24. Once we drop support for Node.js 18 we can do #8499 instead.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only changes that primarily adjust Node versions; main risk is unexpected job failures due to Node.js 24/runtime dependency incompatibilities.
> 
> **Overview**
> Updates `.github/workflows/lint-build-test.yml` to add **Node.js 24** to the `prepare` matrix and switch the `lint`, `validate-changelog`, `build`, and `test-scripts` jobs from **Node.js 22** to **Node.js 24**.
> 
> The per-workspace `test` job matrix remains on `18.x/20.x/22.x`, so Node 24 is added for faster tooling runs without changing the main test coverage matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a0404e591c19ae38441d72ab27d812d932790f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->