### PR TITLE
fix(assets-controllers): refetch snap balances after vault unlock when fetch was skipped while locked

### DIFF
--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `MultichainBalancesController`: when `MultichainAssetsController:accountAssetListUpdated` fires while the vault is locked, balance fetches are skipped and were never retried after unlock, leaving multichain token lists empty despite assets in state; subscribe to `KeyringController:stateChange` and refetch balances for snap-backed accounts that still have no cached balances after unlock.
+- `MultichainBalancesController`: when `MultichainAssetsController:accountAssetListUpdated` fires while the vault is locked, balance fetches are skipped and were never retried after unlock, leaving multichain token lists empty despite assets in state; subscribe to `KeyringController:stateChange` and refetch balances for snap-backed accounts that still have no cached balances after unlock. ([#8579])(https://github.com/MetaMask/core/pull/8579)
 
 ### Added
 

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `MultichainBalancesController`: when `MultichainAssetsController:accountAssetListUpdated` fires while the vault is locked, balance fetches are skipped and were never retried after unlock, leaving multichain token lists empty despite assets in state; subscribe to `KeyringController:stateChange` and refetch balances for snap-backed accounts that still have no cached balances after unlock.
+
 ### Added
 
 - Expose missing public `CurrencyRateController` methods through its messenger ([#8561](https://github.com/MetaMask/core/pull/8561))

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `MultichainBalancesController`: when `MultichainAssetsController:accountAssetListUpdated` fires while the vault is locked, balance fetches are skipped and were never retried after unlock, leaving multichain token lists empty despite assets in state; subscribe to `KeyringController:stateChange` and refetch balances for snap-backed accounts that still have no cached balances after unlock. ([#8579])(https://github.com/MetaMask/core/pull/8579)
+- Fixed `MultichainBalancesController` not retrying balance fetches after unlock, leaving token lists empty; now retries after unlock. ([#8579](https://github.com/MetaMask/core/pull/8579))
 
 ### Added
 

--- a/packages/assets-controllers/src/MultichainBalancesController/MultichainBalancesController.test.ts
+++ b/packages/assets-controllers/src/MultichainBalancesController/MultichainBalancesController.test.ts
@@ -158,6 +158,7 @@ function getRestrictedMessenger(
       'AccountsController:accountRemoved',
       'AccountsController:accountBalancesUpdated',
       'MultichainAssetsController:accountAssetListUpdated',
+      'KeyringController:stateChange',
     ],
   });
   return multichainBalancesControllerMessenger;

--- a/packages/assets-controllers/src/MultichainBalancesController/MultichainBalancesController.ts
+++ b/packages/assets-controllers/src/MultichainBalancesController/MultichainBalancesController.ts
@@ -197,7 +197,9 @@ export class MultichainBalancesController extends BaseController<
 
     // When the keyring transitions from locked → unlocked, fetch balances for
     // any non-EVM account that had its balance fetch skipped while locked.
-    let previouslyUnlocked = false;
+    let previouslyUnlocked = this.messenger.call(
+      'KeyringController:getState',
+    ).isUnlocked;
     this.messenger.subscribe(
       'KeyringController:stateChange',
       ({ isUnlocked }) => {

--- a/packages/assets-controllers/src/MultichainBalancesController/MultichainBalancesController.ts
+++ b/packages/assets-controllers/src/MultichainBalancesController/MultichainBalancesController.ts
@@ -16,7 +16,10 @@ import type {
   CaipAssetType,
   AccountBalancesUpdatedEventPayload,
 } from '@metamask/keyring-api';
-import type { KeyringControllerGetStateAction } from '@metamask/keyring-controller';
+import type {
+  KeyringControllerGetStateAction,
+  KeyringControllerStateChangeEvent,
+} from '@metamask/keyring-controller';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 import { KeyringClient } from '@metamask/keyring-snap-client';
 import type { Messenger } from '@metamask/messenger';
@@ -105,7 +108,8 @@ type AllowedEvents =
   | AccountsControllerAccountAddedEvent
   | AccountsControllerAccountRemovedEvent
   | AccountsControllerAccountBalancesUpdatesEvent
-  | MultichainAssetsControllerAccountAssetListUpdatedEvent;
+  | MultichainAssetsControllerAccountAssetListUpdatedEvent
+  | KeyringControllerStateChangeEvent;
 /**
  * Messenger type for the MultichainBalancesController.
  */
@@ -188,6 +192,29 @@ export class MultichainBalancesController extends BaseController<
         );
 
         await this.#handleOnAccountAssetListUpdated(updatedAccountAssets);
+      },
+    );
+
+    // When the keyring transitions from locked → unlocked, fetch balances for
+    // any non-EVM account that had its balance fetch skipped while locked.
+    let previouslyUnlocked = false;
+    this.messenger.subscribe(
+      'KeyringController:stateChange',
+      ({ isUnlocked }) => {
+        const justUnlocked = isUnlocked && !previouslyUnlocked;
+        previouslyUnlocked = isUnlocked;
+        if (!justUnlocked) {
+          return;
+        }
+        for (const account of this.#listAccounts()) {
+          const hasBalance =
+            this.state.balances[account.id] &&
+            Object.keys(this.state.balances[account.id]).length > 0;
+          if (!hasBalance) {
+            // eslint-disable-next-line no-void
+            void this.updateBalance(account.id);
+          }
+        }
       },
     );
   }


### PR DESCRIPTION
## Explanation

- Subscribe to `KeyringController:stateChange` in `MultichainBalancesController`.
- When the vault transitions from locked → unlocked, call `updateBalance` for any snap-backed (non-EVM) account that still has no cached balance entries.

### Problem

`MultichainAssetsController:accountAssetListUpdated` triggers balance fetches only when `KeyringController:getState().isUnlocked` is true. If that event fires while the vault is locked, the fetch is skipped and never retried after unlock, so the UI can show empty multichain token rows despite assets in `MultichainAssetsController` state.

### Consumer note
**Extension (and any other consumer)** must allow `KeyringController:stateChange` on the `MultichainBalancesController` restricted messenger; otherwise this subscription will not receive events.


<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `KeyringController:stateChange` subscription and triggers balance refetches on unlock, which can change runtime behavior and requires consumers to allow an additional messenger event.
> 
> **Overview**
> Ensures `MultichainBalancesController` **retries fetching balances after a vault unlock** by subscribing to `KeyringController:stateChange` and, on a locked→unlocked transition, calling `updateBalance` for non-EVM accounts that still have no cached balances.
> 
> Updates the controller’s allowed messenger events (and test messenger delegation) to include `KeyringController:stateChange`, and documents the fix in the `assets-controllers` changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b21bf2514f39be6719b4696bb38e08302df6dc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->