### PR TITLE
fix: set network `assets.listUrl` as optional

### DIFF
--- a/packages/config-registry-controller/CHANGELOG.md
+++ b/packages/config-registry-controller/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/messenger` from `^1.0.0` to `^1.1.1` ([#8364](https://github.com/MetaMask/core/pull/8364), [#8373](https://github.com/MetaMask/core/pull/8373))
 - Bump `@metamask/base-controller` from `^9.0.1` to `^9.1.0` ([#8457](https://github.com/MetaMask/core/pull/8457))
 
+### Fixed
+
+- `ConfigRegistryApiService` now accepts chains with no `assets.listUrl` property ([#0000](https://github.com/MetaMask/core/pull/8457))
+
 ## [0.2.0]
 
 ### Changed

--- a/packages/config-registry-controller/CHANGELOG.md
+++ b/packages/config-registry-controller/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `ConfigRegistryApiService` now accepts chains with no `assets.listUrl` property ([#0000](https://github.com/MetaMask/core/pull/8457))
+- `ConfigRegistryApiService` now accepts chains with no `assets.listUrl` property ([#8624](https://github.com/MetaMask/core/pull/8624))
 
 ## [0.2.0]
 

--- a/packages/config-registry-controller/src/config-registry-api-service/types.ts
+++ b/packages/config-registry-controller/src/config-registry-api-service/types.ts
@@ -19,7 +19,7 @@ const AssetSchema = type({
 });
 
 const AssetsSchema = type({
-  listUrl: string(),
+  listUrl: optional(string()),
   native: AssetSchema,
   governance: optional(AssetSchema),
 });


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->
Some networks may not specify an endpoint to fetch their assets list, and this should not cause an error. This change makes the `assets.listUrl` property optional in the network configuration schema.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: schema validation is relaxed to accept missing `assets.listUrl`, with no behavioral changes beyond preventing rejected config responses.
> 
> **Overview**
> `ConfigRegistryApiService` now accepts registry chain configs that omit `assets.listUrl` by making that field optional in the response schema.
> 
> Updates the `config-registry-controller` changelog to document the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb7258f8afd488dcf2700a98833afb520a982378. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->