### PR TITLE
chore: add profileId to position response

### DIFF
--- a/packages/social-controllers/CHANGELOG.md
+++ b/packages/social-controllers/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `positionId` field to `Position` type and `PositionStruct` validation schema ([#8576](https://github.com/MetaMask/core/pull/8576))
+
 ## [2.0.0]
 
 ### Changed

--- a/packages/social-controllers/src/SocialService.test.ts
+++ b/packages/social-controllers/src/SocialService.test.ts
@@ -38,6 +38,7 @@ const mockTrade = {
 };
 
 const mockPosition = {
+  positionId: 'position-1',
   tokenSymbol: 'ETH',
   tokenName: 'Ethereum',
   tokenAddress: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',

--- a/packages/social-controllers/src/SocialService.ts
+++ b/packages/social-controllers/src/SocialService.ts
@@ -58,6 +58,7 @@ const ProfileSummaryStruct = structType({
 });
 
 const PositionStruct = structType({
+  positionId: string(),
   tokenSymbol: string(),
   tokenName: string(),
   tokenAddress: string(),

--- a/packages/social-controllers/src/social-types.ts
+++ b/packages/social-controllers/src/social-types.ts
@@ -133,6 +133,7 @@ export type TraderProfileResponse = {
 // ---------------------------------------------------------------------------
 
 export type Position = {
+  positionId: string;
   tokenSymbol: string;
   tokenName: string;
   tokenAddress: string;


### PR DESCRIPTION
## Explanation

Add profileId to position response.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a type/response-validation schema expansion for positions plus test fixture updates, with no behavioral or endpoint changes. Main risk is consumers now needing to include `positionId` in mocked/expected position payloads to pass validation.
> 
> **Overview**
> Positions returned by `SocialService` now require a new `positionId` field via updates to the `Position` type and the `PositionStruct` superstruct schema.
> 
> Tests and the package changelog are updated accordingly to reflect and validate the new field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27e303a2be2c09510e89cfa5e611a13d12ae0ada. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->