### PR TITLE
Allow Advanced Permissions metadata in signtypeddata payload

### DIFF
--- a/packages/eth-json-rpc-middleware/CHANGELOG.md
+++ b/packages/eth-json-rpc-middleware/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow Advanced Permissions `metadata` in signTypedData V4 requests ([#8603](https://github.com/MetaMask/core/pull/8603))
+
 ## [23.1.2]
 
 ### Changed

--- a/packages/eth-json-rpc-middleware/src/utils/validation.test.ts
+++ b/packages/eth-json-rpc-middleware/src/utils/validation.test.ts
@@ -160,5 +160,122 @@ describe('Validation Utils', () => {
 
       expect(() => validateTypedMessageKeys(data)).toThrow('Invalid input.');
     });
+
+    describe('metadata', () => {
+      const baseTypedData = {
+        types: {
+          EIP712Domain: [{ name: 'name', type: 'string' }],
+        },
+        primaryType: 'EIP712Domain',
+        domain: {},
+        message: {},
+      };
+
+      it('does not throw when metadata has exactly justification and origin as strings', () => {
+        const data = JSON.stringify({
+          ...baseTypedData,
+          metadata: {
+            justification: 'Permission to spend tokens',
+            origin: 'https://example.com',
+          },
+        });
+
+        expect(() => validateTypedMessageKeys(data)).not.toThrow();
+      });
+
+      it('does not throw when metadata is the only top-level key', () => {
+        const data = JSON.stringify({
+          metadata: {
+            justification: 'Permission to spend tokens',
+            origin: 'https://example.com',
+          },
+        });
+
+        expect(() => validateTypedMessageKeys(data)).not.toThrow();
+      });
+
+      it.each([
+        ['null', null],
+        ['a string', 'not-an-object'],
+        ['a number', 42],
+        ['a boolean', true],
+        ['an array', ['justification', 'origin']],
+      ])('throws when metadata is %s', (_label, value) => {
+        const data = JSON.stringify({
+          ...baseTypedData,
+          metadata: value,
+        });
+
+        expect(() => validateTypedMessageKeys(data)).toThrow('Invalid input.');
+      });
+
+      it('throws when metadata is missing justification', () => {
+        const data = JSON.stringify({
+          ...baseTypedData,
+          metadata: {
+            origin: 'https://example.com',
+          },
+        });
+
+        expect(() => validateTypedMessageKeys(data)).toThrow('Invalid input.');
+      });
+
+      it('throws when metadata is missing origin', () => {
+        const data = JSON.stringify({
+          ...baseTypedData,
+          metadata: {
+            justification: 'Permission to spend tokens',
+          },
+        });
+
+        expect(() => validateTypedMessageKeys(data)).toThrow('Invalid input.');
+      });
+
+      it('throws when metadata.justification is not a string', () => {
+        const data = JSON.stringify({
+          ...baseTypedData,
+          metadata: {
+            justification: 123,
+            origin: 'https://example.com',
+          },
+        });
+
+        expect(() => validateTypedMessageKeys(data)).toThrow('Invalid input.');
+      });
+
+      it('throws when metadata.origin is not a string', () => {
+        const data = JSON.stringify({
+          ...baseTypedData,
+          metadata: {
+            justification: 'Permission to spend tokens',
+            origin: 123,
+          },
+        });
+
+        expect(() => validateTypedMessageKeys(data)).toThrow('Invalid input.');
+      });
+
+      it('throws when metadata has an extraneous third key', () => {
+        const data = JSON.stringify({
+          ...baseTypedData,
+          metadata: {
+            justification: 'Permission to spend tokens',
+            origin: 'https://example.com',
+            extra: 'unexpected',
+          },
+        });
+
+        expect(() => validateTypedMessageKeys(data)).toThrow('Invalid input.');
+      });
+
+      it('throws when metadata is an empty object', () => {
+        const data = JSON.stringify({
+          ...baseTypedData,
+          metadata: {},
+        });
+
+        expect(() => validateTypedMessageKeys(data)).toThrow('Invalid input.');
+      });
+    });
   });
 });

--- a/packages/eth-json-rpc-middleware/src/utils/validation.ts
+++ b/packages/eth-json-rpc-middleware/src/utils/validation.ts
@@ -199,12 +199,38 @@ export function validateTypedDataForPrototypePollution(data: string): void {
  */
 export function validateTypedMessageKeys(data: string): void {
   const parsedData = parseTypedMessage(data);
-  const allowedKeys = new Set(Object.keys(TYPED_MESSAGE_SCHEMA.properties));
+  const allowedKeys = new Set([
+    ...Object.keys(TYPED_MESSAGE_SCHEMA.properties),
+    'metadata',
+  ]);
   const hasExtraneousKey = Object.keys(parsedData).some(
     (key) => !allowedKeys.has(key),
   );
 
   if (hasExtraneousKey) {
     throw rpcErrors.invalidInput();
+  }
+
+  // Advanced Permissions adds `metadata: { justification: string, origin: string }` to eth_signTypedData requests.
+  // see GatorPermissionsController.decodePermissionFromPermissionContextForOrigin for more details.
+  const { metadata } = parsedData as { metadata?: unknown };
+  if (metadata !== undefined) {
+    if (typeof metadata !== 'object' || metadata === null) {
+      throw rpcErrors.invalidInput();
+    }
+
+    const { justification, origin } = metadata as {
+      justification?: unknown;
+      origin?: unknown;
+    };
+
+    if (typeof justification !== 'string' || typeof origin !== 'string') {
+      throw rpcErrors.invalidInput();
+    }
+
+    // we only need to check the keys length, because we already checked the known keys (justification and origin).
+    if (Object.keys(metadata).length !== 2) {
+      throw rpcErrors.invalidInput();
+    }
   }
 }


### PR DESCRIPTION
## Explanation

https://github.com/MetaMask/core/pull/8526 adds tighter validation to signtypeddata v4 payloads, to ensure that no extraneous properties are added.

This additional validation disallows Advanced Permissions `metadata` which is used to communicate the origin and justification of the permission.

This change loosens the validation just enough to allow `metadata: { justification: string; origin: string }` as a property on the payload that is not used within the message encoding.

## References

https://github.com/MetaMask/core/pull/8526
https://github.com/MetaMask/metamask-extension/issues/42181


<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security-adjacent request validation for typed-data signing; while the new `metadata` allowance is tightly constrained, any loosening here could affect input filtering behavior.
> 
> **Overview**
> Relaxes `signTypedData` (V4) payload validation to permit an additional top-level `metadata` field used by Advanced Permissions.
> 
> `validateTypedMessageKeys` now explicitly allows `metadata` and enforces it is exactly `{ justification: string, origin: string }` (rejecting non-objects, missing/typed fields, or extra keys), with new unit tests covering the allowed and rejected cases; changelog updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17f9432de8502ce6b04b01ab63d0828759f62367. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->