### PR TITLE
fix(transaction-pay-controller): proxy Across status polling via configured api base

### DIFF
--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/assets-controllers` from `^104.0.0` to `^104.1.0` ([#8509](https://github.com/MetaMask/core/pull/8509))
 
+### Fixed
+
+- Route Across status polling through the configured Across API base and support `depositTxnRef`/`fillTxnRef` for Across status responses ([#8512](https://github.com/MetaMask/core/pull/8512))
+
 ## [19.2.1]
 
 ### Fixed

--- a/packages/transaction-pay-controller/src/strategy/across/across-submit.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/across/across-submit.test.ts
@@ -139,7 +139,7 @@ describe('Across Submit', () => {
       transactionMeta: TRANSACTION_META_MOCK,
     });
     successfulFetchMock.mockResolvedValue({
-      json: async () => ({ status: 'pending' }),
+      json: async () => ({ status: 'success' }),
     } as Response);
   });
 
@@ -576,7 +576,7 @@ describe('Across Submit', () => {
       );
     });
 
-    it('polls Across status endpoint when quote includes a deposit id', async () => {
+    it('polls Across status endpoint with depositTxnRef from the source tx hash', async () => {
       const confirmedTransaction = {
         id: 'new-tx',
         chainId: '0x1',
@@ -633,9 +633,55 @@ describe('Across Submit', () => {
       });
 
       expect(successfulFetchMock).toHaveBeenCalledWith(
-        expect.stringContaining('/deposit/status?'),
+        expect.stringContaining('/deposit/status?depositTxnRef=0xconfirmed'),
         expect.objectContaining({ method: 'GET' }),
       );
+      expect(result.transactionHash).toBe('0xtarget');
+    });
+
+    it('uses the configured proxy for approvals and deposit status polling', async () => {
+      const proxyApiBase = 'https://intents.dev-api.cx.metamask.io/across';
+
+      getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+        ...getDefaultRemoteFeatureFlagControllerState(),
+        remoteFeatureFlags: {
+          confirmations_pay: {
+            payStrategies: {
+              across: {
+                apiBase: proxyApiBase,
+              },
+            },
+          },
+        },
+      });
+
+      setupConfirmedSubmission();
+
+      successfulFetchMock
+        .mockResolvedValueOnce({
+          json: async () => ({
+            ...QUOTE_MOCK.original.quote,
+          }),
+        } as Response)
+        .mockResolvedValueOnce({
+          json: async () => ({
+            destinationTxHash: '0xtarget',
+            status: 'success',
+          }),
+        } as Response);
+
+      const result = await submitAcrossQuotes({
+        messenger,
+        quotes: [buildDepositQuote()],
+        transaction: TRANSACTION_META_MOCK,
+        isSmartTransaction: jest.fn(),
+      });
+
+      const [statusUrl, statusOptions] = successfulFetchMock.mock.calls[1];
+      expect(statusUrl).toStrictEqual(
+        expect.stringContaining(`${proxyApiBase}/deposit/status?`),
+      );
+      expect(statusOptions).toMatchObject({ method: 'GET' });
       expect(result.transactionHash).toBe('0xtarget');
     });
 
@@ -745,6 +791,25 @@ describe('Across Submit', () => {
       });
 
       expect(result.transactionHash).toBe('0xfill');
+    });
+
+    it('returns fill txn ref when destination hash is missing', async () => {
+      setupConfirmedSubmission();
+      successfulFetchMock.mockResolvedValueOnce({
+        json: async () => ({
+          fillTxnRef: '0xfillref',
+          status: 'filled',
+        }),
+      } as Response);
+
+      const result = await submitAcrossQuotes({
+        messenger,
+        quotes: [buildDepositQuote()],
+        transaction: TRANSACTION_META_MOCK,
+        isSmartTransaction: jest.fn(),
+      });
+
+      expect(result.transactionHash).toBe('0xfillref');
     });
 
     it('returns tx hash when destination and fill hashes are missing', async () => {

--- a/packages/transaction-pay-controller/src/strategy/across/across-submit.ts
+++ b/packages/transaction-pay-controller/src/strategy/across/across-submit.ts
@@ -242,34 +242,30 @@ async function submitTransactions(
     ? getTransaction(transactionIds.slice(-1)[0], messenger)?.hash
     : undefined;
 
-  return await waitForAcrossCompletion(
-    quote.original,
-    hash as Hex | undefined,
-    messenger,
-  );
+  return await waitForAcrossCompletion(hash as Hex | undefined, messenger);
 }
 
 type AcrossStatusResponse = {
+  depositId?: number | string;
+  depositTxnRef?: Hex;
   status?: string;
   destinationTxHash?: Hex;
+  fillTxnRef?: Hex;
   fillTxHash?: Hex;
   txHash?: Hex;
 };
 
 async function waitForAcrossCompletion(
-  quote: AcrossQuote,
   transactionHash: Hex | undefined,
   messenger: TransactionPayControllerMessenger,
 ): Promise<Hex | undefined> {
-  if (!transactionHash || !quote.quote.id) {
+  if (!transactionHash) {
     return transactionHash;
   }
 
   const config = getPayStrategiesConfig(messenger);
   const params = new URLSearchParams({
-    depositId: quote.quote.id,
-    originChainId: String(quote.quote.swapTx.chainId),
-    txHash: transactionHash,
+    depositTxnRef: transactionHash,
   });
   const url = `${config.across.apiBase}/deposit/status?${params.toString()}`;
 
@@ -314,6 +310,7 @@ async function waitForAcrossCompletion(
     ) {
       return (
         status.destinationTxHash ??
+        status.fillTxnRef ??
         status.fillTxHash ??
         status.txHash ??
         transactionHash


### PR DESCRIPTION
## Summary
- route Across status polling through the configured Across `apiBase` instead of the direct upstream URL
- poll Across deposit status with `depositTxnRef` and accept `fillTxnRef` as a terminal transaction hash fallback
- read `confirmations_pay` from remote feature flags or local overrides, and use `http://localhost:3000/across` when `confirmations_pay.dev` is enabled without an explicit Across base
- add focused tests and changelog coverage for the new behavior

## Validation
- `yarn workspace @metamask/transaction-pay-controller run jest --no-coverage src/strategy/across/across-submit.test.ts src/utils/feature-flags.test.ts`
- `yarn eslint packages/transaction-pay-controller/src/strategy/across/across-submit.ts packages/transaction-pay-controller/src/strategy/across/across-submit.test.ts packages/transaction-pay-controller/src/utils/feature-flags.ts packages/transaction-pay-controller/src/utils/feature-flags.test.ts`
- `yarn workspace @metamask/transaction-pay-controller run changelog:validate`
- `yarn build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Across bridging completion logic and status polling parameters/base URL; misconfiguration or unexpected API response shapes could cause submissions to appear stuck or resolve to the wrong final hash.
> 
> **Overview**
> Across submission now polls the `/deposit/status` endpoint via the configured `confirmations_pay.payStrategies.across.apiBase` (instead of relying on quote-provided/upstream URL details) and uses the source transaction hash as `depositTxnRef`.
> 
> Status completion handling is updated to accept `fillTxnRef` as an additional terminal transaction hash fallback (before `fillTxHash`/`txHash`). Tests are adjusted/added to assert the new polling URL/params and hash fallback behavior, and the changelog documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c73a02118b333f2ee41cdfe65b584155551a1ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->