### PR TITLE
ci: Disable pull request trigger for update changelogs workflow

### DIFF
--- a/.github/workflows/update-changelogs.yml
+++ b/.github/workflows/update-changelogs.yml
@@ -4,11 +4,11 @@ on:
   issue_comment:
     types:
       - created
-  pull_request:
-    branches:
-      - main
-    types:
-      - opened
+#  pull_request:
+#    branches:
+#      - main
+#    types:
+#      - opened
 
 permissions:
   contents: write


### PR DESCRIPTION
## Explanation

This workflow always fails with this error message:

> Determine whether this PR is a release PR
> Branch "refs/pull/8672/merge" is not allowed to deploy to default-branch due to environment protection rules.

To avoid confusion, I just removed the pull request trigger for now, until we figure out how to fix this.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes when the workflow runs, not its execution logic. The main impact is reduced automatic coverage since PR-open events will no longer trigger changelog updates.
> 
> **Overview**
> **Stops `Update Changelogs` from running on PR open.** The workflow’s `pull_request` trigger is commented out, leaving it to run only on `issue_comment` creation (e.g., `@metamaskbot update-changelogs`), avoiding failures caused by environment protection rules on PR merge refs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee3cd62cf65e3bb9c357370a76b01038db4c2bcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->