### PR TITLE
feat(profile-sync-controller): expose `requestProfilePairing` action and `needsProfilePairing` state

### DIFF
--- a/packages/profile-sync-controller/CHANGELOG.md
+++ b/packages/profile-sync-controller/CHANGELOG.md
@@ -9,12 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add SRP profile pairing support (Accounts ADR 0006) ([#8504](https://github.com/MetaMask/core/pull/8504))
-  - `performSignIn` now automatically pairs all SRPs via `POST /profile/pair` when 2+ SRPs exist (idempotent)
+- Add SRP profile pairing support (Accounts ADR 0006) ([#8504](https://github.com/MetaMask/core/pull/8504), [#XXX](https://github.com/MetaMask/core/pull/XXX))
+  - Add `performProfilePairing` public method (and messenger action) to `AuthenticationController` — pairs all SRPs via `POST /profile/pair` when 2+ SRPs exist; intended to be called by the client-side `useAutoProfilePairing` hook rather than inline with sign-in
+  - Add `hasPairedAtLeastOnce: boolean` to `AuthenticationControllerState` — monotonic flag (false → true, never reset) set by `performProfilePairing` on first successful pairing; persisted across sessions so the client hook can determine first-launch pairing needs
   - Add `canonicalProfileId` to `UserProfile` — the unified profile ID across paired SRPs
   - Add `ProfileAlias` type for transient alias data returned by the pairing API
   - Add `pairSrpProfiles` method to `SRPJwtBearerAuth` and `JwtBearerAuth`
-  - Add `ProfileSignInEvent` (`AuthenticationController:profileSignIn`) emitted after successful pairing
+  - Add `ProfileSignInEvent` (`AuthenticationController:profileSignIn`) emitted by `performProfilePairing` after successful pairing
   - Send `X-MetaMask-Profile-Pairing: enabled` header on all `/srp/login` requests
   - Resolve original per-SRP `profileId` from `profile_aliases` using `computeIdentifierId`
   - Propagate canonical profile ID to all `srpSessionData` entries after pairing

--- a/packages/profile-sync-controller/CHANGELOG.md
+++ b/packages/profile-sync-controller/CHANGELOG.md
@@ -10,12 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add SRP profile pairing support (Accounts ADR 0006) ([#8504](https://github.com/MetaMask/core/pull/8504), [#8642](https://github.com/MetaMask/core/pull/8642))
-  - Add `performProfilePairing` public method (and messenger action) to `AuthenticationController` — pairs all SRPs via `POST /profile/pair` when 2+ SRPs exist; intended to be called by the client-side `useAutoProfilePairing` hook rather than inline with sign-in
-  - Add `hasPairedAtLeastOnce: boolean` to `AuthenticationControllerState` — monotonic flag (false → true, never reset) set by `performProfilePairing` on first successful pairing; persisted across sessions so the client hook can determine first-launch pairing needs
+  - Pairing runs at the end of `performSignIn`; pair failures are swallowed and retried on the next gate fire.
+  - Add `needsProfilePairing?: boolean` to state (defaults `true`, cleared on successful pair, re-armed via `requestProfilePairing()`). Optional in the type to keep partial-state selectors assignable; treat `undefined` as `true`.
+  - Add `requestProfilePairing()` (and `AuthenticationController:requestProfilePairing` action) for clients to signal SRP-set changes so the next auto-sign-in cycle re-pairs.
+  - Upgrade path: existing signed-in users re-pair automatically on the first auto-sign-in cycle. Pre-pairing sessions miss `canonicalProfileId` and re-login on the next `getAccessToken`, so the pair call runs against fresh v2 JWTs — no client migration needed.
+  - JWT staleness note: a newly added SRP's JWT keeps `sub = alias_id` until that SRP's session is re-logged-in. User storage is unaffected (it keys on `x-profile-id`, not `sub`).
   - Add `canonicalProfileId` to `UserProfile` — the unified profile ID across paired SRPs
   - Add `ProfileAlias` type for transient alias data returned by the pairing API
   - Add `pairSrpProfiles` method to `SRPJwtBearerAuth` and `JwtBearerAuth`
-  - Add `ProfileSignInEvent` (`AuthenticationController:profileSignIn`) emitted by `performProfilePairing` after successful pairing
+  - Add `ProfileSignInEvent` (`AuthenticationController:profileSignIn`) emitted after successful pairing when the canonical profile ID changes or new aliases are returned
   - Send `X-MetaMask-Profile-Pairing: enabled` header on all `/srp/login` requests
   - Resolve original per-SRP `profileId` from `profile_aliases` using `computeIdentifierId`
   - Propagate canonical profile ID to all `srpSessionData` entries after pairing

--- a/packages/profile-sync-controller/CHANGELOG.md
+++ b/packages/profile-sync-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add SRP profile pairing support (Accounts ADR 0006) ([#8504](https://github.com/MetaMask/core/pull/8504), [#XXX](https://github.com/MetaMask/core/pull/XXX))
+- Add SRP profile pairing support (Accounts ADR 0006) ([#8504](https://github.com/MetaMask/core/pull/8504), [#8642](https://github.com/MetaMask/core/pull/8642))
   - Add `performProfilePairing` public method (and messenger action) to `AuthenticationController` — pairs all SRPs via `POST /profile/pair` when 2+ SRPs exist; intended to be called by the client-side `useAutoProfilePairing` hook rather than inline with sign-in
   - Add `hasPairedAtLeastOnce: boolean` to `AuthenticationControllerState` — monotonic flag (false → true, never reset) set by `performProfilePairing` on first successful pairing; persisted across sessions so the client hook can determine first-launch pairing needs
   - Add `canonicalProfileId` to `UserProfile` — the unified profile ID across paired SRPs

--- a/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController-method-action-types.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController-method-action-types.ts
@@ -10,6 +10,23 @@ export type AuthenticationControllerPerformSignInAction = {
   handler: AuthenticationController['performSignIn'];
 };
 
+/**
+ * Pairs all SRPs of the wallet via `POST /profile/pair`, propagates the
+ * canonical profile ID into every cached SRP session, and emits
+ * `AuthenticationController:profileSignIn` when the canonical changes or
+ * new aliases are returned. Sets `hasPairedAtLeastOnce = true` on success.
+ *
+ * No-op when the wallet has fewer than 2 SRPs (nothing to pair) or when
+ * the wallet is locked.
+ *
+ * Pairing failures are swallowed so the caller (typically the client-side
+ * `useAutoProfilePairing` hook) can simply re-invoke on the next trigger.
+ */
+export type AuthenticationControllerPerformProfilePairingAction = {
+  type: `AuthenticationController:performProfilePairing`;
+  handler: AuthenticationController['performProfilePairing'];
+};
+
 export type AuthenticationControllerPerformSignOutAction = {
   type: `AuthenticationController:performSignOut`;
   handler: AuthenticationController['performSignOut'];
@@ -85,6 +102,7 @@ export type AuthenticationControllerIsSignedInAction = {
  */
 export type AuthenticationControllerMethodActions =
   | AuthenticationControllerPerformSignInAction
+  | AuthenticationControllerPerformProfilePairingAction
   | AuthenticationControllerPerformSignOutAction
   | AuthenticationControllerGetBearerTokenAction
   | AuthenticationControllerGetSessionProfileAction

--- a/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController-method-action-types.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController-method-action-types.ts
@@ -11,11 +11,9 @@ export type AuthenticationControllerPerformSignInAction = {
 };
 
 /**
- * Marks profile pairing as needed.
- *
- * Clients call this when the SRP set may have changed (e.g. a new keyring
- * was added) so that the next auto-sign-in cycle re-runs `performSignIn`
- * and re-pairs.
+ * Marks profile pairing as needed. Clients call this when the SRP set
+ * changes (e.g. a new keyring was added) so the next auto-sign-in cycle
+ * re-runs `performSignIn` and re-pairs.
  */
 export type AuthenticationControllerRequestProfilePairingAction = {
   type: `AuthenticationController:requestProfilePairing`;

--- a/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController-method-action-types.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController-method-action-types.ts
@@ -11,20 +11,15 @@ export type AuthenticationControllerPerformSignInAction = {
 };
 
 /**
- * Pairs all SRPs of the wallet via `POST /profile/pair`, propagates the
- * canonical profile ID into every cached SRP session, and emits
- * `AuthenticationController:profileSignIn` when the canonical changes or
- * new aliases are returned. Sets `hasPairedAtLeastOnce = true` on success.
+ * Marks profile pairing as needed.
  *
- * No-op when the wallet has fewer than 2 SRPs (nothing to pair) or when
- * the wallet is locked.
- *
- * Pairing failures are swallowed so the caller (typically the client-side
- * `useAutoProfilePairing` hook) can simply re-invoke on the next trigger.
+ * Clients call this when the SRP set may have changed (e.g. a new keyring
+ * was added) so that the next auto-sign-in cycle re-runs `performSignIn`
+ * and re-pairs.
  */
-export type AuthenticationControllerPerformProfilePairingAction = {
-  type: `AuthenticationController:performProfilePairing`;
-  handler: AuthenticationController['performProfilePairing'];
+export type AuthenticationControllerRequestProfilePairingAction = {
+  type: `AuthenticationController:requestProfilePairing`;
+  handler: AuthenticationController['requestProfilePairing'];
 };
 
 export type AuthenticationControllerPerformSignOutAction = {
@@ -102,7 +97,7 @@ export type AuthenticationControllerIsSignedInAction = {
  */
 export type AuthenticationControllerMethodActions =
   | AuthenticationControllerPerformSignInAction
-  | AuthenticationControllerPerformProfilePairingAction
+  | AuthenticationControllerRequestProfilePairingAction
   | AuthenticationControllerPerformSignOutAction
   | AuthenticationControllerGetBearerTokenAction
   | AuthenticationControllerGetSessionProfileAction

--- a/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.test.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.test.ts
@@ -512,6 +512,50 @@ describe('AuthenticationController', () => {
         );
       }
     });
+
+    it('does NOT clear needsProfilePairing if requestProfilePairing is called mid-flight (multi-SRP)', async () => {
+      const metametrics = createMockAuthMetaMetrics();
+      arrangeAuthAPIs();
+      const { messenger } = createMockAuthenticationMessenger();
+
+      const controller = new AuthenticationController({
+        messenger,
+        state: mockSignedInState({ needsProfilePairing: true }),
+        metametrics,
+      });
+
+      // Re-arm BEFORE awaiting performSignIn: the epoch snapshot inside
+      // `performSignIn` runs synchronously, so the increment from this
+      // call lands after it and must prevent the gate from being cleared.
+      const performSignInPromise = controller.performSignIn();
+      controller.requestProfilePairing();
+      await performSignInPromise;
+
+      expect(controller.state.needsProfilePairing).toBe(true);
+    });
+
+    it('does NOT clear needsProfilePairing if requestProfilePairing is called mid-flight (single-SRP)', async () => {
+      const metametrics = createMockAuthMetaMetrics();
+      arrangeAuthAPIs();
+      const { messenger, mockSnapGetAllPublicKeys } =
+        createMockAuthenticationMessenger();
+
+      mockSnapGetAllPublicKeys.mockResolvedValue([
+        ['SINGLE_ENTROPY_SOURCE_ID', 'MOCK_PUBLIC_KEY'],
+      ]);
+
+      const controller = new AuthenticationController({
+        messenger,
+        state: mockSignedInState({ needsProfilePairing: true }),
+        metametrics,
+      });
+
+      const performSignInPromise = controller.performSignIn();
+      controller.requestProfilePairing();
+      await performSignInPromise;
+
+      expect(controller.state.needsProfilePairing).toBe(true);
+    });
   });
 
   describe('requestProfilePairing', () => {

--- a/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.test.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.test.ts
@@ -30,16 +30,17 @@ const MOCK_ENTROPY_SOURCE_IDS = [
  * Return mock state for the scenario where a user is signed in.
  *
  * @param options - Options.
- * @param options.expiresIn - The timestamp to use for the `expiresIn` token property.
- * @param options.hasPairedAtLeastOnce - Whether pairing has completed at least once.
+ * @param options.expiresIn - The `expiresIn` token property.
+ * @param options.needsProfilePairing - Whether pairing is still needed.
+ * Defaults to `false` (post-pair steady state).
  * @returns Mock AuthenticationController state reflecting a signed in user.
  */
 const mockSignedInState = ({
   expiresIn = Date.now() + 3600,
-  hasPairedAtLeastOnce = false,
+  needsProfilePairing = false,
 }: {
   expiresIn?: number;
-  hasPairedAtLeastOnce?: boolean;
+  needsProfilePairing?: boolean;
 } = {}): AuthenticationControllerState => {
   const srpSessionData = {} as Record<string, LoginResponse>;
 
@@ -61,7 +62,7 @@ const mockSignedInState = ({
 
   return {
     isSignedIn: true,
-    hasPairedAtLeastOnce,
+    needsProfilePairing,
     srpSessionData,
   };
 };
@@ -118,7 +119,9 @@ describe('AuthenticationController', () => {
       });
 
       const result = await controller.performSignIn();
-      expect(mockSnapGetAllPublicKeys).toHaveBeenCalledTimes(1);
+      // 1 from `performSignIn` itself + 1 from `#doPair` →
+      // `#getCanonicalProfileId` → `#getPrimaryEntropySourceId` (cold cache).
+      expect(mockSnapGetAllPublicKeys).toHaveBeenCalledTimes(2);
       expect(mockSnapGetPublicKey).toHaveBeenCalledTimes(2);
       expect(mockSnapSignMessage).toHaveBeenCalledTimes(1);
       mockEndpoints.mockNonceUrl.done();
@@ -129,7 +132,6 @@ describe('AuthenticationController', () => {
         MOCK_OATH_TOKEN_RESPONSE.access_token,
       ]);
 
-      // Assert - state shows user is logged in
       expect(controller.state.isSignedIn).toBe(true);
       for (const id of MOCK_ENTROPY_SOURCE_IDS) {
         expect(controller.state.srpSessionData?.[id]).toBeDefined();
@@ -201,22 +203,6 @@ describe('AuthenticationController', () => {
       ]);
     });
 
-    it('does not call pairProfiles', async () => {
-      const metametrics = createMockAuthMetaMetrics();
-      const mockEndpoints = arrangeAuthAPIs();
-      const { messenger } = createMockAuthenticationMessenger();
-
-      const controller = new AuthenticationController({
-        messenger,
-        metametrics,
-      });
-
-      await controller.performSignIn();
-
-      expect(mockEndpoints.mockPairProfilesUrl.isDone()).toBe(false);
-      expect(controller.state.hasPairedAtLeastOnce).toBe(false);
-    });
-
     /**
      * Jest Test & Assert Utility - for testing and asserting endpoint failures
      *
@@ -259,27 +245,8 @@ describe('AuthenticationController', () => {
     }
   });
 
-  describe('performProfilePairing', () => {
-    it('throws when wallet is locked', async () => {
-      const { messenger, baseMessenger, mockKeyringControllerGetState } =
-        createMockAuthenticationMessenger();
-      arrangeAuthAPIs();
-      const metametrics = createMockAuthMetaMetrics();
-
-      mockKeyringControllerGetState.mockReturnValue({ isUnlocked: true });
-
-      const controller = new AuthenticationController({
-        messenger,
-        metametrics,
-      });
-
-      baseMessenger.publish('KeyringController:lock');
-      await expect(controller.performProfilePairing()).rejects.toThrow(
-        expect.any(Error),
-      );
-    });
-
-    it('does nothing and does not flip hasPairedAtLeastOnce when only 1 SRP exists', async () => {
+  describe('pairing (within performSignIn)', () => {
+    it('does NOT call pairProfiles when only 1 SRP exists, but clears needsProfilePairing', async () => {
       const metametrics = createMockAuthMetaMetrics();
       const mockEndpoints = arrangeAuthAPIs();
       const { messenger, mockSnapGetAllPublicKeys } =
@@ -294,51 +261,44 @@ describe('AuthenticationController', () => {
         metametrics,
       });
 
-      await controller.performProfilePairing();
+      await controller.performSignIn();
 
       expect(mockEndpoints.mockPairProfilesUrl.isDone()).toBe(false);
-      expect(controller.state.hasPairedAtLeastOnce).toBe(false);
+      // Clear the gate so the client `useAutoSignIn` hook doesn't loop.
+      expect(controller.state.needsProfilePairing).toBe(false);
     });
 
-    it('calls pairProfiles and flips hasPairedAtLeastOnce when 2+ SRPs exist', async () => {
+    it('pairs and clears needsProfilePairing when 2+ SRPs exist', async () => {
       const metametrics = createMockAuthMetaMetrics();
-      const mockEndpoints = arrangeAuthAPIs({
-        mockPairProfiles: {
-          status: 200,
-          body: {
-            profile: {
-              identifier_id: 'id-1',
-              metametrics_id: 'mm-1',
-              profile_id: 'canonical-1',
-            },
-            profile_aliases: [
-              {
-                alias_profile_id: 'p1',
-                canonical_profile_id: 'canonical-1',
-                identifier_ids: [{ id: 'h1', type: 'SRP' }],
-              },
-              {
-                alias_profile_id: 'p2',
-                canonical_profile_id: 'canonical-1',
-                identifier_ids: [{ id: 'h2', type: 'SRP' }],
-              },
-            ],
-          },
-        },
+      const mockEndpoints = arrangeAuthAPIs();
+      const { messenger } = createMockAuthenticationMessenger();
+
+      const controller = new AuthenticationController({
+        messenger,
+        metametrics,
+      });
+
+      await controller.performSignIn();
+
+      expect(mockEndpoints.mockPairProfilesUrl.isDone()).toBe(true);
+      expect(controller.state.needsProfilePairing).toBe(false);
+    });
+
+    it('does NOT throw out of performSignIn when pairProfiles fails, leaves needsProfilePairing=true', async () => {
+      const metametrics = createMockAuthMetaMetrics();
+      arrangeAuthAPIs({
+        mockPairProfiles: { status: 500 },
       });
       const { messenger } = createMockAuthenticationMessenger();
 
       const controller = new AuthenticationController({
         messenger,
-        // Pre-seed sessions so canonical can be propagated and read back.
-        state: mockSignedInState(),
         metametrics,
       });
 
-      await controller.performProfilePairing();
-
-      expect(mockEndpoints.mockPairProfilesUrl.isDone()).toBe(true);
-      expect(controller.state.hasPairedAtLeastOnce).toBe(true);
+      expect(await controller.performSignIn()).toBeDefined();
+      // Flag stays `true` so the next gate fire retries the pair.
+      expect(controller.state.needsProfilePairing).toBe(true);
     });
 
     it('propagates the canonical profile ID to all srpSessionData entries', async () => {
@@ -371,12 +331,11 @@ describe('AuthenticationController', () => {
 
       const controller = new AuthenticationController({
         messenger,
-        // Pre-seed sessions so the pair flow has something to read/propagate.
-        state: mockSignedInState(),
+        state: mockSignedInState({ needsProfilePairing: true }),
         metametrics,
       });
 
-      await controller.performProfilePairing();
+      await controller.performSignIn();
 
       for (const id of MOCK_ENTROPY_SOURCE_IDS) {
         expect(
@@ -385,7 +344,7 @@ describe('AuthenticationController', () => {
       }
     });
 
-    it('emits profileSignIn event when the canonical profile ID changes after pairing', async () => {
+    it('emits profileSignIn when the canonical profile ID changes after pairing', async () => {
       const metametrics = createMockAuthMetaMetrics();
       arrangeAuthAPIs({
         mockPairProfiles: {
@@ -394,8 +353,7 @@ describe('AuthenticationController', () => {
             profile: {
               identifier_id: 'id-1',
               metametrics_id: 'mm-1',
-              // Intentionally different from the pre-seeded canonical so the
-              // event is triggered by the canonical shift.
+              // Intentionally different from the pre-seeded canonical.
               profile_id: 'new-canonical-after-pairing',
             },
             profile_aliases: [
@@ -420,12 +378,11 @@ describe('AuthenticationController', () => {
 
       const controller = new AuthenticationController({
         messenger,
-        // Pre-seed sessions so there is an existing canonical to compare against.
-        state: mockSignedInState(),
+        state: mockSignedInState({ needsProfilePairing: true }),
         metametrics,
       });
 
-      await controller.performProfilePairing();
+      await controller.performSignIn();
 
       expect(eventPayloads).toHaveLength(1);
       expect(eventPayloads[0].profileId).toBe('new-canonical-after-pairing');
@@ -434,7 +391,6 @@ describe('AuthenticationController', () => {
 
     it('emits profileSignIn with profileIdChanged=false when canonical is unchanged but aliases are returned', async () => {
       const metametrics = createMockAuthMetaMetrics();
-      // Return the same canonical that mockSignedInState pre-seeds, but with aliases.
       arrangeAuthAPIs({
         mockPairProfiles: {
           status: 200,
@@ -466,11 +422,11 @@ describe('AuthenticationController', () => {
 
       const controller = new AuthenticationController({
         messenger,
-        state: mockSignedInState(),
+        state: mockSignedInState({ needsProfilePairing: true }),
         metametrics,
       });
 
-      await controller.performProfilePairing();
+      await controller.performSignIn();
 
       expect(eventPayloads).toHaveLength(1);
       expect(eventPayloads[0].profileIdChanged).toBe(false);
@@ -504,29 +460,13 @@ describe('AuthenticationController', () => {
 
       const controller = new AuthenticationController({
         messenger,
-        state: mockSignedInState(),
+        state: mockSignedInState({ needsProfilePairing: true }),
         metametrics,
       });
 
-      await controller.performProfilePairing();
+      await controller.performSignIn();
 
       expect(eventPayloads).toHaveLength(0);
-    });
-
-    it('does not throw and does not flip hasPairedAtLeastOnce when pairProfiles fails', async () => {
-      const metametrics = createMockAuthMetaMetrics();
-      arrangeAuthAPIs({
-        mockPairProfiles: { status: 500 },
-      });
-      const { messenger } = createMockAuthenticationMessenger();
-
-      const controller = new AuthenticationController({
-        messenger,
-        metametrics,
-      });
-
-      expect(await controller.performProfilePairing()).toBeUndefined();
-      expect(controller.state.hasPairedAtLeastOnce).toBe(false);
     });
 
     it('preserves the original per-SRP profileId after pairing', async () => {
@@ -559,19 +499,63 @@ describe('AuthenticationController', () => {
 
       const controller = new AuthenticationController({
         messenger,
-        state: mockSignedInState(),
+        state: mockSignedInState({ needsProfilePairing: true }),
         metametrics,
       });
 
-      await controller.performProfilePairing();
+      await controller.performSignIn();
 
-      // Pairing only mutates `canonicalProfileId` via `#propagateCanonical`;
-      // each entry's `profileId` keeps the value set at login time.
+      // Pairing only updates `canonicalProfileId`; `profileId` is preserved.
       for (const id of MOCK_ENTROPY_SOURCE_IDS) {
         expect(controller.state.srpSessionData?.[id]?.profile.profileId).toBe(
           MOCK_LOGIN_RESPONSE.profile.profile_id,
         );
       }
+    });
+  });
+
+  describe('requestProfilePairing', () => {
+    it('flips needsProfilePairing from false to true', () => {
+      const metametrics = createMockAuthMetaMetrics();
+      const { messenger } = createMockAuthenticationMessenger();
+      const controller = new AuthenticationController({
+        messenger,
+        state: mockSignedInState({ needsProfilePairing: false }),
+        metametrics,
+      });
+
+      expect(controller.state.needsProfilePairing).toBe(false);
+      controller.requestProfilePairing();
+      expect(controller.state.needsProfilePairing).toBe(true);
+    });
+
+    it('keeps needsProfilePairing true when already true (no-op)', () => {
+      const metametrics = createMockAuthMetaMetrics();
+      const { messenger } = createMockAuthenticationMessenger();
+      const controller = new AuthenticationController({
+        messenger,
+        state: mockSignedInState({ needsProfilePairing: true }),
+        metametrics,
+      });
+
+      const stateBefore = controller.state;
+      controller.requestProfilePairing();
+      expect(controller.state.needsProfilePairing).toBe(true);
+      // Identity preserved: the early-return skips `update` (no Immer alloc).
+      expect(controller.state).toBe(stateBefore);
+    });
+
+    it('is exposed via the messenger registry', () => {
+      const metametrics = createMockAuthMetaMetrics();
+      const { messenger, baseMessenger } = createMockAuthenticationMessenger();
+      const controller = new AuthenticationController({
+        messenger,
+        state: mockSignedInState({ needsProfilePairing: false }),
+        metametrics,
+      });
+
+      baseMessenger.call('AuthenticationController:requestProfilePairing');
+      expect(controller.state.needsProfilePairing).toBe(true);
     });
   });
 
@@ -597,7 +581,7 @@ describe('AuthenticationController', () => {
       const { messenger } = createMockAuthenticationMessenger();
       const controller = new AuthenticationController({
         messenger,
-        state: { isSignedIn: false, hasPairedAtLeastOnce: false },
+        state: { isSignedIn: false, needsProfilePairing: true },
         metametrics,
       });
 
@@ -749,7 +733,7 @@ describe('AuthenticationController', () => {
       await controller.getBearerToken();
       await controller.getBearerToken();
 
-      // getAllPublicKeys should only be called once despite multiple getBearerToken calls
+      // Only the first call hits the snap; subsequent calls hit the cache.
       expect(mockSnapGetAllPublicKeys).toHaveBeenCalledTimes(1);
     });
 
@@ -792,7 +776,7 @@ describe('AuthenticationController', () => {
       const { messenger } = createMockAuthenticationMessenger();
       const controller = new AuthenticationController({
         messenger,
-        state: { isSignedIn: false, hasPairedAtLeastOnce: false },
+        state: { isSignedIn: false, needsProfilePairing: true },
         metametrics,
       });
 
@@ -901,7 +885,7 @@ describe('AuthenticationController', () => {
       const { messenger } = createMockAuthenticationMessenger();
       const controller = new AuthenticationController({
         messenger,
-        state: { isSignedIn: false, hasPairedAtLeastOnce: false },
+        state: { isSignedIn: false, needsProfilePairing: true },
         metametrics,
       });
 
@@ -958,7 +942,7 @@ describe('AuthenticationController', () => {
       const { messenger } = createMockAuthenticationMessenger();
       const controller = new AuthenticationController({
         messenger,
-        state: { isSignedIn: false, hasPairedAtLeastOnce: false },
+        state: { isSignedIn: false, needsProfilePairing: true },
         metametrics,
       });
 
@@ -1013,7 +997,7 @@ describe('AuthenticationController', () => {
       const { messenger } = createMockAuthenticationMessenger();
       const controller = new AuthenticationController({
         messenger,
-        state: { isSignedIn: false, hasPairedAtLeastOnce: false },
+        state: { isSignedIn: false, needsProfilePairing: true },
         metametrics,
       });
 
@@ -1051,8 +1035,8 @@ describe('metadata', () => {
       ),
     ).toMatchInlineSnapshot(`
       {
-        "hasPairedAtLeastOnce": false,
         "isSignedIn": true,
+        "needsProfilePairing": false,
       }
     `);
   });
@@ -1074,8 +1058,8 @@ describe('metadata', () => {
 
       expect(derivedState).toMatchInlineSnapshot(`
         {
-          "hasPairedAtLeastOnce": false,
           "isSignedIn": true,
+          "needsProfilePairing": false,
           "srpSessionData": {
             "MOCK_ENTROPY_SOURCE_ID": {
               "profile": {
@@ -1120,8 +1104,8 @@ describe('metadata', () => {
         ),
       ).toMatchInlineSnapshot(`
         {
-          "hasPairedAtLeastOnce": false,
           "isSignedIn": false,
+          "needsProfilePairing": true,
         }
       `);
     });
@@ -1139,8 +1123,8 @@ describe('metadata', () => {
       deriveStateFromMetadata(controller.state, controller.metadata, 'persist'),
     ).toMatchInlineSnapshot(`
       {
-        "hasPairedAtLeastOnce": false,
         "isSignedIn": true,
+        "needsProfilePairing": false,
         "srpSessionData": {
           "MOCK_ENTROPY_SOURCE_ID": {
             "profile": {
@@ -1189,8 +1173,8 @@ describe('metadata', () => {
       ),
     ).toMatchInlineSnapshot(`
       {
-        "hasPairedAtLeastOnce": false,
         "isSignedIn": true,
+        "needsProfilePairing": false,
         "srpSessionData": {
           "MOCK_ENTROPY_SOURCE_ID": {
             "profile": {

--- a/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.test.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.test.ts
@@ -31,11 +31,16 @@ const MOCK_ENTROPY_SOURCE_IDS = [
  *
  * @param options - Options.
  * @param options.expiresIn - The timestamp to use for the `expiresIn` token property.
+ * @param options.hasPairedAtLeastOnce - Whether pairing has completed at least once.
  * @returns Mock AuthenticationController state reflecting a signed in user.
  */
 const mockSignedInState = ({
   expiresIn = Date.now() + 3600,
-}: { expiresIn?: number } = {}): AuthenticationControllerState => {
+  hasPairedAtLeastOnce = false,
+}: {
+  expiresIn?: number;
+  hasPairedAtLeastOnce?: boolean;
+} = {}): AuthenticationControllerState => {
   const srpSessionData = {} as Record<string, LoginResponse>;
 
   MOCK_ENTROPY_SOURCE_IDS.forEach((id) => {
@@ -56,6 +61,7 @@ const mockSignedInState = ({
 
   return {
     isSignedIn: true,
+    hasPairedAtLeastOnce,
     srpSessionData,
   };
 };
@@ -112,9 +118,7 @@ describe('AuthenticationController', () => {
       });
 
       const result = await controller.performSignIn();
-      // Called twice: once by performSignIn to iterate SRPs, once by
-      // #performPairing to resolve the primary for the canonical lookup.
-      expect(mockSnapGetAllPublicKeys).toHaveBeenCalledTimes(2);
+      expect(mockSnapGetAllPublicKeys).toHaveBeenCalledTimes(1);
       expect(mockSnapGetPublicKey).toHaveBeenCalledTimes(2);
       expect(mockSnapSignMessage).toHaveBeenCalledTimes(1);
       mockEndpoints.mockNonceUrl.done();
@@ -197,53 +201,10 @@ describe('AuthenticationController', () => {
       ]);
     });
 
-    it('calls pairProfiles when 2+ SRPs exist', async () => {
-      const metametrics = createMockAuthMetaMetrics();
-      const mockEndpoints = arrangeAuthAPIs({
-        mockPairProfiles: {
-          status: 200,
-          body: {
-            profile: {
-              identifier_id: 'id-1',
-              metametrics_id: 'mm-1',
-              profile_id: 'canonical-1',
-            },
-            profile_aliases: [
-              {
-                alias_profile_id: 'p1',
-                canonical_profile_id: 'canonical-1',
-                identifier_ids: [{ id: 'h1', type: 'SRP' }],
-              },
-              {
-                alias_profile_id: 'p2',
-                canonical_profile_id: 'canonical-1',
-                identifier_ids: [{ id: 'h2', type: 'SRP' }],
-              },
-            ],
-          },
-        },
-      });
-      const { messenger } = createMockAuthenticationMessenger();
-
-      const controller = new AuthenticationController({
-        messenger,
-        metametrics,
-      });
-
-      await controller.performSignIn();
-
-      expect(mockEndpoints.mockPairProfilesUrl.isDone()).toBe(true);
-    });
-
-    it('does not call pairProfiles when only 1 SRP exists', async () => {
+    it('does not call pairProfiles', async () => {
       const metametrics = createMockAuthMetaMetrics();
       const mockEndpoints = arrangeAuthAPIs();
-      const { messenger, mockSnapGetAllPublicKeys } =
-        createMockAuthenticationMessenger();
-
-      mockSnapGetAllPublicKeys.mockResolvedValue([
-        ['SINGLE_ENTROPY_SOURCE_ID', 'MOCK_PUBLIC_KEY'],
-      ]);
+      const { messenger } = createMockAuthenticationMessenger();
 
       const controller = new AuthenticationController({
         messenger,
@@ -252,184 +213,8 @@ describe('AuthenticationController', () => {
 
       await controller.performSignIn();
 
-      expect(controller.state.isSignedIn).toBe(true);
       expect(mockEndpoints.mockPairProfilesUrl.isDone()).toBe(false);
-    });
-
-    it('propagates canonical profileId to all srpSessionData entries', async () => {
-      const metametrics = createMockAuthMetaMetrics();
-      arrangeAuthAPIs({
-        mockPairProfiles: {
-          status: 200,
-          body: {
-            profile: {
-              identifier_id: 'id-1',
-              metametrics_id: 'mm-1',
-              profile_id: 'new-canonical',
-            },
-            profile_aliases: [
-              {
-                alias_profile_id: 'p1',
-                canonical_profile_id: 'new-canonical',
-                identifier_ids: [{ id: 'h1', type: 'SRP' }],
-              },
-              {
-                alias_profile_id: 'p2',
-                canonical_profile_id: 'new-canonical',
-                identifier_ids: [{ id: 'h2', type: 'SRP' }],
-              },
-            ],
-          },
-        },
-      });
-      const { messenger } = createMockAuthenticationMessenger();
-
-      const controller = new AuthenticationController({
-        messenger,
-        metametrics,
-      });
-
-      await controller.performSignIn();
-
-      for (const id of MOCK_ENTROPY_SOURCE_IDS) {
-        expect(
-          controller.state.srpSessionData?.[id]?.profile.canonicalProfileId,
-        ).toBe('new-canonical');
-      }
-    });
-
-    it('emits profileSignIn event when pairing produces aliases', async () => {
-      const metametrics = createMockAuthMetaMetrics();
-      arrangeAuthAPIs({
-        mockPairProfiles: {
-          status: 200,
-          body: {
-            profile: {
-              identifier_id: 'id-1',
-              metametrics_id: 'mm-1',
-              profile_id: 'canonical-1',
-            },
-            profile_aliases: [
-              {
-                alias_profile_id: 'p1',
-                canonical_profile_id: 'canonical-1',
-                identifier_ids: [{ id: 'h1', type: 'SRP' }],
-              },
-            ],
-          },
-        },
-      });
-      const { messenger, baseMessenger } = createMockAuthenticationMessenger();
-
-      const eventPayloads: ProfileSignInInfo[] = [];
-      baseMessenger.subscribe(
-        'AuthenticationController:profileSignIn',
-        (info: ProfileSignInInfo) => {
-          eventPayloads.push(info);
-        },
-      );
-
-      const controller = new AuthenticationController({
-        messenger,
-        metametrics,
-      });
-
-      await controller.performSignIn();
-
-      expect(eventPayloads).toHaveLength(1);
-      expect(eventPayloads[0].profileAliases).toHaveLength(1);
-      expect(eventPayloads[0].profileId).toBeDefined();
-    });
-
-    it('does not emit profileSignIn event when no pairing and no canonical change', async () => {
-      const metametrics = createMockAuthMetaMetrics();
-      arrangeAuthAPIs();
-      const { messenger, baseMessenger, mockSnapGetAllPublicKeys } =
-        createMockAuthenticationMessenger();
-
-      mockSnapGetAllPublicKeys.mockResolvedValue([
-        ['SINGLE_ENTROPY_SOURCE_ID', 'MOCK_PUBLIC_KEY'],
-      ]);
-
-      const eventPayloads: ProfileSignInInfo[] = [];
-      baseMessenger.subscribe(
-        'AuthenticationController:profileSignIn',
-        (info: ProfileSignInInfo) => {
-          eventPayloads.push(info);
-        },
-      );
-
-      const controller = new AuthenticationController({
-        messenger,
-        metametrics,
-      });
-
-      await controller.performSignIn();
-
-      expect(eventPayloads).toHaveLength(0);
-    });
-
-    it('does not break sign-in when pairProfiles throws', async () => {
-      const metametrics = createMockAuthMetaMetrics();
-      arrangeAuthAPIs({
-        mockPairProfiles: { status: 500 },
-      });
-      const { messenger } = createMockAuthenticationMessenger();
-
-      const controller = new AuthenticationController({
-        messenger,
-        metametrics,
-      });
-
-      const result = await controller.performSignIn();
-
-      expect(result).toStrictEqual([
-        MOCK_OATH_TOKEN_RESPONSE.access_token,
-        MOCK_OATH_TOKEN_RESPONSE.access_token,
-      ]);
-      expect(controller.state.isSignedIn).toBe(true);
-    });
-
-    it('preserves original profileId in srpSessionData after pairing', async () => {
-      const metametrics = createMockAuthMetaMetrics();
-      arrangeAuthAPIs({
-        mockPairProfiles: {
-          status: 200,
-          body: {
-            profile: {
-              identifier_id: 'id-1',
-              metametrics_id: 'mm-1',
-              profile_id: 'canonical-id',
-            },
-            profile_aliases: [
-              {
-                alias_profile_id: 'original-1',
-                canonical_profile_id: 'canonical-id',
-                identifier_ids: [{ id: 'h1', type: 'SRP' }],
-              },
-              {
-                alias_profile_id: 'original-2',
-                canonical_profile_id: 'canonical-id',
-                identifier_ids: [{ id: 'h2', type: 'SRP' }],
-              },
-            ],
-          },
-        },
-      });
-      const { messenger } = createMockAuthenticationMessenger();
-
-      const controller = new AuthenticationController({
-        messenger,
-        metametrics,
-      });
-
-      await controller.performSignIn();
-
-      for (const id of MOCK_ENTROPY_SOURCE_IDS) {
-        expect(controller.state.srpSessionData?.[id]?.profile.profileId).toBe(
-          MOCK_LOGIN_RESPONSE.profile.profile_id,
-        );
-      }
+      expect(controller.state.hasPairedAtLeastOnce).toBe(false);
     });
 
     /**
@@ -474,6 +259,322 @@ describe('AuthenticationController', () => {
     }
   });
 
+  describe('performProfilePairing', () => {
+    it('throws when wallet is locked', async () => {
+      const { messenger, baseMessenger, mockKeyringControllerGetState } =
+        createMockAuthenticationMessenger();
+      arrangeAuthAPIs();
+      const metametrics = createMockAuthMetaMetrics();
+
+      mockKeyringControllerGetState.mockReturnValue({ isUnlocked: true });
+
+      const controller = new AuthenticationController({
+        messenger,
+        metametrics,
+      });
+
+      baseMessenger.publish('KeyringController:lock');
+      await expect(controller.performProfilePairing()).rejects.toThrow(
+        expect.any(Error),
+      );
+    });
+
+    it('does nothing and does not flip hasPairedAtLeastOnce when only 1 SRP exists', async () => {
+      const metametrics = createMockAuthMetaMetrics();
+      const mockEndpoints = arrangeAuthAPIs();
+      const { messenger, mockSnapGetAllPublicKeys } =
+        createMockAuthenticationMessenger();
+
+      mockSnapGetAllPublicKeys.mockResolvedValue([
+        ['SINGLE_ENTROPY_SOURCE_ID', 'MOCK_PUBLIC_KEY'],
+      ]);
+
+      const controller = new AuthenticationController({
+        messenger,
+        metametrics,
+      });
+
+      await controller.performProfilePairing();
+
+      expect(mockEndpoints.mockPairProfilesUrl.isDone()).toBe(false);
+      expect(controller.state.hasPairedAtLeastOnce).toBe(false);
+    });
+
+    it('calls pairProfiles and flips hasPairedAtLeastOnce when 2+ SRPs exist', async () => {
+      const metametrics = createMockAuthMetaMetrics();
+      const mockEndpoints = arrangeAuthAPIs({
+        mockPairProfiles: {
+          status: 200,
+          body: {
+            profile: {
+              identifier_id: 'id-1',
+              metametrics_id: 'mm-1',
+              profile_id: 'canonical-1',
+            },
+            profile_aliases: [
+              {
+                alias_profile_id: 'p1',
+                canonical_profile_id: 'canonical-1',
+                identifier_ids: [{ id: 'h1', type: 'SRP' }],
+              },
+              {
+                alias_profile_id: 'p2',
+                canonical_profile_id: 'canonical-1',
+                identifier_ids: [{ id: 'h2', type: 'SRP' }],
+              },
+            ],
+          },
+        },
+      });
+      const { messenger } = createMockAuthenticationMessenger();
+
+      const controller = new AuthenticationController({
+        messenger,
+        // Pre-seed sessions so canonical can be propagated and read back.
+        state: mockSignedInState(),
+        metametrics,
+      });
+
+      await controller.performProfilePairing();
+
+      expect(mockEndpoints.mockPairProfilesUrl.isDone()).toBe(true);
+      expect(controller.state.hasPairedAtLeastOnce).toBe(true);
+    });
+
+    it('propagates the canonical profile ID to all srpSessionData entries', async () => {
+      const metametrics = createMockAuthMetaMetrics();
+      arrangeAuthAPIs({
+        mockPairProfiles: {
+          status: 200,
+          body: {
+            profile: {
+              identifier_id: 'id-1',
+              metametrics_id: 'mm-1',
+              profile_id: 'new-canonical',
+            },
+            profile_aliases: [
+              {
+                alias_profile_id: 'p1',
+                canonical_profile_id: 'new-canonical',
+                identifier_ids: [{ id: 'h1', type: 'SRP' }],
+              },
+              {
+                alias_profile_id: 'p2',
+                canonical_profile_id: 'new-canonical',
+                identifier_ids: [{ id: 'h2', type: 'SRP' }],
+              },
+            ],
+          },
+        },
+      });
+      const { messenger } = createMockAuthenticationMessenger();
+
+      const controller = new AuthenticationController({
+        messenger,
+        // Pre-seed sessions so the pair flow has something to read/propagate.
+        state: mockSignedInState(),
+        metametrics,
+      });
+
+      await controller.performProfilePairing();
+
+      for (const id of MOCK_ENTROPY_SOURCE_IDS) {
+        expect(
+          controller.state.srpSessionData?.[id]?.profile.canonicalProfileId,
+        ).toBe('new-canonical');
+      }
+    });
+
+    it('emits profileSignIn event when the canonical profile ID changes after pairing', async () => {
+      const metametrics = createMockAuthMetaMetrics();
+      arrangeAuthAPIs({
+        mockPairProfiles: {
+          status: 200,
+          body: {
+            profile: {
+              identifier_id: 'id-1',
+              metametrics_id: 'mm-1',
+              // Intentionally different from the pre-seeded canonical so the
+              // event is triggered by the canonical shift.
+              profile_id: 'new-canonical-after-pairing',
+            },
+            profile_aliases: [
+              {
+                alias_profile_id: 'p1',
+                canonical_profile_id: 'new-canonical-after-pairing',
+                identifier_ids: [{ id: 'h1', type: 'SRP' }],
+              },
+            ],
+          },
+        },
+      });
+      const { messenger, baseMessenger } = createMockAuthenticationMessenger();
+
+      const eventPayloads: ProfileSignInInfo[] = [];
+      baseMessenger.subscribe(
+        'AuthenticationController:profileSignIn',
+        (info: ProfileSignInInfo) => {
+          eventPayloads.push(info);
+        },
+      );
+
+      const controller = new AuthenticationController({
+        messenger,
+        // Pre-seed sessions so there is an existing canonical to compare against.
+        state: mockSignedInState(),
+        metametrics,
+      });
+
+      await controller.performProfilePairing();
+
+      expect(eventPayloads).toHaveLength(1);
+      expect(eventPayloads[0].profileId).toBe('new-canonical-after-pairing');
+      expect(eventPayloads[0].profileIdChanged).toBe(true);
+    });
+
+    it('emits profileSignIn with profileIdChanged=false when canonical is unchanged but aliases are returned', async () => {
+      const metametrics = createMockAuthMetaMetrics();
+      // Return the same canonical that mockSignedInState pre-seeds, but with aliases.
+      arrangeAuthAPIs({
+        mockPairProfiles: {
+          status: 200,
+          body: {
+            profile: {
+              identifier_id: 'id-1',
+              metametrics_id: 'mm-1',
+              profile_id: MOCK_LOGIN_RESPONSE.profile.profile_id,
+            },
+            profile_aliases: [
+              {
+                alias_profile_id: 'p1',
+                canonical_profile_id: MOCK_LOGIN_RESPONSE.profile.profile_id,
+                identifier_ids: [{ id: 'h1', type: 'SRP' }],
+              },
+            ],
+          },
+        },
+      });
+      const { messenger, baseMessenger } = createMockAuthenticationMessenger();
+
+      const eventPayloads: ProfileSignInInfo[] = [];
+      baseMessenger.subscribe(
+        'AuthenticationController:profileSignIn',
+        (info: ProfileSignInInfo) => {
+          eventPayloads.push(info);
+        },
+      );
+
+      const controller = new AuthenticationController({
+        messenger,
+        state: mockSignedInState(),
+        metametrics,
+      });
+
+      await controller.performProfilePairing();
+
+      expect(eventPayloads).toHaveLength(1);
+      expect(eventPayloads[0].profileIdChanged).toBe(false);
+      expect(eventPayloads[0].profileAliases).toHaveLength(1);
+    });
+
+    it('does not emit profileSignIn when canonical is unchanged and no aliases are returned', async () => {
+      const metametrics = createMockAuthMetaMetrics();
+      arrangeAuthAPIs({
+        mockPairProfiles: {
+          status: 200,
+          body: {
+            profile: {
+              identifier_id: 'id-1',
+              metametrics_id: 'mm-1',
+              profile_id: MOCK_LOGIN_RESPONSE.profile.profile_id,
+            },
+            profile_aliases: [],
+          },
+        },
+      });
+      const { messenger, baseMessenger } = createMockAuthenticationMessenger();
+
+      const eventPayloads: ProfileSignInInfo[] = [];
+      baseMessenger.subscribe(
+        'AuthenticationController:profileSignIn',
+        (info: ProfileSignInInfo) => {
+          eventPayloads.push(info);
+        },
+      );
+
+      const controller = new AuthenticationController({
+        messenger,
+        state: mockSignedInState(),
+        metametrics,
+      });
+
+      await controller.performProfilePairing();
+
+      expect(eventPayloads).toHaveLength(0);
+    });
+
+    it('does not throw and does not flip hasPairedAtLeastOnce when pairProfiles fails', async () => {
+      const metametrics = createMockAuthMetaMetrics();
+      arrangeAuthAPIs({
+        mockPairProfiles: { status: 500 },
+      });
+      const { messenger } = createMockAuthenticationMessenger();
+
+      const controller = new AuthenticationController({
+        messenger,
+        metametrics,
+      });
+
+      expect(await controller.performProfilePairing()).toBeUndefined();
+      expect(controller.state.hasPairedAtLeastOnce).toBe(false);
+    });
+
+    it('preserves the original per-SRP profileId after pairing', async () => {
+      const metametrics = createMockAuthMetaMetrics();
+      arrangeAuthAPIs({
+        mockPairProfiles: {
+          status: 200,
+          body: {
+            profile: {
+              identifier_id: 'id-1',
+              metametrics_id: 'mm-1',
+              profile_id: 'canonical-id',
+            },
+            profile_aliases: [
+              {
+                alias_profile_id: 'original-1',
+                canonical_profile_id: 'canonical-id',
+                identifier_ids: [{ id: 'h1', type: 'SRP' }],
+              },
+              {
+                alias_profile_id: 'original-2',
+                canonical_profile_id: 'canonical-id',
+                identifier_ids: [{ id: 'h2', type: 'SRP' }],
+              },
+            ],
+          },
+        },
+      });
+      const { messenger } = createMockAuthenticationMessenger();
+
+      const controller = new AuthenticationController({
+        messenger,
+        state: mockSignedInState(),
+        metametrics,
+      });
+
+      await controller.performProfilePairing();
+
+      // Pairing only mutates `canonicalProfileId` via `#propagateCanonical`;
+      // each entry's `profileId` keeps the value set at login time.
+      for (const id of MOCK_ENTROPY_SOURCE_IDS) {
+        expect(controller.state.srpSessionData?.[id]?.profile.profileId).toBe(
+          MOCK_LOGIN_RESPONSE.profile.profile_id,
+        );
+      }
+    });
+  });
+
   describe('performSignOut', () => {
     it('should remove signed in user and any access tokens', () => {
       const metametrics = createMockAuthMetaMetrics();
@@ -496,7 +597,7 @@ describe('AuthenticationController', () => {
       const { messenger } = createMockAuthenticationMessenger();
       const controller = new AuthenticationController({
         messenger,
-        state: { isSignedIn: false },
+        state: { isSignedIn: false, hasPairedAtLeastOnce: false },
         metametrics,
       });
 
@@ -691,7 +792,7 @@ describe('AuthenticationController', () => {
       const { messenger } = createMockAuthenticationMessenger();
       const controller = new AuthenticationController({
         messenger,
-        state: { isSignedIn: false },
+        state: { isSignedIn: false, hasPairedAtLeastOnce: false },
         metametrics,
       });
 
@@ -800,7 +901,7 @@ describe('AuthenticationController', () => {
       const { messenger } = createMockAuthenticationMessenger();
       const controller = new AuthenticationController({
         messenger,
-        state: { isSignedIn: false },
+        state: { isSignedIn: false, hasPairedAtLeastOnce: false },
         metametrics,
       });
 
@@ -857,7 +958,7 @@ describe('AuthenticationController', () => {
       const { messenger } = createMockAuthenticationMessenger();
       const controller = new AuthenticationController({
         messenger,
-        state: { isSignedIn: false },
+        state: { isSignedIn: false, hasPairedAtLeastOnce: false },
         metametrics,
       });
 
@@ -912,7 +1013,7 @@ describe('AuthenticationController', () => {
       const { messenger } = createMockAuthenticationMessenger();
       const controller = new AuthenticationController({
         messenger,
-        state: { isSignedIn: false },
+        state: { isSignedIn: false, hasPairedAtLeastOnce: false },
         metametrics,
       });
 
@@ -950,6 +1051,7 @@ describe('metadata', () => {
       ),
     ).toMatchInlineSnapshot(`
       {
+        "hasPairedAtLeastOnce": false,
         "isSignedIn": true,
       }
     `);
@@ -972,6 +1074,7 @@ describe('metadata', () => {
 
       expect(derivedState).toMatchInlineSnapshot(`
         {
+          "hasPairedAtLeastOnce": false,
           "isSignedIn": true,
           "srpSessionData": {
             "MOCK_ENTROPY_SOURCE_ID": {
@@ -1017,6 +1120,7 @@ describe('metadata', () => {
         ),
       ).toMatchInlineSnapshot(`
         {
+          "hasPairedAtLeastOnce": false,
           "isSignedIn": false,
         }
       `);
@@ -1035,6 +1139,7 @@ describe('metadata', () => {
       deriveStateFromMetadata(controller.state, controller.metadata, 'persist'),
     ).toMatchInlineSnapshot(`
       {
+        "hasPairedAtLeastOnce": false,
         "isSignedIn": true,
         "srpSessionData": {
           "MOCK_ENTROPY_SOURCE_ID": {
@@ -1084,6 +1189,7 @@ describe('metadata', () => {
       ),
     ).toMatchInlineSnapshot(`
       {
+        "hasPairedAtLeastOnce": false,
         "isSignedIn": true,
         "srpSessionData": {
           "MOCK_ENTROPY_SOURCE_ID": {

--- a/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.test.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.test.ts
@@ -513,7 +513,7 @@ describe('AuthenticationController', () => {
       }
     });
 
-    it('does NOT clear needsProfilePairing if requestProfilePairing is called mid-flight (multi-SRP)', async () => {
+    it('epoch check: a concurrent requestProfilePairing during multi-SRP performSignIn keeps the gate set', async () => {
       const metametrics = createMockAuthMetaMetrics();
       arrangeAuthAPIs();
       const { messenger } = createMockAuthenticationMessenger();
@@ -524,9 +524,10 @@ describe('AuthenticationController', () => {
         metametrics,
       });
 
-      // Re-arm BEFORE awaiting performSignIn: the epoch snapshot inside
-      // `performSignIn` runs synchronously, so the increment from this
-      // call lands after it and must prevent the gate from being cleared.
+      // `performSignIn` snapshots `#profilePairingRequestEpoch` synchronously
+      // before its first await. Calling `requestProfilePairing()` right after
+      // (still in the same tick, but after the snapshot) bumps the epoch — so
+      // the post-pair gate clear must be skipped and the flag must stay true.
       const performSignInPromise = controller.performSignIn();
       controller.requestProfilePairing();
       await performSignInPromise;
@@ -534,7 +535,7 @@ describe('AuthenticationController', () => {
       expect(controller.state.needsProfilePairing).toBe(true);
     });
 
-    it('does NOT clear needsProfilePairing if requestProfilePairing is called mid-flight (single-SRP)', async () => {
+    it('epoch check: a concurrent requestProfilePairing during single-SRP performSignIn keeps the gate set', async () => {
       const metametrics = createMockAuthMetaMetrics();
       arrangeAuthAPIs();
       const { messenger, mockSnapGetAllPublicKeys } =
@@ -553,6 +554,39 @@ describe('AuthenticationController', () => {
       const performSignInPromise = controller.performSignIn();
       controller.requestProfilePairing();
       await performSignInPromise;
+
+      expect(controller.state.needsProfilePairing).toBe(true);
+    });
+
+    it('epoch check: a requestProfilePairing fired from inside #doPair (between snap call and pair API completion) keeps the gate set', async () => {
+      const metametrics = createMockAuthMetaMetrics();
+      arrangeAuthAPIs();
+      const { messenger, mockSnapGetAllPublicKeys } =
+        createMockAuthenticationMessenger();
+
+      const controller = new AuthenticationController({
+        messenger,
+        state: mockSignedInState({ needsProfilePairing: true }),
+        metametrics,
+      });
+
+      // `#snapGetAllPublicKeys` is called twice per `performSignIn`:
+      //  1. directly inside `performSignIn` (to enumerate SRPs)
+      //  2. indirectly inside `#doPair` → `#getCanonicalProfileId` →
+      //     `#getPrimaryEntropySourceId` (cold cache)
+      // We hook the second call to fire the rearm — this is the realistic
+      // production race window (e.g. user adds an SRP while the pair API
+      // request is in flight).
+      mockSnapGetAllPublicKeys
+        .mockResolvedValueOnce(
+          MOCK_ENTROPY_SOURCE_IDS.map((id) => [id, 'MOCK_PUBLIC_KEY']),
+        )
+        .mockImplementationOnce(async () => {
+          controller.requestProfilePairing();
+          return MOCK_ENTROPY_SOURCE_IDS.map((id) => [id, 'MOCK_PUBLIC_KEY']);
+        });
+
+      await controller.performSignIn();
 
       expect(controller.state.needsProfilePairing).toBe(true);
     });

--- a/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.ts
@@ -400,6 +400,8 @@ export class AuthenticationController extends BaseController<
     const profileAliases = await this.#pairSrpProfiles(accessTokens);
     const newCanonical = await this.#getCanonicalProfileId();
 
+    // If somehow we cannot compute the new canonical profile ID after pairing,
+    // we just return now and do not update the `needsProfilePairing` flag.
     if (!newCanonical) {
       return;
     }

--- a/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.ts
@@ -41,19 +41,21 @@ export type AuthenticationControllerState = {
   isSignedIn: boolean;
   srpSessionData?: Record<string, LoginResponse>;
   /**
-   * Whether `performProfilePairing` has ever completed successfully on this
-   * device.
-   * Monotonic — only flips from `false` to `true`, never back. Used by the
-   * client-side `useAutoProfilePairing` hook to decide when to fire the initial
-   * pairing call after install/upgrade. Subsequent re-pairs (e.g. when a
-   * new SRP is added later) are also fired by the hook based on keyring
-   * changes, independently of this flag.
+   * Client gate for profile pairing. Defaults to `true` (fresh install /
+   * upgrade), set to `false` after a successful `performSignIn` pair, set
+   * back to `true` via `requestProfilePairing()` when the SRP set changes,
+   * and left `true` on pair failure so the next state shift retries.
+   *
+   * Optional in the type so partial-state selectors stay assignable to
+   * `AuthenticationControllerState`. The controller seeds it via
+   * `defaultState` at construction; consumers should read `undefined` as
+   * `true` to mirror that runtime default.
    */
-  hasPairedAtLeastOnce?: boolean;
+  needsProfilePairing?: boolean;
 };
 export const defaultState: AuthenticationControllerState = {
   isSignedIn: false,
-  hasPairedAtLeastOnce: false,
+  needsProfilePairing: true,
 };
 const metadata: StateMetadata<AuthenticationControllerState> = {
   isSignedIn: {
@@ -62,7 +64,7 @@ const metadata: StateMetadata<AuthenticationControllerState> = {
     includeInDebugSnapshot: true,
     usedInUi: true,
   },
-  hasPairedAtLeastOnce: {
+  needsProfilePairing: {
     includeInStateLogs: true,
     persist: true,
     includeInDebugSnapshot: true,
@@ -105,12 +107,12 @@ type ControllerConfig = {
 const MESSENGER_EXPOSED_METHODS = [
   'performSignIn',
   'performSignOut',
-  'performProfilePairing',
   'getBearerToken',
   'getSessionProfile',
   'refreshCanonicalProfileId',
   'getUserProfileLineage',
   'isSignedIn',
+  'requestProfilePairing',
 ] as const;
 
 export type Actions =
@@ -328,61 +330,70 @@ export class AuthenticationController extends BaseController<
       accessTokens.push(accessToken);
     }
 
+    if (allPublicKeys.length < 2) {
+      // Single-SRP wallet: nothing to pair. Clear the gate so it doesn't fire.
+      if (this.state.needsProfilePairing) {
+        this.update((state) => {
+          state.needsProfilePairing = false;
+        });
+      }
+    } else {
+      // Pair failures must not break sign-in; the gate stays `true` for retry.
+      try {
+        await this.#doPair(accessTokens);
+      } catch {
+        // noop
+      }
+    }
+
     return accessTokens;
   }
 
   /**
-   * Pairs all SRPs of the wallet via `POST /profile/pair`, propagates the
-   * canonical profile ID into every cached SRP session, and emits
-   * `AuthenticationController:profileSignIn` when the canonical changes or
-   * new aliases are returned. Sets `hasPairedAtLeastOnce = true` on success.
-   *
-   * No-op when the wallet has fewer than 2 SRPs (nothing to pair) or when
-   * the wallet is locked.
-   *
-   * Pairing failures are swallowed so the caller (typically the client-side
-   * `useAutoProfilePairing` hook) can simply re-invoke on the next trigger.
+   * Marks profile pairing as needed. Clients call this when the SRP set
+   * changes (e.g. a new keyring was added) so the next auto-sign-in cycle
+   * re-runs `performSignIn` and re-pairs.
    */
-  public async performProfilePairing(): Promise<void> {
-    this.#assertIsUnlocked('performProfilePairing');
+  public requestProfilePairing(): void {
+    if (!this.state.needsProfilePairing) {
+      this.update((state) => {
+        state.needsProfilePairing = true;
+      });
+    }
+  }
 
-    const allPublicKeys = await this.#snapGetAllPublicKeys();
-    if (allPublicKeys.length < 2) {
+  /**
+   * Pairs all SRPs via `POST /profile/pair`, propagates the canonical
+   * profile ID, clears `needsProfilePairing`, and emits
+   * `AuthenticationController:profileSignIn` when the canonical changes or
+   * new aliases are returned. Throws on failure.
+   *
+   * @param accessTokens - Per-SRP access tokens, primary first.
+   */
+  async #doPair(accessTokens: string[]): Promise<void> {
+    const previousCanonical = await this.#getCanonicalProfileId();
+
+    const profileAliases = await this.#pairSrpProfiles(accessTokens);
+    const newCanonical = await this.#getCanonicalProfileId();
+
+    if (!newCanonical) {
       return;
     }
 
-    const previousCanonical = await this.#getCanonicalProfileId();
+    this.update((state) => {
+      state.needsProfilePairing = false;
+    });
 
-    const accessTokens: string[] = [];
-    for (const [entropySourceId] of allPublicKeys) {
-      accessTokens.push(await this.#auth.getAccessToken(entropySourceId));
-    }
+    const profileIdChanged = previousCanonical !== newCanonical;
+    const shouldEmitProfileSignInEvent =
+      profileIdChanged || profileAliases.length > 0;
 
-    try {
-      const profileAliases = await this.#pairSrpProfiles(accessTokens);
-      const newCanonical = await this.#getCanonicalProfileId();
-
-      if (!newCanonical) {
-        return;
-      }
-
-      this.update((state) => {
-        state.hasPairedAtLeastOnce = true;
+    if (shouldEmitProfileSignInEvent) {
+      this.messenger.publish('AuthenticationController:profileSignIn', {
+        profileId: newCanonical,
+        profileAliases,
+        profileIdChanged,
       });
-
-      const profileIdChanged = previousCanonical !== newCanonical;
-      const shouldEmitProfileSignInEvent =
-        profileIdChanged || profileAliases.length > 0;
-
-      if (shouldEmitProfileSignInEvent) {
-        this.messenger.publish('AuthenticationController:profileSignIn', {
-          profileId: newCanonical,
-          profileAliases,
-          profileIdChanged,
-        });
-      }
-    } catch {
-      // Non-fatal — caller re-invokes on the next trigger.
     }
   }
 

--- a/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.ts
@@ -394,10 +394,7 @@ export class AuthenticationController extends BaseController<
    * Used to skip the gate clear if `requestProfilePairing` ran while the
    * pair API call was in-flight.
    */
-  async #doPair(
-    accessTokens: string[],
-    epochAtStart: number,
-  ): Promise<void> {
+  async #doPair(accessTokens: string[], epochAtStart: number): Promise<void> {
     const previousCanonical = await this.#getCanonicalProfileId();
 
     const profileAliases = await this.#pairSrpProfiles(accessTokens);

--- a/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.ts
@@ -40,12 +40,29 @@ const controllerName = 'AuthenticationController';
 export type AuthenticationControllerState = {
   isSignedIn: boolean;
   srpSessionData?: Record<string, LoginResponse>;
+  /**
+   * Whether `performProfilePairing` has ever completed successfully on this
+   * device.
+   * Monotonic — only flips from `false` to `true`, never back. Used by the
+   * client-side `useAutoProfilePairing` hook to decide when to fire the initial
+   * pairing call after install/upgrade. Subsequent re-pairs (e.g. when a
+   * new SRP is added later) are also fired by the hook based on keyring
+   * changes, independently of this flag.
+   */
+  hasPairedAtLeastOnce: boolean;
 };
 export const defaultState: AuthenticationControllerState = {
   isSignedIn: false,
+  hasPairedAtLeastOnce: false,
 };
 const metadata: StateMetadata<AuthenticationControllerState> = {
   isSignedIn: {
+    includeInStateLogs: true,
+    persist: true,
+    includeInDebugSnapshot: true,
+    usedInUi: true,
+  },
+  hasPairedAtLeastOnce: {
     includeInStateLogs: true,
     persist: true,
     includeInDebugSnapshot: true,
@@ -88,6 +105,7 @@ type ControllerConfig = {
 const MESSENGER_EXPOSED_METHODS = [
   'performSignIn',
   'performSignOut',
+  'performProfilePairing',
   'getBearerToken',
   'getSessionProfile',
   'refreshCanonicalProfileId',
@@ -310,26 +328,53 @@ export class AuthenticationController extends BaseController<
       accessTokens.push(accessToken);
     }
 
-    // Pair SRP profiles (idempotent — no-op if already paired)
-    if (accessTokens.length >= 2) {
-      await this.#performPairing(accessTokens);
-    }
-
     return accessTokens;
   }
 
-  async #performPairing(accessTokens: string[]): Promise<void> {
+  /**
+   * Pairs all SRPs of the wallet via `POST /profile/pair`, propagates the
+   * canonical profile ID into every cached SRP session, and emits
+   * `AuthenticationController:profileSignIn` when the canonical changes or
+   * new aliases are returned. Sets `hasPairedAtLeastOnce = true` on success.
+   *
+   * No-op when the wallet has fewer than 2 SRPs (nothing to pair) or when
+   * the wallet is locked.
+   *
+   * Pairing failures are swallowed so the caller (typically the client-side
+   * `useAutoProfilePairing` hook) can simply re-invoke on the next trigger.
+   */
+  public async performProfilePairing(): Promise<void> {
+    this.#assertIsUnlocked('performProfilePairing');
+
+    const allPublicKeys = await this.#snapGetAllPublicKeys();
+    if (allPublicKeys.length < 2) {
+      return;
+    }
+
     const previousCanonical = await this.#getCanonicalProfileId();
+
+    const accessTokens: string[] = [];
+    for (const [entropySourceId] of allPublicKeys) {
+      accessTokens.push(await this.#auth.getAccessToken(entropySourceId));
+    }
 
     try {
       const profileAliases = await this.#pairSrpProfiles(accessTokens);
-
       const newCanonical = await this.#getCanonicalProfileId();
+
+      if (!newCanonical) {
+        return;
+      }
+
+      this.update((state) => {
+        state.hasPairedAtLeastOnce = true;
+      });
+
       const profileIdChanged = previousCanonical !== newCanonical;
       const shouldEmitProfileSignInEvent =
         profileIdChanged || profileAliases.length > 0;
 
-      if (shouldEmitProfileSignInEvent && newCanonical) {
+      if (shouldEmitProfileSignInEvent) {
         this.messenger.publish('AuthenticationController:profileSignIn', {
           profileId: newCanonical,
           profileAliases,
@@ -337,7 +382,7 @@ export class AuthenticationController extends BaseController<
         });
       }
     } catch {
-      // Pairing failure is non-fatal — retry on next performSignIn
+      // Non-fatal — caller re-invokes on the next trigger.
     }
   }
 

--- a/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.ts
@@ -49,7 +49,7 @@ export type AuthenticationControllerState = {
    * new SRP is added later) are also fired by the hook based on keyring
    * changes, independently of this flag.
    */
-  hasPairedAtLeastOnce: boolean;
+  hasPairedAtLeastOnce?: boolean;
 };
 export const defaultState: AuthenticationControllerState = {
   isSignedIn: false,

--- a/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.ts
@@ -180,6 +180,11 @@ export class AuthenticationController extends BaseController<
 
   #cachedPrimaryEntropySourceId?: string;
 
+  // Bumped by `requestProfilePairing`. `performSignIn` snapshots this
+  // before its first await; if it changes mid-flight we must NOT clear
+  // `needsProfilePairing` (the rearm signal wins).
+  #profilePairingRequestEpoch = 0;
+
   readonly #keyringController = {
     setupLockedStateSubscriptions: () => {
       const { isUnlocked } = this.messenger.call('KeyringController:getState');
@@ -320,6 +325,7 @@ export class AuthenticationController extends BaseController<
   public async performSignIn(): Promise<string[]> {
     this.#assertIsUnlocked('performSignIn');
 
+    const epochAtStart = this.#profilePairingRequestEpoch;
     const allPublicKeys = await this.#snapGetAllPublicKeys();
     const accessTokens: string[] = [];
 
@@ -331,16 +337,12 @@ export class AuthenticationController extends BaseController<
     }
 
     if (allPublicKeys.length < 2) {
-      // Single-SRP wallet: nothing to pair. Clear the gate so it doesn't fire.
-      if (this.state.needsProfilePairing) {
-        this.update((state) => {
-          state.needsProfilePairing = false;
-        });
-      }
+      // Single-SRP wallet: nothing to pair.
+      this.#tryClearNeedsProfilePairing(epochAtStart);
     } else {
       // Pair failures must not break sign-in; the gate stays `true` for retry.
       try {
-        await this.#doPair(accessTokens);
+        await this.#doPair(accessTokens, epochAtStart);
       } catch {
         // noop
       }
@@ -355,9 +357,28 @@ export class AuthenticationController extends BaseController<
    * re-runs `performSignIn` and re-pairs.
    */
   public requestProfilePairing(): void {
+    this.#profilePairingRequestEpoch += 1;
     if (!this.state.needsProfilePairing) {
       this.update((state) => {
         state.needsProfilePairing = true;
+      });
+    }
+  }
+
+  /**
+   * Clears `needsProfilePairing` only if no `requestProfilePairing` call
+   * landed since `epochAtStart` was captured. Prevents `performSignIn`
+   * from silently overwriting a concurrent rearm.
+   *
+   * @param epochAtStart - Epoch value captured at the start of `performSignIn`.
+   */
+  #tryClearNeedsProfilePairing(epochAtStart: number): void {
+    if (this.#profilePairingRequestEpoch !== epochAtStart) {
+      return;
+    }
+    if (this.state.needsProfilePairing) {
+      this.update((state) => {
+        state.needsProfilePairing = false;
       });
     }
   }
@@ -369,8 +390,14 @@ export class AuthenticationController extends BaseController<
    * new aliases are returned. Throws on failure.
    *
    * @param accessTokens - Per-SRP access tokens, primary first.
+   * @param epochAtStart - Pairing-request epoch captured by the caller.
+   * Used to skip the gate clear if `requestProfilePairing` ran while the
+   * pair API call was in-flight.
    */
-  async #doPair(accessTokens: string[]): Promise<void> {
+  async #doPair(
+    accessTokens: string[],
+    epochAtStart: number,
+  ): Promise<void> {
     const previousCanonical = await this.#getCanonicalProfileId();
 
     const profileAliases = await this.#pairSrpProfiles(accessTokens);
@@ -380,9 +407,7 @@ export class AuthenticationController extends BaseController<
       return;
     }
 
-    this.update((state) => {
-      state.needsProfilePairing = false;
-    });
+    this.#tryClearNeedsProfilePairing(epochAtStart);
 
     const profileIdChanged = previousCanonical !== newCanonical;
     const shouldEmitProfileSignInEvent =

--- a/packages/profile-sync-controller/src/controllers/authentication/index.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/index.ts
@@ -7,11 +7,11 @@ export * as Mocks from './mocks';
 
 export type {
   AuthenticationControllerPerformSignInAction,
-  AuthenticationControllerPerformProfilePairingAction,
   AuthenticationControllerPerformSignOutAction,
   AuthenticationControllerGetBearerTokenAction,
   AuthenticationControllerGetSessionProfileAction,
   AuthenticationControllerRefreshCanonicalProfileIdAction,
   AuthenticationControllerGetUserProfileLineageAction,
   AuthenticationControllerIsSignedInAction,
+  AuthenticationControllerRequestProfilePairingAction,
 } from './AuthenticationController-method-action-types';

--- a/packages/profile-sync-controller/src/controllers/authentication/index.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/index.ts
@@ -7,6 +7,7 @@ export * as Mocks from './mocks';
 
 export type {
   AuthenticationControllerPerformSignInAction,
+  AuthenticationControllerPerformProfilePairingAction,
   AuthenticationControllerPerformSignOutAction,
   AuthenticationControllerGetBearerTokenAction,
   AuthenticationControllerGetSessionProfileAction,


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

https://consensyssoftware.atlassian.net/browse/MUL-1791

Client PRs: 
- [Extension](https://github.com/MetaMask/metamask-extension/pull/42120)
- [Mobile](https://github.com/MetaMask/metamask-mobile/pull/29357)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication sign-in/pairing flow and persisted controller state, which can affect auto-sign-in behavior and event emission. Concurrency/epoch logic and swallowing pairing errors reduce crash risk but could hide pairing regressions without monitoring.
> 
> **Overview**
> Adds a new client-controlled pairing gate to `AuthenticationController` by persisting `needsProfilePairing` (default `true`) and exposing a new messenger action/method `requestProfilePairing` to re-arm pairing when the SRP set changes.
> 
> Updates `performSignIn`’s pairing flow to clear the gate after successful pairing (or immediately for single-SRP wallets), swallow pairing failures for retry on the next sign-in cycle, and use an epoch mechanism to avoid clearing the gate if a concurrent `requestProfilePairing()` occurs mid-flight. Tests and changelog are updated to cover the new state/action and event-emission conditions (only emit `profileSignIn` when canonical changes or aliases are returned).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d0955c7a49dab47a0c5e4dc89a46fb2e8d3f042. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->