### PR TITLE
Release 934.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "933.0.0",
+  "version": "934.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.3.0]
+
 ### Added
 
 - Add `coalescePerpsRestRequest` utility for deduplicating concurrent REST requests with account-scoped cache keys ([#8560](https://github.com/MetaMask/core/pull/8560))
@@ -243,7 +245,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/controller-utils` from `^11.18.0` to `^11.19.0` ([#7995](https://github.com/MetaMask/core/pull/7995))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/perps-controller@3.2.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/perps-controller@3.3.0...HEAD
+[3.3.0]: https://github.com/MetaMask/core/compare/@metamask/perps-controller@3.2.0...@metamask/perps-controller@3.3.0
 [3.2.0]: https://github.com/MetaMask/core/compare/@metamask/perps-controller@3.1.1...@metamask/perps-controller@3.2.0
 [3.1.1]: https://github.com/MetaMask/core/compare/@metamask/perps-controller@3.1.0...@metamask/perps-controller@3.1.1
 [3.1.0]: https://github.com/MetaMask/core/compare/@metamask/perps-controller@3.0.0...@metamask/perps-controller@3.1.0

--- a/packages/perps-controller/package.json
+++ b/packages/perps-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/perps-controller",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Controller for perpetual trading functionality in MetaMask",
   "keywords": [
     "Ethereum",


### PR DESCRIPTION
## Explanation

This release bumps \`@metamask/perps-controller\` from \`3.2.0\` to \`3.3.0\`.

### Changes included

**\`@metamask/perps-controller\` v3.3.0** ([#8560](https://github.com/MetaMask/core/pull/8560))

**Added**
- Add \`coalescePerpsRestRequest\` utility for deduplicating concurrent REST requests with account-scoped cache keys
- Add \`accountUtils\` helpers for resolving the active perps account id and pinning it to forwarded provider params

**Changed**
- Account-scope the REST cache and guard cache writes so mount load stays cacheable without cross-account bleed
- Make \`forceRefresh\` provider-agnostic and align rate-limit handling with the extension
- Regenerate \`PerpsController\` method action types; shrink rate-limit diff and drop verbose history logs

**Removed**
- Drop the dead \`spotState\` parameter from \`adaptAccountStateFromSDK\` — spot balances are layered on by \`addSpotBalanceToAccountState\`, which enforces the USDC-only policy via \`SPOT_COLLATERAL_COINS\`, removing the dormant branch keeps one source of truth and prevents a future caller from silently getting ALL-coins behavior

**Fixed**
- HyperLiquid Unified-mode live balance: subscribe to \`spotState\` WS and compute tradeable/total balance from on-chain math
- Complete spot-balance parity with the extension consumer
- Preserve integer trailing zeros when \`szDecimals=0\` in \`perpsFormatters\`
- Preserve candle pagination cancellation and skip coalesce for explicit-\`endTime\` candle paging to avoid stale pages
- Defer account resolution on the non-paginated cache path to prevent race conditions
- Force-refresh on activity mount and evict expired coalesce entries so stale promises cannot resolve to cache
- Normalize \`event.user\` to lowercase when caching the spot-state WS address so \`#ensureSpotState\` hits the cache instead of triggering a redundant REST \`spotClearinghouseState\` refetch when HyperLiquid returns a checksummed address

## References

- [#8560](https://github.com/MetaMask/core/pull/8560)

## Checklist

- I've updated the test suite for new or updated code as appropriate
- I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- I've communicated my changes to consumers by updating changelogs for packages I've changed
- I've introduced breaking changes in this PR and have prepared draft pull requests for clients and consumer packages to resolve them