### PR TITLE
feat: Expose `KeyringController:exportSeedPhrase` through messenger

### DIFF
--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Expose `KeyringController:exportSeedPhrase` method through `KeyringController` messenger ([#8587](https://github.com/MetaMask/core/pull/8587))
 - Expose `KeyringController:isUnlocked` method through `KeyringController` messenger ([#8573](https://github.com/MetaMask/core/pull/8573))
   - Returns `true` when the vault is unlocked, `false` otherwise. Mirrors `state.isUnlocked` and the `isUnlocked()` instance method, allowing consumers to check lock status via the messenger without holding a controller reference.
 - Add `withController` action to run atomic operations on multiple keyrings (within a single transaction) ([#8416](https://github.com/MetaMask/core/pull/8416))
@@ -974,7 +975,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial release
+
   - As a result of converting our shared controllers repo into a monorepo ([#831](https://github.com/MetaMask/core/pull/831)), we've created this package from select parts of [`@metamask/controllers` v33.0.0](https://github.com/MetaMask/core/tree/v33.0.0), namely:
+
     - Everything in `src/keyring`
 
     All changes listed after this point were applied to this package following the monorepo conversion.

--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -975,9 +975,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial release
-
   - As a result of converting our shared controllers repo into a monorepo ([#831](https://github.com/MetaMask/core/pull/831)), we've created this package from select parts of [`@metamask/controllers` v33.0.0](https://github.com/MetaMask/core/tree/v33.0.0), namely:
-
     - Everything in `src/keyring`
 
     All changes listed after this point were applied to this package following the monorepo conversion.

--- a/packages/keyring-controller/src/KeyringController-method-action-types.ts
+++ b/packages/keyring-controller/src/KeyringController-method-action-types.ts
@@ -69,6 +69,18 @@ export type KeyringControllerIsUnlockedAction = {
 };
 
 /**
+ * Gets the seed phrase of the HD keyring.
+ *
+ * @param password - Password of the keyring.
+ * @param keyringId - The id of the keyring.
+ * @returns Promise resolving to the seed phrase.
+ */
+export type KeyringControllerExportSeedPhraseAction = {
+  type: `KeyringController:exportSeedPhrase`;
+  handler: KeyringController['exportSeedPhrase'];
+};
+
+/**
  * Returns the public addresses of all accounts from every keyring.
  *
  * @returns A promise resolving to an array of addresses.
@@ -412,6 +424,7 @@ export type KeyringControllerMethodActions =
   | KeyringControllerCreateNewVaultAndKeychainAction
   | KeyringControllerAddNewKeyringAction
   | KeyringControllerIsUnlockedAction
+  | KeyringControllerExportSeedPhraseAction
   | KeyringControllerGetAccountsAction
   | KeyringControllerGetEncryptionPublicKeyAction
   | KeyringControllerDecryptMessageAction

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -189,7 +189,8 @@ export type KeyringControllerOptions<
   EncryptionKey = encryptorUtils.EncryptionKey | CryptoKey,
   SupportedKeyDerivationOptions = encryptorUtils.KeyDerivationOptions,
   EncryptionResult extends
-    EncryptionResultConstraint<SupportedKeyDerivationOptions> = DefaultEncryptionResult<SupportedKeyDerivationOptions>,
+    EncryptionResultConstraint<SupportedKeyDerivationOptions> =
+    DefaultEncryptionResult<SupportedKeyDerivationOptions>,
 > = {
   keyringBuilders?: { (): EthKeyring; type: string }[];
   keyringV2Builders?: KeyringV2Builder[];
@@ -359,7 +360,8 @@ export type Encryptor<
   EncryptionKey = encryptorUtils.EncryptionKey | CryptoKey,
   SupportedKeyDerivationParams = encryptorUtils.KeyDerivationOptions,
   EncryptionResult extends
-    EncryptionResultConstraint<SupportedKeyDerivationParams> = DefaultEncryptionResult<SupportedKeyDerivationParams>,
+    EncryptionResultConstraint<SupportedKeyDerivationParams> =
+    DefaultEncryptionResult<SupportedKeyDerivationParams>,
 > = {
   /**
    * Encrypts the given object with the given password.
@@ -760,7 +762,8 @@ export class KeyringController<
   EncryptionKey = encryptorUtils.EncryptionKey | CryptoKey,
   SupportedKeyDerivationOptions = encryptorUtils.KeyDerivationOptions,
   EncryptionResult extends
-    EncryptionResultConstraint<SupportedKeyDerivationOptions> = DefaultEncryptionResult<SupportedKeyDerivationOptions>,
+    EncryptionResultConstraint<SupportedKeyDerivationOptions> =
+    DefaultEncryptionResult<SupportedKeyDerivationOptions>,
 > extends BaseController<
   typeof name,
   KeyringControllerState,
@@ -2239,7 +2242,7 @@ export class KeyringController<
     v2,
     selector,
   }: // Use distinct union tags to ensure proper type narrowing of the selector object.
-  | {
+    | {
         v2: false;
         selector: KeyringSelector<SelectedKeyring>;
       }

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -77,6 +77,7 @@ const MESSENGER_EXPOSED_METHODS = [
   'createNewVaultAndRestore',
   'removeAccount',
   'isUnlocked',
+  'exportSeedPhrase',
 ] as const;
 
 /**
@@ -188,8 +189,7 @@ export type KeyringControllerOptions<
   EncryptionKey = encryptorUtils.EncryptionKey | CryptoKey,
   SupportedKeyDerivationOptions = encryptorUtils.KeyDerivationOptions,
   EncryptionResult extends
-    EncryptionResultConstraint<SupportedKeyDerivationOptions> =
-    DefaultEncryptionResult<SupportedKeyDerivationOptions>,
+    EncryptionResultConstraint<SupportedKeyDerivationOptions> = DefaultEncryptionResult<SupportedKeyDerivationOptions>,
 > = {
   keyringBuilders?: { (): EthKeyring; type: string }[];
   keyringV2Builders?: KeyringV2Builder[];
@@ -359,8 +359,7 @@ export type Encryptor<
   EncryptionKey = encryptorUtils.EncryptionKey | CryptoKey,
   SupportedKeyDerivationParams = encryptorUtils.KeyDerivationOptions,
   EncryptionResult extends
-    EncryptionResultConstraint<SupportedKeyDerivationParams> =
-    DefaultEncryptionResult<SupportedKeyDerivationParams>,
+    EncryptionResultConstraint<SupportedKeyDerivationParams> = DefaultEncryptionResult<SupportedKeyDerivationParams>,
 > = {
   /**
    * Encrypts the given object with the given password.
@@ -761,8 +760,7 @@ export class KeyringController<
   EncryptionKey = encryptorUtils.EncryptionKey | CryptoKey,
   SupportedKeyDerivationOptions = encryptorUtils.KeyDerivationOptions,
   EncryptionResult extends
-    EncryptionResultConstraint<SupportedKeyDerivationOptions> =
-    DefaultEncryptionResult<SupportedKeyDerivationOptions>,
+    EncryptionResultConstraint<SupportedKeyDerivationOptions> = DefaultEncryptionResult<SupportedKeyDerivationOptions>,
 > extends BaseController<
   typeof name,
   KeyringControllerState,
@@ -2241,7 +2239,7 @@ export class KeyringController<
     v2,
     selector,
   }: // Use distinct union tags to ensure proper type narrowing of the selector object.
-    | {
+  | {
         v2: false;
         selector: KeyringSelector<SelectedKeyring>;
       }

--- a/packages/keyring-controller/src/index.ts
+++ b/packages/keyring-controller/src/index.ts
@@ -25,6 +25,7 @@ export type {
   KeyringControllerWithKeyringUnsafeAction,
   KeyringControllerWithKeyringV2Action,
   KeyringControllerWithKeyringV2UnsafeAction,
+  KeyringControllerExportSeedPhraseAction,
 } from './KeyringController-method-action-types';
 export type * from './types';
 export * from './errors';


### PR DESCRIPTION
## Explanation

This adds `KeyringController:exportSeedPhrase` to `MESSENGER_EXPOSED_METHODS` and exports the type, as this was missed in https://github.com/MetaMask/core/pull/8391.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new messenger-exposed method for exporting the HD seed phrase, which is security-sensitive despite being mostly wiring/type-surface changes.
> 
> **Overview**
> **Exposes seed phrase export via the KeyringController messenger.** This adds `exportSeedPhrase` to `MESSENGER_EXPOSED_METHODS`, introduces the `KeyringController:exportSeedPhrase` method action type, includes it in the `KeyringControllerMethodActions` union, and re-exports the new action type from `src/index.ts`.
> 
> Updates the keyring-controller changelog to announce the new messenger method.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a33becb747c91c14ee29a7e6ab0d94b3ff12ac7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->