### PR TITLE
fix(messenger): Throw different error for missing delegated actions

### DIFF
--- a/packages/messenger/CHANGELOG.md
+++ b/packages/messenger/CHANGELOG.md
@@ -7,14 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Throw different error for missing delegated actions ([#8557](https://github.com/MetaMask/core/pull/8557))
-
 ### Deprecated
 
 - Deprecate `generate-action-types` CLI tool and `messenger-generate-action-types` binary ([#8378](https://github.com/MetaMask/core/pull/8378))
   - The CLI has been extracted to `@metamask/messenger-cli`. Use `messenger-action-types` from this package instead.
+
+### Fixed
+
+- Throw different error for missing delegated actions ([#8557](https://github.com/MetaMask/core/pull/8557))
 
 ## [1.1.1]
 

--- a/packages/messenger/CHANGELOG.md
+++ b/packages/messenger/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Throw different error for missing delegated actions ([#8557](https://github.com/MetaMask/core/pull/8557))
+
 ### Deprecated
 
 - Deprecate `generate-action-types` CLI tool and `messenger-generate-action-types` binary ([#8378](https://github.com/MetaMask/core/pull/8378))

--- a/packages/messenger/src/Messenger.test.ts
+++ b/packages/messenger/src/Messenger.test.ts
@@ -1914,7 +1914,9 @@ describe('Messenger', () => {
       );
       expect(() =>
         delegatedMessenger.call('Source:getRandomString', 'test'),
-      ).toThrow('A handler for Source:getRandomString has not been delegated to Destination');
+      ).toThrow(
+        'A handler for Source:getRandomString has not been delegated to Destination',
+      );
     });
 
     it('allows revoking a delegated action that is delegated elsewhere', () => {
@@ -1967,7 +1969,9 @@ describe('Messenger', () => {
 
       expect(() =>
         firstDelegatedMessenger.call('Source:getLength', 'test'),
-      ).toThrow('A handler for Source:getLength has not been delegated to FirstDestination');
+      ).toThrow(
+        'A handler for Source:getLength has not been delegated to FirstDestination',
+      );
       const thirdResult = secondDelegatedMessenger.call(
         'Source:getLength',
         'third test', // length 10

--- a/packages/messenger/src/Messenger.test.ts
+++ b/packages/messenger/src/Messenger.test.ts
@@ -1865,7 +1865,7 @@ describe('Messenger', () => {
       });
 
       expect(() => delegatedMessenger.call('Source:getLength', 'test')).toThrow(
-        'A handler for Source:getLength has not been registered',
+        'A handler for Source:getLength has not been delegated to Destination',
       );
     });
 
@@ -1910,11 +1910,11 @@ describe('Messenger', () => {
         }),
       ).not.toThrow();
       expect(() => delegatedMessenger.call('Source:getLength', 'test')).toThrow(
-        'A handler for Source:getLength has not been registered',
+        'A handler for Source:getLength has not been delegated to Destination',
       );
       expect(() =>
         delegatedMessenger.call('Source:getRandomString', 'test'),
-      ).toThrow('A handler for Source:getRandomString has not been registered');
+      ).toThrow('A handler for Source:getRandomString has not been delegated to Destination');
     });
 
     it('allows revoking a delegated action that is delegated elsewhere', () => {
@@ -1967,7 +1967,7 @@ describe('Messenger', () => {
 
       expect(() =>
         firstDelegatedMessenger.call('Source:getLength', 'test'),
-      ).toThrow('A handler for Source:getLength has not been registered');
+      ).toThrow('A handler for Source:getLength has not been delegated to FirstDestination');
       const thirdResult = secondDelegatedMessenger.call(
         'Source:getLength',
         'third test', // length 10

--- a/packages/messenger/src/Messenger.ts
+++ b/packages/messenger/src/Messenger.ts
@@ -421,7 +421,11 @@ export class Messenger<
       ActionType
     >;
     if (!handler) {
-      throw new Error(`A handler for ${actionType} has not been registered`);
+      throw new Error(
+        this.#isInCurrentNamespace(actionType)
+          ? `A handler for ${actionType} has not been registered`
+          : `A handler for ${actionType} has not been delegated to ${this.#namespace}`,
+      );
     }
     return handler(...params);
   }


### PR DESCRIPTION
## Explanation

The error thrown when using `messenger.call` on delegated messengers is misleading as more often than not it is a missing delegation causing the error being thrown. This PR modifies the error message if the action being called is not in the messengers own namespace.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the error message thrown by `Messenger.call` for non-local (delegated) actions, which could break consumers/tests that assert on exact error strings. Logic change is small and covered by updated unit tests.
> 
> **Overview**
> Adjusts `Messenger.call` to throw a **more specific error** when an action is missing because it was never delegated (or was revoked), instead of always reporting it as “not registered”.
> 
> Updates delegation/revocation unit tests to assert the new message and records the fix in the `@metamask/messenger` changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0481f2592b3c6e6faff2ab6238baaa353bf9a99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->