### PR TITLE
fix: send chomp timestamp as number instead of string

### DIFF
--- a/packages/chomp-api-service/CHANGELOG.md
+++ b/packages/chomp-api-service/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING:** Change `AssociateAddressParams.timestamp` type from `string` to `number`. ([#8610](https://github.com/MetaMask/core/pull/8610))
+
 ## [1.0.0]
 
 ### Added

--- a/packages/chomp-api-service/src/types.ts
+++ b/packages/chomp-api-service/src/types.ts
@@ -21,7 +21,7 @@ export type SignedDelegation = {
 
 export type AssociateAddressParams = {
   signature: Hex;
-  timestamp: string;
+  timestamp: number;
   address: Hex;
 };
 

--- a/packages/money-account-upgrade-controller/CHANGELOG.md
+++ b/packages/money-account-upgrade-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Send the CHOMP authentication timestamp as a number instead of a string in the associate-address step. ([#8610](https://github.com/MetaMask/core/pull/8610))
+
 ## [1.1.0]
 
 ### Added

--- a/packages/money-account-upgrade-controller/src/steps/associate-address.test.ts
+++ b/packages/money-account-upgrade-controller/src/steps/associate-address.test.ts
@@ -106,7 +106,7 @@ describe('associateAddressStep', () => {
 
     expect(mocks.associateAddress).toHaveBeenCalledWith({
       signature: MOCK_SIGNATURE,
-      timestamp: MOCK_NOW.toString(),
+      timestamp: MOCK_NOW,
       address: MOCK_ADDRESS,
     });
   });

--- a/packages/money-account-upgrade-controller/src/steps/associate-address.ts
+++ b/packages/money-account-upgrade-controller/src/steps/associate-address.ts
@@ -19,7 +19,7 @@ const ALREADY_ASSOCIATED_STATUS = 'already_associated';
 export const associateAddressStep: Step = {
   name: 'associate-address',
   async run({ messenger, address }) {
-    const timestamp = Date.now().toString();
+    const timestamp = Date.now();
     const message = `CHOMP Authentication ${timestamp}`;
 
     const signature = (await messenger.call(


### PR DESCRIPTION
## Explanation
When attempting to associate an address with chomp, we would send the timestamp as a string, when the API actually expects a number. This PR changes to type, and also the call site in the upgrade controller.


<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a **breaking** type change for `AssociateAddressParams.timestamp`, which can impact any callers/tests still providing a string. Runtime behavior change is small and localized to the CHOMP associate-address flow.
> 
> **Overview**
> Fixes the CHOMP associate-address flow to use a numeric `Date.now()` timestamp end-to-end, updating the signed message and the payload sent to `ChompApiService:associateAddress` (and adjusting the associated unit test).
> 
> Updates `@metamask/chomp-api-service` types so `AssociateAddressParams.timestamp` is a `number` (**breaking change**) and records the change in both packages’ changelogs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91e11f772fbe813de0401b3aa1ad0600a7b76c81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->