### PR TITLE
chore: updated value for socialAI

### DIFF
--- a/packages/authenticated-user-storage/CHANGELOG.md
+++ b/packages/authenticated-user-storage/CHANGELOG.md
@@ -12,4 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release ([#8260](https://github.com/MetaMask/core/pull/8260))
   - `AuthenticatedUserStorageService` class with namespaced domain accessors: `delegations` (list, create, revoke) and `preferences` (getNotifications, putNotifications)
 
+### Changed
+
+- **BREAKING**: Rename `SocialAIPreference.traderProfileIds` to `mutedTraderProfileIds` in types and notification-preferences validation to match the API payload ([#8536](https://github.com/MetaMask/core/pull/8536)).
+
 [Unreleased]: https://github.com/MetaMask/core/

--- a/packages/authenticated-user-storage/src/types.ts
+++ b/packages/authenticated-user-storage/src/types.ts
@@ -96,7 +96,7 @@ export type PerpsPreference = {
 export type SocialAIPreference = {
   enabled: boolean;
   txAmountLimit?: number;
-  traderProfileIds: string[];
+  mutedTraderProfileIds: string[];
 };
 
 /** Notification preferences for the authenticated user. */

--- a/packages/authenticated-user-storage/src/validators.ts
+++ b/packages/authenticated-user-storage/src/validators.ts
@@ -80,7 +80,7 @@ const PerpsPreferenceSchema = type({
 const SocialAIPreferenceSchema = type({
   enabled: boolean(),
   txAmountLimit: optional(number()),
-  traderProfileIds: array(string()),
+  mutedTraderProfileIds: array(string()),
 });
 
 const NotificationPreferencesSchema = type({

--- a/packages/authenticated-user-storage/tests/mocks/authenticated-userstorage.ts
+++ b/packages/authenticated-user-storage/tests/mocks/authenticated-userstorage.ts
@@ -53,7 +53,7 @@ export const MOCK_NOTIFICATION_PREFERENCES: NotificationPreferences = {
   socialAI: {
     enabled: true,
     txAmountLimit: 100,
-    traderProfileIds: [
+    mutedTraderProfileIds: [
       'b3a7c9d1-4e2f-4a8b-9c6d-1f2e3a4b5c6d',
       'e8f2a1b3-5c4d-4e6f-8a9b-2c3d4e5f6a7b',
     ],


### PR DESCRIPTION
## Explanation

Updates the `traderProfileIds` to `mutedTraderProfileIds`. So that its in line with the latest spec.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking rename in a public type/validator can cause downstream compile-time failures and runtime payload mismatches until consumers update.
> 
> **Overview**
> Renames the SocialAI notification preference field from `traderProfileIds` to `mutedTraderProfileIds` across exported types, superstruct validation, and test mocks to align with the API payload.
> 
> Updates the package changelog to flag this as a **BREAKING** change for consumers relying on the old field name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6dc891aa73b5a515ec63dc22a3c9fc8c99af665. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->