### PR TITLE
ci: Enable workflow queue for publish-release workflow

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -1,0 +1,8 @@
+# Please see the documentation for all configuration options:
+# https://github.com/rhysd/actionlint/blob/main/docs/config.md#configuration-file
+
+paths:
+  .github/workflows/publish-release.yml:
+    ignore:
+      # Queue option is not supported by actionlint yet.
+      - 'unexpected key "queue" for "concurrency" section. expected one of "cancel-in-progress", "group"'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Download actionlint
         id: download-actionlint
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/7fdc9630cc360ea1a469eed64ac6d78caeda1234/scripts/download-actionlint.bash) 1.6.25
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/914e7df21a07ef503a81201c76d2b11c789d3fca/scripts/download-actionlint.bash) 1.7.12
         shell: bash
       - name: Check workflow files
         run: ${{ steps.download-actionlint.outputs.executable }} -color

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,6 +8,10 @@ on:
       SLACK_WEBHOOK_URL:
         required: true
 
+concurrency:
+  group: publish-release
+  queue: max
+
 jobs:
   publish-release:
     permissions:


### PR DESCRIPTION
This restores #8640, which was reverted to test if it was related to a workflow issue, but does not appear to be the case.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/workflow-only changes; the main risk is altered release-job scheduling/serialization and relying on an actionlint ignore for the new key.
> 
> **Overview**
> Enables queued concurrency for the `publish-release` GitHub Actions workflow by adding `concurrency.group` and `concurrency.queue: max`, preventing overlapping release publishes.
> 
> Updates the workflow CI to download a newer `actionlint` version, and adds an `actionlint.yml` ignore rule to suppress the current false-positive error for the unsupported `concurrency.queue` key in `publish-release.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff3042995dfe5526ecf8e46af52a4600c0f487f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->