### PR TITLE
fix(controller-utils): update Sei Mainnet explorer to seiscan.io

### DIFF
--- a/packages/controller-utils/CHANGELOG.md
+++ b/packages/controller-utils/CHANGELOG.md
@@ -9,8 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update default Sei Mainnet block explorer URL from `seitrace.com` to
-  `seiscan.io` (`BuiltInNetworkName.SeiMainnet`).
+- Update default Sei Mainnet block explorer URL from `seitrace.com` to `seiscan.io` ([#8545](https://github.com/MetaMask/core/pull/8545))
 
 ## [11.20.0]
 

--- a/packages/controller-utils/CHANGELOG.md
+++ b/packages/controller-utils/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update default Sei Mainnet block explorer URL from `seitrace.com` to
+  `seiscan.io` (`BuiltInNetworkName.SeiMainnet`).
+
 ## [11.20.0]
 
 ### Added

--- a/packages/controller-utils/src/types.ts
+++ b/packages/controller-utils/src/types.ts
@@ -179,7 +179,7 @@ export const BlockExplorerUrl = {
   [BuiltInNetworkName.BscMainnet]: 'https://bscscan.com',
   [BuiltInNetworkName.OptimismMainnet]: 'https://optimistic.etherscan.io',
   [BuiltInNetworkName.PolygonMainnet]: 'https://polygonscan.com',
-  [BuiltInNetworkName.SeiMainnet]: 'https://seitrace.com',
+  [BuiltInNetworkName.SeiMainnet]: 'https://seiscan.io',
 } as const satisfies Record<BuiltInNetworkType, string>;
 export type BlockExplorerUrl =
   (typeof BlockExplorerUrl)[keyof typeof BlockExplorerUrl];


### PR DESCRIPTION
## Explanation

The current default block explorer for Sei Mainnet (`seitrace.com`) is being
decommissioned. This PR updates the `BlockExplorerUrl` entry for
`BuiltInNetworkName.SeiMainnet` to its replacement, `seiscan.io`.

`seiscan.io` is an Etherscan-family explorer. This is a UI-URL change only —
`@metamask/controller-utils` exposes the user-facing block-explorer URL (the
one consumers concatenate `/tx/<hash>` or `/address/<addr>` onto), and the
hostname swap is the only thing that needs to land here.

Clients (metamask-extension, metamask-mobile) will pick this up via a
`@metamask/controller-utils` bump and ship a state migration to rewrite
existing users' stored Sei explorer URL.

## References
- Related PR in [`MetaMask/metafi-sdk`](https://github.com/MetaMask/metafi-sdk/tree/fix/sei-explorer-seitrace-to-seiscan) for the same explorer migration in `@codefi/metafi-common`.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant URL change plus changelog update; no logic, data handling, or security-sensitive behavior is modified.
> 
> **Overview**
> Updates the `BlockExplorerUrl` mapping so `BuiltInNetworkName.SeiMainnet` now resolves to `https://seiscan.io` (replacing `https://seitrace.com`).
> 
> Adds an *Unreleased* changelog entry in `@metamask/controller-utils` documenting the default explorer hostname change for Sei Mainnet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3df134902b719424c30fd2ace356c21a46566851. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->