### PR TITLE
feat(analytics-controller): optional skipUUIDv4Check on platform adapter

### DIFF
--- a/packages/analytics-controller/CHANGELOG.md
+++ b/packages/analytics-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Optional `skipUUIDv4Check` on `AnalyticsPlatformAdapter` to allow non-UUIDv4 `analyticsId` strings when constructing `AnalyticsController`
+
 ### Changed
 
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))

--- a/packages/analytics-controller/CHANGELOG.md
+++ b/packages/analytics-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Optional `skipUUIDv4Check` on `AnalyticsPlatformAdapter` to allow non-UUIDv4 `analyticsId` strings when constructing `AnalyticsController`
+- Optional `skipUUIDv4Check` on `AnalyticsPlatformAdapter` to allow non-UUIDv4 `analyticsId` strings when constructing `AnalyticsController` ([#8543](https://github.com/MetaMask/core/pull/8543))
 
 ### Changed
 

--- a/packages/analytics-controller/src/AnalyticsController.test.ts
+++ b/packages/analytics-controller/src/AnalyticsController.test.ts
@@ -377,6 +377,24 @@ describe('AnalyticsController', () => {
       }).toThrow('Invalid analyticsId');
     });
 
+    it('accepts non-UUID analyticsId when adapter skipUUIDv4Check is true', async () => {
+      const analyticsId = 'not-a-uuid';
+      const platformAdapter = {
+        ...createMockAdapter(),
+        skipUUIDv4Check: true,
+      };
+      const { controller } = await setupController({
+        state: {
+          optedIn: false,
+          analyticsId,
+        },
+        platformAdapter,
+      });
+
+      expect(controller.state.analyticsId).toBe(analyticsId);
+      expect(platformAdapter.onSetupCompleted).toHaveBeenCalledWith(analyticsId);
+    });
+
     it('accepts different valid UUIDv4 values', async () => {
       const analyticsId1 = '11111111-1111-4111-8111-111111111111';
       const analyticsId2 = '22222222-2222-4222-9222-222222222222';

--- a/packages/analytics-controller/src/AnalyticsController.test.ts
+++ b/packages/analytics-controller/src/AnalyticsController.test.ts
@@ -392,7 +392,9 @@ describe('AnalyticsController', () => {
       });
 
       expect(controller.state.analyticsId).toBe(analyticsId);
-      expect(platformAdapter.onSetupCompleted).toHaveBeenCalledWith(analyticsId);
+      expect(platformAdapter.onSetupCompleted).toHaveBeenCalledWith(
+        analyticsId,
+      );
     });
 
     it('accepts different valid UUIDv4 values', async () => {

--- a/packages/analytics-controller/src/AnalyticsController.ts
+++ b/packages/analytics-controller/src/AnalyticsController.ts
@@ -219,7 +219,10 @@ export class AnalyticsController extends BaseController<
       ...state,
     };
 
-    validateAnalyticsControllerState(initialState);
+    validateAnalyticsControllerState(
+      initialState,
+      platformAdapter.skipUUIDv4Check === true,
+    );
 
     super({
       name: controllerName,

--- a/packages/analytics-controller/src/AnalyticsPlatformAdapter.types.ts
+++ b/packages/analytics-controller/src/AnalyticsPlatformAdapter.types.ts
@@ -34,6 +34,12 @@ export type AnalyticsTrackingEvent = {
  */
 export type AnalyticsPlatformAdapter = {
   /**
+   * When `true`, the controller accepts any non-empty `analyticsId` string
+   * instead of requiring UUIDv4 format. Defaults to validation against UUIDv4 when omitted or `false`.
+   */
+  skipUUIDv4Check?: boolean;
+
+  /**
    * Track an analytics event.
    *
    * This is the same as trackEvent in the old analytics system

--- a/packages/analytics-controller/src/analyticsControllerStateValidator.test.ts
+++ b/packages/analytics-controller/src/analyticsControllerStateValidator.test.ts
@@ -54,9 +54,7 @@ describe('analyticsControllerStateValidator', () => {
         analyticsId: 'not-a-uuid',
       };
 
-      expect(() =>
-        validateAnalyticsControllerState(state, true),
-      ).not.toThrow();
+      expect(() => validateAnalyticsControllerState(state, true)).not.toThrow();
     });
 
     it('throws when analyticsId is not UUIDv4 and skipUUIDv4Check is false', () => {
@@ -65,9 +63,9 @@ describe('analyticsControllerStateValidator', () => {
         analyticsId: 'not-a-uuid',
       };
 
-      expect(() =>
-        validateAnalyticsControllerState(state, false),
-      ).toThrow('Invalid analyticsId');
+      expect(() => validateAnalyticsControllerState(state, false)).toThrow(
+        'Invalid analyticsId',
+      );
     });
 
     it('throws when analyticsId is empty string even if skipUUIDv4Check is true', () => {
@@ -76,9 +74,9 @@ describe('analyticsControllerStateValidator', () => {
         analyticsId: '',
       };
 
-      expect(() =>
-        validateAnalyticsControllerState(state, true),
-      ).toThrow('Invalid analyticsId');
+      expect(() => validateAnalyticsControllerState(state, true)).toThrow(
+        'Invalid analyticsId',
+      );
     });
   });
 });

--- a/packages/analytics-controller/src/analyticsControllerStateValidator.test.ts
+++ b/packages/analytics-controller/src/analyticsControllerStateValidator.test.ts
@@ -47,5 +47,38 @@ describe('analyticsControllerStateValidator', () => {
 
       expect(() => validateAnalyticsControllerState(state)).not.toThrow();
     });
+
+    it('does not throw for non-UUID string when skipUUIDv4Check is true', () => {
+      const state: AnalyticsControllerState = {
+        optedIn: false,
+        analyticsId: 'not-a-uuid',
+      };
+
+      expect(() =>
+        validateAnalyticsControllerState(state, true),
+      ).not.toThrow();
+    });
+
+    it('throws when analyticsId is not UUIDv4 and skipUUIDv4Check is false', () => {
+      const state: AnalyticsControllerState = {
+        optedIn: false,
+        analyticsId: 'not-a-uuid',
+      };
+
+      expect(() =>
+        validateAnalyticsControllerState(state, false),
+      ).toThrow('Invalid analyticsId');
+    });
+
+    it('throws when analyticsId is empty string even if skipUUIDv4Check is true', () => {
+      const state: AnalyticsControllerState = {
+        optedIn: false,
+        analyticsId: '',
+      };
+
+      expect(() =>
+        validateAnalyticsControllerState(state, true),
+      ).toThrow('Invalid analyticsId');
+    });
   });
 });

--- a/packages/analytics-controller/src/analyticsControllerStateValidator.ts
+++ b/packages/analytics-controller/src/analyticsControllerStateValidator.ts
@@ -24,12 +24,17 @@ export function isValidUUIDv4(value: string): boolean {
  * Validates that the analytics state has a valid UUIDv4 analyticsId.
  *
  * @param state - The analytics controller state to validate
+ * @param skipUUIDv4Check - When `true`, skips UUIDv4 format validation
  * @throws Error if analyticsId is missing or not a valid UUIDv4
  */
 export function validateAnalyticsControllerState(
   state: AnalyticsControllerState,
+  skipUUIDv4Check?: boolean,
 ): void {
-  if (!state.analyticsId || !isValidUUIDv4(state.analyticsId)) {
+  if (
+    !state.analyticsId ||
+    (skipUUIDv4Check !== true && !isValidUUIDv4(state.analyticsId))
+  ) {
     throw new Error('Invalid analyticsId');
   }
 }


### PR DESCRIPTION
## Explanation

Allow non-UUIDv4 analyticsId when adapter.skipUUIDv4Check is true, as this is needed in Extension, where IDs are not UUIDv4.

## References

NA

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Relaxes `analyticsId` validation when `skipUUIDv4Check` is enabled on the platform adapter, which could allow inconsistent identifiers if misused but remains opt-in and still rejects empty IDs.
> 
> **Overview**
> Adds an optional `skipUUIDv4Check` flag to `AnalyticsPlatformAdapter` and threads it into `AnalyticsController` state validation so platforms can use non-UUIDv4 `analyticsId` values while still requiring a non-empty string.
> 
> Updates the state validator and expands unit tests (controller + validator) to cover the new bypass behavior, and documents the change in the package changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f6e59816de750dcc303fd1773fef1c7ad257abe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->