### PR TITLE
feat: add Forma (chain 984122) to assets-controllers spot price support

### DIFF
--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add Tempo Mainnet (`4217`/`0x1079`) multicall contract support ([#8346](https://github.com/MetaMask/core/pull/8346))
+- Add Forma (`0xf043a` / `eip155:984122`) to `SPOT_PRICES_SUPPORT_INFO`, mapping its native TIA asset to `slip44:984122` so the price-api can resolve it to CoinGecko's `celestia` coin ([#8524](https://github.com/MetaMask/core/pull/8524))
 
 ## [104.1.0]
 

--- a/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
+++ b/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
@@ -319,6 +319,7 @@ export const SPOT_PRICES_SUPPORT_INFO = {
   '0x63564c40': 'eip155:1666600000/slip44:1023', // Harmony Mainnet Shard 0 - Native symbol: ONE
   '0xdef1': 'eip155:57073/slip44:60', // Ink Mainnet - Native symbol: ETH
   '0x3dc': 'eip155:988/erc20:0x779ded0c9e1022225f8e0630b35a9b54be713736', // Stable - Native symbol: USDT0
+  '0xf043a': 'eip155:984122/slip44:984122', // Forma - Native symbol: TIA (Celestia)
 } as const;
 
 // MISSING CHAINS WITH NO NATIVE ASSET PRICES


### PR DESCRIPTION
## Explanation

Forma (`eip155:984122`) uses TIA (Celestia) as its native gas token. Today, `CodefiTokenPricesServiceV2.validateChainIdSupported` returns `false` for Forma because its chain ID is not listed in `SPOT_PRICES_SUPPORT_INFO`, so the extension and mobile clients never even request a spot price for TIA — users see no price when they add Forma as a custom network.

Forma had a working price previously via the `SimpleHashService` fallback in `va-mmcx-price-api`. That fallback was removed in [va-mmcx-price-api#409](https://github.com/consensys-vertical-apps/va-mmcx-price-api/pull/409), leaving CoinGecko as the only remaining path. CoinGecko does not recognise Forma as an EVM asset platform (Celestia is Cosmos-based), so the chain → contract-address lookup path doesn't work for Forma. The same approach already shipped for Sei (`0x531` / `slip44:19000118`) and Injective (`slip44:22000119`) applies here: point Forma's native asset at CoinGecko's `celestia` coin directly instead of relying on the platform-indexed path.

This PR adds:

```ts
'0xf043a': 'eip155:984122/slip44:984122', // Forma - Native symbol: TIA (Celestia)
```

to `SPOT_PRICES_SUPPORT_INFO`. `slip44:984122` is a chain-id-derived pseudo-ref mirroring the `slip44:8453` convention used for Base governance, chosen over `slip44:118` (Cosmos Hub / ATOM) to avoid collision if ATOM is ever priced through `slip44`. The ref matches the companion mapping added to `va-mmcx-price-api`, which resolves it to CoinGecko's `celestia` coin id.

`SUPPORTED_CHAIN_IDS` is derived from `SPOT_PRICES_SUPPORT_INFO`, so the existing parameterised `validateChainIdSupported` test (`codefi-v2.test.ts`) picks up the new entry automatically. No fixture updates were required.

The same pattern will apply to Eden and any future Celestia-based EVM rollup once their chain IDs are published.

## References

- Chain: https://chainlist.org/chain/984122
- CoinGecko coin: https://www.coingecko.com/en/coins/celestia
- Companion PR in `va-mmcx-price-api`: `feat/add-forma-tia-price` (adds `Caip2ChainId.FORMA`, `SLIP44_ASSET_MAP[FORMA]`, and `SLIP44_ASSET_CONFIGS['slip44:984122'] → 'celestia'`)
- Removal that triggered the regression: https://github.com/consensys-vertical-apps/va-mmcx-price-api/pull/409

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single new chain entry to the spot-price support mapping plus a changelog note, with no behavioral changes beyond enabling price requests for that chain.
> 
> **Overview**
> Adds Forma (`0xf043a` / `eip155:984122`) to `SPOT_PRICES_SUPPORT_INFO` in `codefi-v2.ts`, mapping its native token to `slip44:984122` so the price API can resolve it (e.g., to CoinGecko’s `celestia`).
> 
> Updates the assets-controllers changelog to document the new Forma spot-price support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3892ee08da9f22f690e6c0d0ca9433e6ab5d72aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->