### PR TITLE
chore: add performance logs

### DIFF
--- a/packages/account-tree-controller/src/backup-and-sync/syncing/group.ts
+++ b/packages/account-tree-controller/src/backup-and-sync/syncing/group.ts
@@ -38,6 +38,10 @@ export const createMultichainAccountGroupsBatch = async (
   profileId: ProfileId,
   analyticsAction: BackupAndSyncAnalyticsAction,
 ): Promise<void> => {
+  console.log(`[PERFORMANCE DEBUG] createMultichainAccountGroupsBatch - Creating ${maxGroupIndex + 1} account groups (batch) for entropy source: ${entropySourceId}`);
+  console.log(`[PERFORMANCE DEBUG] createMultichainAccountGroupsBatch - Max group index: ${maxGroupIndex}`);
+  console.log(`[PERFORMANCE DEBUG] createMultichainAccountGroupsBatch - Context: ${JSON.stringify(context)}`);
+
   const numberOfAccountGroupsToCreate = maxGroupIndex + 1; // maxGroupIndex is zero-based, so we add 1 to get the count.
   backupAndSyncLogger(
     `Creating ${numberOfAccountGroupsToCreate} account groups (batch) for entropy source: ${entropySourceId}`,

--- a/packages/multichain-account-service/src/MultichainAccountService.ts
+++ b/packages/multichain-account-service/src/MultichainAccountService.ts
@@ -681,7 +681,7 @@ export class MultichainAccountService {
       { from: fromGroupIndex, to: toGroupIndex },
       { waitForAllProvidersToFinishCreatingAccounts: false },
     );
-    const end = performance.now();=\
+    const end = performance.now();
     console.log(`[DEBUGG] Time taken to create multichain account groups: ${end - start}ms`);
     console.log(`[DEBUGG] Result: ${result.length} groups created`);
     return result;

--- a/packages/multichain-account-service/src/MultichainAccountService.ts
+++ b/packages/multichain-account-service/src/MultichainAccountService.ts
@@ -675,10 +675,16 @@ export class MultichainAccountService {
     toGroupIndex: number;
     entropySource: EntropySourceId;
   }): Promise<MultichainAccountGroup<Bip44Account<KeyringAccount>>[]> {
-    return await this.#getWallet(entropySource).createMultichainAccountGroups(
+    console.log(`[DEBUGG] Creating multichain account groups from ${fromGroupIndex} to ${toGroupIndex} for entropy source: ${entropySource}`);
+    const start = performance.now();
+    const result = await this.#getWallet(entropySource).createMultichainAccountGroups(
       { from: fromGroupIndex, to: toGroupIndex },
       { waitForAllProvidersToFinishCreatingAccounts: false },
     );
+    const end = performance.now();=\
+    console.log(`[DEBUGG] Time taken to create multichain account groups: ${end - start}ms`);
+    console.log(`[DEBUGG] Result: ${result.length} groups created`);
+    return result;
   }
 
   /**

--- a/packages/multichain-account-service/src/MultichainAccountService.ts
+++ b/packages/multichain-account-service/src/MultichainAccountService.ts
@@ -679,7 +679,7 @@ export class MultichainAccountService {
     const start = performance.now();
     const result = await this.#getWallet(entropySource).createMultichainAccountGroups(
       { from: fromGroupIndex, to: toGroupIndex },
-      { waitForAllProvidersToFinishCreatingAccounts: false },
+      { waitForAllProvidersToFinishCreatingAccounts: true },
     );
     const end = performance.now();
     console.log(`[PERFORMANCE DEBUG] MultichainAccountService - Time taken to create multichain account groups: ${end - start}ms`);

--- a/packages/multichain-account-service/src/MultichainAccountService.ts
+++ b/packages/multichain-account-service/src/MultichainAccountService.ts
@@ -675,15 +675,15 @@ export class MultichainAccountService {
     toGroupIndex: number;
     entropySource: EntropySourceId;
   }): Promise<MultichainAccountGroup<Bip44Account<KeyringAccount>>[]> {
-    console.log(`[DEBUGG] Creating multichain account groups from ${fromGroupIndex} to ${toGroupIndex} for entropy source: ${entropySource}`);
+    console.log(`[PERFORMANCE DEBUG] MultichainAccountService - Creating multichain account groups from ${fromGroupIndex} to ${toGroupIndex} for entropy source: ${entropySource}`);
     const start = performance.now();
     const result = await this.#getWallet(entropySource).createMultichainAccountGroups(
       { from: fromGroupIndex, to: toGroupIndex },
       { waitForAllProvidersToFinishCreatingAccounts: false },
     );
     const end = performance.now();
-    console.log(`[DEBUGG] Time taken to create multichain account groups: ${end - start}ms`);
-    console.log(`[DEBUGG] Result: ${result.length} groups created`);
+    console.log(`[PERFORMANCE DEBUG] MultichainAccountService - Time taken to create multichain account groups: ${end - start}ms`);
+    console.log(`[PERFORMANCE DEBUG] MultichainAccountService - Result: ${result.length} groups created`);
     return result;
   }
 

--- a/packages/multichain-account-service/src/MultichainAccountWallet.ts
+++ b/packages/multichain-account-service/src/MultichainAccountWallet.ts
@@ -327,6 +327,7 @@ export class MultichainAccountWallet<
     const results = await Promise.allSettled(
       providers.map(async (provider) => {
         const providerName = provider.getName();
+        console.log(`[PERFORMANCE DEBUG] MultichainAccountWallet - Execution of buildGroupStateForRange. Start accounts creation for provider: ${providerName} from ${from} to ${to}`);
         const accounts = await this.#createAccountsRangeForProvider(
           provider,
           from,

--- a/packages/multichain-account-service/src/providers/SnapAccountProvider.ts
+++ b/packages/multichain-account-service/src/providers/SnapAccountProvider.ts
@@ -387,16 +387,18 @@ export abstract class SnapAccountProvider extends BaseBip44AccountProvider {
       if (options.type === `${AccountCreationType.Bip44DeriveIndexRange}`) {
         if (batched) {
           // Batch account creations.
-          console.log(`[DEBUGG] Batching account creations with options: ${JSON.stringify(options)} for provider: ${this.getName()}`);
+          console.log(`[PERFORMANCE DEBUG] SnapAccountProvider ${this.getName()} (createAccountsV2) - Batching account creations with options: ${JSON.stringify(options)}`);
           const start = performance.now();
           snapAccounts = await createAccountsV2(options);
           const end = performance.now();
-          console.log(`[DEBUGG] Time taken to create accounts: ${end - start}ms`);
-          console.log(`[DEBUGG] Result: ${snapAccounts.length} accounts created`);
+          console.log(`[PERFORMANCE DEBUG] SnapAccountProvider ${this.getName()} (createAccountsV2) - Time taken to create accounts: ${end - start} ms`);
+          console.log(`[PERFORMANCE DEBUG] SnapAccountProvider ${this.getName()} (createAccountsV2) - Result: ${snapAccounts.length} accounts created`);
         } else {
+          console.log(`[PERFORMANCE DEBUG] SnapAccountProvider ${this.getName()} (createAccountV1) - Creating accounts one by one with options: ${JSON.stringify(options)}`);
           const { range } = options;
 
           // Create accounts one by one.
+          const start = performance.now();
           for (
             let groupIndex = range.from;
             groupIndex <= range.to;
@@ -406,6 +408,9 @@ export abstract class SnapAccountProvider extends BaseBip44AccountProvider {
 
             snapAccounts.push(snapAccount);
           }
+          const end = performance.now();
+          console.log(`[PERFORMANCE DEBUG] SnapAccountProvider ${this.getName()} (createAccountV1) - Time taken to create accounts: ${end - start} ms`);
+          console.log(`[PERFORMANCE DEBUG] SnapAccountProvider ${this.getName()} (createAccountV1) - Result: ${snapAccounts.length} accounts created`);
         }
 
         // Group indices are sequential, so we just need the starting index.
@@ -444,7 +449,7 @@ export abstract class SnapAccountProvider extends BaseBip44AccountProvider {
   async createAccounts(
     options: CreateAccountOptions,
   ): Promise<Bip44Account<KeyringAccount>[]> {
-    console.log(`[DEBUGG] Creating accounts with options: ${JSON.stringify(options)}`);
+    console.log(`[PERFORMANCE DEBUG] SnapAccountProvider ${this.getName()} - Creating accounts with options: ${JSON.stringify(options)}`);
     assertCreateAccountOptionIsSupported(options, [
       `${AccountCreationType.Bip44DeriveIndex}`,
       `${AccountCreationType.Bip44DeriveIndexRange}`,

--- a/packages/multichain-account-service/src/providers/SnapAccountProvider.ts
+++ b/packages/multichain-account-service/src/providers/SnapAccountProvider.ts
@@ -391,7 +391,7 @@ export abstract class SnapAccountProvider extends BaseBip44AccountProvider {
           const start = performance.now();
           snapAccounts = await createAccountsV2(options);
           const end = performance.now();
-          console.log(`[PERFORMANCE DEBUG] SnapAccountProvider ${this.getName()} (createAccountsV2) - Time taken to create accounts: ${end - start} ms`);
+          console.log(`[PERFORMANCE DEBUG] SnapAccountProvider ${this.getName()} (createAccountsV2) - Time taken to create accounts between ${options.range.from} and ${options.range.to}: ${end - start} ms`);
           console.log(`[PERFORMANCE DEBUG] SnapAccountProvider ${this.getName()} (createAccountsV2) - Result: ${snapAccounts.length} accounts created`);
         } else {
           console.log(`[PERFORMANCE DEBUG] SnapAccountProvider ${this.getName()} (createAccountV1) - Creating accounts one by one with options: ${JSON.stringify(options)}`);

--- a/packages/multichain-account-service/src/providers/SnapAccountProvider.ts
+++ b/packages/multichain-account-service/src/providers/SnapAccountProvider.ts
@@ -387,7 +387,12 @@ export abstract class SnapAccountProvider extends BaseBip44AccountProvider {
       if (options.type === `${AccountCreationType.Bip44DeriveIndexRange}`) {
         if (batched) {
           // Batch account creations.
+          console.log(`[DEBUGG] Batching account creations with options: ${JSON.stringify(options)} for provider: ${this.getName()}`);
+          const start = performance.now();
           snapAccounts = await createAccountsV2(options);
+          const end = performance.now();
+          console.log(`[DEBUGG] Time taken to create accounts: ${end - start}ms`);
+          console.log(`[DEBUGG] Result: ${snapAccounts.length} accounts created`);
         } else {
           const { range } = options;
 
@@ -439,6 +444,7 @@ export abstract class SnapAccountProvider extends BaseBip44AccountProvider {
   async createAccounts(
     options: CreateAccountOptions,
   ): Promise<Bip44Account<KeyringAccount>[]> {
+    console.log(`[DEBUGG] Creating accounts with options: ${JSON.stringify(options)}`);
     assertCreateAccountOptionIsSupported(options, [
       `${AccountCreationType.Bip44DeriveIndex}`,
       `${AccountCreationType.Bip44DeriveIndexRange}`,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds extensive `console.log` performance/debug output (including `JSON.stringify(context)`) and changes `MultichainAccountService#createMultichainAccountGroups` to wait for all providers, which can increase latency and alter behavior in Snap-dependent flows.
> 
> **Overview**
> Adds **performance debug logging** across backup/sync and multichain account creation paths, including timing (`performance.now()`) and counts for group/account creation in `createMultichainAccountGroupsBatch`, `MultichainAccountService#createMultichainAccountGroups`, `MultichainAccountWallet#buildGroupStateForRange`, and `SnapAccountProvider#createAccounts`.
> 
> Also changes `MultichainAccountService#createMultichainAccountGroups` to call wallet creation with `waitForAllProvidersToFinishCreatingAccounts: true` (previously `false`), meaning batch group creation now blocks on non-EVM/Snap providers instead of returning early.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a89313ea94b4aa8c0d0851355944f2c0cf131852. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->