### PR TITLE
Revert "ci: Enable workflow queue for publish-release workflow"

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,8 +1,0 @@
-# Please see the documentation for all configuration options:
-# https://github.com/rhysd/actionlint/blob/main/docs/config.md#configuration-file
-
-paths:
-  .github/workflows/publish-release.yml:
-    ignore:
-      # Queue option is not supported by actionlint yet.
-      - 'unexpected key "queue" for "concurrency" section. expected one of "cancel-in-progress", "group"'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Download actionlint
         id: download-actionlint
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/914e7df21a07ef503a81201c76d2b11c789d3fca/scripts/download-actionlint.bash) 1.7.12
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/7fdc9630cc360ea1a469eed64ac6d78caeda1234/scripts/download-actionlint.bash) 1.6.25
         shell: bash
       - name: Check workflow files
         run: ${{ steps.download-actionlint.outputs.executable }} -color

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,10 +8,6 @@ on:
       SLACK_WEBHOOK_URL:
         required: true
 
-concurrency:
-  group: publish-release
-  queue: max
-
 jobs:
   publish-release:
     permissions:


### PR DESCRIPTION
Reverts MetaMask/core#8640.

Temporarily reverting to see if this causes an issue with a workflow run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI/release GitHub Actions configuration; mistakes could block releases or reduce workflow protection, though the changes are small and a direct revert.
> 
> **Overview**
> Reverts the `publish-release` workflow `concurrency` configuration that enabled queued runs (removes `queue: max` and its group).
> 
> Deletes `.github/actionlint.yml` and downgrades the actionlint download in `main.yml` (script ref + version) to match the workflows’ supported syntax, avoiding the previous lint exception for the unsupported `queue` key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04f0165ccab6ded618908e0bdc7d519dcf7d9881. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->