### PR TITLE
feat: pass explicit params to `RampsController:getQuotes` and persist `rampsQuote` on `fiatPayment`

### DIFF
--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Pass explicit `assetId`, `providers`, and `fiat` to `RampsController:getQuotes` and persist the selected ramps quote on `TransactionFiatPayment` ([#8628](https://github.com/MetaMask/core/pull/8628))
+
 ## [20.2.0]
 
 ### Changed
@@ -19,10 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Relay non-OK responses now surface as `<status> - <body message or error>` (or just `<status>`), replacing the previous URL-leaking generic fetch failure message
 - Bump `@metamask/assets-controller` from `^6.2.1` to `^6.3.0` ([#8661](https://github.com/MetaMask/core/pull/8661))
 - Bump `@metamask/assets-controllers` from `^105.0.0` to `^105.1.0` ([#8661](https://github.com/MetaMask/core/pull/8661))
-
-### Fixed
-
-- Pass explicit `assetId`, `providers`, and `fiat` to `RampsController:getQuotes` and persist the selected ramps quote on `TransactionFiatPayment` ([#8628](https://github.com/MetaMask/core/pull/8628))
 
 ## [20.1.0]
 

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/assets-controller` from `^6.2.1` to `^6.3.0` ([#8661](https://github.com/MetaMask/core/pull/8661))
 - Bump `@metamask/assets-controllers` from `^105.0.0` to `^105.1.0` ([#8661](https://github.com/MetaMask/core/pull/8661))
 
+### Fixed
+
+- Pass explicit `assetId`, `providers`, and `fiat` to `RampsController:getQuotes` and persist the selected ramps quote on `TransactionFiatPayment` ([#8628](https://github.com/MetaMask/core/pull/8628))
+
 ## [20.1.0]
 
 ### Added

--- a/packages/transaction-pay-controller/src/strategy/fiat/constants.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/constants.ts
@@ -7,6 +7,8 @@ import {
   NATIVE_TOKEN_ADDRESS,
 } from '../../constants';
 
+export const DEFAULT_FIAT_CURRENCY = 'USD';
+
 export type TransactionPayFiatAsset = {
   address: Hex;
   caipAssetId: string;

--- a/packages/transaction-pay-controller/src/strategy/fiat/fiat-quotes.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/fiat-quotes.test.ts
@@ -159,9 +159,7 @@ function getRequest({
       if (action === 'RampsController:getState') {
         return {
           providers: {
-            selected: selectedProviderId
-              ? { id: selectedProviderId }
-              : null,
+            selected: selectedProviderId ? { id: selectedProviderId } : null,
           },
         };
       }
@@ -175,10 +173,9 @@ function getRequest({
       }
 
       if (action === 'TransactionPayController:updateFiatPayment') {
-        const { callback } =
-          requestArg as unknown as {
-            callback: (fiatPayment: TransactionFiatPayment) => void;
-          };
+        const { callback } = requestArg as unknown as {
+          callback: (fiatPayment: TransactionFiatPayment) => void;
+        };
         const fiatPayment: TransactionFiatPayment = {};
         callback(fiatPayment);
         return undefined;
@@ -532,10 +529,9 @@ describe('getFiatQuotes', () => {
         }
 
         if (action === 'TransactionPayController:updateFiatPayment') {
-          const { callback } =
-            requestArg as unknown as {
-              callback: (fp: TransactionFiatPayment) => void;
-            };
+          const { callback } = requestArg as unknown as {
+            callback: (fp: TransactionFiatPayment) => void;
+          };
           callback(fiatPaymentState);
           return undefined;
         }

--- a/packages/transaction-pay-controller/src/strategy/fiat/fiat-quotes.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/fiat-quotes.test.ts
@@ -9,6 +9,7 @@ import type { Hex } from '@metamask/utils';
 import { TransactionPayStrategy } from '../../constants';
 import type {
   PayStrategyGetQuotesRequest,
+  TransactionFiatPayment,
   TransactionPayQuote,
   TransactionPayRequiredToken,
 } from '../../types';
@@ -17,7 +18,7 @@ import { getRelayQuotes } from '../relay/relay-quotes';
 import type { RelayQuote } from '../relay/types';
 import type { TransactionPayFiatAsset } from './constants';
 import { getFiatQuotes } from './fiat-quotes';
-import { deriveFiatAssetForFiatPayment, pickBestFiatQuote } from './utils';
+import { deriveFiatAssetForFiatPayment } from './utils';
 
 jest.mock('../relay/relay-quotes');
 jest.mock('../../utils/token');
@@ -66,6 +67,8 @@ const FIAT_QUOTE_MOCK: RampsQuote = {
     providerFee: 0.5,
   },
 };
+
+const SELECTED_PROVIDER_ID = '/providers/transak-native-staging';
 
 const FIAT_QUOTES_RESPONSE_MOCK: RampsQuotesResponse = {
   customActions: [],
@@ -123,47 +126,72 @@ function getRequest({
   amountFiat = '10',
   fiatPaymentMethod = '/payments/debit-credit-card',
   rampsQuotes = FIAT_QUOTES_RESPONSE_MOCK,
+  selectedProviderId = SELECTED_PROVIDER_ID as string | null,
   tokens = [REQUIRED_TOKEN_MOCK],
   throwsOnRampsQuotes,
 }: {
   amountFiat?: string;
   fiatPaymentMethod?: string;
   rampsQuotes?: RampsQuotesResponse;
+  selectedProviderId?: string | null;
   tokens?: TransactionPayRequiredToken[];
   throwsOnRampsQuotes?: Error;
 } = {}): {
   callMock: jest.Mock;
   request: PayStrategyGetQuotesRequest;
 } {
-  const callMock = jest.fn((action: string) => {
-    if (action === 'TransactionPayController:getState') {
-      return {
-        transactionData: {
-          [TRANSACTION_ID]: {
-            fiatPayment: {
-              amountFiat,
+  const callMock = jest.fn(
+    (action: string, requestArg?: Record<string, unknown>) => {
+      if (action === 'TransactionPayController:getState') {
+        return {
+          transactionData: {
+            [TRANSACTION_ID]: {
+              fiatPayment: {
+                amountFiat,
+              },
+              isLoading: false,
+              tokens,
             },
-            isLoading: false,
-            tokens,
           },
-        },
-      };
-    }
-
-    if (action === 'RampsController:getQuotes') {
-      if (throwsOnRampsQuotes) {
-        throw throwsOnRampsQuotes;
+        };
       }
 
-      return rampsQuotes;
-    }
+      if (action === 'RampsController:getState') {
+        return {
+          providers: {
+            selected: selectedProviderId
+              ? { id: selectedProviderId }
+              : null,
+          },
+        };
+      }
 
-    throw new Error(`Unexpected action: ${action}`);
-  });
+      if (action === 'RampsController:getQuotes') {
+        if (throwsOnRampsQuotes) {
+          throw throwsOnRampsQuotes;
+        }
+
+        return rampsQuotes;
+      }
+
+      if (action === 'TransactionPayController:updateFiatPayment') {
+        const { callback } =
+          requestArg as unknown as {
+            callback: (fiatPayment: TransactionFiatPayment) => void;
+          };
+        const fiatPayment: TransactionFiatPayment = {};
+        callback(fiatPayment);
+        return undefined;
+      }
+
+      throw new Error(`Unexpected action: ${action}`);
+    },
+  );
 
   return {
     callMock,
     request: {
+      accountSupports7702: false,
       fiatPaymentMethod,
       messenger: {
         call: callMock,
@@ -181,7 +209,6 @@ describe('getFiatQuotes', () => {
   const deriveFiatAssetForFiatPaymentMock = jest.mocked(
     deriveFiatAssetForFiatPayment,
   );
-  const pickBestFiatQuoteMock = jest.mocked(pickBestFiatQuote);
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -193,7 +220,6 @@ describe('getFiatQuotes', () => {
     });
     computeRawFromFiatAmountMock.mockReturnValue('5000000000000000000');
     getRelayQuotesMock.mockResolvedValue([getRelayQuoteMock()]);
-    pickBestFiatQuoteMock.mockReturnValue(FIAT_QUOTE_MOCK);
   });
 
   it('returns combined fiat quote and calls ramps with adjusted amount', async () => {
@@ -219,8 +245,19 @@ describe('getFiatQuotes', () => {
       'RampsController:getQuotes',
       expect.objectContaining({
         amount: 20,
+        assetId: FIAT_ASSET_MOCK.caipAssetId,
+        fiat: 'USD',
         paymentMethods: ['/payments/debit-credit-card'],
+        providers: [SELECTED_PROVIDER_ID],
         walletAddress: WALLET_ADDRESS,
+      }),
+    );
+
+    expect(callMock).toHaveBeenCalledWith(
+      'TransactionPayController:updateFiatPayment',
+      expect.objectContaining({
+        callback: expect.any(Function),
+        transactionId: TRANSACTION_ID,
       }),
     );
 
@@ -301,16 +338,15 @@ describe('getFiatQuotes', () => {
       throw new Error(`Unexpected action: ${action}`);
     });
 
-    const request: PayStrategyGetQuotesRequest = {
+    const result = await getFiatQuotes({
+      accountSupports7702: false,
       fiatPaymentMethod: '/payments/debit-credit-card',
       messenger: {
         call: callMock,
       } as unknown as PayStrategyGetQuotesRequest['messenger'],
       requests: [],
       transaction: TRANSACTION_MOCK,
-    };
-
-    const result = await getFiatQuotes(request);
+    });
 
     expect(result).toStrictEqual([]);
     expect(getRelayQuotesMock).not.toHaveBeenCalled();
@@ -425,9 +461,15 @@ describe('getFiatQuotes', () => {
     );
   });
 
-  it('returns empty array if preferred fiat quote is missing', async () => {
-    pickBestFiatQuoteMock.mockReturnValue(undefined);
-    const { request } = getRequest();
+  it('returns empty array if no quotes in success array', async () => {
+    const { request } = getRequest({
+      rampsQuotes: {
+        customActions: [],
+        error: [],
+        sorted: [],
+        success: [],
+      },
+    });
 
     const result = await getFiatQuotes(request);
 
@@ -435,7 +477,6 @@ describe('getFiatQuotes', () => {
   });
 
   it('handles ramps response without success property', async () => {
-    pickBestFiatQuoteMock.mockReturnValue(undefined);
     const { request } = getRequest({
       rampsQuotes: {
         customActions: [],
@@ -447,6 +488,73 @@ describe('getFiatQuotes', () => {
     const result = await getFiatQuotes(request);
 
     expect(result).toStrictEqual([]);
+  });
+
+  it('passes undefined providers when no provider is selected', async () => {
+    const { callMock, request } = getRequest({
+      selectedProviderId: null,
+    });
+
+    await getFiatQuotes(request);
+
+    expect(callMock).toHaveBeenCalledWith(
+      'RampsController:getQuotes',
+      expect.objectContaining({
+        providers: undefined,
+      }),
+    );
+  });
+
+  it('stores rampsQuote on fiat payment state via updateFiatPayment', async () => {
+    const fiatPaymentState: TransactionFiatPayment = {};
+    const callMock = jest.fn(
+      (action: string, requestArg?: Record<string, unknown>) => {
+        if (action === 'TransactionPayController:getState') {
+          return {
+            transactionData: {
+              [TRANSACTION_ID]: {
+                fiatPayment: { amountFiat: '10' },
+                isLoading: false,
+                tokens: [REQUIRED_TOKEN_MOCK],
+              },
+            },
+          };
+        }
+
+        if (action === 'RampsController:getState') {
+          return {
+            providers: { selected: { id: SELECTED_PROVIDER_ID } },
+          };
+        }
+
+        if (action === 'RampsController:getQuotes') {
+          return FIAT_QUOTES_RESPONSE_MOCK;
+        }
+
+        if (action === 'TransactionPayController:updateFiatPayment') {
+          const { callback } =
+            requestArg as unknown as {
+              callback: (fp: TransactionFiatPayment) => void;
+            };
+          callback(fiatPaymentState);
+          return undefined;
+        }
+
+        throw new Error(`Unexpected action: ${action}`);
+      },
+    );
+
+    await getFiatQuotes({
+      accountSupports7702: false,
+      fiatPaymentMethod: '/payments/debit-credit-card',
+      messenger: {
+        call: callMock,
+      } as unknown as PayStrategyGetQuotesRequest['messenger'],
+      requests: [],
+      transaction: TRANSACTION_MOCK,
+    });
+
+    expect(fiatPaymentState.rampsQuote).toStrictEqual(FIAT_QUOTE_MOCK);
   });
 
   it('returns empty array if ramps quotes fetch throws', async () => {
@@ -474,15 +582,22 @@ describe('getFiatQuotes', () => {
   });
 
   it('sets providerFiat fee to zero when ramps provider/network fees are missing', async () => {
-    pickBestFiatQuoteMock.mockReturnValue({
+    const quoteWithoutFees: RampsQuote = {
       provider: '/providers/transak-native-staging',
       quote: {
         amountIn: 20,
         amountOut: 5,
         paymentMethod: '/payments/debit-credit-card',
       },
-    } as RampsQuote);
-    const { request } = getRequest();
+    };
+    const { request } = getRequest({
+      rampsQuotes: {
+        customActions: [],
+        error: [],
+        sorted: [],
+        success: [quoteWithoutFees],
+      },
+    });
 
     const result = await getFiatQuotes(request);
 

--- a/packages/transaction-pay-controller/src/strategy/fiat/fiat-quotes.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/fiat-quotes.ts
@@ -14,6 +14,7 @@ import type {
 import { computeRawFromFiatAmount, getTokenFiatRate } from '../../utils/token';
 import { getRelayQuotes } from '../relay/relay-quotes';
 import type { RelayQuote } from '../relay/types';
+import { DEFAULT_FIAT_CURRENCY } from './constants';
 import type { TransactionPayFiatAsset } from './constants';
 import type { FiatQuote } from './types';
 import { deriveFiatAssetForFiatPayment } from './utils';
@@ -171,7 +172,7 @@ async function getRampsQuote({
   const quotes = await messenger.call('RampsController:getQuotes', {
     amount: adjustedAmount,
     assetId: fiatAsset.caipAssetId,
-    fiat: 'USD',
+    fiat: DEFAULT_FIAT_CURRENCY,
     paymentMethods: [fiatPaymentMethod],
     providers: selectedProviderId ? [selectedProviderId] : undefined,
     walletAddress,

--- a/packages/transaction-pay-controller/src/strategy/fiat/fiat-quotes.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/fiat-quotes.ts
@@ -14,8 +14,9 @@ import type {
 import { computeRawFromFiatAmount, getTokenFiatRate } from '../../utils/token';
 import { getRelayQuotes } from '../relay/relay-quotes';
 import type { RelayQuote } from '../relay/types';
+import type { TransactionPayFiatAsset } from './constants';
 import type { FiatQuote } from './types';
-import { deriveFiatAssetForFiatPayment, pickBestFiatQuote } from './utils';
+import { deriveFiatAssetForFiatPayment } from './utils';
 
 const log = createModuleLogger(projectLogger, 'fiat-strategy');
 
@@ -115,22 +116,20 @@ export async function getFiatQuotes(
       transactionId,
     });
 
-    const quotes = await messenger.call('RampsController:getQuotes', {
-      amount: adjustedAmount,
-      paymentMethods: [fiatPaymentMethod],
+    const fiatQuote = await getRampsQuote({
+      adjustedAmount,
+      fiatAsset,
+      fiatPaymentMethod,
+      messenger,
       walletAddress,
     });
 
-    log('Fetched ramps quotes', {
-      rampsQuotesCount: quotes.success?.length ?? 0,
+    messenger.call('TransactionPayController:updateFiatPayment', {
+      callback: (fiatPayment) => {
+        fiatPayment.rampsQuote = fiatQuote;
+      },
       transactionId,
     });
-
-    const fiatQuote = pickBestFiatQuote(quotes);
-
-    if (!fiatQuote) {
-      throw new Error('No matching ramps quote found for selected provider');
-    }
 
     return [
       combineQuotes({
@@ -151,6 +150,45 @@ function getRequiredTokens(
   tokens?: TransactionPayRequiredToken[],
 ): TransactionPayRequiredToken[] {
   return tokens?.filter((token) => !token.skipIfBalance) ?? [];
+}
+
+async function getRampsQuote({
+  adjustedAmount,
+  fiatAsset,
+  fiatPaymentMethod,
+  messenger,
+  walletAddress,
+}: {
+  adjustedAmount: number;
+  fiatAsset: TransactionPayFiatAsset;
+  fiatPaymentMethod: string;
+  messenger: PayStrategyGetQuotesRequest['messenger'];
+  walletAddress: string;
+}): Promise<RampsQuote> {
+  const rampsState = messenger.call('RampsController:getState');
+  const selectedProviderId = rampsState.providers.selected?.id;
+
+  const quotes = await messenger.call('RampsController:getQuotes', {
+    amount: adjustedAmount,
+    assetId: fiatAsset.caipAssetId,
+    fiat: 'USD',
+    paymentMethods: [fiatPaymentMethod],
+    providers: selectedProviderId ? [selectedProviderId] : undefined,
+    walletAddress,
+  });
+
+  log('Fetched ramps quotes', {
+    quotesCount: quotes.success?.length ?? 0,
+    selectedProviderId,
+  });
+
+  const quote = quotes.success?.[0];
+
+  if (!quote) {
+    throw new Error('No matching ramps quote found for selected provider');
+  }
+
+  return quote;
 }
 
 function buildRelayRequestFromAmountFiat({

--- a/packages/transaction-pay-controller/src/strategy/fiat/types.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/types.ts
@@ -1,4 +1,4 @@
-import type { Quote, QuotesResponse } from '@metamask/ramps-controller';
+import type { Quote } from '@metamask/ramps-controller';
 
 import type { RelayQuote } from '../relay/types';
 
@@ -6,5 +6,3 @@ export type FiatQuote = {
   rampsQuote: Quote;
   relayQuote: RelayQuote;
 };
-
-export type FiatQuotesResponse = QuotesResponse;

--- a/packages/transaction-pay-controller/src/strategy/fiat/utils.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/utils.test.ts
@@ -2,8 +2,7 @@ import type { TransactionMeta } from '@metamask/transaction-controller';
 import { TransactionType } from '@metamask/transaction-controller';
 
 import { FIAT_ASSET_ID_BY_TX_TYPE } from './constants';
-import type { FiatQuotesResponse } from './types';
-import { deriveFiatAssetForFiatPayment, pickBestFiatQuote } from './utils';
+import { deriveFiatAssetForFiatPayment } from './utils';
 
 describe('Fiat Utils', () => {
   describe('deriveFiatAssetForFiatPayment', () => {
@@ -38,48 +37,6 @@ describe('Fiat Utils', () => {
       } as TransactionMeta;
 
       const result = deriveFiatAssetForFiatPayment(transaction);
-
-      expect(result).toBeUndefined();
-    });
-  });
-
-  describe('pickBestFiatQuote', () => {
-    it('returns transak-native-staging quote when present', () => {
-      const quotes = {
-        customActions: [],
-        error: [],
-        sorted: [],
-        success: [
-          {
-            provider: '/providers/moonpay',
-            quote: { amountIn: 10, amountOut: 20, paymentMethod: 'card' },
-          },
-          {
-            provider: '/providers/transak-native-staging',
-            quote: { amountIn: 11, amountOut: 22, paymentMethod: 'card' },
-          },
-        ],
-      } as FiatQuotesResponse;
-
-      const result = pickBestFiatQuote(quotes);
-
-      expect(result).toStrictEqual(quotes.success[1]);
-    });
-
-    it('returns undefined when transak-native-staging quote is missing', () => {
-      const quotes = {
-        customActions: [],
-        error: [],
-        sorted: [],
-        success: [
-          {
-            provider: '/providers/moonpay',
-            quote: { amountIn: 10, amountOut: 20, paymentMethod: 'card' },
-          },
-        ],
-      } as FiatQuotesResponse;
-
-      const result = pickBestFiatQuote(quotes);
 
       expect(result).toBeUndefined();
     });

--- a/packages/transaction-pay-controller/src/strategy/fiat/utils.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/utils.ts
@@ -1,7 +1,3 @@
-import type {
-  Quote as RampsQuote,
-  QuotesResponse as RampsQuotesResponse,
-} from '@metamask/ramps-controller';
 import {
   TransactionMeta,
   TransactionType,
@@ -22,13 +18,4 @@ export function deriveFiatAssetForFiatPayment(
   }
 
   return FIAT_ASSET_ID_BY_TX_TYPE[transactionType as TransactionType];
-}
-
-export function pickBestFiatQuote(
-  quotes: RampsQuotesResponse,
-): RampsQuote | undefined {
-  return quotes.success?.find(
-    // TODO: Implement provider selection logic; force Transak staging for now.
-    (quote) => quote.provider === '/providers/transak-native-staging',
-  );
 }

--- a/packages/transaction-pay-controller/src/types.ts
+++ b/packages/transaction-pay-controller/src/types.ts
@@ -20,7 +20,11 @@ import type {
 import type { Messenger } from '@metamask/messenger';
 import type { NetworkControllerFindNetworkClientIdByChainIdAction } from '@metamask/network-controller';
 import type { NetworkControllerGetNetworkClientByIdAction } from '@metamask/network-controller';
-import type { RampsControllerGetQuotesAction } from '@metamask/ramps-controller';
+import type { Quote as RampsQuote } from '@metamask/ramps-controller';
+import type {
+  RampsControllerGetQuotesAction,
+  RampsControllerGetStateAction,
+} from '@metamask/ramps-controller';
 import type { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
 import type {
   AuthorizationList,
@@ -56,6 +60,7 @@ export type AllowedActions =
   | NetworkControllerFindNetworkClientIdByChainIdAction
   | NetworkControllerGetNetworkClientByIdAction
   | RampsControllerGetQuotesAction
+  | RampsControllerGetStateAction
   | RemoteFeatureFlagControllerGetStateAction
   | TokenBalancesControllerGetStateAction
   | TokenRatesControllerGetStateAction
@@ -238,6 +243,9 @@ export type TransactionData = {
 export type TransactionFiatPayment = {
   /** Entered fiat amount for the selected payment method. */
   amountFiat?: string;
+
+  /** The ramps quote received from the ramps provider. */
+  rampsQuote?: RampsQuote;
 
   /** Selected fiat payment method ID. */
   selectedPaymentMethodId?: string;


### PR DESCRIPTION
## Explanation

The fiat quote flow in `transaction-pay-controller` was calling `RampsController:getQuotes` without specifying the asset, provider, or currency - relying on defaults or a hardcoded `pickBestFiatQuote` helper that filtered for a specific staging provider.

This PR:

1. **Passes explicit parameters** to `RampsController:getQuotes`: `assetId` (from `fiatAsset.caipAssetId`), `providers` (from `RampsControllerState.providers.selected.id`), and `fiat: 'USD'`.
2. **Picks the first quote** from `quotes.success[0]` instead of searching by hardcoded provider name via `pickBestFiatQuote`.
3. **Persists the ramps quote** on `TransactionFiatPayment.rampsQuote` via `TransactionPayController:updateFiatPayment` so downstream consumers can access it.
4. **Extracts `getRampsQuote`** helper to isolate ramps state reading and quote fetching for readability.
5. **Removes `pickBestFiatQuote`** and the unused `FiatQuotesResponse` type alias since they are no longer needed.
6. **Adds `RampsControllerGetStateAction`** to allowed actions so the messenger can read ramps controller state.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes the fiat quoting path by selecting providers via `RampsController:getState` and altering how a ramps quote is chosen/persisted, which could affect quote availability and downstream consumers of `fiatPayment` state.
> 
> **Overview**
> Improves the fiat quote flow to call `RampsController:getQuotes` with explicit `assetId`, `fiat` (defaulting to `USD`), and an optional `providers` filter derived from `RampsController:getState` (instead of relying on implicit defaults and a hardcoded provider filter).
> 
> Persists the selected ramps quote onto per-transaction state (`TransactionFiatPayment.rampsQuote`) via `TransactionPayController:updateFiatPayment`, removes the now-unused `pickBestFiatQuote` helper/types, and updates tests to cover provider-selection behavior and persistence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e4c29b5bb5e0cba5494727c027104662bb0799f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->