### PR TITLE
feat: Add Across Gas Station support

### DIFF
--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add Gas Station support for Across source transactions when native balance is insufficient ([#8588](https://github.com/MetaMask/core/pull/8588))
+
 ## [20.2.0]
 
 ### Changed

--- a/packages/transaction-pay-controller/src/strategy/across/across-quotes.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/across/across-quotes.test.ts
@@ -1,7 +1,10 @@
 import { Interface } from '@ethersproject/abi';
 import { successfulFetch } from '@metamask/controller-utils';
 import { TransactionType } from '@metamask/transaction-controller';
-import type { TransactionMeta } from '@metamask/transaction-controller';
+import type {
+  GasFeeToken,
+  TransactionMeta,
+} from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 
 import { getDefaultRemoteFeatureFlagControllerState } from '../../../../remote-feature-flag-controller/src/remote-feature-flag-controller';
@@ -13,10 +16,14 @@ import {
 } from '../../constants';
 import { getMessengerMock } from '../../tests/messenger-mock';
 import type { QuoteRequest } from '../../types';
-import { getGasBuffer, getSlippage } from '../../utils/feature-flags';
-import { calculateGasCost } from '../../utils/gas';
+import {
+  getGasBuffer,
+  getSlippage,
+  isEIP7702Chain,
+} from '../../utils/feature-flags';
+import { calculateGasCost, calculateGasFeeTokenCost } from '../../utils/gas';
 import * as quoteGasUtils from '../../utils/quote-gas';
-import { getTokenFiatRate } from '../../utils/token';
+import { getTokenBalance, getTokenFiatRate } from '../../utils/token';
 import { getAcrossQuotes } from './across-quotes';
 import { ACROSS_HYPERCORE_USDC_PERPS_ADDRESS } from './perps';
 import * as acrossTransactions from './transactions';
@@ -26,6 +33,7 @@ jest.mock('../../utils/token');
 jest.mock('../../utils/gas', () => ({
   ...jest.requireActual('../../utils/gas'),
   calculateGasCost: jest.fn(),
+  calculateGasFeeTokenCost: jest.fn(),
 }));
 jest.mock('../../utils/feature-flags', () => ({
   ...jest.requireActual('../../utils/feature-flags'),
@@ -161,15 +169,32 @@ describe('Across Quotes', () => {
   const getTokenFiatRateMock = jest.mocked(getTokenFiatRate);
   const getGasBufferMock = jest.mocked(getGasBuffer);
   const getSlippageMock = jest.mocked(getSlippage);
+  const isEIP7702ChainMock = jest.mocked(isEIP7702Chain);
   const calculateGasCostMock = jest.mocked(calculateGasCost);
+  const calculateGasFeeTokenCostMock = jest.mocked(calculateGasFeeTokenCost);
+  const getTokenBalanceMock = jest.mocked(getTokenBalance);
 
   const {
     messenger,
     estimateGasMock,
     estimateGasBatchMock,
     findNetworkClientIdByChainIdMock,
+    getGasFeeTokensMock,
     getRemoteFeatureFlagControllerStateMock,
   } = getMessengerMock();
+
+  const GAS_FEE_TOKEN_MOCK: GasFeeToken = {
+    amount: '0x64',
+    balance: '0x1000',
+    decimals: 18,
+    gas: '0x5208',
+    maxFeePerGas: '0x1',
+    maxPriorityFeePerGas: '0x1',
+    rateWei: '0x1',
+    recipient: FROM_MOCK,
+    symbol: 'ETH',
+    tokenAddress: QUOTE_REQUEST_MOCK.sourceTokenAddress,
+  };
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -200,8 +225,17 @@ describe('Across Quotes', () => {
       usd: '3.45',
     });
 
+    calculateGasFeeTokenCostMock.mockReturnValue({
+      fiat: '0.0004',
+      human: '0.0001',
+      raw: '100',
+      usd: '0.0002',
+    });
+
+    getTokenBalanceMock.mockReturnValue('1725000000000000000');
     getGasBufferMock.mockReturnValue(1.0);
     getSlippageMock.mockReturnValue(0.005);
+    isEIP7702ChainMock.mockReturnValue(false);
 
     findNetworkClientIdByChainIdMock.mockReturnValue('mainnet');
     estimateGasMock.mockResolvedValue({
@@ -293,6 +327,187 @@ describe('Across Quotes', () => {
 
       expect(params.get('tradeType')).toBe('exactInput');
       expect(params.get('amount')).toBe(QUOTE_REQUEST_MOCK.sourceTokenAmount);
+    });
+
+    it('re-quotes max amount quotes after reserving source token for gas fee token', async () => {
+      const adjustedSourceAmount = '999999999999999900';
+
+      getTokenBalanceMock.mockReturnValue('0');
+      isEIP7702ChainMock.mockReturnValue(true);
+      getGasFeeTokensMock.mockResolvedValue([
+        {
+          amount: '0x64',
+          balance: '0x1000',
+          decimals: 18,
+          gas: '0x5208',
+          maxFeePerGas: '0x1',
+          maxPriorityFeePerGas: '0x1',
+          rateWei: '0x1',
+          recipient: FROM_MOCK,
+          symbol: 'ETH',
+          tokenAddress: QUOTE_REQUEST_MOCK.sourceTokenAddress,
+        },
+      ]);
+
+      successfulFetchMock
+        .mockResolvedValueOnce({
+          json: async () => QUOTE_MOCK,
+        } as Response)
+        .mockResolvedValueOnce({
+          json: async () => ({
+            ...QUOTE_MOCK,
+            inputAmount: adjustedSourceAmount,
+          }),
+        } as Response);
+
+      const result = await getAcrossQuotes({
+        messenger,
+        requests: [{ ...QUOTE_REQUEST_MOCK, isMaxAmount: true }],
+        transaction: TRANSACTION_META_MOCK,
+      });
+
+      expect(successfulFetchMock).toHaveBeenCalledTimes(2);
+
+      const [phase1Url] = successfulFetchMock.mock.calls[0];
+      const [phase2Url] = successfulFetchMock.mock.calls[1];
+
+      expect(new URL(phase1Url as string).searchParams.get('amount')).toBe(
+        QUOTE_REQUEST_MOCK.sourceTokenAmount,
+      );
+      expect(new URL(phase2Url as string).searchParams.get('amount')).toBe(
+        adjustedSourceAmount,
+      );
+      expect(result[0].sourceAmount.raw).toBe(adjustedSourceAmount);
+      expect(result[0].fees.isSourceGasFeeToken).toBe(true);
+    });
+
+    it('falls back to phase 1 max amount quote when adjusted quote is not affordable', async () => {
+      getTokenBalanceMock.mockReturnValue('0');
+      isEIP7702ChainMock.mockReturnValue(true);
+      calculateGasFeeTokenCostMock
+        .mockReturnValueOnce({
+          fiat: '0.0004',
+          human: '0.0001',
+          raw: '100',
+          usd: '0.0002',
+        })
+        .mockReturnValueOnce({
+          fiat: '0.0008',
+          human: '0.0002',
+          raw: '200',
+          usd: '0.0004',
+        });
+      getGasFeeTokensMock.mockResolvedValue([
+        {
+          amount: '0x64',
+          balance: '0x1000',
+          decimals: 18,
+          gas: '0x5208',
+          maxFeePerGas: '0x1',
+          maxPriorityFeePerGas: '0x1',
+          rateWei: '0x1',
+          recipient: FROM_MOCK,
+          symbol: 'ETH',
+          tokenAddress: QUOTE_REQUEST_MOCK.sourceTokenAddress,
+        },
+      ]);
+
+      successfulFetchMock
+        .mockResolvedValueOnce({
+          json: async () => QUOTE_MOCK,
+        } as Response)
+        .mockResolvedValueOnce({
+          json: async () => ({
+            ...QUOTE_MOCK,
+            inputAmount: '999999999999999900',
+          }),
+        } as Response);
+
+      const result = await getAcrossQuotes({
+        messenger,
+        requests: [{ ...QUOTE_REQUEST_MOCK, isMaxAmount: true }],
+        transaction: TRANSACTION_META_MOCK,
+      });
+
+      expect(successfulFetchMock).toHaveBeenCalledTimes(2);
+      expect(result[0].sourceAmount.raw).toBe(QUOTE_MOCK.inputAmount);
+    });
+
+    it('falls back to phase 1 max amount quote when gas subtraction consumes the source amount', async () => {
+      getTokenBalanceMock.mockReturnValue('0');
+      isEIP7702ChainMock.mockReturnValue(true);
+      getGasFeeTokensMock.mockResolvedValue([GAS_FEE_TOKEN_MOCK]);
+
+      successfulFetchMock.mockResolvedValue({
+        json: async () => QUOTE_MOCK,
+      } as Response);
+
+      const result = await getAcrossQuotes({
+        messenger,
+        requests: [
+          {
+            ...QUOTE_REQUEST_MOCK,
+            isMaxAmount: true,
+            sourceTokenAmount: '100',
+          },
+        ],
+        transaction: TRANSACTION_META_MOCK,
+      });
+
+      expect(successfulFetchMock).toHaveBeenCalledTimes(1);
+      expect(result[0].sourceAmount.raw).toBe(QUOTE_MOCK.inputAmount);
+      expect(result[0].fees.isSourceGasFeeToken).toBe(true);
+    });
+
+    it('falls back to phase 1 max amount quote when phase 2 loses gas fee token eligibility', async () => {
+      getTokenBalanceMock.mockReturnValue('0');
+      isEIP7702ChainMock.mockReturnValue(true);
+      getGasFeeTokensMock
+        .mockResolvedValueOnce([GAS_FEE_TOKEN_MOCK])
+        .mockResolvedValueOnce([]);
+
+      successfulFetchMock
+        .mockResolvedValueOnce({
+          json: async () => QUOTE_MOCK,
+        } as Response)
+        .mockResolvedValueOnce({
+          json: async () => ({
+            ...QUOTE_MOCK,
+            inputAmount: '999999999999999900',
+          }),
+        } as Response);
+
+      const result = await getAcrossQuotes({
+        messenger,
+        requests: [{ ...QUOTE_REQUEST_MOCK, isMaxAmount: true }],
+        transaction: TRANSACTION_META_MOCK,
+      });
+
+      expect(successfulFetchMock).toHaveBeenCalledTimes(2);
+      expect(result[0].sourceAmount.raw).toBe(QUOTE_MOCK.inputAmount);
+      expect(result[0].fees.isSourceGasFeeToken).toBe(true);
+    });
+
+    it('falls back to phase 1 max amount quote when phase 2 fetching fails', async () => {
+      getTokenBalanceMock.mockReturnValue('0');
+      isEIP7702ChainMock.mockReturnValue(true);
+      getGasFeeTokensMock.mockResolvedValue([GAS_FEE_TOKEN_MOCK]);
+
+      successfulFetchMock
+        .mockResolvedValueOnce({
+          json: async () => QUOTE_MOCK,
+        } as Response)
+        .mockRejectedValueOnce(new Error('Phase 2 quote failed'));
+
+      const result = await getAcrossQuotes({
+        messenger,
+        requests: [{ ...QUOTE_REQUEST_MOCK, isMaxAmount: true }],
+        transaction: TRANSACTION_META_MOCK,
+      });
+
+      expect(successfulFetchMock).toHaveBeenCalledTimes(2);
+      expect(result[0].sourceAmount.raw).toBe(QUOTE_MOCK.inputAmount);
+      expect(result[0].fees.isSourceGasFeeToken).toBe(true);
     });
 
     it('forwards the abort signal to the underlying fetch', async () => {
@@ -1170,6 +1385,125 @@ describe('Across Quotes', () => {
           isMax: true,
         }),
       );
+    });
+
+    it('uses source gas fee token pricing when native balance is insufficient', async () => {
+      getTokenBalanceMock.mockReturnValue('0');
+      isEIP7702ChainMock.mockReturnValue(true);
+      getGasFeeTokensMock.mockResolvedValue([GAS_FEE_TOKEN_MOCK]);
+
+      successfulFetchMock.mockResolvedValue({
+        json: async () => QUOTE_MOCK,
+      } as Response);
+
+      const result = await getAcrossQuotes({
+        messenger,
+        requests: [QUOTE_REQUEST_MOCK],
+        transaction: TRANSACTION_META_MOCK,
+      });
+
+      expect(getGasFeeTokensMock).toHaveBeenCalledWith({
+        chainId: QUOTE_REQUEST_MOCK.sourceChainId,
+        data: QUOTE_MOCK.swapTx.data,
+        from: FROM_MOCK,
+        to: QUOTE_MOCK.swapTx.to,
+        value: '0x0',
+      });
+      expect(result[0].fees.isSourceGasFeeToken).toBe(true);
+      expect(result[0].fees.sourceNetwork.max.raw).toBe('100');
+      expect(result[0].fees.sourceNetwork.estimate.raw).toBe('100');
+    });
+
+    it('preserves authorization-list metadata when source gas fee token pricing is used', async () => {
+      estimateGasBatchMock.mockResolvedValue({
+        totalGasLimit: 51000,
+        gasLimits: [51000],
+        requiresAuthorizationList: true,
+      });
+      getTokenBalanceMock.mockReturnValue('0');
+      isEIP7702ChainMock.mockReturnValue(true);
+      getGasFeeTokensMock.mockResolvedValue([GAS_FEE_TOKEN_MOCK]);
+
+      successfulFetchMock.mockResolvedValue({
+        json: async () => ({
+          ...QUOTE_MOCK,
+          approvalTxns: [
+            {
+              chainId: 1,
+              data: '0xaaaa' as Hex,
+              to: '0xapprove1' as Hex,
+              value: '0x1' as Hex,
+            },
+          ],
+        }),
+      } as Response);
+
+      const result = await getAcrossQuotes({
+        messenger,
+        requests: [QUOTE_REQUEST_MOCK],
+        transaction: TRANSACTION_META_MOCK,
+      });
+
+      expect(result[0].fees.isSourceGasFeeToken).toBe(true);
+      expect(result[0].original.metamask.requiresAuthorizationList).toBe(true);
+    });
+
+    it('does not use source gas fee token pricing when gas station is disabled for the source chain', async () => {
+      getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+        ...getDefaultRemoteFeatureFlagControllerState(),
+        remoteFeatureFlags: {
+          confirmations_pay: {
+            payStrategies: {
+              across: {
+                enabled: true,
+                apiBase: 'https://test.across.to/api',
+              },
+            },
+            relayDisabledGasStationChains: [QUOTE_REQUEST_MOCK.sourceChainId],
+          },
+        },
+      });
+      getTokenBalanceMock.mockReturnValue('0');
+      isEIP7702ChainMock.mockReturnValue(true);
+
+      successfulFetchMock.mockResolvedValue({
+        json: async () => QUOTE_MOCK,
+      } as Response);
+
+      const result = await getAcrossQuotes({
+        messenger,
+        requests: [QUOTE_REQUEST_MOCK],
+        transaction: TRANSACTION_META_MOCK,
+      });
+
+      expect(getGasFeeTokensMock).not.toHaveBeenCalled();
+      expect(result[0].fees.isSourceGasFeeToken).toBeUndefined();
+      expect(result[0].fees.sourceNetwork.max.raw).toBe('1725000000000000000');
+    });
+
+    it('does not use source gas fee token pricing when gas station cannot price the source token', async () => {
+      getTokenBalanceMock.mockReturnValue('0');
+      isEIP7702ChainMock.mockReturnValue(true);
+      getGasFeeTokensMock.mockResolvedValue([
+        {
+          ...GAS_FEE_TOKEN_MOCK,
+          tokenAddress: '0xdifferent' as Hex,
+        },
+      ]);
+
+      successfulFetchMock.mockResolvedValue({
+        json: async () => QUOTE_MOCK,
+      } as Response);
+
+      const result = await getAcrossQuotes({
+        messenger,
+        requests: [QUOTE_REQUEST_MOCK],
+        transaction: TRANSACTION_META_MOCK,
+      });
+
+      expect(getGasFeeTokensMock).toHaveBeenCalledTimes(1);
+      expect(result[0].fees.isSourceGasFeeToken).toBeUndefined();
+      expect(result[0].fees.sourceNetwork.max.raw).toBe('1725000000000000000');
     });
 
     it('includes approval gas costs and gas limits when approval transactions exist', async () => {

--- a/packages/transaction-pay-controller/src/strategy/across/across-quotes.ts
+++ b/packages/transaction-pay-controller/src/strategy/across/across-quotes.ts
@@ -16,8 +16,16 @@ import type {
 import { getFiatValueFromUsd, sumAmounts } from '../../utils/amounts';
 import { getPayStrategiesConfig, getSlippage } from '../../utils/feature-flags';
 import { calculateGasCost } from '../../utils/gas';
+import {
+  getGasStationCostInSourceTokenRaw,
+  getGasStationEligibility,
+} from '../../utils/gas-station';
 import { estimateQuoteGasLimits } from '../../utils/quote-gas';
-import { getTokenFiatRate } from '../../utils/token';
+import {
+  getNativeToken,
+  getTokenBalance,
+  getTokenFiatRate,
+} from '../../utils/token';
 import { getAcrossDestination } from './across-actions';
 import { normalizeAcrossRequest } from './perps';
 import { isAcrossQuoteRequest } from './requests';
@@ -63,7 +71,7 @@ export async function getAcrossQuotes(
 
     return await Promise.all(
       normalizedRequests.map((singleRequest) =>
-        getSingleQuote(singleRequest, request),
+        getQuoteWithGasStationHandling(singleRequest, request),
       ),
     );
   } catch (error) {
@@ -123,6 +131,70 @@ async function getSingleQuote(
   };
 
   return await normalizeQuote(originalQuote, normalizedRequest, fullRequest);
+}
+
+async function getQuoteWithGasStationHandling(
+  request: QuoteRequest,
+  fullRequest: PayStrategyGetQuotesRequest,
+): Promise<TransactionPayQuote<AcrossQuote>> {
+  const phase1Quote = await getSingleQuote(request, fullRequest);
+
+  if (!request.isMaxAmount || !phase1Quote.fees.isSourceGasFeeToken) {
+    return phase1Quote;
+  }
+
+  const adjustedSourceAmount = new BigNumber(request.sourceTokenAmount)
+    .minus(phase1Quote.fees.sourceNetwork.max.raw)
+    .integerValue(BigNumber.ROUND_DOWN);
+
+  if (!adjustedSourceAmount.isGreaterThan(0)) {
+    log('Insufficient balance after gas subtraction for Across max quote');
+    return phase1Quote;
+  }
+
+  log('Subtracting gas from source for Across max quote', {
+    adjustedSourceAmount: adjustedSourceAmount.toString(10),
+    gasCostRaw: phase1Quote.fees.sourceNetwork.max.raw,
+    originalSourceAmount: request.sourceTokenAmount,
+  });
+
+  try {
+    const phase2Quote = await getSingleQuote(
+      {
+        ...request,
+        sourceTokenAmount: adjustedSourceAmount.toFixed(
+          0,
+          BigNumber.ROUND_DOWN,
+        ),
+      },
+      fullRequest,
+    );
+
+    if (!phase2Quote.fees.isSourceGasFeeToken) {
+      log('Across max phase 2 lost gas fee token eligibility');
+      return phase1Quote;
+    }
+
+    const phase2GasCost = new BigNumber(phase2Quote.fees.sourceNetwork.max.raw);
+
+    if (
+      adjustedSourceAmount
+        .plus(phase2GasCost)
+        .isGreaterThan(request.sourceTokenAmount)
+    ) {
+      log('Across max phase 2 quote exceeds original source amount', {
+        adjustedSourceAmount: adjustedSourceAmount.toString(10),
+        gasCostRaw: phase2GasCost.toString(10),
+        originalSourceAmount: request.sourceTokenAmount,
+      });
+      return phase1Quote;
+    }
+
+    return phase2Quote;
+  } catch (error) {
+    log('Across max phase 2 quote failed, falling back to phase 1', { error });
+    return phase1Quote;
+  }
 }
 
 type AcrossApprovalRequest = {
@@ -204,8 +276,13 @@ async function normalizeQuote(
   const dustUsd = calculateDustUsd(quote, request, targetFiatRate);
   const dust = getFiatValueFromUsd(dustUsd, usdToFiatRate);
 
-  const { gasLimits, is7702, requiresAuthorizationList, sourceNetwork } =
-    await calculateSourceNetworkCost(quote, messenger, request);
+  const {
+    gasLimits,
+    is7702,
+    isGasFeeToken: isSourceGasFeeToken,
+    requiresAuthorizationList,
+    sourceNetwork,
+  } = await calculateSourceNetworkCost(quote, messenger, request);
 
   const targetNetwork = getFiatValueFromUsd(new BigNumber(0), usdToFiatRate);
 
@@ -252,6 +329,7 @@ async function normalizeQuote(
     dust,
     estimatedDuration: quote.expectedFillTime ?? 0,
     fees: {
+      isSourceGasFeeToken,
       metaMask: metaMaskFee,
       provider,
       sourceNetwork,
@@ -391,12 +469,13 @@ async function calculateSourceNetworkCost(
 ): Promise<{
   sourceNetwork: TransactionPayQuote<AcrossQuote>['fees']['sourceNetwork'];
   gasLimits: AcrossGasLimits;
+  isGasFeeToken?: boolean;
   is7702: boolean;
   requiresAuthorizationList?: true;
 }> {
   const acrossFallbackGas =
     getPayStrategiesConfig(messenger).across.fallbackGas;
-  const { from } = request;
+  const { from, sourceChainId, sourceTokenAddress } = request;
   const orderedTransactions = getAcrossOrderedTransactions({ quote });
   const { swapTx } = quote;
   const swapChainId = toHex(swapTx.chainId);
@@ -412,7 +491,11 @@ async function calculateSourceNetworkCost(
       value: transaction.value ?? '0x0',
     })),
   });
-  const { batchGasLimit, is7702, requiresAuthorizationList } = gasEstimates;
+  const { batchGasLimit, is7702, requiresAuthorizationList, totalGasEstimate } =
+    gasEstimates;
+
+  let sourceNetwork: TransactionPayQuote<AcrossQuote>['fees']['sourceNetwork'];
+  let gasLimits: AcrossGasLimits;
 
   if (is7702) {
     if (!batchGasLimit) {
@@ -435,63 +518,130 @@ async function calculateSourceNetworkCost(
       messenger,
     });
 
-    return {
-      sourceNetwork: {
-        estimate,
-        max,
-      },
-      is7702: true,
-      ...(requiresAuthorizationList ? { requiresAuthorizationList } : {}),
-      gasLimits: [
-        {
-          estimate: batchGasLimit.estimate,
-          max: batchGasLimit.max,
-        },
-      ],
-    };
-  }
-
-  const transactionGasLimits = orderedTransactions.map(
-    (transaction, index) => ({
-      gasEstimate: gasEstimates.gasLimits[index],
-      transaction,
-    }),
-  );
-
-  const estimate = sumAmounts(
-    transactionGasLimits.map(({ gasEstimate, transaction }) =>
-      calculateGasCost({
-        chainId: toHex(transaction.chainId),
-        gas: gasEstimate.estimate,
-        maxFeePerGas: transaction.maxFeePerGas,
-        maxPriorityFeePerGas: transaction.maxPriorityFeePerGas,
-        messenger,
-      }),
-    ),
-  );
-
-  const max = sumAmounts(
-    transactionGasLimits.map(({ gasEstimate, transaction }) =>
-      calculateGasCost({
-        chainId: toHex(transaction.chainId),
-        gas: gasEstimate.max,
-        isMax: true,
-        maxFeePerGas: transaction.maxFeePerGas,
-        maxPriorityFeePerGas: transaction.maxPriorityFeePerGas,
-        messenger,
-      }),
-    ),
-  );
-
-  return {
-    sourceNetwork: {
+    sourceNetwork = {
       estimate,
       max,
-    },
-    is7702: false,
-    gasLimits: transactionGasLimits.map(({ gasEstimate }) => ({
+    };
+    gasLimits = [
+      {
+        estimate: batchGasLimit.estimate,
+        max: batchGasLimit.max,
+      },
+    ];
+  } else {
+    const transactionGasLimits = orderedTransactions.map(
+      (transaction, index) => ({
+        gasEstimate: gasEstimates.gasLimits[index],
+        transaction,
+      }),
+    );
+
+    const estimate = sumAmounts(
+      transactionGasLimits.map(({ gasEstimate, transaction }) =>
+        calculateGasCost({
+          chainId: toHex(transaction.chainId),
+          gas: gasEstimate.estimate,
+          maxFeePerGas: transaction.maxFeePerGas,
+          maxPriorityFeePerGas: transaction.maxPriorityFeePerGas,
+          messenger,
+        }),
+      ),
+    );
+
+    const max = sumAmounts(
+      transactionGasLimits.map(({ gasEstimate, transaction }) =>
+        calculateGasCost({
+          chainId: toHex(transaction.chainId),
+          gas: gasEstimate.max,
+          isMax: true,
+          maxFeePerGas: transaction.maxFeePerGas,
+          maxPriorityFeePerGas: transaction.maxPriorityFeePerGas,
+          messenger,
+        }),
+      ),
+    );
+
+    sourceNetwork = {
+      estimate,
+      max,
+    };
+    gasLimits = transactionGasLimits.map(({ gasEstimate }) => ({
       estimate: gasEstimate.estimate,
       max: gasEstimate.max,
-    })),
+    }));
+  }
+
+  const result = {
+    sourceNetwork,
+    is7702,
+    ...(requiresAuthorizationList ? { requiresAuthorizationList } : {}),
+    gasLimits,
+  };
+
+  const nativeBalance = getTokenBalance(
+    messenger,
+    from,
+    sourceChainId,
+    getNativeToken(sourceChainId),
+  );
+
+  if (
+    new BigNumber(nativeBalance).isGreaterThanOrEqualTo(sourceNetwork.max.raw)
+  ) {
+    return result;
+  }
+
+  const gasStationEligibility = getGasStationEligibility(
+    messenger,
+    sourceChainId,
+  );
+
+  if (gasStationEligibility.isDisabledChain) {
+    log('Skipping Across gas station as disabled chain', { sourceChainId });
+    return result;
+  }
+
+  if (!gasStationEligibility.chainSupportsGasStation) {
+    log('Skipping Across gas station as chain does not support EIP-7702', {
+      sourceChainId,
+    });
+    return result;
+  }
+
+  const firstTransaction = orderedTransactions[0];
+
+  const gasFeeTokenCost = await getGasStationCostInSourceTokenRaw({
+    firstStepData: {
+      data: firstTransaction.data,
+      to: firstTransaction.to,
+      value: firstTransaction.value,
+    },
+    messenger,
+    request: {
+      from,
+      sourceChainId,
+      sourceTokenAddress,
+    },
+    totalGasEstimate,
+    totalItemCount: Math.max(orderedTransactions.length, gasLimits.length),
+  });
+
+  if (!gasFeeTokenCost) {
+    return result;
+  }
+
+  log('Using gas fee token for Across source network', {
+    gasFeeTokenCost,
+  });
+
+  return {
+    isGasFeeToken: true,
+    sourceNetwork: {
+      estimate: gasFeeTokenCost,
+      max: gasFeeTokenCost,
+    },
+    is7702,
+    ...(requiresAuthorizationList ? { requiresAuthorizationList } : {}),
+    gasLimits,
   };
 }

--- a/packages/transaction-pay-controller/src/strategy/across/across-submit.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/across/across-submit.test.ts
@@ -213,6 +213,29 @@ describe('Across Submit', () => {
       );
     });
 
+    it('passes gas fee token to batch submission when source gas fee token is used', async () => {
+      await submitAcrossQuotes({
+        messenger,
+        quotes: [
+          {
+            ...QUOTE_MOCK,
+            fees: {
+              ...QUOTE_MOCK.fees,
+              isSourceGasFeeToken: true,
+            },
+          },
+        ],
+        transaction: TRANSACTION_META_MOCK,
+        isSmartTransaction: jest.fn(),
+      });
+
+      expect(addTransactionBatchMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          gasFeeToken: QUOTE_MOCK.request.sourceTokenAddress,
+        }),
+      );
+    });
+
     it('submits a 7702 batch when the quote contains a combined batch gas limit', async () => {
       const batchGasQuote = {
         ...QUOTE_MOCK,
@@ -287,6 +310,37 @@ describe('Across Submit', () => {
         expect.anything(),
         expect.objectContaining({
           type: TransactionType.perpsAcrossDeposit,
+        }),
+      );
+    });
+
+    it('passes gas fee token to single transaction submission when source gas fee token is used', async () => {
+      const noApprovalQuote = {
+        ...QUOTE_MOCK,
+        fees: {
+          ...QUOTE_MOCK.fees,
+          isSourceGasFeeToken: true,
+        },
+        original: {
+          ...QUOTE_MOCK.original,
+          quote: {
+            ...QUOTE_MOCK.original.quote,
+            approvalTxns: [],
+          },
+        },
+      } as TransactionPayQuote<AcrossQuote>;
+
+      await submitAcrossQuotes({
+        messenger,
+        quotes: [noApprovalQuote],
+        transaction: TRANSACTION_META_MOCK,
+        isSmartTransaction: jest.fn(),
+      });
+
+      expect(addTransactionMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          gasFeeToken: QUOTE_MOCK.request.sourceTokenAddress,
         }),
       );
     });

--- a/packages/transaction-pay-controller/src/strategy/across/across-submit.ts
+++ b/packages/transaction-pay-controller/src/strategy/across/across-submit.ts
@@ -194,6 +194,9 @@ async function submitTransactions(
   );
 
   let result: { result: Promise<string> } | undefined;
+  const gasFeeToken = quote.fees.isSourceGasFeeToken
+    ? quote.request.sourceTokenAddress
+    : undefined;
 
   try {
     if (transactions.length === 1) {
@@ -201,6 +204,7 @@ async function submitTransactions(
         'TransactionController:addTransaction',
         transactions[0].params,
         {
+          gasFeeToken,
           networkClientId,
           origin: ORIGIN_METAMASK,
           requireApproval: false,
@@ -218,6 +222,7 @@ async function submitTransactions(
         disableHook: Boolean(gasLimit7702),
         disableSequential: Boolean(gasLimit7702),
         from,
+        gasFeeToken,
         gasLimit7702,
         networkClientId,
         origin: ORIGIN_METAMASK,

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-max-gas-station.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-max-gas-station.ts
@@ -9,14 +9,14 @@ import type {
   TransactionPayQuote,
 } from '../../types';
 import {
+  getGasStationEligibility,
+  getGasStationCostInSourceTokenRaw,
+} from '../../utils/gas-station';
+import {
   getNativeToken,
   getTokenBalance,
   getTokenInfo,
 } from '../../utils/token';
-import {
-  getGasStationEligibility,
-  getGasStationCostInSourceTokenRaw,
-} from './gas-station';
 import type { RelayQuote, RelayTransactionStep } from './types';
 
 const log = createModuleLogger(projectLogger, 'relay-max-gas-station');

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.ts
@@ -37,6 +37,10 @@ import {
   isRelayExecuteEnabled,
 } from '../../utils/feature-flags';
 import { calculateGasCost } from '../../utils/gas';
+import {
+  getGasStationCostInSourceTokenRaw,
+  getGasStationEligibility,
+} from '../../utils/gas-station';
 import { estimateQuoteGasLimits } from '../../utils/quote-gas';
 import type { QuoteGasTransaction } from '../../utils/quote-gas';
 import {
@@ -48,10 +52,6 @@ import {
 } from '../../utils/token';
 import { isPredictWithdrawTransaction } from '../../utils/transaction';
 import { TOKEN_TRANSFER_FOUR_BYTE } from './constants';
-import {
-  getGasStationCostInSourceTokenRaw,
-  getGasStationEligibility,
-} from './gas-station';
 import { fetchRelayQuote } from './relay-api';
 import { getRelayMaxGasStationQuote } from './relay-max-gas-station';
 import type {

--- a/packages/transaction-pay-controller/src/utils/gas-station.test.ts
+++ b/packages/transaction-pay-controller/src/utils/gas-station.test.ts
@@ -1,15 +1,15 @@
 import type { GasFeeToken } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 
-import { getDefaultRemoteFeatureFlagControllerState } from '../../../../remote-feature-flag-controller/src/remote-feature-flag-controller';
-import { getMessengerMock } from '../../tests/messenger-mock';
-import { calculateGasFeeTokenCost } from '../../utils/gas';
+import { getDefaultRemoteFeatureFlagControllerState } from '../../../remote-feature-flag-controller/src/remote-feature-flag-controller';
+import { getMessengerMock } from '../tests/messenger-mock';
+import { calculateGasFeeTokenCost } from './gas';
 import {
   getGasStationEligibility,
   getGasStationCostInSourceTokenRaw,
 } from './gas-station';
 
-jest.mock('../../utils/gas');
+jest.mock('./gas');
 
 const REQUEST_MOCK = {
   from: '0x1234567890123456789012345678901234567891' as Hex,
@@ -18,8 +18,8 @@ const REQUEST_MOCK = {
 };
 
 const FIRST_STEP_DATA_MOCK = {
-  data: '0x123',
-  to: '0x2',
+  data: '0x123' as Hex,
+  to: '0x2' as Hex,
   value: '0x0',
 };
 

--- a/packages/transaction-pay-controller/src/utils/gas-station.ts
+++ b/packages/transaction-pay-controller/src/utils/gas-station.ts
@@ -4,16 +4,16 @@ import type { Hex } from '@metamask/utils';
 import { createModuleLogger } from '@metamask/utils';
 import { BigNumber } from 'bignumber.js';
 
-import { projectLogger } from '../../logger';
+import { projectLogger } from '../logger';
 import type {
   Amount,
   QuoteRequest,
   TransactionPayControllerMessenger,
-} from '../../types';
-import { getFeatureFlags, isEIP7702Chain } from '../../utils/feature-flags';
-import { calculateGasFeeTokenCost } from '../../utils/gas';
+} from '../types';
+import { getFeatureFlags, isEIP7702Chain } from './feature-flags';
+import { calculateGasFeeTokenCost } from './gas';
 
-const log = createModuleLogger(projectLogger, 'relay-gas-station');
+const log = createModuleLogger(projectLogger, 'gas-station');
 
 type GasStationCostParams = {
   firstStepData: {


### PR DESCRIPTION
## Summary
- Add a shared Gas Station helper and keep Relay using it via the existing relay helper path.
- Let Across quote source-network fees in the source token when native balance is insufficient and Gas Station is eligible.
- Re-quote max-amount Across flows after reserving source token for gas-fee-token payment.
- Pass `gasFeeToken` when submitting Across source transactions that use source-token gas payment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Across quotes and submissions handle gas pricing when native balance is insufficient, including a new two-phase re-quote path for max-amount flows; mistakes could lead to unaffordable quotes or incorrect gas token selection.
> 
> **Overview**
> Adds **Gas Station (gas-fee-token) support to the Across strategy**: when the user’s native balance can’t cover `fees.sourceNetwork`, Across can now price source-network gas in the *source token* via a shared `utils/gas-station` helper and marks quotes with `fees.isSourceGasFeeToken`.
> 
> For **max-amount Across quotes**, introduces a two-phase flow that re-quotes after subtracting the estimated gas-fee-token cost from the input amount, with guarded fallbacks back to the original quote if the adjusted quote is invalid/unaﬀordable.
> 
> During **Across submission**, passes `gasFeeToken` to `TransactionController:addTransaction` / `addTransactionBatch` when `fees.isSourceGasFeeToken` is set, enabling the source-token gas payment on-chain. Also refactors Relay to import the gas-station helpers from `utils/gas-station` and updates/extends tests accordingly, plus a changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c219b149aac0062a92c46eb94574f8dbedc92488. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->