### PR TITLE
feat(passkey-controller): require passkey post-registration verification for enrollment

### DIFF
--- a/packages/passkey-controller/CHANGELOG.md
+++ b/packages/passkey-controller/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING:** `PasskeyController` constructor option `rpID` is replaced with `expectedRPID: string | string[]` (normalized to a string array, which may be empty). Optional `rpId` sets `rp.id` / `rpId` in generated WebAuthn options; when omitted, those fields are omitted. Verification passes that array to `verifyRegistrationResponse` / `verifyAuthenticationResponse` as `expectedRPIDs`.
+- **BREAKING:** `verifyRegistrationResponse` and `verifyAuthenticationResponse` now take `expectedRPIDs: string[]` instead of `expectedRPID: string`.
+- `verifyRegistrationResponse` / `verifyAuthenticationResponse` accept an empty `expectedRPIDs` array to skip RP ID hash allowlist matching; successful authentication then reports `authenticationInfo.rpID` as an empty string.
 - Bump `@metamask/messenger` from `^1.1.1` to `^1.2.0` ([#8632](https://github.com/MetaMask/core/pull/8632))
 
 ## [1.0.0]

--- a/packages/passkey-controller/CHANGELOG.md
+++ b/packages/passkey-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `protectVaultKeyWithPasskey` rejects post-registration assertions whose `userHandle` is missing or does not match the in-flight registration ceremony when using `userHandle` key derivation (assertion `userHandle` is not signature-bound).
+
 ### Changed
 
 - **BREAKING:** `PasskeyController` constructor option `rpID` is replaced with `expectedRPID: string | string[]` (normalized to a string array, which may be empty). Optional `rpId` sets `rp.id` / `rpId` in generated WebAuthn options; when omitted, those fields are omitted. Verification passes that array to `verifyRegistrationResponse` / `verifyAuthenticationResponse` as `expectedRPIDs`.

--- a/packages/passkey-controller/CHANGELOG.md
+++ b/packages/passkey-controller/CHANGELOG.md
@@ -7,17 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
+### Added
 
-- `protectVaultKeyWithPasskey` rejects post-registration assertions whose `userHandle` is missing or does not match the in-flight registration ceremony when using `userHandle` key derivation (assertion `userHandle` is not signature-bound).
+- `generatePostRegistrationAuthenticationOptions` to issue `navigator.credentials.get()` options after `navigator.credentials.create()`, keyed to the in-flight registration ceremony (including PRF eval when a salt was used) ([#8663](https://github.com/MetaMask/core/pull/8663))
+- `already_enrolled` (`PasskeyControllerErrorCode.AlreadyEnrolled`) when calling `protectVaultKeyWithPasskey` while a passkey is already enrolled ([#8663](https://github.com/MetaMask/core/pull/8663))
 
 ### Changed
 
-- **BREAKING:** `PasskeyController` constructor option `rpID` is replaced with `expectedRPID: string | string[]` (normalized to a string array, which may be empty). Optional `rpId` sets `rp.id` / `rpId` in generated WebAuthn options; when omitted, those fields are omitted. Verification passes that array to `verifyRegistrationResponse` / `verifyAuthenticationResponse` as `expectedRPIDs`.
-- **BREAKING:** `verifyRegistrationResponse` and `verifyAuthenticationResponse` now take `expectedRPIDs: string[]` instead of `expectedRPID: string`.
-- `verifyRegistrationResponse` / `verifyAuthenticationResponse` accept an empty `expectedRPIDs` array to skip RP ID hash allowlist matching; successful authentication then reports `authenticationInfo.rpID` as an empty string.
-- Increase `CEREMONY_TTL_SLACK_MS` to 2 minutes so in-flight ceremony state (`CEREMONY_MAX_AGE_MS`, 3 minutes including WebAuthn timeout) tolerates longer gaps between WebAuthn options and completion (e.g. post-registration authentication).
+- **BREAKING:** Enrollment completes in three steps: `generateRegistrationOptions` → `create()` → `generatePostRegistrationAuthenticationOptions` → `get()` → `protectVaultKeyWithPasskey`; `protectVaultKeyWithPasskey` now **requires** `authenticationResponse`, and the vault wrapping key is derived from that post-registration assertion (same path as unlock: PRF when present, otherwise `userHandle`) ([#8663](https://github.com/MetaMask/core/pull/8663))
+- **BREAKING:** `PasskeyController` constructor option `rpID` is replaced with `expectedRPID: string | string[]` (normalized to a string array, which may be empty). Optional `rpId` sets `rp.id` / `rpId` in generated WebAuthn options; when omitted, those fields are omitted. Verification passes that array to `verifyRegistrationResponse` / `verifyAuthenticationResponse` as `expectedRPIDs` ([#8663](https://github.com/MetaMask/core/pull/8663))
+- **BREAKING:** `verifyRegistrationResponse` and `verifyAuthenticationResponse` now take `expectedRPIDs: string[]` instead of `expectedRPID: string` ([#8663](https://github.com/MetaMask/core/pull/8663))
+- `verifyRegistrationResponse` / `verifyAuthenticationResponse` accept an empty `expectedRPIDs` array to skip RP ID hash allowlist matching; successful authentication then reports `authenticationInfo.rpID` as an empty string ([#8663](https://github.com/MetaMask/core/pull/8663))
+- Increase `CEREMONY_TTL_SLACK_MS` to 2 minutes so in-flight ceremony state (`CEREMONY_MAX_AGE_MS`, 3 minutes including WebAuthn timeout) tolerates longer gaps between WebAuthn options and completion (e.g. post-registration authentication) ([#8663](https://github.com/MetaMask/core/pull/8663))
 - Bump `@metamask/messenger` from `^1.1.1` to `^1.2.0` ([#8632](https://github.com/MetaMask/core/pull/8632))
+
+### Fixed
+
+- `protectVaultKeyWithPasskey` rejects post-registration assertions whose `userHandle` is missing or does not match the in-flight registration ceremony when using `userHandle` key derivation (assertion `userHandle` is not signature-bound) ([#8663](https://github.com/MetaMask/core/pull/8663))
 
 ## [1.0.0]
 

--- a/packages/passkey-controller/CHANGELOG.md
+++ b/packages/passkey-controller/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** `PasskeyController` constructor option `rpID` is replaced with `expectedRPID: string | string[]` (normalized to a string array, which may be empty). Optional `rpId` sets `rp.id` / `rpId` in generated WebAuthn options; when omitted, those fields are omitted. Verification passes that array to `verifyRegistrationResponse` / `verifyAuthenticationResponse` as `expectedRPIDs`.
 - **BREAKING:** `verifyRegistrationResponse` and `verifyAuthenticationResponse` now take `expectedRPIDs: string[]` instead of `expectedRPID: string`.
 - `verifyRegistrationResponse` / `verifyAuthenticationResponse` accept an empty `expectedRPIDs` array to skip RP ID hash allowlist matching; successful authentication then reports `authenticationInfo.rpID` as an empty string.
+- Increase `CEREMONY_TTL_SLACK_MS` to 2 minutes so in-flight ceremony state (`CEREMONY_MAX_AGE_MS`, 3 minutes including WebAuthn timeout) tolerates longer gaps between WebAuthn options and completion (e.g. post-registration authentication).
 - Bump `@metamask/messenger` from `^1.1.1` to `^1.2.0` ([#8632](https://github.com/MetaMask/core/pull/8632))
 
 ## [1.0.0]

--- a/packages/passkey-controller/README.md
+++ b/packages/passkey-controller/README.md
@@ -23,10 +23,10 @@ For enrollment, the wrapping key is always derived from the **post-registration*
 
 The controller supports two key derivation methods, selected automatically during enrollment:
 
-| Strategy       | When used                                                                                                                                      | Input key material                                                                 |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| Strategy       | When used                                                                                                                                           | Input key material                                                                    |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
 | **PRF**        | Post-registration assertion includes non-empty [PRF extension](https://w3c.github.io/webauthn/#prf-extension) output and registration used PRF salt | PRF evaluation output from the assertion (ceremony `prfSalt` is stored on the record) |
-| **userHandle** | Otherwise                                                                                                                                      | Random `userHandle` from registration (asserted on the post-registration `get()`)    |
+| **userHandle** | Otherwise                                                                                                                                           | Random `userHandle` from registration (asserted on the post-registration `get()`)     |
 
 Both strategies feed the input key material through **HKDF-SHA256** with the credential ID as salt and a fixed info string to produce the 32-byte AES-256 wrapping key.
 
@@ -62,13 +62,17 @@ const controller = new PasskeyController({
 const regOptions = controller.generateRegistrationOptions();
 
 // 2. Create the passkey in the browser
-const regResponse = await navigator.credentials.create({ publicKey: regOptions });
+const regResponse = await navigator.credentials.create({
+  publicKey: regOptions,
+});
 
 // 3. Post-registration authentication (same wrapping-key path as unlock)
 const authOptions = controller.generatePostRegistrationAuthenticationOptions({
   registrationResponse: regResponse,
 });
-const authResponse = await navigator.credentials.get({ publicKey: authOptions });
+const authResponse = await navigator.credentials.get({
+  publicKey: authOptions,
+});
 
 // 4. Verify registration + post-registration auth once, then persist
 await controller.protectVaultKeyWithPasskey({

--- a/packages/passkey-controller/README.md
+++ b/packages/passkey-controller/README.md
@@ -42,7 +42,9 @@ const messenger: PasskeyControllerMessenger = /* create via root messenger */;
 
 const controller = new PasskeyController({
   messenger,
-  rpID: 'example.com',
+  rpId: 'example.com',
+  // Or multiple verification candidates: expectedRPID: ['a.example', 'b.example']
+  expectedRPID: 'example.com',
   rpName: 'My Wallet',
   expectedOrigin: 'chrome-extension://abcdef1234567890',
   // Optional — both default to `rpName` when omitted.
@@ -50,6 +52,8 @@ const controller = new PasskeyController({
   userDisplayName: 'My Wallet',
 });
 ```
+
+`expectedRPID` is a string or string array used to verify the authenticator `rpIdHash`. Optional `rpId`, when set, is sent as `rp.id` / `rpId` in generated WebAuthn options; when omitted, those fields are omitted so the client uses its default RP ID behavior.
 
 ### Passkey enrollment (registration)
 

--- a/packages/passkey-controller/README.md
+++ b/packages/passkey-controller/README.md
@@ -12,19 +12,21 @@ or
 
 ## Overview
 
-The controller follows a two-phase ceremony pattern for both enrollment and authentication:
+The controller follows a two-phase ceremony pattern for unlock (authentication) and a three-step pattern for enrollment: registration options → post-registration authentication options → combined verify and protect.
 
 1. **Generate options** — call a synchronous method that returns options JSON and records **in-flight ceremony** state (challenge-keyed; not a user login session).
 2. **Verify response** — pass the authenticator's response back to the controller, which verifies the WebAuthn signature and performs the cryptographic operation (protect or retrieve the vault key).
+
+For enrollment, the wrapping key is always derived from the **post-registration** `get()` response (same path as unlock), not from the `create()` response alone.
 
 ### Key derivation strategies
 
 The controller supports two key derivation methods, selected automatically during enrollment:
 
-| Strategy       | When used                                                                                          | Input key material                                |
-| -------------- | -------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
-| **PRF**        | Authenticator supports the [WebAuthn PRF extension](https://w3c.github.io/webauthn/#prf-extension) | PRF evaluation output                             |
-| **userHandle** | PRF is unavailable                                                                                 | Random `userHandle` generated during registration |
+| Strategy       | When used                                                                                                                                      | Input key material                                                                 |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| **PRF**        | Post-registration assertion includes non-empty [PRF extension](https://w3c.github.io/webauthn/#prf-extension) output and registration used PRF salt | PRF evaluation output from the assertion (ceremony `prfSalt` is stored on the record) |
+| **userHandle** | Otherwise                                                                                                                                      | Random `userHandle` from registration (asserted on the post-registration `get()`)    |
 
 Both strategies feed the input key material through **HKDF-SHA256** with the credential ID as salt and a fixed info string to produce the 32-byte AES-256 wrapping key.
 
@@ -53,14 +55,21 @@ const controller = new PasskeyController({
 
 ```typescript
 // 1. Generate registration options (synchronous)
-const options = controller.generateRegistrationOptions();
+const regOptions = controller.generateRegistrationOptions();
 
-// 2. Pass options to the browser WebAuthn API
-const response = await navigator.credentials.create({ publicKey: options });
+// 2. Create the passkey in the browser
+const regResponse = await navigator.credentials.create({ publicKey: regOptions });
 
-// 3. Verify and protect the vault key
+// 3. Post-registration authentication (same wrapping-key path as unlock)
+const authOptions = controller.generatePostRegistrationAuthenticationOptions({
+  registrationResponse: regResponse,
+});
+const authResponse = await navigator.credentials.get({ publicKey: authOptions });
+
+// 4. Verify registration + post-registration auth once, then persist
 await controller.protectVaultKeyWithPasskey({
-  registrationResponse: response,
+  registrationResponse: regResponse,
+  authenticationResponse: authResponse,
   vaultKey: myVaultEncryptionKey,
 });
 ```
@@ -116,8 +125,8 @@ passkeyControllerSelectors.selectIsPasskeyEnrolled(state); // boolean
 
 `PasskeyControllerError` is thrown for controller failures. Expected operational
 cases use a stable `code` from `PasskeyControllerErrorCode` (for example:
-`not_enrolled`, `no_registration_ceremony`, `authentication_verification_failed`,
-`missing_key_material`, `vault_key_decryption_failed`). Human-readable strings
+`not_enrolled`, `already_enrolled`, `no_registration_ceremony`,
+`authentication_verification_failed`, `missing_key_material`, `vault_key_decryption_failed`). Human-readable strings
 live on `PasskeyControllerErrorMessage`. Use `instanceof PasskeyControllerError`
 and a defined `error.code` to tell these apart from malformed WebAuthn payloads
 and other `Error` values. Thrown errors from the internal WebAuthn verify helpers

--- a/packages/passkey-controller/src/PasskeyController.test.ts
+++ b/packages/passkey-controller/src/PasskeyController.test.ts
@@ -144,9 +144,6 @@ function minimalAuthenticationResponse(
   } as PasskeyAuthenticationResponse;
 }
 
-/**
- * Sets up mocks for a full registration + protect flow.
- */
 function setupRegistrationMocks(): void {
   mockVerifyRegistrationResponse.mockResolvedValue({
     verified: true,
@@ -175,11 +172,6 @@ function setupAuthenticationMocks(): void {
   });
 }
 
-/**
- * Completes enrollment with a post-registration `get()` credential (same flow
- * as production): post-reg auth options, synthetic auth response, then
- * {@link PasskeyController.protectVaultKeyWithPasskey}.
- */
 async function enrollWithPostRegistrationAuth(
   controller: PasskeyController,
   options: {
@@ -471,20 +463,21 @@ describe('PasskeyController', () => {
 
     it('throws when passkey is already enrolled', async () => {
       setupRegistrationMocks();
-      const controller = createController();
-      const regOpts = controller.generateRegistrationOptions();
-      controller.update((state) => {
-        state.passkeyRecord = {
-          credential: {
-            id: TEST_CREDENTIAL_ID,
-            publicKey: TEST_PUBLIC_KEY,
-            counter: 0,
-            transports: ['internal'],
-            aaguid: '00000000-0000-0000-0000-000000000000',
+      const regOpts = createController().generateRegistrationOptions();
+      const controller = createController({
+        state: {
+          passkeyRecord: {
+            credential: {
+              id: TEST_CREDENTIAL_ID,
+              publicKey: TEST_PUBLIC_KEY,
+              counter: 0,
+              transports: ['internal'],
+              aaguid: '00000000-0000-0000-0000-000000000000',
+            },
+            encryptedVaultKey: { ciphertext: 'YQ', iv: 'Yg' },
+            keyDerivation: { method: 'userHandle' },
           },
-          encryptedVaultKey: { ciphertext: 'YQ', iv: 'Yg' },
-          keyDerivation: { method: 'userHandle' },
-        };
+        },
       });
       await expect(
         controller.protectVaultKeyWithPasskey({

--- a/packages/passkey-controller/src/PasskeyController.test.ts
+++ b/packages/passkey-controller/src/PasskeyController.test.ts
@@ -511,13 +511,12 @@ describe('PasskeyController', () => {
 
       const controller = createController();
       const regOpts = controller.generateRegistrationOptions();
-      const regResp = minimalRegistrationResponse(
-        undefined,
-        regOpts.challenge,
+      const regResp = minimalRegistrationResponse(undefined, regOpts.challenge);
+      const authOpts = controller.generatePostRegistrationAuthenticationOptions(
+        {
+          registrationResponse: regResp,
+        },
       );
-      const authOpts = controller.generatePostRegistrationAuthenticationOptions({
-        registrationResponse: regResp,
-      });
       const authResp = minimalAuthenticationResponse(
         regOpts.user.id,
         undefined,
@@ -540,13 +539,12 @@ describe('PasskeyController', () => {
 
       const controller = createController();
       const regOpts = controller.generateRegistrationOptions();
-      const regResp = minimalRegistrationResponse(
-        undefined,
-        regOpts.challenge,
+      const regResp = minimalRegistrationResponse(undefined, regOpts.challenge);
+      const authOpts = controller.generatePostRegistrationAuthenticationOptions(
+        {
+          registrationResponse: regResp,
+        },
       );
-      const authOpts = controller.generatePostRegistrationAuthenticationOptions({
-        registrationResponse: regResp,
-      });
       const authResp = minimalAuthenticationResponse(
         regOpts.user.id,
         undefined,
@@ -572,13 +570,12 @@ describe('PasskeyController', () => {
 
       const controller = createController();
       const regOpts = controller.generateRegistrationOptions();
-      const regResp = minimalRegistrationResponse(
-        undefined,
-        regOpts.challenge,
+      const regResp = minimalRegistrationResponse(undefined, regOpts.challenge);
+      const authOpts = controller.generatePostRegistrationAuthenticationOptions(
+        {
+          registrationResponse: regResp,
+        },
       );
-      const authOpts = controller.generatePostRegistrationAuthenticationOptions({
-        registrationResponse: regResp,
-      });
       const authResp = minimalAuthenticationResponse(
         regOpts.user.id,
         undefined,

--- a/packages/passkey-controller/src/PasskeyController.test.ts
+++ b/packages/passkey-controller/src/PasskeyController.test.ts
@@ -81,7 +81,8 @@ function createController(
 ): PasskeyController {
   return new PasskeyController({
     messenger: getPasskeyMessenger(),
-    rpID: TEST_RP_ID,
+    expectedRPID: TEST_RP_ID,
+    rpId: TEST_RP_ID,
     rpName: TEST_RP_NAME,
     expectedOrigin: TEST_ORIGIN,
     ...overrides,
@@ -231,6 +232,18 @@ describe('PasskeyController', () => {
   });
 
   describe('constructor', () => {
+    it('allows expectedRPID to be an empty array', () => {
+      expect(
+        () =>
+          new PasskeyController({
+            messenger: getPasskeyMessenger(),
+            expectedRPID: [],
+            rpName: TEST_RP_NAME,
+            expectedOrigin: TEST_ORIGIN,
+          }),
+      ).not.toThrow();
+    });
+
     it('merges partial initial state with defaults', () => {
       const record: PasskeyRecord = {
         credential: {
@@ -284,14 +297,26 @@ describe('PasskeyController', () => {
       ).toBeDefined();
     });
 
-    it('uses rpID and rpName from constructor', () => {
+    it('uses expectedRPID and rpName from constructor', () => {
       const controller = createController({
-        rpID: 'custom-rp.io',
+        expectedRPID: 'custom-rp.io',
         rpName: 'Custom RP',
+        rpId: undefined,
       });
       const options = controller.generateRegistrationOptions();
-      expect(options.rp.id).toBe('custom-rp.io');
-      expect(options.rp.name).toBe('Custom RP');
+      expect(options.rp).toStrictEqual({
+        name: 'Custom RP',
+        id: undefined,
+      });
+    });
+
+    it('uses optional rpId for WebAuthn rp.id when set', () => {
+      const controller = createController({
+        expectedRPID: ['first.example', 'second.example'],
+        rpId: 'second.example',
+      });
+      const options = controller.generateRegistrationOptions();
+      expect(options.rp.id).toBe('second.example');
     });
 
     it('includes PRF extension when prfAvailable is true', () => {
@@ -1579,8 +1604,9 @@ describe('PasskeyController', () => {
       setupRegistrationMocks();
       setupAuthenticationMocks();
       const controller = createController({
-        rpID: 'custom-rp.com',
+        expectedRPID: 'custom-rp.com',
         expectedOrigin: 'chrome-extension://abc123',
+        rpId: undefined,
       });
 
       const regOpts = controller.generateRegistrationOptions();
@@ -1596,7 +1622,7 @@ describe('PasskeyController', () => {
       expect(mockVerifyRegistrationResponse).toHaveBeenCalledWith(
         expect.objectContaining({
           expectedOrigin: 'chrome-extension://abc123',
-          expectedRPID: 'custom-rp.com',
+          expectedRPIDs: ['custom-rp.com'],
           requireUserVerification: false,
         }),
       );
@@ -1642,7 +1668,7 @@ describe('PasskeyController', () => {
       expect(mockVerifyAuthenticationResponse).toHaveBeenCalledWith(
         expect.objectContaining({
           expectedOrigin: TEST_ORIGIN,
-          expectedRPID: TEST_RP_ID,
+          expectedRPIDs: [TEST_RP_ID],
           credential: expect.objectContaining({
             id: TEST_CREDENTIAL_ID,
             counter: 0,

--- a/packages/passkey-controller/src/PasskeyController.test.ts
+++ b/packages/passkey-controller/src/PasskeyController.test.ts
@@ -631,6 +631,66 @@ describe('PasskeyController', () => {
       expect(record?.keyDerivation.method).toBe('userHandle');
     });
 
+    it('throws when post-registration assertion userHandle does not match the registration ceremony', async () => {
+      setupRegistrationMocks();
+      setupAuthenticationMocks();
+      const controller = createController();
+      const regOpts = controller.generateRegistrationOptions();
+      const regResp = minimalRegistrationResponse(undefined, regOpts.challenge);
+      const authOpts = controller.generatePostRegistrationAuthenticationOptions(
+        {
+          registrationResponse: regResp,
+        },
+      );
+      const wrongUserHandle = bytesToBase64URL(new Uint8Array(64).fill(0xbb));
+
+      await expect(
+        controller.protectVaultKeyWithPasskey({
+          registrationResponse: regResp,
+          authenticationResponse: minimalAuthenticationResponse(
+            wrongUserHandle,
+            undefined,
+            authOpts.challenge,
+          ),
+          vaultKey: 'k',
+        }),
+      ).rejects.toMatchObject({
+        code: PasskeyControllerErrorCode.AuthenticationVerificationFailed,
+      });
+
+      expect(controller.isPasskeyEnrolled()).toBe(false);
+    });
+
+    it('throws when userHandle derivation is required but assertion omits userHandle', async () => {
+      setupRegistrationMocks();
+      setupAuthenticationMocks();
+      const controller = createController();
+      const regOpts = controller.generateRegistrationOptions({
+        prfAvailable: false,
+      });
+      const regResp = minimalRegistrationResponse(undefined, regOpts.challenge);
+      const authOpts = controller.generatePostRegistrationAuthenticationOptions(
+        {
+          registrationResponse: regResp,
+        },
+      );
+      const authResp = minimalAuthenticationResponse(
+        undefined,
+        undefined,
+        authOpts.challenge,
+      );
+
+      await expect(
+        controller.protectVaultKeyWithPasskey({
+          registrationResponse: regResp,
+          authenticationResponse: authResp,
+          vaultKey: 'k',
+        }),
+      ).rejects.toMatchObject({
+        code: PasskeyControllerErrorCode.AuthenticationVerificationFailed,
+      });
+    });
+
     it('uses prf derivation when extension results include PRF output', async () => {
       setupRegistrationMocks();
       setupAuthenticationMocks();

--- a/packages/passkey-controller/src/PasskeyController.test.ts
+++ b/packages/passkey-controller/src/PasskeyController.test.ts
@@ -174,6 +174,45 @@ function setupAuthenticationMocks(): void {
   });
 }
 
+/**
+ * Completes enrollment with a post-registration `get()` credential (same flow
+ * as production): post-reg auth options, synthetic auth response, then
+ * {@link PasskeyController.protectVaultKeyWithPasskey}.
+ */
+async function enrollWithPostRegistrationAuth(
+  controller: PasskeyController,
+  options: {
+    registrationResponse: PasskeyRegistrationResponse;
+    vaultKey: string;
+    /** Assertion userHandle when using userHandle wrapping (must match registration `user.id`). */
+    userHandle?: string;
+    /** PRF (or other) extension results on the post-registration authentication response. */
+    authClientExtensionResults?: Record<string, unknown>;
+  },
+): Promise<void> {
+  const {
+    registrationResponse,
+    vaultKey,
+    userHandle,
+    authClientExtensionResults,
+  } = options;
+  const authOpts = controller.generatePostRegistrationAuthenticationOptions({
+    registrationResponse,
+  });
+  const authResp = minimalAuthenticationResponse(
+    userHandle,
+    {
+      clientExtensionResults: authClientExtensionResults ?? {},
+    },
+    authOpts.challenge,
+  );
+  await controller.protectVaultKeyWithPasskey({
+    registrationResponse,
+    authenticationResponse: authResp,
+    vaultKey,
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -281,6 +320,25 @@ describe('PasskeyController', () => {
       expect(options.extensions).toBeUndefined();
     });
 
+    it('throws when passkey is already enrolled', async () => {
+      setupRegistrationMocks();
+      setupAuthenticationMocks();
+      const controller = createController();
+      const regOptions = controller.generateRegistrationOptions();
+      await enrollWithPostRegistrationAuth(controller, {
+        registrationResponse: minimalRegistrationResponse(
+          undefined,
+          regOptions.challenge,
+        ),
+        vaultKey: 'vault-key',
+        userHandle: regOptions.user.id,
+      });
+      expect(controller.isPasskeyEnrolled()).toBe(true);
+      expect(() => controller.generateRegistrationOptions()).toThrow(
+        PasskeyControllerErrorMessage.AlreadyEnrolled,
+      );
+    });
+
     it('uses userHandle derivation for the full round-trip when prfAvailable is false', async () => {
       setupRegistrationMocks();
       setupAuthenticationMocks();
@@ -294,12 +352,13 @@ describe('PasskeyController', () => {
       expect(regOptions.extensions).toBeUndefined();
 
       const userHandle = regOptions.user.id;
-      await controller.protectVaultKeyWithPasskey({
+      await enrollWithPostRegistrationAuth(controller, {
         registrationResponse: minimalRegistrationResponse(
           undefined,
           regOptions.challenge,
         ),
         vaultKey,
+        userHandle,
       });
 
       expect(controller.state.passkeyRecord?.keyDerivation).toStrictEqual({
@@ -320,6 +379,17 @@ describe('PasskeyController', () => {
     });
   });
 
+  describe('generatePostRegistrationAuthenticationOptions', () => {
+    it('throws when there is no active registration ceremony', () => {
+      const controller = createController();
+      expect(() =>
+        controller.generatePostRegistrationAuthenticationOptions({
+          registrationResponse: minimalRegistrationResponse(),
+        }),
+      ).toThrow(PasskeyControllerErrorMessage.NoRegistrationCeremony);
+    });
+  });
+
   describe('generateAuthenticationOptions', () => {
     it('throws when passkey is not enrolled', () => {
       const controller = createController();
@@ -336,7 +406,7 @@ describe('PasskeyController', () => {
       const controller = createController();
 
       const regOpts = controller.generateRegistrationOptions();
-      await controller.protectVaultKeyWithPasskey({
+      await enrollWithPostRegistrationAuth(controller, {
         registrationResponse: minimalRegistrationResponse(
           {
             clientExtensionResults: prfResults(prfFirst, true),
@@ -344,6 +414,7 @@ describe('PasskeyController', () => {
           regOpts.challenge,
         ),
         vaultKey: 'k',
+        authClientExtensionResults: prfResults(prfFirst, true),
       });
 
       const authOpts = controller.generateAuthenticationOptions();
@@ -367,9 +438,45 @@ describe('PasskeyController', () => {
       await expect(
         controller.protectVaultKeyWithPasskey({
           registrationResponse: minimalRegistrationResponse(),
+          authenticationResponse: minimalAuthenticationResponse(),
           vaultKey: 'k',
         }),
       ).rejects.toThrow(PasskeyControllerErrorMessage.NoRegistrationCeremony);
+    });
+
+    it('throws when passkey is already enrolled', async () => {
+      setupRegistrationMocks();
+      const controller = createController();
+      const regOpts = controller.generateRegistrationOptions();
+      controller.update((state) => {
+        state.passkeyRecord = {
+          credential: {
+            id: TEST_CREDENTIAL_ID,
+            publicKey: TEST_PUBLIC_KEY,
+            counter: 0,
+            transports: ['internal'],
+            aaguid: '00000000-0000-0000-0000-000000000000',
+          },
+          encryptedVaultKey: { ciphertext: 'YQ', iv: 'Yg' },
+          keyDerivation: { method: 'userHandle' },
+        };
+      });
+      await expect(
+        controller.protectVaultKeyWithPasskey({
+          registrationResponse: minimalRegistrationResponse(
+            undefined,
+            regOpts.challenge,
+          ),
+          authenticationResponse: minimalAuthenticationResponse(
+            regOpts.user.id,
+            undefined,
+            TEST_CHALLENGE,
+          ),
+          vaultKey: 'k',
+        }),
+      ).rejects.toMatchObject({
+        code: PasskeyControllerErrorCode.AlreadyEnrolled,
+      });
     });
 
     it('throws when verification fails', async () => {
@@ -379,13 +486,23 @@ describe('PasskeyController', () => {
 
       const controller = createController();
       const regOpts = controller.generateRegistrationOptions();
+      const regResp = minimalRegistrationResponse(
+        undefined,
+        regOpts.challenge,
+      );
+      const authOpts = controller.generatePostRegistrationAuthenticationOptions({
+        registrationResponse: regResp,
+      });
+      const authResp = minimalAuthenticationResponse(
+        regOpts.user.id,
+        undefined,
+        authOpts.challenge,
+      );
 
       await expect(
         controller.protectVaultKeyWithPasskey({
-          registrationResponse: minimalRegistrationResponse(
-            undefined,
-            regOpts.challenge,
-          ),
+          registrationResponse: regResp,
+          authenticationResponse: authResp,
           vaultKey: 'k',
         }),
       ).rejects.toThrow(
@@ -398,13 +515,23 @@ describe('PasskeyController', () => {
 
       const controller = createController();
       const regOpts = controller.generateRegistrationOptions();
+      const regResp = minimalRegistrationResponse(
+        undefined,
+        regOpts.challenge,
+      );
+      const authOpts = controller.generatePostRegistrationAuthenticationOptions({
+        registrationResponse: regResp,
+      });
+      const authResp = minimalAuthenticationResponse(
+        regOpts.user.id,
+        undefined,
+        authOpts.challenge,
+      );
 
       await expect(
         controller.protectVaultKeyWithPasskey({
-          registrationResponse: minimalRegistrationResponse(
-            undefined,
-            regOpts.challenge,
-          ),
+          registrationResponse: regResp,
+          authenticationResponse: authResp,
           vaultKey: 'k',
         }),
       ).rejects.toMatchObject({
@@ -420,13 +547,23 @@ describe('PasskeyController', () => {
 
       const controller = createController();
       const regOpts = controller.generateRegistrationOptions();
+      const regResp = minimalRegistrationResponse(
+        undefined,
+        regOpts.challenge,
+      );
+      const authOpts = controller.generatePostRegistrationAuthenticationOptions({
+        registrationResponse: regResp,
+      });
+      const authResp = minimalAuthenticationResponse(
+        regOpts.user.id,
+        undefined,
+        authOpts.challenge,
+      );
 
       await expect(
         controller.protectVaultKeyWithPasskey({
-          registrationResponse: minimalRegistrationResponse(
-            undefined,
-            regOpts.challenge,
-          ),
+          registrationResponse: regResp,
+          authenticationResponse: authResp,
           vaultKey: 'k',
         }),
       ).rejects.toMatchObject({
@@ -437,9 +574,9 @@ describe('PasskeyController', () => {
 
       await expect(
         controller.protectVaultKeyWithPasskey({
-          registrationResponse: minimalRegistrationResponse(
-            undefined,
-            regOpts.challenge,
+          registrationResponse: regResp,
+          authenticationResponse: minimalAuthenticationResponse(
+            regOpts.user.id,
           ),
           vaultKey: 'k',
         }),
@@ -448,15 +585,17 @@ describe('PasskeyController', () => {
 
     it('stores passkey record with publicKey after successful verification', async () => {
       setupRegistrationMocks();
+      setupAuthenticationMocks();
       const controller = createController();
       const regOpts = controller.generateRegistrationOptions();
 
-      await controller.protectVaultKeyWithPasskey({
+      await enrollWithPostRegistrationAuth(controller, {
         registrationResponse: minimalRegistrationResponse(
           undefined,
           regOpts.challenge,
         ),
         vaultKey: 'test-vault-key',
+        userHandle: regOpts.user.id,
       });
 
       expect(controller.isPasskeyEnrolled()).toBe(true);
@@ -472,11 +611,12 @@ describe('PasskeyController', () => {
 
     it('uses prf derivation when extension results include PRF output', async () => {
       setupRegistrationMocks();
+      setupAuthenticationMocks();
       const controller = createController();
       const regOpts = controller.generateRegistrationOptions();
 
       const prfFirst = bytesToBase64URL(new Uint8Array(32).fill(9));
-      await controller.protectVaultKeyWithPasskey({
+      await enrollWithPostRegistrationAuth(controller, {
         registrationResponse: minimalRegistrationResponse(
           {
             clientExtensionResults: prfResults(prfFirst, true),
@@ -484,6 +624,7 @@ describe('PasskeyController', () => {
           regOpts.challenge,
         ),
         vaultKey: 'vault-key-prf-path',
+        authClientExtensionResults: prfResults(prfFirst, true),
       });
 
       expect(controller.state.passkeyRecord?.keyDerivation.method).toBe('prf');
@@ -508,7 +649,7 @@ describe('PasskeyController', () => {
       ).toBeDefined();
 
       const userHandle = regOptions.user.id;
-      await controller.protectVaultKeyWithPasskey({
+      await enrollWithPostRegistrationAuth(controller, {
         registrationResponse: minimalRegistrationResponse(
           {
             clientExtensionResults: {
@@ -518,6 +659,7 @@ describe('PasskeyController', () => {
           regOptions.challenge,
         ),
         vaultKey,
+        userHandle,
       });
 
       expect(controller.state.passkeyRecord?.keyDerivation).toStrictEqual({
@@ -551,14 +693,16 @@ describe('PasskeyController', () => {
 
     it('throws when there is no authentication ceremony', async () => {
       setupRegistrationMocks();
+      setupAuthenticationMocks();
       const controller = createController();
       const regOpts = controller.generateRegistrationOptions();
-      await controller.protectVaultKeyWithPasskey({
+      await enrollWithPostRegistrationAuth(controller, {
         registrationResponse: minimalRegistrationResponse(
           undefined,
           regOpts.challenge,
         ),
         vaultKey: 'k',
+        userHandle: regOpts.user.id,
       });
 
       await expect(
@@ -570,14 +714,16 @@ describe('PasskeyController', () => {
 
     it('throws when verification fails', async () => {
       setupRegistrationMocks();
+      setupAuthenticationMocks();
       const controller = createController();
       const regOpts = controller.generateRegistrationOptions();
-      await controller.protectVaultKeyWithPasskey({
+      await enrollWithPostRegistrationAuth(controller, {
         registrationResponse: minimalRegistrationResponse(
           undefined,
           regOpts.challenge,
         ),
         vaultKey: 'k',
+        userHandle: regOpts.user.id,
       });
 
       mockVerifyAuthenticationResponse.mockResolvedValue({
@@ -597,14 +743,16 @@ describe('PasskeyController', () => {
 
     it('wraps non-Error verifyAuthenticationResponse rejection in AuthenticationVerificationFailed', async () => {
       setupRegistrationMocks();
+      setupAuthenticationMocks();
       const controller = createController();
       const regOpts = controller.generateRegistrationOptions();
-      await controller.protectVaultKeyWithPasskey({
+      await enrollWithPostRegistrationAuth(controller, {
         registrationResponse: minimalRegistrationResponse(
           undefined,
           regOpts.challenge,
         ),
         vaultKey: 'k',
+        userHandle: regOpts.user.id,
       });
 
       mockVerifyAuthenticationResponse.mockRejectedValue('auth-string-error');
@@ -623,14 +771,16 @@ describe('PasskeyController', () => {
 
     it('wraps verifyAuthenticationResponse rejection in AuthenticationVerificationFailed', async () => {
       setupRegistrationMocks();
+      setupAuthenticationMocks();
       const controller = createController();
       const regOpts = controller.generateRegistrationOptions();
-      await controller.protectVaultKeyWithPasskey({
+      await enrollWithPostRegistrationAuth(controller, {
         registrationResponse: minimalRegistrationResponse(
           undefined,
           regOpts.challenge,
         ),
         vaultKey: 'k',
+        userHandle: regOpts.user.id,
       });
 
       mockVerifyAuthenticationResponse.mockRejectedValue(
@@ -658,7 +808,7 @@ describe('PasskeyController', () => {
       const prfFirst = bytesToBase64URL(new Uint8Array(32).fill(42));
 
       const regOpts = controller.generateRegistrationOptions();
-      await controller.protectVaultKeyWithPasskey({
+      await enrollWithPostRegistrationAuth(controller, {
         registrationResponse: minimalRegistrationResponse(
           {
             clientExtensionResults: prfResults(prfFirst),
@@ -666,6 +816,7 @@ describe('PasskeyController', () => {
           regOpts.challenge,
         ),
         vaultKey: 'secret',
+        authClientExtensionResults: prfResults(prfFirst),
       });
 
       const decryptSpy = jest
@@ -704,7 +855,7 @@ describe('PasskeyController', () => {
       const prfFirst = bytesToBase64URL(new Uint8Array(32).fill(42));
 
       const regOpts = controller.generateRegistrationOptions();
-      await controller.protectVaultKeyWithPasskey({
+      await enrollWithPostRegistrationAuth(controller, {
         registrationResponse: minimalRegistrationResponse(
           {
             clientExtensionResults: prfResults(prfFirst),
@@ -712,6 +863,7 @@ describe('PasskeyController', () => {
           regOpts.challenge,
         ),
         vaultKey: 'secret',
+        authClientExtensionResults: prfResults(prfFirst),
       });
 
       const updateSpy = jest.spyOn(controller, 'update' as never);
@@ -748,7 +900,7 @@ describe('PasskeyController', () => {
       const prfFirst = bytesToBase64URL(new Uint8Array(32).fill(99));
 
       const regOpts = controller.generateRegistrationOptions();
-      await controller.protectVaultKeyWithPasskey({
+      await enrollWithPostRegistrationAuth(controller, {
         registrationResponse: minimalRegistrationResponse(
           {
             clientExtensionResults: prfResults(prfFirst),
@@ -756,6 +908,7 @@ describe('PasskeyController', () => {
           regOpts.challenge,
         ),
         vaultKey: 'secret',
+        authClientExtensionResults: prfResults(prfFirst),
       });
 
       const authOpts = controller.generateAuthenticationOptions();
@@ -792,14 +945,16 @@ describe('PasskeyController', () => {
 
     it('returns false when there is no authentication ceremony', async () => {
       setupRegistrationMocks();
+      setupAuthenticationMocks();
       const controller = createController();
       const regOpts = controller.generateRegistrationOptions();
-      await controller.protectVaultKeyWithPasskey({
+      await enrollWithPostRegistrationAuth(controller, {
         registrationResponse: minimalRegistrationResponse(
           undefined,
           regOpts.challenge,
         ),
         vaultKey: 'k',
+        userHandle: regOpts.user.id,
       });
 
       expect(
@@ -811,14 +966,16 @@ describe('PasskeyController', () => {
 
     it('returns false when verification fails', async () => {
       setupRegistrationMocks();
+      setupAuthenticationMocks();
       const controller = createController();
       const regOpts = controller.generateRegistrationOptions();
-      await controller.protectVaultKeyWithPasskey({
+      await enrollWithPostRegistrationAuth(controller, {
         registrationResponse: minimalRegistrationResponse(
           undefined,
           regOpts.challenge,
         ),
         vaultKey: 'k',
+        userHandle: regOpts.user.id,
       });
 
       mockVerifyAuthenticationResponse.mockResolvedValue({
@@ -835,7 +992,20 @@ describe('PasskeyController', () => {
     });
 
     it('rethrows non-operational errors (e.g. malformed clientDataJSON)', async () => {
+      setupRegistrationMocks();
+      setupAuthenticationMocks();
       const controller = createController();
+      const regOpts = controller.generateRegistrationOptions();
+      await enrollWithPostRegistrationAuth(controller, {
+        registrationResponse: minimalRegistrationResponse(
+          undefined,
+          regOpts.challenge,
+        ),
+        vaultKey: 'k',
+        userHandle: regOpts.user.id,
+      });
+      controller.generateAuthenticationOptions();
+
       const badClientData = bytesToBase64URL(
         new TextEncoder().encode('not-json'),
       );
@@ -860,7 +1030,7 @@ describe('PasskeyController', () => {
       const vaultKey = 'verify-bool-ok';
 
       const regOpts = controller.generateRegistrationOptions();
-      await controller.protectVaultKeyWithPasskey({
+      await enrollWithPostRegistrationAuth(controller, {
         registrationResponse: minimalRegistrationResponse(
           {
             clientExtensionResults: prfResults(prfFirst),
@@ -868,6 +1038,7 @@ describe('PasskeyController', () => {
           regOpts.challenge,
         ),
         vaultKey,
+        authClientExtensionResults: prfResults(prfFirst),
       });
 
       const authOpts = controller.generateAuthenticationOptions();
@@ -895,12 +1066,13 @@ describe('PasskeyController', () => {
 
       const regOpts = controller.generateRegistrationOptions();
 
-      await controller.protectVaultKeyWithPasskey({
+      await enrollWithPostRegistrationAuth(controller, {
         registrationResponse: minimalRegistrationResponse(
           undefined,
           regOpts.challenge,
         ),
         vaultKey,
+        userHandle: regOpts.user.id,
       });
 
       expect(controller.state.passkeyRecord?.keyDerivation.method).toBe(
@@ -941,7 +1113,7 @@ describe('PasskeyController', () => {
       const vaultKey = 'prf-roundtrip-key';
 
       const regOpts = controller.generateRegistrationOptions();
-      await controller.protectVaultKeyWithPasskey({
+      await enrollWithPostRegistrationAuth(controller, {
         registrationResponse: minimalRegistrationResponse(
           {
             clientExtensionResults: prfResults(prfFirst),
@@ -949,6 +1121,7 @@ describe('PasskeyController', () => {
           regOpts.challenge,
         ),
         vaultKey,
+        authClientExtensionResults: prfResults(prfFirst),
       });
 
       const authOpts = controller.generateAuthenticationOptions();
@@ -988,7 +1161,7 @@ describe('PasskeyController', () => {
       const beforeKey = 'vault-key-before-password';
 
       const regOpts = controller.generateRegistrationOptions();
-      await controller.protectVaultKeyWithPasskey({
+      await enrollWithPostRegistrationAuth(controller, {
         registrationResponse: minimalRegistrationResponse(
           {
             clientExtensionResults: prfResults(prfFirst),
@@ -996,6 +1169,7 @@ describe('PasskeyController', () => {
           regOpts.challenge,
         ),
         vaultKey: beforeKey,
+        authClientExtensionResults: prfResults(prfFirst),
       });
 
       let authOpts = controller.generateAuthenticationOptions();
@@ -1033,7 +1207,7 @@ describe('PasskeyController', () => {
       const prfFirst = bytesToBase64URL(new Uint8Array(32).fill(42));
 
       const regOpts = controller.generateRegistrationOptions();
-      await controller.protectVaultKeyWithPasskey({
+      await enrollWithPostRegistrationAuth(controller, {
         registrationResponse: minimalRegistrationResponse(
           {
             clientExtensionResults: prfResults(prfFirst),
@@ -1041,6 +1215,7 @@ describe('PasskeyController', () => {
           regOpts.challenge,
         ),
         vaultKey: 'actual-wrapped-key',
+        authClientExtensionResults: prfResults(prfFirst),
       });
 
       const authOpts = controller.generateAuthenticationOptions();
@@ -1068,7 +1243,7 @@ describe('PasskeyController', () => {
       const prfFirst = bytesToBase64URL(new Uint8Array(32).fill(42));
 
       const regOpts = controller.generateRegistrationOptions();
-      await controller.protectVaultKeyWithPasskey({
+      await enrollWithPostRegistrationAuth(controller, {
         registrationResponse: minimalRegistrationResponse(
           {
             clientExtensionResults: prfResults(prfFirst),
@@ -1076,6 +1251,7 @@ describe('PasskeyController', () => {
           regOpts.challenge,
         ),
         vaultKey: 'wrapped-key',
+        authClientExtensionResults: prfResults(prfFirst),
       });
 
       const decryptSpy = jest
@@ -1112,7 +1288,7 @@ describe('PasskeyController', () => {
       const prfFirst = bytesToBase64URL(new Uint8Array(32).fill(42));
 
       const regOpts = controller.generateRegistrationOptions();
-      await controller.protectVaultKeyWithPasskey({
+      await enrollWithPostRegistrationAuth(controller, {
         registrationResponse: minimalRegistrationResponse(
           {
             clientExtensionResults: prfResults(prfFirst),
@@ -1120,6 +1296,7 @@ describe('PasskeyController', () => {
           regOpts.challenge,
         ),
         vaultKey: 'wrapped-key',
+        authClientExtensionResults: prfResults(prfFirst),
       });
 
       const decryptSpy = jest
@@ -1158,7 +1335,7 @@ describe('PasskeyController', () => {
       const prfFirst = bytesToBase64URL(new Uint8Array(32).fill(42));
 
       const regOpts = controller.generateRegistrationOptions();
-      await controller.protectVaultKeyWithPasskey({
+      await enrollWithPostRegistrationAuth(controller, {
         registrationResponse: minimalRegistrationResponse(
           {
             clientExtensionResults: prfResults(prfFirst),
@@ -1166,6 +1343,7 @@ describe('PasskeyController', () => {
           regOpts.challenge,
         ),
         vaultKey: 'wrapped',
+        authClientExtensionResults: prfResults(prfFirst),
       });
 
       const updateSpy = jest.spyOn(controller, 'update' as never);
@@ -1204,7 +1382,7 @@ describe('PasskeyController', () => {
       const prfFirst = bytesToBase64URL(new Uint8Array(32).fill(42));
 
       const regOpts = controller.generateRegistrationOptions();
-      await controller.protectVaultKeyWithPasskey({
+      await enrollWithPostRegistrationAuth(controller, {
         registrationResponse: minimalRegistrationResponse(
           {
             clientExtensionResults: prfResults(prfFirst),
@@ -1212,6 +1390,7 @@ describe('PasskeyController', () => {
           regOpts.challenge,
         ),
         vaultKey: 'wrapped',
+        authClientExtensionResults: prfResults(prfFirst),
       });
 
       await controller.renewVaultKeyProtection({
@@ -1247,7 +1426,7 @@ describe('PasskeyController', () => {
       const prfFirst = bytesToBase64URL(new Uint8Array(32).fill(42));
 
       const regOpts = controller.generateRegistrationOptions();
-      await controller.protectVaultKeyWithPasskey({
+      await enrollWithPostRegistrationAuth(controller, {
         registrationResponse: minimalRegistrationResponse(
           {
             clientExtensionResults: prfResults(prfFirst),
@@ -1255,6 +1434,7 @@ describe('PasskeyController', () => {
           regOpts.challenge,
         ),
         vaultKey: 'wrapped',
+        authClientExtensionResults: prfResults(prfFirst),
       });
 
       mockVerifyAuthenticationResponse.mockClear();
@@ -1289,6 +1469,9 @@ describe('PasskeyController', () => {
             undefined,
             regOpts.challenge,
           ),
+          authenticationResponse: minimalAuthenticationResponse(
+            regOpts.user.id,
+          ),
           vaultKey: 'k',
         }),
       ).rejects.toThrow(PasskeyControllerErrorMessage.NoRegistrationCeremony);
@@ -1296,14 +1479,16 @@ describe('PasskeyController', () => {
 
     it('clears stored record and resets enrollment', async () => {
       setupRegistrationMocks();
+      setupAuthenticationMocks();
       const controller = createController();
       const regOpts = controller.generateRegistrationOptions();
-      await controller.protectVaultKeyWithPasskey({
+      await enrollWithPostRegistrationAuth(controller, {
         registrationResponse: minimalRegistrationResponse(
           undefined,
           regOpts.challenge,
         ),
         vaultKey: 'k',
+        userHandle: regOpts.user.id,
       });
       expect(controller.isPasskeyEnrolled()).toBe(true);
 
@@ -1316,14 +1501,16 @@ describe('PasskeyController', () => {
   describe('clearState', () => {
     it('clears stored record and resets enrollment', async () => {
       setupRegistrationMocks();
+      setupAuthenticationMocks();
       const controller = createController();
       const regOpts = controller.generateRegistrationOptions();
-      await controller.protectVaultKeyWithPasskey({
+      await enrollWithPostRegistrationAuth(controller, {
         registrationResponse: minimalRegistrationResponse(
           undefined,
           regOpts.challenge,
         ),
         vaultKey: 'k',
+        userHandle: regOpts.user.id,
       });
       expect(controller.isPasskeyEnrolled()).toBe(true);
 
@@ -1346,6 +1533,9 @@ describe('PasskeyController', () => {
           registrationResponse: minimalRegistrationResponse(
             undefined,
             regOpts.challenge,
+          ),
+          authenticationResponse: minimalAuthenticationResponse(
+            regOpts.user.id,
           ),
           vaultKey: 'k',
         }),
@@ -1387,18 +1577,20 @@ describe('PasskeyController', () => {
   describe('verifyRegistrationResponse parameters', () => {
     it('passes expectedOrigin and expectedRPID to verification', async () => {
       setupRegistrationMocks();
+      setupAuthenticationMocks();
       const controller = createController({
         rpID: 'custom-rp.com',
         expectedOrigin: 'chrome-extension://abc123',
       });
 
       const regOpts = controller.generateRegistrationOptions();
-      await controller.protectVaultKeyWithPasskey({
+      await enrollWithPostRegistrationAuth(controller, {
         registrationResponse: minimalRegistrationResponse(
           undefined,
           regOpts.challenge,
         ),
         vaultKey: 'k',
+        userHandle: regOpts.user.id,
       });
 
       expect(mockVerifyRegistrationResponse).toHaveBeenCalledWith(
@@ -1420,7 +1612,7 @@ describe('PasskeyController', () => {
       const prfFirst = bytesToBase64URL(new Uint8Array(32).fill(42));
 
       const regOpts = controller.generateRegistrationOptions();
-      await controller.protectVaultKeyWithPasskey({
+      await enrollWithPostRegistrationAuth(controller, {
         registrationResponse: minimalRegistrationResponse(
           {
             clientExtensionResults: prfResults(prfFirst),
@@ -1428,6 +1620,7 @@ describe('PasskeyController', () => {
           regOpts.challenge,
         ),
         vaultKey: 'k',
+        authClientExtensionResults: prfResults(prfFirst),
       });
 
       const authOpts = controller.generateAuthenticationOptions();
@@ -1461,11 +1654,12 @@ describe('PasskeyController', () => {
 
     it('persists newCounter from authentication and passes it on next auth', async () => {
       setupRegistrationMocks();
+      setupAuthenticationMocks();
       const controller = createController();
       const prfFirst = bytesToBase64URL(new Uint8Array(32).fill(42));
 
       const regOpts = controller.generateRegistrationOptions();
-      await controller.protectVaultKeyWithPasskey({
+      await enrollWithPostRegistrationAuth(controller, {
         registrationResponse: minimalRegistrationResponse(
           {
             clientExtensionResults: prfResults(prfFirst),
@@ -1473,6 +1667,7 @@ describe('PasskeyController', () => {
           regOpts.challenge,
         ),
         vaultKey: 'k',
+        authClientExtensionResults: prfResults(prfFirst),
       });
 
       expect(controller.state.passkeyRecord?.credential.counter).toBe(0);
@@ -1544,7 +1739,7 @@ describe('PasskeyController', () => {
       const vaultKey = 'multi-auth-ceremony';
 
       const regOpts = controller.generateRegistrationOptions();
-      await controller.protectVaultKeyWithPasskey({
+      await enrollWithPostRegistrationAuth(controller, {
         registrationResponse: minimalRegistrationResponse(
           {
             clientExtensionResults: prfResults(prfFirst),
@@ -1552,6 +1747,7 @@ describe('PasskeyController', () => {
           regOpts.challenge,
         ),
         vaultKey,
+        authClientExtensionResults: prfResults(prfFirst),
       });
 
       const authOpts1 = controller.generateAuthenticationOptions();
@@ -1597,12 +1793,13 @@ describe('PasskeyController', () => {
 
     it('does not overwrite passkey fields updated while authentication verification awaits', async () => {
       setupRegistrationMocks();
+      setupAuthenticationMocks();
       const controller = createController();
       const prfFirst = bytesToBase64URL(new Uint8Array(32).fill(99));
       const vaultKey = 'vault-concurrent-field';
 
       const regOpts = controller.generateRegistrationOptions();
-      await controller.protectVaultKeyWithPasskey({
+      await enrollWithPostRegistrationAuth(controller, {
         registrationResponse: minimalRegistrationResponse(
           {
             clientExtensionResults: prfResults(prfFirst),
@@ -1610,6 +1807,7 @@ describe('PasskeyController', () => {
           regOpts.challenge,
         ),
         vaultKey,
+        authClientExtensionResults: prfResults(prfFirst),
       });
 
       let finishVerify!: (value: unknown) => void;
@@ -1670,18 +1868,20 @@ describe('PasskeyController', () => {
 
     it('completes registration using the first challenge after a second generateRegistrationOptions', async () => {
       setupRegistrationMocks();
+      setupAuthenticationMocks();
       const controller = createController();
       const vaultKey = 'multi-reg-ceremony';
 
       const regOpts1 = controller.generateRegistrationOptions();
       controller.generateRegistrationOptions();
 
-      await controller.protectVaultKeyWithPasskey({
+      await enrollWithPostRegistrationAuth(controller, {
         registrationResponse: minimalRegistrationResponse(
           undefined,
           regOpts1.challenge,
         ),
         vaultKey,
+        userHandle: regOpts1.user.id,
       });
 
       expect(controller.isPasskeyEnrolled()).toBe(true);
@@ -1705,6 +1905,9 @@ describe('PasskeyController', () => {
             undefined,
             regOpts.challenge,
           ),
+          authenticationResponse: minimalAuthenticationResponse(
+            regOpts.user.id,
+          ),
           vaultKey: 'k',
         }),
       ).rejects.toThrow(PasskeyControllerErrorMessage.NoRegistrationCeremony);
@@ -1718,12 +1921,13 @@ describe('PasskeyController', () => {
       const controller = createController();
       const regOpts = controller.generateRegistrationOptions();
       const userHandle = regOpts.user.id;
-      await controller.protectVaultKeyWithPasskey({
+      await enrollWithPostRegistrationAuth(controller, {
         registrationResponse: minimalRegistrationResponse(
           undefined,
           regOpts.challenge,
         ),
         vaultKey: 'k',
+        userHandle,
       });
 
       mockVerifyAuthenticationResponse.mockResolvedValue({

--- a/packages/passkey-controller/src/PasskeyController.ts
+++ b/packages/passkey-controller/src/PasskeyController.ts
@@ -6,7 +6,6 @@ import type {
 import { BaseController } from '@metamask/base-controller';
 import type { Messenger } from '@metamask/messenger';
 import { areUint8ArraysEqual, stringToBytes } from '@metamask/utils';
-import { randomBytes } from '@noble/ciphers/webcrypto';
 
 import { WEBAUTHN_TIMEOUT_MS, CeremonyManager } from './ceremony-manager';
 import {
@@ -24,7 +23,11 @@ import type {
   PasskeyRecord,
   PrfClientExtensionResults,
 } from './types';
-import { decryptWithKey, encryptWithKey } from './utils/crypto';
+import {
+  decryptWithKey,
+  encryptWithKey,
+  randomBytesToBase64URL,
+} from './utils/crypto';
 import { base64URLToBytes, bytesToBase64URL } from './utils/encoding';
 import { COSEALG } from './webauthn/constants';
 import { decodeClientDataJSON } from './webauthn/decode-client-data-json';
@@ -211,11 +214,9 @@ export class PasskeyController extends BaseController<
     }
 
     const includePrf = creationOptionsConfig?.prfAvailable !== false;
-    const prfSalt = includePrf
-      ? bytesToBase64URL(randomBytes(32).slice())
-      : undefined;
-    const userHandle = bytesToBase64URL(randomBytes(64).slice());
-    const challenge = bytesToBase64URL(randomBytes(32).slice());
+    const prfSalt = includePrf ? randomBytesToBase64URL(32) : undefined;
+    const userHandle = randomBytesToBase64URL(64);
+    const challenge = randomBytesToBase64URL(32);
 
     const extensions: Record<string, unknown> = {};
     if (prfSalt) {
@@ -283,7 +284,7 @@ export class PasskeyController extends BaseController<
     }
 
     // build auth options
-    const challenge = bytesToBase64URL(randomBytes(32).slice());
+    const challenge = randomBytesToBase64URL(32);
     const extensions: Record<string, unknown> = {};
     if (registrationCeremony.prfSalt) {
       extensions.prf = { eval: { first: registrationCeremony.prfSalt } };
@@ -323,7 +324,7 @@ export class PasskeyController extends BaseController<
   generateAuthenticationOptions(): PasskeyAuthenticationOptions {
     const record = this.#requireEnrolled();
 
-    const challenge = bytesToBase64URL(randomBytes(32).slice());
+    const challenge = randomBytesToBase64URL(32);
 
     const extensions: Record<string, unknown> = {};
     if (record.keyDerivation.method === 'prf') {
@@ -545,15 +546,17 @@ export class PasskeyController extends BaseController<
   }
 
   /**
-   * Re-encrypts the stored vault key after the vault key changes (e.g. password rotation).
+   * Re-wraps the vault key after rotation. Updates persisted `encryptedVaultKey` on success.
    *
-   * Call after verifying the user with {@link retrieveVaultKeyWithPasskey} or
-   * {@link verifyPasskeyAuthentication}, passing the same authentication response.
+   * Does not verify WebAuthn or ceremony state—call only after your layer has authenticated
+   * the user (passkey `get()` + verified assertion, or verified password). On passkey paths,
+   * pass the same `authenticationResponse` you just verified (e.g. from
+   * {@link retrieveVaultKeyWithPasskey} / {@link verifyPasskeyAuthentication}).
    *
    * @param params - Re-wrap inputs.
-   * @param params.authenticationResponse - Assertion from the verification step above.
-   * @param params.oldVaultKey - Expected current vault key before rotation.
-   * @param params.newVaultKey - New vault key to persist encrypted under the passkey.
+   * @param params.authenticationResponse - Used to derive the wrapping key.
+   * @param params.oldVaultKey - Expected current vault key.
+   * @param params.newVaultKey - New vault key to encrypt under the passkey.
    */
   async renewVaultKeyProtection(params: {
     authenticationResponse: PasskeyAuthenticationResponse;
@@ -626,7 +629,8 @@ export class PasskeyController extends BaseController<
   }
 
   /**
-   * Unenrolls the passkey, removing the protected vault key material.
+   * Clears enrolled passkey state and in-flight ceremonies. Call only after the same
+   * auth gate as renewal (verified passkey assertion or password).
    */
   removePasskey(): void {
     this.update(() => getDefaultPasskeyControllerState());

--- a/packages/passkey-controller/src/PasskeyController.ts
+++ b/packages/passkey-controller/src/PasskeyController.ts
@@ -458,6 +458,20 @@ export class PasskeyController extends BaseController<
           ? { method: 'prf', prfSalt: registrationCeremony.prfSalt }
           : { method: 'userHandle' };
 
+      if (
+        keyDerivation.method === 'userHandle' &&
+        authenticationResponse.response.userHandle !==
+          registrationCeremony.userHandle
+      ) {
+        log(
+          'Post-registration assertion userHandle does not match registration ceremony',
+        );
+        throw new PasskeyControllerError(
+          PasskeyControllerErrorMessage.AuthenticationVerificationFailed,
+          { code: PasskeyControllerErrorCode.AuthenticationVerificationFailed },
+        );
+      }
+
       // derive key and encrypt vault key
       const encKey = deriveKeyFromAuthenticationResponse(
         authenticationResponse,

--- a/packages/passkey-controller/src/PasskeyController.ts
+++ b/packages/passkey-controller/src/PasskeyController.ts
@@ -468,7 +468,10 @@ export class PasskeyController extends BaseController<
       // persist passkey record
       this.update((state) => {
         state.passkeyRecord = {
-          credential: { ...credential, counter: Math.max(newCounter, credential.counter) },
+          credential: {
+            ...credential,
+            counter: Math.max(newCounter, credential.counter),
+          },
           encryptedVaultKey: { ciphertext, iv },
           keyDerivation,
         };

--- a/packages/passkey-controller/src/PasskeyController.ts
+++ b/packages/passkey-controller/src/PasskeyController.ts
@@ -15,12 +15,15 @@ import {
   PasskeyControllerErrorMessage,
 } from './constants';
 import { PasskeyControllerError } from './errors';
-import {
-  deriveKeyFromAuthenticationResponse,
-  deriveKeyFromRegistrationResponse,
-} from './key-derivation';
+import { deriveKeyFromAuthenticationResponse } from './key-derivation';
 import { createModuleLogger, projectLogger } from './logger';
-import type { PasskeyRecord } from './types';
+import type {
+  AuthenticatorTransportFuture,
+  PasskeyCredentialInfo,
+  PasskeyKeyDerivation,
+  PasskeyRecord,
+  PrfClientExtensionResults,
+} from './types';
 import { decryptWithKey, encryptWithKey } from './utils/crypto';
 import { base64URLToBytes, bytesToBase64URL } from './utils/encoding';
 import { COSEALG } from './webauthn/constants';
@@ -101,10 +104,8 @@ export const passkeyControllerSelectors = {
 };
 
 /**
- * Passkey-based protection for the vault encryption key (WebAuthn).
- *
- * Uses PRF-backed derivation when available; otherwise uses the credential
- * `userHandle`.
+ * Controller that enrolls a WebAuthn passkey and uses it to protect and unlock
+ * the vault encryption key.
  */
 export class PasskeyController extends BaseController<
   typeof controllerName,
@@ -124,23 +125,16 @@ export class PasskeyController extends BaseController<
   readonly #userDisplayName: string;
 
   /**
-   * Constructs a new {@link PasskeyController}.
+   * Creates a passkey controller with WebAuthn relying-party settings.
    *
-   * @param args - The constructor arguments.
-   * @param args.messenger - The messenger suited for this controller.
-   * @param args.state - Initial state. Missing properties are filled in with
-   *   defaults from {@link getDefaultPasskeyControllerState}.
-   * @param args.rpID - WebAuthn Relying Party ID (typically the eTLD+1 of the
-   *   client origin, or `localhost` in dev).
-   * @param args.rpName - Human-readable Relying Party name shown by the OS
-   *   passkey UI.
-   * @param args.expectedOrigin - One or more acceptable origins for the
-   *   `clientDataJSON.origin` check (e.g. `chrome-extension://...`).
-   * @param args.userName - Optional `user.name` shown by the OS passkey UI.
-   *   Defaults to `rpName` so client builds (Stable, Flask, etc.) can
-   *   differentiate without changes here.
-   * @param args.userDisplayName - Optional `user.displayName` shown by the OS
-   *   passkey UI. Defaults to `rpName`.
+   * @param args - Constructor options.
+   * @param args.messenger - Controller messenger.
+   * @param args.state - Partial initial state; merged with {@link getDefaultPasskeyControllerState}.
+   * @param args.rpID - Relying party identifier (e.g. registrable domain or `localhost`).
+   * @param args.rpName - Relying party name shown in the platform passkey UI.
+   * @param args.expectedOrigin - Allowed value(s) for the WebAuthn client origin.
+   * @param args.userName - Optional passkey user name; defaults to `rpName`.
+   * @param args.userDisplayName - Optional display name; defaults to `rpName`.
    */
   constructor({
     messenger,
@@ -191,26 +185,31 @@ export class PasskeyController extends BaseController<
   }
 
   /**
-   * Checks if the passkey is enrolled.
+   * Whether a passkey is enrolled and vault key material is stored.
    *
-   * @returns Whether the passkey is enrolled.
+   * @returns `true` if enrolled, otherwise `false`.
    */
   isPasskeyEnrolled(): boolean {
     return passkeyControllerSelectors.selectIsPasskeyEnrolled(this.state);
   }
 
   /**
-   * Registration options for enrolling a passkey.
+   * Builds WebAuthn credential creation options for passkey enrollment.
    *
-   * Call before {@link protectVaultKeyWithPasskey}.
-   *
-   * @param creationOptionsConfig - Optional configuration.
-   * @param creationOptionsConfig.prfAvailable - Omit PRF when `false`. Default `true`.
-   * @returns Options for `navigator.credentials.create()`.
+   * @param creationOptionsConfig - Optional creation behavior.
+   * @param creationOptionsConfig.prfAvailable - Request the PRF extension unless `false`. Defaults to `true`.
+   * @returns Public key credential creation options for `navigator.credentials.create()`.
    */
   generateRegistrationOptions(creationOptionsConfig?: {
     prfAvailable?: boolean;
   }): PasskeyRegistrationOptions {
+    if (this.isPasskeyEnrolled()) {
+      throw new PasskeyControllerError(
+        PasskeyControllerErrorMessage.AlreadyEnrolled,
+        { code: PasskeyControllerErrorCode.AlreadyEnrolled },
+      );
+    }
+
     const includePrf = creationOptionsConfig?.prfAvailable !== false;
     const prfSalt = includePrf
       ? bytesToBase64URL(randomBytes(32).slice())
@@ -249,7 +248,7 @@ export class PasskeyController extends BaseController<
 
     this.#ceremonyManager.saveRegistrationCeremony(challenge, {
       userHandle,
-      prfSalt: prfSalt ?? '',
+      prfSalt,
       challenge,
       createdAt: Date.now(),
     });
@@ -258,12 +257,68 @@ export class PasskeyController extends BaseController<
   }
 
   /**
-   * WebAuthn request options for authenticating with the enrolled passkey.
+   * Builds WebAuthn credential request options for the post-registration
+   * authentication step (between `create` and {@link protectVaultKeyWithPasskey}).
    *
-   * Call before {@link retrieveVaultKeyWithPasskey},
-   * {@link verifyPasskeyAuthentication}, or {@link renewVaultKeyProtection}.
+   * @param params - Input for the pending registration ceremony.
+   * @param params.registrationResponse - Result of `navigator.credentials.create()`.
+   * @returns Public key credential request options for `navigator.credentials.get()`.
+   */
+  generatePostRegistrationAuthenticationOptions(params: {
+    registrationResponse: PasskeyRegistrationResponse;
+  }): PasskeyAuthenticationOptions {
+    // get registration ceremony
+    const { registrationResponse } = params;
+    const regChallenge = this.#getChallengeFromClientData(
+      registrationResponse.response.clientDataJSON,
+    );
+    const registrationCeremony =
+      this.#ceremonyManager.getRegistrationCeremony(regChallenge);
+    if (!registrationCeremony) {
+      log('No active passkey registration ceremony for challenge');
+      throw new PasskeyControllerError(
+        PasskeyControllerErrorMessage.NoRegistrationCeremony,
+        { code: PasskeyControllerErrorCode.NoRegistrationCeremony },
+      );
+    }
+
+    // build auth options
+    const challenge = bytesToBase64URL(randomBytes(32).slice());
+    const extensions: Record<string, unknown> = {};
+    if (registrationCeremony.prfSalt) {
+      extensions.prf = { eval: { first: registrationCeremony.prfSalt } };
+    }
+    const options: PasskeyAuthenticationOptions = {
+      challenge,
+      rpId: this.#rpID,
+      allowCredentials: [
+        {
+          id: registrationResponse.id,
+          type: 'public-key',
+          transports: registrationResponse.response.transports as
+            | AuthenticatorTransportFuture[]
+            | undefined,
+        },
+      ],
+      userVerification: 'preferred',
+      hints: ['client-device', 'hybrid'],
+      timeout: WEBAUTHN_TIMEOUT_MS,
+      extensions,
+    };
+
+    // save auth ceremony
+    this.#ceremonyManager.saveAuthenticationCeremony(challenge, {
+      challenge,
+      createdAt: Date.now(),
+    });
+
+    return options;
+  }
+
+  /**
+   * Builds WebAuthn credential request options for the enrolled passkey.
    *
-   * @returns Options for `navigator.credentials.get()`.
+   * @returns Public key credential request options for `navigator.credentials.get()`.
    */
   generateAuthenticationOptions(): PasskeyAuthenticationOptions {
     const record = this.#requireEnrolled();
@@ -300,19 +355,28 @@ export class PasskeyController extends BaseController<
   }
 
   /**
-   * Completes enrollment and binds the vault key to the new passkey.
+   * Verifies registration and post-registration authentication, then stores the
+   * vault key encrypted under the new passkey.
    *
-   * @param params - Protection parameters.
-   * @param params.registrationResponse - Credential from `navigator.credentials.create()`.
-   * @param params.vaultKey - Vault encryption key to protect.
+   * @param params - Enrollment completion inputs.
+   * @param params.registrationResponse - Result of `navigator.credentials.create()`.
+   * @param params.authenticationResponse - Result of `navigator.credentials.get()` after {@link generatePostRegistrationAuthenticationOptions}.
+   * @param params.vaultKey - Vault encryption key to encrypt and persist.
    */
   async protectVaultKeyWithPasskey(params: {
     registrationResponse: PasskeyRegistrationResponse;
+    authenticationResponse: PasskeyAuthenticationResponse;
     vaultKey: string;
   }): Promise<void> {
-    const { registrationResponse, vaultKey } = params;
+    if (this.isPasskeyEnrolled()) {
+      throw new PasskeyControllerError(
+        PasskeyControllerErrorMessage.AlreadyEnrolled,
+        { code: PasskeyControllerErrorCode.AlreadyEnrolled },
+      );
+    }
+    const { registrationResponse, authenticationResponse, vaultKey } = params;
 
-    // get challenge
+    // get registration ceremony
     const challenge = this.#getChallengeFromClientData(
       registrationResponse.response.clientDataJSON,
     );
@@ -354,63 +418,94 @@ export class PasskeyController extends BaseController<
         );
       }
 
-      // derive key
-      const { encKey, keyDerivation } = deriveKeyFromRegistrationResponse(
-        registrationResponse,
-        registrationCeremony,
-        registrationInfo.credentialId,
+      // verify authentication response
+      const credential = {
+        id: registrationInfo.credentialId,
+        publicKey: bytesToBase64URL(registrationInfo.publicKey),
+        counter: registrationInfo.counter,
+        transports: registrationInfo.transports,
+        aaguid: registrationInfo.aaguid,
+      };
+      const { newCounter } = await this.#verifyAuthenticationResponse(
+        authenticationResponse,
+        credential,
       );
 
-      // encrypt vault key
+      // determine key derivation method
+      const prfFirst = (
+        authenticationResponse.clientExtensionResults as PrfClientExtensionResults
+      )?.prf?.results?.first;
+      const authHasPrfOutput =
+        typeof prfFirst === 'string' && prfFirst.length > 0;
+      const keyDerivation: PasskeyKeyDerivation =
+        authHasPrfOutput && registrationCeremony.prfSalt
+          ? { method: 'prf', prfSalt: registrationCeremony.prfSalt }
+          : { method: 'userHandle' };
+
+      // derive key and encrypt vault key
+      const encKey = deriveKeyFromAuthenticationResponse(
+        authenticationResponse,
+        { credential, keyDerivation },
+      );
       const { ciphertext, iv } = encryptWithKey(vaultKey, encKey);
 
       // persist passkey record
       this.update((state) => {
         state.passkeyRecord = {
-          credential: {
-            id: registrationInfo.credentialId,
-            publicKey: bytesToBase64URL(registrationInfo.publicKey),
-            counter: registrationInfo.counter,
-            transports: registrationInfo.transports,
-            aaguid: registrationInfo.aaguid,
-          },
+          credential: { ...credential, counter: Math.max(newCounter, credential.counter) },
           encryptedVaultKey: { ciphertext, iv },
           keyDerivation,
         };
       });
     } finally {
+      // delete registration ceremony
       this.#ceremonyManager.deleteRegistrationCeremony(challenge);
     }
   }
 
   /**
-   * Returns the decrypted vault encryption key from the passkey authentication
-   * response.
+   * Verifies an authentication assertion and returns the decrypted vault key.
    *
-   * @param authenticationResponse - Credential from `navigator.credentials.get()`.
-   * @returns The vault encryption key.
+   * @param authenticationResponse - Result of `navigator.credentials.get()`.
+   * @returns The plaintext vault encryption key.
    */
   async retrieveVaultKeyWithPasskey(
     authenticationResponse: PasskeyAuthenticationResponse,
   ): Promise<string> {
-    // verify authentication response
-    await this.#verifyAuthenticationResponse(authenticationResponse);
-
-    // derive key (#verifyAuthenticationResponse guarantees enrolled)
     const passkeyRecord = this.#requireEnrolled();
+
+    // verify authentication response and update counter
+    const { newCounter } = await this.#verifyAuthenticationResponse(
+      authenticationResponse,
+      passkeyRecord.credential,
+    );
+    this.update((state) => {
+      if (!state.passkeyRecord) {
+        throw new PasskeyControllerError(
+          PasskeyControllerErrorMessage.NotEnrolled,
+          { code: PasskeyControllerErrorCode.NotEnrolled },
+        );
+      }
+      state.passkeyRecord.credential.counter = Math.max(
+        newCounter,
+        state.passkeyRecord.credential.counter,
+      );
+    });
+
+    // derive key
     const encKey = deriveKeyFromAuthenticationResponse(
       authenticationResponse,
       passkeyRecord,
     );
 
     // decrypt vault key
-    let vaultKey: string;
     try {
-      vaultKey = decryptWithKey(
+      const vaultKey = decryptWithKey(
         passkeyRecord.encryptedVaultKey.ciphertext,
         passkeyRecord.encryptedVaultKey.iv,
         encKey,
       );
+      return vaultKey;
     } catch (cause) {
       log(
         'Error decrypting vault key with passkey',
@@ -424,20 +519,16 @@ export class PasskeyController extends BaseController<
         },
       );
     }
-
-    return vaultKey;
   }
 
   /**
-   * Returns whether passkey authentication succeeds for this credential (same
-   * work as {@link retrieveVaultKeyWithPasskey} without exposing the vault key).
+   * Checks whether the given authentication assertion is valid for the enrolled passkey.
    *
-   * Returns `false` only when the failure is a {@link PasskeyControllerError}
-   * with a defined `code`. Unexpected errors (e.g. malformed `clientDataJSON`,
-   * internal bugs) are rethrown.
+   * On failure, returns `false` for {@link PasskeyControllerError} with a `code`;
+   * other errors propagate.
    *
-   * @param authenticationResponse - Credential from `navigator.credentials.get()`.
-   * @returns `true` if authentication succeeds, otherwise `false`.
+   * @param authenticationResponse - Result of `navigator.credentials.get()`.
+   * @returns `true` if verification succeeds, otherwise `false`.
    */
   async verifyPasskeyAuthentication(
     authenticationResponse: PasskeyAuthenticationResponse,
@@ -454,19 +545,15 @@ export class PasskeyController extends BaseController<
   }
 
   /**
-   * Updates the vault encryption key for the same passkey (e.g. after a password change).
+   * Re-encrypts the stored vault key after the vault key changes (e.g. password rotation).
    *
-   * Caller MUST first verify the assertion via {@link verifyPasskeyAuthentication}
-   * or {@link retrieveVaultKeyWithPasskey}. This method does not re-verify
-   * because the ceremony is single-use (deleted on verify) and the signature
-   * counter is advanced (replay would be rejected). Authentication here is
-   * enforced by the prior verification plus the `oldVaultKey` match below.
+   * Call after verifying the user with {@link retrieveVaultKeyWithPasskey} or
+   * {@link verifyPasskeyAuthentication}, passing the same authentication response.
    *
-   * @param params - Renewal parameters.
-   * @param params.authenticationResponse - Credential from `navigator.credentials.get()`,
-   *   already verified by the caller.
-   * @param params.oldVaultKey - Expected current vault key.
-   * @param params.newVaultKey - New vault key to protect.
+   * @param params - Re-wrap inputs.
+   * @param params.authenticationResponse - Assertion from the verification step above.
+   * @param params.oldVaultKey - Expected current vault key before rotation.
+   * @param params.newVaultKey - New vault key to persist encrypted under the passkey.
    */
   async renewVaultKeyProtection(params: {
     authenticationResponse: PasskeyAuthenticationResponse;
@@ -562,34 +649,33 @@ export class PasskeyController extends BaseController<
   }
 
   /**
-   * Verifies an authentication response for the enrolled passkey.
+   * Validates a WebAuthn authentication response against stored credential data.
    *
-   * @param authenticationResponse - Authentication result JSON.
+   * @param authenticationResponse - Parsed authentication response from the client.
+   * @param credential - Credential identifiers and public key material for verification.
+   * @returns Updated authenticator signature counter.
    */
   async #verifyAuthenticationResponse(
     authenticationResponse: PasskeyAuthenticationResponse,
-  ): Promise<void> {
-    let challenge: string | undefined;
-    try {
-      // get challenge
-      challenge = this.#getChallengeFromClientData(
-        authenticationResponse.response.clientDataJSON,
+    credential: PasskeyCredentialInfo,
+  ): Promise<{ newCounter: number }> {
+    // get challenge
+    const challenge = this.#getChallengeFromClientData(
+      authenticationResponse.response.clientDataJSON,
+    );
+
+    // get authentication ceremony
+    const authenticationCeremony =
+      this.#ceremonyManager.getAuthenticationCeremony(challenge);
+    if (!authenticationCeremony) {
+      log('No active passkey authentication ceremony for challenge');
+      throw new PasskeyControllerError(
+        PasskeyControllerErrorMessage.NoAuthenticationCeremony,
+        { code: PasskeyControllerErrorCode.NoAuthenticationCeremony },
       );
+    }
 
-      // get passkey record
-      const record = this.#requireEnrolled();
-
-      // get authentication ceremony
-      const authenticationCeremony =
-        this.#ceremonyManager.getAuthenticationCeremony(challenge);
-      if (!authenticationCeremony) {
-        log('No active passkey authentication ceremony for challenge');
-        throw new PasskeyControllerError(
-          PasskeyControllerErrorMessage.NoAuthenticationCeremony,
-          { code: PasskeyControllerErrorCode.NoAuthenticationCeremony },
-        );
-      }
-
+    try {
       // verify authentication response
       const result = await verifyAuthenticationResponse({
         response: authenticationResponse,
@@ -597,10 +683,10 @@ export class PasskeyController extends BaseController<
         expectedOrigin: this.#expectedOrigin,
         expectedRPID: this.#rpID,
         credential: {
-          id: record.credential.id,
-          publicKey: base64URLToBytes(record.credential.publicKey),
-          counter: record.credential.counter,
-          transports: record.credential.transports,
+          id: credential.id,
+          publicKey: base64URLToBytes(credential.publicKey),
+          counter: credential.counter,
+          transports: credential.transports,
         },
         // UV optional for device compatibility; vault key remains password-gated.
         requireUserVerification: false,
@@ -627,24 +713,10 @@ export class PasskeyController extends BaseController<
         );
       }
 
-      // persist passkey record with updated counter without clobbering concurrent updates
-      this.update((state) => {
-        if (!state.passkeyRecord) {
-          throw new PasskeyControllerError(
-            PasskeyControllerErrorMessage.NotEnrolled,
-            { code: PasskeyControllerErrorCode.NotEnrolled },
-          );
-        }
-        const latest = state.passkeyRecord;
-        latest.credential.counter = Math.max(
-          result.authenticationInfo.newCounter,
-          latest.credential.counter,
-        );
-      });
+      return { newCounter: result.authenticationInfo.newCounter };
     } finally {
-      if (challenge) {
-        this.#ceremonyManager.deleteAuthenticationCeremony(challenge);
-      }
+      // delete authentication ceremony
+      this.#ceremonyManager.deleteAuthenticationCeremony(challenge);
     }
   }
 }

--- a/packages/passkey-controller/src/PasskeyController.ts
+++ b/packages/passkey-controller/src/PasskeyController.ts
@@ -117,7 +117,9 @@ export class PasskeyController extends BaseController<
 > {
   readonly #ceremonyManager = new CeremonyManager();
 
-  readonly #rpID: string;
+  readonly #expectedRPIDs: string[];
+
+  readonly #rpId: string | undefined;
 
   readonly #rpName: string;
 
@@ -133,7 +135,11 @@ export class PasskeyController extends BaseController<
    * @param args - Constructor options.
    * @param args.messenger - Controller messenger.
    * @param args.state - Partial initial state; merged with {@link getDefaultPasskeyControllerState}.
-   * @param args.rpID - Relying party identifier (e.g. registrable domain or `localhost`).
+   * @param args.expectedRPID - Relying party ID(s) for verification (SHA-256 hash match in
+   *   authenticator data). Pass a string or array of strings; an empty array skips RP ID
+   *   allowlist checks in {@link verifyRegistrationResponse} / {@link verifyAuthenticationResponse}.
+   * @param args.rpId - When set, included as `rp.id` on registration options and `rpId` on
+   *   authentication options. When omitted, those fields are left unset (client default RP ID).
    * @param args.rpName - Relying party name shown in the platform passkey UI.
    * @param args.expectedOrigin - Allowed value(s) for the WebAuthn client origin.
    * @param args.userName - Optional passkey user name; defaults to `rpName`.
@@ -142,7 +148,8 @@ export class PasskeyController extends BaseController<
   constructor({
     messenger,
     state = {},
-    rpID,
+    rpId,
+    expectedRPID,
     rpName,
     expectedOrigin,
     userName,
@@ -150,7 +157,8 @@ export class PasskeyController extends BaseController<
   }: {
     messenger: PasskeyControllerMessenger;
     state?: Partial<PasskeyControllerState>;
-    rpID: string;
+    rpId?: string;
+    expectedRPID: string | string[];
     rpName: string;
     expectedOrigin: string | string[];
     userName?: string;
@@ -163,7 +171,11 @@ export class PasskeyController extends BaseController<
       state: { ...getDefaultPasskeyControllerState(), ...state },
     });
 
-    this.#rpID = rpID;
+    const expectedRPIDs = Array.isArray(expectedRPID)
+      ? expectedRPID
+      : [expectedRPID];
+    this.#expectedRPIDs = [...expectedRPIDs];
+    this.#rpId = rpId;
     this.#rpName = rpName;
     this.#expectedOrigin = expectedOrigin;
     this.#userName = userName ?? rpName;
@@ -224,7 +236,10 @@ export class PasskeyController extends BaseController<
     }
 
     const options: PasskeyRegistrationOptions = {
-      rp: { name: this.#rpName, id: this.#rpID },
+      rp: {
+        name: this.#rpName,
+        id: this.#rpId,
+      },
       user: {
         id: userHandle,
         name: this.#userName,
@@ -291,7 +306,7 @@ export class PasskeyController extends BaseController<
     }
     const options: PasskeyAuthenticationOptions = {
       challenge,
-      rpId: this.#rpID,
+      rpId: this.#rpId,
       allowCredentials: [
         {
           id: registrationResponse.id,
@@ -333,7 +348,7 @@ export class PasskeyController extends BaseController<
 
     const options: PasskeyAuthenticationOptions = {
       challenge,
-      rpId: this.#rpID,
+      rpId: this.#rpId,
       allowCredentials: [
         {
           id: record.credential.id,
@@ -397,7 +412,7 @@ export class PasskeyController extends BaseController<
         response: registrationResponse,
         expectedChallenge: registrationCeremony.challenge,
         expectedOrigin: this.#expectedOrigin,
-        expectedRPID: this.#rpID,
+        expectedRPIDs: this.#expectedRPIDs,
         requireUserVerification: false,
       }).catch((error) => {
         log('Error verifying passkey registration response', error);
@@ -685,7 +700,7 @@ export class PasskeyController extends BaseController<
         response: authenticationResponse,
         expectedChallenge: authenticationCeremony.challenge,
         expectedOrigin: this.#expectedOrigin,
-        expectedRPID: this.#rpID,
+        expectedRPIDs: this.#expectedRPIDs,
         credential: {
           id: credential.id,
           publicKey: base64URLToBytes(credential.publicKey),

--- a/packages/passkey-controller/src/ceremony-manager.test.ts
+++ b/packages/passkey-controller/src/ceremony-manager.test.ts
@@ -5,7 +5,7 @@ import {
 } from './ceremony-manager';
 
 describe('CeremonyManager', () => {
-  const baseReg = { userHandle: 'u', prfSalt: '' };
+  const baseReg = { userHandle: 'u' };
 
   beforeEach(() => {
     jest.useFakeTimers();
@@ -138,7 +138,6 @@ describe('CeremonyManager', () => {
 
     manager.saveRegistrationCeremony('reg-chal', {
       userHandle: 'uh',
-      prfSalt: '',
       challenge: 'reg-chal',
       createdAt: now,
     });
@@ -156,7 +155,6 @@ describe('CeremonyManager', () => {
     jest.setSystemTime(now);
     manager.saveRegistrationCeremony('reg2', {
       userHandle: 'uh2',
-      prfSalt: '',
       challenge: 'reg2',
       createdAt: now,
     });

--- a/packages/passkey-controller/src/ceremony-manager.test.ts
+++ b/packages/passkey-controller/src/ceremony-manager.test.ts
@@ -35,7 +35,7 @@ describe('CeremonyManager', () => {
       const manager = new CeremonyManager();
       const tOld = 100_000;
       const tNew = 150_000;
-      const pruneAt = 200_000;
+      const pruneAt = tOld + CEREMONY_MAX_AGE_MS + 1;
       jest.setSystemTime(tOld);
       manager.saveRegistrationCeremony('old', {
         ...baseReg,

--- a/packages/passkey-controller/src/ceremony-manager.ts
+++ b/packages/passkey-controller/src/ceremony-manager.ts
@@ -8,9 +8,10 @@ export const WEBAUTHN_TIMEOUT_MS = 60_000;
 
 /**
  * Extra allowance beyond {@link WEBAUTHN_TIMEOUT_MS} before in-memory
- * ceremony state is discarded (covers slow UX and clock skew).
+ * ceremony state is discarded (covers slow UX, multi-step enrollment, and
+ * clock skew).
  */
-export const CEREMONY_TTL_SLACK_MS = 15_000;
+export const CEREMONY_TTL_SLACK_MS = 120_000;
 
 /**
  * Maximum age for in-flight registration or authentication ceremony state

--- a/packages/passkey-controller/src/constants.ts
+++ b/packages/passkey-controller/src/constants.ts
@@ -6,6 +6,7 @@ export const controllerName = 'PasskeyController';
  */
 export const PasskeyControllerErrorCode = {
   NotEnrolled: 'not_enrolled',
+  AlreadyEnrolled: 'already_enrolled',
   NoRegistrationCeremony: 'no_registration_ceremony',
   RegistrationVerificationFailed: 'registration_verification_failed',
   NoAuthenticationCeremony: 'no_authentication_ceremony',
@@ -23,6 +24,7 @@ export type PasskeyControllerErrorCode =
  */
 export enum PasskeyControllerErrorMessage {
   NotEnrolled = `${controllerName} - Passkey is not enrolled`,
+  AlreadyEnrolled = `${controllerName} - Passkey is already enrolled`,
   NoRegistrationCeremony = `${controllerName} - No active passkey registration ceremony`,
   RegistrationVerificationFailed = `${controllerName} - Passkey registration verification failed`,
   NoAuthenticationCeremony = `${controllerName} - No active passkey authentication ceremony`,

--- a/packages/passkey-controller/src/key-derivation.test.ts
+++ b/packages/passkey-controller/src/key-derivation.test.ts
@@ -35,7 +35,9 @@ function makeAuthenticationResponse(
   };
 }
 
-function makeRecord(derivationMethod: 'prf' | 'userHandle'): Pick<PasskeyRecord, 'credential' | 'keyDerivation'> {
+function makeRecord(
+  derivationMethod: 'prf' | 'userHandle',
+): Pick<PasskeyRecord, 'credential' | 'keyDerivation'> {
   return {
     credential: {
       id: CREDENTIAL_ID,

--- a/packages/passkey-controller/src/key-derivation.test.ts
+++ b/packages/passkey-controller/src/key-derivation.test.ts
@@ -1,13 +1,9 @@
 import { PasskeyControllerErrorMessage } from './constants';
-import {
-  deriveKeyFromAuthenticationResponse,
-  deriveKeyFromRegistrationResponse,
-} from './key-derivation';
-import type { PasskeyRecord, PasskeyRegistrationCeremony } from './types';
-import type {
-  PasskeyAuthenticationResponse,
-  PasskeyRegistrationResponse,
-} from './webauthn/types';
+import { deriveKeyFromAuthenticationResponse } from './key-derivation';
+import { PasskeyRecord } from './types';
+import { deriveEncryptionKey } from './utils/crypto';
+import { base64URLToBytes } from './utils/encoding';
+import type { PasskeyAuthenticationResponse } from './webauthn/types';
 
 function b64url(str: string): string {
   return btoa(str)
@@ -20,30 +16,6 @@ const CREDENTIAL_ID = b64url('credential-id-bytes');
 const USER_HANDLE = b64url('user-handle-bytes');
 const PRF_SALT = b64url('prf-salt-bytes');
 const PRF_FIRST = b64url('prf-output-bytes');
-
-function makeRegistrationCeremony(): PasskeyRegistrationCeremony {
-  return {
-    userHandle: USER_HANDLE,
-    prfSalt: PRF_SALT,
-    challenge: b64url('challenge'),
-    createdAt: 0,
-  };
-}
-
-function makeRegistrationResponse(
-  extensionResults: Record<string, unknown>,
-): PasskeyRegistrationResponse {
-  return {
-    id: CREDENTIAL_ID,
-    rawId: CREDENTIAL_ID,
-    type: 'public-key',
-    response: {
-      clientDataJSON: '',
-      attestationObject: '',
-    },
-    clientExtensionResults: extensionResults,
-  };
-}
 
 function makeAuthenticationResponse(
   extensionResults: Record<string, unknown>,
@@ -63,16 +35,13 @@ function makeAuthenticationResponse(
   };
 }
 
-function makeRecord(derivationMethod: 'prf' | 'userHandle'): PasskeyRecord {
+function makeRecord(derivationMethod: 'prf' | 'userHandle'): Pick<PasskeyRecord, 'credential' | 'keyDerivation'> {
   return {
     credential: {
       id: CREDENTIAL_ID,
       publicKey: 'pubkey',
       counter: 0,
-    },
-    encryptedVaultKey: {
-      ciphertext: 'ciphertext',
-      iv: 'iv',
+      aaguid: '00000000-0000-0000-0000-000000000000',
     },
     keyDerivation:
       derivationMethod === 'prf'
@@ -80,120 +49,6 @@ function makeRecord(derivationMethod: 'prf' | 'userHandle'): PasskeyRecord {
         : { method: 'userHandle' },
   };
 }
-
-describe('deriveKeyFromRegistrationResponse', () => {
-  it('uses PRF output when prf.results.first is present', () => {
-    const response = makeRegistrationResponse({
-      prf: { results: { first: PRF_FIRST } },
-    });
-
-    const { encKey, keyDerivation } = deriveKeyFromRegistrationResponse(
-      response,
-      makeRegistrationCeremony(),
-      CREDENTIAL_ID,
-    );
-
-    expect(keyDerivation).toStrictEqual({ method: 'prf', prfSalt: PRF_SALT });
-    expect(encKey).toBeInstanceOf(Uint8Array);
-    expect(encKey).toHaveLength(32);
-  });
-
-  it('uses PRF output when prf.enabled is true and results.first is present', () => {
-    const response = makeRegistrationResponse({
-      prf: { enabled: true, results: { first: PRF_FIRST } },
-    });
-
-    const { keyDerivation } = deriveKeyFromRegistrationResponse(
-      response,
-      makeRegistrationCeremony(),
-      CREDENTIAL_ID,
-    );
-
-    expect(keyDerivation).toStrictEqual({ method: 'prf', prfSalt: PRF_SALT });
-  });
-
-  it('falls back to userHandle when prf.enabled is true but results.first is absent', () => {
-    const response = makeRegistrationResponse({
-      prf: { enabled: true },
-    });
-
-    const { keyDerivation } = deriveKeyFromRegistrationResponse(
-      response,
-      makeRegistrationCeremony(),
-      CREDENTIAL_ID,
-    );
-
-    expect(keyDerivation).toStrictEqual({ method: 'userHandle' });
-  });
-
-  it('falls back to userHandle when PRF is absent', () => {
-    const response = makeRegistrationResponse({});
-
-    const { encKey, keyDerivation } = deriveKeyFromRegistrationResponse(
-      response,
-      makeRegistrationCeremony(),
-      CREDENTIAL_ID,
-    );
-
-    expect(keyDerivation).toStrictEqual({ method: 'userHandle' });
-    expect(encKey).toBeInstanceOf(Uint8Array);
-    expect(encKey).toHaveLength(32);
-  });
-
-  it('falls back to userHandle when prf.results.first is empty string', () => {
-    const response = makeRegistrationResponse({
-      prf: { results: { first: '' } },
-    });
-
-    const { keyDerivation } = deriveKeyFromRegistrationResponse(
-      response,
-      makeRegistrationCeremony(),
-      CREDENTIAL_ID,
-    );
-
-    expect(keyDerivation).toStrictEqual({ method: 'userHandle' });
-  });
-
-  it('produces different keys for different verified credential IDs', () => {
-    const response = makeRegistrationResponse({});
-    const ceremony = makeRegistrationCeremony();
-
-    const { encKey: key1 } = deriveKeyFromRegistrationResponse(
-      response,
-      ceremony,
-      CREDENTIAL_ID,
-    );
-    const { encKey: key2 } = deriveKeyFromRegistrationResponse(
-      response,
-      ceremony,
-      b64url('different-cred-id'),
-    );
-
-    expect(key1).not.toStrictEqual(key2);
-  });
-
-  it('produces different keys for PRF vs userHandle', () => {
-    const registrationCeremony = makeRegistrationCeremony();
-
-    const responseWithPrf = makeRegistrationResponse({
-      prf: { results: { first: PRF_FIRST } },
-    });
-    const responseWithoutPrf = makeRegistrationResponse({});
-
-    const { encKey: prfKey } = deriveKeyFromRegistrationResponse(
-      responseWithPrf,
-      registrationCeremony,
-      CREDENTIAL_ID,
-    );
-    const { encKey: uhKey } = deriveKeyFromRegistrationResponse(
-      responseWithoutPrf,
-      registrationCeremony,
-      CREDENTIAL_ID,
-    );
-
-    expect(prfKey).not.toStrictEqual(uhKey);
-  });
-});
 
 describe('deriveKeyFromAuthenticationResponse', () => {
   it('uses PRF output when keyDerivation.method is prf', () => {
@@ -249,23 +104,49 @@ describe('deriveKeyFromAuthenticationResponse', () => {
     ).toThrow(PasskeyControllerErrorMessage.MissingKeyMaterial);
   });
 
-  it('produces consistent keys across registration and authentication', () => {
-    const regResponse = makeRegistrationResponse({});
-    const registrationCeremony = makeRegistrationCeremony();
-
-    const { encKey: regKey } = deriveKeyFromRegistrationResponse(
-      regResponse,
-      registrationCeremony,
-      CREDENTIAL_ID,
+  it('userHandle wrapping key matches HKDF of assertion userHandle and credential id', () => {
+    const response = makeAuthenticationResponse({}, USER_HANDLE);
+    const expected = deriveEncryptionKey(
+      base64URLToBytes(USER_HANDLE),
+      base64URLToBytes(CREDENTIAL_ID),
     );
+    const encKey = deriveKeyFromAuthenticationResponse(
+      response,
+      makeRecord('userHandle'),
+    );
+    expect(encKey).toStrictEqual(expected);
+  });
 
-    const authResponse = makeAuthenticationResponse({}, USER_HANDLE);
+  it('prf wrapping key matches HKDF of PRF output and credential id', () => {
+    const response = makeAuthenticationResponse({
+      prf: { results: { first: PRF_FIRST } },
+    });
+    const expected = deriveEncryptionKey(
+      base64URLToBytes(PRF_FIRST),
+      base64URLToBytes(CREDENTIAL_ID),
+    );
+    const encKey = deriveKeyFromAuthenticationResponse(
+      response,
+      makeRecord('prf'),
+    );
+    expect(encKey).toStrictEqual(expected);
+  });
 
-    const authKey = deriveKeyFromAuthenticationResponse(
-      authResponse,
+  it('produces different keys for PRF vs userHandle', () => {
+    const prfResponse = makeAuthenticationResponse({
+      prf: { results: { first: PRF_FIRST } },
+    });
+    const uhResponse = makeAuthenticationResponse({}, USER_HANDLE);
+
+    const prfKey = deriveKeyFromAuthenticationResponse(
+      prfResponse,
+      makeRecord('prf'),
+    );
+    const uhKey = deriveKeyFromAuthenticationResponse(
+      uhResponse,
       makeRecord('userHandle'),
     );
 
-    expect(regKey).toStrictEqual(authKey);
+    expect(prfKey).not.toStrictEqual(uhKey);
   });
 });

--- a/packages/passkey-controller/src/key-derivation.ts
+++ b/packages/passkey-controller/src/key-derivation.ts
@@ -3,10 +3,7 @@ import {
   PasskeyControllerErrorMessage,
 } from './constants';
 import { PasskeyControllerError } from './errors';
-import type {
-  PasskeyRecord,
-  PrfClientExtensionResults,
-} from './types';
+import type { PasskeyRecord, PrfClientExtensionResults } from './types';
 import { deriveEncryptionKey } from './utils/crypto';
 import { base64URLToBytes } from './utils/encoding';
 import type { PasskeyAuthenticationResponse } from './webauthn/types';

--- a/packages/passkey-controller/src/key-derivation.ts
+++ b/packages/passkey-controller/src/key-derivation.ts
@@ -4,64 +4,12 @@ import {
 } from './constants';
 import { PasskeyControllerError } from './errors';
 import type {
-  PasskeyKeyDerivation,
   PasskeyRecord,
-  PasskeyRegistrationCeremony,
   PrfClientExtensionResults,
 } from './types';
 import { deriveEncryptionKey } from './utils/crypto';
 import { base64URLToBytes } from './utils/encoding';
-import type {
-  PasskeyAuthenticationResponse,
-  PasskeyRegistrationResponse,
-} from './webauthn/types';
-
-/**
- * Derives an AES-256 wrapping key from a WebAuthn registration ceremony
- * response.
- *
- * Uses the PRF output as HKDF input key material when
- * `clientExtensionResults.prf.results.first` is a non-empty string;
- * otherwise falls back to the random `userHandle` created during option
- * generation (including when PRF is enabled but no output is present).
- *
- * @param registrationResponse - The registration credential result from
- *   `navigator.credentials.create()`.
- * @param registrationCeremony - In-flight registration ceremony state from
- *   when `generateRegistrationOptions()` was called.
- * @param verifiedCredentialId - Base64url credential id from verified
- *   authenticator data (same value as persisted `credential.id` after
- *   `verifyRegistrationResponse`), not the client wrapper field alone.
- * @returns The derived 32-byte AES wrapping key and the
- *   {@link PasskeyKeyDerivation} parameters needed to reproduce it.
- */
-export function deriveKeyFromRegistrationResponse(
-  registrationResponse: PasskeyRegistrationResponse,
-  registrationCeremony: PasskeyRegistrationCeremony,
-  verifiedCredentialId: string,
-): {
-  encKey: Uint8Array;
-  keyDerivation: PasskeyKeyDerivation;
-} {
-  const prfFirst = (
-    registrationResponse.clientExtensionResults as PrfClientExtensionResults
-  )?.prf?.results?.first;
-  const hasPrfOutput = typeof prfFirst === 'string' && prfFirst.length > 0;
-
-  const keyDerivation: PasskeyKeyDerivation = hasPrfOutput
-    ? { method: 'prf', prfSalt: registrationCeremony.prfSalt }
-    : { method: 'userHandle' };
-  const ikm =
-    keyDerivation.method === 'prf'
-      ? base64URLToBytes(prfFirst as string)
-      : base64URLToBytes(registrationCeremony.userHandle);
-  const encKey = deriveEncryptionKey(
-    ikm,
-    base64URLToBytes(verifiedCredentialId),
-  );
-
-  return { encKey, keyDerivation };
-}
+import type { PasskeyAuthenticationResponse } from './webauthn/types';
 
 /**
  * Derives an AES-256 wrapping key from a WebAuthn authentication ceremony
@@ -73,15 +21,15 @@ export function deriveKeyFromRegistrationResponse(
  *
  * @param authenticationResponse - The authentication credential result
  *   from `navigator.credentials.get()`.
- * @param record - The persisted passkey record that was created during
- *   enrollment.
+ * @param record - Credential id and key derivation parameters (ciphertext is
+ *   not read).
  * @returns The derived 32-byte AES wrapping key.
  * @throws {@link PasskeyControllerError} with code `missing_key_material` if the
  *   required key material (PRF result or userHandle) is missing from the response.
  */
 export function deriveKeyFromAuthenticationResponse(
   authenticationResponse: PasskeyAuthenticationResponse,
-  record: PasskeyRecord,
+  record: Pick<PasskeyRecord, 'credential' | 'keyDerivation'>,
 ): Uint8Array {
   const { userHandle } = authenticationResponse.response;
   const prfFirst = (

--- a/packages/passkey-controller/src/types.ts
+++ b/packages/passkey-controller/src/types.ts
@@ -76,7 +76,7 @@ export type PasskeyRecord = {
  */
 export type PasskeyRegistrationCeremony = {
   userHandle: Base64URLString;
-  prfSalt: Base64URLString;
+  prfSalt?: Base64URLString;
   challenge: Base64URLString;
   /** When this ceremony was started (ms since epoch); used for TTL pruning. */
   createdAt: number;

--- a/packages/passkey-controller/src/utils/crypto.test.ts
+++ b/packages/passkey-controller/src/utils/crypto.test.ts
@@ -1,10 +1,10 @@
-import { base64URLToBytes } from './encoding';
 import {
   decryptWithKey,
   deriveEncryptionKey,
   encryptWithKey,
   randomBytesToBase64URL,
 } from './crypto';
+import { base64URLToBytes } from './encoding';
 
 describe('crypto', () => {
   describe('randomBytesToBase64URL', () => {

--- a/packages/passkey-controller/src/utils/crypto.test.ts
+++ b/packages/passkey-controller/src/utils/crypto.test.ts
@@ -1,6 +1,25 @@
-import { decryptWithKey, deriveEncryptionKey, encryptWithKey } from './crypto';
+import { base64URLToBytes } from './encoding';
+import {
+  decryptWithKey,
+  deriveEncryptionKey,
+  encryptWithKey,
+  randomBytesToBase64URL,
+} from './crypto';
 
 describe('crypto', () => {
+  describe('randomBytesToBase64URL', () => {
+    it('returns base64url whose decoded length matches byteLength', () => {
+      const encoded = randomBytesToBase64URL(32);
+      expect(base64URLToBytes(encoded)).toHaveLength(32);
+    });
+
+    it('returns distinct values on successive calls', () => {
+      const a = randomBytesToBase64URL(32);
+      const b = randomBytesToBase64URL(32);
+      expect(a).not.toBe(b);
+    });
+  });
+
   describe('encryptWithKey / decryptWithKey', () => {
     it('round-trips the encryption key with a derived key', () => {
       const ikm = new Uint8Array(32);

--- a/packages/passkey-controller/src/utils/crypto.ts
+++ b/packages/passkey-controller/src/utils/crypto.ts
@@ -4,9 +4,21 @@ import { randomBytes } from '@noble/ciphers/webcrypto';
 import { hkdf } from '@noble/hashes/hkdf';
 import { sha256 } from '@noble/hashes/sha2';
 
+import { bytesToBase64URL } from './encoding';
+
 const PASSKEY_HKDF_INFO = 'metamask:passkey:encryption-key:v1';
 
 const AES_GCM_IV_LENGTH = 12;
+
+/**
+ * Generates random bytes and returns them as a base64url string (no padding).
+ *
+ * @param byteLength - Number of bytes to generate (e.g. WebAuthn challenge length).
+ * @returns Base64url-encoded random bytes.
+ */
+export function randomBytesToBase64URL(byteLength: number): string {
+  return bytesToBase64URL(randomBytes(byteLength));
+}
 
 /**
  * Derives an AES-256 encryption key from input key material and a credential ID

--- a/packages/passkey-controller/src/webauthn/types.ts
+++ b/packages/passkey-controller/src/webauthn/types.ts
@@ -15,7 +15,7 @@ export type PublicKeyCredentialHint =
   | 'client-device';
 
 export type PasskeyRegistrationOptions = {
-  rp: { name: string; id: string };
+  rp: { name: string; id?: string };
   user: {
     id: Base64URL;
     name: string;

--- a/packages/passkey-controller/src/webauthn/verify-authentication-response.test.ts
+++ b/packages/passkey-controller/src/webauthn/verify-authentication-response.test.ts
@@ -64,12 +64,29 @@ const assertionFirstTimeUsedChallenge = decodeClientDataJSON(
 ).challenge;
 
 describe('verifyAuthenticationResponse', () => {
+  it('verifies when expectedRPIDs is empty', async () => {
+    const verification = await verifyAuthenticationResponse({
+      response: assertionResponse,
+      expectedChallenge: assertionChallenge,
+      expectedOrigin: EXPECTED_ORIGIN,
+      expectedRPIDs: [],
+      credential,
+      requireUserVerification: false,
+    });
+
+    expect(verification.verified).toBe(true);
+    if (!verification.verified) {
+      return;
+    }
+    expect(verification.authenticationInfo.rpID).toBe('');
+  });
+
   it('verifies an assertion response', async () => {
     const verification = await verifyAuthenticationResponse({
       response: assertionResponse,
       expectedChallenge: assertionChallenge,
       expectedOrigin: EXPECTED_ORIGIN,
-      expectedRPID: EXPECTED_RP_ID,
+      expectedRPIDs: [EXPECTED_RP_ID],
       credential,
       requireUserVerification: false,
     });
@@ -82,7 +99,7 @@ describe('verifyAuthenticationResponse', () => {
       response: assertionResponse,
       expectedChallenge: assertionChallenge,
       expectedOrigin: EXPECTED_ORIGIN,
-      expectedRPID: EXPECTED_RP_ID,
+      expectedRPIDs: [EXPECTED_RP_ID],
       credential,
       requireUserVerification: false,
     });
@@ -103,7 +120,7 @@ describe('verifyAuthenticationResponse', () => {
         response: assertionResponse,
         expectedChallenge: 'shouldhavebeenthisvalue',
         expectedOrigin: EXPECTED_ORIGIN,
-        expectedRPID: EXPECTED_RP_ID,
+        expectedRPIDs: [EXPECTED_RP_ID],
         credential,
       }),
     ).rejects.toThrow('Unexpected authentication response challenge');
@@ -115,7 +132,7 @@ describe('verifyAuthenticationResponse', () => {
         response: assertionResponse,
         expectedChallenge: assertionChallenge,
         expectedOrigin: 'https://different.address',
-        expectedRPID: EXPECTED_RP_ID,
+        expectedRPIDs: [EXPECTED_RP_ID],
         credential,
       }),
     ).rejects.toThrow('Unexpected authentication response origin');
@@ -137,7 +154,7 @@ describe('verifyAuthenticationResponse', () => {
       },
       expectedChallenge: assertionChallenge,
       expectedOrigin: EXPECTED_ORIGIN,
-      expectedRPID: EXPECTED_RP_ID,
+      expectedRPIDs: [EXPECTED_RP_ID],
       credential,
     });
 
@@ -166,7 +183,7 @@ describe('verifyAuthenticationResponse', () => {
         },
         expectedChallenge: assertionChallenge,
         expectedOrigin: EXPECTED_ORIGIN,
-        expectedRPID: EXPECTED_RP_ID,
+        expectedRPIDs: [EXPECTED_RP_ID],
         credential,
       }),
     ).rejects.toThrow('Unexpected authentication response type');
@@ -178,7 +195,7 @@ describe('verifyAuthenticationResponse', () => {
         response: assertionResponse,
         expectedChallenge: assertionChallenge,
         expectedOrigin: EXPECTED_ORIGIN,
-        expectedRPID: 'wrong-rp.com',
+        expectedRPIDs: ['wrong-rp.com'],
         credential,
       }),
     ).rejects.toThrow('Unexpected RP ID hash');
@@ -194,7 +211,7 @@ describe('verifyAuthenticationResponse', () => {
         },
         expectedChallenge: assertionChallenge,
         expectedOrigin: EXPECTED_ORIGIN,
-        expectedRPID: EXPECTED_RP_ID,
+        expectedRPIDs: [EXPECTED_RP_ID],
         credential,
       }),
     ).rejects.toThrow('Missing credential ID');
@@ -209,7 +226,7 @@ describe('verifyAuthenticationResponse', () => {
         },
         expectedChallenge: assertionChallenge,
         expectedOrigin: EXPECTED_ORIGIN,
-        expectedRPID: EXPECTED_RP_ID,
+        expectedRPIDs: [EXPECTED_RP_ID],
         credential,
       }),
     ).rejects.toThrow('Credential ID was not base64url-encoded');
@@ -224,7 +241,7 @@ describe('verifyAuthenticationResponse', () => {
         } as unknown as PasskeyAuthenticationResponse,
         expectedChallenge: assertionChallenge,
         expectedOrigin: EXPECTED_ORIGIN,
-        expectedRPID: EXPECTED_RP_ID,
+        expectedRPIDs: [EXPECTED_RP_ID],
         credential,
       }),
     ).rejects.toThrow('Unexpected credential type');
@@ -247,7 +264,7 @@ describe('verifyAuthenticationResponse', () => {
         },
         expectedChallenge: assertionChallenge,
         expectedOrigin: EXPECTED_ORIGIN,
-        expectedRPID: EXPECTED_RP_ID,
+        expectedRPIDs: [EXPECTED_RP_ID],
         credential,
       }),
     ).rejects.toThrow('User not present during authentication');
@@ -259,7 +276,7 @@ describe('verifyAuthenticationResponse', () => {
         response: assertionResponse,
         expectedChallenge: assertionChallenge,
         expectedOrigin: EXPECTED_ORIGIN,
-        expectedRPID: EXPECTED_RP_ID,
+        expectedRPIDs: [EXPECTED_RP_ID],
         credential: {
           ...credential,
           counter: 144,
@@ -277,7 +294,7 @@ describe('verifyAuthenticationResponse', () => {
         response: assertionResponse,
         expectedChallenge: assertionChallenge,
         expectedOrigin: EXPECTED_ORIGIN,
-        expectedRPID: EXPECTED_RP_ID,
+        expectedRPIDs: [EXPECTED_RP_ID],
         credential: {
           ...credential,
           counter: 200,
@@ -294,7 +311,7 @@ describe('verifyAuthenticationResponse', () => {
       response: assertionFirstTimeUsedResponse,
       expectedChallenge: assertionFirstTimeUsedChallenge,
       expectedOrigin: EXPECTED_ORIGIN,
-      expectedRPID: EXPECTED_RP_ID,
+      expectedRPIDs: [EXPECTED_RP_ID],
       credential: authenticatorFirstTimeUsed,
       requireUserVerification: false,
     });
@@ -308,7 +325,7 @@ describe('verifyAuthenticationResponse', () => {
         response: assertionResponse,
         expectedChallenge: assertionChallenge,
         expectedOrigin: EXPECTED_ORIGIN,
-        expectedRPID: EXPECTED_RP_ID,
+        expectedRPIDs: [EXPECTED_RP_ID],
         credential,
         requireUserVerification: true,
       }),
@@ -322,7 +339,7 @@ describe('verifyAuthenticationResponse', () => {
       response: assertionResponse,
       expectedChallenge: assertionChallenge,
       expectedOrigin: ['https://other.com', EXPECTED_ORIGIN],
-      expectedRPID: EXPECTED_RP_ID,
+      expectedRPIDs: [EXPECTED_RP_ID],
       credential,
       requireUserVerification: false,
     });
@@ -342,7 +359,7 @@ describe('verifyAuthenticationResponse', () => {
         },
         expectedChallenge: assertionChallenge,
         expectedOrigin: EXPECTED_ORIGIN,
-        expectedRPID: EXPECTED_RP_ID,
+        expectedRPIDs: [EXPECTED_RP_ID],
         credential,
       }),
     ).rejects.toThrow('Credential response clientDataJSON was not a string');
@@ -360,7 +377,7 @@ describe('verifyAuthenticationResponse', () => {
         },
         expectedChallenge: assertionChallenge,
         expectedOrigin: EXPECTED_ORIGIN,
-        expectedRPID: EXPECTED_RP_ID,
+        expectedRPIDs: [EXPECTED_RP_ID],
         credential,
       }),
     ).rejects.toThrow('Credential response userHandle was not a string');
@@ -387,7 +404,7 @@ describe('verifyAuthenticationResponse', () => {
         },
         expectedChallenge: assertionChallenge,
         expectedOrigin: EXPECTED_ORIGIN,
-        expectedRPID: EXPECTED_RP_ID,
+        expectedRPIDs: [EXPECTED_RP_ID],
         credential,
       }),
     ).rejects.toThrow('ClientDataJSON tokenBinding was not an object');
@@ -414,7 +431,7 @@ describe('verifyAuthenticationResponse', () => {
         },
         expectedChallenge: assertionChallenge,
         expectedOrigin: EXPECTED_ORIGIN,
-        expectedRPID: EXPECTED_RP_ID,
+        expectedRPIDs: [EXPECTED_RP_ID],
         credential,
       }),
     ).rejects.toThrow('Unexpected tokenBinding status');

--- a/packages/passkey-controller/src/webauthn/verify-authentication-response.ts
+++ b/packages/passkey-controller/src/webauthn/verify-authentication-response.ts
@@ -159,9 +159,7 @@ export async function verifyAuthenticationResponse(opts: {
   const { rpIdHash, flags, counter } = parsedAuthData;
 
   const matchedRPID =
-  expectedRPIDs.length > 0
-      ? matchExpectedRPID(rpIdHash, expectedRPIDs)
-      : '';
+    expectedRPIDs.length > 0 ? matchExpectedRPID(rpIdHash, expectedRPIDs) : '';
 
   // WebAuthn only requires the user presence flag be true
   if (!flags.up) {

--- a/packages/passkey-controller/src/webauthn/verify-authentication-response.ts
+++ b/packages/passkey-controller/src/webauthn/verify-authentication-response.ts
@@ -20,6 +20,7 @@ export type VerifiedAuthenticationResponse =
         newCounter: number;
         userVerified: boolean;
         origin: string;
+        /** Matched RP ID, or `""` when `expectedRPIDs` is empty (RP ID hash check skipped). */
         rpID: string;
       };
     };
@@ -46,7 +47,7 @@ export type VerifiedAuthenticationResponse =
  * @param opts.expectedChallenge - The base64url challenge that was issued
  *   for this ceremony.
  * @param opts.expectedOrigin - One or more acceptable origins.
- * @param opts.expectedRPID - The Relying Party ID domain.
+ * @param opts.expectedRPIDs - Relying Party ID strings to match against `rpIdHash`.
  * @param opts.credential - The stored credential record to verify against.
  * @param opts.credential.id - The credential ID (base64url).
  * @param opts.credential.publicKey - The COSE-encoded public key bytes
@@ -62,7 +63,7 @@ export async function verifyAuthenticationResponse(opts: {
   response: PasskeyAuthenticationResponse;
   expectedChallenge: string;
   expectedOrigin: string | string[];
-  expectedRPID: string;
+  expectedRPIDs: string[];
   credential: {
     id: string;
     publicKey: Uint8Array;
@@ -75,7 +76,7 @@ export async function verifyAuthenticationResponse(opts: {
     response,
     expectedChallenge,
     expectedOrigin,
-    expectedRPID,
+    expectedRPIDs,
     credential,
     requireUserVerification = false,
   } = opts;
@@ -157,8 +158,10 @@ export async function verifyAuthenticationResponse(opts: {
     parseAuthenticatorData(authDataBuffer);
   const { rpIdHash, flags, counter } = parsedAuthData;
 
-  // Make sure the response's RP ID is ours
-  const matchedRPID = matchExpectedRPID(rpIdHash, [expectedRPID]);
+  const matchedRPID =
+  expectedRPIDs.length > 0
+      ? matchExpectedRPID(rpIdHash, expectedRPIDs)
+      : '';
 
   // WebAuthn only requires the user presence flag be true
   if (!flags.up) {

--- a/packages/passkey-controller/src/webauthn/verify-registration-response.test.ts
+++ b/packages/passkey-controller/src/webauthn/verify-registration-response.test.ts
@@ -240,12 +240,23 @@ function buildRegistrationResponse(
 }
 
 describe('verifyRegistrationResponse', () => {
+  it('verifies none attestation when expectedRPIDs is empty', async () => {
+    const verification = await verifyRegistrationResponse({
+      response: attestationNone,
+      expectedChallenge: noneChallenge,
+      expectedOrigin: EXPECTED_ORIGIN,
+      expectedRPIDs: [],
+    });
+
+    expect(verification.verified).toBe(true);
+  });
+
   it('verifies none attestation', async () => {
     const verification = await verifyRegistrationResponse({
       response: attestationNone,
       expectedChallenge: noneChallenge,
       expectedOrigin: EXPECTED_ORIGIN,
-      expectedRPID: EXPECTED_RP_ID,
+      expectedRPIDs: [EXPECTED_RP_ID],
     });
 
     expect(verification.verified).toBe(true);
@@ -276,7 +287,7 @@ describe('verifyRegistrationResponse', () => {
       response: attestationPacked,
       expectedChallenge: packedChallenge,
       expectedOrigin: EXPECTED_ORIGIN,
-      expectedRPID: EXPECTED_RP_ID,
+      expectedRPIDs: [EXPECTED_RP_ID],
     });
 
     expect(verification.verified).toBe(true);
@@ -302,7 +313,7 @@ describe('verifyRegistrationResponse', () => {
         response: attestationNone,
         expectedChallenge: 'shouldhavebeenthisvalue',
         expectedOrigin: EXPECTED_ORIGIN,
-        expectedRPID: EXPECTED_RP_ID,
+        expectedRPIDs: [EXPECTED_RP_ID],
       }),
     ).rejects.toThrow('Unexpected registration response challenge');
   });
@@ -313,7 +324,7 @@ describe('verifyRegistrationResponse', () => {
         response: attestationNone,
         expectedChallenge: noneChallenge,
         expectedOrigin: 'https://different.address',
-        expectedRPID: EXPECTED_RP_ID,
+        expectedRPIDs: [EXPECTED_RP_ID],
       }),
     ).rejects.toThrow('Unexpected registration response origin');
   });
@@ -324,7 +335,7 @@ describe('verifyRegistrationResponse', () => {
         response: attestationNone,
         expectedChallenge: noneChallenge,
         expectedOrigin: EXPECTED_ORIGIN,
-        expectedRPID: 'wrong-rp.com',
+        expectedRPIDs: ['wrong-rp.com'],
       }),
     ).rejects.toThrow('Unexpected RP ID hash');
   });
@@ -351,7 +362,7 @@ describe('verifyRegistrationResponse', () => {
         },
         expectedChallenge: noneChallenge,
         expectedOrigin: EXPECTED_ORIGIN,
-        expectedRPID: EXPECTED_RP_ID,
+        expectedRPIDs: [EXPECTED_RP_ID],
       }),
     ).rejects.toThrow('Unexpected registration response type');
   });
@@ -366,7 +377,7 @@ describe('verifyRegistrationResponse', () => {
         },
         expectedChallenge: noneChallenge,
         expectedOrigin: EXPECTED_ORIGIN,
-        expectedRPID: EXPECTED_RP_ID,
+        expectedRPIDs: [EXPECTED_RP_ID],
       }),
     ).rejects.toThrow('Missing credential ID');
   });
@@ -377,7 +388,7 @@ describe('verifyRegistrationResponse', () => {
         response: attestationFIDOU2F,
         expectedChallenge: fidoU2fChallenge,
         expectedOrigin: EXPECTED_ORIGIN,
-        expectedRPID: EXPECTED_RP_ID,
+        expectedRPIDs: [EXPECTED_RP_ID],
         requireUserVerification: false,
       }),
     ).rejects.toThrow('Unsupported attestation format: fido-u2f');
@@ -389,7 +400,7 @@ describe('verifyRegistrationResponse', () => {
         response: attestationPackedX5C,
         expectedChallenge: packedX5cChallenge,
         expectedOrigin: EXPECTED_ORIGIN,
-        expectedRPID: EXPECTED_RP_ID,
+        expectedRPIDs: [EXPECTED_RP_ID],
         requireUserVerification: false,
       }),
     ).rejects.toThrow(
@@ -416,7 +427,7 @@ describe('verifyRegistrationResponse edge cases', () => {
         response,
         expectedChallenge: TEST_CHALLENGE,
         expectedOrigin: TEST_ORIGIN,
-        expectedRPID: TEST_RP_ID,
+        expectedRPIDs: [TEST_RP_ID],
       }),
     ).rejects.toThrow('Credential ID was not base64url-encoded');
   });
@@ -438,7 +449,7 @@ describe('verifyRegistrationResponse edge cases', () => {
         response,
         expectedChallenge: TEST_CHALLENGE,
         expectedOrigin: TEST_ORIGIN,
-        expectedRPID: TEST_RP_ID,
+        expectedRPIDs: [TEST_RP_ID],
       }),
     ).rejects.toThrow('Unexpected credential type');
   });
@@ -466,7 +477,7 @@ describe('verifyRegistrationResponse edge cases', () => {
         response,
         expectedChallenge: TEST_CHALLENGE,
         expectedOrigin: TEST_ORIGIN,
-        expectedRPID: TEST_RP_ID,
+        expectedRPIDs: [TEST_RP_ID],
         requireUserVerification: true,
       }),
     ).rejects.toThrow('User verification was required');
@@ -495,7 +506,7 @@ describe('verifyRegistrationResponse edge cases', () => {
         response,
         expectedChallenge: TEST_CHALLENGE,
         expectedOrigin: TEST_ORIGIN,
-        expectedRPID: TEST_RP_ID,
+        expectedRPIDs: [TEST_RP_ID],
       }),
     ).rejects.toThrow('User presence was required');
   });
@@ -523,7 +534,7 @@ describe('verifyRegistrationResponse edge cases', () => {
         response,
         expectedChallenge: TEST_CHALLENGE,
         expectedOrigin: TEST_ORIGIN,
-        expectedRPID: TEST_RP_ID,
+        expectedRPIDs: [TEST_RP_ID],
       }),
     ).rejects.toThrow(
       'Credential id does not match the credential id in authenticator data',
@@ -561,7 +572,7 @@ describe('verifyRegistrationResponse edge cases', () => {
         response,
         expectedChallenge: TEST_CHALLENGE,
         expectedOrigin: TEST_ORIGIN,
-        expectedRPID: TEST_RP_ID,
+        expectedRPIDs: [TEST_RP_ID],
       }),
     ).rejects.toThrow('Unexpected public key alg');
   });
@@ -597,7 +608,7 @@ describe('verifyRegistrationResponse edge cases', () => {
         response,
         expectedChallenge: TEST_CHALLENGE,
         expectedOrigin: TEST_ORIGIN,
-        expectedRPID: TEST_RP_ID,
+        expectedRPIDs: [TEST_RP_ID],
       }),
     ).rejects.toThrow('Packed attestation statement missing alg');
   });
@@ -634,7 +645,7 @@ describe('verifyRegistrationResponse edge cases', () => {
         response,
         expectedChallenge: TEST_CHALLENGE,
         expectedOrigin: TEST_ORIGIN,
-        expectedRPID: TEST_RP_ID,
+        expectedRPIDs: [TEST_RP_ID],
       }),
     ).rejects.toThrow('does not match credential alg');
   });
@@ -670,7 +681,7 @@ describe('verifyRegistrationResponse edge cases', () => {
         response,
         expectedChallenge: TEST_CHALLENGE,
         expectedOrigin: TEST_ORIGIN,
-        expectedRPID: TEST_RP_ID,
+        expectedRPIDs: [TEST_RP_ID],
       }),
     ).rejects.toThrow('Packed attestation missing signature');
   });
@@ -706,7 +717,7 @@ describe('verifyRegistrationResponse edge cases', () => {
         response,
         expectedChallenge: TEST_CHALLENGE,
         expectedOrigin: TEST_ORIGIN,
-        expectedRPID: TEST_RP_ID,
+        expectedRPIDs: [TEST_RP_ID],
       }),
     ).rejects.toThrow('None attestation had unexpected attestation statement');
   });
@@ -733,7 +744,7 @@ describe('verifyRegistrationResponse edge cases', () => {
       response,
       expectedChallenge: TEST_CHALLENGE,
       expectedOrigin: ['https://other.com', TEST_ORIGIN],
-      expectedRPID: TEST_RP_ID,
+      expectedRPIDs: [TEST_RP_ID],
     });
 
     expect(result.verified).toBe(true);
@@ -760,7 +771,7 @@ describe('verifyRegistrationResponse edge cases', () => {
         },
         expectedChallenge: noneChallenge,
         expectedOrigin: EXPECTED_ORIGIN,
-        expectedRPID: EXPECTED_RP_ID,
+        expectedRPIDs: [EXPECTED_RP_ID],
       }),
     ).rejects.toThrow('ClientDataJSON tokenBinding was not an object');
   });
@@ -786,7 +797,7 @@ describe('verifyRegistrationResponse edge cases', () => {
         },
         expectedChallenge: noneChallenge,
         expectedOrigin: EXPECTED_ORIGIN,
-        expectedRPID: EXPECTED_RP_ID,
+        expectedRPIDs: [EXPECTED_RP_ID],
       }),
     ).rejects.toThrow('Unexpected tokenBinding.status value');
   });
@@ -806,7 +817,7 @@ describe('verifyRegistrationResponse edge cases', () => {
         response,
         expectedChallenge: TEST_CHALLENGE,
         expectedOrigin: TEST_ORIGIN,
-        expectedRPID: TEST_RP_ID,
+        expectedRPIDs: [TEST_RP_ID],
       }),
     ).rejects.toThrow('No credential ID was provided by authenticator');
   });
@@ -840,7 +851,7 @@ describe('verifyRegistrationResponse edge cases', () => {
       response,
       expectedChallenge: TEST_CHALLENGE,
       expectedOrigin: TEST_ORIGIN,
-      expectedRPID: TEST_RP_ID,
+      expectedRPIDs: [TEST_RP_ID],
     });
 
     expect(verification).toStrictEqual({ verified: false });
@@ -872,7 +883,7 @@ describe('verifyRegistrationResponse edge cases', () => {
         response: attestationNone,
         expectedChallenge: noneChallenge,
         expectedOrigin: EXPECTED_ORIGIN,
-        expectedRPID: EXPECTED_RP_ID,
+        expectedRPIDs: [EXPECTED_RP_ID],
       }),
     ).rejects.toThrow('No credential ID was provided by authenticator');
 
@@ -897,7 +908,7 @@ describe('verifyRegistrationResponse edge cases', () => {
         },
         expectedChallenge: noneChallenge,
         expectedOrigin: EXPECTED_ORIGIN,
-        expectedRPID: EXPECTED_RP_ID,
+        expectedRPIDs: [EXPECTED_RP_ID],
       }),
     ).rejects.toThrow('No public key was provided by authenticator');
 
@@ -923,7 +934,7 @@ describe('verifyRegistrationResponse edge cases', () => {
         },
         expectedChallenge: noneChallenge,
         expectedOrigin: EXPECTED_ORIGIN,
-        expectedRPID: EXPECTED_RP_ID,
+        expectedRPIDs: [EXPECTED_RP_ID],
       }),
     ).rejects.toThrow('No AAGUID was present during registration');
 
@@ -962,7 +973,7 @@ describe('verifyRegistrationResponse missing public key fields', () => {
         response,
         expectedChallenge: TEST_CHALLENGE,
         expectedOrigin: TEST_ORIGIN,
-        expectedRPID: TEST_RP_ID,
+        expectedRPIDs: [TEST_RP_ID],
       }),
     ).rejects.toThrow('Credential public key was missing numeric alg');
   });

--- a/packages/passkey-controller/src/webauthn/verify-registration-response.ts
+++ b/packages/passkey-controller/src/webauthn/verify-registration-response.ts
@@ -53,8 +53,8 @@ export type VerifiedRegistrationResponse =
  *   `navigator.credentials.create()`, serialized as JSON.
  * @param opts.expectedChallenge - The base64url challenge that was passed
  *   to the authenticator (must match `clientDataJSON.challenge`).
- * @param opts.expectedOrigin - One or more acceptable origins (e.g.
- *   `"chrome-extension://..."` or `"https://metamask.io"`).
+ * @param opts.expectedOrigin - One or more acceptable values for
+ *   `clientDataJSON.origin` (WebAuthn). Extension and HTTPS contexts differ by scheme.
  * @param opts.expectedRPID - The Relying Party ID domain. The
  *   authenticator's `rpIdHash` is compared against `SHA-256(expectedRPID)`.
  * @param opts.requireUserVerification - When `true`, verification fails

--- a/packages/passkey-controller/src/webauthn/verify-registration-response.ts
+++ b/packages/passkey-controller/src/webauthn/verify-registration-response.ts
@@ -55,8 +55,8 @@ export type VerifiedRegistrationResponse =
  *   to the authenticator (must match `clientDataJSON.challenge`).
  * @param opts.expectedOrigin - One or more acceptable values for
  *   `clientDataJSON.origin` (WebAuthn). Extension and HTTPS contexts differ by scheme.
- * @param opts.expectedRPID - The Relying Party ID domain. The
- *   authenticator's `rpIdHash` is compared against `SHA-256(expectedRPID)`.
+ * @param opts.expectedRPIDs - Relying Party ID strings. The authenticator's
+ *   `rpIdHash` must equal `SHA-256(rpID)` for at least one entry.
  * @param opts.requireUserVerification - When `true`, verification fails
  *   if the UV flag is not set. Defaults to `false`.
  * @param opts.supportedAlgorithmIDs - COSE algorithm identifiers accepted
@@ -69,7 +69,7 @@ export async function verifyRegistrationResponse(opts: {
   response: PasskeyRegistrationResponse;
   expectedChallenge: string;
   expectedOrigin: string | string[];
-  expectedRPID: string;
+  expectedRPIDs: string[];
   requireUserVerification?: boolean;
   supportedAlgorithmIDs?: number[];
 }): Promise<VerifiedRegistrationResponse> {
@@ -77,7 +77,7 @@ export async function verifyRegistrationResponse(opts: {
     response,
     expectedChallenge,
     expectedOrigin,
-    expectedRPID,
+    expectedRPIDs,
     requireUserVerification = false,
     supportedAlgorithmIDs = [COSEALG.EdDSA, COSEALG.ES256, COSEALG.RS256],
   } = opts;
@@ -165,7 +165,9 @@ export async function verifyRegistrationResponse(opts: {
     aaguid,
   } = parsedAuthData;
 
-  matchExpectedRPID(rpIdHash, [expectedRPID]);
+  if (expectedRPIDs.length > 0) {
+    matchExpectedRPID(rpIdHash, expectedRPIDs);
+  }
 
   // Make sure someone was physically present
   if (!flags.up) {


### PR DESCRIPTION
## Explanation

### Context

Today, passkey enrollment can complete after `navigator.credentials.create()` by verifying registration and deriving the vault wrapping key from that ceremony alone.

### Problem

Deriving the wrapping key only from the registration (`create()`) response means enrollment does not exercise the same WebAuthn **authentication** path used at unlock. That mismatch makes it harder to guarantee the authenticator and extensions behave consistently for the credential users actually use to unlock.

### Solution

This change makes enrollment a **three-step** flow aligned with the README:

1. `generateRegistrationOptions()` → `navigator.credentials.create()`
2. **`generatePostRegistrationAuthenticationOptions({ registrationResponse })` → `navigator.credentials.get()`**
3. `protectVaultKeyWithPasskey({ registrationResponse, authenticationResponse, vaultKey })`

The vault wrapping key is **always** derived from the **post-registration** `get()` assertion (same derivation strategy as unlock), using PRF output when available and otherwise `userHandle` checked against the registration ceremony.

**API / behavior changes**

- New: `generatePostRegistrationAuthenticationOptions` — builds assertion options after registration, keyed off the same in-flight registration ceremony (including PRF eval options when a salt was used).
- **Breaking:** `protectVaultKeyWithPasskey` now **requires** `authenticationResponse` (result of the post-registration `get()`).
- Key derivation module/tests were adjusted so derivation inputs match this flow; registration verification still uses `verifyRegistrationResponse`, with a small related tweak in `verify-registration-response.ts`.
- Docs: `README.md` describes the three-step enrollment pattern and updates the key derivation table/comments.

### Non-obvious notes

- Consumers (e.g. MetaMask Extension onboarding) **must** call WebAuthn `get()` between `create()` and `protectVaultKeyWithPasskey`; skipping it will fail verification/protect.
- If you pair this with an extension PR, merge/adapt order should ensure the UI passes both responses into the controller.

## References

<!--
* Fixes #
* Related to #
* Companion consumer PR: (link to mm-ext-passkey or other repo when opened)
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate (`packages/passkey-controller/README.md`)
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md) — **`packages/passkey-controller/CHANGELOG.md` was not modified in this commit; add an `[Unreleased]` entry with a `**BREAKING:**` bullet describing the new enrollment steps and `protectVaultKeyWithPasskey` signature before merge**
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them — **link companion PR(s) when ready**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it introduces breaking API/flow changes to passkey enrollment and verification inputs (new required `authenticationResponse`, RP ID verification semantics), which could break consumers and impact vault key wrapping/unwrapping if integrated incorrectly.
> 
> **Overview**
> **Enrollment is now a 3-step flow.** Adds `generatePostRegistrationAuthenticationOptions()` and makes `protectVaultKeyWithPasskey()` require a post-registration `authenticationResponse`, deriving the vault wrapping key from that `get()` assertion (PRF when present, otherwise `userHandle`).
> 
> **Breaking config/verification changes.** Replaces constructor `rpID` with `expectedRPID: string | string[]` (supports empty array to skip RP ID hash checks) and adds optional `rpId` used only for generated WebAuthn options; `verifyRegistrationResponse`/`verifyAuthenticationResponse` now accept `expectedRPIDs: string[]`.
> 
> **Security/robustness tweaks.** Rejects post-registration assertions with missing/mismatched `userHandle` on the `userHandle` derivation path, adds `already_enrolled` errors, increases ceremony TTL slack, and refactors random value generation via new `randomBytesToBase64URL()`; tests/docs/changelog updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fbb95be8b1b49d93fd854db2a8f46aaa0051ce0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->