### PR TITLE
fix(ramps-controller): replace circuit breaker error with retry copy

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2030,11 +2030,6 @@
       "count": 1
     }
   },
-  "packages/ramps-controller/src/RampsController.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "packages/ramps-controller/src/TransakService.test.ts": {
     "no-restricted-syntax": {
       "count": 4

--- a/packages/ramps-controller/CHANGELOG.md
+++ b/packages/ramps-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Normalize circuit-breaker errors in `RampsController` to a user-facing retry message so consumers do not surface the internal Cockatiel error text to users.
+
 ## [13.2.0]
 
 ### Changed

--- a/packages/ramps-controller/src/RampsController.test.ts
+++ b/packages/ramps-controller/src/RampsController.test.ts
@@ -61,6 +61,9 @@ import type {
 } from './TransakService';
 
 describe('RampsController', () => {
+  const circuitBreakerOpenUserMessage =
+    "We're having trouble connecting right now. Please try again in a few minutes.";
+
   describe('normalizeProviderCode', () => {
     it('strips /providers/ prefix', () => {
       expect(normalizeProviderCode('/providers/transak')).toBe('transak');
@@ -1072,6 +1075,53 @@ describe('RampsController', () => {
         const requestState = controller.state.requests['error-key'];
         expect(requestState?.status).toBe(RequestStatus.ERROR);
         expect(requestState?.error).toBe('Test error');
+      });
+    });
+
+    it('maps circuit breaker errors to a user-facing message', async () => {
+      await withController(async ({ controller, rootMessenger }) => {
+        const error = new Error(
+          'Execution prevented because the circuit breaker is open',
+        );
+        const fetcher = async (): Promise<string> => {
+          throw error;
+        };
+
+        await expect(
+          rootMessenger.call(
+            'RampsController:executeRequest',
+            'error-key-circuit-breaker',
+            fetcher,
+          ),
+        ).rejects.toThrow(circuitBreakerOpenUserMessage);
+
+        const requestState =
+          controller.state.requests['error-key-circuit-breaker'];
+        expect(requestState?.status).toBe(RequestStatus.ERROR);
+        expect(requestState?.error).toBe(circuitBreakerOpenUserMessage);
+        expect(error.message).toBe(circuitBreakerOpenUserMessage);
+      });
+    });
+
+    it('wraps string circuit breaker errors with a user-facing message', async () => {
+      await withController(async ({ controller, rootMessenger }) => {
+        const fetcher = async (): Promise<string> => {
+          // eslint-disable-next-line @typescript-eslint/only-throw-error
+          throw 'Execution prevented because the circuit breaker is open';
+        };
+
+        await expect(
+          rootMessenger.call(
+            'RampsController:executeRequest',
+            'error-key-circuit-breaker-string',
+            fetcher,
+          ),
+        ).rejects.toThrow(circuitBreakerOpenUserMessage);
+
+        const requestState =
+          controller.state.requests['error-key-circuit-breaker-string'];
+        expect(requestState?.status).toBe(RequestStatus.ERROR);
+        expect(requestState?.error).toBe(circuitBreakerOpenUserMessage);
       });
     });
 
@@ -7310,6 +7360,34 @@ describe('RampsController', () => {
           expect(controller.state.nativeProviders.transak.buyQuote.error).toBe(
             'Quote failed',
           );
+        });
+      });
+
+      it('maps circuit breaker errors to a user-facing message', async () => {
+        await withController(async ({ controller, rootMessenger }) => {
+          const error = new Error(
+            'Execution prevented because the circuit breaker is open',
+          );
+          rootMessenger.registerActionHandler(
+            'TransakService:getBuyQuote',
+            async () => {
+              throw error;
+            },
+          );
+          await expect(
+            rootMessenger.call(
+              'RampsController:transakGetBuyQuote',
+              'USD',
+              'BTC',
+              'bitcoin',
+              'credit_debit_card',
+              '100',
+            ),
+          ).rejects.toThrow(circuitBreakerOpenUserMessage);
+          expect(controller.state.nativeProviders.transak.buyQuote.error).toBe(
+            circuitBreakerOpenUserMessage,
+          );
+          expect(error.message).toBe(circuitBreakerOpenUserMessage);
         });
       });
 

--- a/packages/ramps-controller/src/RampsController.ts
+++ b/packages/ramps-controller/src/RampsController.ts
@@ -156,6 +156,67 @@ export const RAMPS_CONTROLLER_REQUIRED_SERVICE_ACTIONS: readonly (
  */
 const DEFAULT_QUOTES_TTL = 15000;
 
+const CIRCUIT_BREAKER_OPEN_ERROR =
+  'Execution prevented because the circuit breaker is open';
+
+const CIRCUIT_BREAKER_OPEN_USER_MESSAGE =
+  "We're having trouble connecting right now. Please try again in a few minutes.";
+
+type ErrorWithMessage = {
+  message: string;
+};
+
+type ErrorWithHttpStatus = Error & {
+  httpStatus: number;
+};
+
+function hasStringMessage(error: unknown): error is ErrorWithMessage {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    typeof (error as { message?: unknown }).message === 'string'
+  );
+}
+
+function hasHttpStatus(error: unknown): error is ErrorWithHttpStatus {
+  return (
+    error instanceof Error &&
+    typeof (error as { httpStatus?: unknown }).httpStatus === 'number'
+  );
+}
+
+function getRampsErrorMessage(error: unknown): string {
+  let rawMessage: string | undefined;
+
+  if (hasStringMessage(error)) {
+    rawMessage = error.message;
+  } else if (typeof error === 'string') {
+    rawMessage = error;
+  }
+
+  if (rawMessage?.includes(CIRCUIT_BREAKER_OPEN_ERROR)) {
+    return CIRCUIT_BREAKER_OPEN_USER_MESSAGE;
+  }
+
+  return rawMessage ?? 'Unknown error';
+}
+
+function normalizeRampsErrorForRethrow(error: unknown): unknown {
+  if (hasStringMessage(error)) {
+    if (error.message.includes(CIRCUIT_BREAKER_OPEN_ERROR)) {
+      error.message = CIRCUIT_BREAKER_OPEN_USER_MESSAGE;
+    }
+
+    return error;
+  }
+
+  if (typeof error === 'string' && error.includes(CIRCUIT_BREAKER_OPEN_ERROR)) {
+    return new Error(CIRCUIT_BREAKER_OPEN_USER_MESSAGE);
+  }
+
+  return error;
+}
+
 // === STATE ===
 
 /**
@@ -902,7 +963,8 @@ export class RampsController extends BaseController<
           throw error;
         }
 
-        const errorMessage = (error as Error)?.message ?? 'Unknown error';
+        const errorMessage = getRampsErrorMessage(error);
+        const normalizedError = normalizeRampsErrorForRethrow(error);
         this.#updateRequestState(
           cacheKey,
           createErrorState(errorMessage, lastFetchedAt),
@@ -914,7 +976,7 @@ export class RampsController extends BaseController<
             this.#setResourceError(resourceType, errorMessage);
           }
         }
-        throw error;
+        throw normalizedError;
       } finally {
         if (
           this.#pendingRequests.get(cacheKey)?.abortController ===
@@ -2052,11 +2114,7 @@ export class RampsController extends BaseController<
    * @param error - The caught error to inspect.
    */
   #syncTransakAuthOnError(error: unknown): void {
-    if (
-      error instanceof Error &&
-      'httpStatus' in error &&
-      (error as Error & { httpStatus: number }).httpStatus === 401
-    ) {
+    if (hasHttpStatus(error) && error.httpStatus === 401) {
       this.transakSetAuthenticated(false);
     }
   }
@@ -2189,12 +2247,13 @@ export class RampsController extends BaseController<
       return details;
     } catch (error) {
       this.#syncTransakAuthOnError(error);
-      const errorMessage = (error as Error)?.message ?? 'Unknown error';
+      const errorMessage = getRampsErrorMessage(error);
+      const normalizedError = normalizeRampsErrorForRethrow(error);
       this.update((state) => {
         state.nativeProviders.transak.userDetails.isLoading = false;
         state.nativeProviders.transak.userDetails.error = errorMessage;
       });
-      throw error;
+      throw normalizedError;
     }
   }
 
@@ -2235,12 +2294,13 @@ export class RampsController extends BaseController<
       });
       return quote;
     } catch (error) {
-      const errorMessage = (error as Error)?.message ?? 'Unknown error';
+      const errorMessage = getRampsErrorMessage(error);
+      const normalizedError = normalizeRampsErrorForRethrow(error);
       this.update((state) => {
         state.nativeProviders.transak.buyQuote.isLoading = false;
         state.nativeProviders.transak.buyQuote.error = errorMessage;
       });
-      throw error;
+      throw normalizedError;
     }
   }
 
@@ -2270,12 +2330,13 @@ export class RampsController extends BaseController<
       return requirement;
     } catch (error) {
       this.#syncTransakAuthOnError(error);
-      const errorMessage = (error as Error)?.message ?? 'Unknown error';
+      const errorMessage = getRampsErrorMessage(error);
+      const normalizedError = normalizeRampsErrorForRethrow(error);
       this.update((state) => {
         state.nativeProviders.transak.kycRequirement.isLoading = false;
         state.nativeProviders.transak.kycRequirement.error = errorMessage;
       });
-      throw error;
+      throw normalizedError;
     }
   }
 


### PR DESCRIPTION
## Explanation

When repeated upstream failures trip the service-policy circuit breaker, `RampsController` currently stores and rethrows the internal Cockatiel message `Execution prevented because the circuit breaker is open`.

That message bubbles up to consumers like Mobile, where ramp error helpers treat it as a normal non-HTTP string and show the raw internal text to users.

This PR normalizes that specific circuit-breaker error in `RampsController` to a user-facing retry message before it is both:

- stored in controller state, and
- rethrown to consumers

It covers the shared `executeRequest` path used by ramp quote/resource calls and the native Transak quote path, adds regression tests for both error surfaces, removes the now-obsolete ESLint suppression in `RampsController.ts`, and updates the `@metamask/ramps-controller` changelog.

## References

- [TRAM-3475](https://consensyssoftware.atlassian.net/browse/TRAM-3475)

## Testing

- `yarn workspace @metamask/ramps-controller test`
- `yarn lint`
- `yarn build:types` (fails in this checkout due unrelated existing monorepo/type-build issues, including `TS6305` referenced-package artifact errors after the repo clean step and pre-existing unchanged `TransakService.ts` type errors on lines 797 and 906)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

[TRAM-3475]: https://consensyssoftware.atlassian.net/browse/TRAM-3475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ