### PR TITLE
chore: Add `approvedGitRepositories` to Yarn config

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,8 @@
+# Allowlist for Git repositories that can be used as dependencies. We set it to
+# an empty array to disallow all Git dependencies, as we don't use any and they
+# can be a security risk.
+approvedGitRepositories: []
+
 compressionLevel: mixed
 
 enableGlobalCache: false
@@ -12,10 +17,6 @@ logFilters:
 
 nodeLinker: node-modules
 
-plugins:
-  - path: .yarn/plugins/@yarnpkg/plugin-allow-scripts.cjs
-    spec: "https://raw.githubusercontent.com/LavaMoat/LavaMoat/main/packages/yarn-plugin-allow-scripts/bundles/@yarnpkg/plugin-allow-scripts.js"
-
 # Configure the NPM minimal age gate to 3 days, meaning packages must be at
 # least 3 days old to be installed.
 npmMinimalAgeGate: 4320 # 3 days (in minutes)
@@ -27,3 +28,7 @@ npmPreapprovedPackages:
   - "@metamask-previews/*"
   - "@lavamoat/*"
   - "@ts-bridge/*"
+
+plugins:
+  - path: .yarn/plugins/@yarnpkg/plugin-allow-scripts.cjs
+    spec: "https://raw.githubusercontent.com/LavaMoat/LavaMoat/main/packages/yarn-plugin-allow-scripts/bundles/@yarnpkg/plugin-allow-scripts.js"

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
   "engines": {
     "node": "^18.18 || >=20"
   },
-  "packageManager": "yarn@4.10.3",
+  "packageManager": "yarn@4.14.1",
   "lavamoat": {
     "allowScripts": {
       "@lavamoat/preinstall-always-fail": false,

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -240,7 +240,7 @@ module.exports = defineConfig({
       if (isChildWorkspace) {
         workspace.unset('packageManager');
       } else {
-        expectWorkspaceField(workspace, 'packageManager', 'yarn@4.10.3');
+        expectWorkspaceField(workspace, 'packageManager', 'yarn@4.14.1');
       }
 
       // All packages must specify a minimum Node.js version of 18.18.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 9
   cacheKey: 10
 
 "@adraffy/ens-normalize@npm:1.10.1":


### PR DESCRIPTION
## Explanation

Yarn recently added an `approvedGitRepositories` setting which is an allowlist for allowed Git repositories that can be installed as dependencies. Git repositories have some security risks, and we don't typically use them, so we can set it to an empty array to disallow Git repositories.

## References

MetaMask/metamask-module-template#310.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: config-only changes that tighten dependency policy and bump the Yarn toolchain; main impact is potential install/CI breakage if any Git-based deps were relied on implicitly.
> 
> **Overview**
> **Hardens Yarn dependency sourcing** by adding `approvedGitRepositories: []` to `.yarnrc.yml`, explicitly disallowing Git-based dependencies.
> 
> Bumps the required Yarn version from `4.10.3` to `4.14.1` (root `packageManager` and matching `yarn constraints` check), and updates `yarn.lock` metadata accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0bd7f1259ac190634c6ad46cc0b9b4332dda29e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->