### PR TITLE
feat(profile-sync-controller): add app version to login payload

### DIFF
--- a/packages/profile-sync-controller/CHANGELOG.md
+++ b/packages/profile-sync-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add optional `getAppVersion` callback to `MetaMetricsAuth`, forwarded as `metametrics.app_version` in the `POST /api/v2/srp/login` payload. ([#XXX](https://github.com/MetaMask/core/pull/XXX))
+
 ### Changed
 
 - Bump `@metamask/keyring-controller` from `^25.1.1` to `^25.2.0` ([#8363](https://github.com/MetaMask/core/pull/8363))

--- a/packages/profile-sync-controller/CHANGELOG.md
+++ b/packages/profile-sync-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add optional `getAppVersion` callback to `MetaMetricsAuth`, forwarded as `metametrics.app_version` in the `POST /api/v2/srp/login` payload. ([#XXX](https://github.com/MetaMask/core/pull/XXX))
+- Add optional `getAppVersion` callback to `MetaMetricsAuth`, forwarded as `metametrics.app_version` in the `POST /api/v2/srp/login` payload. ([#8626](https://github.com/MetaMask/core/pull/8626))
 
 ### Changed
 

--- a/packages/profile-sync-controller/src/sdk/authentication-jwt-bearer/services.test.ts
+++ b/packages/profile-sync-controller/src/sdk/authentication-jwt-bearer/services.test.ts
@@ -407,6 +407,77 @@ describe('services', () => {
       );
     });
 
+    it('should include app_version inside metametrics when getAppVersion is provided', async () => {
+      const mockResponse = createMockResponse(mockAuthResponse);
+      mockFetch.mockResolvedValue(mockResponse);
+
+      const getAppVersion = jest.fn().mockResolvedValue('12.34.5');
+      const getMetaMetricsId = jest.fn().mockResolvedValue('mm-id');
+      const mockMetametrics = {
+        getMetaMetricsId,
+        getAppVersion,
+        agent: Platform.MOBILE as Platform.MOBILE,
+      };
+
+      await authenticate(
+        'raw-message',
+        'signature',
+        AuthType.SRP,
+        Env.DEV,
+        mockMetametrics,
+      );
+
+      expect(getAppVersion).toHaveBeenCalledTimes(1);
+      expect(getMetaMetricsId).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          body: JSON.stringify({
+            signature: 'signature',
+            raw_message: 'raw-message',
+            metametrics: {
+              metametrics_id: 'mm-id',
+              agent: Platform.MOBILE,
+              app_version: '12.34.5',
+            },
+          }),
+        }),
+      );
+    });
+
+    it('should omit app_version when getAppVersion returns undefined', async () => {
+      const mockResponse = createMockResponse(mockAuthResponse);
+      mockFetch.mockResolvedValue(mockResponse);
+
+      const mockMetametrics = {
+        getMetaMetricsId: jest.fn().mockResolvedValue('mm-id'),
+        getAppVersion: jest.fn().mockResolvedValue(undefined),
+        agent: Platform.EXTENSION as Platform.EXTENSION,
+      };
+
+      await authenticate(
+        'raw-message',
+        'signature',
+        AuthType.SRP,
+        Env.DEV,
+        mockMetametrics,
+      );
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          body: JSON.stringify({
+            signature: 'signature',
+            raw_message: 'raw-message',
+            metametrics: {
+              metametrics_id: 'mm-id',
+              agent: Platform.EXTENSION,
+            },
+          }),
+        }),
+      );
+    });
+
     it('should throw SignInError on network failure', async () => {
       mockFetch.mockRejectedValue(new Error('Connection refused'));
 

--- a/packages/profile-sync-controller/src/sdk/authentication-jwt-bearer/services.ts
+++ b/packages/profile-sync-controller/src/sdk/authentication-jwt-bearer/services.ts
@@ -357,6 +357,7 @@ export async function authenticate(
               metametrics: {
                 metametrics_id: await metametrics.getMetaMetricsId(),
                 agent: metametrics.agent,
+                app_version: await metametrics.getAppVersion?.(),
               },
             }
           : {}),

--- a/packages/profile-sync-controller/src/shared/types/services.ts
+++ b/packages/profile-sync-controller/src/shared/types/services.ts
@@ -3,6 +3,7 @@ import type { Platform } from '../env';
 export type ClientMetaMetrics = {
   metametricsId: string;
   agent: Platform.EXTENSION | Platform.MOBILE;
+  appVersion: string;
 };
 
 export type MetaMetricsAuth = {
@@ -10,4 +11,13 @@ export type MetaMetricsAuth = {
     | ClientMetaMetrics['metametricsId']
     | Promise<ClientMetaMetrics['metametricsId']>;
   agent: ClientMetaMetrics['agent'];
+  /**
+   * Optional callback returning the current client app version (e.g. extension
+   * or mobile build version). Forwarded as `metametrics.app_version` in the
+   * `POST /api/v2/srp/login` payload.
+   */
+  getAppVersion?: () =>
+    | ClientMetaMetrics['appVersion']
+    | undefined
+    | Promise<ClientMetaMetrics['appVersion'] | undefined>;
 };


### PR DESCRIPTION
## Explanation

This updates `@metamask/profile-sync-controller` so SRP authentication can include the client app version in the login payload sent to the auth API.

### Client PRS:

- [Extension](https://github.com/MetaMask/metamask-extension/pull/42245)
- [Mobile](https://github.com/MetaMask/metamask-mobile/pull/29466)

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 0021be52f28f427a09dfdbfecf581c37f8ab155d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->