### PR TITLE
fix(eth-json-rpc-middleware): detect EIP-1474 / Infura-style revert errors

### DIFF
--- a/packages/eth-json-rpc-middleware/CHANGELOG.md
+++ b/packages/eth-json-rpc-middleware/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `RetryOnEmptyMiddleware` now correctly propagates execution-revert errors from EIP-1474 / Infura-style providers
+  - `isExecutionRevertedError` previously required `code: -32000` and an exact `"execution reverted"` message, which never matches the response shape returned by Infura, Alchemy, QuickNode, and other production providers (`code: 3`, `message: "execution reverted: <reason>"`)
+  - The check now also accepts `code: 3` (per EIP-1474) and a message that starts with `"execution reverted"`, preserving backward compatibility with geth-style responses
+  - Without this fix, every reverted `eth_call` with a numeric block tag was being retried 10 times (~10s of latency) and the original revert payload was discarded behind a generic `"retries exhausted"` error
+
 ## [23.1.2]
 
 ### Changed

--- a/packages/eth-json-rpc-middleware/src/utils/error.test.ts
+++ b/packages/eth-json-rpc-middleware/src/utils/error.test.ts
@@ -2,35 +2,60 @@ import { errorCodes } from '@metamask/rpc-errors';
 
 import { isExecutionRevertedError } from './error';
 
-const executionRevertedError = {
+const gethStyleRevert = {
   code: errorCodes.rpc.invalidInput,
   message: 'execution reverted',
 };
 
+const infuraStyleRevert = {
+  code: 3,
+  message: 'execution reverted: ERC20: transfer amount exceeds balance',
+  data: '0x08c379a0',
+};
+
 describe('isExecutionRevertedError', () => {
-  it('return false if object is not valid JSON RPC error', async () => {
-    const result = isExecutionRevertedError({ test: 'dummy' });
-    expect(result).toBe(false);
+  it('returns false if the value is not a valid JSON-RPC error', () => {
+    expect(isExecutionRevertedError({ test: 'dummy' })).toBe(false);
   });
 
-  it('return false if error code is not same as errorCodes.rpc.invalidInput', async () => {
-    const result = isExecutionRevertedError({
-      ...executionRevertedError,
-      code: 123,
-    });
-    expect(result).toBe(false);
+  it('returns false if the error code is unrelated to reverts', () => {
+    expect(isExecutionRevertedError({ ...gethStyleRevert, code: 123 })).toBe(
+      false,
+    );
   });
 
-  it('return false if error message is not "execution reverted"', async () => {
-    const result = isExecutionRevertedError({
-      ...executionRevertedError,
-      message: 'test',
-    });
-    expect(result).toBe(false);
+  it('returns false if the error message does not start with "execution reverted"', () => {
+    expect(
+      isExecutionRevertedError({ ...gethStyleRevert, message: 'test' }),
+    ).toBe(false);
   });
 
-  it('return true for correct executionRevertedError', async () => {
-    const result = isExecutionRevertedError(executionRevertedError);
-    expect(result).toBe(true);
+  it('returns true for geth-style reverts (code -32000, exact message)', () => {
+    expect(isExecutionRevertedError(gethStyleRevert)).toBe(true);
+  });
+
+  it('returns true for EIP-1474 / Infura-style reverts (code 3, suffixed message)', () => {
+    expect(isExecutionRevertedError(infuraStyleRevert)).toBe(true);
+  });
+
+  it('returns true for code 3 with the bare "execution reverted" message', () => {
+    expect(
+      isExecutionRevertedError({ code: 3, message: 'execution reverted' }),
+    ).toBe(true);
+  });
+
+  it('returns true for geth-style reverts with a suffixed message', () => {
+    expect(
+      isExecutionRevertedError({
+        code: errorCodes.rpc.invalidInput,
+        message: 'execution reverted: custom reason',
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false when the message is not a string', () => {
+    expect(isExecutionRevertedError({ ...gethStyleRevert, message: 123 })).toBe(
+      false,
+    );
   });
 });

--- a/packages/eth-json-rpc-middleware/src/utils/error.ts
+++ b/packages/eth-json-rpc-middleware/src/utils/error.ts
@@ -2,19 +2,48 @@ import { errorCodes } from '@metamask/rpc-errors';
 import { isJsonRpcError } from '@metamask/utils';
 import type { JsonRpcError } from '@metamask/utils';
 
+const EXECUTION_REVERTED_PREFIX = 'execution reverted';
+
 /**
- * Checks if a value is a JSON-RPC error that indicates an execution reverted error.
+ * EIP-1474 JSON-RPC error code for execution reverts. Returned by Infura
+ * and most production providers, alongside a message that may carry the
+ * decoded reason (e.g. `"execution reverted: ERC20: transfer amount
+ * exceeds balance"`).
+ *
+ * @see https://eips.ethereum.org/EIPS/eip-1474
+ */
+const EXECUTION_REVERTED_ERROR_CODE = 3;
+
+/**
+ * Determine whether a JSON-RPC error represents a contract execution revert.
+ *
+ * Accepts both:
+ * - Geth-style: `code: -32000`, `message: "execution reverted"`
+ * - EIP-1474 / Infura-style: `code: 3`, `message: "execution reverted: <reason>"`
+ *
+ * Public Infura RPCs and most production providers return the EIP-1474
+ * form, so the previous strict check (`code === -32000` and exact
+ * `"execution reverted"`) never matched real-world reverted responses,
+ * causing them to be retried by `RetryOnEmptyMiddleware` and the original
+ * error data to be discarded.
  *
  * @param error - The value to check.
- * @returns True if the value is a JSON-RPC error that indicates an execution reverted
- * error, false otherwise.
+ * @returns `true` if the error represents an execution revert.
  */
 export function isExecutionRevertedError(
   error: unknown,
 ): error is JsonRpcError {
+  if (!isJsonRpcError(error)) {
+    return false;
+  }
+
+  const isExpectedCode =
+    error.code === errorCodes.rpc.invalidInput ||
+    error.code === EXECUTION_REVERTED_ERROR_CODE;
+
   return (
-    isJsonRpcError(error) &&
-    error.code === errorCodes.rpc.invalidInput &&
-    error.message === 'execution reverted'
+    isExpectedCode &&
+    typeof error.message === 'string' &&
+    error.message.startsWith(EXECUTION_REVERTED_PREFIX)
   );
 }


### PR DESCRIPTION
## Explanation

\`isExecutionRevertedError\` (introduced in [#254](https://github.com/MetaMask/eth-json-rpc-middleware/pull/254), Oct 2023) is too strict to match the response shape that Infura, Alchemy, QuickNode, and most production providers actually return:

\`\`\`ts
return isJsonRpcError(error) &&
  error.code === errorCodes.rpc.invalidInput &&  // -32000
  error.message === 'execution reverted';         // exact match
\`\`\`

The real-world EIP-1474 response is:

\`\`\`json
{
  "code": 3,
  "message": "execution reverted: ERC20: transfer amount exceeds balance",
  "data": "0x08c379a0..."
}
\`\`\`

Neither \`code === -32000\` nor \`message === 'execution reverted'\` matches, so the function returns \`false\` for the most common case it's supposed to detect.

### Verification

I tested the same reverted USDC \`transfer\` call against Infura's RPC for 6 chains. **All return identical EIP-1474 shape**:

| Chain | code | message |
|---|---|---|
| Ethereum mainnet | 3 | \`execution reverted: ERC20: transfer amount exceeds balance\` |
| Arbitrum One | 3 | (same) |
| Optimism | 3 | (same) |
| Polygon | 3 | (same) |
| Base | 3 | (same) |
| Linea | 3 | (same) |

### Impact

Limited in practice. \`RetryOnEmptyMiddleware\` only intercepts methods with a block-ref param (\`eth_call\`, \`eth_getBalance\`, \`eth_getCode\`, \`eth_getTransactionCount\`, \`eth_getStorageAt\`, \`eth_getBlockByNumber\`), and only when the block ref is a numeric value — \`'latest'\` and \`'pending'\` are skipped. Most consumer \`eth_call\`s in the monorepo use \`'latest'\`, so the bug doesn't fire.

The cases where it does fire:

1. **Historical \`eth_call\` against a contract that reverts** — gets retried 10× (~10s latency) and the original \`error.data\` is discarded behind a generic \`'retries exhausted'\` error
2. New consumers that want a numeric block tag and expect to receive the revert error (e.g. transaction-controller revert-reason extraction in #8589, which switched to \`eth_estimateGas\` to work around this)

### Fix

\`\`\`ts
const EXECUTION_REVERTED_ERROR_CODE = 3;  // EIP-1474

const isExpectedCode =
  error.code === errorCodes.rpc.invalidInput ||
  error.code === EXECUTION_REVERTED_ERROR_CODE;

return isExpectedCode &&
  typeof error.message === 'string' &&
  error.message.startsWith('execution reverted');
\`\`\`

The new check is a strict superset of the old one — geth-style responses (\`code: -32000\`, exact message) still match.

## References

- Original PR that introduced the strict check: [eth-json-rpc-middleware#254](https://github.com/MetaMask/eth-json-rpc-middleware/pull/254)
- Discovered while implementing transaction-controller revert-reason extraction: #8589

## Changelog

\`\`\`
### Fixed

- \`RetryOnEmptyMiddleware\` now correctly propagates execution-revert errors from EIP-1474 / Infura-style providers
  - \`isExecutionRevertedError\` previously required \`code: -32000\` and an exact \`\"execution reverted\"\` message, which never matches the response shape returned by Infura, Alchemy, QuickNode, and other production providers (\`code: 3\`, \`message: \"execution reverted: <reason>\"\`)
  - The check now also accepts \`code: 3\` (per EIP-1474) and a message that starts with \`\"execution reverted\"\`, preserving backward compatibility with geth-style responses
\`\`\`

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the \`**BREAKING**\` category above as appropriate — *no breaking changes; the new check is a strict superset of the old one*
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes — *no breaking changes*