### PR TITLE
feat(perps-controller): add UI-safe subpath exports for formatters, calculations, constants

### DIFF
--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add UI-safe subpath exports `./formatters`, `./calculations`, and `./constants` so consumers can import pure formatting/calc utilities (`perpsFormatters`, `orderCalculations`, `perpsConfig`) without transitively loading the HyperLiquid SDK. This avoids pulling ESM-only `@noble/hashes` into CJS Jest environments where `transformIgnorePatterns` is not customized.
+- Add UI-safe subpath exports `./formatters`, `./calculations`, `./constants`, and `./constants/hyperliquid` so consumers can import pure formatting/calc utilities (`perpsFormatters`, `orderCalculations`, `perpsConfig`, `hyperLiquidConfig`) without transitively loading the HyperLiquid SDK. This avoids pulling ESM-only `@noble/hashes` into CJS Jest environments where `transformIgnorePatterns` is not customized.
 
 ## [3.2.0]
 

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add UI-safe subpath exports `./formatters`, `./calculations`, and `./constants` so consumers can import pure formatting/calc utilities (`perpsFormatters`, `orderCalculations`, `perpsConfig`) without transitively loading the HyperLiquid SDK. This avoids pulling ESM-only `@noble/hashes` into CJS Jest environments where `transformIgnorePatterns` is not customized.
+
 ## [3.2.0]
 
 ### Added

--- a/packages/perps-controller/package.json
+++ b/packages/perps-controller/package.json
@@ -65,6 +65,16 @@
         "default": "./dist/constants/perpsConfig.cjs"
       }
     },
+    "./constants/hyperliquid": {
+      "import": {
+        "types": "./dist/constants/hyperLiquidConfig.d.mts",
+        "default": "./dist/constants/hyperLiquidConfig.mjs"
+      },
+      "require": {
+        "types": "./dist/constants/hyperLiquidConfig.d.cts",
+        "default": "./dist/constants/hyperLiquidConfig.cjs"
+      }
+    },
     "./package.json": "./package.json"
   },
   "publishConfig": {

--- a/packages/perps-controller/package.json
+++ b/packages/perps-controller/package.json
@@ -35,6 +35,36 @@
         "default": "./dist/index.cjs"
       }
     },
+    "./formatters": {
+      "import": {
+        "types": "./dist/utils/perpsFormatters.d.mts",
+        "default": "./dist/utils/perpsFormatters.mjs"
+      },
+      "require": {
+        "types": "./dist/utils/perpsFormatters.d.cts",
+        "default": "./dist/utils/perpsFormatters.cjs"
+      }
+    },
+    "./calculations": {
+      "import": {
+        "types": "./dist/utils/orderCalculations.d.mts",
+        "default": "./dist/utils/orderCalculations.mjs"
+      },
+      "require": {
+        "types": "./dist/utils/orderCalculations.d.cts",
+        "default": "./dist/utils/orderCalculations.cjs"
+      }
+    },
+    "./constants": {
+      "import": {
+        "types": "./dist/constants/perpsConfig.d.mts",
+        "default": "./dist/constants/perpsConfig.mjs"
+      },
+      "require": {
+        "types": "./dist/constants/perpsConfig.d.cts",
+        "default": "./dist/constants/perpsConfig.cjs"
+      }
+    },
     "./package.json": "./package.json"
   },
   "publishConfig": {


### PR DESCRIPTION
## Explanation

The `@metamask/perps-controller` package currently exposes a single entry point that transitively loads the HyperLiquid SDK, which pulls in the ESM-only `@noble/hashes` package. In CJS Jest environments where consumers have not customized `transformIgnorePatterns`, importing anything from this package forces them to configure Babel/Jest transforms for `@noble/hashes`, or their test suites break.

This PR adds three new UI-safe subpath exports so consumers can import pure formatting/calculation utilities without triggering the SDK chain:

- `@metamask/perps-controller/formatters` → `perpsFormatters`
- `@metamask/perps-controller/calculations` → `orderCalculations`
- `@metamask/perps-controller/constants` → `perpsConfig`

Each entry exports both ESM (`.mjs` / `.d.mts`) and CJS (`.cjs` / `.d.cts`) artifacts matching the existing `.` export shape.

## References

N/A

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds new `package.json` export entrypoints and a changelog note, without changing runtime logic. Main risk is misconfigured export paths/types causing consumer import or build failures.
> 
> **Overview**
> Adds UI-safe subpath exports for `@metamask/perps-controller` (`./formatters`, `./calculations`, `./constants`, `./constants/hyperliquid`) so consumers can import formatting/calculation utilities and config without pulling in the HyperLiquid SDK (and its ESM-only transitive deps) in CJS/Jest environments.
> 
> Updates the package changelog to document these new entrypoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07b4c4c9a3138a4f8262eccc6b3559036be2a9fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->