### PR TITLE
feat: Add `createMethodMiddleware` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ linkStyle default opacity:0.5
   geolocation_controller --> base_controller;
   geolocation_controller --> controller_utils;
   geolocation_controller --> messenger;
+  json_rpc_engine --> messenger;
   json_rpc_middleware_stream --> json_rpc_engine;
   keyring_controller --> base_controller;
   keyring_controller --> messenger;

--- a/packages/json-rpc-engine/CHANGELOG.md
+++ b/packages/json-rpc-engine/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `createOriginMiddleware` utility ([#8522](https://github.com/MetaMask/core/pull/8522))
+- Add `createOriginMiddleware` utility to `v2` ([#8522](https://github.com/MetaMask/core/pull/8522))
+- Add `createMethodMiddleware` utility to `v2` ([#8506](https://github.com/MetaMask/core/pull/8506))
+  - This utility allows JSON-RPC method implementations to use both the hooks pattern and the messenger.
 
 ## [10.2.4]
 

--- a/packages/json-rpc-engine/package.json
+++ b/packages/json-rpc-engine/package.json
@@ -70,6 +70,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
+    "@metamask/messenger": "^1.1.1",
     "@metamask/rpc-errors": "^7.0.2",
     "@metamask/safe-event-emitter": "^3.0.0",
     "@metamask/utils": "^11.9.0",

--- a/packages/json-rpc-engine/src/v2/createMethodMiddleware.test.ts
+++ b/packages/json-rpc-engine/src/v2/createMethodMiddleware.test.ts
@@ -1,0 +1,48 @@
+import { Messenger, MOCK_ANY_NAMESPACE } from '@metamask/messenger';
+
+import { makeRequest } from '../../tests/utils';
+import {
+  createMethodMiddleware,
+  MethodHandler,
+} from './createMethodMiddleware';
+import { JsonRpcEngineV2 } from './JsonRpcEngineV2';
+
+const getValueA = {
+  hookNames: { testHook: true },
+  implementation: ({ hooks }) => hooks.testHook(),
+} satisfies MethodHandler;
+
+const getValueB = {
+  actionNames: ['Example:TestAction'],
+  implementation: ({ messenger }) => messenger.call('Example:TestAction'),
+} satisfies MethodHandler;
+
+const messenger = new Messenger({ namespace: MOCK_ANY_NAMESPACE });
+
+messenger.registerActionHandler('Example:TestAction', async () => 'B');
+
+const middleware = createMethodMiddleware({
+  handlers: { getValueA, getValueB },
+  hooks: { testHook: async () => 'A' },
+  messenger,
+});
+
+const engine = JsonRpcEngineV2.create({ middleware: [middleware] });
+
+describe('createMethodMiddleware', () => {
+  it('passes in the requested hooks', async () => {
+    const result = await engine.handle(makeRequest({ method: 'getValueA' }));
+    expect(result).toBe('A');
+  });
+
+  it('passes in a delegated messenger', async () => {
+    const result = await engine.handle(makeRequest({ method: 'getValueB' }));
+    expect(result).toBe('B');
+  });
+
+  it('skips unrecognized methods', async () => {
+    await expect(
+      engine.handle(makeRequest({ method: 'getValueC' })),
+    ).rejects.toThrow('Nothing ended request');
+  });
+});

--- a/packages/json-rpc-engine/src/v2/createMethodMiddleware.test.ts
+++ b/packages/json-rpc-engine/src/v2/createMethodMiddleware.test.ts
@@ -12,43 +12,53 @@ type TestAction = {
   handler: () => Promise<string>;
 };
 
-const getValueA = {
-  hookNames: { testHook: true },
-  implementation: ({ hooks }): Promise<string> => hooks.testHook(),
-} satisfies MethodHandler<{ testHook: () => Promise<string> }>;
+function setup(): { engine: JsonRpcEngineV2 } {
+  const getValueA = {
+    hookNames: { testHook: true },
+    implementation: ({ hooks }): Promise<string> => hooks.testHook(),
+  } satisfies MethodHandler<{ testHook: () => Promise<string> }>;
 
-const getValueB = {
-  actionNames: ['Example:TestAction'],
-  implementation: ({ messenger }): Promise<string> =>
-    messenger.call('Example:TestAction'),
-} satisfies MethodHandler<never, TestAction>;
+  const getValueB = {
+    actionNames: ['Example:TestAction'],
+    implementation: ({ messenger }): Promise<string> =>
+      messenger.call('Example:TestAction'),
+  } satisfies MethodHandler<never, TestAction>;
 
-const messenger = new Messenger<string, TestAction>({
-  namespace: MOCK_ANY_NAMESPACE,
-});
+  const messenger = new Messenger<string, TestAction>({
+    namespace: MOCK_ANY_NAMESPACE,
+  });
 
-messenger.registerActionHandler('Example:TestAction', async () => 'B');
+  messenger.registerActionHandler('Example:TestAction', async () => 'B');
 
-const middleware = createMethodMiddleware({
-  handlers: { getValueA, getValueB },
-  hooks: { testHook: async () => 'A' },
-  messenger,
-});
+  const middleware = createMethodMiddleware({
+    handlers: { getValueA, getValueB },
+    hooks: { testHook: async () => 'A' },
+    messenger,
+  });
 
-const engine = JsonRpcEngineV2.create({ middleware: [middleware] });
+  const engine = JsonRpcEngineV2.create({ middleware: [middleware] });
+
+  return { engine };
+}
 
 describe('createMethodMiddleware', () => {
   it('passes in the requested hooks', async () => {
+    const { engine } = setup();
+
     const result = await engine.handle(makeRequest({ method: 'getValueA' }));
     expect(result).toBe('A');
   });
 
   it('passes in a delegated messenger', async () => {
+    const { engine } = setup();
+
     const result = await engine.handle(makeRequest({ method: 'getValueB' }));
     expect(result).toBe('B');
   });
 
   it('skips unrecognized methods', async () => {
+    const { engine } = setup();
+
     await expect(
       engine.handle(makeRequest({ method: 'getValueC' })),
     ).rejects.toThrow('Nothing ended request');

--- a/packages/json-rpc-engine/src/v2/createMethodMiddleware.test.ts
+++ b/packages/json-rpc-engine/src/v2/createMethodMiddleware.test.ts
@@ -1,4 +1,5 @@
 import { Messenger, MOCK_ANY_NAMESPACE } from '@metamask/messenger';
+import { JsonRpcParams } from '@metamask/utils';
 
 import { makeRequest } from '../../tests/utils';
 import {
@@ -7,17 +8,24 @@ import {
 } from './createMethodMiddleware';
 import { JsonRpcEngineV2 } from './JsonRpcEngineV2';
 
+type TestAction = {
+  type: 'Example:TestAction';
+  handler: () => Promise<string>;
+};
+
 const getValueA = {
   hookNames: { testHook: true },
   implementation: ({ hooks }) => hooks.testHook(),
-} satisfies MethodHandler;
+} satisfies MethodHandler<{ testHook: () => Promise<string> }>;
 
 const getValueB = {
   actionNames: ['Example:TestAction'],
   implementation: ({ messenger }) => messenger.call('Example:TestAction'),
-} satisfies MethodHandler;
+} satisfies MethodHandler<never, JsonRpcParams, TestAction>;
 
-const messenger = new Messenger({ namespace: MOCK_ANY_NAMESPACE });
+const messenger = new Messenger<string, TestAction>({
+  namespace: MOCK_ANY_NAMESPACE,
+});
 
 messenger.registerActionHandler('Example:TestAction', async () => 'B');
 

--- a/packages/json-rpc-engine/src/v2/createMethodMiddleware.test.ts
+++ b/packages/json-rpc-engine/src/v2/createMethodMiddleware.test.ts
@@ -1,5 +1,4 @@
 import { Messenger, MOCK_ANY_NAMESPACE } from '@metamask/messenger';
-import { JsonRpcParams } from '@metamask/utils';
 
 import { makeRequest } from '../../tests/utils';
 import {
@@ -15,13 +14,14 @@ type TestAction = {
 
 const getValueA = {
   hookNames: { testHook: true },
-  implementation: ({ hooks }) => hooks.testHook(),
+  implementation: ({ hooks }): Promise<string> => hooks.testHook(),
 } satisfies MethodHandler<{ testHook: () => Promise<string> }>;
 
 const getValueB = {
   actionNames: ['Example:TestAction'],
-  implementation: ({ messenger }) => messenger.call('Example:TestAction'),
-} satisfies MethodHandler<never, JsonRpcParams, TestAction>;
+  implementation: ({ messenger }): Promise<string> =>
+    messenger.call('Example:TestAction'),
+} satisfies MethodHandler<never, TestAction>;
 
 const messenger = new Messenger<string, TestAction>({
   namespace: MOCK_ANY_NAMESPACE,

--- a/packages/json-rpc-engine/src/v2/createMethodMiddleware.ts
+++ b/packages/json-rpc-engine/src/v2/createMethodMiddleware.ts
@@ -70,11 +70,11 @@ type ResolvedHandler = {
 
 /**
  * Create a JSON-RPC middleware that handles the passed JSON-RPC method handlers using the messenger and hooks.
- * 
+ *
  * @param options The options.
  * @param options.handlers - The JSON-RPC method handler implementations.
  * @param options.messenger - The messenger to be used by the handlers.
- * @param options.hooks - The hooks to be used by the handlers. 
+ * @param options.hooks - The hooks to be used by the handlers.
  * @returns A JsonRpcEngineV2 middleware.
  */
 export function createMethodMiddleware<

--- a/packages/json-rpc-engine/src/v2/createMethodMiddleware.ts
+++ b/packages/json-rpc-engine/src/v2/createMethodMiddleware.ts
@@ -4,25 +4,22 @@ import { JsonRpcMiddleware, Next } from './JsonRpcEngineV2';
 import { ContextConstraint } from './MiddlewareContext';
 import { Json, JsonRpcParams, JsonRpcRequest } from './utils';
 
-type HandlerActions<Handler> =
-  Handler extends MethodHandler<Record<string, unknown>, infer Actions> ? Actions : never;
+// The helpers below seem excessive, but they are required for inference of hooks/actions.
+type HandlerActions<Handler> = Handler extends {
+  implementation: (options: infer Options) => unknown;
+}
+  ? Options extends { messenger: Messenger<string, infer Actions> }
+    ? Actions
+    : never
+  : never;
 
-type HandlerHooks<Handler> =
-  Handler extends MethodHandler<infer Hooks> ? Hooks : never;
-
-export type MethodHandlerImplementation<
-  Hooks extends Record<string, unknown> = Record<string, never>,
-  MessengerActions extends ActionConstraint = never,
-  Parameters extends JsonRpcParams = JsonRpcParams,
-  Result extends Json = Json,
-  Context extends ContextConstraint = ContextConstraint,
-> = (options: {
-  request: Readonly<JsonRpcRequest<Parameters>>;
-  context: Context;
-  next: Next<JsonRpcRequest>;
-  messenger: Messenger<string, MessengerActions>;
-  hooks: Hooks;
-}) => Promise<Result> | Result;
+type HandlerHooks<Handler> = Handler extends {
+  implementation: (options: infer Options) => unknown;
+}
+  ? Options extends { hooks: infer Hooks }
+    ? Hooks
+    : never
+  : never;
 
 export type MethodHandler<
   Hooks extends Record<string, unknown> = Record<string, unknown>,
@@ -31,62 +28,73 @@ export type MethodHandler<
   Result extends Json = Json,
   Context extends ContextConstraint = ContextConstraint,
 > = {
-  implementation: MethodHandlerImplementation<
-    Hooks,
-    MessengerActions,
-    Parameters,
-    Result,
-    Context
-  >;
+  implementation: (options: {
+    request: Readonly<JsonRpcRequest<Parameters>>;
+    context: Context;
+    next: Next<JsonRpcRequest>;
+    messenger: Messenger<string, MessengerActions>;
+    hooks: Hooks;
+  }) => Promise<Result> | Result;
   hookNames?: { [Key in keyof Hooks]: true };
   actionNames?: MessengerActions['type'][];
 };
 
+type AnyMethodHandler = {
+  implementation(
+    this: void,
+    options: {
+      request: Readonly<JsonRpcRequest>;
+      context: ContextConstraint;
+      next: Next<JsonRpcRequest>;
+      messenger: unknown;
+      hooks: unknown;
+    },
+  ): Promise<Json> | Json;
+  hookNames?: Record<string, true>;
+  actionNames?: readonly string[];
+};
+
 export type CreateMethodMiddlewareOptions<
-  Handlers extends Record<string, MethodHandler>,
+  Handlers extends Record<string, AnyMethodHandler>,
 > = {
   handlers: Handlers;
   messenger: Messenger<string, HandlerActions<Handlers[keyof Handlers]>>;
   hooks: HandlerHooks<Handlers[keyof Handlers]>;
 };
 
-type ResolvedHandler<
-  Hooks extends Record<string, unknown> = Record<string, unknown>,
-  MessengerActions extends ActionConstraint = never,
-  Parameters extends JsonRpcParams = JsonRpcParams,
-  Result extends Json = Json,
-  Context extends ContextConstraint = ContextConstraint,
-> = {
-  implementation: MethodHandlerImplementation<
-    Hooks,
-    MessengerActions,
-    Parameters,
-    Result,
-    Context
-  >;
+type ResolvedHandler = {
+  implementation: AnyMethodHandler['implementation'];
   hooks: Record<string, unknown>;
-  messenger: Messenger<string, MessengerActions>;
+  messenger: Messenger<string, ActionConstraint>;
 };
 
 export function createMethodMiddleware<
-  Handlers extends Record<string, MethodHandler>,
+  Handlers extends Record<string, AnyMethodHandler>,
   Context extends ContextConstraint,
 >(
   options: CreateMethodMiddlewareOptions<Handlers>,
 ): JsonRpcMiddleware<JsonRpcRequest, Json, Context> {
-  const { messenger: rootMessenger, hooks: allHooks } = options;
+  const { messenger: rootMessenger } = options;
+  const allHooks = options.hooks as Record<string, unknown>;
 
   const handlers = Object.entries(options.handlers).reduce<
     Record<string, ResolvedHandler>
   >((accumulator, [handlerName, handler]) => {
     const handlerHooks = selectHooks(allHooks, handler.hookNames) ?? {};
-    const handlerMessenger = new Messenger({
+    const handlerMessenger = new Messenger<
+      string,
+      HandlerActions<Handlers[keyof Handlers]>,
+      never,
+      typeof rootMessenger
+    >({
       namespace: handlerName,
       parent: rootMessenger,
     });
 
     rootMessenger.delegate({
-      actions: handler.actionNames ?? [],
+      actions: (handler.actionNames ?? []) as HandlerActions<
+        Handlers[keyof Handlers]
+      >['type'][],
       messenger: handlerMessenger,
     });
 

--- a/packages/json-rpc-engine/src/v2/createMethodMiddleware.ts
+++ b/packages/json-rpc-engine/src/v2/createMethodMiddleware.ts
@@ -27,7 +27,7 @@ type HandlerHooks<Handler> = Handler extends {
   : never;
 
 export type MethodHandler<
-  Hooks extends Record<string, unknown> = Record<string, unknown>,
+  Hooks extends Record<string, unknown> = never,
   MessengerActions extends ActionConstraint = never,
   Parameters extends JsonRpcParams = JsonRpcParams,
   Result extends Json = Json,
@@ -40,9 +40,12 @@ export type MethodHandler<
     messenger: Messenger<string, MessengerActions>;
     hooks: Hooks;
   }) => Promise<Result> | Result;
-  hookNames?: { [Key in keyof Hooks]: true };
-  actionNames?: MessengerActions['type'][];
-};
+} & ([Hooks] extends [never]
+  ? { hookNames?: undefined }
+  : { hookNames: { [Key in keyof Hooks]: true } }) &
+  ([MessengerActions] extends [never]
+    ? { actionNames?: undefined }
+    : { actionNames: MessengerActions['type'][] });
 
 type AnyMethodHandler = {
   implementation(

--- a/packages/json-rpc-engine/src/v2/createMethodMiddleware.ts
+++ b/packages/json-rpc-engine/src/v2/createMethodMiddleware.ts
@@ -2,7 +2,12 @@ import { ActionConstraint, Messenger } from '@metamask/messenger';
 
 import { JsonRpcMiddleware, Next } from './JsonRpcEngineV2';
 import { ContextConstraint } from './MiddlewareContext';
-import { Json, JsonRpcParams, JsonRpcRequest } from './utils';
+import {
+  Json,
+  JsonRpcParams,
+  JsonRpcRequest,
+  UnionToIntersection,
+} from './utils';
 
 // The helpers below seem excessive, but they are required for inference of hooks/actions.
 type HandlerActions<Handler> = Handler extends {
@@ -59,7 +64,7 @@ export type CreateMethodMiddlewareOptions<
 > = {
   handlers: Handlers;
   messenger: Messenger<string, HandlerActions<Handlers[keyof Handlers]>>;
-  hooks: HandlerHooks<Handlers[keyof Handlers]>;
+  hooks: UnionToIntersection<HandlerHooks<Handlers[keyof Handlers]>>;
 };
 
 type ResolvedHandler = {

--- a/packages/json-rpc-engine/src/v2/createMethodMiddleware.ts
+++ b/packages/json-rpc-engine/src/v2/createMethodMiddleware.ts
@@ -1,37 +1,70 @@
-import { Messenger } from '@metamask/messenger';
+import { ActionConstraint, Messenger } from '@metamask/messenger';
 
 import { JsonRpcMiddleware, Next } from './JsonRpcEngineV2';
 import { ContextConstraint } from './MiddlewareContext';
-import { Json, JsonRpcRequest } from './utils';
+import { Json, JsonRpcParams, JsonRpcRequest } from './utils';
 
-export type MethodHandlerImplementation = (options: {
-  request: Readonly<JsonRpcRequest>;
-  context: any;
+type HandlerActions<Handler> =
+  Handler extends MethodHandler<any, any, infer Actions, any> ? Actions : never;
+
+export type MethodHandlerImplementation<
+  Hooks extends Record<string, unknown> = Record<string, never>,
+  Parameters extends JsonRpcParams = JsonRpcParams,
+  MessengerActions extends ActionConstraint = never,
+  Context extends ContextConstraint = ContextConstraint,
+> = (options: {
+  request: Readonly<JsonRpcRequest<Parameters>>;
+  context: Context;
   next: Next<JsonRpcRequest>;
-  messenger: Messenger;
-  hooks: any;
-}) => Json;
+  messenger: Messenger<string, MessengerActions>;
+  hooks: Hooks;
+}) => Promise<Json> | Json;
 
-export type MethodHandler = {
-  implementation: MethodHandlerImplementation;
-  hookNames?: Record<string, true>;
-  actionNames?: string[];
+export type MethodHandler<
+  Hooks extends Record<string, unknown> = Record<string, unknown>,
+  Parameters extends JsonRpcParams = JsonRpcParams,
+  MessengerActions extends ActionConstraint = never,
+  Context extends ContextConstraint = ContextConstraint,
+> = {
+  implementation: MethodHandlerImplementation<
+    Hooks,
+    Parameters,
+    MessengerActions,
+    Context
+  >;
+  hookNames?: { [Key in keyof Hooks]: true };
+  actionNames?: MessengerActions['type'][];
 };
 
-export type CreateMethodMiddlewareOptions = {
+export type CreateMethodMiddlewareOptions<
+  Handlers extends Record<string, MethodHandler>,
+> = {
   handlers: Record<string, MethodHandler>;
-  messenger: Messenger;
+  messenger: Messenger<string, HandlerActions<Handlers[keyof Handlers]>>;
   hooks: Record<string, unknown>;
 };
 
-type ResolvedHandler = {
-  implementation: MethodHandlerImplementation;
+type ResolvedHandler<
+  Hooks extends Record<string, unknown> = Record<string, unknown>,
+  Parameters extends JsonRpcParams = JsonRpcParams,
+  MessengerActions extends ActionConstraint = never,
+  Context extends ContextConstraint = ContextConstraint,
+> = {
+  implementation: MethodHandlerImplementation<
+    Hooks,
+    Parameters,
+    MessengerActions,
+    Context
+  >;
   hooks: Record<string, unknown>;
-  messenger: Messenger;
+  messenger: Messenger<string, MessengerActions>;
 };
 
-export function createMethodMiddleware<Context extends ContextConstraint>(
-  options: CreateMethodMiddlewareOptions,
+export function createMethodMiddleware<
+  Handlers extends Record<string, MethodHandler>,
+  Context extends ContextConstraint,
+>(
+  options: CreateMethodMiddlewareOptions<Handlers>,
 ): JsonRpcMiddleware<JsonRpcRequest, Json, Context> {
   const { messenger: rootMessenger, hooks: allHooks } = options;
 

--- a/packages/json-rpc-engine/src/v2/createMethodMiddleware.ts
+++ b/packages/json-rpc-engine/src/v2/createMethodMiddleware.ts
@@ -5,12 +5,16 @@ import { ContextConstraint } from './MiddlewareContext';
 import { Json, JsonRpcParams, JsonRpcRequest } from './utils';
 
 type HandlerActions<Handler> =
-  Handler extends MethodHandler<any, any, infer Actions, any> ? Actions : never;
+  Handler extends MethodHandler<Record<string, unknown>, infer Actions> ? Actions : never;
+
+type HandlerHooks<Handler> =
+  Handler extends MethodHandler<infer Hooks> ? Hooks : never;
 
 export type MethodHandlerImplementation<
   Hooks extends Record<string, unknown> = Record<string, never>,
-  Parameters extends JsonRpcParams = JsonRpcParams,
   MessengerActions extends ActionConstraint = never,
+  Parameters extends JsonRpcParams = JsonRpcParams,
+  Result extends Json = Json,
   Context extends ContextConstraint = ContextConstraint,
 > = (options: {
   request: Readonly<JsonRpcRequest<Parameters>>;
@@ -18,18 +22,20 @@ export type MethodHandlerImplementation<
   next: Next<JsonRpcRequest>;
   messenger: Messenger<string, MessengerActions>;
   hooks: Hooks;
-}) => Promise<Json> | Json;
+}) => Promise<Result> | Result;
 
 export type MethodHandler<
   Hooks extends Record<string, unknown> = Record<string, unknown>,
-  Parameters extends JsonRpcParams = JsonRpcParams,
   MessengerActions extends ActionConstraint = never,
+  Parameters extends JsonRpcParams = JsonRpcParams,
+  Result extends Json = Json,
   Context extends ContextConstraint = ContextConstraint,
 > = {
   implementation: MethodHandlerImplementation<
     Hooks,
-    Parameters,
     MessengerActions,
+    Parameters,
+    Result,
     Context
   >;
   hookNames?: { [Key in keyof Hooks]: true };
@@ -39,21 +45,23 @@ export type MethodHandler<
 export type CreateMethodMiddlewareOptions<
   Handlers extends Record<string, MethodHandler>,
 > = {
-  handlers: Record<string, MethodHandler>;
+  handlers: Handlers;
   messenger: Messenger<string, HandlerActions<Handlers[keyof Handlers]>>;
-  hooks: Record<string, unknown>;
+  hooks: HandlerHooks<Handlers[keyof Handlers]>;
 };
 
 type ResolvedHandler<
   Hooks extends Record<string, unknown> = Record<string, unknown>,
-  Parameters extends JsonRpcParams = JsonRpcParams,
   MessengerActions extends ActionConstraint = never,
+  Parameters extends JsonRpcParams = JsonRpcParams,
+  Result extends Json = Json,
   Context extends ContextConstraint = ContextConstraint,
 > = {
   implementation: MethodHandlerImplementation<
     Hooks,
-    Parameters,
     MessengerActions,
+    Parameters,
+    Result,
     Context
   >;
   hooks: Record<string, unknown>;

--- a/packages/json-rpc-engine/src/v2/createMethodMiddleware.ts
+++ b/packages/json-rpc-engine/src/v2/createMethodMiddleware.ts
@@ -68,6 +68,15 @@ type ResolvedHandler = {
   messenger: Messenger<string, ActionConstraint>;
 };
 
+/**
+ * Create a JSON-RPC middleware that handles the passed JSON-RPC method handlers using the messenger and hooks.
+ * 
+ * @param options The options.
+ * @param options.handlers - The JSON-RPC method handler implementations.
+ * @param options.messenger - The messenger to be used by the handlers.
+ * @param options.hooks - The hooks to be used by the handlers. 
+ * @returns A JsonRpcEngineV2 middleware.
+ */
 export function createMethodMiddleware<
   Handlers extends Record<string, AnyMethodHandler>,
   Context extends ContextConstraint,

--- a/packages/json-rpc-engine/src/v2/createMethodMiddleware.ts
+++ b/packages/json-rpc-engine/src/v2/createMethodMiddleware.ts
@@ -1,0 +1,102 @@
+import { Messenger } from '@metamask/messenger';
+
+import { JsonRpcMiddleware, Next } from './JsonRpcEngineV2';
+import { ContextConstraint } from './MiddlewareContext';
+import { Json, JsonRpcRequest } from './utils';
+
+export type MethodHandlerImplementation = (options: {
+  request: Readonly<JsonRpcRequest>;
+  context: any;
+  next: Next<JsonRpcRequest>;
+  messenger: Messenger;
+  hooks: any;
+}) => Json;
+
+export type MethodHandler = {
+  implementation: MethodHandlerImplementation;
+  hookNames?: Record<string, true>;
+  actionNames?: string[];
+};
+
+export type CreateMethodMiddlewareOptions = {
+  handlers: Record<string, MethodHandler>;
+  messenger: Messenger;
+  hooks: Record<string, unknown>;
+};
+
+type ResolvedHandler = {
+  implementation: MethodHandlerImplementation;
+  hooks: Record<string, unknown>;
+  messenger: Messenger;
+};
+
+export function createMethodMiddleware<Context extends ContextConstraint>(
+  options: CreateMethodMiddlewareOptions,
+): JsonRpcMiddleware<JsonRpcRequest, Json, Context> {
+  const { messenger: rootMessenger, hooks: allHooks } = options;
+
+  const handlers = Object.entries(options.handlers).reduce<
+    Record<string, ResolvedHandler>
+  >((accumulator, [handlerName, handler]) => {
+    const handlerHooks = selectHooks(allHooks, handler.hookNames) ?? {};
+    const handlerMessenger = new Messenger({
+      namespace: handlerName,
+      parent: rootMessenger,
+    });
+
+    rootMessenger.delegate({
+      actions: handler.actionNames ?? [],
+      messenger: handlerMessenger,
+    });
+
+    accumulator[handlerName] = {
+      implementation: handler.implementation,
+      hooks: handlerHooks,
+      messenger: handlerMessenger,
+    };
+    return accumulator;
+  }, {});
+
+  return ({ request, context, next }) => {
+    const handler = handlers[request.method];
+    if (handler === undefined) {
+      return next();
+    }
+
+    const { implementation, hooks, messenger } = handler;
+
+    return implementation({ request, context, next, hooks, messenger });
+  };
+}
+
+/**
+ * Returns the subset of the specified `hooks` that are included in the
+ * `hookNames` object. This is a Principle of Least Authority (POLA) measure
+ * to ensure that each RPC method implementation only has access to the
+ * API "hooks" it needs to do its job.
+ *
+ * @param hooks - The hooks to select from.
+ * @param hookNames - The names of the hooks to select.
+ * @returns The selected hooks.
+ * @template Hooks - The hooks to select from.
+ * @template HookName - The names of the hooks to select.
+ */
+export function selectHooks<
+  Hooks extends Record<string, unknown>,
+  HookName extends keyof Hooks,
+>(
+  hooks: Hooks,
+  hookNames?: Record<HookName, true>,
+): Pick<Hooks, HookName> | undefined {
+  if (hookNames) {
+    return Object.keys(hookNames).reduce<Partial<Pick<Hooks, HookName>>>(
+      (hookSubset, _hookName) => {
+        const hookName = _hookName as HookName;
+        hookSubset[hookName] = hooks[hookName];
+        return hookSubset;
+      },
+      {},
+    ) as Pick<Hooks, HookName>;
+  }
+  return undefined;
+}

--- a/packages/json-rpc-engine/src/v2/index.test.ts
+++ b/packages/json-rpc-engine/src/v2/index.test.ts
@@ -9,11 +9,13 @@ describe('@metamask/json-rpc-engine/v2', () => {
         "JsonRpcServer",
         "MiddlewareContext",
         "asLegacyMiddleware",
+        "createMethodMiddleware",
         "createOriginMiddleware",
         "createScaffoldMiddleware",
         "getUniqueId",
         "isNotification",
         "isRequest",
+        "selectHooks",
       ]
     `);
   });

--- a/packages/json-rpc-engine/src/v2/index.ts
+++ b/packages/json-rpc-engine/src/v2/index.ts
@@ -1,5 +1,6 @@
 export { asLegacyMiddleware } from './asLegacyMiddleware';
 export { getUniqueId } from '../getUniqueId';
+export { selectHooks, createMethodMiddleware } from './createMethodMiddleware';
 export { createOriginMiddleware } from './createOriginMiddleware';
 export { createScaffoldMiddleware } from './createScaffoldMiddleware';
 export { JsonRpcEngineV2 } from './JsonRpcEngineV2';

--- a/packages/json-rpc-engine/src/v2/index.ts
+++ b/packages/json-rpc-engine/src/v2/index.ts
@@ -1,6 +1,7 @@
 export { asLegacyMiddleware } from './asLegacyMiddleware';
 export { getUniqueId } from '../getUniqueId';
 export { selectHooks, createMethodMiddleware } from './createMethodMiddleware';
+export type { MethodHandler } from './createMethodMiddleware';
 export { createOriginMiddleware } from './createOriginMiddleware';
 export { createScaffoldMiddleware } from './createScaffoldMiddleware';
 export { JsonRpcEngineV2 } from './JsonRpcEngineV2';

--- a/packages/json-rpc-engine/tsconfig.build.json
+++ b/packages/json-rpc-engine/tsconfig.build.json
@@ -5,5 +5,10 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
+  "references": [
+    {
+      "path": "../messenger/tsconfig.build.json"
+    }
+  ],
   "include": ["../../types", "./src"]
 }

--- a/packages/json-rpc-engine/tsconfig.json
+++ b/packages/json-rpc-engine/tsconfig.json
@@ -9,5 +9,10 @@
     "noUncheckedIndexedAccess": true,
     "target": "es2020"
   },
+  "references": [
+    {
+      "path": "../messenger/tsconfig.json"
+    }
+  ],
   "include": ["../../types", "../../tests", "./src", "./tests"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4152,6 +4152,7 @@ __metadata:
     "@lavamoat/allow-scripts": "npm:^3.0.4"
     "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
     "@metamask/auto-changelog": "npm:^6.1.0"
+    "@metamask/messenger": "npm:^1.1.1"
     "@metamask/rpc-errors": "npm:^7.0.2"
     "@metamask/safe-event-emitter": "npm:^3.0.0"
     "@metamask/utils": "npm:^11.9.0"


### PR DESCRIPTION
## Explanation

This PR implements a `createMethodMiddleware` function which allows usage of **both** hooks and the messenger. Currently hooks are the only way JSON-RPC implementations can leverage controllers, services etc. They require more glue code to be written and are more difficult to type. This PR aims to provide a shared utility for constructing middlewares with multiple method implementations, while also allowing these implementations to use the messenger, cutting down the amount of glue code required in each client significantly.

## References

https://consensyssoftware.atlassian.net/browse/WPC-981

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new public middleware construction path and messenger delegation behavior, which could affect RPC handling/integration patterns for v2 consumers despite being additive.
> 
> **Overview**
> Adds a new `v2` utility, `createMethodMiddleware`, for wiring multiple JSON-RPC method handlers that can consume a *restricted subset* of provided hooks (`selectHooks`) and a per-method delegated `@metamask/messenger` instance.
> 
> Updates `@metamask/json-rpc-engine` to depend on `@metamask/messenger`, exports the new APIs from `v2/index`, adds coverage for hook/messenger delegation behavior, and updates build TS project references plus the changelog/README dependency graph accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a96f8823f26c19a4b19c722ca05ba3ac7feda998. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->