### PR TITLE
fix(AccountTrackerController): prevent balance wipe during account sync

### DIFF
--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `MultichainAssetsController`: fungible `token:` assets from automatic detection are no longer added when Blockaid bulk scan fails, returns empty, or omits that address (previously fail open); an explicit non-malicious per-token result from `PhishingController:bulkScanTokens` is now required before add. ([#8400](https://github.com/MetaMask/core/pull/8400))
+- Fix `AccountTrackerController` wiping existing balances on other chains when syncing accounts for a chain that has no state entry yet ([#8505](https://github.com/MetaMask/core/pull/8505))
 
 ## [104.0.0]
 

--- a/packages/assets-controllers/src/AccountTrackerController.test.ts
+++ b/packages/assets-controllers/src/AccountTrackerController.test.ts
@@ -403,6 +403,72 @@ describe('AccountTrackerController', () => {
     );
   });
 
+  it('should not wipe existing balances when syncing accounts and the selected chain has no state entry', async () => {
+    const networkClientId = 'networkClientId1';
+
+    mockedGetTokenBalancesForMultipleAddresses.mockResolvedValueOnce({
+      tokenBalances: {
+        '0x0000000000000000000000000000000000000000': {},
+      },
+      stakedBalances: {},
+    });
+
+    await withController(
+      {
+        options: {
+          state: {
+            accountsByChainId: {
+              '0xe705': {
+                [CHECKSUM_ADDRESS_1]: {
+                  balance: '0xabc',
+                  stakedBalance: '0x5',
+                },
+              },
+            },
+          },
+        },
+        isMultiAccountBalancesEnabled: true,
+        selectedAccount: ACCOUNT_1,
+        listAccounts: [ACCOUNT_1],
+        networkClientById: {
+          [networkClientId]: buildCustomNetworkClientConfiguration({
+            chainId: '0x999',
+          }),
+        },
+      },
+      async ({ controller, refresh }) => {
+        // Verify initial state has the balance we expect to preserve
+        expect(
+          controller.state.accountsByChainId['0xe705'][CHECKSUM_ADDRESS_1],
+        ).toStrictEqual({
+          balance: '0xabc',
+          stakedBalance: '0x5',
+        });
+
+        // Refresh for a new chain. The selected network (mainnet / 0x1) is
+        // NOT in accountsByChainId, so #syncAccounts sees an empty "existing"
+        // set. Without the fix this would overwrite every address on every
+        // chain with { balance: '0x0' }, wiping both balance and stakedBalance.
+        await refresh(['networkClientId1'], true);
+
+        // Existing balances must be preserved
+        expect(
+          controller.state.accountsByChainId['0xe705'][CHECKSUM_ADDRESS_1],
+        ).toStrictEqual({
+          balance: '0xabc',
+          stakedBalance: '0x5',
+        });
+
+        // New chain should have been initialised with a zero balance
+        expect(
+          controller.state.accountsByChainId['0x999'][CHECKSUM_ADDRESS_1],
+        ).toStrictEqual({
+          balance: '0x0',
+        });
+      },
+    );
+  });
+
   it('sets isActive to true when keyring is unlocked', async () => {
     await withController(
       {

--- a/packages/assets-controllers/src/AccountTrackerController.ts
+++ b/packages/assets-controllers/src/AccountTrackerController.ts
@@ -470,9 +470,11 @@ export class AccountTrackerController extends StaticIntervalPollingController<Ac
     );
     Object.keys(accountsByChainId).forEach((chainId) => {
       newAddresses.forEach((address) => {
-        accountsByChainId[chainId][address] = {
-          balance: '0x0',
-        };
+        if (!accountsByChainId[chainId][address]) {
+          accountsByChainId[chainId][address] = {
+            balance: '0x0',
+          };
+        }
       });
     });
 


### PR DESCRIPTION
## Explanation

Added a test to ensure that existing balances are preserved when syncing accounts, specifically when the selected chain has no state entry. Updated the controller logic to only initialize new addresses with a zero balance if they do not already exist in the accountsByChainId state, preventing unintended overwrites of existing balances.

## References

https://github.com/MetaMask/metamask-extension/issues/40474

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core balance state mutation logic; a small conditional change could affect how new accounts/chains are initialized, so regressions would surface as missing/incorrect balances across networks.
> 
> **Overview**
> Prevents `AccountTrackerController.#syncAccounts` from **overwriting existing address entries** (and their `stakedBalance`) when syncing accounts for a chain that previously had no `accountsByChainId` entry, by only initializing `{ balance: '0x0' }` when the address key is absent.
> 
> Adds a regression test covering the scenario where refreshing on a new chain should initialize the new chain’s account state without wiping balances on other chains, and documents the fix in the `assets-controllers` changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87a6b6a1c0c671fb3de9abf51f5ed67ebf71ea6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->