### PR TITLE
refactor!: narrow `AllowedActions` to individual action types in `transaction-pay-controller`

### DIFF
--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING:** Narrow `AllowedActions` type to use individual action types instead of compound controller action unions (`BridgeControllerActions`, `BridgeStatusControllerActions`, `CurrencyRateControllerActions`, `GasFeeControllerActions`) ([#8670](https://github.com/MetaMask/core/pull/8670))
+
 ### Added
 
 - Add Gas Station support for Across source transactions when native balance is insufficient ([#8588](https://github.com/MetaMask/core/pull/8588))

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -7,13 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- **BREAKING:** Narrow `AllowedActions` type to use individual action types instead of compound controller action unions (`BridgeControllerActions`, `BridgeStatusControllerActions`, `CurrencyRateControllerActions`, `GasFeeControllerActions`) ([#8670](https://github.com/MetaMask/core/pull/8670))
-
 ### Added
 
 - Add Gas Station support for Across source transactions when native balance is insufficient ([#8588](https://github.com/MetaMask/core/pull/8588))
+
+### Changed
+
+- **BREAKING:** Narrow `AllowedActions` type to use individual action types instead of compound controller action unions (`BridgeControllerActions`, `BridgeStatusControllerActions`, `CurrencyRateControllerActions`, `GasFeeControllerActions`) ([#8670](https://github.com/MetaMask/core/pull/8670))
 
 ### Fixed
 

--- a/packages/transaction-pay-controller/src/types.ts
+++ b/packages/transaction-pay-controller/src/types.ts
@@ -1,6 +1,6 @@
 import type { AssetsControllerGetStateForTransactionPayAction } from '@metamask/assets-controller';
 import type {
-  CurrencyRateControllerActions,
+  CurrencyRateControllerGetStateAction,
   TokenBalancesControllerGetStateAction,
 } from '@metamask/assets-controllers';
 import type { TokenRatesControllerGetStateAction } from '@metamask/assets-controllers';
@@ -8,10 +8,13 @@ import type { TokensControllerGetStateAction } from '@metamask/assets-controller
 import type { AccountTrackerControllerGetStateAction } from '@metamask/assets-controllers';
 import type { ControllerStateChangeEvent } from '@metamask/base-controller';
 import type { ControllerGetStateAction } from '@metamask/base-controller';
-import type { BridgeControllerActions } from '@metamask/bridge-controller';
+import type { BridgeControllerFetchQuotesAction } from '@metamask/bridge-controller';
 import type { BridgeStatusControllerStateChangeEvent } from '@metamask/bridge-status-controller';
-import type { BridgeStatusControllerActions } from '@metamask/bridge-status-controller';
-import type { GasFeeControllerActions } from '@metamask/gas-fee-controller';
+import type {
+  BridgeStatusControllerGetStateAction,
+  BridgeStatusControllerSubmitTxAction,
+} from '@metamask/bridge-status-controller';
+import type { GetGasFeeState } from '@metamask/gas-fee-controller';
 import type {
   KeyringControllerGetStateAction,
   KeyringControllerSignTypedMessageAction,
@@ -51,10 +54,11 @@ import type { TransactionPayControllerMethodActions } from './TransactionPayCont
 export type AllowedActions =
   | AccountTrackerControllerGetStateAction
   | AssetsControllerGetStateForTransactionPayAction
-  | BridgeControllerActions
-  | BridgeStatusControllerActions
-  | CurrencyRateControllerActions
-  | GasFeeControllerActions
+  | BridgeControllerFetchQuotesAction
+  | BridgeStatusControllerGetStateAction
+  | BridgeStatusControllerSubmitTxAction
+  | CurrencyRateControllerGetStateAction
+  | GetGasFeeState
   | KeyringControllerGetStateAction
   | KeyringControllerSignTypedMessageAction
   | NetworkControllerFindNetworkClientIdByChainIdAction


### PR DESCRIPTION
## Explanation

The `AllowedActions` type in `transaction-pay-controller` uses four compound controller action unions (`BridgeControllerActions`, `BridgeStatusControllerActions`, `CurrencyRateControllerActions`, `GasFeeControllerActions`) that each expand into multiple individual action types. When flattened, the total `Action` union passed to the `Messenger` generic reaches ~48 members.

TypeScript's `ExtractActionResponse` (a distributive conditional type in `@metamask/messenger`) must distribute over every member of this union to resolve `messenger.call()` return types. At ~48+ members, the cumulative type instantiation cost exceeds TypeScript's internal budget (5,000,000 instantiations), causing `infer` to silently degrade to `unknown`. This means every `messenger.call()` in the package returns `unknown` instead of the correct handler return type, producing ~37 type errors.

This PR replaces the four compound imports with only the five specific action types actually used by the package:

| Before (compound) | Expanded to | After (leaf) |
|---|---|---|
| `BridgeControllerActions` | 8 actions | `BridgeControllerFetchQuotesAction` |
| `BridgeStatusControllerActions` | 8 actions | `BridgeStatusControllerGetStateAction`, `BridgeStatusControllerSubmitTxAction` |
| `CurrencyRateControllerActions` | 3 actions | `CurrencyRateControllerGetStateAction` |
| `GasFeeControllerActions` | 7 actions | `GetGasFeeState` |

This reduces the flattened union from ~48 to ~32, well within TypeScript's resolution capacity, and matches the pattern used by other controllers (e.g., `RampsController` with 34 leaf actions).

## References

- TypeScript type instantiation limit: [microsoft/TypeScript#45898](https://github.com/microsoft/TypeScript/issues/45898)

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because this is a **breaking** public type change that affects consumers constructing the controller messenger and may require downstream TypeScript updates, though it’s compile-time only with no runtime logic changes.
> 
> **Overview**
> **BREAKING:** Narrows `transaction-pay-controller`’s exported `AllowedActions` union by replacing several broad controller action unions with the specific leaf actions actually used (e.g., `BridgeControllerFetchQuotesAction`, `BridgeStatusControllerGetStateAction`, `CurrencyRateControllerGetStateAction`, `GetGasFeeState`).
> 
> Updates the package changelog to document the breaking type change, primarily to reduce TypeScript type-instantiation overhead and restore accurate `messenger.call()` return typing for this package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aeaa36f4d8962a636fa557317754924f740bb697. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->