### PR TITLE
feat(assets-controller): restrict WebSocket data source to allow-list…

### DIFF
--- a/packages/assets-controller/src/data-sources/BackendWebsocketDataSource.ts
+++ b/packages/assets-controller/src/data-sources/BackendWebsocketDataSource.ts
@@ -39,6 +39,30 @@ const CHANNEL_TYPE = 'account-activity.v1';
 
 const log = createModuleLogger(projectLogger, CONTROLLER_NAME);
 
+/**
+ * Hardcoded allow-list of EVM chains the BackendWebsocket subscribes to.
+ *
+ * Even when the portfolio API's `fetchV2SupportedNetworks` advertises a
+ * broader `fullSupport` list, we deliberately constrain the WebSocket
+ * data source to the high-traffic chains we have validated end-to-end
+ * for streaming balance updates. Any other chain — Monad, Sei, etc. —
+ * is intentionally left for the AccountsApi REST poller to handle, with
+ * RPC as the final fallback. This produces the intended waterfall:
+ *
+ *   WebSocket (this list) → AccountsApi polling → RPC
+ *
+ * To extend WebSocket coverage to a new chain, add its CAIP-2 ID here.
+ */
+const WEBSOCKET_SUPPORTED_CHAINS: ReadonlySet<ChainId> = new Set<ChainId>([
+  'eip155:1', // Ethereum mainnet
+  'eip155:10', // Optimism
+  'eip155:56', // BNB Smart Chain
+  'eip155:137', // Polygon
+  'eip155:8453', // Base
+  'eip155:42161', // Arbitrum One
+  'eip155:59144', // Linea
+]);
+
 // ============================================================================
 // MESSENGER TYPES
 // ============================================================================
@@ -319,7 +343,13 @@ export class BackendWebsocketDataSource extends AbstractDataSource<
 
   async #fetchActiveChains(): Promise<ChainId[]> {
     const response = await this.#apiClient.accounts.fetchV2SupportedNetworks();
-    return response.fullSupport.map(toChainId);
+    // Constrain to the hardcoded WebSocket allow-list so we never claim
+    // chains we haven't validated for real-time streaming. Anything in
+    // `fullSupport` but outside the allow-list (and any chain outside
+    // both) falls through to AccountsApi REST polling, then RPC.
+    return response.fullSupport
+      .map(toChainId)
+      .filter((chainId) => WEBSOCKET_SUPPORTED_CHAINS.has(chainId));
   }
 
   #subscribeToEvents(): void {


### PR DESCRIPTION
… of chains

Hardcode the BackendWebsocket data source to a curated list of seven EVM chains validated end-to-end for streaming balance updates: Ethereum mainnet, Optimism, BNB Smart Chain, Polygon, Base, Arbitrum One, and Linea. Chains outside this set — even those advertised in the portfolio API's `fullSupport` — are no longer claimed by the WebSocket and fall through to AccountsApi REST polling, with RPC as the final fallback. This produces the intended waterfall: WebSocket → AccountsApi → RPC.

## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them
