### PR TITLE
ci: Enable workflow queue for publish-release workflow

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,0 +1,8 @@
+# Please see the documentation for all configuration options:
+# https://github.com/rhysd/actionlint/blob/main/docs/config.md#configuration-file
+
+paths:
+  .github/workflows/publish-release.yml:
+    ignore:
+      # Queue option is not supported by actionlint yet.
+      - 'unexpected key "queue" for "concurrency" section. expected one of "cancel-in-progress", "group"'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Download actionlint
         id: download-actionlint
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/7fdc9630cc360ea1a469eed64ac6d78caeda1234/scripts/download-actionlint.bash) 1.6.25
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/914e7df21a07ef503a81201c76d2b11c789d3fca/scripts/download-actionlint.bash) 1.7.12
         shell: bash
       - name: Check workflow files
         run: ${{ steps.download-actionlint.outputs.executable }} -color

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,6 +8,10 @@ on:
       SLACK_WEBHOOK_URL:
         required: true
 
+concurrency:
+  group: publish-release
+  queue: max
+
 jobs:
   publish-release:
     permissions:


### PR DESCRIPTION
## Explanation

This adds a concurrency config with [`queue: max`](https://github.com/orgs/community/discussions/12835#discussioncomment-16602100) to the publish release workflow, which should theoretically queue releases if multiple are created at the same time.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions workflow configuration and linting; main risk is unintended release job serialization/queuing behavior if the concurrency semantics differ from expectations.
> 
> **Overview**
> Adds `concurrency` to `.github/workflows/publish-release.yml` with `group: publish-release` and `queue: max` so multiple release publishes serialize instead of overlapping.
> 
> Updates CI workflow linting by bumping `actionlint` in `main.yml` and adding `.github/actionlint.yml` to ignore the new `queue` key warning (not yet supported by `actionlint`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 919594b5657cb742b675be6a2756d6e4cb2793d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->