### PR TITLE
fix: align mUSD decimals to 6 in default token metadata

### DIFF
--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/keyring-controller` from `^25.2.0` to `^25.3.0` ([#8634](https://github.com/MetaMask/core/pull/8634))
 - Bump `@metamask/network-controller` from `^30.0.1` to `^30.1.0` ([#8636](https://github.com/MetaMask/core/pull/8636))
 
+### Fixed
+
+- Correct mUSD default tracked metadata decimals from `18` to `6` so seeded balances and formatting align with token contract precision ([#8664](https://github.com/MetaMask/core/pull/8664))
+
 ## [6.2.1]
 
 ### Changed

--- a/packages/assets-controller/src/defaults.ts
+++ b/packages/assets-controller/src/defaults.ts
@@ -20,7 +20,7 @@ const MUSD_METADATA: FungibleAssetMetadata = {
   type: 'erc20',
   symbol: 'mUSD',
   name: 'MetaMask USD',
-  decimals: 18,
+  decimals: 6,
 };
 
 /**

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/keyring-controller` from `^25.2.0` to `^25.3.0` ([#8634](https://github.com/MetaMask/core/pull/8634))
 - Bump `@metamask/network-controller` from `^30.0.1` to `^30.1.0` ([#8636](https://github.com/MetaMask/core/pull/8636))
 
+### Fixed
+
+- Correct the seeded mUSD token decimals from `18` to `6` in `TokensController` defaults so the tracked token metadata matches contract precision ([#8664](https://github.com/MetaMask/core/pull/8664))
+
 ## [105.0.0]
 
 ### Added

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Correct the seeded mUSD token decimals from `18` to `6` in `TokensController` defaults so the tracked token metadata matches contract precision ([#8664](https://github.com/MetaMask/core/pull/8664))
+- Correct the seeded mUSD token decimals from `18` to `6` in `TokensController` and `TokenDetectionController` defaults so tracked token metadata matches contract precision ([#8664](https://github.com/MetaMask/core/pull/8664))
 
 ## [105.0.0]
 

--- a/packages/assets-controllers/src/TokenDetectionController.test.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.test.ts
@@ -301,6 +301,25 @@ describe('TokenDetectionController', () => {
       );
     });
 
+    it('seeds mUSD with contract decimals when starting', async () => {
+      await withController(async ({ controller, callActionSpy }) => {
+        await controller.start();
+
+        expect(callActionSpy).toHaveBeenCalledWith(
+          'TokensController:addTokens',
+          [
+            expect.objectContaining({
+              address: '0xaca92e438df0b2401ff60da7e4337b687a2435da',
+              decimals: 6,
+              symbol: 'mUSD',
+              name: 'MetaMask USD',
+            }),
+          ],
+          expect.any(String),
+        );
+      });
+    });
+
     it('should not poll if the controller is not active', async () => {
       await withController(
         {

--- a/packages/assets-controllers/src/TokenDetectionController.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.ts
@@ -72,7 +72,7 @@ const MUSD_ADDRESS = '0xaca92e438df0b2401ff60da7e4337b687a2435da';
  */
 const MUSD_TOKEN: Token = {
   address: MUSD_ADDRESS,
-  decimals: 18,
+  decimals: 6,
   symbol: 'mUSD',
   name: 'MetaMask USD',
 };

--- a/packages/assets-controllers/src/TokensController.test.ts
+++ b/packages/assets-controllers/src/TokensController.test.ts
@@ -4019,7 +4019,7 @@ describe('TokensController', () => {
   const MUSD_ADDRESS = '0xaca92e438df0b2401ff60da7e4337b687a2435da';
   const MUSD_TOKEN = {
     address: MUSD_ADDRESS,
-    decimals: 18,
+    decimals: 6,
     symbol: 'mUSD',
     name: 'MetaMask USD',
   };

--- a/packages/assets-controllers/src/TokensController.ts
+++ b/packages/assets-controllers/src/TokensController.ts
@@ -193,7 +193,7 @@ const MUSD_ADDRESS = '0xaca92e438df0b2401ff60da7e4337b687a2435da';
  */
 const MUSD_TOKEN: Token = {
   address: MUSD_ADDRESS,
-  decimals: 18,
+  decimals: 6,
   symbol: 'mUSD',
   name: 'MetaMask USD',
 };


### PR DESCRIPTION
Set the hardcoded mUSD token metadata to 6 decimals in both assets controllers so seeded defaults match the token contract and render balances correctly.

## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only hardcoded default mUSD metadata/seed values (decimals) and updates/extends unit tests and changelogs; no runtime control flow or security-sensitive logic is altered.
> 
> **Overview**
> Fixes the default/seeded MetaMask USD (`mUSD`) token metadata to use **6 decimals instead of 18** across both `@metamask/assets-controller` (default tracked asset metadata) and `@metamask/assets-controllers` (`TokensController`/`TokenDetectionController` seeding).
> 
> Adds/updates tests to assert the seeded `mUSD` token is added with `decimals: 6`, and records the fix in both package changelogs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 374c277e1207d82bef9829abcd674143e5102559. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->