### PR TITLE
feat: add `isUnlocked` action

### DIFF
--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Expose `KeyringController:isUnlocked` method through `KeyringController` messenger
+  - Returns `true` when the vault is unlocked, `false` otherwise. Mirrors `state.isUnlocked` and the `isUnlocked()` instance method, allowing consumers to check lock status via the messenger without holding a controller reference.
 - Add `withController` action to run atomic operations on multiple keyrings (within a single transaction) ([#8416](https://github.com/MetaMask/core/pull/8416))
   - This action uses a `RestrictedController` object that exposes `addNewKeyring` and `removeKeyring` methods to add and remove keyring during the transaction (atomic) call.
 - Expose `KeyringController:signTransaction` method through `KeyringController` messenger ([#8408](https://github.com/MetaMask/core/pull/8408))

--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Expose `KeyringController:isUnlocked` method through `KeyringController` messenger
+- Expose `KeyringController:isUnlocked` method through `KeyringController` messenger ([#8573](https://github.com/MetaMask/core/pull/8573))
   - Returns `true` when the vault is unlocked, `false` otherwise. Mirrors `state.isUnlocked` and the `isUnlocked()` instance method, allowing consumers to check lock status via the messenger without holding a controller reference.
 - Add `withController` action to run atomic operations on multiple keyrings (within a single transaction) ([#8416](https://github.com/MetaMask/core/pull/8416))
   - This action uses a `RestrictedController` object that exposes `addNewKeyring` and `removeKeyring` methods to add and remove keyring during the transaction (atomic) call.

--- a/packages/keyring-controller/src/KeyringController-method-action-types.ts
+++ b/packages/keyring-controller/src/KeyringController-method-action-types.ts
@@ -59,6 +59,16 @@ export type KeyringControllerAddNewKeyringAction = {
 };
 
 /**
+ * Returns the status of the vault.
+ *
+ * @returns Boolean returning true if the vault is unlocked.
+ */
+export type KeyringControllerIsUnlockedAction = {
+  type: `KeyringController:isUnlocked`;
+  handler: KeyringController['isUnlocked'];
+};
+
+/**
  * Returns the public addresses of all accounts from every keyring.
  *
  * @returns A promise resolving to an array of addresses.
@@ -401,6 +411,7 @@ export type KeyringControllerMethodActions =
   | KeyringControllerCreateNewVaultAndRestoreAction
   | KeyringControllerCreateNewVaultAndKeychainAction
   | KeyringControllerAddNewKeyringAction
+  | KeyringControllerIsUnlockedAction
   | KeyringControllerGetAccountsAction
   | KeyringControllerGetEncryptionPublicKeyAction
   | KeyringControllerDecryptMessageAction

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -76,6 +76,7 @@ const MESSENGER_EXPOSED_METHODS = [
   'createNewVaultAndKeychain',
   'createNewVaultAndRestore',
   'removeAccount',
+  'isUnlocked',
 ] as const;
 
 /**

--- a/packages/keyring-controller/src/index.ts
+++ b/packages/keyring-controller/src/index.ts
@@ -4,6 +4,7 @@ export type {
   KeyringControllerCreateNewVaultAndRestoreAction,
   KeyringControllerCreateNewVaultAndKeychainAction,
   KeyringControllerAddNewKeyringAction,
+  KeyringControllerIsUnlockedAction,
   KeyringControllerGetAccountsAction,
   KeyringControllerGetEncryptionPublicKeyAction,
   KeyringControllerDecryptMessageAction,


### PR DESCRIPTION
## Explanation

This is needed to handle keyring controller locked scenarios when account creation is mid-flight in the multichain account service. Alternative was to do `KeyringController:getState`, but I'd rather not pull in the whole state to do a boolean check.

## References

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new read-only messenger action that returns the existing `state.isUnlocked` boolean, with no changes to unlock/lock behavior or vault persistence.
> 
> **Overview**
> Adds a new `KeyringController:isUnlocked` messenger action so consumers can query vault lock status without fetching full controller state or holding a controller reference.
> 
> This updates the allowed action types/exports and exposes `isUnlocked` via `MESSENGER_EXPOSED_METHODS`, with a changelog entry documenting the new capability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83fffcb42c99c1d4583b9e031c8f47bc5452faa0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->