### PR TITLE
fix(transaction-pay-controller): abort stale quote requests

### DIFF
--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Prevent stale quote responses from overwriting newer ones when `updateQuotes` is called multiple times in quick succession for the same transaction
+  - A fresh call now aborts any in-flight call for the same `transactionId` via `AbortController`; aborted calls bail before writing `data.paymentToken`, `data.quotes`, `data.totals`, `tx.metamaskPay`, or `tx.batchTransactions`
+  - Eliminates a race where a slower earlier quote (e.g. an older amount) could overwrite a faster later quote, causing displayed fees to mismatch the displayed amount
 - Fall back from Across to later pay strategies when Across quotes would require a first-time EIP-7702 authorization list ([#8577](https://github.com/MetaMask/core/pull/8577))
 - **BREAKING:** Fix mUSD conversion for hardware wallets on EIP-7702 chains by gating relay and Across 7702 paths on the account keyring type via `KeyringController:getState` ([#8388](https://github.com/MetaMask/core/pull/8388))
   - The `TransactionPayControllerMessenger` now requires `KeyringController:getState` permission.

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Abort in-flight quote requests when a newer request is made for the same transaction, preventing stale responses from overwriting newer ones ([#8612](https://github.com/MetaMask/core/pull/8612))
 - Bump `@metamask/messenger` from `^1.1.1` to `^1.2.0` ([#8632](https://github.com/MetaMask/core/pull/8632))
 
 ## [20.0.1]
@@ -30,9 +31,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Prevent stale quote responses from overwriting newer ones when `updateQuotes` is called multiple times in quick succession for the same transaction
-  - A fresh call now aborts any in-flight call for the same `transactionId` via `AbortController`; aborted calls bail before writing `data.paymentToken`, `data.quotes`, `data.totals`, `tx.metamaskPay`, or `tx.batchTransactions`
-  - Eliminates a race where a slower earlier quote (e.g. an older amount) could overwrite a faster later quote, causing displayed fees to mismatch the displayed amount
 - Fall back from Across to later pay strategies when Across quotes would require a first-time EIP-7702 authorization list ([#8577](https://github.com/MetaMask/core/pull/8577))
 - **BREAKING:** Fix mUSD conversion for hardware wallets on EIP-7702 chains by gating relay and Across 7702 paths on the account keyring type via `KeyringController:getState` ([#8388](https://github.com/MetaMask/core/pull/8388))
   - The `TransactionPayControllerMessenger` now requires `KeyringController:getState` permission.

--- a/packages/transaction-pay-controller/src/strategy/across/across-quotes.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/across/across-quotes.test.ts
@@ -295,6 +295,26 @@ describe('Across Quotes', () => {
       expect(params.get('amount')).toBe(QUOTE_REQUEST_MOCK.sourceTokenAmount);
     });
 
+    it('forwards the abort signal to the underlying fetch', async () => {
+      successfulFetchMock.mockResolvedValue({
+        json: async () => QUOTE_MOCK,
+      } as Response);
+
+      const controller = new AbortController();
+
+      await getAcrossQuotes({
+        accountSupports7702: true,
+        messenger,
+        requests: [QUOTE_REQUEST_MOCK],
+        signal: controller.signal,
+        transaction: TRANSACTION_META_MOCK,
+      });
+
+      const [, options] = successfulFetchMock.mock.calls[0];
+
+      expect((options as RequestInit).signal).toBe(controller.signal);
+    });
+
     it('uses exactOutput trade type for non-max amount quotes', async () => {
       successfulFetchMock.mockResolvedValue({
         json: async () => QUOTE_MOCK,

--- a/packages/transaction-pay-controller/src/strategy/across/across-quotes.ts
+++ b/packages/transaction-pay-controller/src/strategy/across/across-quotes.ts
@@ -109,6 +109,7 @@ async function getSingleQuote(
     originChainId: sourceChainId,
     outputToken: targetTokenAddress,
     recipient: destination.recipient,
+    signal: fullRequest.signal,
     slippage: slippageDecimal,
     tradeType,
   });
@@ -134,6 +135,7 @@ type AcrossApprovalRequest = {
   originChainId: Hex;
   outputToken: Hex;
   recipient: Hex;
+  signal?: AbortSignal;
   slippage?: number;
   tradeType: 'exactInput' | 'exactOutput';
 };
@@ -151,6 +153,7 @@ async function requestAcrossApproval(
     originChainId,
     outputToken,
     recipient,
+    signal,
     slippage,
     tradeType,
   } = request;
@@ -178,6 +181,7 @@ async function requestAcrossApproval(
       'Content-Type': 'application/json',
     },
     method: 'POST',
+    signal,
   };
   const response = await successfulFetch(url, options);
 

--- a/packages/transaction-pay-controller/src/strategy/across/across-quotes.ts
+++ b/packages/transaction-pay-controller/src/strategy/across/across-quotes.ts
@@ -76,7 +76,7 @@ async function getSingleQuote(
   request: QuoteRequest,
   fullRequest: PayStrategyGetQuotesRequest,
 ): Promise<TransactionPayQuote<AcrossQuote>> {
-  const { messenger, transaction } = fullRequest;
+  const { messenger, signal, transaction } = fullRequest;
   const normalizedRequest = normalizeAcrossRequest(request, transaction.type);
   const {
     from,
@@ -109,7 +109,7 @@ async function getSingleQuote(
     originChainId: sourceChainId,
     outputToken: targetTokenAddress,
     recipient: destination.recipient,
-    signal: fullRequest.signal,
+    signal,
     slippage: slippageDecimal,
     tradeType,
   });

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-api.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-api.test.ts
@@ -85,6 +85,24 @@ describe('relay-api', () => {
 
       expect(quote.details).toStrictEqual(QUOTE_RESPONSE_MOCK.details);
     });
+
+    it('forwards the abort signal to the underlying fetch', async () => {
+      successfulFetchMock.mockResolvedValue({
+        json: async () => QUOTE_RESPONSE_MOCK,
+      } as Response);
+
+      const controller = new AbortController();
+      await fetchRelayQuote(
+        MESSENGER_MOCK,
+        QUOTE_REQUEST_MOCK,
+        controller.signal,
+      );
+
+      expect(successfulFetchMock).toHaveBeenCalledWith(
+        QUOTE_URL_MOCK,
+        expect.objectContaining({ signal: controller.signal }),
+      );
+    });
   });
 
   describe('submitRelayExecute', () => {

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-api.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-api.ts
@@ -16,11 +16,13 @@ import type {
  *
  * @param messenger - Controller messenger.
  * @param body - Quote request parameters.
+ * @param signal - Optional abort signal that cancels the underlying fetch.
  * @returns The Relay quote with the request attached.
  */
 export async function fetchRelayQuote(
   messenger: TransactionPayControllerMessenger,
   body: RelayQuoteRequest,
+  signal?: AbortSignal,
 ): Promise<RelayQuote> {
   const { relayQuoteUrl } = getFeatureFlags(messenger);
 
@@ -28,6 +30,7 @@ export async function fetchRelayQuote(
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
+    signal,
   });
 
   const quote = (await response.json()) as RelayQuote;

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.ts
@@ -191,7 +191,12 @@ async function getSingleQuote(
   request: QuoteRequest,
   fullRequest: PayStrategyGetQuotesRequest,
 ): Promise<TransactionPayQuote<RelayQuote>> {
-  const { messenger, transaction } = fullRequest;
+  const {
+    accountSupports7702: supports7702,
+    messenger,
+    signal,
+    transaction,
+  } = fullRequest;
 
   const {
     from,
@@ -220,8 +225,6 @@ async function getSingleQuote(
     // For regular flows with a target amount, use EXPECTED_OUTPUT.
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     const useExactInput = isMaxAmount || request.isPostQuote;
-
-    const { accountSupports7702: supports7702 } = fullRequest;
 
     const useExecute =
       supports7702 &&
@@ -256,7 +259,7 @@ async function getSingleQuote(
 
     log('Request body', body);
 
-    const quote = await fetchRelayQuote(messenger, body, fullRequest.signal);
+    const quote = await fetchRelayQuote(messenger, body, signal);
 
     log('Fetched relay quote', quote);
 

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.ts
@@ -256,7 +256,7 @@ async function getSingleQuote(
 
     log('Request body', body);
 
-    const quote = await fetchRelayQuote(messenger, body);
+    const quote = await fetchRelayQuote(messenger, body, fullRequest.signal);
 
     log('Fetched relay quote', quote);
 

--- a/packages/transaction-pay-controller/src/types.ts
+++ b/packages/transaction-pay-controller/src/types.ts
@@ -464,6 +464,13 @@ export type PayStrategyGetQuotesRequest = {
   /** Quote requests for required tokens. */
   requests: QuoteRequest[];
 
+  /**
+   * Signal that aborts when a newer quote request supersedes this one.
+   * Strategies that perform their own network IO should forward this to
+   * their fetch calls so cancelled requests release network resources.
+   */
+  signal?: AbortSignal;
+
   /** Metadata of the original target transaction. */
   transaction: TransactionMeta;
 };
@@ -493,6 +500,9 @@ export type PayStrategyGetBatchRequest<OriginalQuote> = {
 
   /** Quotes for required tokens. */
   quotes: TransactionPayQuote<OriginalQuote>[];
+
+  /** Signal that aborts when a newer quote request supersedes this one. */
+  signal?: AbortSignal;
 };
 
 /** Request to check whether retrieved quotes can be executed by a strategy. */
@@ -502,6 +512,9 @@ export type PayStrategyCheckQuoteSupportRequest<OriginalQuote> = {
 
   /** Quotes returned by the strategy. */
   quotes: TransactionPayQuote<OriginalQuote>[];
+
+  /** Signal that aborts when a newer quote request supersedes this one. */
+  signal?: AbortSignal;
 
   /** Metadata of the original target transaction. */
   transaction: TransactionMeta;

--- a/packages/transaction-pay-controller/src/utils/quotes.test.ts
+++ b/packages/transaction-pay-controller/src/utils/quotes.test.ts
@@ -15,7 +15,7 @@ import type {
   TransactionPayRequiredToken,
 } from '../types';
 import type { UpdateQuotesRequest } from './quotes';
-import { inFlightQuoteRequests, refreshQuotes, updateQuotes } from './quotes';
+import { refreshQuotes, updateQuotes } from './quotes';
 import {
   checkStrategyQuoteSupport,
   checkStrategySupport,
@@ -137,7 +137,6 @@ describe('Quotes Utils', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     jest.clearAllTimers();
-    inFlightQuoteRequests.clear();
 
     getKeyringControllerStateMock.mockReturnValue({
       isUnlocked: true,
@@ -971,24 +970,22 @@ describe('Quotes Utils', () => {
         expect(paymentTokenWrites).not.toContain('1111111');
       });
 
-      it('clears the in-flight controller after completion', async () => {
-        await run();
-        expect(inFlightQuoteRequests.has(TRANSACTION_ID_MOCK)).toBe(false);
-      });
-
       it('drops the late strategy response from an aborted call after getQuotes returns', async () => {
         const firstQuotes = deferred<TransactionPayQuote<Json>[]>();
 
-        getQuotesMock.mockImplementationOnce(async () => {
-          inFlightQuoteRequests.get(TRANSACTION_ID_MOCK)?.abort();
-          return firstQuotes;
-        });
+        getQuotesMock.mockImplementationOnce(() => firstQuotes);
+
+        const firstPromise = run();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        const secondPromise = run();
 
         firstQuotes.resolve([QUOTE_MOCK]);
 
-        const result = await run();
+        const [firstResult] = await Promise.all([firstPromise, secondPromise]);
 
-        expect(result).toBe(false);
+        expect(firstResult).toBe(false);
 
         const quoteWrites = updateTransactionDataMock.mock.calls
           .map(([, fn]) => {
@@ -998,7 +995,39 @@ describe('Quotes Utils', () => {
           })
           .filter((data) => Array.isArray(data.quotes));
 
-        expect(quoteWrites).toHaveLength(0);
+        expect(quoteWrites).toHaveLength(1);
+      });
+
+      it('re-throws non-abort errors from the quote pipeline', async () => {
+        const pipelineError = new Error('calculateTotals failed');
+
+        getQuotesMock.mockResolvedValueOnce([QUOTE_MOCK]);
+        calculateTotalsMock.mockImplementationOnce(() => {
+          throw pipelineError;
+        });
+
+        await expect(run()).rejects.toThrow(pipelineError);
+      });
+
+      it('catches abort errors thrown by strategy and returns false', async () => {
+        const strategyError = new Error('The operation was aborted');
+        const gate = deferred<TransactionPayQuote<Json>[]>();
+
+        getQuotesMock.mockImplementationOnce(() => gate);
+
+        const firstPromise = run();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        run().catch(() => undefined);
+
+        gate.reject(strategyError);
+
+        const firstResult = await firstPromise;
+
+        expect(firstResult).toBe(false);
       });
 
       it('forwards an aborting signal to the strategy getQuotes call', async () => {

--- a/packages/transaction-pay-controller/src/utils/quotes.test.ts
+++ b/packages/transaction-pay-controller/src/utils/quotes.test.ts
@@ -15,7 +15,7 @@ import type {
   TransactionPayRequiredToken,
 } from '../types';
 import type { UpdateQuotesRequest } from './quotes';
-import { refreshQuotes, updateQuotes } from './quotes';
+import { inFlightQuoteRequests, refreshQuotes, updateQuotes } from './quotes';
 import {
   checkStrategyQuoteSupport,
   checkStrategySupport,
@@ -137,6 +137,7 @@ describe('Quotes Utils', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     jest.clearAllTimers();
+    inFlightQuoteRequests.clear();
 
     getKeyringControllerStateMock.mockReturnValue({
       isUnlocked: true,
@@ -850,6 +851,172 @@ describe('Quotes Utils', () => {
 
       // paymentToken should NOT be overwritten when fiat rate is unavailable
       expect(transactionDataMock.paymentToken).toBeUndefined();
+    });
+
+    describe('concurrent calls for the same transaction', () => {
+      type Resolver<Value> = {
+        resolve: (value: Value) => void;
+        reject: (error: Error) => void;
+      };
+
+      function deferred<Value>(): Promise<Value> & Resolver<Value> {
+        let resolveFn!: (value: Value) => void;
+        let rejectFn!: (error: Error) => void;
+        const promise = new Promise<Value>((resolve, reject) => {
+          resolveFn = resolve;
+          rejectFn = reject;
+        }) as Promise<Value> & Resolver<Value>;
+        promise.resolve = resolveFn;
+        promise.reject = rejectFn;
+        return promise;
+      }
+
+      it('aborts the previous call so its results are not written to state', async () => {
+        const firstBalance = deferred<string>();
+        const secondBalance = deferred<string>();
+
+        getLiveTokenBalanceMock.mockImplementationOnce(() => firstBalance);
+        getLiveTokenBalanceMock.mockImplementationOnce(() => secondBalance);
+
+        const firstPromise = run();
+        const secondPromise = run();
+
+        secondBalance.resolve('5000000');
+        const secondResult = await secondPromise;
+
+        firstBalance.resolve('5000000');
+        const firstResult = await firstPromise;
+
+        expect(secondResult).toBe(true);
+        expect(firstResult).toBe(false);
+
+        const quoteWrites = updateTransactionDataMock.mock.calls
+          .map(([, fn]) => {
+            const data: Record<string, unknown> = {};
+            (fn as (d: Record<string, unknown>) => void)(data);
+            return data;
+          })
+          .filter((data) => Array.isArray(data.quotes));
+
+        expect(quoteWrites).toHaveLength(1);
+        expect(quoteWrites[0].quotes).toStrictEqual([QUOTE_MOCK]);
+      });
+
+      it('does not flip isLoading off after the winning call has finished', async () => {
+        const firstBalance = deferred<string>();
+        const secondBalance = deferred<string>();
+
+        getLiveTokenBalanceMock.mockImplementationOnce(() => firstBalance);
+        getLiveTokenBalanceMock.mockImplementationOnce(() => secondBalance);
+
+        const firstPromise = run();
+        const secondPromise = run();
+
+        secondBalance.resolve('5000000');
+        await secondPromise;
+
+        const isLoadingFalseCountAfterWinner =
+          updateTransactionDataMock.mock.calls.filter(([, fn]) => {
+            const data: Record<string, unknown> = { isLoading: true };
+            (fn as (d: Record<string, unknown>) => void)(data);
+            return data.isLoading === false;
+          }).length;
+
+        firstBalance.resolve('5000000');
+        await firstPromise;
+
+        const isLoadingFalseCountAfterLoser =
+          updateTransactionDataMock.mock.calls.filter(([, fn]) => {
+            const data: Record<string, unknown> = { isLoading: true };
+            (fn as (d: Record<string, unknown>) => void)(data);
+            return data.isLoading === false;
+          }).length;
+
+        expect(isLoadingFalseCountAfterLoser).toBe(
+          isLoadingFalseCountAfterWinner,
+        );
+      });
+
+      it('does not write payment token balance from an aborted refresh', async () => {
+        const firstBalance = deferred<string>();
+        const secondBalance = deferred<string>();
+
+        getLiveTokenBalanceMock.mockImplementationOnce(() => firstBalance);
+        getLiveTokenBalanceMock.mockImplementationOnce(() => secondBalance);
+
+        const firstPromise = run();
+        const secondPromise = run();
+
+        secondBalance.resolve('9999999');
+        await secondPromise;
+
+        firstBalance.resolve('1111111');
+        await firstPromise;
+
+        const paymentTokenWrites = updateTransactionDataMock.mock.calls
+          .map(([, fn]) => {
+            const data: Record<string, { balanceRaw?: string } | undefined> = {
+              paymentToken: undefined,
+            };
+            (fn as (d: typeof data) => void)(data);
+            return data.paymentToken?.balanceRaw;
+          })
+          .filter(
+            (balanceRaw): balanceRaw is string => balanceRaw !== undefined,
+          );
+
+        expect(paymentTokenWrites).not.toContain('1111111');
+      });
+
+      it('clears the in-flight controller after completion', async () => {
+        await run();
+        expect(inFlightQuoteRequests.has(TRANSACTION_ID_MOCK)).toBe(false);
+      });
+
+      it('drops the late strategy response from an aborted call after getQuotes returns', async () => {
+        const firstQuotes = deferred<TransactionPayQuote<Json>[]>();
+
+        getQuotesMock.mockImplementationOnce(async () => {
+          inFlightQuoteRequests.get(TRANSACTION_ID_MOCK)?.abort();
+          return firstQuotes;
+        });
+
+        firstQuotes.resolve([QUOTE_MOCK]);
+
+        const result = await run();
+
+        expect(result).toBe(false);
+
+        const quoteWrites = updateTransactionDataMock.mock.calls
+          .map(([, fn]) => {
+            const data: Record<string, unknown> = {};
+            (fn as (d: Record<string, unknown>) => void)(data);
+            return data;
+          })
+          .filter((data) => Array.isArray(data.quotes));
+
+        expect(quoteWrites).toHaveLength(0);
+      });
+
+      it('keeps requests for different transactions independent', async () => {
+        const OTHER_TRANSACTION_ID = '789-012';
+
+        getTransactionMock.mockImplementation(
+          (transactionId: string) =>
+            ({
+              ...TRANSACTION_META_MOCK,
+              id: transactionId,
+            }) as TransactionMeta,
+        );
+
+        const [resultA, resultB] = await Promise.all([
+          run({ transactionId: TRANSACTION_ID_MOCK }),
+          run({ transactionId: OTHER_TRANSACTION_ID }),
+        ]);
+
+        expect(resultA).toBe(true);
+        expect(resultB).toBe(true);
+      });
     });
   });
 

--- a/packages/transaction-pay-controller/src/utils/quotes.test.ts
+++ b/packages/transaction-pay-controller/src/utils/quotes.test.ts
@@ -445,6 +445,7 @@ describe('Quotes Utils', () => {
       expect(unsupportedStrategy.checkQuoteSupport).toHaveBeenCalledWith({
         messenger,
         quotes: [QUOTE_MOCK],
+        signal: expect.any(AbortSignal),
         transaction: TRANSACTION_META_MOCK,
       });
       expect(unsupportedStrategy.getBatchTransactions).not.toHaveBeenCalled();
@@ -609,6 +610,7 @@ describe('Quotes Utils', () => {
             targetTokenAddress: TRANSACTION_DATA_MOCK.tokens?.[0].address,
           },
         ],
+        signal: expect.any(AbortSignal),
         transaction: TRANSACTION_META_MOCK,
       });
     });
@@ -643,6 +645,7 @@ describe('Quotes Utils', () => {
             targetAmountMinimum: '0',
           }),
         ],
+        signal: expect.any(AbortSignal),
         transaction: TRANSACTION_META_MOCK,
       });
     });
@@ -998,6 +1001,43 @@ describe('Quotes Utils', () => {
         expect(quoteWrites).toHaveLength(0);
       });
 
+      it('forwards an aborting signal to the strategy getQuotes call', async () => {
+        let capturedSignal: AbortSignal | undefined;
+        getQuotesMock.mockImplementationOnce(
+          (req: { signal?: AbortSignal }) => {
+            capturedSignal = req.signal;
+            return [QUOTE_MOCK];
+          },
+        );
+
+        await run();
+
+        expect(capturedSignal).toBeInstanceOf(AbortSignal);
+        expect(capturedSignal?.aborted).toBe(false);
+      });
+
+      it('aborts the strategy signal when superseded by a newer call', async () => {
+        const firstQuotes = deferred<TransactionPayQuote<Json>[]>();
+        let firstSignal: AbortSignal | undefined;
+
+        getQuotesMock.mockImplementationOnce(
+          (req: { signal?: AbortSignal }) => {
+            firstSignal = req.signal;
+            return firstQuotes;
+          },
+        );
+
+        const firstPromise = run();
+        await Promise.resolve();
+        await Promise.resolve();
+        const secondPromise = run();
+
+        firstQuotes.resolve([QUOTE_MOCK]);
+        await Promise.all([firstPromise, secondPromise]);
+
+        expect(firstSignal?.aborted).toBe(true);
+      });
+
       it('keeps requests for different transactions independent', async () => {
         const OTHER_TRANSACTION_ID = '789-012';
 
@@ -1185,6 +1225,7 @@ describe('Quotes Utils', () => {
             targetTokenAddress: DESTINATION_TOKEN_MOCK.address,
           },
         ],
+        signal: expect.any(AbortSignal),
         transaction: TRANSACTION_META_MOCK,
       });
     });

--- a/packages/transaction-pay-controller/src/utils/quotes.ts
+++ b/packages/transaction-pay-controller/src/utils/quotes.ts
@@ -36,55 +36,7 @@ const DEFAULT_REFRESH_INTERVAL = 30 * 1000; // 30 Seconds
 
 const log = createModuleLogger(projectLogger, 'quotes');
 
-/**
- * Tracks the currently in-flight quote request per transaction so that a
- * subsequent call to {@link updateQuotes} for the same transaction can abort
- * the previous one. This prevents an older/slower quote response from
- * overwriting a newer one in state.
- *
- * Exported for testing only.
- */
-export const inFlightQuoteRequests = new Map<string, AbortController>();
-
-/**
- * Abort any in-flight quote request for the given transaction and install a
- * fresh AbortController. Returns the new controller so the caller can read
- * its signal.
- *
- * @param transactionId - The transaction whose previous request should be aborted.
- * @returns The newly installed AbortController.
- */
-function abortPreviousAndCreateController(
-  transactionId: string,
-): AbortController {
-  const previous = inFlightQuoteRequests.get(transactionId);
-
-  if (previous && !previous.signal.aborted) {
-    log('Aborting previous quote request', { transactionId });
-    previous.abort();
-  }
-
-  const controller = new AbortController();
-  inFlightQuoteRequests.set(transactionId, controller);
-  return controller;
-}
-
-/**
- * Clear the tracked controller for a transaction if it matches the supplied
- * one. This avoids races where a slower aborted call would otherwise erase
- * the entry installed by a newer call.
- *
- * @param transactionId - The transaction to clear.
- * @param controller - The controller that owns the slot.
- */
-function clearControllerIfCurrent(
-  transactionId: string,
-  controller: AbortController,
-): void {
-  if (inFlightQuoteRequests.get(transactionId) === controller) {
-    inFlightQuoteRequests.delete(transactionId);
-  }
-}
+const inFlightQuoteRequests = new Map<string, AbortController>();
 
 export type UpdateQuotesRequest = {
   getStrategies: (transaction: TransactionMeta) => TransactionPayStrategy[];
@@ -216,6 +168,12 @@ export async function updateQuotes(
       data.quotesLastUpdated = Date.now();
       data.totals = totals;
     });
+  } catch (error) {
+    if (signal.aborted) {
+      log('Quote request aborted', { transactionId, reason: signal.reason });
+      return false;
+    }
+    throw error;
   } finally {
     if (!signal.aborted) {
       updateTransactionData(transactionId, (data) => {
@@ -330,6 +288,30 @@ export async function refreshQuotes(
     if (isUpdated) {
       log('Refreshed quotes', { transactionId, strategy: strategyName });
     }
+  }
+}
+
+function abortPreviousAndCreateController(
+  transactionId: string,
+): AbortController {
+  const previous = inFlightQuoteRequests.get(transactionId);
+
+  if (previous && !previous.signal.aborted) {
+    log('Aborting previous quote request', { transactionId });
+    previous.abort(new Error('Superseded by newer quote request'));
+  }
+
+  const controller = new AbortController();
+  inFlightQuoteRequests.set(transactionId, controller);
+  return controller;
+}
+
+function clearControllerIfCurrent(
+  transactionId: string,
+  controller: AbortController,
+): void {
+  if (inFlightQuoteRequests.get(transactionId) === controller) {
+    inFlightQuoteRequests.delete(transactionId);
   }
 }
 
@@ -658,6 +640,10 @@ async function getQuotes(
         quotes,
       };
     } catch (error) {
+      if (signal?.aborted) {
+        throw error;
+      }
+
       log('Strategy failed, trying next', {
         error,
         strategy: name,

--- a/packages/transaction-pay-controller/src/utils/quotes.ts
+++ b/packages/transaction-pay-controller/src/utils/quotes.ts
@@ -184,6 +184,7 @@ export async function updateQuotes(
       getStrategies,
       messenger,
       transactionData.fiatPayment?.selectedPaymentMethodId,
+      signal,
     );
 
     if (signal.aborted) {
@@ -562,6 +563,7 @@ async function refreshPaymentTokenBalance({
  * @param getStrategies - Callback to get ordered strategy names for a transaction.
  * @param messenger - Controller messenger.
  * @param fiatPaymentMethod - Selected fiat payment method ID, if applicable.
+ * @param signal - Signal that aborts when the quote request is superseded.
  * @returns An object containing batch transactions and quotes.
  */
 async function getQuotes(
@@ -571,6 +573,7 @@ async function getQuotes(
   getStrategies: (transaction: TransactionMeta) => TransactionPayStrategy[],
   messenger: TransactionPayControllerMessenger,
   fiatPaymentMethod?: string,
+  signal?: AbortSignal,
 ): Promise<{
   batchTransactions: BatchTransaction[];
   quotes: TransactionPayQuote<Json>[];
@@ -598,6 +601,7 @@ async function getQuotes(
     fiatPaymentMethod,
     messenger,
     requests,
+    signal,
     transaction,
   };
 
@@ -625,6 +629,7 @@ async function getQuotes(
       const quoteSupport = await checkStrategyQuoteSupport(strategy, {
         messenger,
         quotes,
+        signal,
         transaction,
       });
 
@@ -642,6 +647,7 @@ async function getQuotes(
         ? await strategy.getBatchTransactions({
             messenger,
             quotes,
+            signal,
           })
         : [];
 

--- a/packages/transaction-pay-controller/src/utils/quotes.ts
+++ b/packages/transaction-pay-controller/src/utils/quotes.ts
@@ -36,6 +36,56 @@ const DEFAULT_REFRESH_INTERVAL = 30 * 1000; // 30 Seconds
 
 const log = createModuleLogger(projectLogger, 'quotes');
 
+/**
+ * Tracks the currently in-flight quote request per transaction so that a
+ * subsequent call to {@link updateQuotes} for the same transaction can abort
+ * the previous one. This prevents an older/slower quote response from
+ * overwriting a newer one in state.
+ *
+ * Exported for testing only.
+ */
+export const inFlightQuoteRequests = new Map<string, AbortController>();
+
+/**
+ * Abort any in-flight quote request for the given transaction and install a
+ * fresh AbortController. Returns the new controller so the caller can read
+ * its signal.
+ *
+ * @param transactionId - The transaction whose previous request should be aborted.
+ * @returns The newly installed AbortController.
+ */
+function abortPreviousAndCreateController(
+  transactionId: string,
+): AbortController {
+  const previous = inFlightQuoteRequests.get(transactionId);
+
+  if (previous && !previous.signal.aborted) {
+    log('Aborting previous quote request', { transactionId });
+    previous.abort();
+  }
+
+  const controller = new AbortController();
+  inFlightQuoteRequests.set(transactionId, controller);
+  return controller;
+}
+
+/**
+ * Clear the tracked controller for a transaction if it matches the supplied
+ * one. This avoids races where a slower aborted call would otherwise erase
+ * the entry installed by a newer call.
+ *
+ * @param transactionId - The transaction to clear.
+ * @param controller - The controller that owns the slot.
+ */
+function clearControllerIfCurrent(
+  transactionId: string,
+  controller: AbortController,
+): void {
+  if (inFlightQuoteRequests.get(transactionId) === controller) {
+    inFlightQuoteRequests.delete(transactionId);
+  }
+}
+
 export type UpdateQuotesRequest = {
   getStrategies: (transaction: TransactionMeta) => TransactionPayStrategy[];
   messenger: TransactionPayControllerMessenger;
@@ -47,8 +97,13 @@ export type UpdateQuotesRequest = {
 /**
  * Update the quotes for a specific transaction.
  *
+ * Calls for the same `transactionId` are serialised: a fresh call aborts any
+ * previous in-flight call so a slower stale response cannot overwrite a newer
+ * one in state.
+ *
  * @param request - Request parameters.
- * @returns Boolean indicating if the quotes were updated.
+ * @returns Boolean indicating if the quotes were updated. Returns `false` when
+ * the call was aborted by a subsequent call for the same transaction.
  */
 export async function updateQuotes(
   request: UpdateQuotesRequest,
@@ -86,6 +141,9 @@ export async function updateQuotes(
 
   const from = accountOverride ?? (transaction.txParams.from as Hex);
 
+  const controller = abortPreviousAndCreateController(transactionId);
+  const { signal } = controller;
+
   updateTransactionData(transactionId, (data) => {
     data.isLoading = true;
   });
@@ -95,9 +153,15 @@ export async function updateQuotes(
       from,
       messenger,
       paymentToken: originalPaymentToken,
+      signal,
       transactionId,
       updateTransactionData,
     });
+
+    if (signal.aborted) {
+      log('Quote request aborted before building requests', { transactionId });
+      return false;
+    }
 
     const requests = buildQuoteRequests({
       from,
@@ -121,6 +185,11 @@ export async function updateQuotes(
       messenger,
       transactionData.fiatPayment?.selectedPaymentMethodId,
     );
+
+    if (signal.aborted) {
+      log('Quote request aborted before persisting results', { transactionId });
+      return false;
+    }
 
     const totals = calculateTotals({
       isMaxAmount,
@@ -147,9 +216,12 @@ export async function updateQuotes(
       data.totals = totals;
     });
   } finally {
-    updateTransactionData(transactionId, (data) => {
-      data.isLoading = false;
-    });
+    if (!signal.aborted) {
+      updateTransactionData(transactionId, (data) => {
+        data.isLoading = false;
+      });
+    }
+    clearControllerIfCurrent(transactionId, controller);
   }
 
   return true;
@@ -415,12 +487,14 @@ async function refreshPaymentTokenBalance({
   from,
   messenger,
   paymentToken,
+  signal,
   transactionId,
   updateTransactionData,
 }: {
   from: Hex;
   messenger: TransactionPayControllerMessenger;
   paymentToken: TransactionPaymentToken | undefined;
+  signal: AbortSignal;
   transactionId: string;
   updateTransactionData: UpdateTransactionDataCallback;
 }): Promise<TransactionPaymentToken | undefined> {
@@ -445,6 +519,11 @@ async function refreshPaymentTokenBalance({
       paymentToken.chainId,
       paymentToken.address,
     );
+
+    if (signal.aborted) {
+      log('Payment token balance refresh aborted', { transactionId });
+      return paymentToken;
+    }
 
     const {
       raw: balanceRaw,


### PR DESCRIPTION
## Explanation

When `updateQuotes` is called twice in quick succession for the same transaction (e.g. user typing an amount with debounce, toggling max, or switching payment token), two quote fetches race with no cancellation. A slower older response can land after a faster newer one and silently overwrite `data.quotes`, `data.totals`, `tx.metamaskPay`, and `tx.batchTransactions` — so displayed fees no longer match the displayed amount.

This PR adds per-transaction `AbortController` tracking to `updateQuotes`. A fresh call aborts any in-flight predecessor, and aborted calls bail before mutating state. The signal is also forwarded into the Relay and Across `successfulFetch` calls so cancelled requests drop at the network level.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches quote-refresh control flow and state mutation ordering; incorrect abort handling could cause missed updates or loading-state inconsistencies, though changes are localized and well-covered by tests.
> 
> **Overview**
> Prevents stale quote refreshes from racing by **tracking per-transaction in-flight `updateQuotes` calls** and aborting any previous request when a newer call for the same `transactionId` starts, returning `false` for aborted runs and skipping state writes (including `isLoading` teardown) when cancelled.
> 
> Threads an optional `AbortSignal` through pay-strategy request types and forwards it into Relay (`fetchRelayQuote`) and Across (`requestAcrossApproval`) `successfulFetch` calls so cancelled quote requests also stop at the network layer; adds targeted unit tests covering cancellation behavior and signal propagation, and documents the change in the changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 307a0b6e4ba70c4cdceb2a825f5a094f44090d83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->