### PR TITLE
feat(assets-controllers): detect mUSD with zero balance on all paths

### DIFF
--- a/packages/assets-controller/src/AssetsController.ts
+++ b/packages/assets-controller/src/AssetsController.ts
@@ -80,6 +80,7 @@ import { SnapDataSource } from './data-sources/SnapDataSource';
 import type { StakedBalanceDataSourceConfig } from './data-sources/StakedBalanceDataSource';
 import { StakedBalanceDataSource } from './data-sources/StakedBalanceDataSource';
 import { TokenDataSource } from './data-sources/TokenDataSource';
+import { CHAINS_WITH_DEFAULT_TRACKED_ASSETS } from './defaults';
 import { AssetsDataSourceError } from './errors';
 import { projectLogger, createModuleLogger } from './logger';
 import { CustomAssetGraduationMiddleware } from './middlewares/CustomAssetGraduationMiddleware';
@@ -2515,33 +2516,50 @@ export class AssetsController extends BaseController<
     const rpc = this.#rpcDataSource;
     const rpcAvailableChains = new Set(rpc.getActiveChainsSync());
 
-    // Collect chains that have customAssets for at least one of the given
-    // accounts and are NOT already covered by the regular RPC subscription.
+    // Collect chains that need a supplemental RPC subscription:
+    //   1. Chains where this account has user-added customAssets
+    //   2. Chains with controller-managed default tracked assets (e.g.
+    //      mUSD on mainnet/Linea/Monad) — RPC must always poll these
+    //      so the default token shows up even when WS/AccountsApi own
+    //      the chain in the regular handoff and the on-chain balance
+    //      is still zero.
     const supplementalChainSet = new Set<ChainId>();
     const accountsWithCustomAssets = new Set<string>();
-    for (const account of accounts) {
-      const customForAccount = this.state.customAssets[account.id] ?? [];
-      if (customForAccount.length === 0) {
-        continue;
+    const considerChain = (chainId: ChainId): boolean => {
+      if (rpcAssignedChains.has(chainId)) {
+        return false;
       }
-      accountsWithCustomAssets.add(account.id);
-      for (const assetId of customForAccount) {
-        let chainId: ChainId;
-        try {
-          chainId = extractChainId(assetId);
-        } catch {
-          continue;
+      if (!rpcAvailableChains.has(chainId)) {
+        return false;
+      }
+      if (!chainToAccounts.has(chainId)) {
+        return false;
+      }
+      supplementalChainSet.add(chainId);
+      return true;
+    };
+    for (const account of accounts) {
+      // (1) User-added customAssets — only when present.
+      const customForAccount = this.state.customAssets[account.id] ?? [];
+      if (customForAccount.length > 0) {
+        accountsWithCustomAssets.add(account.id);
+        for (const assetId of customForAccount) {
+          let chainId: ChainId;
+          try {
+            chainId = extractChainId(assetId);
+          } catch {
+            continue;
+          }
+          considerChain(chainId);
         }
-        if (rpcAssignedChains.has(chainId)) {
-          continue;
+      }
+
+      // (2) Default tracked assets — always poll the chain for every
+      //     account, regardless of whether the user has added anything.
+      for (const chainId of CHAINS_WITH_DEFAULT_TRACKED_ASSETS) {
+        if (considerChain(chainId)) {
+          accountsWithCustomAssets.add(account.id);
         }
-        if (!rpcAvailableChains.has(chainId)) {
-          continue;
-        }
-        if (!chainToAccounts.has(chainId)) {
-          continue;
-        }
-        supplementalChainSet.add(chainId);
       }
     }
 

--- a/packages/assets-controller/src/data-sources/RpcDataSource.ts
+++ b/packages/assets-controller/src/data-sources/RpcDataSource.ts
@@ -26,6 +26,7 @@ import type {
   AssetsControllerGetStateAction,
   AssetsControllerMessenger,
 } from '../AssetsController';
+import { getDefaultTrackedAssetsForChain } from '../defaults';
 import { projectLogger, createModuleLogger } from '../logger';
 import type {
   ChainId,
@@ -288,6 +289,15 @@ export class RpcDataSource extends AbstractDataSource<
           const { chainId } = parseCaipAssetType(assetId);
           const nativeId = this.#getNativeAssetForChain(chainId);
           return nativeId?.toLowerCase() === assetId.toLowerCase();
+        },
+        // BalanceFetcher polls by hex chain id. Convert to CAIP-2 to
+        // look up controller-managed default tracked assets (e.g. mUSD
+        // on mainnet/Linea/Monad). These are polled for every account
+        // even when the on-chain balance is zero.
+        getDefaultTrackedAssetsForChain: (hexChainId): Caip19AssetId[] => {
+          const decimal = parseInt(hexChainId, 16).toString();
+          const caipChainId = `eip155:${decimal}` as ChainId;
+          return [...getDefaultTrackedAssetsForChain(caipChainId)];
         },
       },
     );

--- a/packages/assets-controller/src/data-sources/evm-rpc-services/services/BalanceFetcher.ts
+++ b/packages/assets-controller/src/data-sources/evm-rpc-services/services/BalanceFetcher.ts
@@ -33,6 +33,13 @@ export type BalanceFetcherConfig = {
   pollingInterval?: number;
   /** Determines whether a CAIP-19 asset ID represents a native asset. */
   isNativeAsset: (assetId: CaipAssetType) => boolean;
+  /**
+   * Returns the controller-managed default tracked assets for the given
+   * hex chain id. These are tokens we always poll for an account on
+   * the chain — even when the on-chain balance is zero — so they
+   * always appear in the UI. Optional; defaults to "no extras".
+   */
+  getDefaultTrackedAssetsForChain?: (chainId: ChainId) => CaipAssetType[];
 };
 
 /**
@@ -81,6 +88,10 @@ export class BalanceFetcher extends StaticIntervalPollingControllerOnly<BalanceP
 
   readonly #isNativeAsset: (assetId: CaipAssetType) => boolean;
 
+  readonly #getDefaultTrackedAssetsForChain: (
+    chainId: ChainId,
+  ) => CaipAssetType[];
+
   #onBalanceUpdate: OnBalanceUpdateCallback | undefined;
 
   constructor(
@@ -96,6 +107,8 @@ export class BalanceFetcher extends StaticIntervalPollingControllerOnly<BalanceP
       defaultTimeoutMs: config.defaultTimeoutMs ?? 30000,
     };
     this.#isNativeAsset = config.isNativeAsset;
+    this.#getDefaultTrackedAssetsForChain =
+      config.getDefaultTrackedAssetsForChain ?? ((): CaipAssetType[] => []);
 
     // Set the polling interval
     this.setIntervalLength(config?.pollingInterval ?? DEFAULT_BALANCE_INTERVAL);
@@ -130,13 +143,16 @@ export class BalanceFetcher extends StaticIntervalPollingControllerOnly<BalanceP
   }
 
   /**
-   * Return asset fetch entries tracked in state for the given account and
-   * chain. Both native (`slip44:`) and ERC-20 (`erc20:`) entries are included.
+   * Return asset fetch entries for the given account and chain. Combines
+   * three sources: assets tracked in state (`assetsBalance`), user-added
+   * custom assets (`customAssets`), and controller-managed default
+   * tracked assets (e.g. mUSD on certain chains). Native (`slip44:`),
+   * ERC-20 (`erc20:`), and other namespaces are all eligible.
    *
    * @param chainId - Hex chain ID (e.g. "0x1").
    * @param accountId - Account UUID.
-   * @param customAssetsOnly - When true, skip `assetsBalance` and only include `customAssets`.
-   * @returns Array of asset fetch entries from state for the requested chain.
+   * @param customAssetsOnly - When true, skip `assetsBalance` and only include `customAssets` and the default tracked assets.
+   * @returns Array of asset fetch entries for the requested chain.
    */
   #getAssetsToFetch(
     chainId: ChainId,
@@ -195,6 +211,15 @@ export class BalanceFetcher extends StaticIntervalPollingControllerOnly<BalanceP
       for (const assetId of customAssets as CaipAssetType[]) {
         collect(assetId);
       }
+    }
+
+    // 3. Controller-managed default tracked assets (e.g. mUSD on
+    //    Ethereum mainnet, Linea, Monad). Always polled for the chain
+    //    so the user sees the token in the UI even when the balance
+    //    is still zero. Behaves like a customAsset for fetching but
+    //    is not stored in state.
+    for (const assetId of this.#getDefaultTrackedAssetsForChain(chainId)) {
+      collect(assetId);
     }
 
     return Array.from(assetsToFetch.values());

--- a/packages/assets-controller/src/defaults.ts
+++ b/packages/assets-controller/src/defaults.ts
@@ -1,0 +1,67 @@
+import type { Caip19AssetId, ChainId } from './types';
+
+/**
+ * Address of MetaMask USD (mUSD) — same canonical contract address
+ * across every chain we deploy it to.
+ */
+const MUSD_ADDRESS = '0xaca92e438df0b2401ff60da7e4337b687a2435da';
+
+/**
+ * Build the CAIP-19 asset ID for the mUSD ERC-20 token on a given EVM
+ * chain.
+ *
+ * @param chainId - The CAIP-2 chain identifier (e.g. `eip155:1`).
+ * @returns The CAIP-19 asset ID for mUSD on that chain.
+ */
+function musdAssetId(chainId: ChainId): Caip19AssetId {
+  return `${chainId}/erc20:${MUSD_ADDRESS}` as Caip19AssetId;
+}
+
+/**
+ * Tokens this controller always tracks for an account on the listed
+ * chain — even when the on-chain balance is zero. Used to surface
+ * MetaMask-promoted tokens in the UI before any inbound transfer
+ * has happened.
+ *
+ * Keyed by CAIP-2 chain id so we can quickly answer "what defaults
+ * apply on chain X?" from the balance fetcher and the supplemental
+ * RPC subscription logic.
+ *
+ * To add a new default token, append its CAIP-19 asset id to the
+ * appropriate chain entry. To extend mUSD to a new chain, add a new
+ * entry pointing at `musdAssetId('eip155:<id>')`.
+ */
+export const DEFAULT_TRACKED_ASSETS_BY_CHAIN: ReadonlyMap<
+  ChainId,
+  readonly Caip19AssetId[]
+> = new Map<ChainId, readonly Caip19AssetId[]>([
+  // Ethereum mainnet
+  ['eip155:1' as ChainId, [musdAssetId('eip155:1' as ChainId)]],
+  // Linea
+  ['eip155:59144' as ChainId, [musdAssetId('eip155:59144' as ChainId)]],
+  // Monad
+  ['eip155:10143' as ChainId, [musdAssetId('eip155:10143' as ChainId)]],
+]);
+
+/**
+ * Return the default tracked assets for the given CAIP-2 chain id.
+ * Empty array when the chain has no defaults.
+ *
+ * @param chainId - CAIP-2 chain id to look up.
+ * @returns The default asset ids for that chain.
+ */
+export function getDefaultTrackedAssetsForChain(
+  chainId: ChainId,
+): readonly Caip19AssetId[] {
+  return DEFAULT_TRACKED_ASSETS_BY_CHAIN.get(chainId) ?? [];
+}
+
+/**
+ * Chains that have at least one default tracked asset. Useful for the
+ * supplemental-subscription logic that needs to know which chains RPC
+ * must poll even when another data source owns the chain in the
+ * regular handoff.
+ */
+export const CHAINS_WITH_DEFAULT_TRACKED_ASSETS: ReadonlySet<ChainId> = new Set(
+  DEFAULT_TRACKED_ASSETS_BY_CHAIN.keys(),
+);

--- a/packages/assets-controller/src/index.ts
+++ b/packages/assets-controller/src/index.ts
@@ -4,6 +4,11 @@ export {
   getDefaultAssetsControllerState,
 } from './AssetsController';
 export { AssetsDataSourceError } from './errors';
+export {
+  DEFAULT_TRACKED_ASSETS_BY_CHAIN,
+  CHAINS_WITH_DEFAULT_TRACKED_ASSETS,
+  getDefaultTrackedAssetsForChain,
+} from './defaults';
 export type { PendingTokenMetadata } from './AssetsController';
 
 // State and messenger types

--- a/packages/assets-controllers/src/TokenBalancesController.ts
+++ b/packages/assets-controllers/src/TokenBalancesController.ts
@@ -11,6 +11,7 @@ import type {
 } from '@metamask/base-controller';
 import {
   BNToHex,
+  isEqualCaseInsensitive,
   isValidHexAddress,
   safelyExecuteWithTimeout,
   toChecksumHexAddress,
@@ -80,7 +81,10 @@ import type {
   TokensControllerState,
   TokensControllerStateChangeEvent,
 } from './TokensController';
+import { MUSD_ERC20_ADDRESS_LOWER, MUSD_TOKEN_DETECTION_CHAIN_IDS } from './constants';
 import { createBatchedHandler } from './utils/create-batch-handler';
+
+const MUSD_IMPORT_CHAIN_ID_SET = new Set<Hex>(MUSD_TOKEN_DETECTION_CHAIN_IDS);
 
 export type ChainIdHex = Hex;
 export type ChecksumAddress = Hex;
@@ -821,7 +825,7 @@ export class TokenBalancesController extends StaticIntervalPollingController<{
       }
     }
 
-    await this.#importUntrackedTokens(filteredAggregated);
+    await this.#importUntrackedTokens(filteredAggregated, targetChains);
   }
 
   #getTargetChains(chainIds?: ChainIdHex[]): ChainIdHex[] {
@@ -1156,14 +1160,20 @@ export class TokenBalancesController extends StaticIntervalPollingController<{
   /**
    * Import untracked tokens that have non-zero balances.
    * This mirrors the v2 behavior where only tokens with actual balances are added.
+   * For mUSD default networks, the mUSD contract is also scheduled for import when
+   * balance is zero (Accounts API omits it like the single-call contract).
    * Delegates to TokenDetectionController:addDetectedTokensViaPolling which handles:
    * - Checking if useTokenDetection preference is enabled
    * - Filtering tokens already in allTokens or allIgnoredTokens
    * - Token metadata lookup and addition via TokensController
    *
    * @param balances - Array of processed balance results from fetchers
+   * @param targetChainIds - Chains included in this balance update (for mUSD zero-balance import)
    */
-  async #importUntrackedTokens(balances: ProcessedBalance[]): Promise<void> {
+  async #importUntrackedTokens(
+    balances: ProcessedBalance[],
+    targetChainIds: ChainIdHex[],
+  ): Promise<void> {
     const tokensByChain = new Map<ChainIdHex, string[]>();
 
     for (const balance of balances) {
@@ -1183,6 +1193,22 @@ export class TokenBalancesController extends StaticIntervalPollingController<{
         existing.push(tokenAddress);
         tokensByChain.set(balance.chainId, existing);
       }
+    }
+
+    for (const chainId of targetChainIds) {
+      if (!MUSD_IMPORT_CHAIN_ID_SET.has(chainId)) {
+        continue;
+      }
+      const existing = tokensByChain.get(chainId) ?? [];
+      if (
+        existing.some((addr) =>
+          isEqualCaseInsensitive(addr, MUSD_ERC20_ADDRESS_LOWER),
+        )
+      ) {
+        continue;
+      }
+      const next = [...existing, MUSD_ERC20_ADDRESS_LOWER];
+      tokensByChain.set(chainId, next);
     }
 
     // Add detected tokens via TokenDetectionController (handles preference check,

--- a/packages/assets-controllers/src/TokenDetectionController.test.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.test.ts
@@ -3,6 +3,7 @@ import {
   NetworkType,
   convertHexToDecimal,
   InfuraNetworkType,
+  toChecksumHexAddress,
 } from '@metamask/controller-utils';
 import type { KeyringControllerState } from '@metamask/keyring-controller';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
@@ -37,6 +38,7 @@ import {
   buildInfuraNetworkConfiguration,
 } from '../../network-controller/tests/helpers';
 import { formatAggregatorNames } from './assetsUtil';
+import { MUSD_ERC20_ADDRESS_LOWER } from './constants';
 import { TOKEN_END_POINT_API } from './token-service';
 import type { TokenDetectionControllerMessenger } from './TokenDetectionController';
 import {
@@ -3149,6 +3151,94 @@ describe('TokenDetectionController', () => {
         },
       );
     });
+
+    it('adds mUSD from the token list cache when RPC reports zero balance', async () => {
+      const mockGetBalancesInSingleCall = jest.fn().mockResolvedValue({});
+      const selectedAccount = createMockInternalAccount({
+        address: '0x0000000000000000000000000000000000000001',
+      });
+      await withController(
+        {
+          options: {
+            disabled: false,
+            getBalancesInSingleCall: mockGetBalancesInSingleCall,
+          },
+          mocks: {
+            getSelectedAccount: selectedAccount,
+            getAccount: selectedAccount,
+          },
+        },
+        async ({
+          controller,
+          mockNetworkState,
+          mockFindNetworkClientIdByChainId,
+          mockTokenListGetState,
+          triggerPreferencesStateChange,
+          callActionSpy,
+        }) => {
+          const defaultState = getDefaultNetworkControllerState();
+          mockNetworkState({
+            ...defaultState,
+            selectedNetworkClientId: 'mainnet',
+            networkConfigurationsByChainId: {
+              ...defaultState.networkConfigurationsByChainId,
+              '0x1': {
+                chainId: '0x1',
+                name: 'Ethereum Mainnet',
+                nativeCurrency: 'ETH',
+                blockExplorerUrls: [],
+                defaultBlockExplorerUrlIndex: 0,
+                defaultRpcEndpointIndex: 0,
+                rpcEndpoints: [
+                  {
+                    networkClientId: 'mainnet',
+                    type: RpcEndpointType.Custom,
+                    url: 'https://mainnet.infura.io/v3/test',
+                    failoverUrls: [],
+                  },
+                ],
+              },
+            },
+          });
+          mockFindNetworkClientIdByChainId(() => 'mainnet');
+
+          mockTokenListGetState({
+            ...getDefaultTokenListState(),
+            tokensChainsCache: {
+              '0x1': {
+                timestamp: 0,
+                data: {},
+              },
+            },
+          });
+
+          triggerPreferencesStateChange({
+            ...getDefaultPreferencesState(),
+            useTokenDetection: true,
+          });
+
+          await controller.detectTokens({
+            chainIds: [ChainId.mainnet],
+            selectedAddress: selectedAccount.address,
+            forceRpc: true,
+          });
+
+          expect(mockGetBalancesInSingleCall).toHaveBeenCalled();
+          expect(callActionSpy).toHaveBeenCalledWith(
+            'TokensController:addTokens',
+            expect.arrayContaining([
+              expect.objectContaining({
+                address: MUSD_ERC20_ADDRESS_LOWER,
+                name: 'MetaMask USD',
+                symbol: 'MUSD',
+                decimals: 6,
+              }),
+            ]),
+            'mainnet',
+          );
+        },
+      );
+    });
   });
 
   describe('mapChainIdWithTokenListMap', () => {
@@ -3403,6 +3493,41 @@ describe('TokenDetectionController', () => {
               },
             ],
             'avalanche',
+          );
+        },
+      );
+    });
+
+    it('adds mUSD from merged token list when WebSocket provides no token addresses (zero balance)', async () => {
+      await withController(
+        {
+          options: { disabled: false },
+          mockTokenListState: {
+            tokensChainsCache: {
+              [ChainId.mainnet]: {
+                timestamp: 0,
+                data: {},
+              },
+            },
+          },
+        },
+        async ({ controller, callActionSpy, mockFindNetworkClientIdByChainId }) => {
+          mockFindNetworkClientIdByChainId(() => 'mainnet');
+          await controller.addDetectedTokensViaWs({
+            tokensSlice: [],
+            chainId: ChainId.mainnet,
+          });
+          expect(callActionSpy).toHaveBeenCalledWith(
+            'TokensController:addTokens',
+            expect.arrayContaining([
+              expect.objectContaining({
+                address: toChecksumHexAddress(MUSD_ERC20_ADDRESS_LOWER),
+                name: 'MetaMask USD',
+                symbol: 'MUSD',
+                decimals: 6,
+              }),
+            ]),
+            'mainnet',
           );
         },
       );
@@ -3694,6 +3819,41 @@ describe('TokenDetectionController', () => {
               },
             ],
             'avalanche',
+          );
+        },
+      );
+    });
+
+    it('adds mUSD from merged token list when polling has no other token addresses (zero balance)', async () => {
+      await withController(
+        {
+          options: { disabled: false, useTokenDetection: () => true },
+          mockTokenListState: {
+            tokensChainsCache: {
+              [ChainId.mainnet]: {
+                timestamp: 0,
+                data: {},
+              },
+            },
+          },
+        },
+        async ({ controller, callActionSpy, mockFindNetworkClientIdByChainId }) => {
+          mockFindNetworkClientIdByChainId(() => 'mainnet');
+          await controller.addDetectedTokensViaPolling({
+            tokensSlice: [],
+            chainId: ChainId.mainnet,
+          });
+          expect(callActionSpy).toHaveBeenCalledWith(
+            'TokensController:addTokens',
+            expect.arrayContaining([
+              expect.objectContaining({
+                address: toChecksumHexAddress(MUSD_ERC20_ADDRESS_LOWER),
+                name: 'MetaMask USD',
+                symbol: 'MUSD',
+                decimals: 6,
+              }),
+            ]),
+            'mainnet',
           );
         },
       );

--- a/packages/assets-controllers/src/TokenDetectionController.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.ts
@@ -42,13 +42,22 @@ import type { Hex } from '@metamask/utils';
 import { isEqual, mapValues, isObject, get } from 'lodash';
 
 import type { AssetsContractController } from './AssetsContractController';
-import { isTokenDetectionSupportedForNetwork } from './assetsUtil';
-import { SUPPORTED_NETWORKS_ACCOUNTS_API_V4 } from './constants';
+import {
+  formatIconUrlWithProxy,
+  isTokenDetectionSupportedForNetwork,
+} from './assetsUtil';
+import {
+  MUSD_ERC20_ADDRESS_LOWER,
+  MUSD_TOKEN_DETECTION_CHAIN_IDS,
+  MUSD_TOKEN_METADATA_BY_CHAIN,
+  SUPPORTED_NETWORKS_ACCOUNTS_API_V4,
+} from './constants';
 import type { TokenDetectionControllerMethodActions } from './TokenDetectionController-method-action-types';
 import type {
   GetTokenListState,
   TokenListMap,
   TokenListStateChange,
+  TokenListToken,
   TokensChainsCache,
 } from './TokenListController';
 import type { Token } from './TokenRatesController';
@@ -92,6 +101,10 @@ export const STATIC_MAINNET_TOKEN_LIST = Object.entries<LegacyToken>(
     },
   };
 }, {});
+
+const MUSD_TOKEN_DETECTION_CHAIN_ID_SET = new Set<Hex>(
+  MUSD_TOKEN_DETECTION_CHAIN_IDS,
+);
 
 /**
  * Function that takes a TokensChainsCache object and maps chainId with TokenListMap.
@@ -557,7 +570,10 @@ export class TokenDetectionController extends StaticIntervalPollingController<To
       const { tokensChainsCache } = this.messenger.call(
         'TokenListController:getState',
       );
-      this.#tokensChainsCache = tokensChainsCache ?? {};
+      this.#tokensChainsCache = this.#applyMusdDefaultToTokensChainsCache(
+        chainId,
+        tokensChainsCache ?? {},
+      );
     }
 
     return true;
@@ -704,12 +720,114 @@ export class TokenDetectionController extends StaticIntervalPollingController<To
       }),
       {},
     );
+    const dataWithMusd = this.#mergeMusdIntoTokenListMap(ChainId.mainnet, data);
     return {
       '0x1': {
-        data,
+        data: dataWithMusd,
         timestamp: 0,
       },
     };
+  }
+
+  /**
+   * mUSD token list row derived from Tokens API v3/assets (baked in for offline detection).
+   *
+   * @param chainId - Hex chain id (mainnet, Linea, or Monad).
+   * @returns Token list entry for the detection cache.
+   */
+  #buildMusdTokenListToken(chainId: Hex): TokenListToken {
+    const meta =
+      MUSD_TOKEN_METADATA_BY_CHAIN[
+        chainId as (typeof MUSD_TOKEN_DETECTION_CHAIN_IDS)[number]
+      ];
+    return {
+      address: MUSD_ERC20_ADDRESS_LOWER,
+      name: meta.name,
+      symbol: meta.symbol,
+      decimals: meta.decimals,
+      aggregators: [...meta.aggregators],
+      iconUrl: formatIconUrlWithProxy({
+        chainId,
+        tokenAddress: MUSD_ERC20_ADDRESS_LOWER,
+      }),
+      occurrences: 999,
+    };
+  }
+
+  /**
+   * Merge mUSD into a flat token map when the chain is one of the default mUSD networks.
+   *
+   * @param chainId - Network being detected.
+   * @param data - Existing token map for that chain.
+   * @returns New map including mUSD when applicable.
+   */
+  #mergeMusdIntoTokenListMap(chainId: Hex, data: TokenListMap): TokenListMap {
+    if (!MUSD_TOKEN_DETECTION_CHAIN_ID_SET.has(chainId)) {
+      return data;
+    }
+    return {
+      ...data,
+      [MUSD_ERC20_ADDRESS_LOWER]: this.#buildMusdTokenListToken(chainId),
+    };
+  }
+
+  /**
+   * Shallow-clone the token list cache for the current chain and merge mUSD so we never
+   * mutate `TokenListController` state by reference.
+   *
+   * @param chainId - Network being detected.
+   * @param cache - Full tokens-by-chain cache from `TokenListController`.
+   * @returns Cache object safe to read and mutate for this detection pass.
+   */
+  #applyMusdDefaultToTokensChainsCache(
+    chainId: Hex,
+    cache: TokensChainsCache,
+  ): TokensChainsCache {
+    if (!MUSD_TOKEN_DETECTION_CHAIN_ID_SET.has(chainId)) {
+      return cache;
+    }
+    const existing = cache[chainId];
+    return {
+      ...cache,
+      [chainId]: {
+        data: this.#mergeMusdIntoTokenListMap(chainId, existing?.data ?? {}),
+        timestamp: existing?.timestamp ?? 0,
+      },
+    };
+  }
+
+  /**
+   * If mUSD is in the (possibly merged) token list for this chain, include its address
+   * in the slice so we still run detection when balance is zero (single-call / Accounts API
+   * / WebSocket do not list the contract when balance is zero).
+   *
+   * @param tokensSlice - Address batch from the caller.
+   * @param chainId - Network being updated.
+   * @returns The slice, possibly with mUSD appended.
+   */
+  #includeMusdInTokenDetectionSlice(
+    tokensSlice: string[],
+    chainId: Hex,
+  ): string[] {
+    if (!MUSD_TOKEN_DETECTION_CHAIN_ID_SET.has(chainId)) {
+      return tokensSlice;
+    }
+    if (
+      tokensSlice.some((a) => isEqualCaseInsensitive(a, MUSD_ERC20_ADDRESS_LOWER))
+    ) {
+      return tokensSlice;
+    }
+    const listData = this.#tokensChainsCache[chainId]?.data;
+    if (!listData) {
+      return tokensSlice;
+    }
+    const hasMusd = Object.keys(listData).some((k) =>
+      isEqualCaseInsensitive(k, MUSD_ERC20_ADDRESS_LOWER),
+    );
+    if (!hasMusd) {
+      return tokensSlice;
+    }
+    return [...tokensSlice, MUSD_ERC20_ADDRESS_LOWER];
   }
 
   async #addDetectedTokens({
@@ -746,6 +864,41 @@ export class TokenDetectionController extends StaticIntervalPollingController<To
           name,
           ...(rwaData && { rwaData }),
         });
+      }
+
+      // mUSD is always in the chain token cache on supported networks, but
+      // getBalancesInSingleCall omits zero balances; still add mUSD so the wallet
+      // shows the asset (balance updates via the usual balance pipeline).
+      if (MUSD_TOKEN_DETECTION_CHAIN_ID_SET.has(chainId)) {
+        const musdInSlice = tokensSlice.some((addr) =>
+          isEqualCaseInsensitive(addr, MUSD_ERC20_ADDRESS_LOWER),
+        );
+        const musdHasNonZeroFromRpc = Object.keys(balances).some((addr) =>
+          isEqualCaseInsensitive(addr, MUSD_ERC20_ADDRESS_LOWER),
+        );
+        if (musdInSlice && !musdHasNonZeroFromRpc) {
+          const listData = this.#tokensChainsCache[chainId].data;
+          const musdListToken = Object.entries(listData).find(([key]) =>
+            isEqualCaseInsensitive(key, MUSD_ERC20_ADDRESS_LOWER),
+          )?.[1];
+          if (musdListToken) {
+            const { decimals, symbol, aggregators, iconUrl, name, rwaData } =
+              musdListToken;
+            eventTokensDetails.push(
+              `${symbol} - ${MUSD_ERC20_ADDRESS_LOWER}`,
+            );
+            tokensWithBalance.push({
+              address: MUSD_ERC20_ADDRESS_LOWER,
+              decimals,
+              symbol,
+              aggregators,
+              image: iconUrl,
+              isERC721: false,
+              name,
+              ...(rwaData && { rwaData }),
+            });
+          }
+        }
       }
 
       if (tokensWithBalance.length) {
@@ -804,12 +957,20 @@ export class TokenDetectionController extends StaticIntervalPollingController<To
     const { tokensChainsCache } = this.messenger.call(
       'TokenListController:getState',
     );
-    this.#tokensChainsCache = tokensChainsCache ?? {};
+    this.#tokensChainsCache = this.#applyMusdDefaultToTokensChainsCache(
+      chainId,
+      tokensChainsCache ?? {},
+    );
+
+    const effectiveSlice = this.#includeMusdInTokenDetectionSlice(
+      tokensSlice,
+      chainId,
+    );
 
     const tokensWithBalance: Token[] = [];
     const eventTokensDetails: string[] = [];
 
-    for (const tokenAddress of tokensSlice) {
+    for (const tokenAddress of effectiveSlice) {
       // Normalize addresses explicitly (don't assume input format)
       const lowercaseTokenAddress = tokenAddress.toLowerCase();
       const checksummedTokenAddress = toChecksumHexAddress(tokenAddress);
@@ -900,7 +1061,10 @@ export class TokenDetectionController extends StaticIntervalPollingController<To
     const { tokensChainsCache } = this.messenger.call(
       'TokenListController:getState',
     );
-    this.#tokensChainsCache = tokensChainsCache ?? {};
+    this.#tokensChainsCache = this.#applyMusdDefaultToTokensChainsCache(
+      chainId,
+      tokensChainsCache ?? {},
+    );
 
     const selectedAddress = this.#getSelectedAddress();
 
@@ -917,10 +1081,15 @@ export class TokenDetectionController extends StaticIntervalPollingController<To
       allIgnoredTokens[chainId]?.[selectedAddress] ?? []
     ).map((address) => address.toLowerCase());
 
+    const effectiveSlice = this.#includeMusdInTokenDetectionSlice(
+      tokensSlice,
+      chainId,
+    );
+
     const tokensWithBalance: Token[] = [];
     const eventTokensDetails: string[] = [];
 
-    for (const tokenAddress of tokensSlice) {
+    for (const tokenAddress of effectiveSlice) {
       const lowercaseTokenAddress = tokenAddress.toLowerCase();
       const checksummedTokenAddress = toChecksumHexAddress(tokenAddress);
 

--- a/packages/assets-controllers/src/constants.ts
+++ b/packages/assets-controllers/src/constants.ts
@@ -1,4 +1,8 @@
-import { CHAIN_IDS_WITH_NO_NATIVE_TOKEN } from '@metamask/controller-utils';
+import {
+  CHAIN_IDS_WITH_NO_NATIVE_TOKEN,
+  ChainId,
+} from '@metamask/controller-utils';
+import type { Hex } from '@metamask/utils';
 
 export enum Source {
   Custom = 'custom',
@@ -20,6 +24,52 @@ export const SUPPORTED_NETWORKS_ACCOUNTS_API_V4 = [
   '0x8f', // 143
   '0x3e7', // 999 HyperEVM
 ];
+
+/** Lowercase ERC-20 address for MetaMask USD (mUSD), same contract on listed chains. */
+export const MUSD_ERC20_ADDRESS_LOWER =
+  '0xaca92e438df0b2401ff60da7e4337b687a2435da';
+
+/**
+ * EVM chains where mUSD is always merged into the token-detection candidate list.
+ * Metadata matches `GET /v3/assets` on `tokens.api.cx.metamask.io` (assetIds CAIP-19).
+ */
+export const MUSD_TOKEN_DETECTION_CHAIN_IDS: readonly Hex[] = [
+  ChainId.mainnet,
+  ChainId['linea-mainnet'],
+  '0x8f', // Monad mainnet (eip155:143)
+] as const;
+
+/** Raw `aggregators` keys from the Tokens API (same shape as token list cache). */
+export type MusdTokenDetectionMetadata = {
+  name: string;
+  symbol: string;
+  decimals: number;
+  aggregators: string[];
+};
+
+export const MUSD_TOKEN_METADATA_BY_CHAIN: Record<
+  (typeof MUSD_TOKEN_DETECTION_CHAIN_IDS)[number],
+  MusdTokenDetectionMetadata
+> = {
+  [ChainId.mainnet]: {
+    name: 'MetaMask USD',
+    symbol: 'MUSD',
+    decimals: 6,
+    aggregators: ['metamask', 'liFi', 'socket', 'rubic', 'rango'],
+  },
+  [ChainId['linea-mainnet']]: {
+    name: 'MetaMask USD',
+    symbol: 'MUSD',
+    decimals: 6,
+    aggregators: ['metamask', 'liFi', 'socket', 'rubic', 'squid', 'rango'],
+  },
+  '0x8f': {
+    name: 'MetaMask USD',
+    symbol: 'mUSD',
+    decimals: 6,
+    aggregators: ['dynamic'],
+  },
+};
 
 /**
  * Determines if native token fetching should be included for the given chain.


### PR DESCRIPTION
Merge mUSD into the token list cache for WS/polling and append it to detection slices when the RPC/API omits zero balances. Extend Accounts API import to schedule mUSD on supported chains per poll. Single-call path already merged in prior work.

Made-with: Cursor

## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them
