### PR TITLE
chore: rename `executeEnabled` flag to `gaslessEnabled`

### DIFF
--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -9,8 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Rename `confirmations_pay.payStrategies.relay.executeEnabled` remote feature flag to `gaslessEnabled` ([#8607](https://github.com/MetaMask/core/pull/8607))
-  - Clients setting the flag must update the key; the old key is no longer read and will be treated as `false`.
+- Rename `executeEnabled` feature flag to `gaslessEnabled` ([#8607](https://github.com/MetaMask/core/pull/8607))
 - Bump `@metamask/transaction-controller` from `^64.3.0` to `^64.4.0` ([#8585](https://github.com/MetaMask/core/pull/8585))
 - Bump `@metamask/assets-controller` from `^6.1.0` to `^6.2.0` ([#8590](https://github.com/MetaMask/core/pull/8590))
 

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING:** Rename `confirmations_pay.payStrategies.relay.executeEnabled` remote feature flag to `gaslessEnabled`
+  - Clients setting the flag must update the key; the old key is no longer read and will be treated as `false`.
 - Bump `@metamask/transaction-controller` from `^64.3.0` to `^64.4.0` ([#8585](https://github.com/MetaMask/core/pull/8585))
 - Bump `@metamask/assets-controller` from `^6.1.0` to `^6.2.0` ([#8590](https://github.com/MetaMask/core/pull/8590))
 

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Rename `confirmations_pay.payStrategies.relay.executeEnabled` remote feature flag to `gaslessEnabled`
+- **BREAKING:** Rename `confirmations_pay.payStrategies.relay.executeEnabled` remote feature flag to `gaslessEnabled` ([#8607](https://github.com/MetaMask/core/pull/8607))
   - Clients setting the flag must update the key; the old key is no longer read and will be treated as `false`.
 - Bump `@metamask/transaction-controller` from `^64.3.0` to `^64.4.0` ([#8585](https://github.com/MetaMask/core/pull/8585))
 - Bump `@metamask/assets-controller` from `^6.1.0` to `^6.2.0` ([#8590](https://github.com/MetaMask/core/pull/8590))

--- a/packages/transaction-pay-controller/src/utils/feature-flags.test.ts
+++ b/packages/transaction-pay-controller/src/utils/feature-flags.test.ts
@@ -461,14 +461,14 @@ describe('Feature Flags Utils', () => {
       expect(isRelayExecuteEnabled(messenger)).toBe(false);
     });
 
-    it('returns true when executeEnabled is true', () => {
+    it('returns true when gaslessEnabled is true', () => {
       getRemoteFeatureFlagControllerStateMock.mockReturnValue({
         ...getDefaultRemoteFeatureFlagControllerState(),
         remoteFeatureFlags: {
           confirmations_pay: {
             payStrategies: {
               relay: {
-                executeEnabled: true,
+                gaslessEnabled: true,
               },
             },
           },
@@ -478,14 +478,14 @@ describe('Feature Flags Utils', () => {
       expect(isRelayExecuteEnabled(messenger)).toBe(true);
     });
 
-    it('returns false when executeEnabled is false', () => {
+    it('returns false when gaslessEnabled is false', () => {
       getRemoteFeatureFlagControllerStateMock.mockReturnValue({
         ...getDefaultRemoteFeatureFlagControllerState(),
         remoteFeatureFlags: {
           confirmations_pay: {
             payStrategies: {
               relay: {
-                executeEnabled: false,
+                gaslessEnabled: false,
               },
             },
           },

--- a/packages/transaction-pay-controller/src/utils/feature-flags.ts
+++ b/packages/transaction-pay-controller/src/utils/feature-flags.ts
@@ -121,7 +121,7 @@ export type PayStrategiesConfigRaw = {
   across?: AcrossConfigRaw;
   relay?: {
     enabled?: boolean;
-    executeEnabled?: boolean;
+    gaslessEnabled?: boolean;
     originGasOverhead?: string;
     pollingInterval?: number;
     pollingTimeout?: number;
@@ -477,7 +477,7 @@ export function isRelayExecuteEnabled(
     (state.remoteFeatureFlags?.confirmations_pay as
       | FeatureFlagsRaw
       | undefined) ?? {};
-  return featureFlags.payStrategies?.relay?.executeEnabled ?? false;
+  return featureFlags.payStrategies?.relay?.gaslessEnabled ?? false;
 }
 
 /**


### PR DESCRIPTION
Rename the `executeEnabled` feature flag to `gaslessEnabled`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low-code-change but behavior-affecting: the Relay execute/gasless flow now keys off a renamed remote feature flag, so mismatched backend/flag payloads could unintentionally disable the flow.
> 
> **Overview**
> Updates Relay pay-strategy feature-flag wiring to use `payStrategies.relay.gaslessEnabled` instead of `executeEnabled`, including type updates and `isRelayExecuteEnabled()` logic.
> 
> Adjusts associated unit tests and documents the flag rename in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdf0cdc7b44d257fc775b62c248af7bbe9862816. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->