### PR TITLE
ci: Remove `concurrency` config for update changelogs workflow

### DIFF
--- a/.github/workflows/update-changelogs.yml
+++ b/.github/workflows/update-changelogs.yml
@@ -10,10 +10,6 @@ on:
     types:
       - opened
 
-concurrency:
-  group: update-changelogs-${{ github.event.issue.number || github.event.pull_request.number }}
-  cancel-in-progress: true
-
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
## Explanation

This removes the `concurrency` config for the "Update changelogs" workflow. It was causing issues because the workflow is triggered by issue comments, and the action itself leaves a comment on the pull request, meaning the workflow ends up cancelling itself. This can be seen in [this run](https://github.com/MetaMask/core/actions/runs/24832034034) for example.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts GitHub Actions workflow execution behavior by removing `concurrency`, reducing the chance of runs canceling themselves; no product code or data/auth logic changes.
> 
> **Overview**
> Removes the `concurrency` grouping/cancelation configuration from the `Update Changelogs` GitHub Actions workflow so comment-triggered runs don’t cancel in-progress executions (e.g., when the workflow posts back to the PR).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc3de51921c382f25cde235919a035f7630fe7ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->