### PR TITLE
chore: Update docs of passkey controller

### DIFF
--- a/packages/passkey-controller/CHANGELOG.md
+++ b/packages/passkey-controller/CHANGELOG.md
@@ -9,16 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Initial `@metamask/passkey-controller` ([#8422](https://github.com/MetaMask/core/pull/8422)): `PasskeyController` for WebAuthn passkey vault key protection (HKDF-derived keys, AES-256-GCM wrap/unwrap), PRF or `userHandle` derivation, challenge-keyed `CeremonyManager`, enrollment/unlock/renewal flows, `verifyPasskeyAuthentication`, selectors, and exported ceremony timing constants.
-- `PasskeyControllerError` with stable `code`, optional `cause` / `context`, `toJSON`, and `toString`; `PasskeyControllerErrorCode`, `PasskeyControllerErrorMessage`, and `controllerName`. Replaces `PasskeyAuthenticationRejectedError`—use `PasskeyControllerError` and `code` for auth failures.
-- **BREAKING:** Operational error messages are prefixed with `PasskeyController - `; prefer `code` or `instanceof PasskeyControllerError` over matching raw strings.
-- `renewVaultKeyProtection` uses the same `vault_key_decryption_failed` code as `retrieveVaultKeyWithPasskey` when AES-GCM decrypt fails.
-- Thrown failures from `verifyRegistrationResponse` / `verifyAuthenticationResponse` are wrapped in `PasskeyControllerError` with `registration_verification_failed` / `authentication_verification_failed` and the underlying error as `cause` (aligned with the `verified: false` path).
-- Debug logging (via `@metamask/utils`) for registration/authentication verification failures, missing ceremony state, vault decrypt failures, and vault key mismatch during renewal.
-
-### Fixed
-
-- Registration verification requires the credential `id`/`rawId` to match the credential id in authenticator data; vault wrapping key derivation uses that verified credential id so enrollment keys align with the stored credential.
-- Registration options request attestation conveyance `'none'` so clients are not asked for direct attestation formats the verifier does not implement (`none` and self-attested `packed` only).
+- Initial `@metamask/passkey-controller` ([#8422](https://github.com/MetaMask/core/pull/8422)).
+- `PasskeyController` for WebAuthn passkey vault key protection: synchronous `generateRegistrationOptions` / `generateAuthenticationOptions` (challenge-keyed in-memory ceremonies), `protectVaultKeyWithPasskey` for enrollment, `retrieveVaultKeyWithPasskey` for unlock, `renewVaultKeyProtection` for re-wrapping the vault key after the caller has verified the same assertion, and `verifyPasskeyAuthentication` when you need a boolean check without returning the vault key.
+- AES-256-GCM wrapping of the vault encryption key; wrapping keys from HKDF-SHA256 over PRF extension output when present, otherwise the random `userHandle` created at registration, with the verified credential id as HKDF salt.
+- Bounded in-flight ceremony storage (WebAuthn timeout plus TTL slack, and a cap on concurrent ceremonies per flow).
+- `PasskeyControllerError` with stable `PasskeyControllerErrorCode` / `PasskeyControllerErrorMessage`, including wrapped registration and authentication verification failures with `cause`.
+- `passkeyControllerSelectors` and `getDefaultPasskeyControllerState` for Redux-style consumers; package `README` covers setup, flows, errors, and constructor options.
 
 [Unreleased]: https://github.com/MetaMask/core/

--- a/packages/passkey-controller/README.md
+++ b/packages/passkey-controller/README.md
@@ -1,6 +1,6 @@
 # `@metamask/passkey-controller`
 
-Manages passkey-based vault key protection using [WebAuthn](https://www.w3.org/TR/webauthn-3/). Orchestrates the full passkey lifecycle: generating WebAuthn ceremony options, verifying authenticator responses, and protecting/retrieving the vault encryption key via AES-256-GCM wrapping with HKDF-derived keys.
+WebAuthn passkey support for protecting a vault encryption key: ceremony options, assertion verification, and AES-256-GCM wrapping with HKDF-derived keys.
 
 ## Installation
 
@@ -12,21 +12,21 @@ or
 
 ## Overview
 
-The controller follows a two-phase ceremony pattern for both enrollment and authentication:
+Two-phase flow for enrollment and authentication:
 
-1. **Generate options** — call a synchronous method that returns options JSON and records **in-flight ceremony** state (challenge-keyed; not a user login session).
-2. **Verify response** — pass the authenticator's response back to the controller, which verifies the WebAuthn signature and performs the cryptographic operation (protect or retrieve the vault key).
+1. **Generate options** — synchronous call returns WebAuthn options JSON and stores **in-flight ceremony** state (challenge-keyed; not a login session).
+2. **Complete ceremony** — pass the authenticator response to the controller to verify the assertion and protect or unwrap the vault key.
 
-### Key derivation strategies
+### Key derivation
 
-The controller supports two key derivation methods, selected automatically during enrollment:
+Enrollment picks PRF or `userHandle` automatically from the registration result:
 
-| Strategy       | When used                                                                                          | Input key material                                |
-| -------------- | -------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
-| **PRF**        | Authenticator supports the [WebAuthn PRF extension](https://w3c.github.io/webauthn/#prf-extension) | PRF evaluation output                             |
-| **userHandle** | PRF is unavailable                                                                                 | Random `userHandle` generated during registration |
+| Strategy       | When used                                                                                          | Input key material                            |
+| -------------- | -------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| **PRF**        | Authenticator supports the [WebAuthn PRF extension](https://w3c.github.io/webauthn/#prf-extension) | PRF evaluation output                         |
+| **userHandle** | PRF output absent                                                                                  | Random `userHandle` from registration options |
 
-Both strategies feed the input key material through **HKDF-SHA256** with the credential ID as salt and a fixed info string to produce the 32-byte AES-256 wrapping key.
+HKDF-SHA256 uses the verified credential id as salt and info label `metamask:passkey:encryption-key:v1` for the 32-byte AES-256 wrapping key.
 
 ## Usage
 
@@ -43,46 +43,47 @@ const controller = new PasskeyController({
   rpID: 'example.com',
   rpName: 'My Wallet',
   expectedOrigin: 'chrome-extension://abcdef1234567890',
-  // Optional — both default to `rpName` when omitted.
   userName: 'My Wallet',
   userDisplayName: 'My Wallet',
 });
 ```
 
+`expectedOrigin` may be `string` or `string[]`. Optional `state` is merged with **`getDefaultPasskeyControllerState()`** when rehydrating. Call **`destroy()`** when disposing the controller so in-flight ceremonies are cleared. See [Constructor](#constructor) for the full argument list.
+
 ### Passkey enrollment (registration)
 
 ```typescript
-// 1. Generate registration options (synchronous)
 const options = controller.generateRegistrationOptions();
-
-// 2. Pass options to the browser WebAuthn API
 const response = await navigator.credentials.create({ publicKey: options });
 
-// 3. Verify and protect the vault key
 await controller.protectVaultKeyWithPasskey({
   registrationResponse: response,
   vaultKey: myVaultEncryptionKey,
 });
 ```
 
+Use **`generateRegistrationOptions({ prfAvailable: false })`** to skip the PRF extension (e.g. tests or environments without PRF).
+
 ### Passkey unlock (authentication)
 
 ```typescript
-// 1. Generate authentication options (synchronous)
 const options = controller.generateAuthenticationOptions();
-
-// 2. Pass options to the browser WebAuthn API
 const response = await navigator.credentials.get({ publicKey: options });
 
-// 3. Verify and retrieve the vault key
 const vaultKey = await controller.retrieveVaultKeyWithPasskey(response);
 ```
 
 ### Password change (vault key renewal)
 
+`renewVaultKeyProtection` does not verify the WebAuthn assertion. Call **`verifyPasskeyAuthentication`** or **`retrieveVaultKeyWithPasskey`** on the **same** `response` first so the signature, challenge, origin, and counter are checked and the authentication ceremony is consumed.
+
 ```typescript
 const options = controller.generateAuthenticationOptions();
 const response = await navigator.credentials.get({ publicKey: options });
+
+if (!(await controller.verifyPasskeyAuthentication(response))) {
+  throw new Error('Passkey verification failed');
+}
 
 await controller.renewVaultKeyProtection({
   authenticationResponse: response,
@@ -91,65 +92,58 @@ await controller.renewVaultKeyProtection({
 });
 ```
 
-### Checking enrollment and removing a passkey
+### Enrollment status and lifecycle
 
 ```typescript
 controller.isPasskeyEnrolled(); // boolean
 
-controller.removePasskey(); // user-facing unenroll; clears persisted passkey and in-flight ceremonies
+controller.removePasskey(); // unenroll: clears passkey + in-flight ceremonies
+controller.clearState(); // same as `removePasskey()` (wallet reset naming)
 
-controller.clearState(); // same persisted reset + clears in-flight ceremony state; use for app lifecycle (e.g. wallet reset)
+controller.destroy(); // ceremonies + BaseController teardown
 ```
 
 ### Selectors
 
-For Redux selectors and other code paths without access to the controller
-instance, use the exported selector(s):
-
 ```typescript
 import { passkeyControllerSelectors } from '@metamask/passkey-controller';
 
-passkeyControllerSelectors.selectIsPasskeyEnrolled(state); // boolean
+passkeyControllerSelectors.selectIsPasskeyEnrolled(state); // `state`: `PasskeyControllerState` slice
 ```
 
 ### Errors
 
-`PasskeyControllerError` is thrown for controller failures. Expected operational
-cases use a stable `code` from `PasskeyControllerErrorCode` (for example:
-`not_enrolled`, `no_registration_ceremony`, `authentication_verification_failed`,
-`missing_key_material`, `vault_key_decryption_failed`). Human-readable strings
-live on `PasskeyControllerErrorMessage`. Use `instanceof PasskeyControllerError`
-and a defined `error.code` to tell these apart from malformed WebAuthn payloads
-and other `Error` values. Thrown errors from the internal WebAuthn verify helpers
-are also surfaced as `PasskeyControllerError` with the same `registration_verification_failed`
-or `authentication_verification_failed` code and the original error as `cause`.
-`verifyPasskeyAuthentication` returns `false` only for
-those controller errors (with `code`) and rethrows everything else.
+Handle failures with **`instanceof PasskeyControllerError`** and **`error.code`** from **`PasskeyControllerErrorCode`** (not raw `message` strings). Codes include `not_enrolled`, `no_registration_ceremony`, `registration_verification_failed`, `no_authentication_ceremony`, `authentication_verification_failed`, `missing_key_material`, `vault_key_decryption_failed`, and `vault_key_mismatch`. Human-readable text is on **`PasskeyControllerErrorMessage`**. Verification failures from internal WebAuthn helpers are wrapped with `registration_verification_failed` or `authentication_verification_failed` and **`cause`**.
+
+**`verifyPasskeyAuthentication`** delegates to **`retrieveVaultKeyWithPasskey`**. It returns **`false`** when that throws a `PasskeyControllerError` with a defined **`code`**; any other throw is propagated.
 
 ## API
 
+### Constructor
+
+| Argument          | Type                              | Required | Description                                            |
+| ----------------- | --------------------------------- | -------- | ------------------------------------------------------ |
+| `messenger`       | `PasskeyControllerMessenger`      | Yes      | Messenger for this controller.                         |
+| `rpID`            | `string`                          | Yes      | WebAuthn relying party ID.                             |
+| `rpName`          | `string`                          | Yes      | Human-readable RP name in the OS UI.                   |
+| `expectedOrigin`  | `string \| string[]`              | Yes      | Allowed `clientDataJSON.origin` value(s).              |
+| `userName`        | `string`                          | No       | Registration `user.name`; defaults to `rpName`.        |
+| `userDisplayName` | `string`                          | No       | Registration `user.displayName`; defaults to `rpName`. |
+| `state`           | `Partial<PasskeyControllerState>` | No       | Merged with `getDefaultPasskeyControllerState()`.      |
+
 ### State
 
-| Property        | Type                    | Description                                                                                   |
-| --------------- | ----------------------- | --------------------------------------------------------------------------------------------- |
-| `passkeyRecord` | `PasskeyRecord \| null` | Enrolled passkey credential data and encrypted vault key. `null` when no passkey is enrolled. |
+| Property        | Type                    | Description                                                     |
+| --------------- | ----------------------- | --------------------------------------------------------------- |
+| `passkeyRecord` | `PasskeyRecord \| null` | Credential metadata and encrypted vault key, or `null` if none. |
 
-### Messenger actions
+### Messenger
 
-| Action                       | Handler                              |
-| ---------------------------- | ------------------------------------ |
-| `PasskeyController:getState` | Returns the current controller state |
-
-For derived enrollment status outside of components that hold a controller
-reference, use `passkeyControllerSelectors.selectIsPasskeyEnrolled` (see
-[Selectors](#selectors)).
-
-### Messenger events
-
-| Event                            | Payload                                                      |
-| -------------------------------- | ------------------------------------------------------------ |
-| `PasskeyController:stateChanged` | Emitted when state changes (standard `BaseController` event) |
+| Kind   | Name                             | Notes                                   |
+| ------ | -------------------------------- | --------------------------------------- |
+| Action | `PasskeyController:getState`     | Current controller state.               |
+| Event  | `PasskeyController:stateChanged` | Standard `BaseController` state change. |
 
 ## Contributing
 
-This package is part of a monorepo. Instructions for contributing can be found in the [monorepo README](https://github.com/MetaMask/core#readme).
+This package is part of a monorepo. See the [monorepo README](https://github.com/MetaMask/core#readme).


### PR DESCRIPTION
## Explanation

This pull request updates **`@metamask/passkey-controller`** documentation so it matches the implementation and is easier for integrators to use.

**Current state:** The README and changelog had gaps or extra noise relative to the controller (for example, vault renewal without calling verification first, incomplete error-code coverage, and duplicated setup vs. API tables).

**Solution:** The README now documents the required **`verifyPasskeyAuthentication` / `retrieveVaultKeyWithPasskey`** step before **`renewVaultKeyProtection`**, lists stable **`PasskeyControllerErrorCode`** values and **`verifyPasskeyAuthentication`** behavior, and trims repetition while keeping HKDF info, constructor/messenger/state, and lifecycle notes. The package **CHANGELOG** under `[Unreleased]` is tightened into a few **Added** bullets that describe the initial release surface without redundant **Changed**/**Fixed** sections; the **`[Unreleased]: …`** footer is kept because **`@metamask/auto-changelog` validate** requires it.

No runtime behavior, public API, or tests are changed—documentation and changelog only.

## References

* TO-541 _(replace with issue URL if applicable, e.g. `https://github.com/MetaMask/core/issues/…` or internal tracker link)_

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate _(N/A — docs only)_
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them _(N/A)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are documentation-only, but integrators may adjust usage based on the clarified renewal/verification sequence and error-code guidance.
> 
> **Overview**
> Tightens `@metamask/passkey-controller` docs to reflect the intended integration flow, including clarifying the **required verification step** (`verifyPasskeyAuthentication`/`retrieveVaultKeyWithPasskey`) before calling `renewVaultKeyProtection` and documenting `verifyPasskeyAuthentication` return/throw behavior.
> 
> Refreshes the README’s setup/API sections (constructor args, `expectedOrigin` type, state rehydration with `getDefaultPasskeyControllerState`, lifecycle via `destroy`, selector usage) and expands error guidance around `PasskeyControllerError` and stable `PasskeyControllerErrorCode` values.
> 
> Condenses the package `CHANGELOG` `[Unreleased]` entry into a short set of **Added** bullets describing the initial release surface, removing redundant/overly detailed notes while keeping the required `[Unreleased]` link footer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd0ecf59046a8121b7ca84a034554a8f60a44eaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->