### PR TITLE
feat(perps-controller): sync controller from mobile c2248a8a9e

### DIFF
--- a/packages/perps-controller/.sync-state.json
+++ b/packages/perps-controller/.sync-state.json
@@ -1,8 +1,8 @@
 {
-  "lastSyncedMobileCommit": "14dbdb4e3c7d218fe4f74984969c55142656fcf1",
-  "lastSyncedMobileBranch": "fix/perps/myx-webpack-ignore-restore",
-  "lastSyncedCoreCommit": "796d13b6e190fc481461bd268a1dd3820ca7b9a9",
-  "lastSyncedCoreBranch": "fix/perps/myx-webpack-ignore-restore-clean",
-  "lastSyncedDate": "2026-04-15T16:45:31Z",
-  "sourceChecksum": "5be7d584829db03e7449d06a8c329816966d2dd218a9fa42d57f07c22b00bc51"
+  "lastSyncedMobileCommit": "c2248a8a9e83e02f1fcb1b95ec33c23f5cde2a5d",
+  "lastSyncedMobileBranch": "sync-perps-core",
+  "lastSyncedCoreCommit": "e30c0b11e0808242382f62283b1643cc6723cf4a",
+  "lastSyncedCoreBranch": "latest-perps-sync",
+  "lastSyncedDate": "2026-04-17T16:42:46Z",
+  "sourceChecksum": "8cd74a6ee57a4ead596f0eea26176aa9d386da905b6306928b347aafbf28a0c0"
 }

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -9,19 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `isAbortError` utility export from `utils` for distinguishing expected cancellation errors from real failures ([#8510](https://github.com/MetaMask/core/pull/8510))
+- Add `isAbortError` utility export from `utils` for distinguishing expected cancellation errors from real failures ([#8515](https://github.com/MetaMask/core/pull/8515))
 
 ### Changed
 
-- `TradingService.flipPosition()` no longer passes stale position `entryPrice` as `currentPrice` on reverse-position orders; providers now validate and price flips against live market data ([#8510](https://github.com/MetaMask/core/pull/8510))
+- `TradingService.flipPosition()` no longer passes stale position `entryPrice` as `currentPrice` on reverse-position orders; providers now validate and price flips against live market data ([#8515](https://github.com/MetaMask/core/pull/8515))
 
 ### Removed
 
-- Remove unused `ESTIMATED_FEE_RATE` export from `constants/hyperLiquidConfig` (dead code after reverse-position fee precheck was removed) ([#8510](https://github.com/MetaMask/core/pull/8510))
+- Remove unused `ESTIMATED_FEE_RATE` export from `constants/hyperLiquidConfig` (dead code after reverse-position fee precheck was removed) ([#8515](https://github.com/MetaMask/core/pull/8515))
 
 ### Fixed
 
-- Suppress noisy Sentry reports from expected historical-candle fetch cancellations (`AbortError`) during navigation, while preserving real error reporting in `HyperLiquidClientService` and `MarketDataService` ([#8510](https://github.com/MetaMask/core/pull/8510))
+- Suppress noisy Sentry reports from expected historical-candle fetch cancellations (`AbortError`) during navigation, while preserving real error reporting in `HyperLiquidClientService` and `MarketDataService` ([#8515](https://github.com/MetaMask/core/pull/8515))
 
 ## [3.1.1]
 

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `isAbortError` utility export from `utils` for distinguishing expected cancellation errors from real failures ([#8510](https://github.com/MetaMask/core/pull/8510))
+
+### Changed
+
+- `TradingService.flipPosition()` no longer passes stale position `entryPrice` as `currentPrice` on reverse-position orders; providers now validate and price flips against live market data ([#8510](https://github.com/MetaMask/core/pull/8510))
+
+### Removed
+
+- Remove unused `ESTIMATED_FEE_RATE` export from `constants/hyperLiquidConfig` (dead code after reverse-position fee precheck was removed) ([#8510](https://github.com/MetaMask/core/pull/8510))
+
+### Fixed
+
+- Suppress noisy Sentry reports from expected historical-candle fetch cancellations (`AbortError`) during navigation, while preserving real error reporting in `HyperLiquidClientService` and `MarketDataService` ([#8510](https://github.com/MetaMask/core/pull/8510))
+
 ## [3.1.1]
 
 ### Fixed

--- a/packages/perps-controller/src/constants/hyperLiquidConfig.ts
+++ b/packages/perps-controller/src/constants/hyperLiquidConfig.ts
@@ -199,7 +199,6 @@ export const DEPOSIT_CONFIG = {
 
 // Withdrawal constants (HyperLiquid-specific)
 export const HYPERLIQUID_WITHDRAWAL_MINUTES = 5; // HyperLiquid withdrawal processing time in minutes
-export const ESTIMATED_FEE_RATE = 0.0009; // 0.09% taker fee estimate for flip operations (close + open)
 
 // Type helpers
 export type SupportedAsset = keyof typeof HYPERLIQUID_ASSET_CONFIGS;

--- a/packages/perps-controller/src/index.ts
+++ b/packages/perps-controller/src/index.ts
@@ -431,7 +431,7 @@ export {
   aggregateAccountStates,
 } from './utils';
 export type { ReturnOnEquityInput } from './utils';
-export { ensureError } from './utils';
+export { ensureError, isAbortError } from './utils';
 export type {
   OrderBookCacheEntry,
   ProcessL2BookDataParams,

--- a/packages/perps-controller/src/services/HyperLiquidClientService.ts
+++ b/packages/perps-controller/src/services/HyperLiquidClientService.ts
@@ -18,7 +18,7 @@ import type {
 } from '../types';
 import type { HyperLiquidNetwork } from '../types/config';
 import type { CandleData } from '../types/perps-types';
-import { ensureError } from '../utils/errorUtils';
+import { ensureError, isAbortError } from '../utils/errorUtils';
 import { getPerpsConnectionAttemptContext } from '../utils/perpsConnectionAttemptContext';
 
 /**
@@ -532,6 +532,11 @@ export class HyperLiquidClientService {
         error,
         'HyperLiquidClientService.fetchHistoricalCandles',
       );
+
+      // Expected cancellation — skip Sentry to avoid noisy abort reports
+      if (isAbortError(error)) {
+        throw error;
+      }
 
       // Log to Sentry: prevents initial chart data load
       this.#deps.logger.error(errorInstance, {

--- a/packages/perps-controller/src/services/MarketDataService.ts
+++ b/packages/perps-controller/src/services/MarketDataService.ts
@@ -32,7 +32,7 @@ import type {
   PerpsPlatformDependencies,
 } from '../types';
 import type { CandleData } from '../types/perps-types';
-import { ensureError } from '../utils/errorUtils';
+import { ensureError, isAbortError } from '../utils/errorUtils';
 import type { ServiceContext } from './ServiceContext';
 
 /**
@@ -779,33 +779,36 @@ export class MarketDataService {
           ? error.message
           : 'Failed to fetch historical candles';
 
-      this.#deps.logger.error(
-        ensureError(error, 'MarketDataService.fetchHistoricalCandles'),
-        {
-          tags: {
-            feature: PERPS_CONSTANTS.FeatureName,
-            provider: context.tracingContext.provider,
-            network: context.tracingContext.isTestnet ? 'testnet' : 'mainnet',
-          },
-          context: {
-            name: context.errorContext.controller,
-            data: {
-              method: context.errorContext.method,
-              symbol,
-              interval,
-              limit,
-              endTime,
+      // Expected cancellation — skip Sentry and state updates
+      if (!isAbortError(error)) {
+        this.#deps.logger.error(
+          ensureError(error, 'MarketDataService.fetchHistoricalCandles'),
+          {
+            tags: {
+              feature: PERPS_CONSTANTS.FeatureName,
+              provider: context.tracingContext.provider,
+              network: context.tracingContext.isTestnet ? 'testnet' : 'mainnet',
+            },
+            context: {
+              name: context.errorContext.controller,
+              data: {
+                method: context.errorContext.method,
+                symbol,
+                interval,
+                limit,
+                endTime,
+              },
             },
           },
-        },
-      );
+        );
 
-      // Update error state (if stateManager is provided)
-      if (context.stateManager) {
-        context.stateManager.update((state) => {
-          state.lastError = errorMessage;
-          state.lastUpdateTimestamp = Date.now();
-        });
+        // Update error state (if stateManager is provided)
+        if (context.stateManager) {
+          context.stateManager.update((state) => {
+            state.lastError = errorMessage;
+            state.lastUpdateTimestamp = Date.now();
+          });
+        }
       }
 
       traceData = {

--- a/packages/perps-controller/src/services/TradingService.ts
+++ b/packages/perps-controller/src/services/TradingService.ts
@@ -4,7 +4,6 @@ import {
   PERPS_EVENT_PROPERTY,
   PERPS_EVENT_VALUE,
 } from '../constants/eventNames';
-import { ESTIMATED_FEE_RATE } from '../constants/hyperLiquidConfig';
 import { isTPSLOrder } from '../constants/orderTypes';
 import { PerpsMeasurementName } from '../constants/performanceMetrics';
 import { PERPS_CONSTANTS } from '../constants/perpsConfig';
@@ -1942,43 +1941,28 @@ export class TradingService {
       const isCurrentlyLong = parseFloat(position.size) > 0;
       const oppositeDirection = !isCurrentlyLong;
 
-      // Validate available balance for fees
-      const accountState = await provider.getAccountState?.();
-      if (!accountState) {
-        throw new Error('Failed to get account state');
-      }
-
-      const availableBalance = parseFloat(accountState.availableBalance);
-
-      // Estimate fees: ESTIMATED_FEE_RATE (0.09%) already accounts for both legs
-      // (close at 0.045% + open at 0.045% = 0.09% of position notional).
-      // Apply to 1x notional (positionSize * entryPrice), not 2x (flipSize * entryPrice).
-      const entryPrice = parseFloat(position.entryPrice);
       const flipSize = positionSize * 2;
-      const notionalValue = positionSize * entryPrice;
-      const estimatedFees = notionalValue * ESTIMATED_FEE_RATE;
-
-      if (estimatedFees > availableBalance) {
-        throw new Error(
-          `Insufficient balance for flip fees. Need $${estimatedFees.toFixed(2)}, have $${availableBalance.toFixed(2)}`,
-        );
-      }
 
       // Create order params for flip
-      // Use 2x position size: 1x to close current position + 1x to open opposite position
+      // Use 2x position size: 1x to close current position + 1x to open opposite position.
+      // Do not pass the position entry price as currentPrice: the provider must fetch
+      // live market data for validation and IOC pricing.
       const orderParams: OrderParams = {
         symbol: position.symbol,
         isBuy: oppositeDirection,
         size: flipSize.toString(),
         orderType: 'market',
         leverage: position.leverage?.value,
-        currentPrice: entryPrice,
       };
 
       // Place flip order (HyperLiquid handles margin transfer automatically)
       const result = await provider.placeOrder(orderParams);
 
       const completionDuration = this.#deps.performance.now() - startTime;
+
+      const executedPrice = parseFloat(
+        result.averagePrice ?? position.entryPrice,
+      );
 
       if (result.success) {
         // Update state on success
@@ -2006,8 +1990,7 @@ export class TradingService {
             [PERPS_EVENT_PROPERTY.ORDER_SIZE]: positionSize,
             [PERPS_EVENT_PROPERTY.COMPLETION_DURATION]: completionDuration,
             [PERPS_EVENT_PROPERTY.ACTION]: flipAction,
-            [PERPS_EVENT_PROPERTY.ORDER_VALUE]:
-              positionSize * parseFloat(position.entryPrice),
+            [PERPS_EVENT_PROPERTY.ORDER_VALUE]: positionSize * executedPrice,
           },
         );
 

--- a/packages/perps-controller/src/utils/errorUtils.ts
+++ b/packages/perps-controller/src/utils/errorUtils.ts
@@ -5,6 +5,25 @@
 import { hasProperty } from '@metamask/utils';
 
 /**
+ * Detects expected cancellation/abort errors that should not be reported to Sentry.
+ * These occur during normal navigation or view teardown when in-flight fetch requests
+ * are cancelled via AbortController.
+ *
+ * @param error - The error to check.
+ * @returns True if the error is an expected abort/cancellation.
+ */
+export function isAbortError(error: unknown): boolean {
+  if (error instanceof Error) {
+    return (
+      error.name === 'AbortError' ||
+      error.message.includes('signal is aborted') ||
+      error.message.includes('The operation was aborted')
+    );
+  }
+  return false;
+}
+
+/**
  * Ensures we have a proper Error object for logging.
  * Converts unknown/string errors to proper Error instances.
  * Handles undefined/null specially for better Sentry context.


### PR DESCRIPTION
Syncs app/controllers/perps/ from mobile commit c2248a8a9e.

Changes:
- Add isAbortError utility; suppress noisy Sentry reports from expected historical-candle fetch cancellations (HyperLiquidClientService, MarketDataService) ([#28953](https://github.com/MetaMask/metamask-mobile/pull/28953))
- Remove unused ESTIMATED_FEE_RATE from hyperLiquidConfig ([#28957](https://github.com/MetaMask/metamask-mobile/pull/28957))
- TradingService.flipPosition no longer passes stale entryPrice as currentPrice; providers now price flips against live market data ([#28897](https://github.com/MetaMask/metamask-mobile/pull/28897))

## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches trading execution (`flipPosition`) and error-reporting/state-update paths for candle fetching; behavior changes could affect flip validation/pricing and reduce visibility if abort detection misclassifies real failures.
> 
> **Overview**
> Updates perps historical-candle fetching to treat `AbortError` as an expected cancellation: adds `isAbortError` (exported from `utils`) and uses it in `HyperLiquidClientService`/`MarketDataService` to skip Sentry logging (and error-state updates in `MarketDataService`) for aborted requests.
> 
> Changes `TradingService.flipPosition()` to stop sending the position’s `entryPrice` as `currentPrice` on flip market orders, relying on providers to validate/price against live market data; analytics `ORDER_VALUE` now prefers the order’s executed `averagePrice` when available. Removes the now-dead `ESTIMATED_FEE_RATE` constant and updates the changelog/sync metadata accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 043ebf334fb6cac8452a33c1a919b94a8689e1bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->