### PR TITLE
fix: Make `isVaultUpdated` required on `Encryptor`

### DIFF
--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -380,14 +380,13 @@ export type Encryptor<
    */
   decrypt: (password: string, encryptedString: string) => Promise<unknown>;
   /**
-   * Optional vault migration helper. Checks if the provided vault is up to date
-   * with the desired encryption algorithm.
+   * Checks if the provided vault is up to date with the desired encryption algorithm.
    *
    * @param vault - The encrypted string to check.
    * @param targetDerivationParams - The desired target derivation params.
    * @returns The updated encrypted string.
    */
-  isVaultUpdated?: (
+  isVaultUpdated: (
     vault: string,
     targetDerivationParams?: encryptorUtils.KeyDerivationOptions,
   ) => boolean;
@@ -2755,7 +2754,7 @@ export class KeyringController<
   #isNewEncryptionAvailable(): boolean {
     const { vault } = this.state;
 
-    if (!vault || !this.#encryptor.isVaultUpdated) {
+    if (!vault) {
       return false;
     }
 


### PR DESCRIPTION
## Explanation

The `isVaultUpdated` property does not need to be optional on `Encryptor`. We have two implementations of the Encryptor and they both include `isVaultUpdated`. This difference between our actual implementations and the type cause type issues in both clients, e.g: https://github.com/MetaMask/metamask-extension/blob/main/app/scripts/messenger-client-init/snaps/snap-controller-init.ts#L126

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them
