### PR TITLE
Ogp/conf 1151 2

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Add `KeyringControllerGetStateAction` to `AllowedActions` to support publish hooks that need to check keyring type for EIP-7702 compatibility ([#8388](https://github.com/MetaMask/core/pull/8388))
+- **BREAKING:** Add `KeyringControllerGetStateAction` to `AllowedActions` to enable keyring-based EIP-7702 account compatibility checks in `addTransactionBatch` ([#8388](https://github.com/MetaMask/core/pull/8388))
+  - `addTransactionBatch` now automatically checks whether the account's keyring supports EIP-7702 before attempting the 7702 batch path, falling back to STX/sequential when unsupported
+  - Clients must add `KeyringController:getState` to the TransactionController messenger's allowed actions
 
 ## [64.3.0]
 

--- a/packages/transaction-controller/src/utils/batch.ts
+++ b/packages/transaction-controller/src/utils/batch.ts
@@ -51,6 +51,7 @@ import type {
 import type { TransactionBatchResult, TransactionParams } from '../types';
 import {
   ERROR_MESSGE_PUBLIC_KEY,
+  doesAccountSupportEIP7702,
   doesChainSupportEIP7702,
   generateEIP7702BatchTransaction,
   isAccountUpgradedToEIP7702,
@@ -136,7 +137,12 @@ export async function addTransactionBatch(
 
   log('Adding', transactionBatchRequest);
 
-  if (!transactionBatchRequest.disable7702) {
+  const accountCanUse7702 = doesAccountSupportEIP7702(
+    messenger,
+    transactionBatchRequest.from,
+  );
+
+  if (!transactionBatchRequest.disable7702 && accountCanUse7702) {
     try {
       return await addTransactionBatchWith7702(request);
     } catch (error: unknown) {

--- a/packages/transaction-controller/src/utils/eip7702.ts
+++ b/packages/transaction-controller/src/utils/eip7702.ts
@@ -40,6 +40,37 @@ const ERC7579_EXEC_TYPE_TRY = '01';
 
 const log = createModuleLogger(projectLogger, 'eip-7702');
 
+const KEYRING_TYPES_SUPPORTING_7702 = ['HD Key Tree', 'Simple Key Pair'];
+
+/**
+ * Check whether a given account's keyring supports EIP-7702 authorization
+ * signing.
+ *
+ * Looks up the account's keyring via `KeyringController:getState` and returns
+ * `true` only when the keyring type is in the supported list.
+ * Falls back to `true` when the keyring cannot be resolved.
+ *
+ * @param messenger - Controller messenger.
+ * @param account - The account address to check.
+ * @returns Whether the account supports EIP-7702.
+ */
+export function doesAccountSupportEIP7702(
+  messenger: TransactionControllerMessenger,
+  account: string,
+): boolean {
+  const { keyrings } = messenger.call('KeyringController:getState');
+  const keyring = keyrings.find(
+    (k: { type: string; accounts: string[] }) =>
+      k.accounts.some(
+        (a: string) => a.toLowerCase() === account.toLowerCase(),
+      ),
+  );
+
+  return keyring
+    ? KEYRING_TYPES_SUPPORTING_7702.includes(keyring.type)
+    : true;
+}
+
 /**
  * Determine if a chain supports EIP-7702 using LaunchDarkly feature flag.
  *

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -13,7 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix mUSD conversion for hardware wallets on EIP-7702 chains by gating relay and Across 7702 paths on the account keyring type via `KeyringController:getState` ([#8388](https://github.com/MetaMask/core/pull/8388))
+- **BREAKING:** Fix mUSD conversion for hardware wallets on EIP-7702 chains by gating relay and Across 7702 paths on the account keyring type via `KeyringController:getState` ([#8388](https://github.com/MetaMask/core/pull/8388))
+  - `AccountSupports7702Callback` type export has been removed. Use the `accountSupports7702` util from `utils/7702` instead.
+  - The `TransactionPayControllerMessenger` now requires `KeyringController:getState` permission (previously only needed in the publish hook).
 
 ## [19.2.1]
 

--- a/packages/transaction-pay-controller/src/TransactionPayController.test.ts
+++ b/packages/transaction-pay-controller/src/TransactionPayController.test.ts
@@ -253,7 +253,6 @@ describe('TransactionPayController', () => {
         .mockResolvedValue(resultMock);
 
       new TransactionPayController({
-        accountSupports7702: jest.fn().mockResolvedValue(true),
         getDelegationTransaction: getDelegationTransactionMock,
         messenger,
       });
@@ -284,7 +283,6 @@ describe('TransactionPayController', () => {
 
     it('returns callback value if provided', async () => {
       new TransactionPayController({
-        accountSupports7702: jest.fn().mockResolvedValue(true),
         getDelegationTransaction: jest.fn(),
         getStrategy: (): TransactionPayStrategy => TransactionPayStrategy.Test,
         messenger,
@@ -300,7 +298,6 @@ describe('TransactionPayController', () => {
 
     it('does not query feature flag strategy order when getStrategies callback returns values', async () => {
       new TransactionPayController({
-        accountSupports7702: jest.fn().mockResolvedValue(true),
         getDelegationTransaction: jest.fn(),
         getStrategies: (): TransactionPayStrategy[] => [
           TransactionPayStrategy.Test,
@@ -324,7 +321,6 @@ describe('TransactionPayController', () => {
       getStrategyOrderMock.mockReturnValue([TransactionPayStrategy.Test]);
 
       new TransactionPayController({
-        accountSupports7702: jest.fn().mockResolvedValue(true),
         getDelegationTransaction: jest.fn(),
         getStrategies: (): TransactionPayStrategy[] => [],
         messenger,
@@ -342,7 +338,6 @@ describe('TransactionPayController', () => {
       getStrategyOrderMock.mockReturnValue([TransactionPayStrategy.Bridge]);
 
       new TransactionPayController({
-        accountSupports7702: jest.fn().mockResolvedValue(true),
         getDelegationTransaction: jest.fn(),
         getStrategies: (): TransactionPayStrategy[] =>
           [undefined] as unknown as TransactionPayStrategy[],
@@ -480,7 +475,6 @@ describe('TransactionPayController', () => {
       );
 
       expect(updateQuotesMock).toHaveBeenCalledWith({
-        accountSupports7702: expect.any(Function),
         getStrategies: expect.any(Function),
         messenger,
         transactionData: expect.objectContaining({
@@ -489,90 +483,6 @@ describe('TransactionPayController', () => {
         transactionId: TRANSACTION_ID_MOCK,
         updateTransactionData: expect.any(Function),
       });
-    });
-  });
-
-  describe('accountSupports7702', () => {
-    it('returns true for HD keyring account', async () => {
-      const controller = createController();
-
-      controller.updatePaymentToken({
-        transactionId: TRANSACTION_ID_MOCK,
-        tokenAddress: TOKEN_ADDRESS_MOCK,
-        chainId: CHAIN_ID_MOCK,
-      });
-
-      const { updateTransactionData } = updatePaymentTokenMock.mock.calls[0][1];
-
-      updateTransactionData(TRANSACTION_ID_MOCK, (data) => {
-        data.sourceAmounts = [
-          { sourceAmountHuman: '1.23' } as TransactionPaySourceAmount,
-        ];
-      });
-
-      const { accountSupports7702 } = updateQuotesMock.mock.calls[0][0];
-      const result = await accountSupports7702(
-        '0x1234567890123456789012345678901234567891',
-      );
-
-      expect(result).toBe(true);
-    });
-
-    it('returns false for Ledger keyring account', async () => {
-      getKeyringControllerStateMock.mockReturnValue({
-        isUnlocked: true,
-        keyrings: [
-          {
-            type: 'Ledger Hardware',
-            accounts: ['0xledger'],
-            metadata: { id: 'ledger', name: 'Ledger' },
-          },
-        ],
-      });
-
-      const controller = createController();
-
-      controller.updatePaymentToken({
-        transactionId: TRANSACTION_ID_MOCK,
-        tokenAddress: TOKEN_ADDRESS_MOCK,
-        chainId: CHAIN_ID_MOCK,
-      });
-
-      const { updateTransactionData } = updatePaymentTokenMock.mock.calls[0][1];
-
-      updateTransactionData(TRANSACTION_ID_MOCK, (data) => {
-        data.sourceAmounts = [
-          { sourceAmountHuman: '1.23' } as TransactionPaySourceAmount,
-        ];
-      });
-
-      const { accountSupports7702 } = updateQuotesMock.mock.calls[0][0];
-      const result = await accountSupports7702('0xledger');
-
-      expect(result).toBe(false);
-    });
-
-    it('returns true when keyring is not found', async () => {
-      const controller = createController();
-
-      controller.updatePaymentToken({
-        transactionId: TRANSACTION_ID_MOCK,
-        tokenAddress: TOKEN_ADDRESS_MOCK,
-        chainId: CHAIN_ID_MOCK,
-      });
-
-      const { updateTransactionData } = updatePaymentTokenMock.mock.calls[0][1];
-
-      updateTransactionData(TRANSACTION_ID_MOCK, (data) => {
-        data.sourceAmounts = [
-          { sourceAmountHuman: '1.23' } as TransactionPaySourceAmount,
-        ];
-      });
-
-      const { accountSupports7702 } = updateQuotesMock.mock.calls[0][0];
-      const result = await accountSupports7702('0xunknown');
-
-      expect(result).toBe(true);
     });
   });
 

--- a/packages/transaction-pay-controller/src/TransactionPayController.ts
+++ b/packages/transaction-pay-controller/src/TransactionPayController.ts
@@ -22,7 +22,6 @@ import type {
   UpdateFiatPaymentRequest,
   UpdatePaymentTokenRequest,
 } from './types';
-import { KEYRING_TYPES_SUPPORTING_7702 } from './types';
 import { getStrategyOrder } from './utils/feature-flags';
 import { updateQuotes } from './utils/quotes';
 import { updateSourceAmounts } from './utils/source-amounts';
@@ -95,7 +94,6 @@ export class TransactionPayController extends BaseController<
 
     // eslint-disable-next-line no-new
     new QuoteRefresher({
-      accountSupports7702: this.#accountSupports7702.bind(this),
       getStrategies: this.#getStrategiesWithFallback.bind(this),
       messenger,
       updateTransactionData: this.#updateTransactionData.bind(this),
@@ -253,7 +251,6 @@ export class TransactionPayController extends BaseController<
 
     if (shouldUpdateQuotes) {
       updateQuotes({
-        accountSupports7702: this.#accountSupports7702.bind(this),
         getStrategies: this.#getStrategiesWithFallback.bind(this),
         messenger: this.messenger,
         transactionData: this.state.transactionData[transactionId],
@@ -261,17 +258,6 @@ export class TransactionPayController extends BaseController<
         updateTransactionData: this.#updateTransactionData.bind(this),
       }).catch(noop);
     }
-  }
-
-  async #accountSupports7702(account: string): Promise<boolean> {
-    const { keyrings } = this.messenger.call('KeyringController:getState');
-    const keyring = keyrings.find((k) =>
-      k.accounts.some((a) => a.toLowerCase() === account.toLowerCase()),
-    );
-
-    return keyring
-      ? (KEYRING_TYPES_SUPPORTING_7702 as string[]).includes(keyring.type)
-      : true;
   }
 
   #getStrategiesWithFallback(

--- a/packages/transaction-pay-controller/src/helpers/QuoteRefresher.test.ts
+++ b/packages/transaction-pay-controller/src/helpers/QuoteRefresher.test.ts
@@ -52,7 +52,6 @@ describe('QuoteRefresher', () => {
 
   it('polls if quotes detected in state', async () => {
     new QuoteRefresher({
-      accountSupports7702: jest.fn().mockResolvedValue(true),
       getStrategies: jest.fn().mockReturnValue([TransactionPayStrategy.Relay]),
       messenger,
       updateTransactionData: jest.fn(),
@@ -68,7 +67,6 @@ describe('QuoteRefresher', () => {
 
   it('does not poll if no quotes in state', async () => {
     new QuoteRefresher({
-      accountSupports7702: jest.fn().mockResolvedValue(true),
       getStrategies: jest.fn().mockReturnValue([TransactionPayStrategy.Relay]),
       messenger,
       updateTransactionData: jest.fn(),
@@ -84,7 +82,6 @@ describe('QuoteRefresher', () => {
 
   it('polls again after interval', async () => {
     new QuoteRefresher({
-      accountSupports7702: jest.fn().mockResolvedValue(true),
       getStrategies: jest.fn().mockReturnValue([TransactionPayStrategy.Relay]),
       messenger,
       updateTransactionData: jest.fn(),
@@ -103,7 +100,6 @@ describe('QuoteRefresher', () => {
 
   it('stops polling if quotes removed', async () => {
     new QuoteRefresher({
-      accountSupports7702: jest.fn().mockResolvedValue(true),
       getStrategies: jest.fn().mockReturnValue([TransactionPayStrategy.Relay]),
       messenger,
       updateTransactionData: jest.fn(),
@@ -122,7 +118,6 @@ describe('QuoteRefresher', () => {
     const updateTransactionData = jest.fn();
 
     new QuoteRefresher({
-      accountSupports7702: jest.fn().mockResolvedValue(true),
       getStrategies: jest.fn().mockReturnValue([TransactionPayStrategy.Relay]),
       messenger,
       updateTransactionData,
@@ -145,7 +140,6 @@ describe('QuoteRefresher', () => {
     const updateTransactionData = jest.fn();
 
     new QuoteRefresher({
-      accountSupports7702: jest.fn().mockResolvedValue(true),
       getStrategies: jest.fn().mockReturnValue([TransactionPayStrategy.Relay]),
       messenger,
       updateTransactionData,
@@ -172,7 +166,6 @@ describe('QuoteRefresher', () => {
     const updateTransactionData = jest.fn();
 
     new QuoteRefresher({
-      accountSupports7702: jest.fn().mockResolvedValue(true),
       getStrategies: jest.fn().mockReturnValue([TransactionPayStrategy.Relay]),
       messenger,
       updateTransactionData,

--- a/packages/transaction-pay-controller/src/helpers/QuoteRefresher.ts
+++ b/packages/transaction-pay-controller/src/helpers/QuoteRefresher.ts
@@ -2,13 +2,13 @@ import type { TransactionMeta } from '@metamask/transaction-controller';
 import { createModuleLogger } from '@metamask/utils';
 import { noop } from 'lodash';
 
-import { TransactionPayStrategy } from '../constants';
-import { projectLogger } from '../logger';
 import type {
   TransactionPayControllerMessenger,
   TransactionPayControllerState,
-  UpdateTransactionDataCallback,
-} from '../types';
+} from '..';
+import { TransactionPayStrategy } from '../constants';
+import { projectLogger } from '../logger';
+import type { UpdateTransactionDataCallback } from '../types';
 import { refreshQuotes } from '../utils/quotes';
 
 const CHECK_INTERVAL = 1000; // 1 Second

--- a/packages/transaction-pay-controller/src/helpers/QuoteRefresher.ts
+++ b/packages/transaction-pay-controller/src/helpers/QuoteRefresher.ts
@@ -5,7 +5,6 @@ import { noop } from 'lodash';
 import { TransactionPayStrategy } from '../constants';
 import { projectLogger } from '../logger';
 import type {
-  AccountSupports7702Callback,
   TransactionPayControllerMessenger,
   TransactionPayControllerState,
   UpdateTransactionDataCallback,
@@ -31,24 +30,19 @@ export class QuoteRefresher {
 
   readonly #updateTransactionData: UpdateTransactionDataCallback;
 
-  readonly #accountSupports7702: AccountSupports7702Callback;
-
   constructor({
     getStrategies,
     messenger,
     updateTransactionData,
-    accountSupports7702,
   }: {
     getStrategies: (transaction: TransactionMeta) => TransactionPayStrategy[];
     messenger: TransactionPayControllerMessenger;
     updateTransactionData: UpdateTransactionDataCallback;
-    accountSupports7702: AccountSupports7702Callback;
   }) {
     this.#getStrategies = getStrategies;
     this.#messenger = messenger;
     this.#isRunning = false;
     this.#isUpdating = false;
-    this.#accountSupports7702 = accountSupports7702;
     this.#updateTransactionData = updateTransactionData;
 
     messenger.subscribe(
@@ -87,7 +81,6 @@ export class QuoteRefresher {
         this.#messenger,
         this.#updateTransactionData,
         this.#getStrategies,
-        this.#accountSupports7702,
       );
     } catch (error) {
       log('Error refreshing quotes', error);

--- a/packages/transaction-pay-controller/src/helpers/TransactionPayPublishHook.ts
+++ b/packages/transaction-pay-controller/src/helpers/TransactionPayPublishHook.ts
@@ -9,7 +9,7 @@ import type {
   TransactionPayControllerMessenger,
   TransactionPayQuote,
 } from '../types';
-import { KEYRING_TYPES_SUPPORTING_7702 } from '../types';
+import { accountSupports7702 } from '../utils/7702';
 import { getStrategyByName } from '../utils/strategy';
 import { updateTransaction } from '../utils/transaction';
 
@@ -84,16 +84,8 @@ export class TransactionPayPublishHook {
     const strategy = getStrategyByName(quotes[0].strategy);
     const from = transactionMeta.txParams.from as Hex;
 
-    const { keyrings } = this.#messenger.call('KeyringController:getState');
-    const keyring = keyrings.find((k) =>
-      k.accounts.some((a) => a.toLowerCase() === from.toLowerCase()),
-    );
-    const accountSupports7702 = keyring
-      ? (KEYRING_TYPES_SUPPORTING_7702 as string[]).includes(keyring.type)
-      : true;
-
     return await strategy.execute({
-      accountSupports7702,
+      accountSupports7702: accountSupports7702(this.#messenger, from),
       isSmartTransaction: this.#isSmartTransaction,
       quotes,
       messenger: this.#messenger,

--- a/packages/transaction-pay-controller/src/index.ts
+++ b/packages/transaction-pay-controller/src/index.ts
@@ -1,5 +1,4 @@
 export type {
-  AccountSupports7702Callback,
   TransactionConfig,
   TransactionConfigCallback,
   TransactionFiatPayment,

--- a/packages/transaction-pay-controller/src/strategy/across/across-quotes.ts
+++ b/packages/transaction-pay-controller/src/strategy/across/across-quotes.ts
@@ -193,7 +193,7 @@ async function normalizeQuote(
   request: QuoteRequest,
   fullRequest: PayStrategyGetQuotesRequest,
 ): Promise<TransactionPayQuote<AcrossQuote>> {
-  const { accountSupports7702, messenger } = fullRequest;
+  const { messenger } = fullRequest;
   const { quote } = original;
 
   const { usdToFiatRate, sourceFiatRate, targetFiatRate } = getFiatRates(
@@ -208,7 +208,6 @@ async function normalizeQuote(
     quote,
     messenger,
     request,
-    accountSupports7702,
   );
 
   const targetNetwork = getFiatValueFromUsd(new BigNumber(0), usdToFiatRate);
@@ -391,7 +390,6 @@ async function calculateSourceNetworkCost(
   quote: AcrossSwapApprovalResponse,
   messenger: TransactionPayControllerMessenger,
   request: QuoteRequest,
-  accountSupports7702: boolean,
 ): Promise<{
   sourceNetwork: TransactionPayQuote<AcrossQuote>['fees']['sourceNetwork'];
   gasLimits: AcrossGasLimits;
@@ -414,7 +412,6 @@ async function calculateSourceNetworkCost(
       to: transaction.to,
       value: transaction.value ?? '0x0',
     })),
-    accountSupports7702,
   });
   const { batchGasLimit, is7702 } = gasEstimates;
 

--- a/packages/transaction-pay-controller/src/strategy/across/across-submit.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/across/across-submit.test.ts
@@ -241,7 +241,7 @@ describe('Across Submit', () => {
       expect(addTransactionBatchMock).toHaveBeenCalledWith(
         expect.objectContaining({
           disable7702: false,
-          disableHook: false,
+          disableHook: true,
           disableSequential: true,
           gasLimit7702: toHex(64000),
           transactions: [
@@ -262,7 +262,7 @@ describe('Across Submit', () => {
       );
     });
 
-    it('submits batch sequentially when account does not support 7702', async () => {
+    it('submits batch without 7702 when quote is7702 is false', async () => {
       const nonIs7702Quote = {
         ...QUOTE_MOCK,
         original: {
@@ -278,7 +278,7 @@ describe('Across Submit', () => {
       } as unknown as TransactionPayQuote<AcrossQuote>;
 
       await submitAcrossQuotes({
-        accountSupports7702: false,
+        accountSupports7702: true,
         messenger,
         quotes: [nonIs7702Quote],
         transaction: TRANSACTION_META_MOCK,
@@ -289,7 +289,9 @@ describe('Across Submit', () => {
       expect(addTransactionBatchMock).toHaveBeenCalledWith(
         expect.objectContaining({
           disable7702: true,
+          disableHook: false,
           disableSequential: false,
+          gasLimit7702: undefined,
         }),
       );
       expect(addTransactionMock).not.toHaveBeenCalled();

--- a/packages/transaction-pay-controller/src/strategy/across/across-submit.ts
+++ b/packages/transaction-pay-controller/src/strategy/across/across-submit.ts
@@ -48,7 +48,6 @@ export async function submitAcrossQuotes(
   log('Executing quotes', request);
 
   const { quotes, messenger, transaction } = request;
-
   let transactionHash: Hex | undefined;
 
   for (const quote of quotes) {
@@ -118,8 +117,7 @@ async function submitTransactions(
   messenger: TransactionPayControllerMessenger,
 ): Promise<Hex | undefined> {
   const { swapTx } = quote.original.quote;
-  const { gasLimits: quoteGasLimits, is7702 } =
-    quote.original.metamask;
+  const { gasLimits: quoteGasLimits, is7702 } = quote.original.metamask;
   const { from } = quote.request;
   const chainId = toHex(swapTx.chainId);
   const orderedTransactions = getAcrossOrderedTransactions({

--- a/packages/transaction-pay-controller/src/strategy/across/across-submit.ts
+++ b/packages/transaction-pay-controller/src/strategy/across/across-submit.ts
@@ -48,7 +48,6 @@ export async function submitAcrossQuotes(
   log('Executing quotes', request);
 
   const { quotes, messenger, transaction } = request;
-  const { accountSupports7702 } = request;
 
   let transactionHash: Hex | undefined;
 
@@ -57,7 +56,6 @@ export async function submitAcrossQuotes(
       quote,
       messenger,
       transaction,
-      accountSupports7702,
     ));
   }
 
@@ -68,7 +66,6 @@ async function executeSingleQuote(
   quote: TransactionPayQuote<AcrossQuote>,
   messenger: TransactionPayControllerMessenger,
   transaction: TransactionMeta,
-  accountSupports7702: boolean,
 ): Promise<{ transactionHash?: Hex }> {
   log('Executing single quote', quote);
 
@@ -89,7 +86,6 @@ async function executeSingleQuote(
     transaction.id,
     acrossDepositType,
     messenger,
-    accountSupports7702,
   );
 
   updateTransaction(
@@ -113,7 +109,6 @@ async function executeSingleQuote(
  * @param parentTransactionId - ID of the parent transaction.
  * @param acrossDepositType - Transaction type used for the swap/deposit step.
  * @param messenger - Controller messenger.
- * @param accountSupports7702 - Whether the account supports EIP-7702.
  * @returns Hash of the last submitted transaction, if available.
  */
 async function submitTransactions(
@@ -121,13 +116,11 @@ async function submitTransactions(
   parentTransactionId: string,
   acrossDepositType: TransactionType,
   messenger: TransactionPayControllerMessenger,
-  accountSupports7702: boolean,
 ): Promise<Hex | undefined> {
   const { swapTx } = quote.original.quote;
-  const { gasLimits: quoteGasLimits, is7702: apiIs7702 } =
+  const { gasLimits: quoteGasLimits, is7702 } =
     quote.original.metamask;
   const { from } = quote.request;
-  const is7702 = apiIs7702 && accountSupports7702;
   const chainId = toHex(swapTx.chainId);
   const orderedTransactions = getAcrossOrderedTransactions({
     quote: quote.original.quote,
@@ -224,7 +217,7 @@ async function submitTransactions(
 
       await messenger.call('TransactionController:addTransactionBatch', {
         disable7702: !gasLimit7702,
-        disableHook: !gasLimit7702,
+        disableHook: Boolean(gasLimit7702),
         disableSequential: Boolean(gasLimit7702),
         from,
         gasLimit7702,

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.ts
@@ -810,7 +810,7 @@ async function calculateSourceNetworkCost(
 async function calculateSourceNetworkGasLimit(
   params: RelayTransactionStep['items'][0]['data'][],
   messenger: TransactionPayControllerMessenger,
-  fromOverride: Hex | undefined,
+  fromOverride?: Hex,
 ): Promise<{
   totalGasEstimate: number;
   totalGasLimit: number;

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.ts
@@ -221,8 +221,10 @@ async function getSingleQuote(
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     const useExactInput = isMaxAmount || request.isPostQuote;
 
+    const { accountSupports7702: supports7702 } = fullRequest;
+
     const useExecute =
-      fullRequest.accountSupports7702 &&
+      supports7702 &&
       isRelayExecuteEnabled(messenger) &&
       isEIP7702Chain(messenger, sourceChainId);
 
@@ -454,7 +456,6 @@ async function normalizeQuote(
     messenger,
     request,
     fullRequest.transaction,
-    fullRequest.accountSupports7702,
   );
 
   const targetNetwork = {
@@ -590,7 +591,6 @@ function getFiatRates(
  * @param messenger - Controller messenger.
  * @param request - Quote request.
  * @param transaction - Original transaction metadata.
- * @param accountSupports7702 - Whether the account supports EIP-7702.
  * @returns Total source network cost in USD and fiat.
  */
 async function calculateSourceNetworkCost(
@@ -598,7 +598,6 @@ async function calculateSourceNetworkCost(
   messenger: TransactionPayControllerMessenger,
   request: QuoteRequest,
   transaction: TransactionMeta,
-  accountSupports7702: boolean,
 ): Promise<
   TransactionPayQuote<RelayQuote>['fees']['sourceNetwork'] & {
     gasLimits: number[];
@@ -655,7 +654,6 @@ async function calculateSourceNetworkCost(
     relayParams,
     messenger,
     fromOverride,
-    accountSupports7702,
   );
 
   const { gasLimits, is7702, totalGasEstimate, totalGasLimit } =
@@ -807,14 +805,12 @@ async function calculateSourceNetworkCost(
  * @param fromOverride - Optional address to use as `from` in gas estimation
  * instead of the address in the relay params. Used in predict withdraw flows
  * to estimate with the proxy/Safe address that holds the source token balance.
- * @param accountSupports7702 - Whether the account supports EIP-7702.
  * @returns Total gas estimates and per-transaction gas limits.
  */
 async function calculateSourceNetworkGasLimit(
   params: RelayTransactionStep['items'][0]['data'][],
   messenger: TransactionPayControllerMessenger,
   fromOverride: Hex | undefined,
-  accountSupports7702: boolean,
 ): Promise<{
   totalGasEstimate: number;
   totalGasLimit: number;
@@ -826,7 +822,6 @@ async function calculateSourceNetworkGasLimit(
   );
 
   const relayGasResult = await estimateQuoteGasLimits({
-    accountSupports7702,
     fallbackGas: getFeatureFlags(messenger).relayFallbackGas,
     fallbackOnSimulationFailure: true,
     messenger,

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-submit.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-submit.test.ts
@@ -465,8 +465,8 @@ describe('Relay Submit Utils', () => {
       );
     });
 
-    it('does not add authorization list when account does not support 7702', async () => {
-      request.accountSupports7702 = false;
+    it('does not add authorization list when quote is7702 is false', async () => {
+      request.quotes[0].original.metamask.is7702 = false;
       request.quotes[0].original.details.currencyOut.currency.chainId = 1;
       request.quotes[0].original.request = {
         authorizationList: [
@@ -502,12 +502,14 @@ describe('Relay Submit Utils', () => {
       expect(addTransactionBatchMock).toHaveBeenCalledTimes(1);
       expect(addTransactionBatchMock).toHaveBeenCalledWith({
         disable7702: true,
-        disableHook: true,
+        disableHook: false,
         disableSequential: false,
         from: FROM_MOCK,
+        gasFeeToken: undefined,
+        gasLimit7702: undefined,
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         origin: ORIGIN_METAMASK,
-        overwriteUpgrade: false,
+        overwriteUpgrade: true,
         requireApproval: false,
         transactions: [
           {
@@ -899,11 +901,14 @@ describe('Relay Submit Utils', () => {
         expect(addTransactionBatchMock).toHaveBeenCalledTimes(1);
         expect(addTransactionBatchMock).toHaveBeenCalledWith(
           expect.objectContaining({
+            disable7702: true,
+            disableHook: false,
+            disableSequential: false,
             from: FROM_MOCK,
             gasFeeToken: undefined,
             networkClientId: NETWORK_CLIENT_ID_MOCK,
             origin: ORIGIN_METAMASK,
-            overwriteUpgrade: false,
+            overwriteUpgrade: true,
             requireApproval: false,
             transactions: [
               {
@@ -1013,9 +1018,10 @@ describe('Relay Submit Utils', () => {
         expect(addTransactionBatchMock).toHaveBeenCalledWith(
           expect.objectContaining({
             disable7702: true,
-            disableHook: true,
+            disableHook: false,
             disableSequential: false,
             gasLimit7702: undefined,
+            overwriteUpgrade: true,
             transactions: [
               expect.objectContaining({
                 params: expect.objectContaining({
@@ -1042,10 +1048,8 @@ describe('Relay Submit Utils', () => {
 
         expect(addTransactionBatchMock).toHaveBeenCalledWith(
           expect.objectContaining({
-            disable7702: false,
-            disableHook: false,
-            disableSequential: true,
             gasLimit7702: '0x31955',
+            overwriteUpgrade: true,
             transactions: [
               expect.objectContaining({
                 params: expect.objectContaining({
@@ -1078,10 +1082,8 @@ describe('Relay Submit Utils', () => {
       expect(addTransactionBatchMock).toHaveBeenCalledTimes(1);
       expect(addTransactionBatchMock).toHaveBeenCalledWith(
         expect.objectContaining({
-          disable7702: false,
-          disableHook: false,
-          disableSequential: true,
           gasLimit7702: '0xa410',
+          overwriteUpgrade: true,
           transactions: [
             expect.objectContaining({
               params: expect.objectContaining({
@@ -1098,9 +1100,7 @@ describe('Relay Submit Utils', () => {
       );
     });
 
-    it('submits batch sequentially when account does not support 7702', async () => {
-      request.accountSupports7702 = false;
-
+    it('uses 7702 mode based on quote metadata regardless of account support', async () => {
       request.quotes[0].original.steps[0].items.push({
         ...request.quotes[0].original.steps[0].items[0],
       });
@@ -1113,16 +1113,14 @@ describe('Relay Submit Utils', () => {
       expect(addTransactionBatchMock).toHaveBeenCalledTimes(1);
       expect(addTransactionBatchMock).toHaveBeenCalledWith(
         expect.objectContaining({
-          disable7702: true,
-          disableSequential: false,
+          overwriteUpgrade: true,
+          gasLimit7702: '0x5208',
         }),
       );
       expect(addTransactionMock).not.toHaveBeenCalled();
     });
 
     it('omits per-transaction gas when entry is missing in batch submission', async () => {
-      request.accountSupports7702 = false;
-
       request.quotes[0].original.steps[0].items.push({
         ...request.quotes[0].original.steps[0].items[0],
       });
@@ -1149,9 +1147,7 @@ describe('Relay Submit Utils', () => {
       );
     });
 
-    it('waits for on-chain confirmation for non-7702 accounts with multiple transactions', async () => {
-      request.accountSupports7702 = false;
-
+    it('waits for on-chain confirmation with multiple transactions', async () => {
       request.quotes[0].original.steps[0].items.push({
         ...request.quotes[0].original.steps[0].items[0],
       });
@@ -1164,9 +1160,7 @@ describe('Relay Submit Utils', () => {
       expect(waitForTransactionConfirmedMock).toHaveBeenCalled();
     });
 
-    it('uses addTransactionBatch for non-7702 accounts with multiple transactions', async () => {
-      request.accountSupports7702 = false;
-
+    it('uses addTransactionBatch with multiple transactions', async () => {
       request.quotes[0].original.steps[0].items.push({
         ...request.quotes[0].original.steps[0].items[0],
       });
@@ -1179,21 +1173,19 @@ describe('Relay Submit Utils', () => {
       expect(addTransactionMock).not.toHaveBeenCalled();
     });
 
-    it('still waits for on-chain confirmation for 7702 accounts with multiple transactions', async () => {
-      request.accountSupports7702 = true;
-
+    it('waits for on-chain confirmation with multiple transactions in 7702 mode', async () => {
       request.quotes[0].original.steps[0].items.push({
         ...request.quotes[0].original.steps[0].items[0],
       });
+
+      request.quotes[0].original.metamask.is7702 = true;
 
       await submitRelayQuotes(request);
 
       expect(waitForTransactionConfirmedMock).toHaveBeenCalled();
     });
 
-    it('still waits for on-chain confirmation for non-7702 accounts with single transaction', async () => {
-      request.accountSupports7702 = false;
-
+    it('waits for on-chain confirmation with single transaction', async () => {
       await submitRelayQuotes(request);
 
       expect(addTransactionMock).toHaveBeenCalledTimes(1);
@@ -1213,9 +1205,10 @@ describe('Relay Submit Utils', () => {
       expect(addTransactionBatchMock).toHaveBeenCalledWith(
         expect.objectContaining({
           disable7702: true,
-          disableHook: true,
+          disableHook: false,
           disableSequential: false,
           gasLimit7702: undefined,
+          overwriteUpgrade: true,
           transactions: [
             expect.objectContaining({
               params: expect.objectContaining({

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-submit.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-submit.ts
@@ -61,7 +61,6 @@ export async function submitRelayQuotes(
   log('Executing quotes', request);
 
   const { quotes, messenger, transaction } = request;
-  const { accountSupports7702 } = request;
 
   let transactionHash: Hex | undefined;
 
@@ -70,7 +69,6 @@ export async function submitRelayQuotes(
       quote,
       messenger,
       transaction,
-      accountSupports7702,
     ));
   }
 
@@ -83,14 +81,12 @@ export async function submitRelayQuotes(
  * @param quote - Relay quote to execute.
  * @param messenger - Controller messenger.
  * @param transaction - Original transaction meta.
- * @param accountSupports7702 - Whether the account supports EIP-7702.
  * @returns An object containing the transaction hash if available.
  */
 async function executeSingleQuote(
   quote: TransactionPayQuote<RelayQuote>,
   messenger: TransactionPayControllerMessenger,
   transaction: TransactionMeta,
-  accountSupports7702: boolean,
 ): Promise<{ transactionHash?: Hex }> {
   log('Executing single quote', quote);
 
@@ -113,7 +109,6 @@ async function executeSingleQuote(
       quote,
       transaction,
       messenger,
-      accountSupports7702,
     );
   }
 
@@ -318,14 +313,12 @@ async function validateSourceBalance(
  * @param quote - Relay quote.
  * @param transaction - Original transaction meta.
  * @param messenger - Controller messenger.
- * @param accountSupports7702 - Whether the account supports EIP-7702.
  * @returns Hash of the last submitted transaction.
  */
 async function submitTransactions(
   quote: TransactionPayQuote<RelayQuote>,
   transaction: TransactionMeta,
   messenger: TransactionPayControllerMessenger,
-  accountSupports7702: boolean,
 ): Promise<Hex> {
   const { steps } = quote.original;
   const txSteps = steps.filter(
@@ -383,7 +376,6 @@ async function submitTransactions(
     quote,
     transaction,
     messenger,
-    accountSupports7702,
     normalizedParams,
     allParams,
   );
@@ -479,7 +471,6 @@ async function submitViaRelayExecute(
  * @param quote - Relay quote.
  * @param transaction - Original transaction meta.
  * @param messenger - Controller messenger.
- * @param accountSupports7702 - Whether the account supports EIP-7702.
  * @param normalizedParams - Normalized relay-only params (without prepended original tx).
  * @param allParams - All params including any prepended original tx for post-quote flows.
  * @returns Hash of the last submitted transaction.
@@ -488,7 +479,6 @@ async function submitViaTransactionController(
   quote: TransactionPayQuote<RelayQuote>,
   transaction: TransactionMeta,
   messenger: TransactionPayControllerMessenger,
-  accountSupports7702: boolean,
   normalizedParams: TransactionParams[],
   allParams: TransactionParams[],
 ): Promise<Hex> {
@@ -545,8 +535,11 @@ async function submitViaTransactionController(
     quote.original.details.currencyIn.currency.chainId ===
     quote.original.details.currencyOut.currency.chainId;
 
+  const { metamask } = quote.original;
+  const { gasLimits, is7702 } = metamask;
+
   const authorizationList: AuthorizationList | undefined =
-    accountSupports7702 &&
+    is7702 &&
     isSameChain &&
     quote.original.request.authorizationList?.length
       ? quote.original.request.authorizationList.map((a) => ({
@@ -554,11 +547,6 @@ async function submitViaTransactionController(
           chainId: toHex(a.chainId),
         }))
       : undefined;
-
-  const { metamask } = quote.original;
-  const { gasLimits } = metamask;
-
-  const is7702 = metamask.is7702 && accountSupports7702;
 
   if (allParams.length === 1) {
     const transactionParams = {
@@ -607,13 +595,13 @@ async function submitViaTransactionController(
     await messenger.call('TransactionController:addTransactionBatch', {
       from,
       disable7702: !gasLimit7702,
-      disableHook: !gasLimit7702,
+      disableHook: Boolean(gasLimit7702),
       disableSequential: Boolean(gasLimit7702),
       gasFeeToken,
       gasLimit7702,
       networkClientId,
       origin: ORIGIN_METAMASK,
-      overwriteUpgrade: is7702,
+      overwriteUpgrade: true,
       requireApproval: false,
       transactions,
     });

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-submit.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-submit.ts
@@ -105,11 +105,7 @@ async function executeSingleQuote(
     const from = transaction.txParams.from as Hex;
     await submitHyperliquidWithdraw(quote, from, messenger);
   } else {
-    await submitTransactions(
-      quote,
-      transaction,
-      messenger,
-    );
+    await submitTransactions(quote, transaction, messenger);
   }
 
   const targetHash = await waitForRelayCompletion(
@@ -535,18 +531,16 @@ async function submitViaTransactionController(
     quote.original.details.currencyIn.currency.chainId ===
     quote.original.details.currencyOut.currency.chainId;
 
-  const { metamask } = quote.original;
-  const { gasLimits, is7702 } = metamask;
-
   const authorizationList: AuthorizationList | undefined =
-    is7702 &&
-    isSameChain &&
-    quote.original.request.authorizationList?.length
+    isSameChain && quote.original.request.authorizationList?.length
       ? quote.original.request.authorizationList.map((a) => ({
           address: a.address,
           chainId: toHex(a.chainId),
         }))
       : undefined;
+
+  const { metamask } = quote.original;
+  const { gasLimits } = metamask;
 
   if (allParams.length === 1) {
     const transactionParams = {
@@ -567,7 +561,9 @@ async function submitViaTransactionController(
       },
     );
   } else {
-    const gasLimit7702 = is7702 ? toHex(metamask.gasLimits[0]) : undefined;
+    const gasLimit7702 = metamask.is7702
+      ? toHex(metamask.gasLimits[0])
+      : undefined;
 
     const transactions = allParams.map((singleParams, index) => {
       const gasLimit = gasLimits[index];

--- a/packages/transaction-pay-controller/src/types.ts
+++ b/packages/transaction-pay-controller/src/types.ts
@@ -134,9 +134,6 @@ export type TransactionPayControllerMessenger = Messenger<
   TransactionPayControllerEvents | AllowedEvents
 >;
 
-/** Callback to check whether an account supports EIP-7702 authorization signing. */
-export type AccountSupports7702Callback = (account: string) => Promise<boolean>;
-
 /**
  * Keyring types that support EIP-7702 authorization signing.
  * Hardware wallets, snap keyrings, and money keyrings do not support 7702.

--- a/packages/transaction-pay-controller/src/utils/7702.ts
+++ b/packages/transaction-pay-controller/src/utils/7702.ts
@@ -1,0 +1,28 @@
+import type { TransactionPayControllerMessenger } from '../types';
+import { KEYRING_TYPES_SUPPORTING_7702 } from '../types';
+
+/**
+ * Check whether a given account supports EIP-7702 authorization signing.
+ *
+ * Looks up the account's keyring via `KeyringController:getState` and returns
+ * `true` only when the keyring type is in the supported list (HD Key Tree,
+ * Simple Key Pair). Hardware wallets, snap keyrings, and other types return
+ * `false`. Falls back to `true` when the keyring cannot be resolved.
+ *
+ * @param messenger - Controller messenger used to call KeyringController.
+ * @param account - The account address to check.
+ * @returns Whether the account supports EIP-7702.
+ */
+export function accountSupports7702(
+  messenger: TransactionPayControllerMessenger,
+  account: string,
+): boolean {
+  const { keyrings } = messenger.call('KeyringController:getState');
+  const keyring = keyrings.find((k) =>
+    k.accounts.some((a) => a.toLowerCase() === account.toLowerCase()),
+  );
+
+  return keyring
+    ? (KEYRING_TYPES_SUPPORTING_7702 as string[]).includes(keyring.type)
+    : true;
+}

--- a/packages/transaction-pay-controller/src/utils/quote-gas.ts
+++ b/packages/transaction-pay-controller/src/utils/quote-gas.ts
@@ -6,6 +6,7 @@ import { BigNumber } from 'bignumber.js';
 
 import type { TransactionPayControllerMessenger } from '..';
 import { projectLogger } from '../logger';
+import { accountSupports7702 } from './7702';
 import { getGasBuffer } from './feature-flags';
 import { estimateGasLimit } from './gas';
 
@@ -26,13 +27,11 @@ export type QuoteGasLimit = {
 };
 
 export async function estimateQuoteGasLimits({
-  accountSupports7702 = true,
   fallbackGas,
   fallbackOnSimulationFailure = false,
   messenger,
   transactions,
 }: {
-  accountSupports7702?: boolean;
   fallbackGas?: {
     estimate: number;
     max: number;
@@ -55,37 +54,12 @@ export async function estimateQuoteGasLimits({
   const useBatch = transactions.length > 1;
 
   if (useBatch) {
-    const result = await estimateQuoteGasLimitsBatch(transactions, messenger);
-
-    // If the batch returned a combined 7702 gas limit but the account cannot
-    // sign EIP-7702 authorizations (e.g. hardware wallet), re-estimate each
-    // transaction individually so callers receive per-transaction gas limits.
-    if (result.is7702 && !accountSupports7702) {
-      const individualResults = await Promise.all(
-        transactions.map((transaction) =>
-          estimateQuoteGasLimitSingle({
-            fallbackGas,
-            fallbackOnSimulationFailure,
-            messenger,
-            transaction,
-          }),
-        ),
-      );
-
-      return {
-        gasLimits: individualResults.map((res) => res.gasLimits[0]),
-        is7702: false,
-        totalGasEstimate: individualResults.reduce(
-          (acc, res) => acc + res.totalGasEstimate,
-          0,
-        ),
-        totalGasLimit: individualResults.reduce(
-          (acc, res) => acc + res.totalGasLimit,
-          0,
-        ),
-        usedBatch: true,
-      };
-    }
+    const result = await estimateQuoteGasLimitsBatch(
+      transactions,
+      messenger,
+      fallbackGas,
+      fallbackOnSimulationFailure,
+    );
 
     return {
       ...result,
@@ -108,6 +82,8 @@ export async function estimateQuoteGasLimits({
 async function estimateQuoteGasLimitsBatch(
   transactions: QuoteGasTransaction[],
   messenger: TransactionPayControllerMessenger,
+  fallbackGas?: { estimate: number; max: number },
+  fallbackOnSimulationFailure?: boolean,
 ): Promise<{
   batchGasLimit?: QuoteGasLimit;
   gasLimits: QuoteGasLimit[];
@@ -159,6 +135,41 @@ async function estimateQuoteGasLimitsBatch(
     0,
   );
   const is7702 = bufferedGasLimits.length === 1;
+
+  // If the batch returned a combined 7702 gas limit but the account cannot
+  // sign EIP-7702 authorizations (e.g. hardware wallet), re-estimate each
+  // transaction individually so callers never see is7702=true.
+  const supports7702 = accountSupports7702(
+    messenger,
+    firstTransaction.from,
+  );
+
+  if (is7702 && !supports7702) {
+    const individualResults = await Promise.all(
+      transactions.map((transaction) =>
+        estimateQuoteGasLimitSingle({
+          fallbackGas,
+          fallbackOnSimulationFailure: fallbackOnSimulationFailure ?? false,
+          messenger,
+          transaction,
+        }),
+      ),
+    );
+
+    return {
+      gasLimits: individualResults.map((res) => res.gasLimits[0]),
+      is7702: false,
+      totalGasEstimate: individualResults.reduce(
+        (acc, res) => acc + res.totalGasEstimate,
+        0,
+      ),
+      totalGasLimit: individualResults.reduce(
+        (acc, res) => acc + res.totalGasLimit,
+        0,
+      ),
+    };
+  }
+
   const batchGasLimit = is7702 ? bufferedGasLimits[0] : undefined;
 
   return {

--- a/packages/transaction-pay-controller/src/utils/quotes.test.ts
+++ b/packages/transaction-pay-controller/src/utils/quotes.test.ts
@@ -7,7 +7,6 @@ import { cloneDeep } from 'lodash';
 import { TransactionPayStrategy } from '../constants';
 import { getMessengerMock } from '../tests/messenger-mock';
 import type {
-  AccountSupports7702Callback,
   TransactionPaySourceAmount,
   TransactionData,
   TransactionPayQuote,
@@ -98,8 +97,6 @@ const BATCH_TRANSACTION_MOCK = {
 
 describe('Quotes Utils', () => {
   const { messenger, getControllerStateMock } = getMessengerMock();
-  const accountSupports7702Mock: jest.MockedFunction<AccountSupports7702Callback> =
-    jest.fn();
   const updateTransactionDataMock = jest.fn();
   const getStrategyByNameMock = jest.mocked(getStrategyByName);
   const getStrategiesByNameMock = jest.mocked(getStrategiesByName);
@@ -120,7 +117,6 @@ describe('Quotes Utils', () => {
    */
   async function run(params?: Partial<UpdateQuotesRequest>): Promise<boolean> {
     return await updateQuotes({
-      accountSupports7702: accountSupports7702Mock,
       getStrategies: getStrategiesMock,
       messenger,
       transactionData: cloneDeep(TRANSACTION_DATA_MOCK),
@@ -162,7 +158,6 @@ describe('Quotes Utils', () => {
     getQuotesMock.mockResolvedValue([QUOTE_MOCK]);
     getBatchTransactionsMock.mockResolvedValue([BATCH_TRANSACTION_MOCK]);
     calculateTotalsMock.mockReturnValue(TOTALS_MOCK);
-    accountSupports7702Mock.mockResolvedValue(true);
 
     getLiveTokenBalanceMock.mockResolvedValue('5000000');
     getTokenFiatRateMock.mockReturnValue({
@@ -505,6 +500,31 @@ describe('Quotes Utils', () => {
       });
     });
 
+    it('gets quotes with no minimum if allowUnderMinimum is true', async () => {
+      await run({
+        transactionData: {
+          ...TRANSACTION_DATA_MOCK,
+          tokens: [
+            {
+              ...TRANSACTION_DATA_MOCK.tokens?.[0],
+              allowUnderMinimum: true,
+            } as TransactionPayRequiredToken,
+          ],
+        },
+      });
+
+      expect(getQuotesMock).toHaveBeenCalledWith({
+        accountSupports7702: true,
+        messenger,
+        requests: [
+          expect.objectContaining({
+            targetAmountMinimum: '0',
+          }),
+        ],
+        transaction: TRANSACTION_META_MOCK,
+      });
+    });
+
     it('resolves strategies via getStrategiesByName', async () => {
       await run();
 
@@ -567,9 +587,7 @@ describe('Quotes Utils', () => {
       );
     });
 
-    it('clears batch transactions when account does not support 7702', async () => {
-      accountSupports7702Mock.mockResolvedValue(false);
-
+    it('always passes batch transactions regardless of 7702 support', async () => {
       await run();
 
       const transactionMetaMock = {} as TransactionMeta;
@@ -577,8 +595,8 @@ describe('Quotes Utils', () => {
 
       expect(transactionMetaMock).toMatchObject(
         expect.objectContaining({
-          batchTransactions: undefined,
-          batchTransactionsOptions: undefined,
+          batchTransactions: [BATCH_TRANSACTION_MOCK],
+          batchTransactionsOptions: {},
         }),
       );
     });
@@ -764,7 +782,6 @@ describe('Quotes Utils', () => {
         messenger,
         updateTransactionDataMock,
         getStrategiesMock,
-        accountSupports7702Mock,
       );
 
       expect(updateTransactionDataMock).toHaveBeenCalledTimes(4);
@@ -794,7 +811,6 @@ describe('Quotes Utils', () => {
         messenger,
         updateTransactionDataMock,
         getStrategiesMock,
-        accountSupports7702Mock,
       );
 
       expect(updateTransactionDataMock).toHaveBeenCalledTimes(4);
@@ -825,7 +841,6 @@ describe('Quotes Utils', () => {
         messenger,
         updateTransactionDataMock,
         getStrategiesMock,
-        accountSupports7702Mock,
       );
 
       expect(updateTransactionDataMock).toHaveBeenCalledTimes(0);
@@ -847,7 +862,6 @@ describe('Quotes Utils', () => {
         messenger,
         updateTransactionDataMock,
         getStrategiesMock,
-        accountSupports7702Mock,
       );
 
       expect(updateTransactionDataMock).toHaveBeenCalledTimes(0);
@@ -899,25 +913,27 @@ describe('Quotes Utils', () => {
         transactionData: POST_QUOTE_TRANSACTION_DATA,
       });
 
-      expect(getQuotesMock).toHaveBeenCalledWith({
-        accountSupports7702: true,
-        messenger,
-        requests: [
-          {
-            from: TRANSACTION_META_MOCK.txParams.from,
-            isMaxAmount: false,
-            isPostQuote: true,
-            sourceBalanceRaw: SOURCE_TOKEN_MOCK.balanceRaw,
-            sourceChainId: SOURCE_TOKEN_MOCK.chainId,
-            sourceTokenAddress: SOURCE_TOKEN_MOCK.address,
-            sourceTokenAmount: '10000000',
-            targetAmountMinimum: '0',
-            targetChainId: DESTINATION_TOKEN_MOCK.chainId,
-            targetTokenAddress: DESTINATION_TOKEN_MOCK.address,
-          },
-        ],
-        transaction: TRANSACTION_META_MOCK,
-      });
+      expect(getQuotesMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          accountSupports7702: true,
+          messenger,
+          requests: [
+            {
+              from: TRANSACTION_META_MOCK.txParams.from,
+              isMaxAmount: false,
+              isPostQuote: true,
+              sourceBalanceRaw: SOURCE_TOKEN_MOCK.balanceRaw,
+              sourceChainId: SOURCE_TOKEN_MOCK.chainId,
+              sourceTokenAddress: SOURCE_TOKEN_MOCK.address,
+              sourceTokenAmount: '10000000',
+              targetAmountMinimum: '0',
+              targetChainId: DESTINATION_TOKEN_MOCK.chainId,
+              targetTokenAddress: DESTINATION_TOKEN_MOCK.address,
+            },
+          ],
+          transaction: TRANSACTION_META_MOCK,
+        }),
+      );
     });
 
     it('includes refundTo in post-quote request when set in transaction data', async () => {

--- a/packages/transaction-pay-controller/src/utils/quotes.ts
+++ b/packages/transaction-pay-controller/src/utils/quotes.ts
@@ -7,7 +7,6 @@ import { createModuleLogger } from '@metamask/utils';
 import { TransactionPayStrategy } from '../constants';
 import { projectLogger } from '../logger';
 import type {
-  AccountSupports7702Callback,
   QuoteRequest,
   TransactionData,
   TransactionPayControllerMessenger,
@@ -18,6 +17,7 @@ import type {
   TransactionPaymentToken,
   UpdateTransactionDataCallback,
 } from '../types';
+import { accountSupports7702 } from './7702';
 import { getStrategiesByName, getStrategyByName } from './strategy';
 import {
   computeTokenAmounts,
@@ -32,7 +32,6 @@ const DEFAULT_REFRESH_INTERVAL = 30 * 1000; // 30 Seconds
 const log = createModuleLogger(projectLogger, 'quotes');
 
 export type UpdateQuotesRequest = {
-  accountSupports7702: AccountSupports7702Callback;
   getStrategies: (transaction: TransactionMeta) => TransactionPayStrategy[];
   messenger: TransactionPayControllerMessenger;
   transactionData: TransactionData | undefined;
@@ -50,7 +49,6 @@ export async function updateQuotes(
   request: UpdateQuotesRequest,
 ): Promise<boolean> {
   const {
-    accountSupports7702,
     getStrategies,
     messenger,
     transactionData,
@@ -107,7 +105,7 @@ export async function updateQuotes(
       transactionId,
     });
 
-    const supports7702 = await accountSupports7702(from);
+    const supports7702 = accountSupports7702(messenger, from);
 
     const { batchTransactions, quotes } = await getQuotes(
       transaction,
@@ -129,7 +127,7 @@ export async function updateQuotes(
     log('Calculated totals', { transactionId, totals });
 
     syncTransaction({
-      batchTransactions: supports7702 ? batchTransactions : undefined,
+      batchTransactions,
       isPostQuote,
       messenger: messenger as never,
       paymentToken,
@@ -210,13 +208,11 @@ function syncTransaction({
  * @param messenger - Messenger instance.
  * @param updateTransactionData - Callback to update transaction data.
  * @param getStrategies - Callback to get ordered strategy names for a transaction.
- * @param accountSupports7702 - Callback to check account EIP-7702 support.
  */
 export async function refreshQuotes(
   messenger: TransactionPayControllerMessenger,
   updateTransactionData: UpdateTransactionDataCallback,
   getStrategies: (transaction: TransactionMeta) => TransactionPayStrategy[],
-  accountSupports7702: AccountSupports7702Callback,
 ): Promise<void> {
   const state = messenger.call('TransactionPayController:getState');
   const transactionIds = Object.keys(state.transactionData);
@@ -245,7 +241,6 @@ export async function refreshQuotes(
     }
 
     const isUpdated = await updateQuotes({
-      accountSupports7702,
       getStrategies,
       messenger,
       transactionData,


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transaction batching and MetaMask Pay execution paths for EIP-7702 and introduces a new required messenger permission (`KeyringController:getState`), which can break clients and alters how/when batches are submitted with hooks and upgrade overwrites.
> 
> **Overview**
> **EIP-7702 flows are now gated by keyring support.** `TransactionController:addTransactionBatch` checks the sender’s keyring type (via `KeyringController:getState`) before attempting the EIP-7702 batch path, otherwise falling back to sequential/STX.
> 
> **MetaMask Pay (Relay/Across) removes the injectable 7702-support callback and centralizes the check.** A new `utils/7702` helper performs the keyring lookup, quote gas estimation re-estimates individually for unsupported keyrings, and submission logic is adjusted to rely on quote `metamask.is7702` metadata (with updated `disableHook`/`overwriteUpgrade` behavior) to fix hardware-wallet mUSD conversion on 7702 chains.
> 
> Changelogs document **breaking** permission/API changes: clients must allow `KeyringController:getState`, and the exported `AccountSupports7702Callback` type is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c372c6d803e858425b31bd96687fb3e1089ac49b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->