### PR TITLE
feat(perps): sync controller from mobile

### DIFF
--- a/packages/perps-controller/.sync-state.json
+++ b/packages/perps-controller/.sync-state.json
@@ -1,8 +1,8 @@
 {
-  "lastSyncedMobileCommit": "cf20fa64fa5d919c87005f35578498b37f522e2a",
-  "lastSyncedMobileBranch": "feat/unified-account",
-  "lastSyncedCoreCommit": "6f8329297fd1d61ff72d8359d32856d1bda7559f",
-  "lastSyncedCoreBranch": "feat/perps/controller-apr-30",
-  "lastSyncedDate": "2026-04-30T15:10:24Z",
-  "sourceChecksum": "a1ead6bd8f4bf1aae32c95aa27a3b6cddf1c4e4b74ea4761952ea313cb109c80"
+  "lastSyncedMobileCommit": "b3d1f4071ad5394f8e553333529815c5dbbcb205",
+  "lastSyncedMobileBranch": "main",
+  "lastSyncedCoreCommit": "7fccd4bfde97ae8147a9e67174ac4d6c16ac3678",
+  "lastSyncedCoreBranch": "feat/perps/coltroller-4-may-26",
+  "lastSyncedDate": "2026-05-04T14:16:27Z",
+  "sourceChecksum": "82b73f9701cd3e99c984463b91b5daa68b13f3e3882f3ef6e5a8f4c6ad136aa8"
 }

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Sync controller from mobile — inline hardware keyring type strings in `HyperLiquidWalletService` to remove the `ExtendedKeyringTypes` import, improving portability between mobile and the core monorepo ([#NNNN](https://github.com/MetaMask/core/pull/NNNN))
+- Sync controller from mobile — inline hardware keyring type strings in `HyperLiquidWalletService` to remove the `ExtendedKeyringTypes` import, improving portability between mobile and the core monorepo ([#8677](https://github.com/MetaMask/core/pull/8677))
 
 ## [5.0.0]
 

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Sync controller from mobile — inline hardware keyring type strings in `HyperLiquidWalletService` to remove the `ExtendedKeyringTypes` import, improving portability between mobile and the core monorepo ([#NNNN](https://github.com/MetaMask/core/pull/NNNN))
+
 ## [5.0.0]
 
 ### Added


### PR DESCRIPTION
## Explanation

Syncs `app/controllers/perps/` from MetaMask Mobile (`b3d1f407`) to `packages/perps-controller/src/` in the core monorepo.

### Changes

- **HyperLiquidWalletService**: Inline hardware keyring type strings (`'Ledger Hardware'`, `'QR Hardware Wallet Device'`) instead of importing from the mobile-only `ExtendedKeyringTypes` constant. This eliminates the platform-specific import and makes the service portable between mobile and core.
- **Sync state**: Updated `.sync-state.json` to reflect the current mobile HEAD.

### Validation

All sync validation steps pass:
- Pre-flight checks, conflict check, source copy
- ESLint auto-fix + suppressions (8 suppressions, 0 new)
- oxfmt formatting
- Lint, test, changelog check
- Sync state written

## Changelog

Updated `packages/perps-controller/CHANGELOG.md` with entry under `## [Unreleased]`.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to syncing metadata and a small portability tweak (inlining hardware keyring type strings) without altering core trading or network logic.
> 
> **Overview**
> Syncs the perps controller from mobile and updates `.sync-state.json` to the new mobile/core commit references.
> 
> In `HyperLiquidWalletService`, hardware keyring type checks now use inlined string constants instead of importing `ExtendedKeyringTypes`, improving portability between mobile and the core monorepo; adds a corresponding entry to `CHANGELOG.md` under *Unreleased*.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd760f31dd9ad4024e09894dc03db51a1976d415. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->