### PR TITLE
fix(bridge-status-controller): preserve original transaction id when recording intent swaps in history

### DIFF
--- a/packages/bridge-status-controller/CHANGELOG.md
+++ b/packages/bridge-status-controller/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/keyring-controller` from `^25.2.0` to `^25.3.0` ([#8634](https://github.com/MetaMask/core/pull/8634))
 - Bump `@metamask/network-controller` from `^30.0.1` to `^30.1.0` ([#8636](https://github.com/MetaMask/core/pull/8636))
 
+### Fixed
+
+- When `submitIntent` records bridge history keyed by `orderUid`, pass `originalTransactionId` at the top level to `#addTxToHistory` so `getInitialHistoryItem` links the history item to the synthetic `TransactionController` entry instead of incorrectly using `orderUid` ([#8655](https://github.com/MetaMask/core/pull/8655))
+
 ## [71.1.0]
 
 ### Added

--- a/packages/bridge-status-controller/src/bridge-status-controller.ts
+++ b/packages/bridge-status-controller/src/bridge-status-controller.ts
@@ -1486,10 +1486,10 @@ export class BridgeStatusController extends StaticIntervalPollingController<Brid
 
       // Record in bridge history with actual transaction metadata
       try {
-       // Create a bridge transaction metadata keyed by orderUid for intent polling
+        // Create a bridge transaction metadata keyed by orderUid for intent polling
         const bridgeTxMetaForHistory = {
           ...syntheticMeta,
-          id: orderUid
+          id: orderUid,
         };
 
         // Use orderId as the history key for intent transactions

--- a/packages/bridge-status-controller/src/bridge-status-controller.ts
+++ b/packages/bridge-status-controller/src/bridge-status-controller.ts
@@ -1486,17 +1486,23 @@ export class BridgeStatusController extends StaticIntervalPollingController<Brid
 
       // Record in bridge history with actual transaction metadata
       try {
-        // Create a bridge transaction metadata that includes the original txId
+       // Create a bridge transaction metadata keyed by orderUid for intent polling
         const bridgeTxMetaForHistory = {
           ...syntheticMeta,
-          id: orderUid,
-          originalTransactionId: syntheticMeta.id, // Keep original txId for TransactionController updates
+          id: orderUid
         };
 
         // Use orderId as the history key for intent transactions
+        // IMPORTANT: pass originalTransactionId as a top-level argument so
+        // `getInitialHistoryItem` reads it. Setting it on `bridgeTxMeta` is a no-op
+        // because `getInitialHistoryItem` destructures `originalTransactionId` from
+        // the top-level args, not from `bridgeTxMeta`. Without this, the field
+        // falls back to `bridgeTxMeta.id` (the orderUid), severing the link between
+        // the bridge history record and the synthetic TransactionController entry.
         const historyKey = this.#addTxToHistory({
           accountAddress,
           bridgeTxMeta: bridgeTxMetaForHistory,
+          originalTransactionId: syntheticMeta.id,
           quoteResponse,
           slippagePercentage: 0,
           isStxEnabled: false,


### PR DESCRIPTION
## Explanation

When `submitIntent` records a synthetic transaction in the bridge history under the `orderUid` key, it needs to keep a back-reference to the original `TransactionController` entry so subsequent status updates from intent polling can update the right transaction.

Previously this back-reference was set on `bridgeTxMeta.originalTransactionId`, but `#addTxToHistory` → `getInitialHistoryItem` destructures `originalTransactionId` from the **top-level argument**, not from `bridgeTxMeta`. As a result the field on `bridgeTxMeta` was a no-op and the history item silently fell back to `bridgeTxMeta.id` (the `orderUid`), severing the link between the bridge history record and the synthetic `TransactionController` entry. This caused the activity status of Ondo intent swaps to get out of sync with the underlying transaction.

This PR:

- Removes `originalTransactionId` from `bridgeTxMetaForHistory` (where it had no effect).
- Passes `originalTransactionId: syntheticMeta.id` as a top-level argument to `#addTxToHistory`, which is where `getInitialHistoryItem` actually reads it.
- Adds a comment explaining why this argument has to live at the top level so the next reader doesn't fall into the same trap.

Behavior change: the bridge history item for an intent swap is now correctly linked to its synthetic `TransactionController` transaction, so activity-screen status reflects the real intent order status instead of getting stuck.

## References

Fixes the Ondo intent swap activity status mismatch.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches intent transaction history keying/linking logic; a small change, but mistakes here could cause bridge activity status to desync or polling updates to target the wrong transaction.
> 
> **Overview**
> Fixes intent-swap history linking by ensuring `submitIntent` passes `originalTransactionId` as a **top-level** argument to `#addTxToHistory` when re-keying history items by `orderUid`, instead of (ineffectively) setting it on `bridgeTxMeta`.
> 
> This preserves the back-reference from the bridge history item to the synthetic `TransactionController` transaction so subsequent intent polling updates apply to the correct transaction; the package changelog is updated to document the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60ee344a5dc9ae5e427469ac7be2bcd8c80104de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->