### PR TITLE
feat: Expose `TransactionController:wipeTransactions` through messenger

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Expose `TransactionController:wipeTransactions` method through `TransactionController` messenger ([#8592](https://github.com/MetaMask/core/pull/8592))
+
 ## [64.4.0]
 
 ### Changed

--- a/packages/transaction-controller/src/TransactionController-method-action-types.ts
+++ b/packages/transaction-controller/src/TransactionController-method-action-types.ts
@@ -162,6 +162,18 @@ export type TransactionControllerUpdateTransactionAction = {
 };
 
 /**
+ * Remove transactions from state.
+ *
+ * @param options - The options bag.
+ * @param options.address - Remove transactions from this account only. Defaults to all accounts.
+ * @param options.chainId - Remove transactions for the specified chain only. Defaults to all chains.
+ */
+export type TransactionControllerWipeTransactionsAction = {
+  type: `TransactionController:wipeTransactions`;
+  handler: TransactionController['wipeTransactions'];
+};
+
+/**
  * Adds external provided transaction to state as confirmed transaction.
  *
  * @param transactionMeta - TransactionMeta to add transactions.
@@ -367,6 +379,7 @@ export type TransactionControllerMethodActions =
   | TransactionControllerEstimateGasBatchAction
   | TransactionControllerEstimateGasBufferedAction
   | TransactionControllerUpdateTransactionAction
+  | TransactionControllerWipeTransactionsAction
   | TransactionControllerConfirmExternalTransactionAction
   | TransactionControllerGetNonceLockAction
   | TransactionControllerUpdateEditableParamsAction

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -759,6 +759,7 @@ const MESSENGER_EXPOSED_METHODS = [
   'updateEditableParams',
   'updateIncomingTransactions',
   'updateTransaction',
+  'wipeTransactions',
 ] as const;
 
 /**

--- a/packages/transaction-controller/src/index.ts
+++ b/packages/transaction-controller/src/index.ts
@@ -53,6 +53,7 @@ export type {
   TransactionControllerClearUnapprovedTransactionsAction,
   TransactionControllerAbortTransactionSigningAction,
   TransactionControllerUpdateAtomicBatchDataAction,
+  TransactionControllerWipeTransactionsAction,
 } from './TransactionController-method-action-types';
 export {
   CANCEL_RATE,


### PR DESCRIPTION
## Explanation

This adds `TransactionController:wipeTransactions` to `MESSENGER_EXPOSED_METHODS` and exports the type, as this was missed in https://github.com/MetaMask/core/pull/8183.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds a new messenger-exposed method and corresponding TypeScript action type/export, without changing transaction processing logic.
> 
> **Overview**
> Adds messenger support for `TransactionController:wipeTransactions` by including it in `MESSENGER_EXPOSED_METHODS` and introducing the corresponding `TransactionControllerWipeTransactionsAction` in the generated method action types.
> 
> Updates the package public API exports and documents the new exposed action in the `transaction-controller` changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dbc86f54106cce1959f4b2b485dadd10a57b513. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->