### PR TITLE
feat: Add `subscribeOnce` and `waitUntil` methods

### DIFF
--- a/packages/messenger/CHANGELOG.md
+++ b/packages/messenger/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Allow overriding action handler in subclass ([#8617](https://github.com/MetaMask/core/pull/8617))
   - The `Messenger` class now has a protected `getAction` method which returns the action handler for a given action name.
+- Add `subscribeOnce` and `waitUntil` utility methods to `Messenger` ([#8575](https://github.com/MetaMask/core/pull/8575))
 
 ### Deprecated
 

--- a/packages/messenger/src/Messenger.test.ts
+++ b/packages/messenger/src/Messenger.test.ts
@@ -1036,6 +1036,131 @@ describe('Messenger', () => {
     });
   });
 
+  describe('subscribeOnce', () => {
+    it('unsubscribes automatically after receiving the first event', () => {
+      type MessageEvent = {
+        type: 'Fixture:message';
+        payload: [string];
+      };
+
+      const messenger = new Messenger<'Fixture', never, MessageEvent>({
+        namespace: 'Fixture',
+      });
+
+      const handler = jest.fn();
+      messenger.subscribeOnce('Fixture:message', handler);
+      messenger.publish('Fixture:message', 'foo');
+      messenger.publish('Fixture:message', 'bar');
+
+      expect(handler).toHaveBeenCalledWith('foo');
+      expect(handler).not.toHaveBeenCalledWith('bar');
+      expect(handler.mock.calls).toHaveLength(1);
+    });
+
+    it('supports selectors', () => {
+      type MessageEvent = {
+        type: 'Fixture:message';
+        payload: [{ value: string }];
+      };
+
+      const messenger = new Messenger<'Fixture', never, MessageEvent>({
+        namespace: 'Fixture',
+      });
+
+      const handler = jest.fn();
+      messenger.subscribeOnce('Fixture:message', handler, ({ value }) => value);
+      messenger.publish('Fixture:message', { value: 'foo' });
+      messenger.publish('Fixture:message', { value: 'bar' });
+
+      expect(handler).toHaveBeenCalledWith('foo');
+      expect(handler).not.toHaveBeenCalledWith('bar');
+      expect(handler.mock.calls).toHaveLength(1);
+    });
+
+    it('supports conditions', () => {
+      type MessageEvent = {
+        type: 'Fixture:message';
+        payload: [{ value: string }];
+      };
+
+      const messenger = new Messenger<'Fixture', never, MessageEvent>({
+        namespace: 'Fixture',
+      });
+
+      const handler = jest.fn();
+      messenger.subscribeOnce(
+        'Fixture:message',
+        handler,
+        ({ value }) => value,
+        (value) => value === 'bar',
+      );
+      messenger.publish('Fixture:message', { value: 'foo' });
+      messenger.publish('Fixture:message', { value: 'bar' });
+
+      expect(handler).not.toHaveBeenCalledWith('foo');
+      expect(handler).toHaveBeenCalledWith('bar');
+      expect(handler.mock.calls).toHaveLength(1);
+    });
+  });
+
+  describe('waitUntil', () => {
+    it('resolves the promise when the event fires', async () => {
+      type MessageEvent = {
+        type: 'Fixture:message';
+        payload: [string];
+      };
+
+      const messenger = new Messenger<'Fixture', never, MessageEvent>({
+        namespace: 'Fixture',
+      });
+
+      const promise = messenger.waitUntil('Fixture:message');
+      messenger.publish('Fixture:message', 'foo');
+
+      expect(await promise).toBe('foo');
+    });
+
+    it('supports selectors', async () => {
+      type MessageEvent = {
+        type: 'Fixture:message';
+        payload: [{ value: string }];
+      };
+
+      const messenger = new Messenger<'Fixture', never, MessageEvent>({
+        namespace: 'Fixture',
+      });
+
+      const promise = messenger.waitUntil(
+        'Fixture:message',
+        ({ value }) => value,
+      );
+      messenger.publish('Fixture:message', { value: 'foo' });
+
+      expect(await promise).toBe('foo');
+    });
+
+    it('supports conditions', async () => {
+      type MessageEvent = {
+        type: 'Fixture:message';
+        payload: [{ value: string }];
+      };
+
+      const messenger = new Messenger<'Fixture', never, MessageEvent>({
+        namespace: 'Fixture',
+      });
+
+      const promise = messenger.waitUntil(
+        'Fixture:message',
+        ({ value }) => value,
+        (value) => value === 'bar',
+      );
+      messenger.publish('Fixture:message', { value: 'foo' });
+      messenger.publish('Fixture:message', { value: 'bar' });
+
+      expect(await promise).toBe('bar');
+    });
+  });
+
   describe('clearEventSubscriptions', () => {
     it('does not call subscriber after clearing event subscriptions', () => {
       type MessageEvent = { type: 'Fixture:message'; payload: [string] };

--- a/packages/messenger/src/Messenger.test.ts
+++ b/packages/messenger/src/Messenger.test.ts
@@ -1139,7 +1139,23 @@ describe('Messenger', () => {
       const promise = messenger.waitUntil('Fixture:message');
       messenger.publish('Fixture:message', 'foo');
 
-      expect(await promise).toBe('foo');
+      expect(await promise).toStrictEqual(['foo']);
+    });
+
+    it('resolves the promise with multiple parameters', async () => {
+      type MessageEvent = {
+        type: 'Fixture:message';
+        payload: [string, string, string];
+      };
+
+      const messenger = new Messenger<'Fixture', never, MessageEvent>({
+        namespace: 'Fixture',
+      });
+
+      const promise = messenger.waitUntil('Fixture:message');
+      messenger.publish('Fixture:message', 'foo', 'bar', 'baz');
+
+      expect(await promise).toStrictEqual(['foo', 'bar', 'baz']);
     });
 
     it('supports selectors', async () => {
@@ -1157,7 +1173,7 @@ describe('Messenger', () => {
       });
       messenger.publish('Fixture:message', { value: 'foo' });
 
-      expect(await promise).toBe('foo');
+      expect(await promise).toStrictEqual(['foo', undefined]);
     });
 
     it('supports conditions without a selector', async () => {
@@ -1176,7 +1192,7 @@ describe('Messenger', () => {
       messenger.publish('Fixture:message', 'foo');
       messenger.publish('Fixture:message', 'bar');
 
-      expect(await promise).toBe('bar');
+      expect(await promise).toStrictEqual(['bar']);
     });
 
     it('supports conditions with a selector', async () => {
@@ -1196,7 +1212,7 @@ describe('Messenger', () => {
       messenger.publish('Fixture:message', { value: 'foo' });
       messenger.publish('Fixture:message', { value: 'bar' });
 
-      expect(await promise).toBe('bar');
+      expect(await promise).toStrictEqual(['bar', 'foo']);
     });
   });
 

--- a/packages/messenger/src/Messenger.test.ts
+++ b/packages/messenger/src/Messenger.test.ts
@@ -1052,8 +1052,8 @@ describe('Messenger', () => {
       messenger.publish('Fixture:message', 'foo');
       messenger.publish('Fixture:message', 'bar');
 
-      expect(handler).toHaveBeenCalledWith('foo', undefined);
-      expect(handler).not.toHaveBeenCalledWith('bar', 'foo');
+      expect(handler).toHaveBeenCalledWith('foo');
+      expect(handler).not.toHaveBeenCalledWith('bar');
       expect(handler.mock.calls).toHaveLength(1);
     });
 
@@ -1068,7 +1068,9 @@ describe('Messenger', () => {
       });
 
       const handler = jest.fn();
-      messenger.subscribeOnce('Fixture:message', handler, ({ value }) => value);
+      messenger.subscribeOnce('Fixture:message', handler, {
+        selector: ({ value }) => value,
+      });
       messenger.publish('Fixture:message', { value: 'foo' });
       messenger.publish('Fixture:message', { value: 'bar' });
 
@@ -1077,7 +1079,29 @@ describe('Messenger', () => {
       expect(handler.mock.calls).toHaveLength(1);
     });
 
-    it('supports conditions', () => {
+    it('supports conditions without a selector', () => {
+      type MessageEvent = {
+        type: 'Fixture:message';
+        payload: [string];
+      };
+
+      const messenger = new Messenger<'Fixture', never, MessageEvent>({
+        namespace: 'Fixture',
+      });
+
+      const handler = jest.fn();
+      messenger.subscribeOnce('Fixture:message', handler, {
+        condition: (value) => value === 'bar',
+      });
+      messenger.publish('Fixture:message', 'foo');
+      messenger.publish('Fixture:message', 'bar');
+
+      expect(handler).not.toHaveBeenCalledWith('foo');
+      expect(handler).toHaveBeenCalledWith('bar');
+      expect(handler.mock.calls).toHaveLength(1);
+    });
+
+    it('supports conditions with a selector', () => {
       type MessageEvent = {
         type: 'Fixture:message';
         payload: [{ value: string }];
@@ -1088,12 +1112,10 @@ describe('Messenger', () => {
       });
 
       const handler = jest.fn();
-      messenger.subscribeOnce(
-        'Fixture:message',
-        handler,
-        ({ value }) => value,
-        (value) => value === 'bar',
-      );
+      messenger.subscribeOnce('Fixture:message', handler, {
+        selector: ({ value }) => value,
+        condition: (value) => value === 'bar',
+      });
       messenger.publish('Fixture:message', { value: 'foo' });
       messenger.publish('Fixture:message', { value: 'bar' });
 
@@ -1130,16 +1152,34 @@ describe('Messenger', () => {
         namespace: 'Fixture',
       });
 
-      const promise = messenger.waitUntil(
-        'Fixture:message',
-        ({ value }) => value,
-      );
+      const promise = messenger.waitUntil('Fixture:message', {
+        selector: ({ value }) => value,
+      });
       messenger.publish('Fixture:message', { value: 'foo' });
 
       expect(await promise).toBe('foo');
     });
 
-    it('supports conditions', async () => {
+    it('supports conditions without a selector', async () => {
+      type MessageEvent = {
+        type: 'Fixture:message';
+        payload: [string];
+      };
+
+      const messenger = new Messenger<'Fixture', never, MessageEvent>({
+        namespace: 'Fixture',
+      });
+
+      const promise = messenger.waitUntil('Fixture:message', {
+        condition: (value) => value === 'bar',
+      });
+      messenger.publish('Fixture:message', 'foo');
+      messenger.publish('Fixture:message', 'bar');
+
+      expect(await promise).toBe('bar');
+    });
+
+    it('supports conditions with a selector', async () => {
       type MessageEvent = {
         type: 'Fixture:message';
         payload: [{ value: string }];
@@ -1149,11 +1189,10 @@ describe('Messenger', () => {
         namespace: 'Fixture',
       });
 
-      const promise = messenger.waitUntil(
-        'Fixture:message',
-        ({ value }) => value,
-        (value) => value === 'bar',
-      );
+      const promise = messenger.waitUntil('Fixture:message', {
+        selector: ({ value }) => value,
+        condition: (value) => value === 'bar',
+      });
       messenger.publish('Fixture:message', { value: 'foo' });
       messenger.publish('Fixture:message', { value: 'bar' });
 

--- a/packages/messenger/src/Messenger.test.ts
+++ b/packages/messenger/src/Messenger.test.ts
@@ -1052,8 +1052,8 @@ describe('Messenger', () => {
       messenger.publish('Fixture:message', 'foo');
       messenger.publish('Fixture:message', 'bar');
 
-      expect(handler).toHaveBeenCalledWith('foo');
-      expect(handler).not.toHaveBeenCalledWith('bar');
+      expect(handler).toHaveBeenCalledWith('foo', undefined);
+      expect(handler).not.toHaveBeenCalledWith('bar', 'foo');
       expect(handler.mock.calls).toHaveLength(1);
     });
 
@@ -1072,8 +1072,8 @@ describe('Messenger', () => {
       messenger.publish('Fixture:message', { value: 'foo' });
       messenger.publish('Fixture:message', { value: 'bar' });
 
-      expect(handler).toHaveBeenCalledWith('foo');
-      expect(handler).not.toHaveBeenCalledWith('bar');
+      expect(handler).toHaveBeenCalledWith('foo', undefined);
+      expect(handler).not.toHaveBeenCalledWith('bar', 'foo');
       expect(handler.mock.calls).toHaveLength(1);
     });
 
@@ -1098,7 +1098,7 @@ describe('Messenger', () => {
       messenger.publish('Fixture:message', { value: 'bar' });
 
       expect(handler).not.toHaveBeenCalledWith('foo');
-      expect(handler).toHaveBeenCalledWith('bar');
+      expect(handler).toHaveBeenCalledWith('bar', 'foo');
       expect(handler.mock.calls).toHaveLength(1);
     });
   });

--- a/packages/messenger/src/Messenger.ts
+++ b/packages/messenger/src/Messenger.ts
@@ -674,33 +674,122 @@ export class Messenger<
     subscribers.set(handler, metadata);
   }
 
+  /**
+   * Subscribe to an event, invoking the handler exactly once.
+   *
+   * Registers the given function as an event handler for the given event type
+   * and automatically unsubscribes after the first invocation.
+   *
+   * @param eventType - The event type. This is a unique identifier for this event.
+   * @param handler - The event handler. The type of the parameters for this event handler must
+   * match the type of the payload for this event type.
+   * @template EventType - A type union of Event type strings.
+   */
+  subscribeOnce<EventType extends Event['type']>(
+    eventType: EventType,
+    handler: ExtractEventHandler<Event, EventType>,
+  ): void;
+
+  /**
+   * Subscribe to an event, with a selector, invoking the handler exactly once.
+   *
+   * Registers the given handler function as an event handler for the given
+   * event type. When an event is published, its payload is first passed to the
+   * selector. The event handler is only called if the selector's return value
+   * differs from its last known return value. Additionally if the optional condition
+   * function is provided, it is checked whether it returns `true`. 
+   * The handler is invoked at most once, after which the subscription is removed.
+   *
+   * @param eventType - The event type. This is a unique identifier for this event.
+   * @param handler - The event handler. The type of the parameters for this event
+   * handler must match the return type of the selector.
+   * @param selector - The selector function used to select relevant data from
+   * the event payload. The type of the parameters for this selector must match
+   * the type of the payload for this event type.
+   * @param condition - An optional predicate evaluated against the selector's return
+   * value. The handler is only invoked when this returns `true`.
+   * @template EventType - A type union of Event type strings.
+   * @template SelectorReturnValue - The selector return value.
+   */
+  subscribeOnce<EventType extends Event['type'], SelectorReturnValue>(
+    eventType: EventType,
+    handler: SelectorEventHandler<SelectorReturnValue>,
+    selector: SelectorFunction<Event, EventType, SelectorReturnValue>,
+    condition?: (value: SelectorReturnValue) => boolean,
+  ): void;
+
   subscribeOnce<EventType extends Event['type'], SelectorReturnValue>(
     eventType: EventType,
     handler:
       | ExtractEventHandler<Event, EventType>
       | SelectorEventHandler<SelectorReturnValue>,
     selector?: SelectorFunction<Event, EventType, SelectorReturnValue>,
-    condition?: any,
+    condition?: (value: SelectorReturnValue) => boolean,
   ): void {
-    const internalHandler = (value) => {
+    // Casting to selector specific types though this handles non-selector code paths as well.
+    const internalHandler: SelectorEventHandler<SelectorReturnValue> = (
+      value,
+      previousValue,
+    ) => {
       if (condition && !condition(value)) {
         return;
       }
-
-      handler(value);
+      (handler as SelectorEventHandler<SelectorReturnValue>)(
+        value,
+        previousValue,
+      );
       this.unsubscribe(eventType, internalHandler);
     };
 
-    this.subscribe(eventType, internalHandler, selector);
+    this.subscribe(
+      eventType,
+      internalHandler,
+      selector as SelectorFunction<Event, EventType, SelectorReturnValue>,
+    );
   }
+
+  /**
+   * Return a promise that resolves the next time the given event is published.
+   *
+   * @param eventType - The event type. This is a unique identifier for this event.
+   * @template EventType - A type union of Event type strings.
+   * @returns A promise that resolves with the event payload's first argument.
+   */
+  waitUntil<EventType extends Event['type']>(
+    eventType: EventType,
+  ): Promise<ExtractEventPayload<Event, EventType>[0]>;
+
+  /**
+   * Return a promise that resolves the next time the selector's return value
+   * changes and, if provided, the condition function returns `true`.
+   *
+   * @param eventType - The event type. This is a unique identifier for this event.
+   * @param selector - The selector function used to select relevant data from
+   * the event payload.
+   * @param condition - An optional function which is executed with the selector's return
+   * value. The promise only resolves when this returns `true`.
+   * @template EventType - A type union of Event type strings.
+   * @template SelectorReturnValue - The selector return value.
+   * @returns A promise that resolves with the selector's return value.
+   */
+  waitUntil<EventType extends Event['type'], SelectorReturnValue>(
+    eventType: EventType,
+    selector: SelectorFunction<Event, EventType, SelectorReturnValue>,
+    condition?: (value: SelectorReturnValue) => boolean,
+  ): Promise<SelectorReturnValue>;
 
   waitUntil<EventType extends Event['type'], SelectorReturnValue>(
     eventType: EventType,
     selector?: SelectorFunction<Event, EventType, SelectorReturnValue>,
-    condition?: any,
-  ): Promise<void> {
+    condition?: (value: SelectorReturnValue) => boolean,
+  ): Promise<SelectorReturnValue | ExtractEventPayload<Event, EventType>[0]> {
     return new Promise((resolve) => {
-      this.subscribeOnce(eventType, resolve, selector, condition);
+      this.subscribeOnce(
+        eventType,
+        resolve as SelectorEventHandler<SelectorReturnValue>,
+        selector as SelectorFunction<Event, EventType, SelectorReturnValue>,
+        condition,
+      );
     });
   }
 

--- a/packages/messenger/src/Messenger.ts
+++ b/packages/messenger/src/Messenger.ts
@@ -746,7 +746,7 @@ export class Messenger<
   ): void {
     const { selector, condition } = options ?? {};
     // Casting to unknown to handle both the code path where a selector is defined where it is omitted.
-    const internalHandler = (...args: unknown[]) => {
+    const internalHandler = (...args: unknown[]): void => {
       if (
         condition &&
         !(condition as (...args: unknown[]) => boolean)(...args)

--- a/packages/messenger/src/Messenger.ts
+++ b/packages/messenger/src/Messenger.ts
@@ -745,7 +745,7 @@ export class Messenger<
     },
   ): void {
     const { selector, condition } = options ?? {};
-    // Casting to unknown to handle both the code path where a selector is defined where it is omitted.
+    // Casting to unknown to handle both the code path where a selector is defined and where it is omitted.
     const internalHandler = (...args: unknown[]): void => {
       if (
         condition &&

--- a/packages/messenger/src/Messenger.ts
+++ b/packages/messenger/src/Messenger.ts
@@ -695,6 +695,14 @@ export class Messenger<
    * selector's return value. The handler is only invoked when this returns `true`.
    * @template EventType - A type union of Event type strings.
    * @template SelectorReturnValue - The selector return value.
+   * @example
+   * ```typescript
+   * messenger.subscribeOnce(
+   *   'TransactionController:transactionConfirmed',
+   *   (hash) => { ... },
+   *   { selector: (tx) => tx.hash, condition: (hash) => hash === 'foo' },
+   * );
+   * ```
    */
   subscribeOnce<EventType extends Event['type'], SelectorReturnValue>(
     eventType: EventType,
@@ -721,6 +729,14 @@ export class Messenger<
    * @param options.condition - A predicate evaluated against the event payload.
    * The handler is only invoked when this returns `true`.
    * @template EventType - A type union of Event type strings.
+   * @example
+   * ```typescript
+   * messenger.subscribeOnce(
+   *   'TransactionController:transactionConfirmed',
+   *   (tx) => { ... },
+   *   { condition: (tx) => tx.hash === 'foo' },
+   * );
+   * ```
    */
   subscribeOnce<EventType extends Event['type']>(
     eventType: EventType,
@@ -777,6 +793,13 @@ export class Messenger<
    * @template EventType - A type union of Event type strings.
    * @template SelectorReturnValue - The selector return value.
    * @returns A promise that resolves with the selector's return value.
+   * @example
+   * ```typescript
+   * const [hash] = await messenger.waitUntil(
+   *   'TransactionController:transactionConfirmed',
+   *   { selector: (tx) => tx.hash, condition: (hash) => hash === 'foo' },
+   * );
+   * ```
    */
   waitUntil<EventType extends Event['type'], SelectorReturnValue>(
     eventType: EventType,
@@ -798,6 +821,13 @@ export class Messenger<
    * The promise only resolves when this returns `true`.
    * @template EventType - A type union of Event type strings.
    * @returns A promise that resolves with the event payload.
+   * @example
+   * ```typescript
+   * const [transactionMeta] = await messenger.waitUntil(
+   *   'TransactionController:transactionConfirmed',
+   *   { condition: (tx) => tx.hash === 'foo' },
+   * );
+   * ```
    */
   waitUntil<EventType extends Event['type']>(
     eventType: EventType,

--- a/packages/messenger/src/Messenger.ts
+++ b/packages/messenger/src/Messenger.ts
@@ -674,6 +674,36 @@ export class Messenger<
     subscribers.set(handler, metadata);
   }
 
+  subscribeOnce<EventType extends Event['type'], SelectorReturnValue>(
+    eventType: EventType,
+    handler:
+      | ExtractEventHandler<Event, EventType>
+      | SelectorEventHandler<SelectorReturnValue>,
+    selector?: SelectorFunction<Event, EventType, SelectorReturnValue>,
+    condition?: any,
+  ): void {
+    const internalHandler = (value) => {
+      if (condition && !condition(value)) {
+        return;
+      }
+
+      handler(value);
+      this.unsubscribe(eventType, internalHandler);
+    };
+
+    this.subscribe(eventType, internalHandler, selector);
+  }
+
+  waitUntil<EventType extends Event['type'], SelectorReturnValue>(
+    eventType: EventType,
+    selector?: SelectorFunction<Event, EventType, SelectorReturnValue>,
+    condition?: any,
+  ): Promise<void> {
+    return new Promise((resolve) => {
+      this.subscribeOnce(eventType, resolve, selector, condition);
+    });
+  }
+
   /**
    * Unsubscribe from an event.
    *

--- a/packages/messenger/src/Messenger.ts
+++ b/packages/messenger/src/Messenger.ts
@@ -753,8 +753,8 @@ export class Messenger<
       ) {
         return;
       }
-      (handler as (...args: unknown[]) => void)(...args);
       this.unsubscribe(eventType, internalHandler);
+      (handler as (...args: unknown[]) => void)(...args);
     };
 
     this.subscribe(

--- a/packages/messenger/src/Messenger.ts
+++ b/packages/messenger/src/Messenger.ts
@@ -784,7 +784,7 @@ export class Messenger<
       selector: SelectorFunction<Event, EventType, SelectorReturnValue>;
       condition?: (value: SelectorReturnValue) => boolean;
     },
-  ): Promise<SelectorReturnValue>;
+  ): Promise<[SelectorReturnValue, SelectorReturnValue | undefined]>;
 
   /**
    * Return a promise that resolves the next time the given event is published.
@@ -797,7 +797,7 @@ export class Messenger<
    * @param options.condition - A predicate evaluated against the event payload.
    * The promise only resolves when this returns `true`.
    * @template EventType - A type union of Event type strings.
-   * @returns A promise that resolves with the event payload's first argument.
+   * @returns A promise that resolves with the event payload.
    */
   waitUntil<EventType extends Event['type']>(
     eventType: EventType,
@@ -806,7 +806,7 @@ export class Messenger<
         ...payload: ExtractEventPayload<Event, EventType>
       ) => boolean;
     },
-  ): Promise<ExtractEventPayload<Event, EventType>[0]>;
+  ): Promise<ExtractEventPayload<Event, EventType>>;
 
   waitUntil<EventType extends Event['type'], SelectorReturnValue>(
     eventType: EventType,
@@ -820,7 +820,7 @@ export class Messenger<
     return new Promise((resolve) => {
       this.subscribeOnce(
         eventType,
-        resolve as SelectorEventHandler<SelectorReturnValue>,
+        (...args) => resolve(args),
         options as {
           selector: SelectorFunction<Event, EventType, SelectorReturnValue>;
           condition?: (value: SelectorReturnValue) => boolean;

--- a/packages/messenger/src/Messenger.ts
+++ b/packages/messenger/src/Messenger.ts
@@ -675,47 +675,61 @@ export class Messenger<
   }
 
   /**
-   * Subscribe to an event, invoking the handler exactly once.
-   *
-   * Registers the given function as an event handler for the given event type
-   * and automatically unsubscribes after the first invocation.
-   *
-   * @param eventType - The event type. This is a unique identifier for this event.
-   * @param handler - The event handler. The type of the parameters for this event handler must
-   * match the type of the payload for this event type.
-   * @template EventType - A type union of Event type strings.
-   */
-  subscribeOnce<EventType extends Event['type']>(
-    eventType: EventType,
-    handler: ExtractEventHandler<Event, EventType>,
-  ): void;
-
-  /**
    * Subscribe to an event, with a selector, invoking the handler exactly once.
    *
    * Registers the given handler function as an event handler for the given
    * event type. When an event is published, its payload is first passed to the
    * selector. The event handler is only called if the selector's return value
    * differs from its last known return value. Additionally if the optional condition
-   * function is provided, it is checked whether it returns `true`. 
+   * function is provided, it is checked whether it returns `true`.
    * The handler is invoked at most once, after which the subscription is removed.
    *
    * @param eventType - The event type. This is a unique identifier for this event.
    * @param handler - The event handler. The type of the parameters for this event
    * handler must match the return type of the selector.
-   * @param selector - The selector function used to select relevant data from
-   * the event payload. The type of the parameters for this selector must match
-   * the type of the payload for this event type.
-   * @param condition - An optional predicate evaluated against the selector's return
-   * value. The handler is only invoked when this returns `true`.
+   * @param options - Options bag.
+   * @param options.selector - The selector function used to select relevant data
+   * from the event payload. The type of the parameters for this selector must
+   * match the type of the payload for this event type.
+   * @param options.condition - An optional predicate evaluated against the
+   * selector's return value. The handler is only invoked when this returns `true`.
    * @template EventType - A type union of Event type strings.
    * @template SelectorReturnValue - The selector return value.
    */
   subscribeOnce<EventType extends Event['type'], SelectorReturnValue>(
     eventType: EventType,
     handler: SelectorEventHandler<SelectorReturnValue>,
-    selector: SelectorFunction<Event, EventType, SelectorReturnValue>,
-    condition?: (value: SelectorReturnValue) => boolean,
+    options: {
+      selector: SelectorFunction<Event, EventType, SelectorReturnValue>;
+      condition?: (value: SelectorReturnValue) => boolean;
+    },
+  ): void;
+
+  /**
+   * Subscribe to an event, invoking the handler exactly once.
+   *
+   * Registers the given function as an event handler for the given event type
+   * and automatically unsubscribes after the first invocation.
+   *
+   * If `options.condition` is provided, the handler is only invoked (and the
+   * subscription only removed) when the condition returns `true`.
+   *
+   * @param eventType - The event type. This is a unique identifier for this event.
+   * @param handler - The event handler. The type of the parameters for this event
+   * handler must match the type of the payload for this event type.
+   * @param options - Options bag.
+   * @param options.condition - A predicate evaluated against the event payload.
+   * The handler is only invoked when this returns `true`.
+   * @template EventType - A type union of Event type strings.
+   */
+  subscribeOnce<EventType extends Event['type']>(
+    eventType: EventType,
+    handler: ExtractEventHandler<Event, EventType>,
+    options?: {
+      condition?: (
+        ...payload: ExtractEventPayload<Event, EventType>
+      ) => boolean;
+    },
   ): void;
 
   subscribeOnce<EventType extends Event['type'], SelectorReturnValue>(
@@ -723,21 +737,23 @@ export class Messenger<
     handler:
       | ExtractEventHandler<Event, EventType>
       | SelectorEventHandler<SelectorReturnValue>,
-    selector?: SelectorFunction<Event, EventType, SelectorReturnValue>,
-    condition?: (value: SelectorReturnValue) => boolean,
+    options?: {
+      selector?: SelectorFunction<Event, EventType, SelectorReturnValue>;
+      condition?:
+        | ((...payload: ExtractEventPayload<Event, EventType>) => boolean)
+        | ((value: SelectorReturnValue) => boolean);
+    },
   ): void {
-    // Casting to selector specific types though this handles non-selector code paths as well.
-    const internalHandler: SelectorEventHandler<SelectorReturnValue> = (
-      value,
-      previousValue,
-    ) => {
-      if (condition && !condition(value)) {
+    const { selector, condition } = options ?? {};
+    // Casting to unknown to handle both the code path where a selector is defined where it is omitted.
+    const internalHandler = (...args: unknown[]) => {
+      if (
+        condition &&
+        !(condition as (...args: unknown[]) => boolean)(...args)
+      ) {
         return;
       }
-      (handler as SelectorEventHandler<SelectorReturnValue>)(
-        value,
-        previousValue,
-      );
+      (handler as (...args: unknown[]) => void)(...args);
       this.unsubscribe(eventType, internalHandler);
     };
 
@@ -749,46 +765,66 @@ export class Messenger<
   }
 
   /**
-   * Return a promise that resolves the next time the given event is published.
-   *
-   * @param eventType - The event type. This is a unique identifier for this event.
-   * @template EventType - A type union of Event type strings.
-   * @returns A promise that resolves with the event payload's first argument.
-   */
-  waitUntil<EventType extends Event['type']>(
-    eventType: EventType,
-  ): Promise<ExtractEventPayload<Event, EventType>[0]>;
-
-  /**
    * Return a promise that resolves the next time the selector's return value
-   * changes and, if provided, the condition function returns `true`.
+   * changes and, if provided, the `options.condition` predicate returns `true`.
    *
    * @param eventType - The event type. This is a unique identifier for this event.
-   * @param selector - The selector function used to select relevant data from
-   * the event payload.
-   * @param condition - An optional function which is executed with the selector's return
-   * value. The promise only resolves when this returns `true`.
+   * @param options - Options bag.
+   * @param options.selector - The selector function used to select relevant data
+   * from the event payload.
+   * @param options.condition - An optional predicate evaluated against the
+   * selector's return value. The promise only resolves when this returns `true`.
    * @template EventType - A type union of Event type strings.
    * @template SelectorReturnValue - The selector return value.
    * @returns A promise that resolves with the selector's return value.
    */
   waitUntil<EventType extends Event['type'], SelectorReturnValue>(
     eventType: EventType,
-    selector: SelectorFunction<Event, EventType, SelectorReturnValue>,
-    condition?: (value: SelectorReturnValue) => boolean,
+    options: {
+      selector: SelectorFunction<Event, EventType, SelectorReturnValue>;
+      condition?: (value: SelectorReturnValue) => boolean;
+    },
   ): Promise<SelectorReturnValue>;
+
+  /**
+   * Return a promise that resolves the next time the given event is published.
+   *
+   * If `options.condition` is provided, the promise only resolves when the
+   * condition returns `true`.
+   *
+   * @param eventType - The event type. This is a unique identifier for this event.
+   * @param options - Options bag.
+   * @param options.condition - A predicate evaluated against the event payload.
+   * The promise only resolves when this returns `true`.
+   * @template EventType - A type union of Event type strings.
+   * @returns A promise that resolves with the event payload's first argument.
+   */
+  waitUntil<EventType extends Event['type']>(
+    eventType: EventType,
+    options?: {
+      condition?: (
+        ...payload: ExtractEventPayload<Event, EventType>
+      ) => boolean;
+    },
+  ): Promise<ExtractEventPayload<Event, EventType>[0]>;
 
   waitUntil<EventType extends Event['type'], SelectorReturnValue>(
     eventType: EventType,
-    selector?: SelectorFunction<Event, EventType, SelectorReturnValue>,
-    condition?: (value: SelectorReturnValue) => boolean,
+    options?: {
+      selector?: SelectorFunction<Event, EventType, SelectorReturnValue>;
+      condition?:
+        | ((...payload: ExtractEventPayload<Event, EventType>) => boolean)
+        | ((value: SelectorReturnValue) => boolean);
+    },
   ): Promise<SelectorReturnValue | ExtractEventPayload<Event, EventType>[0]> {
     return new Promise((resolve) => {
       this.subscribeOnce(
         eventType,
         resolve as SelectorEventHandler<SelectorReturnValue>,
-        selector as SelectorFunction<Event, EventType, SelectorReturnValue>,
-        condition,
+        options as {
+          selector: SelectorFunction<Event, EventType, SelectorReturnValue>;
+          condition?: (value: SelectorReturnValue) => boolean;
+        },
       );
     });
   }

--- a/packages/messenger/src/Messenger.ts
+++ b/packages/messenger/src/Messenger.ts
@@ -828,6 +828,10 @@ export class Messenger<
    *   { condition: (tx) => tx.hash === 'foo' },
    * );
    * ```
+   * @example
+   * ```typescript
+   * await messenger.waitUntil('KeyringController:unlock');
+   * ```
    */
   waitUntil<EventType extends Event['type']>(
     eventType: EventType,


### PR DESCRIPTION
## Explanation

Add `subscribeOnce` and `waitUntil` utility methods to `Messenger`. These are useful for subscribing to and waiting for a certain event to fire without wanting to listen for more than one invocation.

Additionally the methods support a `condition` parameter which can be used as a predicate for whether the event should be consumed in the first place.

A similar approach is already in-use on mobile, this is a "native" replacement.

## References

https://consensyssoftware.atlassian.net/browse/WPC-985

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core event-subscription behavior by introducing auto-unsubscription and Promise-based waiting, which could subtly affect event delivery/ordering and handler lifecycle. Coverage is added, but the new logic interacts with the existing selector/cache and unsubscribe paths.
> 
> **Overview**
> Adds two new event utilities to `Messenger`: `subscribeOnce` to auto-unsubscribe after the first matching event (optionally gated by a `condition`, and supporting selector-based subscriptions), and `waitUntil` to return a Promise that resolves on the next matching event using the same selector/condition options.
> 
> Updates the test suite with coverage for one-shot subscriptions, selector behavior (including previous value), conditional consumption, and Promise resolution, and records the feature in the `@metamask/messenger` changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e57a2546b778129982e15ed3c585667e2fac0e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->