### PR TITLE
Revert "Release 948.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "948.0.0",
+  "version": "947.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {

--- a/packages/config-registry-controller/CHANGELOG.md
+++ b/packages/config-registry-controller/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.0]
-
 ### Changed
 
 - Bump `@metamask/keyring-controller` from `^25.1.1` to `^25.3.0` ([#8363](https://github.com/MetaMask/core/pull/8363), [#8634](https://github.com/MetaMask/core/pull/8634))
@@ -45,8 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release ([#7668](https://github.com/MetaMask/core/pull/7668), [#7809](https://github.com/MetaMask/core/pull/7809))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/config-registry-controller@0.3.0...HEAD
-[0.3.0]: https://github.com/MetaMask/core/compare/@metamask/config-registry-controller@0.2.0...@metamask/config-registry-controller@0.3.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/config-registry-controller@0.2.0...HEAD
 [0.2.0]: https://github.com/MetaMask/core/compare/@metamask/config-registry-controller@0.1.1...@metamask/config-registry-controller@0.2.0
 [0.1.1]: https://github.com/MetaMask/core/compare/@metamask/config-registry-controller@0.1.0...@metamask/config-registry-controller@0.1.1
 [0.1.0]: https://github.com/MetaMask/core/releases/tag/@metamask/config-registry-controller@0.1.0

--- a/packages/config-registry-controller/package.json
+++ b/packages/config-registry-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/config-registry-controller",
-  "version": "0.3.0",
+  "version": "0.2.0",
   "description": "Manages configuration registry for MetaMask",
   "keywords": [
     "Ethereum",


### PR DESCRIPTION
Reverts MetaMask/core#8639. Workflow is stuck for unknown reasons, so trying to recreate this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes package versions and changelog references; no runtime code or dependency behavior is modified.
> 
> **Overview**
> Reverts release metadata by downgrading the root `package.json` version from `948.0.0` to `947.0.0`.
> 
> Rolls back `@metamask/config-registry-controller` from `0.3.0` to `0.2.0` and removes the `0.3.0` changelog section/update, including adjusting the `[Unreleased]` compare link to point from `0.2.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 147288a22d7784fdd612dfd7c081ba6daf1f5af1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->