### PR TITLE
Add guideline for defining the name of a controller

### DIFF
--- a/docs/code-guidelines/controller-guidelines.md
+++ b/docs/code-guidelines/controller-guidelines.md
@@ -374,70 +374,70 @@ rootMessenger.subscribe('FooController:someEvent', () => {
 
 ## Define, but do not export, a name for the controller
 
-Every controller has a name, which is not only used to namespace the controller's messenger actions and events, but also to namespace the controller's state data when composed with other controllers.
+Every controller has a name, which is used to namespace not only the controller's messenger actions and events, but also the controller's state data when composed with other controllers.
 
-The name should be defined in a constant called `CONTROLLER_NAME` so that it can be easily changed if the need arises. (This variable was formerly called `controllerName`.) The name should be used to initialize the messenger, and should also be passed to the `BaseController` constructor.
+The name should be defined in a constant called `CONTROLLER_NAME` so that it can be easily changed if the need arises. The name should be used to initialize the messenger, and it should also be passed to the `BaseController` constructor.
 
 The constant should be used to define actions and events. It may be exported from the file in which it is defined, but should not listed as an export of the package:
 
 🚫 **The messenger namespace is not defined as a constant, but is repeated**
 
 ```typescript
-export type FooControllerSomeCustomAction = {
-  type: 'FooController:someCustomAction';
-  handler: (bar: string) => void;
-};
-
-export type FooControllerAnotherCustomAction = {
-  type: 'FooController:anotherCustomAction';
-  handler: (baz: number) => void;
-};
-
-export type FooControllerActions =
-  | FooControllerSomeCustomAction
-  | FooControllerAnotherCustomAction;
-
-export type FooControllerMessenger = Messenger<
-  'FooController',
-  FooControllerActions,
-  never
+export type TransactionsControllerStateChangedEvent = ControllerStateChangedEvent<
+  'TransactionsController',
+  TransactionsControllerState
 >;
 
-export class FooController extends BaseController</* ... */ {
+export type TransactionsControllerTransactionApprovedEvent = {
+  type: 'TransactionsController:transactionApprovedEvent';
+  payload: [transaction: Transaction]
+};
+
+export type TransactionsControllerEvents =
+  | TransactionsControllerStateChangedEvent
+  | TransactionsControllerTransactionApprovedEvent
+
+export type TransactionsControllerMessenger = Messenger<
+  'TransactionsController',
+  never,
+  TransactionsControllerEvents
+>;
+
+export class TransactionsController extends BaseController</* ... */ {
   constructor(/* ... */) {
-    super({ name: 'FooController', /* ... */ })
+    super({ name: 'TransactionsController', /* ... */ })
 
     // ...
   }
 }
 ```
 
-🚫 **The messenger namespace is defined as a constant, but it is called `controllerName`**
+🚫 **The messenger namespace is defined as a constant, but it is called `controllerName` (legacy name)**
 
 ```typescript
-const controllerName = 'FooController';
+const controllerName = 'TransactionsController';
 
-export type FooControllerSomeCustomAction = {
-  type: `${typeof controllerName}:someCustomAction`;
-  handler: (bar: string) => void;
-};
-
-export type FooControllerAnotherCustomAction = {
-  type: `${typeof controllerName}:anotherCustomAction`;
-  handler: (baz: number) => void;
-};
-
-export type FooControllerActions =
-  | FooControllerSomeCustomAction
-  | FooControllerAnotherCustomAction;
-
-export type FooControllerMessenger = Messenger<
+export type TransactionsControllerStateChangedEvent = ControllerStateChangedEvent<
   typeof controllerName,
-  FooControllerActions,
-  never
+  TransactionsControllerState
 >;
 
-export class FooController extends BaseController</* ... */ {
+export type TransactionsControllerTransactionApprovedEvent = {
+  type: `${typeof controllerName}:transactionApprovedEvent`;
+  payload: [transaction: Transaction]
+};
+
+export type TransactionsControllerEvents =
+  | TransactionsControllerStateChangedEvent
+  | TransactionsControllerTransactionApprovedEvent
+
+export type TransactionsControllerMessenger = Messenger<
+  typeof controllerName,
+  never,
+  TransactionsControllerEvents
+>;
+
+export class TransactionsController extends BaseController</* ... */ {
   constructor(/* ... */) {
     super({ name: controllerName, /* ... */ })
 
@@ -449,31 +449,31 @@ export class FooController extends BaseController</* ... */ {
 🚫 **The messenger namespace is defined as a constant, but it is exported from the package**
 
 ```typescript
-/* packages/foo-controller/src/foo-controller.ts */
+/* packages/transactions-controller/src/transactions-controller.ts */
 
-export const CONTROLLER_NAME = 'FooController';
+export const CONTROLLER_NAME = 'TransactionsController';
 
-export type FooControllerSomeCustomAction = {
-  type: `${typeof CONTROLLER_NAME}:someCustomAction`;
-  handler: (bar: string) => void;
-};
-
-export type FooControllerAnotherCustomAction = {
-  type: `${typeof CONTROLLER_NAME}:anotherCustomAction`;
-  handler: (baz: number) => void;
-};
-
-export type FooControllerActions =
-  | FooControllerSomeCustomAction
-  | FooControllerAnotherCustomAction;
-
-export type FooControllerMessenger = Messenger<
+export type TransactionsControllerStateChangedEvent = ControllerStateChangedEvent<
   typeof CONTROLLER_NAME,
-  FooControllerActions,
-  never
+  TransactionsControllerState
 >;
 
-export class FooController extends BaseController</* ... */ {
+export type TransactionsControllerTransactionApprovedEvent = {
+  type: `${typeof CONTROLLER_NAME}:transactionApprovedEvent`;
+  payload: [transaction: Transaction]
+};
+
+export type TransactionsControllerEvents =
+  | TransactionsControllerStateChangedEvent
+  | TransactionsControllerTransactionApprovedEvent
+
+export type TransactionsControllerMessenger = Messenger<
+  typeof CONTROLLER_NAME,
+  never,
+  TransactionsControllerEvents
+>;
+
+export class TransactionsController extends BaseController</* ... */ {
   constructor(/* ... */) {
     super({ name: CONTROLLER_NAME, /* ... */ })
 
@@ -481,42 +481,42 @@ export class FooController extends BaseController</* ... */ {
   }
 }
 
-/* packages/foo-controller/src/index.ts */
+/* packages/transactions-controller/src/index.ts */
 
 export {
   CONTROLLER_NAME,
-  FooController
-} from './foo-controller';
+  TransactionsController
+} from './transactions-controller';
 ```
 
 ✅ **The messenger namespace is defined as a constant, and it is kept internal instead of being exported**
 
 ```typescript
-/* packages/foo-controller/src/foo-controller.ts */
+/* packages/transactions-controller/src/transactions-controller.ts */
 
-const CONTROLLER_NAME = 'FooController';
+const CONTROLLER_NAME = 'TransactionsController';
 
-export type FooControllerSomeCustomAction = {
-  type: `${CONTROLLER_NAME}:someCustomAction`;
-  handler: (bar: string) => void;
-};
-
-export type FooControllerAnotherCustomAction = {
-  type: `${CONTROLLER_NAME}:anotherCustomAction`;
-  handler: (baz: number) => void;
-};
-
-export type FooControllerActions =
-  | FooControllerSomeCustomAction
-  | FooControllerAnotherCustomAction;
-
-export type FooControllerMessenger = Messenger<
-  CONTROLLER_NAME,
-  FooControllerActions,
-  never
+export type TransactionsControllerStateChangedEvent = ControllerStateChangedEvent<
+  typeof CONTROLLER_NAME,
+  TransactionsControllerState
 >;
 
-export class FooController extends BaseController</* ... */ {
+export type TransactionsControllerTransactionApprovedEvent = {
+  type: `${typeof CONTROLLER_NAME}:transactionApprovedEvent`;
+  payload: [transaction: Transaction]
+};
+
+export type TransactionsControllerEvents =
+  | TransactionsControllerStateChangedEvent
+  | TransactionsControllerTransactionApprovedEvent
+
+export type TransactionsControllerMessenger = Messenger<
+  typeof CONTROLLER_NAME,
+  never,
+  TransactionsControllerEvents
+>;
+
+export class TransactionsController extends BaseController</* ... */ {
   constructor(/* ... */) {
     super({ name: CONTROLLER_NAME, /* ... */ })
 
@@ -524,9 +524,9 @@ export class FooController extends BaseController</* ... */ {
   }
 }
 
-/* packages/foo-controller/src/index.ts */
+/* packages/transactions-controller/src/index.ts */
 
-export { FooController } from './foo-controller';
+export { TransactionsController } from './transactions-controller';
 ```
 
 ## Expose controller methods through messenger in bulk

--- a/docs/code-guidelines/controller-guidelines.md
+++ b/docs/code-guidelines/controller-guidelines.md
@@ -372,6 +372,163 @@ rootMessenger.subscribe('FooController:someEvent', () => {
 });
 ```
 
+## Define, but do not export, a name for the controller
+
+Every controller has a name, which is not only used to namespace the controller's messenger actions and events, but also to namespace the controller's state data when composed with other controllers.
+
+The name should be defined in a constant called `CONTROLLER_NAME` so that it can be easily changed if the need arises. (This variable was formerly called `controllerName`.) The name should be used to initialize the messenger, and should also be passed to the `BaseController` constructor.
+
+The constant should be used to define actions and events. It may be exported from the file in which it is defined, but should not listed as an export of the package:
+
+🚫 **The messenger namespace is not defined as a constant, but is repeated**
+
+```typescript
+export type FooControllerSomeCustomAction = {
+  type: 'FooController:someCustomAction';
+  handler: (bar: string) => void;
+};
+
+export type FooControllerAnotherCustomAction = {
+  type: 'FooController:anotherCustomAction';
+  handler: (baz: number) => void;
+};
+
+export type FooControllerActions =
+  | FooControllerSomeCustomAction
+  | FooControllerAnotherCustomAction;
+
+export type FooControllerMessenger = Messenger<
+  'FooController',
+  FooControllerActions,
+  never
+>;
+
+export class FooController extends BaseController</* ... */ {
+  constructor(/* ... */) {
+    super({ name: 'FooController', /* ... */ })
+
+    // ...
+  }
+}
+```
+
+🚫 **The messenger namespace is defined as a constant, but it is called `controllerName`**
+
+```typescript
+const controllerName = 'FooController';
+
+export type FooControllerSomeCustomAction = {
+  type: `${typeof controllerName}:someCustomAction`;
+  handler: (bar: string) => void;
+};
+
+export type FooControllerAnotherCustomAction = {
+  type: `${typeof controllerName}:anotherCustomAction`;
+  handler: (baz: number) => void;
+};
+
+export type FooControllerActions =
+  | FooControllerSomeCustomAction
+  | FooControllerAnotherCustomAction;
+
+export type FooControllerMessenger = Messenger<
+  typeof controllerName,
+  FooControllerActions,
+  never
+>;
+
+export class FooController extends BaseController</* ... */ {
+  constructor(/* ... */) {
+    super({ name: controllerName, /* ... */ })
+
+    // ...
+  }
+}
+```
+
+🚫 **The messenger namespace is defined as a constant, but it is exported from the package**
+
+```typescript
+/* packages/foo-controller/src/foo-controller.ts */
+
+export const CONTROLLER_NAME = 'FooController';
+
+export type FooControllerSomeCustomAction = {
+  type: `${typeof CONTROLLER_NAME}:someCustomAction`;
+  handler: (bar: string) => void;
+};
+
+export type FooControllerAnotherCustomAction = {
+  type: `${typeof CONTROLLER_NAME}:anotherCustomAction`;
+  handler: (baz: number) => void;
+};
+
+export type FooControllerActions =
+  | FooControllerSomeCustomAction
+  | FooControllerAnotherCustomAction;
+
+export type FooControllerMessenger = Messenger<
+  typeof CONTROLLER_NAME,
+  FooControllerActions,
+  never
+>;
+
+export class FooController extends BaseController</* ... */ {
+  constructor(/* ... */) {
+    super({ name: CONTROLLER_NAME, /* ... */ })
+
+    // ...
+  }
+}
+
+/* packages/foo-controller/src/index.ts */
+
+export {
+  CONTROLLER_NAME,
+  FooController
+} from './foo-controller';
+```
+
+✅ **The messenger namespace is defined as a constant, and it is kept internal instead of being exported**
+
+```typescript
+/* packages/foo-controller/src/foo-controller.ts */
+
+const CONTROLLER_NAME = 'FooController';
+
+export type FooControllerSomeCustomAction = {
+  type: `${CONTROLLER_NAME}:someCustomAction`;
+  handler: (bar: string) => void;
+};
+
+export type FooControllerAnotherCustomAction = {
+  type: `${CONTROLLER_NAME}:anotherCustomAction`;
+  handler: (baz: number) => void;
+};
+
+export type FooControllerActions =
+  | FooControllerSomeCustomAction
+  | FooControllerAnotherCustomAction;
+
+export type FooControllerMessenger = Messenger<
+  CONTROLLER_NAME,
+  FooControllerActions,
+  never
+>;
+
+export class FooController extends BaseController</* ... */ {
+  constructor(/* ... */) {
+    super({ name: CONTROLLER_NAME, /* ... */ })
+
+    // ...
+  }
+}
+
+/* packages/foo-controller/src/index.ts */
+
+export { FooController } from './foo-controller';
+```
+
 ## Expose controller methods through messenger in bulk
 
 Exposing controller methods through the messenger can be tedious. An action type must be created for each method, each action type must be added to the messenger type, and each action must be registered through the messenger. This creates a lot of boilerplate that must be maintained.

--- a/docs/code-guidelines/controller-guidelines.md
+++ b/docs/code-guidelines/controller-guidelines.md
@@ -42,11 +42,13 @@ The constant should be used to define actions and events. It may be exported fro
 
 ```typescript
 export type TransactionsControllerStateChangedEvent = ControllerStateChangedEvent<
+   // 🚫 Name is repeated.
   'TransactionsController',
   TransactionsControllerState
 >;
 
 export type TransactionsControllerTransactionApprovedEvent = {
+   // 🚫 Name is repeated.
   type: 'TransactionsController:transactionApprovedEvent';
   payload: [transaction: Transaction]
 };
@@ -56,6 +58,7 @@ export type TransactionsControllerEvents =
   | TransactionsControllerTransactionApprovedEvent
 
 export type TransactionsControllerMessenger = Messenger<
+   // 🚫 Name is repeated.
   'TransactionsController',
   never,
   TransactionsControllerEvents
@@ -73,6 +76,7 @@ export class TransactionsController extends BaseController</* ... */ {
 🚫 **The messenger namespace is defined as a constant, but it is called `controllerName` (legacy name)**
 
 ```typescript
+// 🚫 Uses legacy name.
 const controllerName = 'TransactionsController';
 
 export type TransactionsControllerStateChangedEvent = ControllerStateChangedEvent<
@@ -142,6 +146,7 @@ export class TransactionsController extends BaseController</* ... */ {
 /* packages/transactions-controller/src/index.ts */
 
 export {
+  // 🚫 The controller name should not be exported from the package.
   CONTROLLER_NAME,
   TransactionsController
 } from './transactions-controller';

--- a/docs/code-guidelines/controller-guidelines.md
+++ b/docs/code-guidelines/controller-guidelines.md
@@ -151,7 +151,8 @@ export class TransactionsController extends BaseController<typeof CONTROLLER_NAM
 export {
   // 🚫 The controller name should not be exported from the package.
   CONTROLLER_NAME,
-  TransactionsController
+  TransactionsController,
+  // ...
 } from './transactions-controller';
 ```
 
@@ -160,6 +161,7 @@ export {
 ```typescript
 /* packages/transactions-controller/src/transactions-controller.ts */
 
+// ✅ Using correct name.
 const CONTROLLER_NAME = 'TransactionsController';
 
 export type TransactionsControllerStateChangedEvent = ControllerStateChangedEvent<
@@ -192,7 +194,11 @@ export class TransactionsController extends BaseController<typeof CONTROLLER_NAM
 
 /* packages/transactions-controller/src/index.ts */
 
-export { TransactionsController } from './transactions-controller';
+export {
+  // ✅ Name is not exported.
+  TransactionsController,
+  // ...
+} from './transactions-controller';
 ```
 
 ## Accept an optional, partial representation of state

--- a/docs/code-guidelines/controller-guidelines.md
+++ b/docs/code-guidelines/controller-guidelines.md
@@ -36,7 +36,7 @@ Every controller has a name, which is used to namespace not only the controller'
 
 The name should be defined in a constant called `CONTROLLER_NAME` so that it can be easily changed if the need arises. The name should be used to initialize the messenger, and it should also be passed to the `BaseController` constructor.
 
-The constant should be used to define actions and events. It may be exported from the file in which it is defined, but should not listed as an export of the package:
+The constant should be used to define actions and events. It may be exported from the file in which it is defined, but should not listed as an export of the package.
 
 🚫 **The messenger namespace is not defined as a constant, but is repeated**
 

--- a/docs/code-guidelines/controller-guidelines.md
+++ b/docs/code-guidelines/controller-guidelines.md
@@ -41,32 +41,35 @@ The constant should be used to define actions and events. It may be exported fro
 🚫 **The messenger namespace is not defined as a constant, but is repeated**
 
 ```typescript
-export type TransactionsControllerStateChangedEvent = ControllerStateChangedEvent<
-   // 🚫 Name is repeated.
-  'TransactionsController',
-  TransactionsControllerState
->;
+export type TransactionsControllerStateChangedEvent =
+  ControllerStateChangedEvent<
+    // 🚫 Name is repeated.
+    'TransactionsController',
+    TransactionsControllerState
+  >;
 
 export type TransactionsControllerTransactionApprovedEvent = {
-   // 🚫 Name is repeated.
+  // 🚫 Name is repeated.
   type: 'TransactionsController:transactionApprovedEvent';
-  payload: [transaction: Transaction]
+  payload: [transaction: Transaction];
 };
 
 export type TransactionsControllerEvents =
   | TransactionsControllerStateChangedEvent
-  | TransactionsControllerTransactionApprovedEvent
+  | TransactionsControllerTransactionApprovedEvent;
 
 export type TransactionsControllerMessenger = Messenger<
-   // 🚫 Name is repeated.
+  // 🚫 Name is repeated.
   'TransactionsController',
   never,
   TransactionsControllerEvents
 >;
 
-export class TransactionsController extends BaseController</* ... */ {
+// 🚫 Name is repeated.
+export class TransactionsController extends BaseController<'TransactionsController' /*,  ... */> {
   constructor(/* ... */) {
-    super({ name: 'TransactionsController', /* ... */ })
+    // 🚫 Name is repeated.
+    super({ name: 'TransactionsController' /* ... */ });
 
     // ...
   }
@@ -99,7 +102,7 @@ export type TransactionsControllerMessenger = Messenger<
   TransactionsControllerEvents
 >;
 
-export class TransactionsController extends BaseController</* ... */ {
+export class TransactionsController extends BaseController<typeof controllerName /*, ... */ {
   constructor(/* ... */) {
     super({ name: controllerName, /* ... */ })
 
@@ -135,7 +138,7 @@ export type TransactionsControllerMessenger = Messenger<
   TransactionsControllerEvents
 >;
 
-export class TransactionsController extends BaseController</* ... */ {
+export class TransactionsController extends BaseController<typeof CONTROLLER_NAME /*, ... */ {
   constructor(/* ... */) {
     super({ name: CONTROLLER_NAME, /* ... */ })
 
@@ -179,7 +182,7 @@ export type TransactionsControllerMessenger = Messenger<
   TransactionsControllerEvents
 >;
 
-export class TransactionsController extends BaseController</* ... */ {
+export class TransactionsController extends BaseController<typeof CONTROLLER_NAME /*, ... */ {
   constructor(/* ... */) {
     super({ name: CONTROLLER_NAME, /* ... */ })
 

--- a/docs/code-guidelines/controller-guidelines.md
+++ b/docs/code-guidelines/controller-guidelines.md
@@ -30,6 +30,163 @@ The name of the controller should reflect its responsibility. If, when creating 
 
 Each public method and each state property of a controller should have a purpose, and the name of the method or state property should be readable and should reflect the purpose clearly. If something does not need to be public, it should be made private; if it is unnecessary, it should be removed.
 
+## Define, but do not export, a name for the controller
+
+Every controller has a name, which is used to namespace not only the controller's messenger actions and events, but also the controller's state data when composed with other controllers.
+
+The name should be defined in a constant called `CONTROLLER_NAME` so that it can be easily changed if the need arises. The name should be used to initialize the messenger, and it should also be passed to the `BaseController` constructor.
+
+The constant should be used to define actions and events. It may be exported from the file in which it is defined, but should not listed as an export of the package:
+
+🚫 **The messenger namespace is not defined as a constant, but is repeated**
+
+```typescript
+export type TransactionsControllerStateChangedEvent = ControllerStateChangedEvent<
+  'TransactionsController',
+  TransactionsControllerState
+>;
+
+export type TransactionsControllerTransactionApprovedEvent = {
+  type: 'TransactionsController:transactionApprovedEvent';
+  payload: [transaction: Transaction]
+};
+
+export type TransactionsControllerEvents =
+  | TransactionsControllerStateChangedEvent
+  | TransactionsControllerTransactionApprovedEvent
+
+export type TransactionsControllerMessenger = Messenger<
+  'TransactionsController',
+  never,
+  TransactionsControllerEvents
+>;
+
+export class TransactionsController extends BaseController</* ... */ {
+  constructor(/* ... */) {
+    super({ name: 'TransactionsController', /* ... */ })
+
+    // ...
+  }
+}
+```
+
+🚫 **The messenger namespace is defined as a constant, but it is called `controllerName` (legacy name)**
+
+```typescript
+const controllerName = 'TransactionsController';
+
+export type TransactionsControllerStateChangedEvent = ControllerStateChangedEvent<
+  typeof controllerName,
+  TransactionsControllerState
+>;
+
+export type TransactionsControllerTransactionApprovedEvent = {
+  type: `${typeof controllerName}:transactionApprovedEvent`;
+  payload: [transaction: Transaction]
+};
+
+export type TransactionsControllerEvents =
+  | TransactionsControllerStateChangedEvent
+  | TransactionsControllerTransactionApprovedEvent
+
+export type TransactionsControllerMessenger = Messenger<
+  typeof controllerName,
+  never,
+  TransactionsControllerEvents
+>;
+
+export class TransactionsController extends BaseController</* ... */ {
+  constructor(/* ... */) {
+    super({ name: controllerName, /* ... */ })
+
+    // ...
+  }
+}
+```
+
+🚫 **The messenger namespace is defined as a constant, but it is exported from the package**
+
+```typescript
+/* packages/transactions-controller/src/transactions-controller.ts */
+
+export const CONTROLLER_NAME = 'TransactionsController';
+
+export type TransactionsControllerStateChangedEvent = ControllerStateChangedEvent<
+  typeof CONTROLLER_NAME,
+  TransactionsControllerState
+>;
+
+export type TransactionsControllerTransactionApprovedEvent = {
+  type: `${typeof CONTROLLER_NAME}:transactionApprovedEvent`;
+  payload: [transaction: Transaction]
+};
+
+export type TransactionsControllerEvents =
+  | TransactionsControllerStateChangedEvent
+  | TransactionsControllerTransactionApprovedEvent
+
+export type TransactionsControllerMessenger = Messenger<
+  typeof CONTROLLER_NAME,
+  never,
+  TransactionsControllerEvents
+>;
+
+export class TransactionsController extends BaseController</* ... */ {
+  constructor(/* ... */) {
+    super({ name: CONTROLLER_NAME, /* ... */ })
+
+    // ...
+  }
+}
+
+/* packages/transactions-controller/src/index.ts */
+
+export {
+  CONTROLLER_NAME,
+  TransactionsController
+} from './transactions-controller';
+```
+
+✅ **The messenger namespace is defined as a constant, and it is kept internal instead of being exported**
+
+```typescript
+/* packages/transactions-controller/src/transactions-controller.ts */
+
+const CONTROLLER_NAME = 'TransactionsController';
+
+export type TransactionsControllerStateChangedEvent = ControllerStateChangedEvent<
+  typeof CONTROLLER_NAME,
+  TransactionsControllerState
+>;
+
+export type TransactionsControllerTransactionApprovedEvent = {
+  type: `${typeof CONTROLLER_NAME}:transactionApprovedEvent`;
+  payload: [transaction: Transaction]
+};
+
+export type TransactionsControllerEvents =
+  | TransactionsControllerStateChangedEvent
+  | TransactionsControllerTransactionApprovedEvent
+
+export type TransactionsControllerMessenger = Messenger<
+  typeof CONTROLLER_NAME,
+  never,
+  TransactionsControllerEvents
+>;
+
+export class TransactionsController extends BaseController</* ... */ {
+  constructor(/* ... */) {
+    super({ name: CONTROLLER_NAME, /* ... */ })
+
+    // ...
+  }
+}
+
+/* packages/transactions-controller/src/index.ts */
+
+export { TransactionsController } from './transactions-controller';
+```
+
 ## Accept an optional, partial representation of state
 
 Although `BaseController` requires a full representation of controller state, in practice, controllers should accept a partial version and then supply missing properties with defaults. In fact, the `state` argument should be optional:
@@ -370,163 +527,6 @@ const fooController = new FooController({
 rootMessenger.subscribe('FooController:someEvent', () => {
   // do something with the event
 });
-```
-
-## Define, but do not export, a name for the controller
-
-Every controller has a name, which is used to namespace not only the controller's messenger actions and events, but also the controller's state data when composed with other controllers.
-
-The name should be defined in a constant called `CONTROLLER_NAME` so that it can be easily changed if the need arises. The name should be used to initialize the messenger, and it should also be passed to the `BaseController` constructor.
-
-The constant should be used to define actions and events. It may be exported from the file in which it is defined, but should not listed as an export of the package:
-
-🚫 **The messenger namespace is not defined as a constant, but is repeated**
-
-```typescript
-export type TransactionsControllerStateChangedEvent = ControllerStateChangedEvent<
-  'TransactionsController',
-  TransactionsControllerState
->;
-
-export type TransactionsControllerTransactionApprovedEvent = {
-  type: 'TransactionsController:transactionApprovedEvent';
-  payload: [transaction: Transaction]
-};
-
-export type TransactionsControllerEvents =
-  | TransactionsControllerStateChangedEvent
-  | TransactionsControllerTransactionApprovedEvent
-
-export type TransactionsControllerMessenger = Messenger<
-  'TransactionsController',
-  never,
-  TransactionsControllerEvents
->;
-
-export class TransactionsController extends BaseController</* ... */ {
-  constructor(/* ... */) {
-    super({ name: 'TransactionsController', /* ... */ })
-
-    // ...
-  }
-}
-```
-
-🚫 **The messenger namespace is defined as a constant, but it is called `controllerName` (legacy name)**
-
-```typescript
-const controllerName = 'TransactionsController';
-
-export type TransactionsControllerStateChangedEvent = ControllerStateChangedEvent<
-  typeof controllerName,
-  TransactionsControllerState
->;
-
-export type TransactionsControllerTransactionApprovedEvent = {
-  type: `${typeof controllerName}:transactionApprovedEvent`;
-  payload: [transaction: Transaction]
-};
-
-export type TransactionsControllerEvents =
-  | TransactionsControllerStateChangedEvent
-  | TransactionsControllerTransactionApprovedEvent
-
-export type TransactionsControllerMessenger = Messenger<
-  typeof controllerName,
-  never,
-  TransactionsControllerEvents
->;
-
-export class TransactionsController extends BaseController</* ... */ {
-  constructor(/* ... */) {
-    super({ name: controllerName, /* ... */ })
-
-    // ...
-  }
-}
-```
-
-🚫 **The messenger namespace is defined as a constant, but it is exported from the package**
-
-```typescript
-/* packages/transactions-controller/src/transactions-controller.ts */
-
-export const CONTROLLER_NAME = 'TransactionsController';
-
-export type TransactionsControllerStateChangedEvent = ControllerStateChangedEvent<
-  typeof CONTROLLER_NAME,
-  TransactionsControllerState
->;
-
-export type TransactionsControllerTransactionApprovedEvent = {
-  type: `${typeof CONTROLLER_NAME}:transactionApprovedEvent`;
-  payload: [transaction: Transaction]
-};
-
-export type TransactionsControllerEvents =
-  | TransactionsControllerStateChangedEvent
-  | TransactionsControllerTransactionApprovedEvent
-
-export type TransactionsControllerMessenger = Messenger<
-  typeof CONTROLLER_NAME,
-  never,
-  TransactionsControllerEvents
->;
-
-export class TransactionsController extends BaseController</* ... */ {
-  constructor(/* ... */) {
-    super({ name: CONTROLLER_NAME, /* ... */ })
-
-    // ...
-  }
-}
-
-/* packages/transactions-controller/src/index.ts */
-
-export {
-  CONTROLLER_NAME,
-  TransactionsController
-} from './transactions-controller';
-```
-
-✅ **The messenger namespace is defined as a constant, and it is kept internal instead of being exported**
-
-```typescript
-/* packages/transactions-controller/src/transactions-controller.ts */
-
-const CONTROLLER_NAME = 'TransactionsController';
-
-export type TransactionsControllerStateChangedEvent = ControllerStateChangedEvent<
-  typeof CONTROLLER_NAME,
-  TransactionsControllerState
->;
-
-export type TransactionsControllerTransactionApprovedEvent = {
-  type: `${typeof CONTROLLER_NAME}:transactionApprovedEvent`;
-  payload: [transaction: Transaction]
-};
-
-export type TransactionsControllerEvents =
-  | TransactionsControllerStateChangedEvent
-  | TransactionsControllerTransactionApprovedEvent
-
-export type TransactionsControllerMessenger = Messenger<
-  typeof CONTROLLER_NAME,
-  never,
-  TransactionsControllerEvents
->;
-
-export class TransactionsController extends BaseController</* ... */ {
-  constructor(/* ... */) {
-    super({ name: CONTROLLER_NAME, /* ... */ })
-
-    // ...
-  }
-}
-
-/* packages/transactions-controller/src/index.ts */
-
-export { TransactionsController } from './transactions-controller';
 ```
 
 ## Expose controller methods through messenger in bulk

--- a/packages/sample-controllers/src/sample-gas-prices-controller.ts
+++ b/packages/sample-controllers/src/sample-gas-prices-controller.ts
@@ -22,7 +22,7 @@ import type { SampleGasPricesServiceFetchGasPricesAction } from './sample-gas-pr
  * controller's actions and events and to namespace the controller's state data
  * when composed with other controllers.
  */
-export const controllerName = 'SampleGasPricesController';
+const CONTROLLER_NAME = 'SampleGasPricesController';
 
 // === STATE ===
 
@@ -94,7 +94,7 @@ const MESSENGER_EXPOSED_METHODS = ['updateGasPrices'] as const;
  * Retrieves the state of the {@link SampleGasPricesController}.
  */
 export type SampleGasPricesControllerGetStateAction = ControllerGetStateAction<
-  typeof controllerName,
+  typeof CONTROLLER_NAME,
   SampleGasPricesControllerState
 >;
 
@@ -117,7 +117,7 @@ type AllowedActions =
  */
 export type SampleGasPricesControllerStateChangeEvent =
   ControllerStateChangeEvent<
-    typeof controllerName,
+    typeof CONTROLLER_NAME,
     SampleGasPricesControllerState
   >;
 
@@ -138,7 +138,7 @@ type AllowedEvents = NetworkControllerStateChangeEvent;
  * {@link SampleGasPricesController}.
  */
 export type SampleGasPricesControllerMessenger = Messenger<
-  typeof controllerName,
+  typeof CONTROLLER_NAME,
   SampleGasPricesControllerActions | AllowedActions,
   SampleGasPricesControllerEvents | AllowedEvents
 >;
@@ -219,7 +219,7 @@ export type SampleGasPricesControllerMessenger = Messenger<
  * ```
  */
 export class SampleGasPricesController extends BaseController<
-  typeof controllerName,
+  typeof CONTROLLER_NAME,
   SampleGasPricesControllerState,
   SampleGasPricesControllerMessenger
 > {
@@ -246,7 +246,7 @@ export class SampleGasPricesController extends BaseController<
     super({
       messenger,
       metadata: gasPricesControllerMetadata,
-      name: controllerName,
+      name: CONTROLLER_NAME,
       state: {
         ...getDefaultSampleGasPricesControllerState(),
         ...state,

--- a/packages/sample-controllers/src/sample-petnames-controller.ts
+++ b/packages/sample-controllers/src/sample-petnames-controller.ts
@@ -17,7 +17,7 @@ import type { SamplePetnamesControllerMethodActions } from './sample-petnames-co
  * controller's actions and events and to namespace the controller's state data
  * when composed with other controllers.
  */
-export const controllerName = 'SamplePetnamesController';
+const CONTROLLER_NAME = 'SamplePetnamesController';
 
 // === STATE ===
 
@@ -70,7 +70,7 @@ const MESSENGER_EXPOSED_METHODS = ['assignPetname'] as const;
  * Retrieves the state of the {@link SamplePetnamesController}.
  */
 export type SamplePetnamesControllerGetStateAction = ControllerGetStateAction<
-  typeof controllerName,
+  typeof CONTROLLER_NAME,
   SamplePetnamesControllerState
 >;
 
@@ -91,7 +91,7 @@ type AllowedActions = never;
  */
 export type SamplePetnamesControllerStateChangeEvent =
   ControllerStateChangeEvent<
-    typeof controllerName,
+    typeof CONTROLLER_NAME,
     SamplePetnamesControllerState
   >;
 
@@ -112,7 +112,7 @@ type AllowedEvents = never;
  * {@link SamplePetnamesController}.
  */
 export type SamplePetnamesControllerMessenger = Messenger<
-  typeof controllerName,
+  typeof CONTROLLER_NAME,
   SamplePetnamesControllerActions | AllowedActions,
   SamplePetnamesControllerEvents | AllowedEvents
 >;
@@ -167,7 +167,7 @@ export type SamplePetnamesControllerMessenger = Messenger<
  * ```
  */
 export class SamplePetnamesController extends BaseController<
-  typeof controllerName,
+  typeof CONTROLLER_NAME,
   SamplePetnamesControllerState,
   SamplePetnamesControllerMessenger
 > {
@@ -189,7 +189,7 @@ export class SamplePetnamesController extends BaseController<
     super({
       messenger,
       metadata: samplePetnamesControllerMetadata,
-      name: controllerName,
+      name: CONTROLLER_NAME,
       state: {
         ...getDefaultPetnamesControllerState(),
         ...state,


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

There is no written standard for defining the name of a controller, and some contributors do not have a common understanding of the do's and dont's for the name.

This commit adds such a guideline, highlighting the following points:

- The name of a controller should be defined in a variable called `CONTROLLER_NAME` (formerly `controllerName`)
- The name should be used to define custom actions and events and should be passed to `BaseController`
- The name should not be exported from the package

Besides updating the guidelines, this commit also updates the `sample-controllers` package to follow them, most notably changing `controllerName` to `CONTROLLER_NAME` and removing the `export` from this constant.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes an exported constant and renames `controllerName` to `CONTROLLER_NAME` in sample controllers, which could break any consumers importing that symbol even though runtime behavior is unchanged.
> 
> **Overview**
> Adds a new controller guideline requiring a single internal `CONTROLLER_NAME` constant to namespace messenger actions/events and `BaseController` state, and explicitly discouraging exporting that constant from the package.
> 
> Updates the `sample-controllers` examples (`sample-gas-prices-controller` and `sample-petnames-controller`) to follow the guideline by replacing exported `controllerName` with an internal `CONTROLLER_NAME` and wiring all messenger/type and `BaseController` references to it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4757fdb82a12c7cfc1307f2e0a0461c4a7ba8094. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->