### PR TITLE
[wip] fix: add the abilty to cancel a batch if there is a failure or rejection

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/messenger` from `^1.1.1` to `^1.2.0` ([#8632](https://github.com/MetaMask/core/pull/8632))
 - Bump `@metamask/network-controller` from `^30.0.1` to `^30.1.0` ([#8636](https://github.com/MetaMask/core/pull/8636))
 
+### Fixed
+
+- Reject pending batch publish hooks when a batch member fails before every publish hook has fired, preventing orphaned approved transactions after hardware wallet rejection
+
 ## [65.0.0]
 
 ### Added

--- a/packages/transaction-controller/src/utils/batch.test.ts
+++ b/packages/transaction-controller/src/utils/batch.test.ts
@@ -2025,6 +2025,150 @@ describe('Batch Utils', () => {
         );
       });
 
+      it('rejects individual publish hooks if a batch member fails before every publish hook is called', async () => {
+        const publishBatchHook: jest.MockedFn<PublishBatchHook> = jest.fn();
+        let publishHookPromise: Promise<unknown> | undefined;
+
+        const txMeta1 = {
+          ...TRANSACTION_META_MOCK,
+          id: TRANSACTION_ID_MOCK,
+          status: TransactionStatus.signed,
+        } as TransactionMeta;
+        const txMeta2 = {
+          ...TRANSACTION_META_MOCK,
+          id: TRANSACTION_ID_2_MOCK,
+          status: TransactionStatus.signed,
+        } as TransactionMeta;
+
+        addTransactionMock
+          .mockResolvedValueOnce({
+            transactionMeta: txMeta1,
+            result: Promise.resolve(''),
+          })
+          .mockImplementationOnce((_params, options) => {
+            publishHookPromise = options.publishHook?.(
+              txMeta2,
+              TRANSACTION_SIGNATURE_2_MOCK,
+            );
+            publishHookPromise?.catch(() => {
+              // Intentionally empty
+            });
+            return Promise.resolve({
+              transactionMeta: txMeta2,
+              result: Promise.resolve(''),
+            });
+          });
+
+        getTransactionMock.mockImplementation(
+          (id: string) =>
+            (id === TRANSACTION_ID_MOCK ? txMeta1 : txMeta2) as TransactionMeta,
+        );
+
+        const resultPromise = addTransactionBatch({
+          ...request,
+          publishBatchHook,
+          request: {
+            ...request.request,
+            requireApproval: false,
+            disable7702: true,
+          },
+        }).then(
+          () => 'resolved',
+          (error: Error) => error.message,
+        );
+
+        await flushPromises();
+
+        const statusUpdatedHandler = jest
+          .mocked(MESSENGER_MOCK.subscribe)
+          .mock.calls.find(
+            ([event]) =>
+              event === 'TransactionController:transactionStatusUpdated',
+          )?.[1] as
+          | ((payload: { transactionMeta: TransactionMeta }) => void)
+          | undefined;
+
+        statusUpdatedHandler?.({
+          transactionMeta: {
+            ...txMeta1,
+            status: TransactionStatus.failed,
+            error: { message: ERROR_MESSAGE_MOCK },
+          },
+        });
+
+        const result = await Promise.race([
+          resultPromise,
+          flushPromises().then(() => 'pending'),
+        ]);
+
+        expect(result).toBe(ERROR_MESSAGE_MOCK);
+        await expect(publishHookPromise).rejects.toThrow(ERROR_MESSAGE_MOCK);
+      });
+
+      it('rejects individual publish hooks if a batch member was already rejected before subscribing to status updates', async () => {
+        const publishBatchHook: jest.MockedFn<PublishBatchHook> = jest.fn();
+        let publishHookPromise: Promise<unknown> | undefined;
+
+        const txMeta1 = {
+          ...TRANSACTION_META_MOCK,
+          id: TRANSACTION_ID_MOCK,
+          status: TransactionStatus.signed,
+        } as TransactionMeta;
+        const txMeta2 = {
+          ...TRANSACTION_META_MOCK,
+          id: TRANSACTION_ID_2_MOCK,
+          status: TransactionStatus.signed,
+        } as TransactionMeta;
+        const rejectedTxMeta1 = {
+          ...txMeta1,
+          status: TransactionStatus.rejected,
+          error: { message: ERROR_MESSAGE_MOCK },
+        } as TransactionMeta;
+
+        addTransactionMock
+          .mockResolvedValueOnce({
+            transactionMeta: txMeta1,
+            result: Promise.resolve(''),
+          })
+          .mockImplementationOnce((_params, options) => {
+            publishHookPromise = options.publishHook?.(
+              txMeta2,
+              TRANSACTION_SIGNATURE_2_MOCK,
+            );
+            publishHookPromise?.catch(() => {
+              // Intentionally empty
+            });
+            return Promise.resolve({
+              transactionMeta: txMeta2,
+              result: Promise.resolve(''),
+            });
+          });
+
+        getTransactionMock
+          .mockReturnValueOnce(txMeta1)
+          .mockReturnValueOnce(txMeta2)
+          .mockReturnValueOnce(rejectedTxMeta1)
+          .mockReturnValue(txMeta2);
+
+        const resultPromise = addTransactionBatch({
+          ...request,
+          publishBatchHook,
+          request: {
+            ...request.request,
+            requireApproval: false,
+            disable7702: true,
+          },
+        }).then(
+          () => 'resolved',
+          (error: Error) => error.message,
+        );
+
+        await flushPromises();
+
+        expect(await resultPromise).toBe(ERROR_MESSAGE_MOCK);
+        await expect(publishHookPromise).rejects.toThrow(ERROR_MESSAGE_MOCK);
+      });
+
       it('rejects individual publish hooks if add transaction throws', async () => {
         const publishBatchHook: jest.MockedFn<PublishBatchHook> = jest.fn();
 

--- a/packages/transaction-controller/src/utils/batch.ts
+++ b/packages/transaction-controller/src/utils/batch.ts
@@ -525,6 +525,90 @@ function waitForTransactionStatus(
 }
 
 /**
+ * Wait for any transaction in a batch to fail while the collected publish hooks
+ * are still waiting for every transaction signature.
+ *
+ * @param transactionIds - The IDs of the transactions in the batch.
+ * @param request - The batch request containing messenger and getTransaction.
+ * @returns A promise that rejects if any transaction fails and an unsubscribe function.
+ */
+function waitForBatchTransactionFailure(
+  transactionIds: string[],
+  request: Pick<AddTransactionBatchRequest, 'getTransaction' | 'messenger'>,
+): { promise: Promise<never>; unsubscribe: () => void } {
+  const { getTransaction, messenger } = request;
+  const transactionIdSet = new Set(transactionIds);
+  let settled = false;
+  let unsubscribe = (): void => undefined;
+
+  const getFailureError = (tx?: TransactionMeta): Error | undefined => {
+    if (!transactionIdSet.has(String(tx?.id))) {
+      return undefined;
+    }
+
+    if (
+      tx?.status === TransactionStatus.failed ||
+      tx?.status === TransactionStatus.rejected
+    ) {
+      return new Error(
+        tx.error?.message ?? `Transaction ${String(tx.id)} ${tx.status}`,
+      );
+    }
+
+    return undefined;
+  };
+
+  const promise = new Promise<never>((_resolve, reject) => {
+    const rejectIfFailed = (tx?: TransactionMeta): boolean => {
+      const error = getFailureError(tx);
+
+      if (!error) {
+        return false;
+      }
+
+      settled = true;
+      unsubscribe();
+      reject(error);
+      return true;
+    };
+
+    if (transactionIds.some((id) => rejectIfFailed(getTransaction(id)))) {
+      return;
+    }
+
+    const handler = ({
+      transactionMeta,
+    }: {
+      transactionMeta: TransactionMeta;
+    }): void => {
+      if (settled) {
+        return;
+      }
+
+      rejectIfFailed(transactionMeta);
+    };
+
+    unsubscribe = (): void =>
+      messenger.unsubscribe(
+        'TransactionController:transactionStatusUpdated',
+        handler,
+      );
+
+    messenger.subscribe('TransactionController:transactionStatusUpdated', handler);
+  });
+
+  return {
+    promise,
+    unsubscribe: (): void => {
+      if (!settled) {
+        settled = true;
+        unsubscribe();
+      }
+    },
+  };
+}
+
+/**
  * Process a batch transaction using a publish batch hook.
  *
  * @param request - The request object including the user request and necessary callbacks.
@@ -639,7 +723,15 @@ async function addTransactionBatchWithHook(
       );
     }
 
-    const { signedTransactions } = await collectHook.ready();
+    const batchFailure = waitForBatchTransactionFailure(
+      hookTransactions.map((transaction) => String(transaction.id)),
+      request,
+    );
+
+    const { signedTransactions } = await Promise.race([
+      collectHook.ready(),
+      batchFailure.promise,
+    ]).finally(batchFailure.unsubscribe);
 
     const transactions = hookTransactions.map((transaction, i) => ({
       ...transaction,


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes batch publishing control-flow to race signature collection against transaction failure/rejection events, which could affect timing and error propagation in batch submissions.
> 
> **Overview**
> Prevents orphaned transactions when using `publishBatchHook` by aborting signature collection if any batch member transitions to `failed` or `rejected` before all per-tx publish hooks have fired.
> 
> This introduces `waitForBatchTransactionFailure` and races it against `collectHook.ready()` in `addTransactionBatchWithHook`, plus adds targeted tests covering early failure/rejection scenarios and documents the fix in the package changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53e60e1a573ecb947573ea4300d875360aa7e7cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->