### PR TITLE
refactor(permission-controller)!: Add messenger alternative to restricted method hooks

### DIFF
--- a/packages/permission-controller/CHANGELOG.md
+++ b/packages/permission-controller/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `createPermissionMiddlewareV2`, a `JsonRpcEngineV2` variant of the standalone permission middleware factory ([#8532](https://github.com/MetaMask/core/pull/8532))
+- Add `messenger` option to permission specification builders, allowing restricted-method specs to receive a scoped messenger in place of `methodHooks` ([#8551](https://github.com/MetaMask/core/pull/8551))
+  - Use the `actionNames` field on the specification builder and `createRestrictedMethodMessenger` to construct the scoped messenger.
 
 ### Changed
 
@@ -24,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 - Deprecate `createPermissionMiddleware` in favor of `createPermissionMiddlewareV2`, which targets `JsonRpcEngineV2` ([#8532](https://github.com/MetaMask/core/pull/8532))
+
+### Removed
+
+- **BREAKING:** `factoryHooks`, `validatorHooks`, and related fields from permission specification builders ([#8551](https://github.com/MetaMask/core/pull/8551))
 
 ## [12.3.0]
 

--- a/packages/permission-controller/CHANGELOG.md
+++ b/packages/permission-controller/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- **BREAKING:** `factoryHooks`, `validatorHooks`, and related fields from permission specification builders ([#8551](https://github.com/MetaMask/core/pull/8551))
+- **BREAKING:** Remove `factoryHooks`, `validatorHooks`, and related fields from permission specification builders ([#8551](https://github.com/MetaMask/core/pull/8551))
 
 ## [12.3.0]
 

--- a/packages/permission-controller/src/Permission.test.ts
+++ b/packages/permission-controller/src/Permission.test.ts
@@ -101,7 +101,32 @@ describe('permission specification messenger option', () => {
     handler: () => number;
   };
 
-  it('closes a scoped messenger into methodImplementation', () => {
+  const targetName = 'wallet_getAnswer';
+
+  type HostRootMessenger = Messenger<'Root', HostAction>;
+
+  type SpecMessenger = ReturnType<
+    typeof createRestrictedMethodMessenger<
+      typeof targetName,
+      HostRootMessenger,
+      readonly ['Host:computeAnswer']
+    >
+  >;
+
+  const buildSpecificationBuilder = (): PermissionSpecificationBuilder<
+    PermissionType.RestrictedMethod,
+    { messenger: SpecMessenger },
+    RestrictedMethodSpecificationConstraint
+  > => {
+    return ({ messenger }) => ({
+      permissionType: PermissionType.RestrictedMethod,
+      targetName,
+      allowedCaveats: null,
+      methodImplementation: (): number => messenger.call('Host:computeAnswer'),
+    });
+  };
+
+  const getRootMessenger = (): HostRootMessenger => {
     const rootMessenger = new Messenger<'Root', HostAction>({
       namespace: 'Root',
     });
@@ -112,41 +137,24 @@ describe('permission specification messenger option', () => {
       typeof rootMessenger
     >({ namespace: 'Host', parent: rootMessenger });
     hostMessenger.registerActionHandler('Host:computeAnswer', () => 42);
+    return rootMessenger;
+  };
 
-    const actionNames = ['Host:computeAnswer'] as const;
-    const targetName = 'wallet_getAnswer';
-
-    const specificationBuilder: PermissionSpecificationBuilder<
-      PermissionType.RestrictedMethod,
-      {
-        messenger?: ReturnType<
-          typeof createRestrictedMethodMessenger<
-            typeof rootMessenger,
-            typeof actionNames
-          >
-        >;
-      },
-      RestrictedMethodSpecificationConstraint
-    > = ({ messenger }) => ({
-      permissionType: PermissionType.RestrictedMethod,
-      targetName,
-      allowedCaveats: null,
-      methodImplementation: (): number => {
-        if (!messenger) {
-          throw new Error('messenger is required');
-        }
-        return messenger.call('Host:computeAnswer');
-      },
-    });
+  it('invokes the spec-declared action via the scoped messenger', () => {
+    const rootMessenger = getRootMessenger();
+    const specificationBuilder = buildSpecificationBuilder();
 
     const messenger = createRestrictedMethodMessenger({
       rootMessenger,
       namespace: targetName,
-      actionNames,
+      actionNames: ['Host:computeAnswer'] as const,
     });
 
     const specification = specificationBuilder({ messenger });
 
+    expect(specification.targetName).toBe(targetName);
+    expect(specification.allowedCaveats).toBeNull();
+    expect(specification.permissionType).toBe(PermissionType.RestrictedMethod);
     expect(
       specification.methodImplementation({
         method: targetName,

--- a/packages/permission-controller/src/Permission.test.ts
+++ b/packages/permission-controller/src/Permission.test.ts
@@ -1,5 +1,13 @@
-import type { CaveatConstraint, PermissionConstraint } from '.';
-import { constructPermission } from '.';
+import { Messenger } from '@metamask/messenger';
+
+import type {
+  CaveatConstraint,
+  PermissionConstraint,
+  PermissionSpecificationBuilder,
+  RestrictedMethodSpecificationConstraint,
+} from '.';
+import { constructPermission, PermissionType } from '.';
+import { createRestrictedMethodMessenger } from './createRestrictedMethodMessenger';
 import { findCaveat } from './Permission';
 
 describe('constructPermission', () => {
@@ -84,5 +92,67 @@ describe('findCaveat', () => {
     };
 
     expect(findCaveat(permission, 'doesNotExist')).toBeUndefined();
+  });
+});
+
+describe('permission specification messenger option', () => {
+  type HostAction = {
+    type: 'Host:computeAnswer';
+    handler: () => number;
+  };
+
+  it('closes a scoped messenger into methodImplementation', () => {
+    const rootMessenger = new Messenger<'Root', HostAction>({
+      namespace: 'Root',
+    });
+    const hostMessenger = new Messenger<
+      'Host',
+      HostAction,
+      never,
+      typeof rootMessenger
+    >({ namespace: 'Host', parent: rootMessenger });
+    hostMessenger.registerActionHandler('Host:computeAnswer', () => 42);
+
+    const actionNames = ['Host:computeAnswer'] as const;
+    const targetName = 'wallet_getAnswer';
+
+    const specificationBuilder: PermissionSpecificationBuilder<
+      PermissionType.RestrictedMethod,
+      {
+        messenger?: ReturnType<
+          typeof createRestrictedMethodMessenger<
+            typeof rootMessenger,
+            typeof actionNames
+          >
+        >;
+      },
+      RestrictedMethodSpecificationConstraint
+    > = ({ messenger }) => ({
+      permissionType: PermissionType.RestrictedMethod,
+      targetName,
+      allowedCaveats: null,
+      methodImplementation: (): number => {
+        if (!messenger) {
+          throw new Error('messenger is required');
+        }
+        return messenger.call('Host:computeAnswer');
+      },
+    });
+
+    const messenger = createRestrictedMethodMessenger({
+      rootMessenger,
+      namespace: targetName,
+      actionNames,
+    });
+
+    const specification = specificationBuilder({ messenger });
+
+    expect(
+      specification.methodImplementation({
+        method: targetName,
+        params: [],
+        context: { origin: 'example.com' },
+      }),
+    ).toBe(42);
   });
 });

--- a/packages/permission-controller/src/Permission.ts
+++ b/packages/permission-controller/src/Permission.ts
@@ -485,10 +485,17 @@ export type PermissionSpecificationConstraint =
  */
 type PermissionSpecificationBuilderOptions<
   MethodHooks extends Record<string, unknown>,
+  SpecMessenger = unknown,
 > = {
   targetName?: string;
   allowedCaveats?: Readonly<NonEmptyArray<string>> | null;
   methodHooks?: MethodHooks;
+  /**
+   * A messenger scoped to this permission specification, typically constructed
+   * via {@link createRestrictedMethodMessenger} from the spec's declared
+   * `actionNames`.
+   */
+  messenger?: SpecMessenger;
 };
 
 /**
@@ -519,6 +526,12 @@ export type PermissionSpecificationBuilderExportConstraint = {
     PermissionSpecificationConstraint
   >;
   methodHookNames?: Record<string, true>;
+  /**
+   * The messenger action types this specification requires. Hosts pass these
+   * to {@link createRestrictedMethodMessenger} to build a minimally-scoped
+   * child messenger to inject into the builder.
+   */
+  actionNames?: readonly string[];
 };
 
 type ValidRestrictedMethodSpecification<

--- a/packages/permission-controller/src/Permission.ts
+++ b/packages/permission-controller/src/Permission.ts
@@ -484,15 +484,11 @@ export type PermissionSpecificationConstraint =
  * Options for {@link PermissionSpecificationBuilder} functions.
  */
 type PermissionSpecificationBuilderOptions<
-  FactoryHooks extends Record<string, unknown>,
   MethodHooks extends Record<string, unknown>,
-  ValidatorHooks extends Record<string, unknown>,
 > = {
   targetName?: string;
   allowedCaveats?: Readonly<NonEmptyArray<string>> | null;
-  factoryHooks?: FactoryHooks;
   methodHooks?: MethodHooks;
-  validatorHooks?: ValidatorHooks;
 };
 
 /**
@@ -504,8 +500,6 @@ type PermissionSpecificationBuilderOptions<
 export type PermissionSpecificationBuilder<
   Type extends PermissionType,
   Options extends PermissionSpecificationBuilderOptions<
-    Record<string, unknown>,
-    Record<string, unknown>,
     Record<string, unknown>
   >,
   Specification extends PermissionSpecificationConstraint & {
@@ -521,16 +515,10 @@ export type PermissionSpecificationBuilderExportConstraint = {
   targetName: string;
   specificationBuilder: PermissionSpecificationBuilder<
     PermissionType,
-    PermissionSpecificationBuilderOptions<
-      Record<string, unknown>,
-      Record<string, unknown>,
-      Record<string, unknown>
-    >,
+    PermissionSpecificationBuilderOptions<Record<string, unknown>>,
     PermissionSpecificationConstraint
   >;
-  factoryHookNames?: Record<string, true>;
   methodHookNames?: Record<string, true>;
-  validatorHookNames?: Record<string, true>;
 };
 
 type ValidRestrictedMethodSpecification<

--- a/packages/permission-controller/src/Permission.ts
+++ b/packages/permission-controller/src/Permission.ts
@@ -491,9 +491,10 @@ type PermissionSpecificationBuilderOptions<
   allowedCaveats?: Readonly<NonEmptyArray<string>> | null;
   methodHooks?: MethodHooks;
   /**
-   * A messenger scoped to this permission specification, typically constructed
-   * via {@link createRestrictedMethodMessenger} from the spec's declared
-   * `actionNames`.
+   * A messenger scoped to this permission specification. The messenger is
+   * expected to have exactly the actions declared by the spec's `actionNames`
+   * delegated to it; {@link createRestrictedMethodMessenger} is the canonical
+   * way to construct it.
    */
   messenger?: SpecMessenger;
 };
@@ -527,11 +528,12 @@ export type PermissionSpecificationBuilderExportConstraint = {
   >;
   methodHookNames?: Record<string, true>;
   /**
-   * The messenger action types this specification requires. Hosts pass these
-   * to {@link createRestrictedMethodMessenger} to build a minimally-scoped
-   * child messenger to inject into the builder.
+   * The messenger action types this specification requires. Host applications
+   * pass these to {@link createRestrictedMethodMessenger} to build a
+   * minimally-scoped child messenger to inject into the builder. If present,
+   * this must be a non-empty tuple — omit the field to opt out.
    */
-  actionNames?: readonly string[];
+  actionNames?: readonly [string, ...string[]] | undefined;
 };
 
 type ValidRestrictedMethodSpecification<

--- a/packages/permission-controller/src/Permission.ts
+++ b/packages/permission-controller/src/Permission.ts
@@ -515,27 +515,6 @@ export type PermissionSpecificationBuilder<
   },
 > = (options: Options) => Specification;
 
-/**
- * A restricted method permission export object, containing the
- * {@link PermissionSpecificationBuilder} function and "hook name" objects.
- */
-export type PermissionSpecificationBuilderExportConstraint = {
-  targetName: string;
-  specificationBuilder: PermissionSpecificationBuilder<
-    PermissionType,
-    PermissionSpecificationBuilderOptions<Record<string, unknown>>,
-    PermissionSpecificationConstraint
-  >;
-  methodHookNames?: Record<string, true>;
-  /**
-   * The messenger action types this specification requires. Host applications
-   * pass these to {@link createRestrictedMethodMessenger} to build a
-   * minimally-scoped child messenger to inject into the builder. If present,
-   * this must be a non-empty tuple — omit the field to opt out.
-   */
-  actionNames?: readonly [string, ...string[]] | undefined;
-};
-
 type ValidRestrictedMethodSpecification<
   Specification extends RestrictedMethodSpecificationConstraint,
 > =

--- a/packages/permission-controller/src/createRestrictedMethodMessenger.test.ts
+++ b/packages/permission-controller/src/createRestrictedMethodMessenger.test.ts
@@ -1,0 +1,100 @@
+import { Messenger } from '@metamask/messenger';
+
+import { createRestrictedMethodMessenger } from './createRestrictedMethodMessenger';
+
+type FooAction = {
+  type: 'Foo:ping';
+  handler: () => string;
+};
+
+type BarAction = {
+  type: 'Bar:double';
+  handler: (n: number) => number;
+};
+
+type RootActions = FooAction | BarAction;
+
+const getRootMessenger = (): Messenger<'Root', RootActions> => {
+  const messenger = new Messenger<'Root', RootActions>({ namespace: 'Root' });
+  const fooMessenger = new Messenger<'Foo', FooAction, never, typeof messenger>(
+    {
+      namespace: 'Foo',
+      parent: messenger,
+    },
+  );
+  const barMessenger = new Messenger<'Bar', BarAction, never, typeof messenger>(
+    {
+      namespace: 'Bar',
+      parent: messenger,
+    },
+  );
+  fooMessenger.registerActionHandler('Foo:ping', () => 'pong');
+  barMessenger.registerActionHandler('Bar:double', (value) => value * 2);
+  return messenger;
+};
+
+describe('createRestrictedMethodMessenger', () => {
+  it('returns undefined when actionNames is omitted', () => {
+    const rootMessenger = getRootMessenger();
+
+    expect(
+      createRestrictedMethodMessenger({
+        rootMessenger,
+        namespace: 'wallet_example',
+      }),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when actionNames is empty', () => {
+    const rootMessenger = getRootMessenger();
+
+    expect(
+      createRestrictedMethodMessenger({
+        rootMessenger,
+        namespace: 'wallet_example',
+        actionNames: [],
+      }),
+    ).toBeUndefined();
+  });
+
+  it('returns a child messenger that can call the delegated action', () => {
+    const rootMessenger = getRootMessenger();
+
+    const messenger = createRestrictedMethodMessenger({
+      rootMessenger,
+      namespace: 'wallet_example',
+      actionNames: ['Foo:ping'] as const,
+    });
+
+    expect(messenger).toBeDefined();
+    expect(messenger?.call('Foo:ping')).toBe('pong');
+  });
+
+  it('does not delegate actions that were not requested', () => {
+    const rootMessenger = getRootMessenger();
+
+    const messenger = createRestrictedMethodMessenger({
+      rootMessenger,
+      namespace: 'wallet_example',
+      actionNames: ['Foo:ping'] as const,
+    });
+
+    expect(() =>
+      // @ts-expect-error Intentionally calling an undelegated action.
+      messenger?.call('Bar:double', 2),
+    ).toThrow('A handler for Bar:double has not been registered');
+  });
+
+  it('delegates multiple actions when requested', () => {
+    const rootMessenger = getRootMessenger();
+
+    const messenger = createRestrictedMethodMessenger({
+      rootMessenger,
+      namespace: 'wallet_example',
+      actionNames: ['Foo:ping', 'Bar:double'] as const,
+    });
+
+    expect(messenger?.call('Foo:ping')).toBe('pong');
+    expect(messenger?.call('Bar:double', 3)).toBe(6);
+  });
+});

--- a/packages/permission-controller/src/createRestrictedMethodMessenger.test.ts
+++ b/packages/permission-controller/src/createRestrictedMethodMessenger.test.ts
@@ -52,12 +52,14 @@ describe('createRestrictedMethodMessenger', () => {
       createRestrictedMethodMessenger({
         rootMessenger,
         namespace: 'wallet_example',
+        // @ts-expect-error An empty array is rejected by the type system, but
+        // the runtime handles it as a no-op.
         actionNames: [],
       }),
     ).toBeUndefined();
   });
 
-  it('returns a child messenger that can call the delegated action', () => {
+  it('exposes the requested action on the returned messenger', () => {
     const rootMessenger = getRootMessenger();
 
     const messenger = createRestrictedMethodMessenger({
@@ -66,11 +68,28 @@ describe('createRestrictedMethodMessenger', () => {
       actionNames: ['Foo:ping'] as const,
     });
 
-    expect(messenger).toBeDefined();
-    expect(messenger?.call('Foo:ping')).toBe('pong');
+    expect(messenger.call('Foo:ping')).toBe('pong');
   });
 
-  it('does not delegate actions that were not requested', () => {
+  it('uses the provided namespace for the returned messenger', () => {
+    const rootMessenger = getRootMessenger();
+
+    const messenger = createRestrictedMethodMessenger({
+      rootMessenger,
+      namespace: 'wallet_example',
+      actionNames: ['Foo:ping'] as const,
+    });
+
+    // Registering an action under a different namespace must fail with an
+    // error that names the messenger's configured namespace.
+    expect(() =>
+      // @ts-expect-error Deliberately registering outside the child's action
+      // surface to probe its namespace.
+      messenger.registerActionHandler('Other:noop', () => undefined),
+    ).toThrow(/wallet_example/u);
+  });
+
+  it('rejects calls to actions that were not requested', () => {
     const rootMessenger = getRootMessenger();
 
     const messenger = createRestrictedMethodMessenger({
@@ -81,11 +100,11 @@ describe('createRestrictedMethodMessenger', () => {
 
     expect(() =>
       // @ts-expect-error Intentionally calling an undelegated action.
-      messenger?.call('Bar:double', 2),
-    ).toThrow('A handler for Bar:double has not been registered');
+      messenger.call('Bar:double', 2),
+    ).toThrow(/Bar:double/u);
   });
 
-  it('delegates multiple actions when requested', () => {
+  it('exposes every requested action when multiple are delegated', () => {
     const rootMessenger = getRootMessenger();
 
     const messenger = createRestrictedMethodMessenger({
@@ -94,7 +113,7 @@ describe('createRestrictedMethodMessenger', () => {
       actionNames: ['Foo:ping', 'Bar:double'] as const,
     });
 
-    expect(messenger?.call('Foo:ping')).toBe('pong');
-    expect(messenger?.call('Bar:double', 3)).toBe(6);
+    expect(messenger.call('Foo:ping')).toBe('pong');
+    expect(messenger.call('Bar:double', 3)).toBe(6);
   });
 });

--- a/packages/permission-controller/src/createRestrictedMethodMessenger.ts
+++ b/packages/permission-controller/src/createRestrictedMethodMessenger.ts
@@ -1,0 +1,71 @@
+import type {
+  ActionConstraint,
+  EventConstraint,
+  MessengerActions,
+} from '@metamask/messenger';
+import { Messenger } from '@metamask/messenger';
+
+/**
+ * Create a child messenger scoped to a restricted-method permission
+ * specification, with the spec's declared actions delegated from the root
+ * messenger. Analogous to `selectHooks` for `methodHooks`, but for messenger
+ * actions.
+ *
+ * Returns `undefined` when the spec declares no actions — there is nothing to
+ * scope, and the builder can be invoked without a messenger.
+ *
+ * @param args - The arguments.
+ * @param args.rootMessenger - The root messenger to delegate actions from.
+ * @param args.namespace - The namespace for the scoped child messenger,
+ * typically the spec's `targetName`.
+ * @param args.actionNames - The action types the specification requires,
+ * typically the spec's declared `actionNames`.
+ * @returns A scoped child messenger with the requested actions delegated, or
+ * `undefined` if no actions were requested.
+ */
+export function createRestrictedMethodMessenger<
+  RootMessenger extends Messenger<string, ActionConstraint, EventConstraint>,
+  DelegatedActions extends readonly MessengerActions<RootMessenger>['type'][],
+>({
+  rootMessenger,
+  namespace,
+  actionNames,
+}: {
+  rootMessenger: RootMessenger;
+  namespace: string;
+  actionNames?: DelegatedActions;
+}):
+  | Messenger<
+      string,
+      Extract<
+        MessengerActions<RootMessenger>,
+        { type: DelegatedActions[number] }
+      >,
+      never,
+      RootMessenger
+    >
+  | undefined {
+  if (!actionNames?.length) {
+    return undefined;
+  }
+
+  const restrictedMethodMessenger = new Messenger<
+    string,
+    Extract<
+      MessengerActions<RootMessenger>,
+      { type: DelegatedActions[number] }
+    >,
+    never,
+    RootMessenger
+  >({
+    namespace,
+    parent: rootMessenger,
+  });
+
+  rootMessenger.delegate({
+    actions: [...actionNames],
+    messenger: restrictedMethodMessenger,
+  });
+
+  return restrictedMethodMessenger;
+}

--- a/packages/permission-controller/src/createRestrictedMethodMessenger.ts
+++ b/packages/permission-controller/src/createRestrictedMethodMessenger.ts
@@ -65,7 +65,7 @@ export function createRestrictedMethodMessenger<
 export function createRestrictedMethodMessenger<
   Namespace extends string,
   RootMessenger extends Messenger<string, ActionConstraint, EventConstraint>,
-  DelegatedActions extends readonly [
+  DelegatedActions extends [
     MessengerActions<RootMessenger>['type'],
     ...MessengerActions<RootMessenger>['type'][],
   ],
@@ -100,7 +100,7 @@ export function createRestrictedMethodMessenger<
   });
 
   rootMessenger.delegate({
-    actions: [...actionNames],
+    actions: actionNames,
     messenger: restrictedMethodMessenger,
   });
 

--- a/packages/permission-controller/src/createRestrictedMethodMessenger.ts
+++ b/packages/permission-controller/src/createRestrictedMethodMessenger.ts
@@ -6,12 +6,23 @@ import type {
 import { Messenger } from '@metamask/messenger';
 
 /**
+ * The subset of `RootMessenger`'s actions selected by `DelegatedActions`.
+ */
+type SelectedActions<
+  RootMessenger extends Messenger<string, ActionConstraint, EventConstraint>,
+  DelegatedActions extends readonly MessengerActions<RootMessenger>['type'][],
+> = Extract<
+  MessengerActions<RootMessenger>,
+  { type: DelegatedActions[number] }
+>;
+
+/**
  * Create a child messenger scoped to a restricted-method permission
- * specification, with the spec's declared actions delegated from the root
- * messenger. Analogous to `selectHooks` for `methodHooks`, but for messenger
- * actions.
+ * specification, delegating only the spec's declared actions from the root
+ * messenger. This produces a minimally-scoped messenger whose action surface
+ * matches exactly what the spec has declared it needs.
  *
- * Returns `undefined` when the spec declares no actions — there is nothing to
+ * Returns `undefined` when `actionNames` is omitted — there is nothing to
  * scope, and the builder can be invoked without a messenger.
  *
  * @param args - The arguments.
@@ -19,28 +30,57 @@ import { Messenger } from '@metamask/messenger';
  * @param args.namespace - The namespace for the scoped child messenger,
  * typically the spec's `targetName`.
  * @param args.actionNames - The action types the specification requires,
- * typically the spec's declared `actionNames`.
+ * typically the spec's declared `actionNames`. Must be a non-empty tuple of
+ * action types that exist on the root messenger.
  * @returns A scoped child messenger with the requested actions delegated, or
  * `undefined` if no actions were requested.
  */
 export function createRestrictedMethodMessenger<
+  Namespace extends string,
   RootMessenger extends Messenger<string, ActionConstraint, EventConstraint>,
-  DelegatedActions extends readonly MessengerActions<RootMessenger>['type'][],
+  DelegatedActions extends readonly [
+    MessengerActions<RootMessenger>['type'],
+    ...MessengerActions<RootMessenger>['type'][],
+  ],
+>(args: {
+  rootMessenger: RootMessenger;
+  namespace: Namespace;
+  actionNames: DelegatedActions;
+}): Messenger<
+  Namespace,
+  SelectedActions<RootMessenger, DelegatedActions>,
+  never,
+  RootMessenger
+>;
+
+export function createRestrictedMethodMessenger<
+  Namespace extends string,
+  RootMessenger extends Messenger<string, ActionConstraint, EventConstraint>,
+>(args: {
+  rootMessenger: RootMessenger;
+  namespace: Namespace;
+  actionNames?: undefined;
+}): undefined;
+
+export function createRestrictedMethodMessenger<
+  Namespace extends string,
+  RootMessenger extends Messenger<string, ActionConstraint, EventConstraint>,
+  DelegatedActions extends readonly [
+    MessengerActions<RootMessenger>['type'],
+    ...MessengerActions<RootMessenger>['type'][],
+  ],
 >({
   rootMessenger,
   namespace,
   actionNames,
 }: {
   rootMessenger: RootMessenger;
-  namespace: string;
+  namespace: Namespace;
   actionNames?: DelegatedActions;
 }):
   | Messenger<
-      string,
-      Extract<
-        MessengerActions<RootMessenger>,
-        { type: DelegatedActions[number] }
-      >,
+      Namespace,
+      SelectedActions<RootMessenger, DelegatedActions>,
       never,
       RootMessenger
     >
@@ -50,11 +90,8 @@ export function createRestrictedMethodMessenger<
   }
 
   const restrictedMethodMessenger = new Messenger<
-    string,
-    Extract<
-      MessengerActions<RootMessenger>,
-      { type: DelegatedActions[number] }
-    >,
+    Namespace,
+    SelectedActions<RootMessenger, DelegatedActions>,
     never,
     RootMessenger
   >({

--- a/packages/permission-controller/src/index.ts
+++ b/packages/permission-controller/src/index.ts
@@ -1,4 +1,5 @@
 export * from './Caveat';
+export { createRestrictedMethodMessenger } from './createRestrictedMethodMessenger';
 export * from './errors';
 export * from './Permission';
 export * from './PermissionController';


### PR DESCRIPTION
## Explanation

Adds a `messenger` option to permission specification builders as an alternative to `methodHooks`, aligning spec builders with the messenger-based method middleware introduced in #8506. Restricted-method specs can now declare the root-messenger actions they need via `actionNames` and consume a minimally-scoped `Messenger`.

Incidentally, also removes the `factoryHooks` and `validatorHooks` fields from the spec builder surface. Both of these were unused in practice.

## References

- Related to #8506
- Preview build PRs:
  - https://github.com/MetaMask/metamask-extension/pull/42128
    - Extension CI failing as of merge due to unrelated problems, but succeeds when testing manually.
  - https://github.com/MetaMask/metamask-mobile/pull/29343
  - https://github.com/MetaMask/snaps/pull/3969

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking type-surface changes to permission specification builders (removing `factoryHooks`/`validatorHooks` and adding optional scoped `messenger`) may require downstream updates; new messenger delegation logic could impact how restricted-method specs invoke host actions.
> 
> **Overview**
> Restricted-method permission specification builders can now receive an optional scoped `messenger` (constructed from spec-declared `actionNames`) as an alternative to relying on `methodHooks`, enabling specs to call only explicitly-delegated host actions.
> 
> Introduces `createRestrictedMethodMessenger` (exported from the package) to create a child `Messenger` with a minimal delegated action surface, and adds tests covering delegation behavior and the new builder option. **BREAKING:** removes `factoryHooks`, `validatorHooks`, and related export fields from the permission specification builder API surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e2fe74a0d5d011aec80f922af0054600f3d2bba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->