### PR TITLE
feat: add security data type in bridge metrics

### DIFF
--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Add `token_security_type_destination` as security classification of the destination token (`securityData.type`). Omitted if `securityData` is not present. ([#8591](https://github.com/MetaMask/core/pull/8591))
 - Bump `@metamask/transaction-controller` from `^64.3.0` to `^64.4.0` ([#8585](https://github.com/MetaMask/core/pull/8585))
 
 ## [70.2.0]

--- a/packages/bridge-controller/src/utils/metrics/types.ts
+++ b/packages/bridge-controller/src/utils/metrics/types.ts
@@ -122,6 +122,7 @@ type RequiredEventContextFromClientBase = {
     token_address_destination: RequestParams['token_address_destination'];
     chain_id_source: RequestParams['chain_id_source'];
     chain_id_destination: RequestParams['chain_id_destination'];
+    token_security_type_destination?: string;
   } & Pick<RequestMetadata, 'security_warnings'>;
   [UnifiedSwapBridgeEventName.QuotesRequested]: Pick<
     RequestMetadata,
@@ -168,6 +169,7 @@ type RequiredEventContextFromClientBase = {
       quote_vs_execution_ratio: number;
       quoted_vs_used_gas_ratio: number;
       action_type: MetricsActionType;
+      token_security_type_destination?: string;
     };
   [UnifiedSwapBridgeEventName.Failed]:
     | // Tx failed before confirmation
@@ -191,6 +193,7 @@ type RequiredEventContextFromClientBase = {
         TradeData & {
           actual_time_minutes: number;
           error_message?: string;
+          token_security_type_destination?: string;
         });
   // Emitted by clients
   [UnifiedSwapBridgeEventName.AllQuotesOpened]: Pick<


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Add `token_security_type_destination` as security classification of the destination token (securityData.type). Omitted if securityData is not present.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Related: https://github.com/Consensys/segment-schema/pull/544
fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-4420

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: type-only analytics payload changes (new optional field) plus a changelog entry; no runtime logic changes.
> 
> **Overview**
> Adds a new optional metrics property, `token_security_type_destination`, to multiple Unified Swap/Bridge analytics event context payload types (including `InputSourceDestinationSwitched`, `Completed`, and `Failed`) so clients can report the destination token’s `securityData.type` when available.
> 
> Updates the `bridge-controller` changelog to document the new analytics field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ec891e369b952fc425b87898ec674ad2317fa25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->