### PR TITLE
fix(transaction-pay-controller): ignore synthetic across gas legs

### DIFF
--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Ignore synthetic gas legs when determining Across support for perps direct deposits ([#8527](https://github.com/MetaMask/core/pull/8527))
 - Route Across status polling through the configured Across API base and support `depositTxnRef`/`fillTxnRef` for Across status responses ([#8512](https://github.com/MetaMask/core/pull/8512))
 
 ## [19.2.1]

--- a/packages/transaction-pay-controller/src/strategy/across/AcrossStrategy.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/across/AcrossStrategy.test.ts
@@ -153,6 +153,50 @@ describe('AcrossStrategy', () => {
     ).toBe(true);
   });
 
+  it('returns false when all requests are synthetic zero-minimum legs', () => {
+    const strategy = new AcrossStrategy();
+    expect(
+      strategy.supports({
+        ...baseRequest,
+        requests: [
+          {
+            from: '0xabc' as Hex,
+            sourceBalanceRaw: '100',
+            sourceChainId: CHAIN_ID_ARBITRUM,
+            sourceTokenAddress: ARBITRUM_USDC_ADDRESS,
+            sourceTokenAmount: '100',
+            targetAmountMinimum: '0',
+            targetChainId: CHAIN_ID_ARBITRUM,
+            targetTokenAddress:
+              '0x0000000000000000000000000000000000000000' as Hex,
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it('treats max-amount requests as actionable even with zero minimums', () => {
+    const strategy = new AcrossStrategy();
+    expect(
+      strategy.supports({
+        ...baseRequest,
+        requests: [
+          {
+            from: '0xabc' as Hex,
+            isMaxAmount: true,
+            sourceBalanceRaw: '100',
+            sourceChainId: '0x1' as Hex,
+            sourceTokenAddress: '0xabc' as Hex,
+            sourceTokenAmount: '100',
+            targetAmountMinimum: '0',
+            targetChainId: '0x2' as Hex,
+            targetTokenAddress: '0xdef' as Hex,
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
   it('returns false for unsupported perps deposits', () => {
     const strategy = new AcrossStrategy();
     expect(

--- a/packages/transaction-pay-controller/src/strategy/across/AcrossStrategy.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/across/AcrossStrategy.test.ts
@@ -117,6 +117,42 @@ describe('AcrossStrategy', () => {
     ).toBe(true);
   });
 
+  it('ignores synthetic gas legs for supported perps direct deposits', () => {
+    const strategy = new AcrossStrategy();
+    expect(
+      strategy.supports({
+        ...baseRequest,
+        transaction: {
+          ...TRANSACTION_META_MOCK,
+          type: TransactionType.perpsDeposit,
+        } as TransactionMeta,
+        requests: [
+          {
+            from: '0xabc' as Hex,
+            sourceBalanceRaw: '100',
+            sourceChainId: CHAIN_ID_ARBITRUM,
+            sourceTokenAddress: ARBITRUM_USDC_ADDRESS,
+            sourceTokenAmount: '100',
+            targetAmountMinimum: '100',
+            targetChainId: CHAIN_ID_ARBITRUM,
+            targetTokenAddress: ARBITRUM_USDC_ADDRESS,
+          },
+          {
+            from: '0xabc' as Hex,
+            sourceBalanceRaw: '100',
+            sourceChainId: CHAIN_ID_ARBITRUM,
+            sourceTokenAddress: ARBITRUM_USDC_ADDRESS,
+            sourceTokenAmount: '100',
+            targetAmountMinimum: '0',
+            targetChainId: CHAIN_ID_ARBITRUM,
+            targetTokenAddress:
+              '0x0000000000000000000000000000000000000000' as Hex,
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
   it('returns false for unsupported perps deposits', () => {
     const strategy = new AcrossStrategy();
     expect(

--- a/packages/transaction-pay-controller/src/strategy/across/AcrossStrategy.ts
+++ b/packages/transaction-pay-controller/src/strategy/across/AcrossStrategy.ts
@@ -1,10 +1,5 @@
 import { TransactionType } from '@metamask/transaction-controller';
 
-import { getAcrossQuotes } from './across-quotes';
-import { submitAcrossQuotes } from './across-submit';
-import { isSupportedAcrossPerpsDepositRequest } from './perps';
-import { isAcrossQuoteRequest } from './requests';
-import type { AcrossQuote } from './types';
 import type {
   PayStrategy,
   PayStrategyExecuteRequest,
@@ -12,6 +7,11 @@ import type {
   TransactionPayQuote,
 } from '../../types';
 import { getPayStrategiesConfig } from '../../utils/feature-flags';
+import { getAcrossQuotes } from './across-quotes';
+import { submitAcrossQuotes } from './across-submit';
+import { isSupportedAcrossPerpsDepositRequest } from './perps';
+import { isAcrossQuoteRequest } from './requests';
+import type { AcrossQuote } from './types';
 
 export class AcrossStrategy implements PayStrategy<AcrossQuote> {
   supports(request: PayStrategyGetQuotesRequest): boolean {

--- a/packages/transaction-pay-controller/src/strategy/across/AcrossStrategy.ts
+++ b/packages/transaction-pay-controller/src/strategy/across/AcrossStrategy.ts
@@ -1,5 +1,10 @@
 import { TransactionType } from '@metamask/transaction-controller';
 
+import { getAcrossQuotes } from './across-quotes';
+import { submitAcrossQuotes } from './across-submit';
+import { isSupportedAcrossPerpsDepositRequest } from './perps';
+import { isAcrossQuoteRequest } from './requests';
+import type { AcrossQuote } from './types';
 import type {
   PayStrategy,
   PayStrategyExecuteRequest,
@@ -7,10 +12,6 @@ import type {
   TransactionPayQuote,
 } from '../../types';
 import { getPayStrategiesConfig } from '../../utils/feature-flags';
-import { getAcrossQuotes } from './across-quotes';
-import { submitAcrossQuotes } from './across-submit';
-import { isSupportedAcrossPerpsDepositRequest } from './perps';
-import type { AcrossQuote } from './types';
 
 export class AcrossStrategy implements PayStrategy<AcrossQuote> {
   supports(request: PayStrategyGetQuotesRequest): boolean {
@@ -20,8 +21,14 @@ export class AcrossStrategy implements PayStrategy<AcrossQuote> {
       return false;
     }
 
+    const actionableRequests = request.requests.filter(isAcrossQuoteRequest);
+
+    if (actionableRequests.length === 0) {
+      return false;
+    }
+
     if (request.transaction?.type === TransactionType.perpsDeposit) {
-      return request.requests.every((singleRequest) =>
+      return actionableRequests.every((singleRequest) =>
         isSupportedAcrossPerpsDepositRequest(
           singleRequest,
           request.transaction?.type,
@@ -30,7 +37,7 @@ export class AcrossStrategy implements PayStrategy<AcrossQuote> {
     }
 
     // Across doesn't support same-chain swaps (e.g. mUSD conversions).
-    return request.requests.every(
+    return actionableRequests.every(
       (singleRequest) =>
         singleRequest.sourceChainId !== singleRequest.targetChainId,
     );

--- a/packages/transaction-pay-controller/src/strategy/across/across-quotes.ts
+++ b/packages/transaction-pay-controller/src/strategy/across/across-quotes.ts
@@ -3,6 +3,17 @@ import type { Hex } from '@metamask/utils';
 import { createModuleLogger } from '@metamask/utils';
 import { BigNumber } from 'bignumber.js';
 
+import { getAcrossDestination } from './across-actions';
+import { normalizeAcrossRequest } from './perps';
+import { isAcrossQuoteRequest } from './requests';
+import { getAcrossOrderedTransactions } from './transactions';
+import type {
+  AcrossAction,
+  AcrossActionRequestBody,
+  AcrossGasLimits,
+  AcrossQuote,
+  AcrossSwapApprovalResponse,
+} from './types';
 import { TransactionPayStrategy } from '../../constants';
 import { projectLogger } from '../../logger';
 import type {
@@ -18,16 +29,6 @@ import { getPayStrategiesConfig, getSlippage } from '../../utils/feature-flags';
 import { calculateGasCost } from '../../utils/gas';
 import { estimateQuoteGasLimits } from '../../utils/quote-gas';
 import { getTokenFiatRate } from '../../utils/token';
-import { getAcrossDestination } from './across-actions';
-import { normalizeAcrossRequest } from './perps';
-import { getAcrossOrderedTransactions } from './transactions';
-import type {
-  AcrossAction,
-  AcrossActionRequestBody,
-  AcrossGasLimits,
-  AcrossQuote,
-  AcrossSwapApprovalResponse,
-} from './types';
 
 const log = createModuleLogger(projectLogger, 'across-strategy');
 
@@ -50,12 +51,7 @@ export async function getAcrossQuotes(
   log('Fetching quotes', requests);
 
   try {
-    const normalizedRequests = requests.filter(
-      (singleRequest) =>
-        singleRequest.isMaxAmount === true ||
-        (singleRequest.targetAmountMinimum !== undefined &&
-          singleRequest.targetAmountMinimum !== '0'),
-    );
+    const normalizedRequests = requests.filter(isAcrossQuoteRequest);
 
     if (normalizedRequests.length === 0) {
       return [];

--- a/packages/transaction-pay-controller/src/strategy/across/across-quotes.ts
+++ b/packages/transaction-pay-controller/src/strategy/across/across-quotes.ts
@@ -3,17 +3,6 @@ import type { Hex } from '@metamask/utils';
 import { createModuleLogger } from '@metamask/utils';
 import { BigNumber } from 'bignumber.js';
 
-import { getAcrossDestination } from './across-actions';
-import { normalizeAcrossRequest } from './perps';
-import { isAcrossQuoteRequest } from './requests';
-import { getAcrossOrderedTransactions } from './transactions';
-import type {
-  AcrossAction,
-  AcrossActionRequestBody,
-  AcrossGasLimits,
-  AcrossQuote,
-  AcrossSwapApprovalResponse,
-} from './types';
 import { TransactionPayStrategy } from '../../constants';
 import { projectLogger } from '../../logger';
 import type {
@@ -29,6 +18,17 @@ import { getPayStrategiesConfig, getSlippage } from '../../utils/feature-flags';
 import { calculateGasCost } from '../../utils/gas';
 import { estimateQuoteGasLimits } from '../../utils/quote-gas';
 import { getTokenFiatRate } from '../../utils/token';
+import { getAcrossDestination } from './across-actions';
+import { normalizeAcrossRequest } from './perps';
+import { isAcrossQuoteRequest } from './requests';
+import { getAcrossOrderedTransactions } from './transactions';
+import type {
+  AcrossAction,
+  AcrossActionRequestBody,
+  AcrossGasLimits,
+  AcrossQuote,
+  AcrossSwapApprovalResponse,
+} from './types';
 
 const log = createModuleLogger(projectLogger, 'across-strategy');
 

--- a/packages/transaction-pay-controller/src/strategy/across/requests.ts
+++ b/packages/transaction-pay-controller/src/strategy/across/requests.ts
@@ -1,0 +1,9 @@
+import type { QuoteRequest } from '../../types';
+
+export function isAcrossQuoteRequest(request: QuoteRequest): boolean {
+  return (
+    request.isMaxAmount === true ||
+    (request.targetAmountMinimum !== undefined &&
+      request.targetAmountMinimum !== '0')
+  );
+}


### PR DESCRIPTION
## Problem observed in testing

The perps direct deposit flow could include a synthetic gas-funding leg, generated internally for native ETH on Arbitrum, with targetAmountMinimum: '0'. That leg was optional and not the real asset the user was trying to deposit, but the Across strategy support check still evaluated it as if it were a required quote leg. As a result, a valid perps deposit request could be marked unsupported before quote resolution, because the optional gas leg made the whole request set fail strategy validation.

The fix was to make Across treat those zero-minimum synthetic gas legs consistently everywhere. A shared helper was introduced to identify “real” Across quote requests, and both quote fetching and strategy support now filter out requests where targetAmountMinimum === '0' unless it is a max-amount flow. In practice, that means the real deposit leg can proceed while the optional gas top-up leg no longer disqualifies the route. The turn also added a regression test covering exactly that case: one real perps deposit leg plus one synthetic native-token gas leg, and the strategy now correctly returns supported.

## Summary
- ignore synthetic zero-target gas legs when evaluating Across support
- share the same request filter between Across support checks and quote building
- add coverage for perps direct deposits that include a synthetic gas leg

## Testing
- yarn jest --config packages/transaction-pay-controller/jest.config.js --watchman=false packages/transaction-pay-controller/src/strategy/across/AcrossStrategy.test.ts --coverage=false

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Across strategy request filtering, which affects whether routes are considered supported and which legs are quoted; mistakes could cause valid quotes to be skipped or unsupported routes to be attempted.
> 
> **Overview**
> Fixes Across strategy validation/quoting to **ignore synthetic “gas” legs** (requests with `targetAmountMinimum: '0'`) so they don’t cause perps direct deposits to be marked unsupported.
> 
> Introduces a shared `isAcrossQuoteRequest` helper and applies it consistently in both `AcrossStrategy.supports` and `getAcrossQuotes`, and adds regression tests covering mixed real+synthetic legs, all-synthetic legs, and `isMaxAmount` zero-minimum behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d773fd302489d4734eceac39bb012f771c9d816c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->