### PR TITLE
chore: Expose missing `PermissionController` methods through the messenger

### DIFF
--- a/packages/permission-controller/CHANGELOG.md
+++ b/packages/permission-controller/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Expose missing public `PermissionController` methods through its messenger ([#8675](https://github.com/MetaMask/core/pull/8675))
+  - The following actions are now available:
+    - `PermissionController:acceptPermissionsRequest`,
+    - `PermissionController:rejectPermissionsRequest`,
+    - `PermissionController:revokePermission`,
+    - `PermissionController:updatePermissionsByCaveat`,
+    - `PermissionController:getPermission`
+  - Corresponding action types are available as well.
+
 ## [13.0.0]
 
 ### Added

--- a/packages/permission-controller/src/PermissionController-method-action-types.ts
+++ b/packages/permission-controller/src/PermissionController-method-action-types.ts
@@ -38,6 +38,20 @@ export type PermissionControllerGetSubjectNamesAction = {
 };
 
 /**
+ * Gets the permission for the specified target of the subject corresponding
+ * to the specified origin.
+ *
+ * @param origin - The origin of the subject.
+ * @param targetName - The method name as invoked by a third party (i.e., not
+ * a method key).
+ * @returns The permission if it exists, or undefined otherwise.
+ */
+export type PermissionControllerGetPermissionAction = {
+  type: `PermissionController:getPermission`;
+  handler: PermissionController['getPermission'];
+};
+
+/**
  * Gets all permissions for the specified subject, if any.
  *
  * @param origin - The origin of the subject.
@@ -83,6 +97,20 @@ export type PermissionControllerHasPermissionsAction = {
 export type PermissionControllerRevokeAllPermissionsAction = {
   type: `PermissionController:revokeAllPermissions`;
   handler: PermissionController['revokeAllPermissions'];
+};
+
+/**
+ * Revokes the specified permission from the subject with the specified
+ * origin.
+ *
+ * Throws an error if the subject or the permission does not exist.
+ *
+ * @param origin - The origin of the subject whose permission to revoke.
+ * @param target - The target name of the permission to revoke.
+ */
+export type PermissionControllerRevokePermissionAction = {
+  type: `PermissionController:revokePermission`;
+  handler: PermissionController['revokePermission'];
 };
 
 /**
@@ -150,6 +178,34 @@ export type PermissionControllerGetCaveatAction = {
 export type PermissionControllerUpdateCaveatAction = {
   type: `PermissionController:updateCaveat`;
   handler: PermissionController['updateCaveat'];
+};
+
+/**
+ * Updates all caveats with the specified type for all subjects and
+ * permissions by applying the specified mutator function to them.
+ *
+ * ATTN: Permissions can be revoked entirely by the action of this method,
+ * read on for details.
+ *
+ * Caveat mutators are functions that receive a caveat value and return a
+ * tuple consisting of a {@link CaveatMutatorOperation} and, optionally, a new
+ * value to update the existing caveat with.
+ *
+ * For each caveat, depending on the mutator result, this method will:
+ * - Do nothing ({@link CaveatMutatorOperation.Noop})
+ * - Update the value of the caveat ({@link CaveatMutatorOperation.UpdateValue}). The caveat specification validator, if any, will be called after updating the value.
+ * - Delete the caveat ({@link CaveatMutatorOperation.DeleteCaveat}). The permission specification validator, if any, will be called after deleting the caveat.
+ * - Revoke the parent permission ({@link CaveatMutatorOperation.RevokePermission})
+ *
+ * This method throws if the validation of any caveat or permission fails.
+ *
+ * @param targetCaveatType - The type of the caveats to update.
+ * @param mutator - The mutator function which will be applied to all caveat
+ * values.
+ */
+export type PermissionControllerUpdatePermissionsByCaveatAction = {
+  type: `PermissionController:updatePermissionsByCaveat`;
+  handler: PermissionController['updatePermissionsByCaveat'];
 };
 
 /**
@@ -267,6 +323,28 @@ export type PermissionControllerRequestPermissionsIncrementalAction = {
 };
 
 /**
+ * Accepts a permissions request created by
+ * {@link PermissionController.requestPermissions}.
+ *
+ * @param request - The permissions request.
+ */
+export type PermissionControllerAcceptPermissionsRequestAction = {
+  type: `PermissionController:acceptPermissionsRequest`;
+  handler: PermissionController['acceptPermissionsRequest'];
+};
+
+/**
+ * Rejects a permissions request created by
+ * {@link PermissionController.requestPermissions}.
+ *
+ * @param id - The id of the request to be rejected.
+ */
+export type PermissionControllerRejectPermissionsRequestAction = {
+  type: `PermissionController:rejectPermissionsRequest`;
+  handler: PermissionController['rejectPermissionsRequest'];
+};
+
+/**
  * Gets the subject's endowments per the specified endowment permission.
  * Throws if the subject does not have the required permission or if the
  * permission is not an endowment permission.
@@ -320,17 +398,22 @@ export type PermissionControllerMethodActions =
   | PermissionControllerHasUnrestrictedMethodAction
   | PermissionControllerClearStateAction
   | PermissionControllerGetSubjectNamesAction
+  | PermissionControllerGetPermissionAction
   | PermissionControllerGetPermissionsAction
   | PermissionControllerHasPermissionAction
   | PermissionControllerHasPermissionsAction
   | PermissionControllerRevokeAllPermissionsAction
+  | PermissionControllerRevokePermissionAction
   | PermissionControllerRevokePermissionsAction
   | PermissionControllerRevokePermissionForAllSubjectsAction
   | PermissionControllerGetCaveatAction
   | PermissionControllerUpdateCaveatAction
+  | PermissionControllerUpdatePermissionsByCaveatAction
   | PermissionControllerGrantPermissionsAction
   | PermissionControllerGrantPermissionsIncrementalAction
   | PermissionControllerRequestPermissionsAction
   | PermissionControllerRequestPermissionsIncrementalAction
+  | PermissionControllerAcceptPermissionsRequestAction
+  | PermissionControllerRejectPermissionsRequestAction
   | PermissionControllerGetEndowmentsAction
   | PermissionControllerExecuteRestrictedMethodAction;

--- a/packages/permission-controller/src/PermissionController.ts
+++ b/packages/permission-controller/src/PermissionController.ts
@@ -191,6 +191,11 @@ const MESSENGER_EXPOSED_METHODS = [
   'revokePermissions',
   'updateCaveat',
   'getCaveat',
+  'acceptPermissionsRequest',
+  'rejectPermissionsRequest',
+  'revokePermission',
+  'updatePermissionsByCaveat',
+  'getPermission',
 ] as const;
 
 /**

--- a/packages/permission-controller/src/index.ts
+++ b/packages/permission-controller/src/index.ts
@@ -21,6 +21,11 @@ export type {
   PermissionControllerRevokePermissionForAllSubjectsAction,
   PermissionControllerRevokePermissionsAction,
   PermissionControllerUpdateCaveatAction,
+  PermissionControllerGetPermissionAction,
+  PermissionControllerRevokePermissionAction,
+  PermissionControllerUpdatePermissionsByCaveatAction,
+  PermissionControllerAcceptPermissionsRequestAction,
+  PermissionControllerRejectPermissionsRequestAction,
 } from './PermissionController-method-action-types';
 export {
   createPermissionMiddleware,


### PR DESCRIPTION
## Explanation
This exposes missing methods used in the clients through the messenger after https://github.com/MetaMask/core/pull/8201
## References
Progresses https://consensyssoftware.atlassian.net/browse/WPC-989

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this primarily expands the messenger-exposed API surface and TypeScript action types without changing permission logic, but consumers may start depending on these newly exposed actions.
> 
> **Overview**
> **Exposes additional `PermissionController` methods via the messenger** by adding new action types and including them in the controller’s `MESSENGER_EXPOSED_METHODS` allowlist.
> 
> Newly exposed actions include `acceptPermissionsRequest`, `rejectPermissionsRequest`, `revokePermission`, `updatePermissionsByCaveat`, and `getPermission`, with corresponding exports from the package entrypoint and a changelog entry documenting the additions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 092f6a5d680cc743c11bfc43b7dabda08c6bb4ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->