### PR TITLE
Revert "Update Release 929.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "929.0.0",
+  "version": "928.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {

--- a/packages/authenticated-user-storage/CHANGELOG.md
+++ b/packages/authenticated-user-storage/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0]
-
 ### Added
 
 - Initial release ([#8260](https://github.com/MetaMask/core/pull/8260))
@@ -18,5 +16,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **BREAKING**: Rename `SocialAIPreference.traderProfileIds` to `mutedTraderProfileIds` in types and notification-preferences validation to match the API payload ([#8536](https://github.com/MetaMask/core/pull/8536)).
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/authenticated-user-storage@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/core/releases/tag/@metamask/authenticated-user-storage@1.0.0
+[Unreleased]: https://github.com/MetaMask/core/

--- a/packages/authenticated-user-storage/package.json
+++ b/packages/authenticated-user-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/authenticated-user-storage",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "SDK for authenticated (non-encrypted) user storage endpoints",
   "keywords": [
     "Ethereum",


### PR DESCRIPTION
Reverts MetaMask/core#8538

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only reverts version/changelog metadata, but it can affect publishing and release automation if downstream expects the previously bumped versions.
> 
> **Overview**
> Reverts the `929.0.0` release metadata by downgrading the monorepo `package.json` version back to `928.0.0`.
> 
> Also resets `@metamask/authenticated-user-storage` from `1.0.0` to `0.0.0` and removes the `1.0.0` section/linking from its `CHANGELOG.md`, leaving the entries under `Unreleased`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a5700aadcd3643cc308bb03677eab9a8c734041. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->