### PR TITLE
chore: Expose missing `KeyringController` methods through the messenger

### DIFF
--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Expose missing public `KeyringController` methods through its messenger ([#8674](https://github.com/MetaMask/core/pull/8674))
+  - The following actions are now available:
+    - `KeyringController:changePassword`,
+    - `KeyringController:exportAccount`,
+    - `KeyringController:exportEncryptionKey`,
+    - `KeyringController:getAccountKeyringType`,
+    - `KeyringController:importAccountWithStrategy`,
+    - `KeyringController:setLocked`,
+    - `KeyringController:submitEncryptionKey`,
+    - `KeyringController:submitPassword`,
+    - `KeyringController:verifyPassword`,
+  - Corresponding action types are available as well.
+
 ## [25.4.0]
 
 ### Changed

--- a/packages/keyring-controller/src/KeyringController-method-action-types.ts
+++ b/packages/keyring-controller/src/KeyringController-method-action-types.ts
@@ -59,6 +59,17 @@ export type KeyringControllerAddNewKeyringAction = {
 };
 
 /**
+ * Method to verify a given password validity. Throws an
+ * error if the password is invalid.
+ *
+ * @param password - Password of the keyring.
+ */
+export type KeyringControllerVerifyPasswordAction = {
+  type: `KeyringController:verifyPassword`;
+  handler: KeyringController['verifyPassword'];
+};
+
+/**
  * Returns the status of the vault.
  *
  * @returns Boolean returning true if the vault is unlocked.
@@ -78,6 +89,18 @@ export type KeyringControllerIsUnlockedAction = {
 export type KeyringControllerExportSeedPhraseAction = {
   type: `KeyringController:exportSeedPhrase`;
   handler: KeyringController['exportSeedPhrase'];
+};
+
+/**
+ * Gets the private key from the keyring controlling an address.
+ *
+ * @param password - Password of the keyring.
+ * @param address - Address to export.
+ * @returns Promise resolving to the private key for an address.
+ */
+export type KeyringControllerExportAccountAction = {
+  type: `KeyringController:exportAccount`;
+  handler: KeyringController['exportAccount'];
 };
 
 /**
@@ -158,6 +181,19 @@ export type KeyringControllerPersistAllKeyringsAction = {
 };
 
 /**
+ * Imports an account with the specified import strategy.
+ *
+ * @param strategy - Import strategy name.
+ * @param args - Array of arguments to pass to the underlying stategy.
+ * @throws Will throw when passed an unrecognized strategy.
+ * @returns Promise resolving to the imported account address.
+ */
+export type KeyringControllerImportAccountWithStrategyAction = {
+  type: `KeyringController:importAccountWithStrategy`;
+  handler: KeyringController['importAccountWithStrategy'];
+};
+
+/**
  * Removes an account from keyring state.
  *
  * @param address - Address of the account to remove.
@@ -167,6 +203,16 @@ export type KeyringControllerPersistAllKeyringsAction = {
 export type KeyringControllerRemoveAccountAction = {
   type: `KeyringController:removeAccount`;
   handler: KeyringController['removeAccount'];
+};
+
+/**
+ * Deallocates all secrets and locks the wallet.
+ *
+ * @returns Promise resolving when the operation completes.
+ */
+export type KeyringControllerSetLockedAction = {
+  type: `KeyringController:setLocked`;
+  handler: KeyringController['setLocked'];
 };
 
 /**
@@ -267,6 +313,53 @@ export type KeyringControllerPatchUserOperationAction = {
 export type KeyringControllerSignUserOperationAction = {
   type: `KeyringController:signUserOperation`;
   handler: KeyringController['signUserOperation'];
+};
+
+/**
+ * Changes the password used to encrypt the vault.
+ *
+ * @param password - The new password.
+ * @returns Promise resolving when the operation completes.
+ */
+export type KeyringControllerChangePasswordAction = {
+  type: `KeyringController:changePassword`;
+  handler: KeyringController['changePassword'];
+};
+
+/**
+ * Attempts to decrypt the current vault and load its keyrings, using the
+ * given encryption key and salt. The optional salt can be used to check for
+ * consistency with the vault salt.
+ *
+ * @param encryptionKey - Key to unlock the keychain.
+ * @param encryptionSalt - Optional salt to unlock the keychain.
+ * @returns Promise resolving when the operation completes.
+ */
+export type KeyringControllerSubmitEncryptionKeyAction = {
+  type: `KeyringController:submitEncryptionKey`;
+  handler: KeyringController['submitEncryptionKey'];
+};
+
+/**
+ * Exports the vault encryption key.
+ *
+ * @returns The vault encryption key.
+ */
+export type KeyringControllerExportEncryptionKeyAction = {
+  type: `KeyringController:exportEncryptionKey`;
+  handler: KeyringController['exportEncryptionKey'];
+};
+
+/**
+ * Attempts to decrypt the current vault and load its keyrings,
+ * using the given password.
+ *
+ * @param password - Password to unlock the keychain.
+ * @returns Promise resolving when the operation completes.
+ */
+export type KeyringControllerSubmitPasswordAction = {
+  type: `KeyringController:submitPassword`;
+  handler: KeyringController['submitPassword'];
 };
 
 /**
@@ -416,6 +509,17 @@ export type KeyringControllerWithControllerAction = {
 };
 
 /**
+ * Gets the type of the keyring that manages the specified account.
+ *
+ * @param account - The account address to look up.
+ * @returns A promise that resolves to the type of the keyring managing the account.
+ */
+export type KeyringControllerGetAccountKeyringTypeAction = {
+  type: `KeyringController:getAccountKeyringType`;
+  handler: KeyringController['getAccountKeyringType'];
+};
+
+/**
  * Union of all KeyringController action types.
  */
 export type KeyringControllerMethodActions =
@@ -423,15 +527,19 @@ export type KeyringControllerMethodActions =
   | KeyringControllerCreateNewVaultAndRestoreAction
   | KeyringControllerCreateNewVaultAndKeychainAction
   | KeyringControllerAddNewKeyringAction
+  | KeyringControllerVerifyPasswordAction
   | KeyringControllerIsUnlockedAction
   | KeyringControllerExportSeedPhraseAction
+  | KeyringControllerExportAccountAction
   | KeyringControllerGetAccountsAction
   | KeyringControllerGetEncryptionPublicKeyAction
   | KeyringControllerDecryptMessageAction
   | KeyringControllerGetKeyringForAccountAction
   | KeyringControllerGetKeyringsByTypeAction
   | KeyringControllerPersistAllKeyringsAction
+  | KeyringControllerImportAccountWithStrategyAction
   | KeyringControllerRemoveAccountAction
+  | KeyringControllerSetLockedAction
   | KeyringControllerSignMessageAction
   | KeyringControllerSignEip7702AuthorizationAction
   | KeyringControllerSignPersonalMessageAction
@@ -440,8 +548,13 @@ export type KeyringControllerMethodActions =
   | KeyringControllerPrepareUserOperationAction
   | KeyringControllerPatchUserOperationAction
   | KeyringControllerSignUserOperationAction
+  | KeyringControllerChangePasswordAction
+  | KeyringControllerSubmitEncryptionKeyAction
+  | KeyringControllerExportEncryptionKeyAction
+  | KeyringControllerSubmitPasswordAction
   | KeyringControllerWithKeyringAction
   | KeyringControllerWithKeyringUnsafeAction
   | KeyringControllerWithKeyringV2Action
   | KeyringControllerWithKeyringV2UnsafeAction
-  | KeyringControllerWithControllerAction;
+  | KeyringControllerWithControllerAction
+  | KeyringControllerGetAccountKeyringTypeAction;

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -78,6 +78,15 @@ const MESSENGER_EXPOSED_METHODS = [
   'removeAccount',
   'isUnlocked',
   'exportSeedPhrase',
+  'changePassword',
+  'exportAccount',
+  'exportEncryptionKey',
+  'getAccountKeyringType',
+  'importAccountWithStrategy',
+  'setLocked',
+  'submitEncryptionKey',
+  'submitPassword',
+  'verifyPassword',
 ] as const;
 
 /**
@@ -189,8 +198,7 @@ export type KeyringControllerOptions<
   EncryptionKey = encryptorUtils.EncryptionKey | CryptoKey,
   SupportedKeyDerivationOptions = encryptorUtils.KeyDerivationOptions,
   EncryptionResult extends
-    EncryptionResultConstraint<SupportedKeyDerivationOptions> =
-    DefaultEncryptionResult<SupportedKeyDerivationOptions>,
+    EncryptionResultConstraint<SupportedKeyDerivationOptions> = DefaultEncryptionResult<SupportedKeyDerivationOptions>,
 > = {
   keyringBuilders?: { (): EthKeyring; type: string }[];
   keyringV2Builders?: KeyringV2Builder[];
@@ -360,8 +368,7 @@ export type Encryptor<
   EncryptionKey = encryptorUtils.EncryptionKey | CryptoKey,
   SupportedKeyDerivationParams = encryptorUtils.KeyDerivationOptions,
   EncryptionResult extends
-    EncryptionResultConstraint<SupportedKeyDerivationParams> =
-    DefaultEncryptionResult<SupportedKeyDerivationParams>,
+    EncryptionResultConstraint<SupportedKeyDerivationParams> = DefaultEncryptionResult<SupportedKeyDerivationParams>,
 > = {
   /**
    * Encrypts the given object with the given password.
@@ -762,8 +769,7 @@ export class KeyringController<
   EncryptionKey = encryptorUtils.EncryptionKey | CryptoKey,
   SupportedKeyDerivationOptions = encryptorUtils.KeyDerivationOptions,
   EncryptionResult extends
-    EncryptionResultConstraint<SupportedKeyDerivationOptions> =
-    DefaultEncryptionResult<SupportedKeyDerivationOptions>,
+    EncryptionResultConstraint<SupportedKeyDerivationOptions> = DefaultEncryptionResult<SupportedKeyDerivationOptions>,
 > extends BaseController<
   typeof name,
   KeyringControllerState,
@@ -2207,6 +2213,12 @@ export class KeyringController<
     });
   }
 
+  /**
+   * Gets the type of the keyring that manages the specified account.
+   *
+   * @param account - The account address to look up.
+   * @returns A promise that resolves to the type of the keyring managing the account.
+   */
   async getAccountKeyringType(account: string): Promise<string> {
     this.#assertIsUnlocked();
 
@@ -2242,7 +2254,7 @@ export class KeyringController<
     v2,
     selector,
   }: // Use distinct union tags to ensure proper type narrowing of the selector object.
-    | {
+  | {
         v2: false;
         selector: KeyringSelector<SelectedKeyring>;
       }

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -198,7 +198,8 @@ export type KeyringControllerOptions<
   EncryptionKey = encryptorUtils.EncryptionKey | CryptoKey,
   SupportedKeyDerivationOptions = encryptorUtils.KeyDerivationOptions,
   EncryptionResult extends
-    EncryptionResultConstraint<SupportedKeyDerivationOptions> = DefaultEncryptionResult<SupportedKeyDerivationOptions>,
+    EncryptionResultConstraint<SupportedKeyDerivationOptions> =
+    DefaultEncryptionResult<SupportedKeyDerivationOptions>,
 > = {
   keyringBuilders?: { (): EthKeyring; type: string }[];
   keyringV2Builders?: KeyringV2Builder[];
@@ -368,7 +369,8 @@ export type Encryptor<
   EncryptionKey = encryptorUtils.EncryptionKey | CryptoKey,
   SupportedKeyDerivationParams = encryptorUtils.KeyDerivationOptions,
   EncryptionResult extends
-    EncryptionResultConstraint<SupportedKeyDerivationParams> = DefaultEncryptionResult<SupportedKeyDerivationParams>,
+    EncryptionResultConstraint<SupportedKeyDerivationParams> =
+    DefaultEncryptionResult<SupportedKeyDerivationParams>,
 > = {
   /**
    * Encrypts the given object with the given password.
@@ -769,7 +771,8 @@ export class KeyringController<
   EncryptionKey = encryptorUtils.EncryptionKey | CryptoKey,
   SupportedKeyDerivationOptions = encryptorUtils.KeyDerivationOptions,
   EncryptionResult extends
-    EncryptionResultConstraint<SupportedKeyDerivationOptions> = DefaultEncryptionResult<SupportedKeyDerivationOptions>,
+    EncryptionResultConstraint<SupportedKeyDerivationOptions> =
+    DefaultEncryptionResult<SupportedKeyDerivationOptions>,
 > extends BaseController<
   typeof name,
   KeyringControllerState,
@@ -2254,7 +2257,7 @@ export class KeyringController<
     v2,
     selector,
   }: // Use distinct union tags to ensure proper type narrowing of the selector object.
-  | {
+    | {
         v2: false;
         selector: KeyringSelector<SelectedKeyring>;
       }

--- a/packages/keyring-controller/src/index.ts
+++ b/packages/keyring-controller/src/index.ts
@@ -26,6 +26,15 @@ export type {
   KeyringControllerWithKeyringV2Action,
   KeyringControllerWithKeyringV2UnsafeAction,
   KeyringControllerExportSeedPhraseAction,
+  KeyringControllerVerifyPasswordAction,
+  KeyringControllerExportAccountAction,
+  KeyringControllerImportAccountWithStrategyAction,
+  KeyringControllerSetLockedAction,
+  KeyringControllerChangePasswordAction,
+  KeyringControllerSubmitEncryptionKeyAction,
+  KeyringControllerExportEncryptionKeyAction,
+  KeyringControllerSubmitPasswordAction,
+  KeyringControllerGetAccountKeyringTypeAction,
 } from './KeyringController-method-action-types';
 export type * from './types';
 export * from './errors';


### PR DESCRIPTION
## Explanation

This exposes missing methods used in the clients through the messenger after #8391

## References

* Progresses https://consensyssoftware.atlassian.net/browse/WPC-989

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broadens the messenger API surface to include password/key export and lock/unlock-related actions, which are sensitive operations even though underlying implementations are unchanged.
> 
> **Overview**
> **Exposes additional `KeyringController` capabilities via the messenger.** The controller now allowlists and types new messenger actions for `changePassword`, `verifyPassword`, `submitPassword`, `submitEncryptionKey`, `setLocked`, `exportEncryptionKey`, `exportAccount`, `importAccountWithStrategy`, and `getAccountKeyringType`.
> 
> Updates the generated method action-type union/exports and adds an Unreleased changelog entry documenting the newly available actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ab76398030e95dcd0a85c6b27794623359f20a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->