### PR TITLE
fix: update chomp-api-service to properly reflect the API

### DIFF
--- a/packages/chomp-api-service/CHANGELOG.md
+++ b/packages/chomp-api-service/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING:** update types and methods of chomp-api-service to properly reflect the API ([#8635](https://github.com/MetaMask/core/pull/8635))
 - Bump `@metamask/messenger` from `^1.1.1` to `^1.2.0` ([#8632](https://github.com/MetaMask/core/pull/8632))
 
 ## [2.0.0]

--- a/packages/chomp-api-service/src/chomp-api-service-method-action-types.ts
+++ b/packages/chomp-api-service/src/chomp-api-service-method-action-types.ts
@@ -6,7 +6,13 @@
 import type { ChompApiService } from './chomp-api-service';
 
 /**
- * Associates an address with a CHOMP profile via POST /v1/auth/address.
+ * Associates an address with a CHOMP profile.
+ *
+ * POST /v1/auth/address
+ *
+ * @param params - The association params containing signature, timestamp,
+ * and address.
+ * @returns The profile association result. Returns on both 201 and 409.
  */
 export type ChompApiServiceAssociateAddressAction = {
   type: `ChompApiService:associateAddress`;
@@ -14,7 +20,13 @@ export type ChompApiServiceAssociateAddressAction = {
 };
 
 /**
- * Creates an account upgrade via POST /v1/account-upgrade.
+ * Creates an account upgrade request.
+ *
+ * POST /v1/account-upgrade
+ *
+ * @param params - The upgrade params containing signature components and
+ * chain details.
+ * @returns The upgrade result.
  */
 export type ChompApiServiceCreateUpgradeAction = {
   type: `ChompApiService:createUpgrade`;
@@ -22,15 +34,26 @@ export type ChompApiServiceCreateUpgradeAction = {
 };
 
 /**
- * Fetches the upgrade record for an address via GET /v1/account-upgrade/:address.
+ * Fetches all EIP-7702 upgrade authorizations for a given address (one per
+ * chain).
+ *
+ * GET /v1/account-upgrade/:address
+ *
+ * @param address - The address to look up.
+ * @returns The upgrade entries; empty array if none exist.
  */
-export type ChompApiServiceGetUpgradeAction = {
-  type: `ChompApiService:getUpgrade`;
-  handler: ChompApiService['getUpgrade'];
+export type ChompApiServiceGetUpgradesAction = {
+  type: `ChompApiService:getUpgrades`;
+  handler: ChompApiService['getUpgrades'];
 };
 
 /**
- * Verifies a delegation via POST /v1/intent/verify-delegation.
+ * Verifies a delegation signature.
+ *
+ * POST /v1/intent/verify-delegation
+ *
+ * @param params - The delegation verification params.
+ * @returns The verification result including validity and optional errors.
  */
 export type ChompApiServiceVerifyDelegationAction = {
   type: `ChompApiService:verifyDelegation`;
@@ -38,7 +61,12 @@ export type ChompApiServiceVerifyDelegationAction = {
 };
 
 /**
- * Submits intents via POST /v1/intent.
+ * Submits one or more intents to the CHOMP API.
+ *
+ * POST /v1/intent
+ *
+ * @param intents - The array of intents to submit.
+ * @returns The array of intent responses.
  */
 export type ChompApiServiceCreateIntentsAction = {
   type: `ChompApiService:createIntents`;
@@ -46,7 +74,12 @@ export type ChompApiServiceCreateIntentsAction = {
 };
 
 /**
- * Fetches intents by address via GET /v1/intent/account/:address.
+ * Fetches intents associated with a given address.
+ *
+ * GET /v1/intent/account/:address
+ *
+ * @param address - The address to look up intents for.
+ * @returns The array of intents for the address.
  */
 export type ChompApiServiceGetIntentsByAddressAction = {
   type: `ChompApiService:getIntentsByAddress`;
@@ -54,7 +87,13 @@ export type ChompApiServiceGetIntentsByAddressAction = {
 };
 
 /**
- * Submits a withdrawal request via POST /v1/withdrawal
+ * Creates a withdrawal for card spend flows.
+ *
+ * POST /v1/withdrawal
+ *
+ * @param params - The withdrawal params containing chainId, amount
+ * (decimal or hex string), and account address.
+ * @returns The withdrawal result.
  */
 export type ChompApiServiceCreateWithdrawalAction = {
   type: `ChompApiService:createWithdrawal`;
@@ -62,7 +101,14 @@ export type ChompApiServiceCreateWithdrawalAction = {
 };
 
 /**
- * Retrieves service details via GET /v1/chomp.
+ * Retrieves service details including delegation redeemer addresses and DeFi
+ * contract details for signing delegations for auto-deposit functionality.
+ *
+ * GET /v1/chomp
+ *
+ * @param chainIds - Array of chain IDs (0x-prefixed hex strings) to retrieve
+ * details for.
+ * @returns The service details for the requested chains.
  */
 export type ChompApiServiceGetServiceDetailsAction = {
   type: `ChompApiService:getServiceDetails`;
@@ -75,7 +121,7 @@ export type ChompApiServiceGetServiceDetailsAction = {
 export type ChompApiServiceMethodActions =
   | ChompApiServiceAssociateAddressAction
   | ChompApiServiceCreateUpgradeAction
-  | ChompApiServiceGetUpgradeAction
+  | ChompApiServiceGetUpgradesAction
   | ChompApiServiceVerifyDelegationAction
   | ChompApiServiceCreateIntentsAction
   | ChompApiServiceGetIntentsByAddressAction

--- a/packages/chomp-api-service/src/chomp-api-service.test.ts
+++ b/packages/chomp-api-service/src/chomp-api-service.test.ts
@@ -17,7 +17,7 @@ describe('ChompApiService', () => {
   describe('associateAddress', () => {
     const associateParams = {
       signature: '0x123' as const,
-      timestamp: '2026-01-01T00:00:00Z',
+      timestamp: 1735689600,
       address: '0xabc' as const,
     };
 
@@ -47,18 +47,16 @@ describe('ChompApiService', () => {
 
     it('returns the response on 409 without throwing', async () => {
       nock(BASE_URL).post('/v1/auth/address').reply(409, {
-        profileId: 'p1',
         address: '0xabc',
-        status: 'already_associated',
+        status: 'active',
       });
       const { service } = createService();
 
       const result = await service.associateAddress(associateParams);
 
       expect(result).toStrictEqual({
-        profileId: 'p1',
         address: '0xabc',
-        status: 'already_associated',
+        status: 'active',
       });
     });
 
@@ -81,7 +79,7 @@ describe('ChompApiService', () => {
       const { service } = createService();
 
       await expect(service.associateAddress(associateParams)).rejects.toThrow(
-        'At path: profileId -- Expected a string',
+        'At path: address',
       );
     });
   });
@@ -99,6 +97,9 @@ describe('ChompApiService', () => {
 
     const upgradeResponse = {
       signerAddress: '0xdef',
+      address: '0xabc',
+      chainId: '0xa4b1',
+      nonce: '0x0',
       status: 'pending',
       createdAt: '2026-01-01T00:00:00Z',
     };
@@ -142,57 +143,68 @@ describe('ChompApiService', () => {
     });
   });
 
-  describe('getUpgrade', () => {
-    const upgradeRecord = {
+  describe('getUpgrades', () => {
+    const upgradeEntry = {
       signerAddress: '0xdef',
+      chainId: '0xa4b1',
+      nonce: '0x0',
+      authorization: {
+        r: '0x1',
+        s: '0x2',
+        v: 27,
+        yParity: 0,
+        address: '0xabc',
+        chainId: '0xa4b1',
+        nonce: '0x0',
+      },
       status: 'pending',
       createdAt: '2026-01-01T00:00:00Z',
     };
 
-    it('sends a GET with auth headers and returns the upgrade record', async () => {
+    it('sends a GET with auth headers and returns the upgrade entries', async () => {
       nock(BASE_URL)
         .get('/v1/account-upgrade/0xabc')
         .matchHeader('Authorization', `Bearer ${MOCK_TOKEN}`)
-        .reply(200, upgradeRecord);
+        .reply(200, [upgradeEntry]);
       const { rootMessenger } = createService();
 
       const result = await rootMessenger.call(
-        'ChompApiService:getUpgrade',
+        'ChompApiService:getUpgrades',
         '0xabc',
       );
 
-      expect(result).toStrictEqual(upgradeRecord);
+      expect(result).toStrictEqual([upgradeEntry]);
     });
 
-    it('returns null on 404', async () => {
-      nock(BASE_URL).get('/v1/account-upgrade/0xabc').reply(404);
+    it('returns an empty array when no upgrades exist', async () => {
+      nock(BASE_URL).get('/v1/account-upgrade/0xabc').reply(200, []);
       const { service } = createService();
 
-      const result = await service.getUpgrade('0xabc');
+      const result = await service.getUpgrades('0xabc');
 
-      expect(result).toBeNull();
+      expect(result).toStrictEqual([]);
     });
 
-    it('throws on non-OK/non-404 status', async () => {
+    it('throws on non-OK status', async () => {
       nock(BASE_URL)
         .get('/v1/account-upgrade/0xabc')
         .times(DEFAULT_MAX_RETRIES + 1)
         .reply(500);
       const { service } = createService();
 
-      await expect(service.getUpgrade('0xabc')).rejects.toThrow(
-        "Get upgrade request failed with status '500'",
+      await expect(service.getUpgrades('0xabc')).rejects.toThrow(
+        "Get upgrades request failed with status '500'",
       );
     });
 
     it('throws on malformed response', async () => {
       nock(BASE_URL)
         .get('/v1/account-upgrade/0xabc')
-        .reply(200, JSON.stringify({ bad: 'data' }));
+        .reply(200, JSON.stringify([{ bad: 'data' }]));
       const { service } = createService();
 
-      await expect(service.getUpgrade('0xabc')).rejects.toThrow(
-        'At path: signerAddress -- Expected a string',
+      await expect(service.getUpgrades('0xabc')).rejects.toThrow(
+        'At path: 0.signerAddress -- Expected a string',
       );
     });
   });
@@ -344,7 +356,7 @@ describe('ChompApiService', () => {
           allowance: '0xff',
           tokenAddress: '0x123',
           tokenSymbol: 'USDC',
-          type: 'deposit',
+          type: 'cash-deposit',
         },
       },
     ];

--- a/packages/chomp-api-service/src/chomp-api-service.ts
+++ b/packages/chomp-api-service/src/chomp-api-service.ts
@@ -28,7 +28,8 @@ import type {
   AssociateAddressParams,
   AssociateAddressResponse,
   CreateUpgradeParams,
-  UpgradeResponse,
+  CreateUpgradeResponse,
+  UpgradeEntry,
   CreateWithdrawalParams,
   CreateWithdrawalResponse,
   IntentEntry,
@@ -56,7 +57,7 @@ export const serviceName = 'ChompApiService';
 const MESSENGER_EXPOSED_METHODS = [
   'associateAddress',
   'createUpgrade',
-  'getUpgrade',
+  'getUpgrades',
   'verifyDelegation',
   'createIntents',
   'getIntentsByAddress',
@@ -123,16 +124,42 @@ export type ChompApiServiceMessenger = Messenger<
 // === RESPONSE VALIDATION ===
 
 const AssociateAddressResponseStruct = type({
-  profileId: string(),
+  profileId: optional(string()),
   address: StrictHexStruct,
-  status: string(),
+  status: enums(['active', 'created']),
 });
 
-const UpgradeResponseStruct = type({
+const AccountUpgradeStatusStruct = enums(['pending', 'upgraded']);
+
+const AuthorizationDataStruct = type({
+  r: StrictHexStruct,
+  s: StrictHexStruct,
+  v: number(),
+  yParity: number(),
+  address: StrictHexStruct,
+  chainId: StrictHexStruct,
+  nonce: StrictHexStruct,
+});
+
+const CreateUpgradeResponseStruct = type({
   signerAddress: StrictHexStruct,
-  status: string(),
+  address: StrictHexStruct,
+  chainId: StrictHexStruct,
+  nonce: StrictHexStruct,
+  status: AccountUpgradeStatusStruct,
   createdAt: string(),
 });
+
+const UpgradeEntryArrayStruct = array(
+  type({
+    signerAddress: StrictHexStruct,
+    chainId: StrictHexStruct,
+    nonce: StrictHexStruct,
+    authorization: AuthorizationDataStruct,
+    status: AccountUpgradeStatusStruct,
+    createdAt: string(),
+  }),
+);
 
 const VerifyDelegationResponseStruct = type({
   valid: boolean(),
@@ -163,7 +190,7 @@ const IntentEntryArrayStruct = array(
       allowance: StrictHexStruct,
       tokenAddress: StrictHexStruct,
       tokenSymbol: string(),
-      type: enums(['deposit', 'withdraw']),
+      type: enums(['cash-deposit', 'cash-withdrawal']),
     }),
   }),
 );
@@ -310,7 +337,9 @@ export class ChompApiService extends BaseDataService<
    * chain details.
    * @returns The upgrade result.
    */
-  async createUpgrade(params: CreateUpgradeParams): Promise<UpgradeResponse> {
+  async createUpgrade(
+    params: CreateUpgradeParams,
+  ): Promise<CreateUpgradeResponse> {
     const jsonResponse = await this.fetchQuery({
       queryKey: [`${this.name}:createUpgrade`, params],
       staleTime: 0,
@@ -336,20 +365,21 @@ export class ChompApiService extends BaseDataService<
       },
     });
 
-    return create(jsonResponse, UpgradeResponseStruct);
+    return create(jsonResponse, CreateUpgradeResponseStruct);
   }
 
   /**
-   * Fetches the upgrade record for a given address.
+   * Fetches all EIP-7702 upgrade authorizations for a given address (one per
+   * chain).
    *
    * GET /v1/account-upgrade/:address
    *
    * @param address - The address to look up.
-   * @returns The upgrade record, or null if not found.
+   * @returns The upgrade entries; empty array if none exist.
    */
-  async getUpgrade(address: Hex): Promise<UpgradeResponse | null> {
+  async getUpgrades(address: Hex): Promise<UpgradeEntry[]> {
     const jsonResponse = await this.fetchQuery({
-      queryKey: [`${this.name}:getUpgrade`, address],
+      queryKey: [`${this.name}:getUpgrades`, address],
       queryFn: async () => {
         const headers = await this.#authHeaders();
         const response = await fetch(
@@ -357,14 +387,10 @@ export class ChompApiService extends BaseDataService<
           { headers },
         );
 
-        if (response.status === 404) {
-          return null;
-        }
-
         if (!response.ok) {
           throw new HttpError(
             response.status,
-            `Get upgrade request failed with status '${response.status}'`,
+            `Get upgrades request failed with status '${response.status}'`,
           );
         }
 
@@ -372,11 +398,7 @@ export class ChompApiService extends BaseDataService<
       },
     });
 
-    if (jsonResponse === null) {
-      return null;
-    }
-
-    return create(jsonResponse, UpgradeResponseStruct);
+    return create(jsonResponse, UpgradeEntryArrayStruct);
   }
 
   /**

--- a/packages/chomp-api-service/src/index.ts
+++ b/packages/chomp-api-service/src/index.ts
@@ -10,7 +10,7 @@ export type {
 export type {
   ChompApiServiceAssociateAddressAction,
   ChompApiServiceCreateUpgradeAction,
-  ChompApiServiceGetUpgradeAction,
+  ChompApiServiceGetUpgradesAction,
   ChompApiServiceVerifyDelegationAction,
   ChompApiServiceCreateIntentsAction,
   ChompApiServiceGetIntentsByAddressAction,
@@ -18,13 +18,16 @@ export type {
   ChompApiServiceGetServiceDetailsAction,
 } from './chomp-api-service-method-action-types';
 export type {
+  AccountUpgradeStatus,
   AssociateAddressParams,
   AssociateAddressResponse,
+  AuthorizationData,
   CreateUpgradeParams,
+  CreateUpgradeResponse,
   CreateWithdrawalParams,
   CreateWithdrawalResponse,
   DelegationCaveat,
-  UpgradeResponse,
+  UpgradeEntry,
   IntentEntry,
   IntentMetadataParams,
   IntentMetadataResponse,

--- a/packages/chomp-api-service/src/types.ts
+++ b/packages/chomp-api-service/src/types.ts
@@ -63,15 +63,53 @@ export type CreateWithdrawalParams = {
 
 // === RESPONSE TYPES ===
 
+/**
+ * Returned by POST /v1/auth/address.
+ *
+ * `profileId` is only included when the address was newly associated
+ * (`status: 'created'`). When the address was already associated with the
+ * authenticated profile (`status: 'active'`), only `address` is returned.
+ */
 export type AssociateAddressResponse = {
-  profileId: string;
+  profileId?: string;
   address: Hex;
-  status: string;
+  status: 'active' | 'created';
 };
 
-export type UpgradeResponse = {
+export type AccountUpgradeStatus = 'pending' | 'upgraded';
+
+export type AuthorizationData = {
+  r: Hex;
+  s: Hex;
+  v: number;
+  yParity: number;
+  address: Hex;
+  chainId: Hex;
+  nonce: Hex;
+};
+
+/**
+ * Returned by POST /v1/account-upgrade.
+ */
+export type CreateUpgradeResponse = {
   signerAddress: Hex;
-  status: string;
+  address: Hex;
+  chainId: Hex;
+  nonce: Hex;
+  status: AccountUpgradeStatus;
+  createdAt: string;
+};
+
+/**
+ * One entry returned by GET /v1/account-upgrade/:address. The endpoint returns
+ * an array of these (one per chain).
+ */
+export type UpgradeEntry = {
+  signerAddress: Hex;
+  chainId: Hex;
+  nonce: Hex;
+  authorization: AuthorizationData;
+  status: AccountUpgradeStatus;
   createdAt: string;
 };
 
@@ -96,9 +134,6 @@ export type SendIntentResponse = {
 
 /**
  * The shape returned by GET /v1/intent/account/:address for each intent.
- *
- * Note: the metadata `type` uses 'deposit' | 'withdraw' here, whereas the
- * create-intent endpoint uses 'cash-deposit' | 'cash-withdrawal'.
  */
 export type IntentEntry = {
   account: Hex;
@@ -109,7 +144,7 @@ export type IntentEntry = {
     allowance: Hex;
     tokenAddress: Hex;
     tokenSymbol: string;
-    type: 'deposit' | 'withdraw';
+    type: 'cash-deposit' | 'cash-withdrawal';
   };
 };
 

--- a/packages/money-account-upgrade-controller/CHANGELOG.md
+++ b/packages/money-account-upgrade-controller/CHANGELOG.md
@@ -9,9 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Bump `@metamask/chomp-api-service` from `^2.0.0` to `^3.0.0` ([#8635](https://github.com/MetaMask/core/pull/8635))
 - Bump `@metamask/messenger` from `^1.1.1` to `^1.2.0` ([#8632](https://github.com/MetaMask/core/pull/8632))
 - Bump `@metamask/keyring-controller` from `^25.2.0` to `^25.3.0` ([#8634](https://github.com/MetaMask/core/pull/8634))
 - Bump `@metamask/network-controller` from `^30.0.1` to `^30.1.0` ([#8636](https://github.com/MetaMask/core/pull/8636))
+
+### Fixed
+
+- Fix the associate-address step to detect the already-associated case via `status: 'active'`. ([#8635](https://github.com/MetaMask/core/pull/8635))
 
 ## [1.2.0]
 

--- a/packages/money-account-upgrade-controller/src/MoneyAccountUpgradeController.test.ts
+++ b/packages/money-account-upgrade-controller/src/MoneyAccountUpgradeController.test.ts
@@ -100,10 +100,13 @@ function setup(): {
     associateAddress: jest.fn().mockResolvedValue({
       profileId: 'profile-1',
       address: MOCK_ACCOUNT_ADDRESS,
-      status: 'CREATED',
+      status: 'created',
     }),
     createUpgrade: jest.fn().mockResolvedValue({
       signerAddress: MOCK_ACCOUNT_ADDRESS,
+      address: MOCK_CONFIG.delegatorImplAddress,
+      chainId: MOCK_CHAIN_ID,
+      nonce: '0x0',
       status: 'pending',
       createdAt: '2026-04-21T12:00:00.000Z',
     }),

--- a/packages/money-account-upgrade-controller/src/steps/associate-address.test.ts
+++ b/packages/money-account-upgrade-controller/src/steps/associate-address.test.ts
@@ -124,12 +124,11 @@ describe('associateAddressStep', () => {
     expect(result).toBe('completed');
   });
 
-  it('returns "already-done" when CHOMP responds with already_associated (409)', async () => {
+  it('returns "already-done" when CHOMP responds with active (409)', async () => {
     const { messenger, mocks } = setup();
     mocks.associateAddress.mockResolvedValue({
-      profileId: 'profile-1',
       address: MOCK_ADDRESS,
-      status: 'already_associated',
+      status: 'active',
     });
 
     const result = await associateAddressStep.run({

--- a/packages/money-account-upgrade-controller/src/steps/associate-address.ts
+++ b/packages/money-account-upgrade-controller/src/steps/associate-address.ts
@@ -2,8 +2,6 @@ import type { Hex } from '@metamask/utils';
 
 import type { Step } from './step';
 
-const ALREADY_ASSOCIATED_STATUS = 'already_associated';
-
 /**
  * Associates the Money Account address with the user's CHOMP profile.
  *
@@ -11,10 +9,11 @@ const ALREADY_ASSOCIATED_STATUS = 'already_associated';
  * and submits the signature to CHOMP, which verifies the timestamp is fresh,
  * recovers the signer, and records the profile–address mapping.
  *
- * CHOMP responds with 201 and `status: 'created'` when the association is
- * made, and 409 with `status: 'already_associated'` when the address is
- * already linked to a profile. The service surfaces both responses, so this
- * step reports `'already-done'` for the 409 case and `'completed'` otherwise.
+ * CHOMP responds with 201 and `status: 'created'` when a new association is
+ * made, and 409 with `status: 'active'` when the address is already
+ * associated with the authenticated profile. The service surfaces both
+ * responses, so this step reports `'already-done'` for the 409 case and
+ * `'completed'` otherwise.
  */
 export const associateAddressStep: Step = {
   name: 'associate-address',
@@ -33,7 +32,7 @@ export const associateAddressStep: Step = {
       address,
     });
 
-    if (response.status === ALREADY_ASSOCIATED_STATUS) {
+    if (response.status === 'active') {
       return 'already-done';
     }
 

--- a/packages/money-account-upgrade-controller/src/steps/eip-7702-authorization.test.ts
+++ b/packages/money-account-upgrade-controller/src/steps/eip-7702-authorization.test.ts
@@ -79,6 +79,9 @@ function setup(): {
   const mocks: Mocks = {
     createUpgrade: jest.fn().mockResolvedValue({
       signerAddress: MOCK_ADDRESS,
+      address: MOCK_DELEGATOR_IMPL,
+      chainId: MOCK_CHAIN_ID,
+      nonce: MOCK_NONCE_HEX,
       status: 'pending',
       createdAt: '2026-04-21T12:00:00.000Z',
     }),


### PR DESCRIPTION
## Explanation
In testing the chomp-api-service I noticed that there were a number of places where the types in this service package didn't correctly reflect the real API. I've update those places, and now it should properly reflect the real implementation.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking API/type changes in a shared service and its consumer can cause runtime or integration issues if any downstream callers still expect the old `getUpgrade`/status/type shapes.
> 
> **Overview**
> Aligns `@metamask/chomp-api-service` with the real CHOMP API shapes and semantics, introducing **breaking** type/method changes and updating validation/tests accordingly.
> 
> Key changes: `associateAddress` now treats `profileId` as optional and normalizes status to `'created' | 'active'`; account-upgrade is refactored so `createUpgrade` returns a richer `CreateUpgradeResponse`, and `getUpgrade` is replaced by `getUpgrades` returning an array of per-chain `UpgradeEntry` objects (with nested authorization data) and no longer special-cases 404. Intent entry metadata types are updated to `'cash-deposit' | 'cash-withdrawal'`. The money account upgrade flow is updated to consume the new status values and response shapes, and bumps its `@metamask/chomp-api-service` dependency to `^3.0.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8ee9d6371b5ab3223df54bbf30c0aa155b3bdd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->