### PR TITLE
chore: fail-open-multichain assets controller filter logic

### DIFF
--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** Standardize names of `CurrencyRateController` messenger action types ([#8561](https://github.com/MetaMask/core/pull/8561))
   - The `GetCurrencyRateState` messenger action has been renamed to `CurrencyRateControllerGetStateAction` to follow the convention. You will need to update imports appropriately.
   - These changes only affect the types. The action type strings themselves have not changed, so you do not need to update the list of actions you pass when initializing `CurrencyRateController` messenger.
+- `MultichainAssetsController`: Change Blockaid spam token filter to fail-open behavior ([#8580](https://github.com/MetaMask/core/pull/8580))
+  - When Blockaid bulk token scan API calls fail or are rejected, tokens are now allowed through rather than being blocked
+  - This prevents legitimate tokens from being blocked due to API outages or network issues
+  - Tokens are still filtered when the API succeeds and marks them as malicious
 
 ## [104.3.0]
 

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -20,10 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** Standardize names of `CurrencyRateController` messenger action types ([#8561](https://github.com/MetaMask/core/pull/8561))
   - The `GetCurrencyRateState` messenger action has been renamed to `CurrencyRateControllerGetStateAction` to follow the convention. You will need to update imports appropriately.
   - These changes only affect the types. The action type strings themselves have not changed, so you do not need to update the list of actions you pass when initializing `CurrencyRateController` messenger.
-- `MultichainAssetsController`: Change Blockaid spam token filter to fail-open behavior ([#8580](https://github.com/MetaMask/core/pull/8580))
-  - When Blockaid bulk token scan API calls fail or are rejected, tokens are now allowed through rather than being blocked
-  - This prevents legitimate tokens from being blocked due to API outages or network issues
-  - Tokens are still filtered when the API succeeds and marks them as malicious
+- `MultichainAssetsController`: Restore fail-open behavior for Blockaid spam token filter ([#8580](https://github.com/MetaMask/core/pull/8580))
+  - Uses blacklist approach: only rejects tokens explicitly marked as malicious by Blockaid
+  - When Blockaid bulk token scan API calls fail or return no results, tokens are allowed through
+  - This prevents legitimate tokens from being blocked due to API outages, network issues, or missing token data
+  - Malicious tokens that slip through are caught by the periodic rescan (runs daily by default)
 
 ## [104.3.0]
 

--- a/packages/assets-controllers/src/MultichainAssetsController/MultichainAssetsController.test.ts
+++ b/packages/assets-controllers/src/MultichainAssetsController/MultichainAssetsController.test.ts
@@ -1514,7 +1514,7 @@ describe('MultichainAssetsController', () => {
       ]);
     });
 
-    it('does not add tokens when bulkScanTokens throws (fail closed)', async () => {
+    it('adds tokens when bulkScanTokens throws (fail open)', async () => {
       const mockAccountId = 'account1';
       const token = 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1/token:SomeAddr';
 
@@ -1536,7 +1536,9 @@ describe('MultichainAssetsController', () => {
 
       await jestAdvanceTime({ duration: 1 });
 
-      expect(controller.state.accountsAssets[mockAccountId]).toStrictEqual([]);
+      expect(controller.state.accountsAssets[mockAccountId]).toStrictEqual([
+        token,
+      ]);
     });
 
     it('does not add tokens when bulkScanTokens returns empty (API error handled internally)', async () => {
@@ -1765,7 +1767,7 @@ describe('MultichainAssetsController', () => {
       ).toBeUndefined();
     });
 
-    it('drops tokens from batches that fail (partial fail closed)', async () => {
+    it('keeps tokens from batches that fail (partial fail open)', async () => {
       const mockAccountId = 'account1';
       // 120 tokens = batch 1 (100) + batch 2 (20)
       const tokens = Array.from(
@@ -1800,7 +1802,7 @@ describe('MultichainAssetsController', () => {
           }
           return Promise.resolve(results);
         }
-        // Second batch fails — its tokens must not be added
+        // Second batch fails — its tokens are allowed through (fail open)
         return Promise.reject(new Error('API timeout'));
       });
 
@@ -1822,12 +1824,14 @@ describe('MultichainAssetsController', () => {
         ),
       ).toBeUndefined();
 
+      // Tokens from the failed second batch (100-119) should be added (fail open)
       for (let i = 100; i < 120; i++) {
         const tokenCaip = `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1/token:Token${String(i).padStart(3, '0')}`;
-        expect(storedAssets).not.toContain(tokenCaip);
+        expect(storedAssets).toContain(tokenCaip);
       }
 
-      expect(storedAssets).toHaveLength(99);
+      // 99 from batch 1 (excluding Token099) + 20 from batch 2 = 119 total
+      expect(storedAssets).toHaveLength(119);
     });
 
     it('periodic rescan ignores SPL tokens that Blockaid later marks malicious', async () => {

--- a/packages/assets-controllers/src/MultichainAssetsController/MultichainAssetsController.test.ts
+++ b/packages/assets-controllers/src/MultichainAssetsController/MultichainAssetsController.test.ts
@@ -1541,7 +1541,7 @@ describe('MultichainAssetsController', () => {
       ]);
     });
 
-    it('does not add tokens when bulkScanTokens returns empty (API error handled internally)', async () => {
+    it('adds tokens when bulkScanTokens returns empty (fail open - no result means not rejected)', async () => {
       const mockAccountId = 'account1';
       const token = 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1/token:SomeAddr';
 
@@ -1564,7 +1564,10 @@ describe('MultichainAssetsController', () => {
 
       await jestAdvanceTime({ duration: 1 });
 
-      expect(controller.state.accountsAssets[mockAccountId]).toStrictEqual([]);
+      // With fail-open blacklist approach, no result means not rejected
+      expect(controller.state.accountsAssets[mockAccountId]).toStrictEqual([
+        token,
+      ]);
     });
 
     it('does not scan native (slip44) assets', async () => {
@@ -1594,7 +1597,7 @@ describe('MultichainAssetsController', () => {
       expect(mockBulkScanTokens).not.toHaveBeenCalled();
     });
 
-    it('does not add tokens with no result in the scan response (fail closed)', async () => {
+    it('adds tokens with no result in the scan response (fail open)', async () => {
       const mockAccountId = 'account1';
       const knownToken =
         'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1/token:KnownAddr';
@@ -1626,8 +1629,10 @@ describe('MultichainAssetsController', () => {
 
       await jestAdvanceTime({ duration: 1 });
 
+      // With fail-open blacklist approach, tokens without results are not rejected
       expect(controller.state.accountsAssets[mockAccountId]).toStrictEqual([
         knownToken,
+        unknownToken,
       ]);
     });
 

--- a/packages/assets-controllers/src/MultichainAssetsController/MultichainAssetsController.ts
+++ b/packages/assets-controllers/src/MultichainAssetsController/MultichainAssetsController.ts
@@ -826,7 +826,7 @@ export class MultichainAssetsController extends StaticIntervalPollingController<
   }
 
   /**
-   * Fail-closed Blockaid filter for newly detected `token:` assets (native/other namespaces unchanged).
+   * Fail-open Blockaid filter for newly detected `token:` assets (native/other namespaces unchanged).
    *
    * @param assets - CAIP assets to filter.
    * @returns Filtered list, original order preserved.
@@ -850,6 +850,10 @@ export class MultichainAssetsController extends StaticIntervalPollingController<
 
       for (const outcome of batchOutcomes) {
         if (outcome.status === 'rejected') {
+          // Fail-open: if API fails, allow all tokens in this batch through
+          for (const entry of outcome.entries) {
+            keptTokenAssets.add(entry.asset);
+          }
           continue;
         }
         for (const entry of outcome.entries) {

--- a/packages/assets-controllers/src/MultichainAssetsController/MultichainAssetsController.ts
+++ b/packages/assets-controllers/src/MultichainAssetsController/MultichainAssetsController.ts
@@ -840,7 +840,7 @@ export class MultichainAssetsController extends StaticIntervalPollingController<
       return [...assets];
     }
 
-    const keptTokenAssets = new Set<CaipAssetType>();
+    const rejectedAssets = new Set<CaipAssetType>();
 
     for (const [chainName, tokenEntries] of Object.entries(tokensByChain)) {
       const batchOutcomes = await this.#runBatchedBulkTokenScans(
@@ -851,33 +851,22 @@ export class MultichainAssetsController extends StaticIntervalPollingController<
       for (const outcome of batchOutcomes) {
         if (outcome.status === 'rejected') {
           // Fail-open: if API fails, allow all tokens in this batch through
-          for (const entry of outcome.entries) {
-            keptTokenAssets.add(entry.asset);
-          }
           continue;
         }
         for (const entry of outcome.entries) {
           const scanned = outcome.response[entry.address];
+          // Reject only if we have a definitive malicious result
           if (
             scanned?.result_type &&
-            scanned.result_type !== TokenScanResultType.Malicious
+            scanned.result_type === TokenScanResultType.Malicious
           ) {
-            keptTokenAssets.add(entry.asset);
+            rejectedAssets.add(entry.asset);
           }
         }
       }
     }
 
-    return assets.filter((asset) => {
-      try {
-        if (parseCaipAssetType(asset).assetNamespace === 'token') {
-          return keptTokenAssets.has(asset);
-        }
-      } catch {
-        return false;
-      }
-      return true;
-    });
+    return assets.filter((asset) => !rejectedAssets.has(asset));
   }
 
   /**


### PR DESCRIPTION
## Explanation

Restores the original fail-open behavior in `MultichainAssetsController`'s Blockaid spam token filter, ensuring legitimate tokens aren't blocked due to API failures or missing data.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the spam/malicious token gating behavior so tokens may be added when the Blockaid bulk-scan call fails, which can reduce protection during outages and affects security-sensitive filtering logic.
> 
> **Overview**
> Updates Blockaid-based filtering for newly detected `token:` CAIP assets to be **fail-open**: if a `bulkScanTokens` batch rejects, tokens in that batch are now allowed through instead of being dropped.
> 
> Adjusts unit tests to reflect the new behavior, including scenarios where `bulkScanTokens` throws or where only some scan batches fail, while still filtering tokens explicitly marked `Malicious` in successful scan responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3be6a8cacc02a4a4be611268307ef1fac12a9628. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->