### PR TITLE
feat(social-controllers): source profileId from JWT on follow/unfollow/updateFollowing

### DIFF
--- a/packages/social-controllers/CHANGELOG.md
+++ b/packages/social-controllers/CHANGELOG.md
@@ -9,10 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** `SocialService.follow`, `SocialService.unfollow`, and `SocialController.followTrader`, `SocialController.unfollowTrader` no longer accept an `addressOrUid` option. The caller is identified server-side from the JWT `sub` claim carried in the `Authorization` header.
-- **BREAKING:** `SocialService.fetchFollowing` and `SocialController.updateFollowing` now take no arguments (previously `{ addressOrUid }`).
-- **BREAKING:** Remove `FetchFollowingOptions` type export (no longer needed).
-- `SocialService` now calls `PUT /v1/users/me/follows`, `DELETE /v1/users/me/follows`, and `GET /v1/users/me/following` (previously `/v1/users/:addressOrUid/...`).
+- **BREAKING:** `SocialService.follow`, `SocialService.unfollow`, and `SocialController.followTrader`, `SocialController.unfollowTrader` no longer accept an `addressOrUid` option. The caller is identified server-side from the JWT `sub` claim carried in the `Authorization` header. ([#8520](https://github.com/MetaMask/core/pull/8520))
+- **BREAKING:** `SocialService.fetchFollowing` and `SocialController.updateFollowing` now take no arguments (previously `{ addressOrUid }`). ([#8520](https://github.com/MetaMask/core/pull/8520))
+- **BREAKING:** Remove `FetchFollowingOptions` type export (no longer needed). ([#8520](https://github.com/MetaMask/core/pull/8520))
+- `SocialService` now calls `PUT /v1/users/me/follows`, `DELETE /v1/users/me/follows`, and `GET /v1/users/me/following` (previously `/v1/users/:addressOrUid/...`). ([#8520](https://github.com/MetaMask/core/pull/8520))
 
 ## [1.0.0]
 

--- a/packages/social-controllers/CHANGELOG.md
+++ b/packages/social-controllers/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING:** `SocialService.follow`, `SocialService.unfollow`, and `SocialController.followTrader`, `SocialController.unfollowTrader` no longer accept an `addressOrUid` option. The caller is identified server-side from the JWT `sub` claim carried in the `Authorization` header.
+- **BREAKING:** `SocialService.fetchFollowing` and `SocialController.updateFollowing` now take no arguments (previously `{ addressOrUid }`).
+- **BREAKING:** Remove `FetchFollowingOptions` type export (no longer needed).
+- `SocialService` now calls `PUT /v1/users/me/follows`, `DELETE /v1/users/me/follows`, and `GET /v1/users/me/following` (previously `/v1/users/:addressOrUid/...`).
+
 ## [1.0.0]
 
 ### Uncategorized

--- a/packages/social-controllers/src/SocialController-method-action-types.ts
+++ b/packages/social-controllers/src/SocialController-method-action-types.ts
@@ -17,10 +17,11 @@ export type SocialControllerUpdateLeaderboardAction = {
 };
 
 /**
- * Follows one or more traders and updates the following list in state.
+ * Follows one or more traders on behalf of the current user and updates
+ * the following list in state. The caller is identified server-side from
+ * the JWT attached by the SocialService.
  *
  * @param options - Options bag.
- * @param options.addressOrUid - Wallet address or Clicker profile ID of the current user.
  * @param options.targets - Addresses or profile IDs to follow.
  * @returns The follow response with confirmed follows.
  */
@@ -30,10 +31,11 @@ export type SocialControllerFollowTraderAction = {
 };
 
 /**
- * Unfollows one or more traders and updates the following list in state.
+ * Unfollows one or more traders on behalf of the current user and updates
+ * the following list in state. The caller is identified server-side from
+ * the JWT attached by the SocialService.
  *
  * @param options - Options bag.
- * @param options.addressOrUid - Wallet address or Clicker profile ID of the current user.
  * @param options.targets - Addresses or profile IDs to unfollow.
  * @returns The unfollow response with confirmed unfollows.
  */
@@ -44,10 +46,9 @@ export type SocialControllerUnfollowTraderAction = {
 
 /**
  * Fetches the list of traders the current user follows and replaces
- * the following addresses in state.
+ * the following addresses in state. The caller is identified server-side
+ * from the JWT attached by the SocialService.
  *
- * @param options - Options bag.
- * @param options.addressOrUid - Wallet address or Clicker profile ID of the current user.
  * @returns The following response.
  */
 export type SocialControllerUpdateFollowingAction = {

--- a/packages/social-controllers/src/SocialController.test.ts
+++ b/packages/social-controllers/src/SocialController.test.ts
@@ -237,12 +237,10 @@ describe('SocialController', () => {
       const { controller } = createController({ rootMessenger });
 
       const result = await controller.followTrader({
-        addressOrUid: '0xuser',
         targets: ['0x1111111111111111111111111111111111111111'],
       });
 
       expect(follow).toHaveBeenCalledWith({
-        addressOrUid: '0xuser',
         targets: ['0x1111111111111111111111111111111111111111'],
       });
       expect(result.followed).toStrictEqual([mockProfileSummary]);
@@ -267,7 +265,6 @@ describe('SocialController', () => {
       const { controller } = createController({ rootMessenger });
 
       await controller.followTrader({
-        addressOrUid: '0xuser',
         targets: [
           '0x1111111111111111111111111111111111111111',
           '0x2222222222222222222222222222222222222222',
@@ -297,7 +294,6 @@ describe('SocialController', () => {
       const { controller } = createController({ rootMessenger });
 
       await controller.followTrader({
-        addressOrUid: '0xuser',
         targets: ['0x1111111111111111111111111111111111111111'],
       });
 
@@ -320,11 +316,9 @@ describe('SocialController', () => {
       const { controller } = createController({ rootMessenger });
 
       await controller.followTrader({
-        addressOrUid: '0xuser',
         targets: ['0x1111111111111111111111111111111111111111'],
       });
       await controller.followTrader({
-        addressOrUid: '0xuser',
         targets: ['0x1111111111111111111111111111111111111111'],
       });
 
@@ -347,7 +341,6 @@ describe('SocialController', () => {
       const { messenger } = createController({ rootMessenger });
 
       const result = await messenger.call('SocialController:followTrader', {
-        addressOrUid: '0xuser',
         targets: ['0xaaaa'],
       });
 
@@ -378,12 +371,10 @@ describe('SocialController', () => {
       });
 
       const result = await controller.unfollowTrader({
-        addressOrUid: '0xuser',
         targets: ['0x1111111111111111111111111111111111111111'],
       });
 
       expect(unfollow).toHaveBeenCalledWith({
-        addressOrUid: '0xuser',
         targets: ['0x1111111111111111111111111111111111111111'],
       });
       expect(result.unfollowed).toStrictEqual([mockProfileSummary]);
@@ -409,7 +400,6 @@ describe('SocialController', () => {
       });
 
       await controller.unfollowTrader({
-        addressOrUid: '0xuser',
         targets: ['0x1111111111111111111111111111111111111111'],
       });
 
@@ -428,7 +418,6 @@ describe('SocialController', () => {
       const { messenger } = createController({ rootMessenger });
 
       const result = await messenger.call('SocialController:unfollowTrader', {
-        addressOrUid: '0xuser',
         targets: ['0xaaaa'],
       });
 
@@ -457,13 +446,9 @@ describe('SocialController', () => {
         },
       });
 
-      const result = await controller.updateFollowing({
-        addressOrUid: '0xuser',
-      });
+      const result = await controller.updateFollowing();
 
-      expect(fetchFollowing).toHaveBeenCalledWith({
-        addressOrUid: '0xuser',
-      });
+      expect(fetchFollowing).toHaveBeenCalledWith();
       expect(result.following).toStrictEqual([mockProfileSummary]);
       expect(controller.state.followingAddresses).toStrictEqual([
         '0x1111111111111111111111111111111111111111',
@@ -489,7 +474,7 @@ describe('SocialController', () => {
         },
       });
 
-      await controller.updateFollowing({ addressOrUid: '0xuser' });
+      await controller.updateFollowing();
 
       expect(controller.state.followingAddresses).toStrictEqual([]);
       expect(controller.state.followingProfileIds).toStrictEqual([]);
@@ -508,9 +493,9 @@ describe('SocialController', () => {
 
       const { messenger } = createController({ rootMessenger });
 
-      const result = await messenger.call('SocialController:updateFollowing', {
-        addressOrUid: '0xuser',
-      });
+      const result = await messenger.call(
+        'SocialController:updateFollowing',
+      );
 
       expect(result.following).toStrictEqual([mockProfileSummary]);
     });
@@ -545,7 +530,6 @@ describe('SocialController', () => {
 
       await expect(
         controller.followTrader({
-          addressOrUid: '0xuser',
           targets: ['0xaaaa'],
         }),
       ).rejects.toThrow('follow failed');
@@ -567,7 +551,6 @@ describe('SocialController', () => {
 
       await expect(
         controller.unfollowTrader({
-          addressOrUid: '0xuser',
           targets: ['0xaaaa'],
         }),
       ).rejects.toThrow('unfollow failed');
@@ -588,7 +571,7 @@ describe('SocialController', () => {
       });
 
       await expect(
-        controller.updateFollowing({ addressOrUid: '0xuser' }),
+        controller.updateFollowing(),
       ).rejects.toThrow('fetch following failed');
       expect(controller.state.followingAddresses).toStrictEqual(['0xold']);
     });

--- a/packages/social-controllers/src/SocialController.test.ts
+++ b/packages/social-controllers/src/SocialController.test.ts
@@ -493,9 +493,7 @@ describe('SocialController', () => {
 
       const { messenger } = createController({ rootMessenger });
 
-      const result = await messenger.call(
-        'SocialController:updateFollowing',
-      );
+      const result = await messenger.call('SocialController:updateFollowing');
 
       expect(result.following).toStrictEqual([mockProfileSummary]);
     });
@@ -570,9 +568,9 @@ describe('SocialController', () => {
         state: { followingAddresses: ['0xold'] },
       });
 
-      await expect(
-        controller.updateFollowing(),
-      ).rejects.toThrow('fetch following failed');
+      await expect(controller.updateFollowing()).rejects.toThrow(
+        'fetch following failed',
+      );
       expect(controller.state.followingAddresses).toStrictEqual(['0xold']);
     });
   });

--- a/packages/social-controllers/src/SocialController.ts
+++ b/packages/social-controllers/src/SocialController.ts
@@ -8,7 +8,6 @@ import type { Messenger } from '@metamask/messenger';
 
 import { controllerName } from './social-constants';
 import type {
-  FetchFollowingOptions,
   FetchLeaderboardOptions,
   FollowOptions,
   FollowResponse,
@@ -172,10 +171,11 @@ export class SocialController extends BaseController<
   }
 
   /**
-   * Follows one or more traders and updates the following list in state.
+   * Follows one or more traders on behalf of the current user and updates
+   * the following list in state. The caller is identified server-side from
+   * the JWT attached by the SocialService.
    *
    * @param options - Options bag.
-   * @param options.addressOrUid - Wallet address or Clicker profile ID of the current user.
    * @param options.targets - Addresses or profile IDs to follow.
    * @returns The follow response with confirmed follows.
    */
@@ -208,10 +208,11 @@ export class SocialController extends BaseController<
   }
 
   /**
-   * Unfollows one or more traders and updates the following list in state.
+   * Unfollows one or more traders on behalf of the current user and updates
+   * the following list in state. The caller is identified server-side from
+   * the JWT attached by the SocialService.
    *
    * @param options - Options bag.
-   * @param options.addressOrUid - Wallet address or Clicker profile ID of the current user.
    * @param options.targets - Addresses or profile IDs to unfollow.
    * @returns The unfollow response with confirmed unfollows.
    */
@@ -242,18 +243,14 @@ export class SocialController extends BaseController<
 
   /**
    * Fetches the list of traders the current user follows and replaces
-   * the following addresses in state.
+   * the following addresses in state. The caller is identified server-side
+   * from the JWT attached by the SocialService.
    *
-   * @param options - Options bag.
-   * @param options.addressOrUid - Wallet address or Clicker profile ID of the current user.
    * @returns The following response.
    */
-  async updateFollowing(
-    options: FetchFollowingOptions,
-  ): Promise<FollowingResponse> {
+  async updateFollowing(): Promise<FollowingResponse> {
     const followingResponse = await this.messenger.call(
       'SocialService:fetchFollowing',
-      options,
     );
 
     this.update((state) => {

--- a/packages/social-controllers/src/SocialService-method-action-types.ts
+++ b/packages/social-controllers/src/SocialService-method-action-types.ts
@@ -83,12 +83,11 @@ export type SocialServiceFetchFollowersAction = {
 };
 
 /**
- * Fetches the list of traders a user is following.
+ * Fetches the list of traders the current user is following.
  *
- * Calls `GET ${baseUrl}/users/${addressOrUid}/following`.
+ * Calls `GET ${baseUrl}/users/me/following`. The caller is identified
+ * server-side from the JWT sub claim carried in the Authorization header.
  *
- * @param options - Options bag.
- * @param options.addressOrUid - Wallet address or Clicker profile ID.
  * @returns The following response.
  */
 export type SocialServiceFetchFollowingAction = {
@@ -97,12 +96,12 @@ export type SocialServiceFetchFollowingAction = {
 };
 
 /**
- * Follows one or more traders.
+ * Follows one or more traders on behalf of the current user.
  *
- * Calls `PUT ${baseUrl}/users/${addressOrUid}/follows`.
+ * Calls `PUT ${baseUrl}/users/me/follows`. The caller is identified
+ * server-side from the JWT sub claim carried in the Authorization header.
  *
  * @param options - Options bag.
- * @param options.addressOrUid - Wallet address or Clicker profile ID of the user.
  * @param options.targets - Array of wallet addresses or profile IDs to follow.
  * @returns The follow response with confirmed follows.
  */
@@ -112,14 +111,14 @@ export type SocialServiceFollowAction = {
 };
 
 /**
- * Unfollows one or more traders.
+ * Unfollows one or more traders on behalf of the current user.
  *
- * Calls `DELETE ${baseUrl}/users/${addressOrUid}/follows?targets=...`.
- * Targets are sent as query params because Fastify does not parse
- * request bodies on DELETE requests per RFC 9110.
+ * Calls `DELETE ${baseUrl}/users/me/follows?targets=...`. Targets are sent
+ * as query params because Fastify does not parse request bodies on DELETE
+ * requests per RFC 9110. The caller is identified server-side from the JWT
+ * sub claim carried in the Authorization header.
  *
  * @param options - Options bag.
- * @param options.addressOrUid - Wallet address or Clicker profile ID of the user.
  * @param options.targets - Array of wallet addresses or profile IDs to unfollow.
  * @returns The unfollow response with confirmed unfollows.
  */

--- a/packages/social-controllers/src/SocialService.test.ts
+++ b/packages/social-controllers/src/SocialService.test.ts
@@ -633,7 +633,7 @@ describe('SocialService', () => {
       count: 1,
     };
 
-    it('fetches following from correct endpoint', async () => {
+    it('fetches following from the /users/me/following endpoint', async () => {
       mockFetch.mockResolvedValue({
         ok: true,
         status: 200,
@@ -641,15 +641,12 @@ describe('SocialService', () => {
       });
 
       const service = createService();
-      const result = await service.fetchFollowing({
-        addressOrUid: '0x1234',
-      });
+      const result = await service.fetchFollowing();
 
       expect(result).toStrictEqual(mockFollowingResponse);
-      expect(mockFetch).toHaveBeenCalledWith(
-        `${V1_URL}/users/0x1234/following`,
-        { headers: { Authorization: `Bearer ${MOCK_TOKEN}` } },
-      );
+      expect(mockFetch).toHaveBeenCalledWith(`${V1_URL}/users/me/following`, {
+        headers: { Authorization: `Bearer ${MOCK_TOKEN}` },
+      });
     });
 
     it('throws HttpError on non-ok response', async () => {
@@ -657,9 +654,7 @@ describe('SocialService', () => {
 
       const service = createService();
 
-      await expect(
-        service.fetchFollowing({ addressOrUid: '0x1234' }),
-      ).rejects.toThrow(
+      await expect(service.fetchFollowing()).rejects.toThrow(
         `${SocialServiceErrorMessage.FETCH_FOLLOWING_FAILED}: 500`,
       );
     });
@@ -673,9 +668,7 @@ describe('SocialService', () => {
 
       const service = createService();
 
-      await expect(
-        service.fetchFollowing({ addressOrUid: '0x1234' }),
-      ).rejects.toThrow(
+      await expect(service.fetchFollowing()).rejects.toThrow(
         SocialServiceErrorMessage.FETCH_FOLLOWING_INVALID_RESPONSE,
       );
     });
@@ -688,8 +681,8 @@ describe('SocialService', () => {
       });
 
       const service = createService();
-      await service.fetchFollowing({ addressOrUid: '0x1234' });
-      await service.fetchFollowing({ addressOrUid: '0x1234' });
+      await service.fetchFollowing();
+      await service.fetchFollowing();
 
       expect(mockFetch).toHaveBeenCalledTimes(2);
     });
@@ -700,7 +693,7 @@ describe('SocialService', () => {
       followed: [mockProfileSummary],
     };
 
-    it('sends PUT request with targets in body', async () => {
+    it('sends PUT request with targets in body to /users/me/follows', async () => {
       mockFetch.mockResolvedValue({
         ok: true,
         status: 200,
@@ -709,12 +702,11 @@ describe('SocialService', () => {
 
       const service = createService();
       const result = await service.follow({
-        addressOrUid: '0x1234',
         targets: ['0xaaaa', '0xbbbb'],
       });
 
       expect(result).toStrictEqual(mockFollowResponse);
-      expect(mockFetch).toHaveBeenCalledWith(`${V1_URL}/users/0x1234/follows`, {
+      expect(mockFetch).toHaveBeenCalledWith(`${V1_URL}/users/me/follows`, {
         method: 'PUT',
         headers: {
           Authorization: `Bearer ${MOCK_TOKEN}`,
@@ -729,9 +721,9 @@ describe('SocialService', () => {
 
       const service = createService();
 
-      await expect(
-        service.follow({ addressOrUid: '0x1234', targets: ['0xaaaa'] }),
-      ).rejects.toThrow(`${SocialServiceErrorMessage.FOLLOW_FAILED}: 400`);
+      await expect(service.follow({ targets: ['0xaaaa'] })).rejects.toThrow(
+        `${SocialServiceErrorMessage.FOLLOW_FAILED}: 400`,
+      );
     });
 
     it('throws when response schema is invalid', async () => {
@@ -743,9 +735,9 @@ describe('SocialService', () => {
 
       const service = createService();
 
-      await expect(
-        service.follow({ addressOrUid: '0x1234', targets: ['0xaaaa'] }),
-      ).rejects.toThrow(SocialServiceErrorMessage.FOLLOW_INVALID_RESPONSE);
+      await expect(service.follow({ targets: ['0xaaaa'] })).rejects.toThrow(
+        SocialServiceErrorMessage.FOLLOW_INVALID_RESPONSE,
+      );
     });
   });
 
@@ -754,7 +746,7 @@ describe('SocialService', () => {
       unfollowed: [mockProfileSummary],
     };
 
-    it('sends DELETE request with targets as query params', async () => {
+    it('sends DELETE request with targets as query params to /users/me/follows', async () => {
       mockFetch.mockResolvedValue({
         ok: true,
         status: 200,
@@ -763,12 +755,12 @@ describe('SocialService', () => {
 
       const service = createService();
       const result = await service.unfollow({
-        addressOrUid: '0x1234',
         targets: ['0xaaaa', '0xbbbb'],
       });
 
       expect(result).toStrictEqual(mockUnfollowResponse);
       const calledUrl = mockFetch.mock.calls[0][0] as string;
+      expect(calledUrl).toContain(`${V1_URL}/users/me/follows`);
       expect(calledUrl).toContain('targets=0xaaaa');
       expect(calledUrl).toContain('targets=0xbbbb');
       expect(mockFetch.mock.calls[0][1]).toStrictEqual({
@@ -782,9 +774,9 @@ describe('SocialService', () => {
 
       const service = createService();
 
-      await expect(
-        service.unfollow({ addressOrUid: '0x1234', targets: ['0xaaaa'] }),
-      ).rejects.toThrow(`${SocialServiceErrorMessage.UNFOLLOW_FAILED}: 400`);
+      await expect(service.unfollow({ targets: ['0xaaaa'] })).rejects.toThrow(
+        `${SocialServiceErrorMessage.UNFOLLOW_FAILED}: 400`,
+      );
     });
 
     it('throws when response schema is invalid', async () => {
@@ -796,9 +788,9 @@ describe('SocialService', () => {
 
       const service = createService();
 
-      await expect(
-        service.unfollow({ addressOrUid: '0x1234', targets: ['0xaaaa'] }),
-      ).rejects.toThrow(SocialServiceErrorMessage.UNFOLLOW_INVALID_RESPONSE);
+      await expect(service.unfollow({ targets: ['0xaaaa'] })).rejects.toThrow(
+        SocialServiceErrorMessage.UNFOLLOW_INVALID_RESPONSE,
+      );
     });
   });
 });

--- a/packages/social-controllers/src/SocialService.ts
+++ b/packages/social-controllers/src/SocialService.ts
@@ -23,7 +23,6 @@ import {
 import { serviceName, SocialServiceErrorMessage } from './social-constants';
 import type {
   FetchFollowersOptions,
-  FetchFollowingOptions,
   FetchLeaderboardOptions,
   FetchPositionsOptions,
   FetchTraderProfileOptions,
@@ -423,24 +422,19 @@ export class SocialService extends BaseDataService<
   }
 
   /**
-   * Fetches the list of traders a user is following.
+   * Fetches the list of traders the current user is following.
    *
-   * Calls `GET ${baseUrl}/users/${addressOrUid}/following`.
+   * Calls `GET ${baseUrl}/users/me/following`. The caller is identified
+   * server-side from the JWT sub claim carried in the Authorization header.
    *
-   * @param options - Options bag.
-   * @param options.addressOrUid - Wallet address or Clicker profile ID.
    * @returns The following response.
    */
-  async fetchFollowing(
-    options: FetchFollowingOptions,
-  ): Promise<FollowingResponse> {
-    const { addressOrUid } = options;
-
+  async fetchFollowing(): Promise<FollowingResponse> {
     const followingResponse = await this.fetchQuery({
-      queryKey: [`${this.name}:fetchFollowing`, addressOrUid],
+      queryKey: [`${this.name}:fetchFollowing`],
       staleTime: 0,
       queryFn: async () => {
-        const url = `${this.#v1Url}/users/${encodeURIComponent(addressOrUid)}/following`;
+        const url = `${this.#v1Url}/users/me/following`;
         const authHeaders = await this.#getAuthHeaders();
         const response = await fetch(url, { headers: authHeaders });
         SocialService.#throwIfNotOk(
@@ -461,23 +455,23 @@ export class SocialService extends BaseDataService<
   }
 
   /**
-   * Follows one or more traders.
+   * Follows one or more traders on behalf of the current user.
    *
-   * Calls `PUT ${baseUrl}/users/${addressOrUid}/follows`.
+   * Calls `PUT ${baseUrl}/users/me/follows`. The caller is identified
+   * server-side from the JWT sub claim carried in the Authorization header.
    *
    * @param options - Options bag.
-   * @param options.addressOrUid - Wallet address or Clicker profile ID of the user.
    * @param options.targets - Array of wallet addresses or profile IDs to follow.
    * @returns The follow response with confirmed follows.
    */
   async follow(options: FollowOptions): Promise<FollowResponse> {
-    const { addressOrUid, targets } = options;
+    const { targets } = options;
 
     const followResponse = await this.fetchQuery({
-      queryKey: [`${this.name}:follow`, addressOrUid, targets],
+      queryKey: [`${this.name}:follow`, targets],
       staleTime: 0,
       queryFn: async () => {
-        const url = `${this.#v1Url}/users/${encodeURIComponent(addressOrUid)}/follows`;
+        const url = `${this.#v1Url}/users/me/follows`;
         const authHeaders = await this.#getAuthHeaders();
         const response = await fetch(url, {
           method: 'PUT',
@@ -500,27 +494,25 @@ export class SocialService extends BaseDataService<
   }
 
   /**
-   * Unfollows one or more traders.
+   * Unfollows one or more traders on behalf of the current user.
    *
-   * Calls `DELETE ${baseUrl}/users/${addressOrUid}/follows?targets=...`.
-   * Targets are sent as query params because Fastify does not parse
-   * request bodies on DELETE requests per RFC 9110.
+   * Calls `DELETE ${baseUrl}/users/me/follows?targets=...`. Targets are sent
+   * as query params because Fastify does not parse request bodies on DELETE
+   * requests per RFC 9110. The caller is identified server-side from the JWT
+   * sub claim carried in the Authorization header.
    *
    * @param options - Options bag.
-   * @param options.addressOrUid - Wallet address or Clicker profile ID of the user.
    * @param options.targets - Array of wallet addresses or profile IDs to unfollow.
    * @returns The unfollow response with confirmed unfollows.
    */
   async unfollow(options: UnfollowOptions): Promise<UnfollowResponse> {
-    const { addressOrUid, targets } = options;
+    const { targets } = options;
 
     const unfollowResponse = await this.fetchQuery({
-      queryKey: [`${this.name}:unfollow`, addressOrUid, targets],
+      queryKey: [`${this.name}:unfollow`, targets],
       staleTime: 0,
       queryFn: async () => {
-        const url = new URL(
-          `${this.#v1Url}/users/${encodeURIComponent(addressOrUid)}/follows`,
-        );
+        const url = new URL(`${this.#v1Url}/users/me/follows`);
         for (const target of targets) {
           url.searchParams.append('targets', target);
         }

--- a/packages/social-controllers/src/index.ts
+++ b/packages/social-controllers/src/index.ts
@@ -39,7 +39,6 @@ export type {
 export { TradeStruct } from './social-types';
 export type {
   FetchFollowersOptions,
-  FetchFollowingOptions,
   FetchLeaderboardOptions,
   FetchPositionsOptions,
   FetchTraderProfileOptions,

--- a/packages/social-controllers/src/social-types.ts
+++ b/packages/social-controllers/src/social-types.ts
@@ -187,7 +187,7 @@ export type FollowersResponse = {
 // ---------------------------------------------------------------------------
 
 /**
- * Response from `GET /v1/users/:addressOrUid/following`.
+ * Response from `GET /v1/users/me/following`.
  */
 export type FollowingResponse = {
   following: ProfileSummary[];
@@ -199,14 +199,14 @@ export type FollowingResponse = {
 // ---------------------------------------------------------------------------
 
 /**
- * Response from `PUT /v1/users/:addressOrUid/follows`.
+ * Response from `PUT /v1/users/me/follows`.
  */
 export type FollowResponse = {
   followed: ProfileSummary[];
 };
 
 /**
- * Response from `DELETE /v1/users/:addressOrUid/follows`.
+ * Response from `DELETE /v1/users/me/follows`.
  */
 export type UnfollowResponse = {
   unfollowed: ProfileSummary[];
@@ -241,21 +241,12 @@ export type FetchFollowersOptions = {
   addressOrId: string;
 };
 
-export type FetchFollowingOptions = {
-  /** Wallet address or Clicker profile ID. */
-  addressOrUid: string;
-};
-
 export type FollowOptions = {
-  /** Wallet address or Clicker profile ID of the user. */
-  addressOrUid: string;
   /** Array of wallet addresses or profile IDs to follow. */
   targets: string[];
 };
 
 export type UnfollowOptions = {
-  /** Wallet address or Clicker profile ID of the user. */
-  addressOrUid: string;
   /** Array of wallet addresses or profile IDs to unfollow. */
   targets: string[];
 };


### PR DESCRIPTION
## Explanation

Part of [TSA-398](https://consensyssoftware.atlassian.net/browse/TSA-398).

The social-api has been updated so that the three caller-centric follow endpoints derive the caller's `profileId` from the OIDC JWT (`sub` claim) instead of accepting it as a path parameter:

| Before | After |
| --- | --- |
| `PUT    /v1/users/:addressOrUid/follows`   | `PUT    /v1/users/me/follows`   |
| `DELETE /v1/users/:addressOrUid/follows`   | `DELETE /v1/users/me/follows`   |
| `GET    /v1/users/:addressOrUid/following` | `GET    /v1/users/me/following` |

This PR adapts `@metamask/social-controllers` to the new contract:

- `SocialService.follow` / `unfollow` / `fetchFollowing` now target `/users/me/...`.
- `FollowOptions` and `UnfollowOptions` are reduced to `{ targets }`; `FetchFollowingOptions` is removed entirely (no options are needed anymore).
- `SocialController.followTrader` / `unfollowTrader` / `updateFollowing` expose the updated signatures, and their messenger action types are regenerated accordingly.
- JSDoc cleaned up to drop `addressOrUid` references.

### Breaking changes

The `addressOrUid` argument has been removed from `follow` / `unfollow` / `updateFollowing`. Callers must rely on the JWT passed via the `Authorization` header (handled by the existing auth strategy) to identify the current user. A `CHANGELOG.md` entry has been added under "Unreleased → Changed".

## References

- Jira: [TSA-398](https://consensyssoftware.atlassian.net/browse/TSA-398)
- API PR: consensys-vertical-apps/va-mmcx-social-api#49
- Mobile consumer (draft, depends on the version bump from this PR): MetaMask/metamask-mobile#<tbd>

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

Made with [Cursor](https://cursor.com)

[TSA-398]: https://consensyssoftware.atlassian.net/browse/TSA-398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TSA-398]: https://consensyssoftware.atlassian.net/browse/TSA-398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking signature and endpoint changes for follow/unfollow/following can disrupt downstream consumers and will fail at runtime if clients aren’t updated or JWT auth isn’t present.
> 
> **Overview**
> Updates follow/unfollow/following flows to **identify the caller via the JWT `sub` claim** rather than an explicit `addressOrUid` parameter.
> 
> `SocialService.follow`, `unfollow`, and `fetchFollowing` now call the `/v1/users/me/...` endpoints, update cache keys accordingly, and remove `addressOrUid`/`FetchFollowingOptions` from the exported types and controller/service method signatures. Tests, generated messenger action types, JSDoc, and the changelog are updated to reflect these **breaking** API changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2ee1cbcbc0b6f40f16beaa6bb3cf6a33a997600. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->