### PR TITLE
feat: fix errors in eip-7702 step

### DIFF
--- a/packages/money-account-upgrade-controller/CHANGELOG.md
+++ b/packages/money-account-upgrade-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix the ChompApiService:createUpgrade call in the EIP-7702 auth step, pasing correct arguments ([#8657](https://github.com/MetaMask/core/pull/8657))
+
 ## [1.3.0]
 
 ### Changed

--- a/packages/money-account-upgrade-controller/src/MoneyAccountUpgradeController.test.ts
+++ b/packages/money-account-upgrade-controller/src/MoneyAccountUpgradeController.test.ts
@@ -306,7 +306,11 @@ describe('MoneyAccountUpgradeController', () => {
         }),
       );
       expect(mocks.createUpgrade).toHaveBeenCalledWith(
-        expect.objectContaining({ address: MOCK_ACCOUNT_ADDRESS }),
+        expect.objectContaining({
+          address: MOCK_CONFIG.delegatorImplAddress,
+          chainId: MOCK_CHAIN_ID,
+          nonce: '0x0',
+        }),
       );
     });
 

--- a/packages/money-account-upgrade-controller/src/steps/eip-7702-authorization.test.ts
+++ b/packages/money-account-upgrade-controller/src/steps/eip-7702-authorization.test.ts
@@ -259,7 +259,7 @@ describe('eip7702AuthorizationStep', () => {
       });
     });
 
-    it('submits the split signature and decimal-string chainId/nonce to CHOMP', async () => {
+    it('submits the split signature, delegator impl address, and hex-formatted chainId/nonce to CHOMP', async () => {
       const { messenger, mocks } = setup();
 
       await run(messenger);
@@ -269,9 +269,9 @@ describe('eip7702AuthorizationStep', () => {
         s: MOCK_S,
         v: 28,
         yParity: 1,
-        address: MOCK_ADDRESS,
-        chainId: MOCK_CHAIN_ID_DECIMAL.toString(),
-        nonce: MOCK_NONCE.toString(),
+        address: MOCK_DELEGATOR_IMPL,
+        chainId: MOCK_CHAIN_ID,
+        nonce: MOCK_NONCE_HEX,
       });
     });
 

--- a/packages/money-account-upgrade-controller/src/steps/eip-7702-authorization.ts
+++ b/packages/money-account-upgrade-controller/src/steps/eip-7702-authorization.ts
@@ -72,9 +72,9 @@ export const eip7702AuthorizationStep: Step = {
       s,
       v,
       yParity,
-      address,
-      chainId: chainIdDecimal.toString(),
-      nonce: nonce.toString(),
+      address: delegatorImplAddress,
+      chainId,
+      nonce: add0x(nonce.toString(16)),
     });
 
     return 'completed';


### PR DESCRIPTION
## Explanation
This PR updates the ChompApiService:createUpgrade call in money-account-upgrade-controller to correct some errors that were revealed in testing. These changes have been verified in the mobile repo, and the step now completes successfully. 

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the account-upgrade flow and changes the wire format sent to `ChompApiService:createUpgrade`, which could affect upgrade success if mismatched with backend expectations; scope is small and covered by updated tests.
> 
> **Overview**
> Fixes the EIP-7702 authorization step to submit the CHOMP upgrade request with **correct parameters**: using `delegatorImplAddress` (not the signer EOA) as `address`, and sending `chainId` plus a `0x`-prefixed hex `nonce` (not decimal strings).
> 
> Updates unit tests to match the new request shape and documents the fix in the package changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27bcd4b4936044b1e037378224f6004d36cca62a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->