### PR TITLE
feat: Allow overriding action handler in subclass

### DIFF
--- a/packages/messenger/CHANGELOG.md
+++ b/packages/messenger/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Allow overriding action handler in subclass ([#8617](https://github.com/MetaMask/core/pull/8617))
+  - The `Messenger` class now has a protected `getAction` method which returns the action handler for a given action name.
+
 ### Deprecated
 
 - Deprecate `generate-action-types` CLI tool and `messenger-generate-action-types` binary ([#8378](https://github.com/MetaMask/core/pull/8378))

--- a/packages/messenger/src/Messenger.test.ts
+++ b/packages/messenger/src/Messenger.test.ts
@@ -1,6 +1,7 @@
 import type { Patch } from 'immer';
 
 import { Messenger, MOCK_ANY_NAMESPACE } from './Messenger';
+import type { ActionConstraint } from './Messenger';
 import type { MockAnyNamespace } from './Messenger';
 
 describe('Messenger', () => {
@@ -172,14 +173,14 @@ describe('Messenger', () => {
     });
 
     it('allows overriding the action handler in child classes', () => {
-      type Action = { type: 'Fixture:ping'; handler: () => 'foo' };
+      type Action = { type: 'Fixture:ping'; handler: () => string };
 
       const handler = jest.fn().mockReturnValue('foo');
 
       class CustomMessenger extends Messenger<'Fixture', Action> {
         protected getAction(
           _actionType: Action['type'],
-        ): Action['handler'] | undefined {
+        ): ActionConstraint['handler'] | undefined {
           return handler;
         }
       }

--- a/packages/messenger/src/Messenger.test.ts
+++ b/packages/messenger/src/Messenger.test.ts
@@ -194,7 +194,7 @@ describe('Messenger', () => {
       expect(messenger.call('Fixture:ping')).toBe('foo');
       expect(handler).toHaveBeenCalled();
       expect(realHandler).not.toHaveBeenCalled();
-    })
+    });
 
     it('throws when calling unregistered action', () => {
       type PingAction = { type: 'Fixture:ping'; handler: () => void };

--- a/packages/messenger/src/Messenger.test.ts
+++ b/packages/messenger/src/Messenger.test.ts
@@ -171,6 +171,31 @@ describe('Messenger', () => {
       }).toThrow('A handler for Fixture:ping has already been registered');
     });
 
+    it('allows overriding the action handler in child classes', () => {
+      type Action = { type: 'Fixture:ping'; handler: () => 'foo' };
+
+      const handler = jest.fn().mockReturnValue('foo');
+
+      class CustomMessenger extends Messenger<'Fixture', Action> {
+        protected getAction(
+          _actionType: Action['type'],
+        ): Action['handler'] | undefined {
+          return handler;
+        }
+      }
+
+      const messenger = new CustomMessenger({
+        namespace: 'Fixture',
+      });
+
+      const realHandler = jest.fn().mockReturnValue('bar');
+      messenger.registerActionHandler('Fixture:ping', realHandler);
+
+      expect(messenger.call('Fixture:ping')).toBe('foo');
+      expect(handler).toHaveBeenCalled();
+      expect(realHandler).not.toHaveBeenCalled();
+    })
+
     it('throws when calling unregistered action', () => {
       type PingAction = { type: 'Fixture:ping'; handler: () => void };
       const messenger = new Messenger<'Fixture', PingAction, never>({

--- a/packages/messenger/src/Messenger.ts
+++ b/packages/messenger/src/Messenger.ts
@@ -412,7 +412,7 @@ export class Messenger<
    */
   protected getAction(
     actionType: Action['type'],
-  ): Action['handler'] | undefined {
+  ): ActionConstraint['handler'] | undefined {
     return this.#actions.get(actionType);
   }
 

--- a/packages/messenger/src/Messenger.ts
+++ b/packages/messenger/src/Messenger.ts
@@ -400,6 +400,23 @@ export class Messenger<
   }
 
   /**
+   * Get the action handler for a given action type.
+   *
+   * This is a protected method to allow subclasses to override the way action
+   * handlers are retrieved, for example to implement custom delegation logic.
+   *
+   * @param actionType - The action type. This is a unique identifier for this
+   * action.
+   * @returns The action handler for the given action type, or undefined if no
+   * handler has been registered.
+   */
+  protected getAction(
+    actionType: Action['type'],
+  ): Action['handler'] | undefined {
+    return this.#actions.get(actionType);
+  }
+
+  /**
    * Call an action.
    *
    * This function will call the action handler corresponding to the given action type, passing
@@ -416,10 +433,10 @@ export class Messenger<
     actionType: ActionType,
     ...params: ExtractActionParameters<Action, ActionType>
   ): ExtractActionResponse<Action, ActionType> {
-    const handler = this.#actions.get(actionType) as ActionHandler<
-      Action,
-      ActionType
-    >;
+    const handler = this.getAction(actionType) as
+      | ActionHandler<Action, ActionType>
+      | undefined;
+
     if (!handler) {
       throw new Error(
         this.#isInCurrentNamespace(actionType)
@@ -427,6 +444,7 @@ export class Messenger<
           : `A handler for ${actionType} has not been delegated to ${this.#namespace}`,
       );
     }
+
     return handler(...params);
   }
 

--- a/packages/messenger/src/Messenger.ts
+++ b/packages/messenger/src/Messenger.ts
@@ -803,17 +803,19 @@ export class Messenger<
       > => {
         // Cast to get more specific type, for this specific action
         // The types get collapsed by `this.#actions`
-        const actionHandler = this.#actions.get(actionType) as
+        const actionHandler = this.getAction(actionType) as
           | ActionHandler<
               MessengerActions<Delegatee> & Action,
               typeof actionType
             >
           | undefined;
+
         if (!actionHandler) {
           throw new Error(
             `A handler for ${actionType} has not been registered`,
           );
         }
+
         return actionHandler(...args);
       };
       let delegationTargets = this.#actionDelegationTargets.get(actionType);


### PR DESCRIPTION
## Explanation

This adds a new protected `getAction` method to the `Messenger` class which returns the actual handler implementation function. In most cases this is simply the handler registered in the `#actions` property (i.e., through `registerActionHandler`).

I ran into the problem when implementing the UI messenger that no actions were registered on the UI messenger itself (since it's just a wrapper around a connection to the client background), meaning delegation does not work, and had to call the internal `_internalRegisterDelegatedActionHandler` method to make the UI and route messengers work. Making the `getAction` method overridable enables much cleaner delegation in the UI messenger. See this diff for a comparison: https://github.com/MetaMask/metamask-extension/pull/42115/changes/3610b3bd907cf56c202790c40585acb4011e163b.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 5fd10d14026a96d83939df097eac44f4d991fcb3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->