### PR TITLE
feat: adding more validations for types sign v4 messages

### DIFF
--- a/packages/eth-json-rpc-middleware/CHANGELOG.md
+++ b/packages/eth-json-rpc-middleware/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add more strict validation for signTypedData V4 requests ([#8526](https://github.com/MetaMask/core/pull/8526))
+
 ## [23.1.1]
 
 ### Changed

--- a/packages/eth-json-rpc-middleware/CHANGELOG.md
+++ b/packages/eth-json-rpc-middleware/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
+### Changed
 
 - Add more strict validation for signTypedData V4 requests ([#8526](https://github.com/MetaMask/core/pull/8526))
 

--- a/packages/eth-json-rpc-middleware/src/utils/validation.test.ts
+++ b/packages/eth-json-rpc-middleware/src/utils/validation.test.ts
@@ -8,6 +8,7 @@ import {
   resemblesAddress,
   validateAndNormalizeKeyholder,
   validateParams,
+  validateTypedMessageKeys,
 } from './validation';
 
 jest.mock('@metamask/superstruct', () => ({
@@ -123,6 +124,41 @@ describe('Validation Utils', () => {
         test1 > test2 - test message
         test3 - test message 2"
       `);
+    });
+  });
+
+  describe('validateTypedMessageKeys', () => {
+    it('does not throw for data with only schema-defined keys', () => {
+      const data = JSON.stringify({
+        types: {
+          EIP712Domain: [{ name: 'name', type: 'string' }],
+        },
+      });
+
+      expect(() => validateTypedMessageKeys(data)).not.toThrow();
+    });
+
+    it('throws for data with extraneous keys', () => {
+      const data = JSON.stringify({
+        types: {
+          EIP712Domain: [{ name: 'name', type: 'string' }],
+        },
+        primaryType: 'EIP712Domain',
+        domain: {},
+        message: {},
+        extraKey: 'unexpected',
+      });
+
+      expect(() => validateTypedMessageKeys(data)).toThrow('Invalid input.');
+    });
+
+    it('throws when data contains only extraneous keys', () => {
+      const data = JSON.stringify({
+        foo: 'bar',
+        baz: 123,
+      });
+
+      expect(() => validateTypedMessageKeys(data)).toThrow('Invalid input.');
     });
   });
 });

--- a/packages/eth-json-rpc-middleware/src/utils/validation.ts
+++ b/packages/eth-json-rpc-middleware/src/utils/validation.ts
@@ -200,11 +200,11 @@ export function validateTypedDataForPrototypePollution(data: string): void {
 export function validateTypedMessageKeys(data: string): void {
   const parsedData = parseTypedMessage(data);
   const allowedKeys = new Set(Object.keys(TYPED_MESSAGE_SCHEMA.properties));
-  const extraneousKeys = Object.keys(parsedData).filter(
+  const hasExtraneousKey = Object.keys(parsedData).some(
     (key) => !allowedKeys.has(key),
   );
 
-  if (extraneousKeys.length > 0) {
+  if (hasExtraneousKey) {
     throw rpcErrors.invalidInput();
   }
 }

--- a/packages/eth-json-rpc-middleware/src/utils/validation.ts
+++ b/packages/eth-json-rpc-middleware/src/utils/validation.ts
@@ -1,3 +1,4 @@
+import { TYPED_MESSAGE_SCHEMA } from '@metamask/eth-sig-util';
 import { providerErrors, rpcErrors } from '@metamask/rpc-errors';
 import type { Struct, StructError } from '@metamask/superstruct';
 import { validate } from '@metamask/superstruct';
@@ -185,5 +186,25 @@ export function validateTypedDataForPrototypePollution(data: string): void {
   // Check message recursively for dangerous properties
   if (message !== undefined) {
     checkObjectForPrototypePollution(message);
+  }
+}
+
+/**
+ * Validates that EIP-712 typed message data contains only keys defined in
+ * the TYPED_MESSAGE_SCHEMA from `@metamask/eth-sig-util`. Rejects messages
+ * with extraneous top-level keys.
+ *
+ * @param data - The stringified typed data to validate.
+ * @throws rpcErrors.invalidInput() if extraneous keys are detected.
+ */
+export function validateTypedMessageKeys(data: string): void {
+  const parsedData = parseTypedMessage(data);
+  const allowedKeys = new Set(Object.keys(TYPED_MESSAGE_SCHEMA.properties));
+  const extraneousKeys = Object.keys(parsedData).filter(
+    (key) => !allowedKeys.has(key),
+  );
+
+  if (extraneousKeys.length > 0) {
+    throw rpcErrors.invalidInput();
   }
 }

--- a/packages/eth-json-rpc-middleware/src/wallet.test.ts
+++ b/packages/eth-json-rpc-middleware/src/wallet.test.ts
@@ -757,6 +757,29 @@ describe('wallet', () => {
         engine.handle(...createHandleParams(payload)),
       ).rejects.toThrow('Invalid input.');
     });
+
+    it('should throw if message data contains extraneous keys', async () => {
+      const getAccounts = async (): Promise<string[]> => testAddresses.slice();
+      const processTypedMessageV4 = async (): Promise<string> => testMsgSig;
+      const engine = JsonRpcEngineV2.create({
+        middleware: [
+          createWalletMiddleware({ getAccounts, processTypedMessageV4 }),
+        ],
+      });
+
+      const messageParams = getMsgParams();
+      const payload = {
+        method: 'eth_signTypedData_v4',
+        params: [
+          testAddresses[0],
+          JSON.stringify({ ...messageParams, extraKey: 'unexpected' }),
+        ],
+      };
+
+      await expect(
+        engine.handle(...createHandleParams(payload)),
+      ).rejects.toThrow('Invalid input.');
+    });
   });
 
   describe('sign', () => {

--- a/packages/eth-json-rpc-middleware/src/wallet.ts
+++ b/packages/eth-json-rpc-middleware/src/wallet.ts
@@ -25,6 +25,7 @@ import {
   validateAndNormalizeKeyholder as validateKeyholder,
   validateTypedDataForPrototypePollution,
   validateTypedDataV1ForPrototypePollution,
+  validateTypedMessageKeys,
 } from './utils/validation';
 
 export type TransactionParams = {
@@ -408,6 +409,7 @@ export function createWalletMiddleware({
 
     const address = await validateAndNormalizeKeyholder(params[0], context);
     const message = normalizeTypedMessage(params[1]);
+    validateTypedMessageKeys(message);
     validatePrimaryType(message);
     validateVerifyingContract(message);
     validateTypedDataForPrototypePollution(message);


### PR DESCRIPTION
## Explanation

Adding more validations for typed sign v4 messaged.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [X] I've updated the test suite for new or updated code as appropriate
- [X] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [X] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [X] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens validation on `eth_signTypedData_v4` inputs, which may break dapps that previously sent additional top-level fields in typed data. Change is localized but affects a commonly used signing path.
> 
> **Overview**
> **Stricter `eth_signTypedData_v4` input validation:** the wallet middleware now rejects EIP-712 typed-data JSON that includes any *extraneous top-level keys* beyond those defined by `@metamask/eth-sig-util`’s `TYPED_MESSAGE_SCHEMA`.
> 
> This introduces a new `validateTypedMessageKeys` utility (and tests) and wires it into the `eth_signTypedData_v4` flow, plus adds coverage ensuring requests with unexpected keys fail with `Invalid input.`; the changelog is updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c2ae43efc033a93c32c2ea0baa57856f8be285e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->