### PR TITLE
feat(perps-controller): sync controller from mobile 394fe407d2

### DIFF
--- a/packages/perps-controller/.sync-state.json
+++ b/packages/perps-controller/.sync-state.json
@@ -1,8 +1,8 @@
 {
   "lastSyncedMobileCommit": "394fe407d23bebe43a87bcccb2ce7f0fc1e5741c",
   "lastSyncedMobileBranch": "perps-inv",
-  "lastSyncedCoreCommit": "35d85382031859ebe5a7c835625c4e303a48df10",
+  "lastSyncedCoreCommit": "9654ee732182d5e92825fb8f6d2690afa814a866",
   "lastSyncedCoreBranch": "feat/perps/controller-apr-23rd",
-  "lastSyncedDate": "2026-04-23T09:15:16Z",
+  "lastSyncedDate": "2026-04-23T09:37:47Z",
   "sourceChecksum": "36e6a6bed41012b512b0ae7f723ba79ef39c066f50a81ff3bdaf2ee5f5c2737d"
 }

--- a/packages/perps-controller/.sync-state.json
+++ b/packages/perps-controller/.sync-state.json
@@ -1,8 +1,8 @@
 {
-  "lastSyncedMobileCommit": "c2248a8a9e83e02f1fcb1b95ec33c23f5cde2a5d",
-  "lastSyncedMobileBranch": "sync-perps-core",
-  "lastSyncedCoreCommit": "e30c0b11e0808242382f62283b1643cc6723cf4a",
-  "lastSyncedCoreBranch": "latest-perps-sync",
-  "lastSyncedDate": "2026-04-17T16:42:46Z",
-  "sourceChecksum": "8cd74a6ee57a4ead596f0eea26176aa9d386da905b6306928b347aafbf28a0c0"
+  "lastSyncedMobileCommit": "394fe407d23bebe43a87bcccb2ce7f0fc1e5741c",
+  "lastSyncedMobileBranch": "perps-inv",
+  "lastSyncedCoreCommit": "35d85382031859ebe5a7c835625c4e303a48df10",
+  "lastSyncedCoreBranch": "feat/perps/controller-apr-23rd",
+  "lastSyncedDate": "2026-04-23T09:15:16Z",
+  "sourceChecksum": "36e6a6bed41012b512b0ae7f723ba79ef39c066f50a81ff3bdaf2ee5f5c2737d"
 }

--- a/packages/perps-controller/.sync-state.json
+++ b/packages/perps-controller/.sync-state.json
@@ -1,8 +1,8 @@
 {
-  "lastSyncedMobileCommit": "394fe407d23bebe43a87bcccb2ce7f0fc1e5741c",
-  "lastSyncedMobileBranch": "perps-inv",
-  "lastSyncedCoreCommit": "9654ee732182d5e92825fb8f6d2690afa814a866",
+  "lastSyncedMobileCommit": "d4c68052ccec878922a9909ee95306252a959ff8",
+  "lastSyncedMobileBranch": "fix/core-sync-bugbot",
+  "lastSyncedCoreCommit": "5ea3b550b9e52744443da89da4a929ba2a7b0df7",
   "lastSyncedCoreBranch": "feat/perps/controller-apr-23rd",
-  "lastSyncedDate": "2026-04-23T09:37:47Z",
-  "sourceChecksum": "36e6a6bed41012b512b0ae7f723ba79ef39c066f50a81ff3bdaf2ee5f5c2737d"
+  "lastSyncedDate": "2026-04-23T10:22:26Z",
+  "sourceChecksum": "9afe08e6639a1705e1ac7b51f47d7617e1195504ec05928783e8bf0fcda44f9d"
 }

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `coalescePerpsRestRequest` utility for deduplicating concurrent REST requests with account-scoped cache keys ([#8560](https://github.com/MetaMask/core/pull/8560))
+- Add `accountUtils` helpers for resolving the active perps account id and pinning it to forwarded provider params ([#8560](https://github.com/MetaMask/core/pull/8560))
+
+### Changed
+
+- Account-scope the REST cache and guard cache writes so mount load stays cacheable without cross-account bleed ([#8560](https://github.com/MetaMask/core/pull/8560))
+- Make `forceRefresh` provider-agnostic and align rate-limit handling with the extension ([#8560](https://github.com/MetaMask/core/pull/8560))
+- Regenerate `PerpsController` method action types; shrink rate-limit diff and drop verbose history logs ([#8560](https://github.com/MetaMask/core/pull/8560))
+
+### Fixed
+
+- HyperLiquid Unified-mode live balance: subscribe to `spotState` WS and compute tradeable/total balance from on-chain math ([#8560](https://github.com/MetaMask/core/pull/8560))
+- Complete spot-balance parity with the extension consumer ([#8560](https://github.com/MetaMask/core/pull/8560))
+- Preserve integer trailing zeros when `szDecimals=0` in `perpsFormatters` ([#8560](https://github.com/MetaMask/core/pull/8560))
+- Preserve candle pagination cancellation and skip coalesce for explicit-`endTime` candle paging to avoid stale pages ([#8560](https://github.com/MetaMask/core/pull/8560))
+- Defer account resolution on the non-paginated cache path to prevent race conditions ([#8560](https://github.com/MetaMask/core/pull/8560))
+- Force-refresh on activity mount and evict expired coalesce entries so stale promises cannot resolve to cache ([#8560](https://github.com/MetaMask/core/pull/8560))
+
 ## [3.2.0]
 
 ### Added

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make `forceRefresh` provider-agnostic and align rate-limit handling with the extension ([#8560](https://github.com/MetaMask/core/pull/8560))
 - Regenerate `PerpsController` method action types; shrink rate-limit diff and drop verbose history logs ([#8560](https://github.com/MetaMask/core/pull/8560))
 
+### Removed
+
+- Drop the dead `spotState` parameter from `adaptAccountStateFromSDK`. Spot balances are layered on by `addSpotBalanceToAccountState`, which enforces the USDC-only policy via `SPOT_COLLATERAL_COINS`; removing the dormant branch keeps one source of truth and prevents a future caller from silently getting ALL-coins behavior ([#8560](https://github.com/MetaMask/core/pull/8560))
+
 ### Fixed
 
 - HyperLiquid Unified-mode live balance: subscribe to `spotState` WS and compute tradeable/total balance from on-chain math ([#8560](https://github.com/MetaMask/core/pull/8560))
@@ -26,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Preserve candle pagination cancellation and skip coalesce for explicit-`endTime` candle paging to avoid stale pages ([#8560](https://github.com/MetaMask/core/pull/8560))
 - Defer account resolution on the non-paginated cache path to prevent race conditions ([#8560](https://github.com/MetaMask/core/pull/8560))
 - Force-refresh on activity mount and evict expired coalesce entries so stale promises cannot resolve to cache ([#8560](https://github.com/MetaMask/core/pull/8560))
+- Normalize `event.user` to lowercase when caching the spot-state WS address so `#ensureSpotState` hits the cache instead of triggering a redundant REST `spotClearinghouseState` refetch when HyperLiquid returns a checksummed address ([#8560](https://github.com/MetaMask/core/pull/8560))
 
 ## [3.2.0]
 

--- a/packages/perps-controller/src/PerpsController-method-action-types.ts
+++ b/packages/perps-controller/src/PerpsController-method-action-types.ts
@@ -306,6 +306,9 @@ export type PerpsControllerGetPositionsAction = {
  * Thin delegation to MarketDataService
  *
  * @param params - The operation parameters.
+ * @param options - Optional call modifiers.
+ * @param options.forceRefresh - Bypass the request-coalesce cache
+ * end-to-end (user-initiated refresh).
  * @returns Array of historical trade executions (fills).
  */
 export type PerpsControllerGetOrderFillsAction = {
@@ -318,6 +321,9 @@ export type PerpsControllerGetOrderFillsAction = {
  * Thin delegation to MarketDataService
  *
  * @param params - The operation parameters.
+ * @param options - Optional call modifiers.
+ * @param options.forceRefresh - Bypass the request-coalesce cache
+ * end-to-end (user-initiated refresh).
  * @returns Array of historical orders.
  */
 export type PerpsControllerGetOrdersAction = {
@@ -345,6 +351,9 @@ export type PerpsControllerGetOpenOrdersAction = {
  * Thin delegation to MarketDataService
  *
  * @param params - The operation parameters.
+ * @param options - Optional call modifiers.
+ * @param options.forceRefresh - Bypass the request-coalesce cache
+ * end-to-end (user-initiated refresh).
  * @returns Array of historical funding payments.
  */
 export type PerpsControllerGetFundingAction = {

--- a/packages/perps-controller/src/PerpsController.ts
+++ b/packages/perps-controller/src/PerpsController.ts
@@ -2761,14 +2761,21 @@ export class PerpsController extends BaseController<
    * Thin delegation to MarketDataService
    *
    * @param params - The operation parameters.
+   * @param options - Optional call modifiers.
+   * @param options.forceRefresh - Bypass the request-coalesce cache
+   * end-to-end (user-initiated refresh).
    * @returns Array of historical trade executions (fills).
    */
-  async getOrderFills(params?: GetOrderFillsParams): Promise<OrderFill[]> {
+  async getOrderFills(
+    params?: GetOrderFillsParams,
+    options?: { forceRefresh?: boolean },
+  ): Promise<OrderFill[]> {
     const provider = this.getActiveProvider();
     return this.#marketDataService.getOrderFills({
       provider,
       params,
       context: this.#createServiceContext('getOrderFills'),
+      forceRefresh: options?.forceRefresh,
     });
   }
 
@@ -2777,14 +2784,21 @@ export class PerpsController extends BaseController<
    * Thin delegation to MarketDataService
    *
    * @param params - The operation parameters.
+   * @param options - Optional call modifiers.
+   * @param options.forceRefresh - Bypass the request-coalesce cache
+   * end-to-end (user-initiated refresh).
    * @returns Array of historical orders.
    */
-  async getOrders(params?: GetOrdersParams): Promise<Order[]> {
+  async getOrders(
+    params?: GetOrdersParams,
+    options?: { forceRefresh?: boolean },
+  ): Promise<Order[]> {
     const provider = this.getActiveProvider();
     return this.#marketDataService.getOrders({
       provider,
       params,
       context: this.#createServiceContext('getOrders'),
+      forceRefresh: options?.forceRefresh,
     });
   }
 
@@ -2819,14 +2833,21 @@ export class PerpsController extends BaseController<
    * Thin delegation to MarketDataService
    *
    * @param params - The operation parameters.
+   * @param options - Optional call modifiers.
+   * @param options.forceRefresh - Bypass the request-coalesce cache
+   * end-to-end (user-initiated refresh).
    * @returns Array of historical funding payments.
    */
-  async getFunding(params?: GetFundingParams): Promise<Funding[]> {
+  async getFunding(
+    params?: GetFundingParams,
+    options?: { forceRefresh?: boolean },
+  ): Promise<Funding[]> {
     const provider = this.getActiveProvider();
     return this.#marketDataService.getFunding({
       provider,
       params,
       context: this.#createServiceContext('getFunding'),
+      forceRefresh: options?.forceRefresh,
     });
   }
 

--- a/packages/perps-controller/src/constants/perpsConfig.ts
+++ b/packages/perps-controller/src/constants/perpsConfig.ts
@@ -135,6 +135,37 @@ export const PERFORMANCE_CONFIG = {
   // Prevents WS subscription churn during rapid market switching (#28141)
   CandleConnectDebounceMs: 500,
 
+  // Candle WS teardown delay (milliseconds)
+  // When the last subscriber for a cacheKey unsubscribes, wait this long before
+  // tearing down the WS. A subsequent subscribe inside the window cancels the
+  // teardown so rapid back-and-forth switches do not churn the connection.
+  CandleTeardownDelayMs: 150,
+
+  // Perps REST coalesce TTL (milliseconds)
+  //
+  // Window in which identical GET-style REST calls (getOrderFills, getOrders,
+  // getFunding, historicalOrders) share a single in-flight promise / cached
+  // result. `forceRefresh` still bypasses the cache end-to-end (hooks →
+  // controller → MarketDataService → provider → HyperLiquidClientService), so
+  // pull-to-refresh always hits the network.
+  //
+  // Why 60 s: HyperLiquid's documented rate limit is 1200 weight / IP /
+  // rolling 60 s window. Sizing TTL = window length caps each endpoint-per-
+  // account at ≤1 REST hit per window under any UI activity pattern — rapid
+  // market switching, re-mounts (usePerpsMarketFills, usePerpsTransactionHistory),
+  // and multi-tab scans all share a single request. Live fills/orders/prices
+  // still flow via WS subscriptions, so REST is seed/backfill only — cache
+  // staleness inside the 60 s window is never user-visible.
+  PerpsRestCoalesceTtlMs: 60_000,
+
+  // Candle snapshot REST coalesce TTL (milliseconds).
+  // Longer than PerpsRestCoalesceTtlMs because WS stream keeps live candles
+  // fresh — the REST snapshot only seeds the chart on initial subscribe. A
+  // 30 s window lets rapid market switching (pass 1 → pass 2 of a stress
+  // loop) share the same snapshot per (symbol, interval), cutting
+  // candleSnapshot REST weight roughly in half.
+  PerpsCandleCoalesceTtlMs: 30_000,
+
   // Navigation params delay (milliseconds)
   // Required for React Navigation to complete state transitions before setting params
   // This ensures navigation context is available when programmatically selecting tabs

--- a/packages/perps-controller/src/providers/AggregatedPerpsProvider.ts
+++ b/packages/perps-controller/src/providers/AggregatedPerpsProvider.ts
@@ -79,6 +79,7 @@ import type {
   WithdrawParams,
   WithdrawResult,
   RawLedgerUpdate,
+  PerpsReadOptions,
 } from '../types';
 
 /**
@@ -297,10 +298,13 @@ export class AggregatedPerpsProvider implements PerpsProvider {
     ).flat();
   }
 
-  async getOrderFills(params?: GetOrderFillsParams): Promise<OrderFill[]> {
+  async getOrderFills(
+    params?: GetOrderFillsParams,
+    options?: PerpsReadOptions,
+  ): Promise<OrderFill[]> {
     const results = await Promise.allSettled(
       this.#getActiveProviders().map(async ([id, provider]) => {
-        const fills = await provider.getOrderFills(params);
+        const fills = await provider.getOrderFills(params, options);
         return fills.map((fill) => ({ ...fill, providerId: id }));
       }),
     );
@@ -319,10 +323,13 @@ export class AggregatedPerpsProvider implements PerpsProvider {
     return this.#extractSuccessfulResults(results, 'getOrFetchFills').flat();
   }
 
-  async getOrders(params?: GetOrdersParams): Promise<Order[]> {
+  async getOrders(
+    params?: GetOrdersParams,
+    options?: PerpsReadOptions,
+  ): Promise<Order[]> {
     const results = await Promise.allSettled(
       this.#getActiveProviders().map(async ([id, provider]) => {
-        const orders = await provider.getOrders(params);
+        const orders = await provider.getOrders(params, options);
         return orders.map((order) => ({ ...order, providerId: id }));
       }),
     );
@@ -341,10 +348,13 @@ export class AggregatedPerpsProvider implements PerpsProvider {
     return this.#extractSuccessfulResults(results, 'getOpenOrders').flat();
   }
 
-  async getFunding(params?: GetFundingParams): Promise<Funding[]> {
+  async getFunding(
+    params?: GetFundingParams,
+    options?: PerpsReadOptions,
+  ): Promise<Funding[]> {
     const results = await Promise.allSettled(
       this.#getActiveProviders().map(async ([_providerId, provider]) => {
-        const funding = await provider.getFunding(params);
+        const funding = await provider.getFunding(params, options);
         // Funding type doesn't have providerId - we could add it if needed
         return funding;
       }),
@@ -376,6 +386,17 @@ export class AggregatedPerpsProvider implements PerpsProvider {
   }): Promise<RawLedgerUpdate[]> {
     // Delegate to default provider (protocol-specific)
     return this.#getDefaultProvider().getUserNonFundingLedgerUpdates(params);
+  }
+
+  /**
+   * Resolve the currently selected CAIP account identifier. Accounts are
+   * shared across sub-providers (same InternalAccountController), so the
+   * default provider's view is authoritative.
+   *
+   * @returns Resolved CAIP account id from the default sub-provider.
+   */
+  async getCurrentAccountId(): Promise<CaipAccountId> {
+    return this.#getDefaultProvider().getCurrentAccountId();
   }
 
   /**

--- a/packages/perps-controller/src/providers/HyperLiquidProvider.ts
+++ b/packages/perps-controller/src/providers/HyperLiquidProvider.ts
@@ -1,5 +1,6 @@
 import { CaipAccountId, hasProperty } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
+import type { ExchangeClient } from '@nktkas/hyperliquid';
 import { v4 as uuidv4 } from 'uuid';
 
 import type { CandlePeriod } from '../constants/chartConfig';
@@ -99,6 +100,7 @@ import type {
   WithdrawParams,
   WithdrawResult,
   RawLedgerUpdate,
+  PerpsReadOptions,
 } from '../types';
 import type {
   SDKOrderParams,
@@ -109,7 +111,10 @@ import type {
 } from '../types/hyperliquid-types';
 import type { PerpsControllerMessengerBase } from '../types/messenger';
 import type { ExtendedAssetMeta, ExtendedPerpDex } from '../types/perps-types';
-import { aggregateAccountStates } from '../utils/accountUtils';
+import {
+  addSpotBalanceToAccountState,
+  aggregateAccountStates,
+} from '../utils/accountUtils';
 import { ensureError } from '../utils/errorUtils';
 import {
   adaptAccountStateFromSDK,
@@ -4918,9 +4923,13 @@ export class HyperLiquidProvider implements PerpsProvider {
    * Get historical user fills (trade executions)
    *
    * @param params - The operation parameters.
+   * @param options - Optional cache-control modifiers for this read.
    * @returns A promise that resolves to the result.
    */
-  async getOrderFills(params?: GetOrderFillsParams): Promise<OrderFill[]> {
+  async getOrderFills(
+    params?: GetOrderFillsParams,
+    options?: PerpsReadOptions,
+  ): Promise<OrderFill[]> {
     try {
       this.#deps.debugLogger.log(
         'Getting user fills via HyperLiquid SDK:',
@@ -4957,16 +4966,20 @@ export class HyperLiquidProvider implements PerpsProvider {
       // Start fetching historical orders in parallel with fill transformation.
       // The fills API does not return order type, so we cross-reference
       // with historical orders to enable TP/SL pill rendering in activity.
-      const historicalOrdersPromise = (
-        infoClient.historicalOrders?.({ user: userAddress }) ??
-        Promise.resolve(null)
-      ).catch((enrichError: unknown) => {
-        this.#deps.debugLogger.log(
-          'Warning: failed to enrich fills with order types:',
-          enrichError,
-        );
-        return null;
-      });
+      // Routed through the client-service coalesce so the enrichment sidecar
+      // rides the same cache as an explicit getOrders call, preventing a
+      // second REST fire under rapid market switching.
+      const historicalOrdersPromise = this.#clientService
+        .fetchHistoricalOrders(userAddress, {
+          forceRefresh: options?.forceRefresh,
+        })
+        .catch((enrichError: unknown) => {
+          this.#deps.debugLogger.log(
+            'Warning: failed to enrich fills with order types:',
+            enrichError,
+          );
+          return null;
+        });
 
       // Transform HyperLiquid fills to abstract OrderFill type
       const fills = (rawFills || []).reduce((acc: OrderFill[], fill) => {
@@ -5035,9 +5048,13 @@ export class HyperLiquidProvider implements PerpsProvider {
    * Get historical orders (order lifecycle)
    *
    * @param params - The operation parameters.
+   * @param options - Optional cache-control modifiers for this read.
    * @returns A promise that resolves to the result.
    */
-  async getOrders(params?: GetOrdersParams): Promise<Order[]> {
+  async getOrders(
+    params?: GetOrdersParams,
+    options?: PerpsReadOptions,
+  ): Promise<Order[]> {
     try {
       this.#deps.debugLogger.log(
         'Getting user orders via HyperLiquid SDK:',
@@ -5048,14 +5065,14 @@ export class HyperLiquidProvider implements PerpsProvider {
       await this.#ensureClientsInitialized();
       this.#clientService.ensureInitialized();
 
-      const infoClient = this.#clientService.getInfoClient();
       const userAddress = await this.#walletService.getUserAddressWithDefault(
         params?.accountId,
       );
 
-      const rawOrders = await infoClient.historicalOrders({
-        user: userAddress,
-      });
+      const rawOrders = await this.#clientService.fetchHistoricalOrders(
+        userAddress,
+        { forceRefresh: options?.forceRefresh },
+      );
 
       this.#deps.debugLogger.log('User orders received:', {
         count: rawOrders?.length ?? 0,
@@ -5253,9 +5270,14 @@ export class HyperLiquidProvider implements PerpsProvider {
    * Get user funding history
    *
    * @param params - The operation parameters.
+   * @param _options - Cache-control modifiers (unused — funding has no
+   * provider-internal cache; coalescing happens at MarketDataService).
    * @returns A promise that resolves to the result.
    */
-  async getFunding(params?: GetFundingParams): Promise<Funding[]> {
+  async getFunding(
+    params?: GetFundingParams,
+    _options?: PerpsReadOptions,
+  ): Promise<Funding[]> {
     try {
       this.#deps.debugLogger.log(
         'Getting user funding via HyperLiquid SDK:',
@@ -5416,6 +5438,19 @@ export class HyperLiquidProvider implements PerpsProvider {
   }
 
   /**
+   * Resolve the provider's currently active CAIP account identifier.
+   * Used by the MarketDataService REST coalesce layer so cached payloads
+   * are keyed by the actual resolved address rather than a shared
+   * "default" sentinel — prevents one account's data from being served
+   * after an account switch within the coalesce TTL window.
+   *
+   * @returns CAIP account id for the currently selected HyperLiquid account.
+   */
+  async getCurrentAccountId(): Promise<CaipAccountId> {
+    return this.#walletService.getCurrentAccountId();
+  }
+
+  /**
    * Get user history (deposits, withdrawals, transfers)
    *
    * @param params - The operation parameters.
@@ -5553,17 +5588,38 @@ export class HyperLiquidProvider implements PerpsProvider {
           isTestnet: this.#clientService.isTestnetMode(),
         });
         const dexs = await this.#getStandaloneValidatedDexs();
-        const results = await queryStandaloneClearinghouseStates(
-          standaloneInfoClient,
-          userAddress,
-          dexs,
-        );
+        const [standaloneSpotStateResult, standalonePerpsResults] =
+          await Promise.all([
+            standaloneInfoClient
+              .spotClearinghouseState({ user: userAddress })
+              .catch((error: unknown) => {
+                this.#deps.debugLogger.log(
+                  'Standalone spot state fetch failed — falling back to perps-only totals',
+                  {
+                    error: ensureError(
+                      error,
+                      'HyperLiquidProvider.getAccountState.standalone.spot',
+                    ).message,
+                  },
+                );
+                return null;
+              }),
+            queryStandaloneClearinghouseStates(
+              standaloneInfoClient,
+              userAddress,
+              dexs,
+            ),
+          ]);
 
-        // Aggregate account states across all DEXs
-        const dexAccountStates = results.map((perpsState) =>
+        // Aggregate account states across all DEXs, then apply spot-backed
+        // adjustments so streamed/standalone/full paths report the same totals.
+        const dexAccountStates = standalonePerpsResults.map((perpsState) =>
           adaptAccountStateFromSDK(perpsState),
         );
-        const aggregatedAccountState = aggregateAccountStates(dexAccountStates);
+        const aggregatedAccountState = addSpotBalanceToAccountState(
+          aggregateAccountStates(dexAccountStates),
+          standaloneSpotStateResult,
+        );
 
         this.#deps.debugLogger.log(
           'HyperLiquidProvider: standalone account state fetched',
@@ -5678,19 +5734,10 @@ export class HyperLiquidProvider implements PerpsProvider {
         );
         return dexAccountState;
       });
-      const aggregatedAccountState = aggregateAccountStates(dexAccountStates);
-
-      // Add spot balance to totalBalance (spot is global, not per-DEX)
-      let spotBalance = 0;
-      if (spotState?.balances && Array.isArray(spotState.balances)) {
-        spotBalance = spotState.balances.reduce(
-          (sum, balance) => sum + parseFloat(balance.total || '0'),
-          0,
-        );
-      }
-      aggregatedAccountState.totalBalance = (
-        parseFloat(aggregatedAccountState.totalBalance) + spotBalance
-      ).toString();
+      const aggregatedAccountState = addSpotBalanceToAccountState(
+        aggregateAccountStates(dexAccountStates),
+        spotState,
+      );
 
       // Build per-sub-account breakdown (HIP-3 DEXs map to sub-accounts)
       const subAccountBreakdown: Record<
@@ -7752,6 +7799,19 @@ export class HyperLiquidProvider implements PerpsProvider {
       this.#userFeeCache.clear();
       this.#deps.debugLogger.log('Cleared all fee cache');
     }
+  }
+
+  /**
+   * Escape hatch for agentic validation flows and test harnesses that drive
+   * HL mutations directly. NOT part of the PerpsProvider interface.
+   * Production code paths must go through the provider's own methods.
+   *
+   * @returns A promise resolving to the underlying HyperLiquid SDK
+   * ExchangeClient. Promise shape matches the existing agentic flows
+   * (hl-provision-fixture) that chain `.then` on the result.
+   */
+  public async getExchangeClient(): Promise<ExchangeClient> {
+    return this.#clientService.getExchangeClient();
   }
 
   /**

--- a/packages/perps-controller/src/providers/MYXProvider.ts
+++ b/packages/perps-controller/src/providers/MYXProvider.ts
@@ -82,6 +82,7 @@ import type {
   WithdrawParams,
   WithdrawResult,
   RawLedgerUpdate,
+  PerpsReadOptions,
 } from '../types';
 import { MYXOrderStatusEnum } from '../types/myx-types';
 import type {
@@ -695,7 +696,10 @@ export class MYXProvider implements PerpsProvider {
     }
   }
 
-  async getOrders(_params?: GetOrdersParams): Promise<Order[]> {
+  async getOrders(
+    _params?: GetOrdersParams,
+    _options?: PerpsReadOptions,
+  ): Promise<Order[]> {
     try {
       await this.#ensureAuthenticated();
       const address = this.#getWalletService().getUserAddress();
@@ -738,7 +742,10 @@ export class MYXProvider implements PerpsProvider {
     }
   }
 
-  async getOrderFills(_params?: GetOrderFillsParams): Promise<OrderFill[]> {
+  async getOrderFills(
+    _params?: GetOrderFillsParams,
+    _options?: PerpsReadOptions,
+  ): Promise<OrderFill[]> {
     try {
       await this.#ensureAuthenticated();
       const address = this.#getWalletService().getUserAddress();
@@ -773,7 +780,10 @@ export class MYXProvider implements PerpsProvider {
     return this.getOrderFills(_params);
   }
 
-  async getFunding(_params?: GetFundingParams): Promise<Funding[]> {
+  async getFunding(
+    _params?: GetFundingParams,
+    _options?: PerpsReadOptions,
+  ): Promise<Funding[]> {
     try {
       await this.#ensureAuthenticated();
       const address = this.#getWalletService().getUserAddress();
@@ -812,6 +822,18 @@ export class MYXProvider implements PerpsProvider {
     endTime?: number;
   }): Promise<RawLedgerUpdate[]> {
     return [];
+  }
+
+  /**
+   * Resolve the provider's currently active CAIP account identifier.
+   * Used by the MarketDataService REST coalesce layer so cached payloads
+   * are keyed by the actual resolved address rather than a shared
+   * "default" sentinel.
+   *
+   * @returns CAIP account id for the currently selected MYX account.
+   */
+  async getCurrentAccountId(): Promise<CaipAccountId> {
+    return this.#getWalletService().getCurrentAccountId();
   }
 
   async getUserHistory(_params?: {

--- a/packages/perps-controller/src/services/HyperLiquidClientService.ts
+++ b/packages/perps-controller/src/services/HyperLiquidClientService.ts
@@ -6,10 +6,11 @@ import {
   SubscriptionClient,
   WebSocketTransport,
 } from '@nktkas/hyperliquid';
+import type { HistoricalOrdersResponse } from '@nktkas/hyperliquid';
 
 import { CandlePeriod, calculateCandleCount } from '../constants/chartConfig';
 import { HYPERLIQUID_TRANSPORT_CONFIG } from '../constants/hyperLiquidConfig';
-import { PERPS_CONSTANTS } from '../constants/perpsConfig';
+import { PERFORMANCE_CONFIG, PERPS_CONSTANTS } from '../constants/perpsConfig';
 import { PERPS_ERROR_CODES } from '../perpsErrorCodes';
 import { WebSocketConnectionState } from '../types';
 import type {
@@ -18,6 +19,7 @@ import type {
 } from '../types';
 import type { HyperLiquidNetwork } from '../types/config';
 import type { CandleData } from '../types/perps-types';
+import { coalescePerpsRestRequest } from '../utils/coalescePerpsRestRequest';
 import { ensureError, isAbortError } from '../utils/errorUtils';
 import { getPerpsConnectionAttemptContext } from '../utils/perpsConnectionAttemptContext';
 
@@ -484,8 +486,60 @@ export class HyperLiquidClientService {
     const { symbol, interval, limit = 100, endTime, signal } = options;
     this.ensureInitialized();
 
+    if (signal?.aborted) {
+      const abortError = new Error('Aborted');
+      abortError.name = 'AbortError';
+      throw abortError;
+    }
+
+    // Explicit endTime is a paging call — the caller owns that exact window
+    // and expects a fresh page. Coalescing per-millisecond endTimes produces
+    // keys that never dedupe and never evict (TTL-miss sweep only fires on
+    // re-access with the same key), so route paging straight to the SDK and
+    // only coalesce the live-snapshot path where all callers share 'now'.
+    if (endTime !== undefined) {
+      return this.#runCandleSnapshotFetch({
+        symbol,
+        interval,
+        limit,
+        endTime,
+        signal,
+      });
+    }
+
+    // Live snapshot: coalesce across rapid market switches (pass 1 → pass 2
+    // of the 10-market stress loop) so callers share one snapshot per
+    // (symbol, interval).
+    // Signal is intentionally dropped inside the coalesced fetch — the HL
+    // SDK charges weight for any request already sent, and dropping a
+    // per-caller abort lets the next caller reuse the in-flight/cached
+    // result instead of re-firing the REST. The WS stream keeps live
+    // candles fresh, so reusing the first-caller snapshot for up to the
+    // TTL is acceptable.
+    const cacheKey = [
+      'candleSnapshot',
+      this.#isTestnet ? 'testnet' : 'mainnet',
+      symbol,
+      interval,
+      limit,
+    ].join('|');
+
+    return coalescePerpsRestRequest<CandleData | null>(
+      cacheKey,
+      () => this.#runCandleSnapshotFetch({ symbol, interval, limit }),
+      { ttlMs: PERFORMANCE_CONFIG.PerpsCandleCoalesceTtlMs },
+    );
+  }
+
+  async #runCandleSnapshotFetch(options: {
+    symbol: string;
+    interval: ValidCandleInterval;
+    limit: number;
+    endTime?: number;
+    signal?: AbortSignal;
+  }): Promise<CandleData | null> {
+    const { symbol, interval, limit, endTime, signal } = options;
     try {
-      // Calculate start and end times based on interval and limit
       const now = endTime ?? Date.now();
       const intervalMs = this.#getIntervalMilliseconds(interval);
       const startTime = now - limit * intervalMs;
@@ -494,17 +548,16 @@ export class HyperLiquidClientService {
       // This avoids the WebSocket abort race condition that causes 429s
       // during rapid market switching on extension (#TAT-2954).
       const infoClient = this.getInfoClient({ useHttp: true });
-      const data = await infoClient.candleSnapshot(
-        {
-          coin: symbol, // Map to HyperLiquid SDK's 'coin' parameter
-          interval,
-          startTime,
-          endTime: now,
-        },
-        signal,
-      );
+      const request = {
+        coin: symbol, // Map to HyperLiquid SDK's 'coin' parameter
+        interval,
+        startTime,
+        endTime: now,
+      };
+      const data = signal
+        ? await infoClient.candleSnapshot(request, signal)
+        : await infoClient.candleSnapshot(request);
 
-      // Transform API response to match expected format
       if (Array.isArray(data) && data.length > 0) {
         const candles = data.map((candle) => ({
           time: candle.t, // open time
@@ -533,7 +586,6 @@ export class HyperLiquidClientService {
         'HyperLiquidClientService.fetchHistoricalCandles',
       );
 
-      // Expected cancellation — skip Sentry to avoid noisy abort reports
       if (isAbortError(error)) {
         throw error;
       }
@@ -559,6 +611,52 @@ export class HyperLiquidClientService {
 
       throw error;
     }
+  }
+
+  /**
+   * Fetch the user's historical orders via the HyperLiquid SDK, coalesced
+   * across concurrent callers and cached for {@link PERFORMANCE_CONFIG.PerpsRestCoalesceTtlMs}.
+   *
+   * Both getOrders (service layer) and the getUserFills enrichment sidecar
+   * (fills→order-type resolution for TP/SL pills in activity) hit the same
+   * `historicalOrders` info-post. Routing both through this wrapper means the
+   * enrichment path rides the same cache as an explicit activity-page fetch,
+   * so rapid market switching never fires redundant HL traffic.
+   *
+   * Pass `forceRefresh: true` to bypass the coalesce cache end-to-end
+   * (hooks → controller → MarketDataService → provider → this method), which
+   * is required for pull-to-refresh to fetch fresh data from the network.
+   *
+   * @param userAddress - The user's 0x address to query.
+   * @param options - Optional cache-control options.
+   * @param options.forceRefresh - When true, bypasses the coalesce cache.
+   * @returns Array of historical orders, empty array on SDK null.
+   */
+  public async fetchHistoricalOrders(
+    userAddress: Hex,
+    options?: { forceRefresh?: boolean },
+  ): Promise<HistoricalOrdersResponse> {
+    this.ensureInitialized();
+
+    const cacheKey = [
+      'historicalOrders',
+      this.#isTestnet ? 'testnet' : 'mainnet',
+      userAddress.toLowerCase(),
+    ].join('|');
+
+    return coalescePerpsRestRequest<HistoricalOrdersResponse>(
+      cacheKey,
+      () => this.#runHistoricalOrdersFetch(userAddress),
+      { forceRefresh: options?.forceRefresh },
+    );
+  }
+
+  async #runHistoricalOrdersFetch(
+    userAddress: Hex,
+  ): Promise<HistoricalOrdersResponse> {
+    const infoClient = this.getInfoClient();
+    const result = await infoClient.historicalOrders({ user: userAddress });
+    return result ?? [];
   }
 
   /**

--- a/packages/perps-controller/src/services/HyperLiquidSubscriptionService.ts
+++ b/packages/perps-controller/src/services/HyperLiquidSubscriptionService.ts
@@ -1144,7 +1144,10 @@ export class HyperLiquidSubscriptionService {
             // its result instead of overwriting this fresher WS snapshot.
             this.#spotStateGeneration += 1;
             this.#cachedSpotState = event.spotState;
-            this.#cachedSpotStateUserAddress = event.user;
+            // Normalize to match REST path (stores lowercase) so the
+            // #ensureSpotState strict-equal check hits the cache regardless
+            // of whether HL returns a checksummed or lowercase user field.
+            this.#cachedSpotStateUserAddress = event.user.toLowerCase();
 
             if (this.#dexAccountCache.size > 0) {
               this.#aggregateAndNotifySubscribers();
@@ -1595,7 +1598,6 @@ export class HyperLiquidSubscriptionService {
               // Extract account data (webData2 provides clearinghouseState)
               const accountState: AccountState = adaptAccountStateFromSDK(
                 data.clearinghouseState,
-                undefined, // webData2 doesn't include spotState
               );
 
               // Store in caches (main DEX only)
@@ -1800,7 +1802,6 @@ export class HyperLiquidSubscriptionService {
             // Update account state
             const accountState: AccountState = adaptAccountStateFromSDK(
               data.clearinghouseState,
-              undefined,
             );
 
             // Update caches

--- a/packages/perps-controller/src/services/HyperLiquidSubscriptionService.ts
+++ b/packages/perps-controller/src/services/HyperLiquidSubscriptionService.ts
@@ -14,6 +14,7 @@ import type {
   FrontendOpenOrdersResponse,
   ClearinghouseStateWsEvent,
   OpenOrdersWsEvent,
+  SpotStateWsEvent,
 } from '@nktkas/hyperliquid';
 
 import { TP_SL_CONFIG, PERPS_CONSTANTS } from '../constants/perpsConfig';
@@ -36,7 +37,11 @@ import type {
   PerpsPlatformDependencies,
   PerpsLogger,
 } from '../types';
-import { calculateWeightedReturnOnEquity } from '../utils/accountUtils';
+import type { SpotClearinghouseStateResponse } from '../types/hyperliquid-types';
+import {
+  addSpotBalanceToAccountState,
+  calculateWeightedReturnOnEquity,
+} from '../utils/accountUtils';
 import { ensureError } from '../utils/errorUtils';
 import {
   adaptPositionFromSDK,
@@ -133,6 +138,15 @@ export class HyperLiquidSubscriptionService {
   // Order fill subscriptions keyed by accountId (normalized: undefined -> 'default')
   readonly #orderFillSubscriptions = new Map<string, ISubscription>();
 
+  readonly #spotStateSubscriptions = new Map<string, ISubscription>();
+
+  readonly #spotStateSubscriptionPromises = new Map<string, Promise<void>>();
+
+  // Bumped on cleanup so in-flight #ensureSpotStateSubscription
+  // continuations discard their subscription instead of rehydrating
+  // #spotStateSubscriptions after clearAll/cleanupSharedWebData3.
+  #spotStateSubscriptionGeneration = 0;
+
   readonly #symbolSubscriberCounts = new Map<string, number>();
 
   readonly #dexSubscriberCounts = new Map<string, number>(); // Track subscribers per DEX for assetCtxs
@@ -156,6 +170,20 @@ export class HyperLiquidSubscriptionService {
   readonly #dexOrdersCache = new Map<string, Order[]>(); // Per-DEX orders
 
   readonly #dexAccountCache = new Map<string, AccountState>(); // Per-DEX account state
+
+  #cachedSpotState: SpotClearinghouseStateResponse | null = null;
+
+  #cachedSpotStateUserAddress: string | null = null;
+
+  #spotStatePromise?: Promise<void>;
+
+  #spotStatePromiseUserAddress?: string;
+
+  // Monotonic token bumped on cleanUp/clearAll and on each new fetch.
+  // Any in-flight #refreshSpotState that resolves with a stale token
+  // discards its result, preventing cross-account cache contamination
+  // when accounts are switched mid-fetch.
+  #spotStateGeneration = 0;
 
   #cachedPositions: Position[] | null = null; // Aggregated positions
 
@@ -981,15 +1009,177 @@ export class HyperLiquidSubscriptionService {
     // Calculate weighted returnOnEquity across all DEXs
     const returnOnEquity = calculateWeightedReturnOnEquity(accountStatesForROE);
 
-    return {
-      ...firstDexAccount,
-      availableBalance: totalAvailableBalance.toString(),
-      totalBalance: totalBalance.toString(),
-      marginUsed: totalMarginUsed.toString(),
-      unrealizedPnl: totalUnrealizedPnl.toString(),
-      subAccountBreakdown,
-      returnOnEquity,
-    };
+    return addSpotBalanceToAccountState(
+      {
+        ...firstDexAccount,
+        availableBalance: totalAvailableBalance.toString(),
+        totalBalance: totalBalance.toString(),
+        marginUsed: totalMarginUsed.toString(),
+        unrealizedPnl: totalUnrealizedPnl.toString(),
+        subAccountBreakdown,
+        returnOnEquity,
+      },
+      this.#cachedSpotState,
+    );
+  }
+
+  async #ensureSpotState(accountId?: CaipAccountId): Promise<void> {
+    const userAddress =
+      await this.#walletService.getUserAddressWithDefault(accountId);
+
+    if (
+      this.#cachedSpotState &&
+      this.#cachedSpotStateUserAddress === userAddress
+    ) {
+      return;
+    }
+
+    // Share an in-flight fetch only if it targets the same user.
+    // A pending fetch for a different user is stale after an account switch —
+    // start a fresh fetch; the stale one will self-discard via generation check.
+    if (
+      this.#spotStatePromise &&
+      this.#spotStatePromiseUserAddress === userAddress
+    ) {
+      await this.#spotStatePromise;
+      return;
+    }
+
+    this.#spotStateGeneration += 1;
+    const generation = this.#spotStateGeneration;
+    const promise = this.#refreshSpotState(userAddress, generation);
+    this.#spotStatePromise = promise;
+    this.#spotStatePromiseUserAddress = userAddress;
+
+    try {
+      await promise;
+    } finally {
+      // Only clear tracker if we're still the latest in-flight fetch.
+      // A newer fetch may have already replaced us.
+      if (this.#spotStatePromise === promise) {
+        this.#spotStatePromise = undefined;
+        this.#spotStatePromiseUserAddress = undefined;
+      }
+    }
+  }
+
+  async #refreshSpotState(
+    userAddress: string,
+    generation: number,
+  ): Promise<void> {
+    try {
+      // Cold-start safety: getInfoClient() throws until the SDK has been
+      // initialized via ensureSubscriptionClient. On a fresh service
+      // instance subscribeToAccount can race ahead of the webData3 path,
+      // so initialize here first — subsequent calls are no-ops.
+      await this.#clientService.ensureSubscriptionClient(
+        this.#walletService.createWalletAdapter(),
+      );
+
+      if (generation !== this.#spotStateGeneration) {
+        return;
+      }
+
+      const infoClient = this.#clientService.getInfoClient();
+      const result = await infoClient.spotClearinghouseState({
+        user: userAddress,
+      });
+
+      // Drop stale results: cleanUp/clearAll or a newer fetch bumped generation.
+      // Writing here would re-populate the cache with a different user's data.
+      if (generation !== this.#spotStateGeneration) {
+        return;
+      }
+
+      this.#cachedSpotState = result;
+      this.#cachedSpotStateUserAddress = userAddress;
+
+      if (this.#dexAccountCache.size > 0) {
+        this.#aggregateAndNotifySubscribers();
+      }
+    } catch (error) {
+      if (generation !== this.#spotStateGeneration) {
+        return;
+      }
+      this.#logErrorUnlessClearing(
+        ensureError(error, 'HyperLiquidSubscriptionService.refreshSpotState'),
+        this.#getErrorContext('refreshSpotState'),
+      );
+    }
+  }
+
+  async #ensureSpotStateSubscription(accountId?: CaipAccountId): Promise<void> {
+    const userAddress =
+      await this.#walletService.getUserAddressWithDefault(accountId);
+
+    if (this.#spotStateSubscriptions.has(userAddress)) {
+      return;
+    }
+
+    const inFlight = this.#spotStateSubscriptionPromises.get(userAddress);
+    if (inFlight) {
+      await inFlight;
+      return;
+    }
+
+    const startGeneration = this.#spotStateSubscriptionGeneration;
+
+    const promise = (async (): Promise<void> => {
+      await this.#clientService.ensureSubscriptionClient(
+        this.#walletService.createWalletAdapter(),
+      );
+      const subscriptionClient = this.#clientService.getSubscriptionClient();
+      if (!subscriptionClient) {
+        throw new Error('SubscriptionClient not available');
+      }
+
+      const subscription = await subscriptionClient.spotState(
+        { user: userAddress },
+        (event: SpotStateWsEvent) => {
+          try {
+            if (event.user.toLowerCase() !== userAddress.toLowerCase()) {
+              return;
+            }
+            // Invalidate any in-flight REST refreshSpotState so it drops
+            // its result instead of overwriting this fresher WS snapshot.
+            this.#spotStateGeneration += 1;
+            this.#cachedSpotState = event.spotState;
+            this.#cachedSpotStateUserAddress = event.user;
+
+            if (this.#dexAccountCache.size > 0) {
+              this.#aggregateAndNotifySubscribers();
+            }
+          } catch (error) {
+            this.#logErrorUnlessClearing(
+              ensureError(
+                error,
+                'HyperLiquidSubscriptionService.ensureSpotStateSubscription',
+              ),
+              this.#getErrorContext('spotState callback error', {
+                user: userAddress,
+              }),
+            );
+          }
+        },
+      );
+
+      // Discard if cleanup ran while we were awaiting the subscription
+      // handshake; rehydrating #spotStateSubscriptions here would leave
+      // a stale entry that short-circuits future resubscribe attempts.
+      if (startGeneration !== this.#spotStateSubscriptionGeneration) {
+        await subscription.unsubscribe().catch(() => undefined);
+        return;
+      }
+
+      this.#spotStateSubscriptions.set(userAddress, subscription);
+    })();
+
+    this.#spotStateSubscriptionPromises.set(userAddress, promise);
+    try {
+      await promise;
+    } finally {
+      this.#spotStateSubscriptionPromises.delete(userAddress);
+    }
   }
 
   /**
@@ -1425,10 +1615,17 @@ export class HyperLiquidSubscriptionService {
                 this.#oiCapSubscribers.forEach((callback) => callback(oiCaps));
               }
 
-              // Notify subscribers (no aggregation needed - only main DEX)
+              // Notify subscribers (no aggregation needed - only main DEX).
+              // Apply spot balance so single-DEX accounts see the same
+              // spot-inclusive totalBalance as the HIP-3 aggregation path.
+              const spotAdjustedAccount = addSpotBalanceToAccountState(
+                accountState,
+                this.#cachedSpotState,
+              );
+
               const positionsHash = this.#hashPositions(positionsWithTPSL);
               const ordersHash = this.#hashOrders(orders);
-              const accountHash = this.#hashAccountState(accountState);
+              const accountHash = this.#hashAccountState(spotAdjustedAccount);
 
               if (positionsHash !== this.#cachedPositionsHash) {
                 this.#cachedPositions = positionsWithTPSL;
@@ -1447,10 +1644,10 @@ export class HyperLiquidSubscriptionService {
               }
 
               if (accountHash !== this.#cachedAccountHash) {
-                this.#cachedAccount = accountState;
+                this.#cachedAccount = spotAdjustedAccount;
                 this.#cachedAccountHash = accountHash;
                 this.#accountSubscribers.forEach((callback) =>
-                  callback(accountState),
+                  callback(spotAdjustedAccount),
                 );
               }
             } catch (error) {
@@ -1877,6 +2074,30 @@ export class HyperLiquidSubscriptionService {
         this.#webData3SubscriptionPromise = undefined;
       }
 
+      // Cleanup spotState subscriptions (per-user). Bump generation +
+      // drop in-flight promises so a racing #ensureSpotStateSubscription
+      // continuation discards its subscription rather than rehydrating
+      // #spotStateSubscriptions after this clear.
+      this.#spotStateSubscriptionGeneration += 1;
+      this.#spotStateSubscriptionPromises.clear();
+      if (this.#spotStateSubscriptions.size > 0) {
+        this.#spotStateSubscriptions.forEach((subscription, user) => {
+          subscription.unsubscribe().catch((error: Error) => {
+            this.#logErrorUnlessClearing(
+              ensureError(
+                error,
+                'HyperLiquidSubscriptionService.cleanupSharedWebData3ISubscription',
+              ),
+              this.#getErrorContext(
+                'cleanupSharedWebData3ISubscription.spotState',
+                { user },
+              ),
+            );
+          });
+        });
+        this.#spotStateSubscriptions.clear();
+      }
+
       // Cleanup individual subscriptions (clearinghouseState + openOrders)
       if (this.#clearinghouseStateSubscriptions.size > 0) {
         this.#clearinghouseStateSubscriptions.forEach(
@@ -1943,6 +2164,13 @@ export class HyperLiquidSubscriptionService {
       this.#cachedPositions = null;
       this.#cachedOrders = null;
       this.#cachedAccount = null;
+      this.#cachedSpotState = null;
+      this.#cachedSpotStateUserAddress = null;
+      // Bump generation so any in-flight spot fetch from a prior user discards
+      // its result instead of re-populating the cache post-cleanup.
+      this.#spotStateGeneration += 1;
+      this.#spotStatePromise = undefined;
+      this.#spotStatePromiseUserAddress = undefined;
       this.#ordersCacheInitialized = false; // Reset cache initialization flag
       this.#positionsCacheInitialized = false; // Reset cache initialization flag
 
@@ -2252,10 +2480,28 @@ export class HyperLiquidSubscriptionService {
     // Increment account subscriber count
     this.#accountSubscriberCount += 1;
 
-    // Immediately provide cached data if available
+    // Immediately provide cached data if available. May be spot-less if the
+    // spot fetch has not resolved yet (or permanently failed) — subscribers
+    // prefer stale-but-present data over silent starvation; the next
+    // aggregation after #ensureSpotState / next WebSocket update pushes the
+    // spot-inclusive value.
     if (this.#cachedAccount) {
       callback(this.#cachedAccount);
     }
+
+    this.#ensureSpotState(accountId).catch((error) => {
+      this.#logErrorUnlessClearing(
+        ensureError(error, 'HyperLiquidSubscriptionService.subscribeToAccount'),
+        this.#getErrorContext('subscribeToAccount.ensureSpotState'),
+      );
+    });
+
+    this.#ensureSpotStateSubscription(accountId).catch((error) => {
+      this.#logErrorUnlessClearing(
+        ensureError(error, 'HyperLiquidSubscriptionService.subscribeToAccount'),
+        this.#getErrorContext('subscribeToAccount.ensureSpotStateSubscription'),
+      );
+    });
 
     // Ensure shared subscription is active (reuses existing connection)
     this.#ensureSharedWebData3Subscription(accountId).catch((error) => {
@@ -3648,6 +3894,18 @@ export class HyperLiquidSubscriptionService {
     });
     this.#orderFillSubscriptions.clear();
 
+    // Clear spotState subscriptions. Bump generation + drop in-flight
+    // promises so any racing #ensureSpotStateSubscription continuation
+    // unsubscribes its fresh sub instead of rehydrating the cleared map.
+    this.#spotStateSubscriptionGeneration += 1;
+    this.#spotStateSubscriptionPromises.clear();
+    this.#spotStateSubscriptions.forEach((subscription) => {
+      subscription.unsubscribe().catch(() => {
+        // Ignore errors during cleanup
+      });
+    });
+    this.#spotStateSubscriptions.clear();
+
     // Clear cached data
     this.#cachedPriceData = null;
     this.#allMidsSnapshots.clear();
@@ -3684,6 +3942,11 @@ export class HyperLiquidSubscriptionService {
     this.#dexPositionsCache.clear();
     this.#dexOrdersCache.clear();
     this.#dexAccountCache.clear();
+    this.#cachedSpotState = null;
+    this.#cachedSpotStateUserAddress = null;
+    this.#spotStateGeneration += 1;
+    this.#spotStatePromise = undefined;
+    this.#spotStatePromiseUserAddress = undefined;
     this.#dexAssetCtxsCache.clear();
 
     // Unsubscribe all active subscriptions before clearing references.

--- a/packages/perps-controller/src/services/MarketDataService.ts
+++ b/packages/perps-controller/src/services/MarketDataService.ts
@@ -32,6 +32,7 @@ import type {
   PerpsPlatformDependencies,
 } from '../types';
 import type { CandleData } from '../types/perps-types';
+import { coalescePerpsRestRequest } from '../utils/coalescePerpsRestRequest';
 import { ensureError, isAbortError } from '../utils/errorUtils';
 import type { ServiceContext } from './ServiceContext';
 
@@ -135,14 +136,21 @@ export class MarketDataService {
    * @param options.provider - The perps provider instance.
    * @param options.params - The operation parameters.
    * @param options.context - The service context for dependencies.
+   * @param options.forceRefresh - Bypass the request-coalesce cache end-to-end
+   * (user-initiated refresh).
    * @returns The result of the operation.
    */
   async getOrderFills(options: {
     provider: PerpsProvider;
     params?: GetOrderFillsParams;
     context: ServiceContext;
+    /**
+     * Bypass the request-coalesce cache. Use for user-initiated refresh
+     * (pull-to-refresh, polling tick) so the fetch runs fresh.
+     */
+    forceRefresh?: boolean;
   }): Promise<OrderFill[]> {
-    const { provider, params, context } = options;
+    const { provider, params, context, forceRefresh } = options;
     const traceId = uuidv4();
     let traceData: { success: boolean; error?: string } | undefined;
 
@@ -157,7 +165,46 @@ export class MarketDataService {
         },
       });
 
-      const result = await provider.getOrderFills(params);
+      // Pagination / explicit end-window callers bypass the shared cache so
+      // their specific page never collides with the default "recent fills"
+      // bucket. Day-granular startTime bucket prevents a ~90d caller from
+      // sharing payloads with an all-history caller.
+      const isPaginated =
+        params?.limit !== undefined || params?.endTime !== undefined;
+
+      if (isPaginated) {
+        const result = await provider.getOrderFills(params, { forceRefresh });
+        traceData = { success: true };
+        return result;
+      }
+
+      // Non-paginated: resolve the caller's account so the cache key is
+      // account-scoped. Without this, callers that omit params.accountId
+      // (the common hook path) would collide on a shared "default" bucket —
+      // after an account switch, account B could receive account A's
+      // still-fresh payload until the TTL expired. Pin the resolved id onto
+      // the forwarded params so the provider cannot re-resolve to a different
+      // account between our resolve() and its fetch (TOCTOU guard).
+      const resolvedAccountId =
+        params?.accountId ?? (await provider.getCurrentAccountId());
+      const pinnedParams: GetOrderFillsParams = {
+        ...params,
+        accountId: resolvedAccountId,
+      };
+      const result = await coalescePerpsRestRequest(
+        [
+          context.tracingContext.provider,
+          context.tracingContext.isTestnet ? 'testnet' : 'mainnet',
+          'getOrderFills',
+          resolvedAccountId,
+          params?.aggregateByTime === true ? 'agg' : 'raw',
+          params?.startTime === undefined
+            ? 'unbounded'
+            : `s${Math.floor(params.startTime / 86_400_000)}`,
+        ].join('|'),
+        () => provider.getOrderFills(pinnedParams, { forceRefresh }),
+        { forceRefresh },
+      );
 
       traceData = { success: true };
       return result;
@@ -202,14 +249,20 @@ export class MarketDataService {
    * @param options.provider - The perps provider instance.
    * @param options.params - The operation parameters.
    * @param options.context - The service context for dependencies.
+   * @param options.forceRefresh - Bypass the request-coalesce cache end-to-end
+   * (user-initiated refresh).
    * @returns The result of the operation.
    */
   async getOrders(options: {
     provider: PerpsProvider;
     params?: GetOrdersParams;
     context: ServiceContext;
+    /**
+     * Bypass the request-coalesce cache. Use for user-initiated refresh.
+     */
+    forceRefresh?: boolean;
   }): Promise<Order[]> {
-    const { provider, params, context } = options;
+    const { provider, params, context, forceRefresh } = options;
     const traceId = uuidv4();
     let traceData: { success: boolean; error?: string } | undefined;
 
@@ -224,7 +277,37 @@ export class MarketDataService {
         },
       });
 
-      const result = await provider.getOrders(params);
+      const isPaginated =
+        params?.limit !== undefined ||
+        params?.offset !== undefined ||
+        params?.endTime !== undefined;
+
+      if (isPaginated) {
+        const result = await provider.getOrders(params, { forceRefresh });
+        traceData = { success: true };
+        return result;
+      }
+
+      // Non-paginated: resolve the caller's account so the cache key is
+      // account-scoped (see getOrderFills for rationale). Pin the resolved
+      // id onto the forwarded params so the provider cannot re-resolve to a
+      // different account between our resolve() and its fetch.
+      const resolvedAccountId =
+        params?.accountId ?? (await provider.getCurrentAccountId());
+      const pinnedParams: GetOrdersParams = {
+        ...params,
+        accountId: resolvedAccountId,
+      };
+      const result = await coalescePerpsRestRequest(
+        [
+          context.tracingContext.provider,
+          context.tracingContext.isTestnet ? 'testnet' : 'mainnet',
+          'getOrders',
+          resolvedAccountId,
+        ].join('|'),
+        () => provider.getOrders(pinnedParams, { forceRefresh }),
+        { forceRefresh },
+      );
 
       traceData = { success: true };
       return result;
@@ -344,14 +427,20 @@ export class MarketDataService {
    * @param options.provider - The perps provider instance.
    * @param options.params - The operation parameters.
    * @param options.context - The service context for dependencies.
+   * @param options.forceRefresh - Bypass the request-coalesce cache end-to-end
+   * (user-initiated refresh).
    * @returns The result of the operation.
    */
   async getFunding(options: {
     provider: PerpsProvider;
     params?: GetFundingParams;
     context: ServiceContext;
+    /**
+     * Bypass the request-coalesce cache. Use for user-initiated refresh.
+     */
+    forceRefresh?: boolean;
   }): Promise<Funding[]> {
-    const { provider, params, context } = options;
+    const { provider, params, context, forceRefresh } = options;
     const traceId = uuidv4();
     let traceData: { success: boolean; error?: string } | undefined;
 
@@ -366,7 +455,38 @@ export class MarketDataService {
         },
       });
 
-      const result = await provider.getFunding(params);
+      const isPaginated =
+        params?.limit !== undefined ||
+        params?.offset !== undefined ||
+        params?.startTime !== undefined ||
+        params?.endTime !== undefined;
+
+      if (isPaginated) {
+        const result = await provider.getFunding(params, { forceRefresh });
+        traceData = { success: true };
+        return result;
+      }
+
+      // Non-paginated: resolve the caller's account so the cache key is
+      // account-scoped (see getOrderFills for rationale). Pin the resolved
+      // id onto the forwarded params so the provider cannot re-resolve to a
+      // different account between our resolve() and its fetch.
+      const resolvedAccountId =
+        params?.accountId ?? (await provider.getCurrentAccountId());
+      const pinnedParams: GetFundingParams = {
+        ...params,
+        accountId: resolvedAccountId,
+      };
+      const result = await coalescePerpsRestRequest(
+        [
+          context.tracingContext.provider,
+          context.tracingContext.isTestnet ? 'testnet' : 'mainnet',
+          'getFunding',
+          resolvedAccountId,
+        ].join('|'),
+        () => provider.getFunding(pinnedParams, { forceRefresh }),
+        { forceRefresh },
+      );
 
       traceData = { success: true };
       return result;

--- a/packages/perps-controller/src/types/index.ts
+++ b/packages/perps-controller/src/types/index.ts
@@ -213,6 +213,7 @@ export type Position = {
 // Using 'type' instead of 'interface' for BaseController Json compatibility
 export type AccountState = {
   availableBalance: string; // Based on HyperLiquid: withdrawable
+  availableToTradeBalance?: string; // withdrawable + unreserved spot collateral (order-entry path)
   totalBalance: string; // Based on HyperLiquid: accountValue
   marginUsed: string; // Based on HyperLiquid: marginUsed
   unrealizedPnl: string; // Based on HyperLiquid: unrealizedPnl
@@ -718,6 +719,16 @@ export type GetOrdersParams = {
   userAddress?: string; // Optional: required when standalone is true - user address to query orders for
 };
 
+/**
+ * Options for cache-aware provider read calls (getOrders, getOrderFills, etc.).
+ * Provider-agnostic: providers without inner caches can ignore; providers that
+ * cache at the service layer (e.g. HyperLiquid) must honor forceRefresh.
+ */
+export type PerpsReadOptions = {
+  /** Bypass any provider-internal cache. Used for user-initiated refresh (pull-to-refresh). */
+  forceRefresh?: boolean;
+};
+
 export type GetFundingParams = {
   accountId?: CaipAccountId; // Optional: defaults to selected account
   startTime?: number; // Optional: start timestamp (Unix milliseconds)
@@ -973,7 +984,10 @@ export type PerpsProvider = {
    * Purpose: Track what actually happened when orders were executed.
    * Example: Market long 1 ETH @ $50,000 → OrderFill with exact execution price and fees
    */
-  getOrderFills(params?: GetOrderFillsParams): Promise<OrderFill[]>;
+  getOrderFills(
+    params?: GetOrderFillsParams,
+    options?: PerpsReadOptions,
+  ): Promise<OrderFill[]>;
 
   /**
    * Get fills using WebSocket cache first, falling back to REST API.
@@ -1000,7 +1014,10 @@ export type PerpsProvider = {
    * Purpose: Track the complete journey of orders from request to completion.
    * Example: Limit buy 1 ETH @ $48,000 → Order with status 'open' → 'filled' when executed
    */
-  getOrders(params?: GetOrdersParams): Promise<Order[]>;
+  getOrders(
+    params?: GetOrdersParams,
+    options?: PerpsReadOptions,
+  ): Promise<Order[]>;
 
   /**
    * Currently active open orders (real-time status).
@@ -1015,7 +1032,10 @@ export type PerpsProvider = {
    * Purpose: Track ongoing expenses and income from position maintenance.
    * Example: Holding long ETH position → Funding payment of -$5.00 (you pay the funding)
    */
-  getFunding(params?: GetFundingParams): Promise<Funding[]>;
+  getFunding(
+    params?: GetFundingParams,
+    options?: PerpsReadOptions,
+  ): Promise<Funding[]>;
 
   /**
    * Get user non-funding ledger updates (deposits, transfers, withdrawals)
@@ -1025,6 +1045,15 @@ export type PerpsProvider = {
     startTime?: number;
     endTime?: number;
   }): Promise<RawLedgerUpdate[]>;
+
+  /**
+   * Resolve the provider's currently active account identifier.
+   * Used by the REST coalesce layer so cached payloads are account-scoped
+   * even when callers omit params.accountId (the common hook path) — prevents
+   * one account's data from being served after an account switch within
+   * the coalesce TTL window.
+   */
+  getCurrentAccountId(): Promise<CaipAccountId>;
 
   /**
    * Get user history (deposits, withdrawals, transfers)

--- a/packages/perps-controller/src/utils/accountUtils.ts
+++ b/packages/perps-controller/src/utils/accountUtils.ts
@@ -6,6 +6,7 @@ import type { InternalAccount } from '@metamask/keyring-internal-api';
 
 import { PERPS_CONSTANTS } from '../constants/perpsConfig';
 import type { AccountState, PerpsInternalAccount } from '../types';
+import type { SpotClearinghouseStateResponse } from '../types/hyperliquid-types';
 
 const EVM_ACCOUNT_TYPES = new Set(['eip155:eoa', 'eip155:erc4337']);
 
@@ -89,6 +90,92 @@ export function calculateWeightedReturnOnEquity(
   return weightedROE.toString();
 }
 
+// Spot coins counted toward currently supported funded-state gating.
+// Today the in-app HyperLiquid market surface is USDC-collateralized only,
+// so USDH must not inflate the shared funded-state path that hides Add Funds.
+// Non-stablecoin spot assets (HYPE, PURR, …) also remain excluded.
+const SPOT_COLLATERAL_COINS = new Set<string>(['USDC']);
+
+export function getSpotBalance(
+  spotState?: SpotClearinghouseStateResponse | null,
+): number {
+  if (!spotState?.balances || !Array.isArray(spotState.balances)) {
+    return 0;
+  }
+
+  return spotState.balances.reduce(
+    (sum: number, balance: { coin?: string; total?: string }) => {
+      if (!balance.coin || !SPOT_COLLATERAL_COINS.has(balance.coin)) {
+        return sum;
+      }
+      const value = parseFloat(balance.total ?? '0');
+      return Number.isFinite(value) ? sum + value : sum;
+    },
+    0,
+  );
+}
+
+export function getSpotHold(
+  spotState?: SpotClearinghouseStateResponse | null,
+): number {
+  if (!spotState?.balances || !Array.isArray(spotState.balances)) {
+    return 0;
+  }
+
+  return spotState.balances.reduce(
+    (sum: number, balance: { coin?: string; hold?: string }) => {
+      if (!balance.coin || !SPOT_COLLATERAL_COINS.has(balance.coin)) {
+        return sum;
+      }
+      const value = parseFloat(balance.hold ?? '0');
+      return Number.isFinite(value) ? sum + value : sum;
+    },
+    0,
+  );
+}
+
+export function addSpotBalanceToAccountState(
+  accountState: AccountState,
+  spotState?: SpotClearinghouseStateResponse | null,
+): AccountState {
+  const spotBalance = getSpotBalance(spotState);
+  const spotHold = getSpotHold(spotState);
+  const freeSpot = Math.max(0, spotBalance - spotHold);
+
+  const currentTotal = parseFloat(accountState.totalBalance);
+  const currentAvailable = parseFloat(accountState.availableBalance);
+
+  // Preserve sentinel totals (e.g. PERPS_CONSTANTS.FallbackDataDisplay '--')
+  // rather than coercing them to NaN.
+  if (!Number.isFinite(currentTotal)) {
+    return accountState;
+  }
+
+  if (spotBalance === 0) {
+    return {
+      ...accountState,
+      availableToTradeBalance: Number.isFinite(currentAvailable)
+        ? currentAvailable.toString()
+        : accountState.availableBalance,
+    };
+  }
+
+  const availableToTrade = Number.isFinite(currentAvailable)
+    ? (currentAvailable + freeSpot).toString()
+    : freeSpot.toString();
+
+  // Subtract spotHold to avoid double-counting on Unified/PM accounts:
+  // marginSummary.accountValue already includes the margin that HL
+  // surfaces via spot.hold. Standard mode has spotHold = 0, no-op.
+  const nextTotal = currentTotal + spotBalance - spotHold;
+
+  return {
+    ...accountState,
+    totalBalance: nextTotal.toString(),
+    availableToTradeBalance: availableToTrade,
+  };
+}
+
 /**
  * Aggregate multiple per-DEX AccountState objects into one by summing numeric fields.
  * ROE is recalculated as (totalUnrealizedPnl / totalMarginUsed) * 100.
@@ -113,10 +200,25 @@ export function aggregateAccountStates(states: AccountState[]): AccountState {
     if (index === 0) {
       return { ...state };
     }
+    const accAvailableToTrade = parseFloat(
+      acc.availableToTradeBalance ?? acc.availableBalance,
+    );
+    const stateAvailableToTrade = parseFloat(
+      state.availableToTradeBalance ?? state.availableBalance,
+    );
+    const availableToTradeSum =
+      Number.isFinite(accAvailableToTrade) &&
+      Number.isFinite(stateAvailableToTrade)
+        ? (accAvailableToTrade + stateAvailableToTrade).toString()
+        : undefined;
+
     return {
       availableBalance: (
         parseFloat(acc.availableBalance) + parseFloat(state.availableBalance)
       ).toString(),
+      ...(availableToTradeSum !== undefined && {
+        availableToTradeBalance: availableToTradeSum,
+      }),
       totalBalance: (
         parseFloat(acc.totalBalance) + parseFloat(state.totalBalance)
       ).toString(),

--- a/packages/perps-controller/src/utils/coalescePerpsRestRequest.ts
+++ b/packages/perps-controller/src/utils/coalescePerpsRestRequest.ts
@@ -1,0 +1,106 @@
+import { PERFORMANCE_CONFIG } from '../constants/perpsConfig';
+
+// Rapid perps market switching (candle bridge + activity tab burst) drives
+// duplicate REST calls against api.hyperliquid.xyz and occasionally trips 429.
+// This helper collapses concurrent identical calls into one in-flight promise
+// and serves a short TTL cache to absorb the burst. Explicit refresh bypasses
+// the cache so user-initiated refetch still re-runs.
+//
+// Lives at the service layer (MarketDataService) rather than per-hook so every
+// current and future caller — hooks, controller, aggregated provider — is
+// deduped automatically. Centralized at MarketDataService because it is
+// already a single choke point.
+
+type CacheEntry<TValue> = {
+  value: TValue;
+  expiresAt: number;
+};
+
+const inflight = new Map<string, Promise<unknown>>();
+const cache = new Map<string, CacheEntry<unknown>>();
+
+export type CoalesceOptions = {
+  /**
+   * Cache TTL in milliseconds. Defaults to
+   * {@link PERFORMANCE_CONFIG.PerpsRestCoalesceTtlMs}.
+   */
+  ttlMs?: number;
+  /**
+   * Bypass the cache and any in-flight promise. The fresh result will be
+   * written back to the cache under the same key.
+   */
+  forceRefresh?: boolean;
+};
+
+/**
+ * Coalesce an idempotent perps REST call.
+ *
+ * - If a fresh cached value exists for `key`, it is returned immediately.
+ * - If an in-flight promise exists for `key`, it is shared with the caller.
+ * - Otherwise, `fetcher` runs once; the result populates the cache for `ttlMs`.
+ *
+ * `forceRefresh` skips both cache and in-flight dedup.
+ *
+ * @param key - Stable cache key identifying this logical REST call.
+ * @param fetcher - Thunk that performs the REST call when no cache/inflight hit.
+ * @param options - Optional overrides for TTL and forceRefresh behavior.
+ * @returns The fetched (or cached) value.
+ */
+export function coalescePerpsRestRequest<TValue>(
+  key: string,
+  fetcher: () => Promise<TValue>,
+  options: CoalesceOptions = {},
+): Promise<TValue> {
+  const ttlMs = options.ttlMs ?? PERFORMANCE_CONFIG.PerpsRestCoalesceTtlMs;
+  const forceRefresh = options.forceRefresh ?? false;
+
+  if (forceRefresh) {
+    cache.delete(key);
+  } else {
+    const now = Date.now();
+    const cached = cache.get(key) as CacheEntry<TValue> | undefined;
+    if (cached) {
+      if (cached.expiresAt > now) {
+        return Promise.resolve(cached.value);
+      }
+      // Evict expired entry so callers with per-call-unique keys (e.g.
+      // CandleStreamChannel historical paging with per-page endTime) do
+      // not accumulate dead blobs for the life of the process.
+      cache.delete(key);
+    }
+    const existing = inflight.get(key) as Promise<TValue> | undefined;
+    if (existing !== undefined) {
+      return existing;
+    }
+  }
+
+  const run = fetcher().then(
+    (value) => {
+      // Only the currently-tracked in-flight promise writes to cache. A stale
+      // in-flight (e.g. one that was racing a later forceRefresh=true caller)
+      // must not clobber the fresh value once it finally resolves.
+      if (inflight.get(key) === run) {
+        cache.set(key, { value, expiresAt: Date.now() + ttlMs });
+        inflight.delete(key);
+      }
+      return value;
+    },
+    (error) => {
+      if (inflight.get(key) === run) {
+        inflight.delete(key);
+      }
+      throw error;
+    },
+  );
+
+  inflight.set(key, run);
+  return run;
+}
+
+/**
+ * Test-only: wipe all cached entries and in-flight promises.
+ */
+export function resetPerpsRestCacheForTests(): void {
+  cache.clear();
+  inflight.clear();
+}

--- a/packages/perps-controller/src/utils/hyperLiquidAdapter.ts
+++ b/packages/perps-controller/src/utils/hyperLiquidAdapter.ts
@@ -289,18 +289,28 @@ export function adaptAccountStateFromSDK(
   const perpsBalance = parseFloat(perpsState.marginSummary.accountValue);
 
   let spotBalance = 0;
+  let spotHold = 0;
   if (spotState?.balances && Array.isArray(spotState.balances)) {
-    spotBalance = spotState.balances.reduce(
-      (sum: number, balance: { total?: string }) =>
-        sum + parseFloat(balance.total ?? '0'),
-      0,
-    );
+    for (const balance of spotState.balances) {
+      spotBalance += parseFloat(balance.total ?? '0');
+      spotHold += parseFloat((balance as { hold?: string }).hold ?? '0');
+    }
   }
 
-  const totalBalance = (spotBalance + perpsBalance).toString();
+  // Subtract spotHold to avoid double-counting margin on Unified/PM:
+  // perpsBalance already includes the margin HL surfaces as spot.hold.
+  // Standard mode has spotHold = 0. See addSpotBalanceToAccountState.
+  const totalBalance = (spotBalance + perpsBalance - spotHold).toString();
+
+  const withdrawable = parseFloat(perpsState.withdrawable || '0');
+  const freeSpot = Math.max(0, spotBalance - spotHold);
+  const availableToTradeBalance = (
+    (Number.isFinite(withdrawable) ? withdrawable : 0) + freeSpot
+  ).toString();
 
   const accountState: AccountState = {
     availableBalance: perpsState.withdrawable || '0',
+    availableToTradeBalance,
     totalBalance: totalBalance || '0',
     marginUsed: perpsState.marginSummary.totalMarginUsed || '0',
     unrealizedPnl: totalUnrealizedPnl.toString() || '0',

--- a/packages/perps-controller/src/utils/hyperLiquidAdapter.ts
+++ b/packages/perps-controller/src/utils/hyperLiquidAdapter.ts
@@ -15,7 +15,6 @@ import type {
   AssetPosition,
   FrontendOrder,
   ClearinghouseStateResponse,
-  SpotClearinghouseStateResponse,
   MetaResponse,
   SDKOrderParams,
 } from '../types/hyperliquid-types';
@@ -255,9 +254,12 @@ export function adaptMarketFromSDK(
   };
 }
 
+// Perps-only account adapter. Spot balances are layered on afterwards by
+// addSpotBalanceToAccountState, which enforces the USDC-only policy via
+// SPOT_COLLATERAL_COINS. Keeping spot logic out of here preserves a single
+// source of truth for spot balance math.
 export function adaptAccountStateFromSDK(
   perpsState: ClearinghouseStateResponse,
-  spotState?: SpotClearinghouseStateResponse | null,
 ): AccountState {
   const { totalUnrealizedPnl, weightedReturnOnEquity } =
     perpsState.assetPositions.reduce(
@@ -288,30 +290,10 @@ export function adaptAccountStateFromSDK(
 
   const perpsBalance = parseFloat(perpsState.marginSummary.accountValue);
 
-  let spotBalance = 0;
-  let spotHold = 0;
-  if (spotState?.balances && Array.isArray(spotState.balances)) {
-    for (const balance of spotState.balances) {
-      spotBalance += parseFloat(balance.total ?? '0');
-      spotHold += parseFloat((balance as { hold?: string }).hold ?? '0');
-    }
-  }
-
-  // Subtract spotHold to avoid double-counting margin on Unified/PM:
-  // perpsBalance already includes the margin HL surfaces as spot.hold.
-  // Standard mode has spotHold = 0. See addSpotBalanceToAccountState.
-  const totalBalance = (spotBalance + perpsBalance - spotHold).toString();
-
-  const withdrawable = parseFloat(perpsState.withdrawable || '0');
-  const freeSpot = Math.max(0, spotBalance - spotHold);
-  const availableToTradeBalance = (
-    (Number.isFinite(withdrawable) ? withdrawable : 0) + freeSpot
-  ).toString();
-
   const accountState: AccountState = {
     availableBalance: perpsState.withdrawable || '0',
-    availableToTradeBalance,
-    totalBalance: totalBalance || '0',
+    availableToTradeBalance: perpsState.withdrawable || '0',
+    totalBalance: perpsBalance.toString() || '0',
     marginUsed: perpsState.marginSummary.totalMarginUsed || '0',
     unrealizedPnl: totalUnrealizedPnl.toString() || '0',
     returnOnEquity: totalReturnOnEquityPercentage || '0',

--- a/packages/perps-controller/src/utils/perpsFormatters.ts
+++ b/packages/perps-controller/src/utils/perpsFormatters.ts
@@ -522,7 +522,11 @@ export const formatPositionSize = (
 
   // Use asset-specific decimals if provided (Hyperliquid metadata)
   if (szDecimals !== undefined) {
-    return value.toFixed(szDecimals).replace(/\.?0+$/u, '');
+    const fixed = value.toFixed(szDecimals);
+    // Only strip trailing zeros when a decimal point is present; toFixed(0)
+    // returns an integer string and the regex would otherwise eat valid zeros
+    // on whole-unit assets (szDecimals=0), e.g. "100" -> "1".
+    return fixed.includes('.') ? fixed.replace(/\.?0+$/u, '') : fixed;
   }
 
   // Fallback: magnitude-based decimal logic for backwards compatibility


### PR DESCRIPTION
Syncs app/controllers/perps/ from mobile commit 394fe407d2.

Changes:
- HL Unified-mode live balance: spotState WS + tradeable-balance + total-balance math ([#29226](https://github.com/MetaMask/metamask-mobile/pull/29226))
- Complete spot-balance parity with extension ([#29110](https://github.com/MetaMask/metamask-mobile/pull/29110))
- Preserve integer trailing zeros when szDecimals=0 ([#29016](https://github.com/MetaMask/metamask-mobile/pull/29016))
- Add `coalescePerpsRestRequest` util + `accountUtils`; account-scoped REST cache and guarded cache writes
- Preserve candle pagination cancellation; skip coalesce for explicit-endTime candle paging
- Parity with extension rate-limit fix + provider-agnostic `forceRefresh`
- Pin resolved account id to forwarded provider params; defer account resolution to non-paginated cache path
- Force-refresh activity mount and evict expired coalesce entries
- Regenerate `PerpsController` method action types; shrink rate-limit diff and drop verbose history logs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core market-data fetching, caching, and account-balance computation/WS subscriptions; regressions could surface stale/cross-account activity data or incorrect balances, but changes are localized and add explicit cache scoping and refresh escape hatches.
> 
> **Overview**
> Adds a new service-layer REST request coalescing/TTL cache (`coalescePerpsRestRequest`) and wires it into `MarketDataService` (orders/fills/funding) and HyperLiquid candle snapshots to reduce duplicate REST traffic and 429s, with an end-to-end `forceRefresh` bypass for user-initiated refreshes.
> 
> Fixes HyperLiquid unified-mode balance parity by subscribing to `spotState` over WS, computing spot-adjusted `totalBalance` plus a new `availableToTradeBalance`, and centralizing spot math in `accountUtils` (including USDC-only spot collateral policy). Also scopes caches by resolved account via new `PerpsProvider.getCurrentAccountId()` and updates controller/provider method signatures and adapter/formatter behavior (e.g., preserve integer trailing zeros when `szDecimals=0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 166054135ec7eb8a573cfc08c9ece807f1e0871b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->