### PR TITLE
feat(perps): sync controller from mobile — balance split + mode-aware spot fold

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1584,6 +1584,11 @@
       "count": 3
     }
   },
+  "packages/perps-controller/src/services/HyperLiquidSubscriptionService.ts": {
+    "@typescript-eslint/no-unused-vars": {
+      "count": 1
+    }
+  },
   "packages/perps-controller/src/utils/myxAdapter.ts": {
     "@typescript-eslint/no-base-to-string": {
       "count": 2

--- a/packages/perps-controller/.sync-state.json
+++ b/packages/perps-controller/.sync-state.json
@@ -1,8 +1,8 @@
 {
-  "lastSyncedMobileCommit": "cf20fa64fa5d919c87005f35578498b37f522e2a",
-  "lastSyncedMobileBranch": "feat/unified-account",
-  "lastSyncedCoreCommit": "6f8329297fd1d61ff72d8359d32856d1bda7559f",
-  "lastSyncedCoreBranch": "feat/perps/controller-apr-30",
-  "lastSyncedDate": "2026-04-30T15:10:24Z",
-  "sourceChecksum": "a1ead6bd8f4bf1aae32c95aa27a3b6cddf1c4e4b74ea4761952ea313cb109c80"
+  "lastSyncedMobileCommit": "355c9b656b9b51e154212666275f6d83ccb60fc5",
+  "lastSyncedMobileBranch": "main",
+  "lastSyncedCoreCommit": "fe175509d6f54207a06ebc710a9e5c07c5bc2cd8",
+  "lastSyncedCoreBranch": "feat/perps/sync-4-may-2026",
+  "lastSyncedDate": "2026-05-04T14:25:52Z",
+  "sourceChecksum": "2e7e9eab35667ca1bed2e2c3cd2f59361467910574b428ec47e9c6a7d0958bf5"
 }

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING:** Rename `AccountState.availableBalance` to `spendableBalance` and `AccountState.availableToTradeBalance` to `withdrawableBalance` for clearer semantics across abstraction modes ([#NNNN](https://github.com/MetaMask/core/pull/NNNN))
+- Mode-aware spot fold: `addSpotBalanceToAccountState` now folds free spot USDC into both `spendableBalance` and `withdrawableBalance` for Unified/Portfolio modes, while Standard/DEX-abstraction modes keep spot separate ([#NNNN](https://github.com/MetaMask/core/pull/NNNN))
+- Add throttled WS-driven `userAbstraction` refresh so HL-web mode flips propagate back without requiring a restart or account switch ([#NNNN](https://github.com/MetaMask/core/pull/NNNN))
+- Sync controller from mobile — inline hardware keyring type strings in `HyperLiquidWalletService` to remove the `ExtendedKeyringTypes` import, improving portability between mobile and the core monorepo ([#8677](https://github.com/MetaMask/core/pull/8677))
+
 ## [5.0.0]
 
 ### Added

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Rename `AccountState.availableBalance` to `spendableBalance` and `AccountState.availableToTradeBalance` to `withdrawableBalance` for clearer semantics across abstraction modes ([#NNNN](https://github.com/MetaMask/core/pull/NNNN))
-- Mode-aware spot fold: `addSpotBalanceToAccountState` now folds free spot USDC into both `spendableBalance` and `withdrawableBalance` for Unified/Portfolio modes, while Standard/DEX-abstraction modes keep spot separate ([#NNNN](https://github.com/MetaMask/core/pull/NNNN))
-- Add throttled WS-driven `userAbstraction` refresh so HL-web mode flips propagate back without requiring a restart or account switch ([#NNNN](https://github.com/MetaMask/core/pull/NNNN))
+- **BREAKING:** Rename `AccountState.availableBalance` to `spendableBalance` and `AccountState.availableToTradeBalance` to `withdrawableBalance` for clearer semantics across abstraction modes ([#8678](https://github.com/MetaMask/core/pull/NNNN))
+- Mode-aware spot fold: `addSpotBalanceToAccountState` now folds free spot USDC into both `spendableBalance` and `withdrawableBalance` for Unified/Portfolio modes, while Standard/DEX-abstraction modes keep spot separate ([#8678](https://github.com/MetaMask/core/pull/NNNN))
+- Add throttled WS-driven `userAbstraction` refresh so HL-web mode flips propagate back without requiring a restart or account switch ([#8678](https://github.com/MetaMask/core/pull/NNNN))
 - Sync controller from mobile — inline hardware keyring type strings in `HyperLiquidWalletService` to remove the `ExtendedKeyringTypes` import, improving portability between mobile and the core monorepo ([#8677](https://github.com/MetaMask/core/pull/8677))
 
 ## [5.0.0]

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** Rename `AccountState.availableBalance` to `spendableBalance` and `AccountState.availableToTradeBalance` to `withdrawableBalance` for clearer semantics across abstraction modes ([#8678](https://github.com/MetaMask/core/pull/8678))
 - Mode-aware spot fold: `addSpotBalanceToAccountState` now folds free spot USDC into both `spendableBalance` and `withdrawableBalance` for Unified/Portfolio modes, while Standard/DEX-abstraction modes keep spot separate ([#8678](https://github.com/MetaMask/core/pull/8678))
 - Add throttled WS-driven `userAbstraction` refresh so HL-web mode flips propagate back without requiring a restart or account switch ([#8678](https://github.com/MetaMask/core/pull/8678))
-- Sync controller from mobile — inline hardware keyring type strings in `HyperLiquidWalletService` to remove the `ExtendedKeyringTypes` import, improving portability between mobile and the core monorepo ([#8677](https://github.com/MetaMask/core/pull/8677))
 
 ## [5.0.0]
 

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Rename `AccountState.availableBalance` to `spendableBalance` and `AccountState.availableToTradeBalance` to `withdrawableBalance` for clearer semantics across abstraction modes ([#8678](https://github.com/MetaMask/core/pull/NNNN))
-- Mode-aware spot fold: `addSpotBalanceToAccountState` now folds free spot USDC into both `spendableBalance` and `withdrawableBalance` for Unified/Portfolio modes, while Standard/DEX-abstraction modes keep spot separate ([#8678](https://github.com/MetaMask/core/pull/NNNN))
-- Add throttled WS-driven `userAbstraction` refresh so HL-web mode flips propagate back without requiring a restart or account switch ([#8678](https://github.com/MetaMask/core/pull/NNNN))
+- **BREAKING:** Rename `AccountState.availableBalance` to `spendableBalance` and `AccountState.availableToTradeBalance` to `withdrawableBalance` for clearer semantics across abstraction modes ([#8678](https://github.com/MetaMask/core/pull/8678))
+- Mode-aware spot fold: `addSpotBalanceToAccountState` now folds free spot USDC into both `spendableBalance` and `withdrawableBalance` for Unified/Portfolio modes, while Standard/DEX-abstraction modes keep spot separate ([#8678](https://github.com/MetaMask/core/pull/8678))
+- Add throttled WS-driven `userAbstraction` refresh so HL-web mode flips propagate back without requiring a restart or account switch ([#8678](https://github.com/MetaMask/core/pull/8678))
 - Sync controller from mobile — inline hardware keyring type strings in `HyperLiquidWalletService` to remove the `ExtendedKeyringTypes` import, improving portability between mobile and the core monorepo ([#8677](https://github.com/MetaMask/core/pull/8677))
 
 ## [5.0.0]

--- a/packages/perps-controller/src/constants/hyperLiquidConfig.ts
+++ b/packages/perps-controller/src/constants/hyperLiquidConfig.ts
@@ -411,7 +411,7 @@ export const MAINNET_HIP3_CONFIG = {
  * HIP-3 margin management configuration
  * Controls margin buffers and auto-rebalance behavior for HIP-3 DEXes with isolated margin
  *
- * Background: HyperLiquid validates availableBalance >= totalRequiredMargin BEFORE reallocating
+ * Background: HyperLiquid validates spendableBalance >= totalRequiredMargin BEFORE reallocating
  * existing locked margin. This requires temporary over-funding when increasing positions,
  * followed by automatic cleanup to minimize locked capital.
  */

--- a/packages/perps-controller/src/constants/perpsConfig.ts
+++ b/packages/perps-controller/src/constants/perpsConfig.ts
@@ -404,10 +404,23 @@ export const PROVIDER_CONFIG = {
   MYX_TESTNET_ONLY: false,
 } as const;
 
-// Disk-backed cold-start cache keys and throttle interval
+// Disk-backed cold-start cache keys and throttle interval.
+// The user-data key ends in _V2 because the AccountState balance contract
+// changed (TAT-3047) and has no in-payload version field. Bumping the key
+// forces a one-time empty cache on upgrade — consumers fall through to
+// skeleton/fallback until the first WS tick, avoiding stale legacy-shape
+// reads that would surface as $0 balances.
 export const PERPS_DISK_CACHE_MARKETS = 'PERPS_DISK_CACHE_MARKETS';
-export const PERPS_DISK_CACHE_USER_DATA = 'PERPS_DISK_CACHE_USER_DATA';
+export const PERPS_DISK_CACHE_USER_DATA = 'PERPS_DISK_CACHE_USER_DATA_V2';
 export const PERPS_DISK_CACHE_THROTTLE_MS = 30_000;
+
+/**
+ * Minimum interval between WebSocket-triggered HL `userAbstraction`
+ * refreshes. Balances picking up HL-web mode flips (Unified ↔ Standard)
+ * promptly against burning REST quota on every spot tick. Covers the
+ * observed user pattern of flipping mode once per session at most.
+ */
+export const ABSTRACTION_MODE_REFRESH_THROTTLE_MS = 60_000;
 
 /**
  * Build the standard provider:network cache key from controller state.

--- a/packages/perps-controller/src/providers/HyperLiquidProvider.ts
+++ b/packages/perps-controller/src/providers/HyperLiquidProvider.ts
@@ -2721,7 +2721,7 @@ export class HyperLiquidProvider implements PerpsProvider {
 
     const accountState = await infoClient.clearinghouseState(queryParams);
     const adapted = adaptAccountStateFromSDK(accountState);
-    return parseFloat(adapted.availableBalance);
+    return parseFloat(adapted.withdrawableBalance);
   }
 
   /**
@@ -3014,7 +3014,7 @@ export class HyperLiquidProvider implements PerpsProvider {
       const orderIsLong = isBuy;
 
       if (existingIsLong === orderIsLong) {
-        // Increasing position - HyperLiquid validates availableBalance >= totalRequiredMargin
+        // Increasing position - HyperLiquid validates spendableBalance >= totalRequiredMargin
         // BEFORE reallocating existing locked margin. Must transfer TOTAL margin temporarily.
         const existingSize = Math.abs(parseFloat(existingPosition.size));
         const existingMargin = parseFloat(existingPosition.marginUsed);
@@ -3130,7 +3130,7 @@ export class HyperLiquidProvider implements PerpsProvider {
             '🔄 HyperLiquidProvider: Auto-rebalancing excess margin back to main DEX',
             {
               dex: dexName,
-              availableBalance: postOrderBalance.toFixed(2),
+              spendableBalance: postOrderBalance.toFixed(2),
               desiredBuffer: desiredBuffer.toFixed(2),
               excessAmount: excessAmount.toFixed(2),
               destinationDex: transferInfo.sourceDex,
@@ -4769,6 +4769,20 @@ export class HyperLiquidProvider implements PerpsProvider {
         ntli,
       });
 
+      // Guard: confirm spendableBalance can cover margin addition.
+      // spendableBalance is already mode-aware (includes free spot in Unified,
+      // excludes it in Standard), so no extra spot fetch needed.
+      if (amountFloat > 0) {
+        const accountState = await this.getAccountState();
+        const spendable = parseFloat(accountState.spendableBalance);
+
+        if (spendable < amountFloat) {
+          throw new Error(
+            `Insufficient balance for margin addition: need ${amountFloat}, available ${spendable.toFixed(2)}`,
+          );
+        }
+      }
+
       // Call SDK to update isolated margin
       const exchangeClient = this.#clientService.getExchangeClient();
       const result = await exchangeClient.updateIsolatedMargin({
@@ -5852,7 +5866,9 @@ export class HyperLiquidProvider implements PerpsProvider {
         this.#clientService.isTestnetMode() ? 'TESTNET' : 'MAINNET',
       );
 
-      // Get Spot balance (global, not DEX-specific) and Perps states across all DEXs.
+      // Get Spot balance, Perps states across DEXs, and the HL abstraction
+      // mode (Unified / Standard / Portfolio / DEX-abstraction). Mode decides
+      // whether spot USDC is perps collateral — see addSpotBalanceToAccountState.
       // One transient DEX failure should not blank the entire account state.
       const [spotStateResult, perpsStateResult, abstractionResult] =
         await Promise.allSettled([
@@ -5947,7 +5963,8 @@ export class HyperLiquidProvider implements PerpsProvider {
           `DEX ${result.dex ?? 'main'} account state:`,
           {
             totalBalance: dexAccountState.totalBalance,
-            availableBalance: dexAccountState.availableBalance,
+            spendableBalance: dexAccountState.spendableBalance,
+            withdrawableBalance: dexAccountState.withdrawableBalance,
             marginUsed: dexAccountState.marginUsed,
             unrealizedPnl: dexAccountState.unrealizedPnl,
           },
@@ -5957,15 +5974,17 @@ export class HyperLiquidProvider implements PerpsProvider {
       const aggregatedAccountState = addSpotBalanceToAccountState(
         aggregateAccountStates(dexAccountStates),
         spotState,
-        {
-          foldIntoCollateral: hyperLiquidModeFoldsSpot(abstractionMode),
-        },
+        { foldIntoCollateral: hyperLiquidModeFoldsSpot(abstractionMode) },
       );
 
       // Build per-sub-account breakdown (HIP-3 DEXs map to sub-accounts)
       const subAccountBreakdown: Record<
         string,
-        { availableBalance: string; totalBalance: string }
+        {
+          spendableBalance: string;
+          withdrawableBalance: string;
+          totalBalance: string;
+        }
       > = {};
       perpsStateResults.forEach((result) => {
         const { dex, data: perpsState } = result;
@@ -5973,7 +5992,8 @@ export class HyperLiquidProvider implements PerpsProvider {
         const subAccountKey = dex ?? ''; // Empty string for main DEX
 
         subAccountBreakdown[subAccountKey] = {
-          availableBalance: dexAccountState.availableBalance,
+          spendableBalance: dexAccountState.spendableBalance,
+          withdrawableBalance: dexAccountState.withdrawableBalance,
           totalBalance: dexAccountState.totalBalance,
         };
       });
@@ -7053,16 +7073,10 @@ export class HyperLiquidProvider implements PerpsProvider {
         'HyperLiquidProvider: CHECKING ACCOUNT BALANCE',
       );
       const accountState = await this.getAccountState();
-      // Release-branch bridge for Unified Account: availableToTradeBalance
-      // includes collateral HL can draw in target mode. The larger balance
-      // contract will replace this with an explicit withdrawableBalance field.
-      const availableBalance = parseFloat(
-        accountState.availableToTradeBalance ?? accountState.availableBalance,
-      );
+      const withdrawableBalance = parseFloat(accountState.withdrawableBalance);
       this.#deps.debugLogger.log('HyperLiquidProvider: ACCOUNT BALANCE', {
-        availableBalance,
-        clearinghouseAvailableBalance: accountState.availableBalance,
-        availableToTradeBalance: accountState.availableToTradeBalance,
+        withdrawableBalance,
+        spendableBalance: accountState.spendableBalance,
         totalBalance: accountState.totalBalance,
         marginUsed: accountState.marginUsed,
         unrealizedPnl: accountState.unrealizedPnl,
@@ -7080,13 +7094,17 @@ export class HyperLiquidProvider implements PerpsProvider {
       const withdrawAmount = parseFloat(params.amount);
       this.#deps.debugLogger.log('HyperLiquidProvider: WITHDRAWAL AMOUNT', {
         requestedAmount: withdrawAmount,
-        availableBalance,
-        sufficientBalance: withdrawAmount <= availableBalance,
+        withdrawableBalance,
+        sufficientBalance: withdrawAmount <= withdrawableBalance,
       });
 
+      // Validate against withdrawableBalance — the mode-aware cap.
+      // No spot sweep: withdrawableBalance already reflects what withdraw3
+      // can pull. In Unified mode HL handles cross-wallet internally; in
+      // Standard mode spot is not withdrawable via perps.
       const balanceValidation = validateBalance(
         withdrawAmount,
-        availableBalance,
+        withdrawableBalance,
       );
       if (!balanceValidation.isValid) {
         this.#deps.debugLogger.log(
@@ -7094,8 +7112,8 @@ export class HyperLiquidProvider implements PerpsProvider {
           {
             error: balanceValidation.error,
             requestedAmount: withdrawAmount,
-            availableBalance,
-            difference: withdrawAmount - availableBalance,
+            withdrawableBalance,
+            difference: withdrawAmount - withdrawableBalance,
           },
         );
         throw new Error(balanceValidation.error);

--- a/packages/perps-controller/src/providers/MYXProvider.ts
+++ b/packages/perps-controller/src/providers/MYXProvider.ts
@@ -687,7 +687,8 @@ export class MYXProvider implements PerpsProvider {
         ...this.#getErrorContext('getAccountState'),
       });
       return {
-        availableBalance: '0',
+        spendableBalance: '0',
+        withdrawableBalance: '0',
         totalBalance: '0',
         marginUsed: '0',
         unrealizedPnl: '0',
@@ -958,7 +959,8 @@ export class MYXProvider implements PerpsProvider {
     setTimeout(
       () =>
         params.callback({
-          availableBalance: '0',
+          spendableBalance: '0',
+          withdrawableBalance: '0',
           totalBalance: '0',
           marginUsed: '0',
           unrealizedPnl: '0',

--- a/packages/perps-controller/src/services/HyperLiquidSubscriptionService.ts
+++ b/packages/perps-controller/src/services/HyperLiquidSubscriptionService.ts
@@ -17,7 +17,11 @@ import type {
   SpotStateWsEvent,
 } from '@nktkas/hyperliquid';
 
-import { TP_SL_CONFIG, PERPS_CONSTANTS } from '../constants/perpsConfig';
+import {
+  TP_SL_CONFIG,
+  PERPS_CONSTANTS,
+  ABSTRACTION_MODE_REFRESH_THROTTLE_MS,
+} from '../constants/perpsConfig';
 import { WebSocketConnectionState } from '../types';
 import type {
   PriceUpdate,
@@ -37,11 +41,12 @@ import type {
   PerpsPlatformDependencies,
   PerpsLogger,
 } from '../types';
-import { hyperLiquidModeFoldsSpot } from '../types/hyperliquid-types';
 import type {
   SpotClearinghouseStateResponse,
+  HyperLiquidAbstractionMode,
   UserAbstractionResponse,
 } from '../types/hyperliquid-types';
+import { hyperLiquidModeFoldsSpot } from '../types/hyperliquid-types';
 import {
   addSpotBalanceToAccountState,
   calculateWeightedReturnOnEquity,
@@ -178,9 +183,27 @@ export class HyperLiquidSubscriptionService {
 
   #cachedSpotState: SpotClearinghouseStateResponse | null = null;
 
-  #cachedSpotStateUserAddress: string | null = null;
+  // HL abstraction mode (Unified / Standard / Portfolio / DEX-abstraction).
+  // Gates spot→perps folding in addSpotBalanceToAccountState. Keyed by user
+  // address so an in-flight refresh or late response for one wallet cannot
+  // overwrite another wallet's fold semantics after an account switch.
+  readonly #abstractionModeByUser = new Map<
+    string,
+    HyperLiquidAbstractionMode
+  >();
 
-  readonly #abstractionModeByUser = new Map<string, UserAbstractionResponse>();
+  // Timestamp of the last successful WS-driven userAbstraction refresh per
+  // user. This throttle intentionally does not count the initial bootstrap
+  // fetch so the first spot tick after app launch can still detect an HL-web
+  // mode flip immediately.
+  readonly #abstractionModeLastWsRefreshAtByUser = new Map<string, number>();
+
+  // In-flight promises for WS-triggered refreshes, keyed by user so concurrent
+  // ticks for the same wallet share one fetch while account switches can start
+  // their own refresh immediately.
+  readonly #abstractionModeInflightByUser = new Map<string, Promise<void>>();
+
+  #cachedSpotStateUserAddress: string | null = null;
 
   #spotStatePromise?: Promise<void>;
 
@@ -719,9 +742,7 @@ export class HyperLiquidSubscriptionService {
   }
 
   #hashAccountState(account: AccountState): string {
-    return `${account.availableBalance}:${account.availableToTradeBalance ?? ''}:${
-      account.totalBalance
-    }:${account.marginUsed}:${account.unrealizedPnl}`;
+    return `${account.spendableBalance}:${account.withdrawableBalance}:${account.totalBalance}:${account.marginUsed}:${account.unrealizedPnl}`;
   }
 
   // Cache hashes to avoid recomputation
@@ -977,9 +998,14 @@ export class HyperLiquidSubscriptionService {
   #aggregateAccountStates(): AccountState {
     const subAccountBreakdown: Record<
       string,
-      { availableBalance: string; totalBalance: string }
+      {
+        spendableBalance: string;
+        withdrawableBalance: string;
+        totalBalance: string;
+      }
     > = {};
-    let totalAvailableBalance = 0;
+    let totalSpendableBalance = 0;
+    let totalWithdrawableBalance = 0;
     let totalBalance = 0;
     let totalMarginUsed = 0;
     let totalUnrealizedPnl = 0;
@@ -995,10 +1021,12 @@ export class HyperLiquidSubscriptionService {
       ([currentDex, state]) => {
         const dexKey = currentDex === '' ? 'main' : currentDex;
         subAccountBreakdown[dexKey] = {
-          availableBalance: state.availableBalance,
+          spendableBalance: state.spendableBalance,
+          withdrawableBalance: state.withdrawableBalance,
           totalBalance: state.totalBalance,
         };
-        totalAvailableBalance += parseFloat(state.availableBalance);
+        totalSpendableBalance += parseFloat(state.spendableBalance);
+        totalWithdrawableBalance += parseFloat(state.withdrawableBalance);
         totalBalance += parseFloat(state.totalBalance);
         totalMarginUsed += parseFloat(state.marginUsed);
         totalUnrealizedPnl += parseFloat(state.unrealizedPnl);
@@ -1021,7 +1049,8 @@ export class HyperLiquidSubscriptionService {
     return addSpotBalanceToAccountState(
       {
         ...firstDexAccount,
-        availableBalance: totalAvailableBalance.toString(),
+        spendableBalance: totalSpendableBalance.toString(),
+        withdrawableBalance: totalWithdrawableBalance.toString(),
         totalBalance: totalBalance.toString(),
         marginUsed: totalMarginUsed.toString(),
         unrealizedPnl: totalUnrealizedPnl.toString(),
@@ -1033,13 +1062,22 @@ export class HyperLiquidSubscriptionService {
     );
   }
 
+  /**
+   * Return the cached HL abstraction mode for the given user address.
+   *
+   * Returns `null` when the address is unknown or this user has not been
+   * fetched yet — callers pass this through `hyperLiquidModeFoldsSpot`,
+   * which fail-closes (no fold) when the mode is unresolved.
+   *
+   * @param userAddress - Current user address; null/empty returns null.
+   * @returns Cached abstraction mode when the user matches; otherwise null.
+   */
   #getAbstractionModeForUser(
     userAddress?: string | null,
-  ): UserAbstractionResponse | null {
+  ): HyperLiquidAbstractionMode | null {
     if (!userAddress) {
       return null;
     }
-
     return this.#abstractionModeByUser.get(userAddress.toLowerCase()) ?? null;
   }
 
@@ -1054,34 +1092,105 @@ export class HyperLiquidSubscriptionService {
   /**
    * Record a user's resolved abstraction mode and immediately re-aggregate.
    * Call after the provider has confirmed the on-chain mode (already-enabled
-   * or just-migrated). Setting the mode (rather than deleting it) ensures
-   * `hyperLiquidModeFoldsSpot` returns the correct fold decision on the next
-   * aggregation — a delete would leave the user pinned to fail-closed
-   * (no fold) until the next refresh, under-reporting balance for Unified
-   * and Portfolio Margin users.
-   *
-   * Seals `#cachedSpotStateUserAddress` if spot is already cached for this
-   * user (fast-path optimization for the next `#ensureSpotState`). Skips the
-   * seal if spot belongs to a different user — the next refresh will sort
-   * everything out.
+   * or just-migrated) so the WS-driven aggregator picks up the correct fold
+   * decision on the next tick.
    *
    * @param userAddress - The EVM address whose mode is being recorded.
    * @param mode - The current abstraction mode for this user.
    */
   public setUserAbstractionMode(
     userAddress: string,
-    mode: UserAbstractionResponse,
+    mode: HyperLiquidAbstractionMode,
   ): void {
     const lower = userAddress.toLowerCase();
     this.#abstractionModeByUser.set(lower, mode);
 
-    // No need to seal #cachedSpotStateUserAddress here — the WS handler and
-    // #refreshSpotState success path always set it to the spot owner. The
-    // re-aggregation below will pick up the new mode via the now-populated
-    // #abstractionModeByUser entry.
     if (this.#dexAccountCache.size > 0) {
       this.#aggregateAndNotifySubscribers();
     }
+  }
+
+  /**
+   * Fetch userAbstraction and update the cache, throttled so the long-lived
+   * spotState WebSocket can trigger a background refresh on every tick
+   * without burning REST quota. Handles HL-web mode flips propagating back
+   * to mobile without requiring a restart or account switch.
+   *
+   * Concurrent callers share the same in-flight promise so an in-flight
+   * fetch (especially a slow-failing one) doesn't ratchet the throttle
+   * forward on every WS tick and leave mode stale during a network hang.
+   *
+   * @param userAddress - Current user address to refresh the cache for.
+   * @returns Promise that resolves once the refresh completes (or immediately when throttled).
+   */
+  async #refreshAbstractionModeThrottled(userAddress: string): Promise<void> {
+    const normalizedUser = userAddress.toLowerCase();
+    const existing = this.#abstractionModeInflightByUser.get(normalizedUser);
+    if (existing) {
+      await existing;
+      return undefined;
+    }
+    const now = Date.now();
+    const lastWsRefreshAt =
+      this.#abstractionModeLastWsRefreshAtByUser.get(normalizedUser) ?? 0;
+    if (now - lastWsRefreshAt < ABSTRACTION_MODE_REFRESH_THROTTLE_MS) {
+      return undefined;
+    }
+    const inflight: Promise<void> = (async (): Promise<void> => {
+      try {
+        const infoClient = this.#clientService.getInfoClient();
+        const mode = await infoClient.userAbstraction({ user: userAddress });
+        const previousMode =
+          this.#abstractionModeByUser.get(normalizedUser) ?? null;
+        this.#abstractionModeByUser.set(normalizedUser, mode);
+        // Set timestamp only on success; a hanging/failed fetch must not
+        // ratchet the throttle window forward (which would silence every
+        // subsequent spot WS tick for the full throttle duration).
+        this.#abstractionModeLastWsRefreshAtByUser.set(
+          normalizedUser,
+          Date.now(),
+        );
+
+        // If the fold semantics actually changed for this user, trigger a
+        // re-aggregation so balance-dependent UI (withdraw cap, order-entry
+        // validation) picks up the new mode immediately — otherwise a
+        // Unified→Standard flip can stay folded with old semantics until the
+        // next spot/account event happens to arrive.
+        const foldChanged =
+          hyperLiquidModeFoldsSpot(previousMode) !==
+          hyperLiquidModeFoldsSpot(mode);
+        if (foldChanged && this.#dexAccountCache.size > 0) {
+          this.#aggregateAndNotifySubscribers();
+        }
+      } catch (error) {
+        // Non-fatal — preserve the last known mode for this user. Leave
+        // timestamp at its previous value so a genuine retry on the next
+        // WS tick is allowed (no forward ratchet on slow failures). Route
+        // through the shared Sentry helper so repeated failures become
+        // visible on the perps ops dashboard (consistent with other async
+        // boundary errors in this file, e.g. #refreshSpotState).
+        this.#logErrorUnlessClearing(
+          ensureError(
+            error,
+            'HyperLiquidSubscriptionService.refreshAbstractionModeThrottled',
+          ),
+          this.#getErrorContext('refreshAbstractionModeThrottled', {
+            user: normalizedUser,
+          }),
+        );
+      }
+    })();
+    this.#abstractionModeInflightByUser.set(normalizedUser, inflight);
+    try {
+      await inflight;
+    } finally {
+      if (
+        this.#abstractionModeInflightByUser.get(normalizedUser) === inflight
+      ) {
+        this.#abstractionModeInflightByUser.delete(normalizedUser);
+      }
+    }
+    return undefined;
   }
 
   async #ensureSpotState(accountId?: CaipAccountId): Promise<void> {
@@ -1150,14 +1259,33 @@ export class HyperLiquidSubscriptionService {
       // correctly handles the generation-changed case (seal + re-aggregate
       // instead of overwriting WS spot).
       const infoClient = this.#clientService.getInfoClient();
-      const [spotResult, abstractionResult] = await Promise.allSettled([
-        infoClient.spotClearinghouseState({
-          user: userAddress,
-        }),
-        infoClient.userAbstraction({ user: userAddress }),
-      ]);
-
       const lowerUserAddress = userAddress.toLowerCase();
+      // Fetch spot state + abstraction mode in parallel — mode decides
+      // whether the spot fold applies in addSpotBalanceToAccountState.
+      // Register the userAbstraction call in `#abstractionModeInflightByUser`
+      // so a concurrent WS-driven `#refreshAbstractionModeThrottled` awaits
+      // this fetch instead of duplicating the REST round-trip.
+      const abstractionFetch = infoClient.userAbstraction({
+        user: userAddress,
+      });
+      const trackedAbstraction = abstractionFetch.then(
+        () => undefined,
+        () => undefined,
+      );
+      this.#abstractionModeInflightByUser.set(
+        lowerUserAddress,
+        trackedAbstraction,
+      );
+      const [spotResult, abstractionResult] = await Promise.allSettled([
+        infoClient.spotClearinghouseState({ user: userAddress }),
+        abstractionFetch,
+      ]);
+      if (
+        this.#abstractionModeInflightByUser.get(lowerUserAddress) ===
+        trackedAbstraction
+      ) {
+        this.#abstractionModeInflightByUser.delete(lowerUserAddress);
+      }
 
       // Record the abstraction mode regardless of generation. The mode is
       // user-keyed (independent of the spot snapshot generation) so a WS
@@ -1268,6 +1396,17 @@ export class HyperLiquidSubscriptionService {
             // Fast-path eligibility is gated separately in #ensureSpotState
             // by checking #abstractionModeByUser.has(...).
             this.#cachedSpotStateUserAddress = userAddress.toLowerCase();
+
+            // Kick a throttled userAbstraction refresh so HL-web mode
+            // flips (Unified → Standard or vice versa) propagate back to
+            // mobile while the app stays open. Fire-and-forget: the
+            // refresh updates the per-user abstraction-mode cache and the next
+            // fold picks up the new value.
+            this.#refreshAbstractionModeThrottled(
+              event.user.toLowerCase(),
+            ).catch(() => {
+              // Errors are logged inside the throttled refresh helper.
+            });
 
             if (this.#dexAccountCache.size > 0) {
               this.#aggregateAndNotifySubscribers();
@@ -2289,6 +2428,10 @@ export class HyperLiquidSubscriptionService {
       this.#cachedSpotState = null;
       this.#cachedSpotStateUserAddress = null;
       this.#abstractionModeByUser.clear();
+      this.#abstractionModeLastWsRefreshAtByUser.clear();
+      // Drop in-flight refresh handles so stale hanging userAbstraction
+      // requests from the prior connection can't be awaited by future calls.
+      this.#abstractionModeInflightByUser.clear();
       // Bump generation so any in-flight spot fetch from a prior user discards
       // its result instead of re-populating the cache post-cleanup.
       this.#spotStateGeneration += 1;
@@ -4068,6 +4211,8 @@ export class HyperLiquidSubscriptionService {
     this.#cachedSpotState = null;
     this.#cachedSpotStateUserAddress = null;
     this.#abstractionModeByUser.clear();
+    this.#abstractionModeLastWsRefreshAtByUser.clear();
+    this.#abstractionModeInflightByUser.clear();
     this.#spotStateGeneration += 1;
     this.#spotStatePromise = undefined;
     this.#spotStatePromiseUserAddress = undefined;

--- a/packages/perps-controller/src/types/hyperliquid-types.ts
+++ b/packages/perps-controller/src/types/hyperliquid-types.ts
@@ -21,6 +21,19 @@ import type {
 } from '@nktkas/hyperliquid';
 
 /**
+ * HL account abstraction mode returned by the `userAbstraction` info endpoint.
+ * Re-exported here to keep HL-specific types centralised.
+ *
+ * `unifiedAccount` / `portfolioMargin`: spot is unified with perps;
+ * `withdraw3` draws from the unified ledger, spot folds into perps collateral.
+ *
+ * `disabled` (Standard) / `dexAbstraction` (deprecated) / `default` (unset):
+ * spot and perps are separate ledgers; spot is NOT auto-collateral until the
+ * user is migrated to unified mode.
+ */
+export type HyperLiquidAbstractionMode = UserAbstractionResponse;
+
+/**
  * Wire codes accepted by `agentSetAbstraction({ abstraction })`. The SDK
  * types these as a `"i" | "u" | "p"` literal union with no exported constant.
  *
@@ -43,23 +56,25 @@ export const HL_ABSTRACTION_WIRE = {
 export const HL_UNIFIED_ACCOUNT_MODE = 'unifiedAccount' as const;
 
 /**
- * True when the given HL abstraction mode treats spot balances as perps
- * collateral. Fail-CLOSED on missing mode: until userAbstraction has been
- * resolved we do not fold spot, because over-reporting withdrawable funds
- * for Standard / dexAbstraction users (which `withdraw3` cannot actually
- * draw) is worse than briefly under-reporting for Unified users during the
- * initial subscription window or a transient REST outage.
+ * True when the given HL abstraction mode treats spot USDC as perps collateral.
+ * Used by the provider + subscription service to gate `addSpotBalanceToAccountState`'s
+ * `foldIntoCollateral` option.
  *
- * @param mode - Abstraction mode returned by HyperLiquid.
- * @returns Whether spot balances should fold into perps collateral.
+ * Fail-CLOSED on missing mode: until userAbstraction has been resolved we do
+ * NOT fold spot, because over-reporting withdrawable funds for Standard /
+ * dexAbstraction users (which `withdraw3` cannot actually draw) is worse than
+ * briefly under-reporting for Unified users during the initial subscription
+ * window or a transient REST outage.
+ *
+ * @param mode - Abstraction mode from `userAbstraction` endpoint; null/undefined means unknown.
+ * @returns `true` when spot folds into spendable/withdrawable (Unified / Portfolio); `false` for Standard / DEX abstraction / unknown.
  */
 export function hyperLiquidModeFoldsSpot(
-  mode?: UserAbstractionResponse | null,
+  mode?: HyperLiquidAbstractionMode | null,
 ): boolean {
   if (mode === null || mode === undefined) {
     return false;
   }
-
   return mode === 'unifiedAccount' || mode === 'portfolioMargin';
 }
 

--- a/packages/perps-controller/src/types/index.ts
+++ b/packages/perps-controller/src/types/index.ts
@@ -212,12 +212,34 @@ export type Position = {
 
 // Using 'type' instead of 'interface' for BaseController Json compatibility
 export type AccountState = {
-  availableBalance: string; // Based on HyperLiquid: withdrawable
-  availableToTradeBalance?: string; // withdrawable + unreserved spot collateral (order-entry path)
-  totalBalance: string; // Based on HyperLiquid: accountValue
-  marginUsed: string; // Based on HyperLiquid: marginUsed
-  unrealizedPnl: string; // Based on HyperLiquid: unrealizedPnl
-  returnOnEquity: string; // Based on HyperLiquid: returnOnEquity adjusted for weighted margin
+  /**
+   * Total USD equity on this venue — collateral + unrealized PnL. Live MTM.
+   * HL: crossMarginSummary.accountValue + spot(USDC) − spot.hold
+   * MYX: walletBalance + marginUsed + unrealizedPnl
+   */
+  totalBalance: string;
+  /**
+   * Max USD that can immediately collateralize a new position on this venue,
+   * with no internal transfer required.
+   * HL Unified: withdrawable + freeSpotUSDC
+   * HL Standard: withdrawable
+   * MYX: walletBalance
+   */
+  spendableBalance: string;
+  /**
+   * Max USD that can leave this venue to the user's external wallet.
+   * UI reads this value without branching on provider; the provider
+   * contract guarantees HL's own abstraction (Unified) or the direct
+   * perps-clearinghouse (Standard) is what actually settles the
+   * withdraw — no client-side spot→perps sweep is performed.
+   * HL Unified: withdrawable + freeSpotUSDC (USDC only; `freeSpotUSDC = spot.total - spot.hold`, and HL withdraw3 draws from the unified ledger server-side)
+   * HL Standard: withdrawable (perps-clearinghouse only; spot is a separate ledger)
+   * MYX: walletBalance
+   */
+  withdrawableBalance: string;
+  marginUsed: string;
+  unrealizedPnl: string;
+  returnOnEquity: string;
   /**
    * Per-sub-account balance breakdown (protocol-specific, optional)
    * Maps sub-account identifier to its balance details.
@@ -233,7 +255,8 @@ export type AccountState = {
   subAccountBreakdown?: Record<
     string,
     {
-      availableBalance: string;
+      spendableBalance: string;
+      withdrawableBalance: string;
       totalBalance: string;
     }
   >;

--- a/packages/perps-controller/src/utils/accountUtils.ts
+++ b/packages/perps-controller/src/utils/accountUtils.ts
@@ -90,14 +90,6 @@ export function calculateWeightedReturnOnEquity(
   return weightedROE.toString();
 }
 
-export type AddSpotBalanceOptions = {
-  /**
-   * Whether the user's abstraction mode folds spot balances into perps
-   * collateral. Standard / DEX abstraction keep spot separate.
-   */
-  foldIntoCollateral?: boolean;
-};
-
 // The release-branch balance bridge is USDC-only. Non-USDC spot assets must
 // not inflate the balances shown or validated by withdraw/payment flows.
 const SPOT_COLLATERAL_COINS = new Set<string>(['USDC']);
@@ -140,6 +132,40 @@ export function getSpotHold(
   );
 }
 
+/**
+ * Options controlling how `addSpotBalanceToAccountState` folds spot balance
+ * into the three-field AccountState contract.
+ */
+export type AddSpotBalanceOptions = {
+  /**
+   * When `true`, free spot USDC contributes to both `spendableBalance` and
+   * `withdrawableBalance` in addition to `totalBalance` — appropriate for
+   * venues where spot is automatically used as perps collateral (e.g.
+   * HyperLiquid Unified/Portfolio mode, where `withdraw3` draws from the
+   * unified ledger).
+   *
+   * When `false`, free spot contributes to `totalBalance` only; spendable
+   * and withdrawable stay perps-only — appropriate for venues where spot
+   * is a separate ledger the backend cannot auto-draw from (e.g. HL
+   * Standard mode). The caller is responsible for translating
+   * provider-specific state into this flag.
+   *
+   * Defaults to `true` for backward compatibility with call sites that
+   * haven't yet been wired with provider-specific context.
+   */
+  foldIntoCollateral?: boolean;
+};
+
+/**
+ * Add spot USDC to the AccountState contract. Caller decides whether the
+ * spot balance counts as perps collateral via `options.foldIntoCollateral`
+ * — the util stays provider-agnostic.
+ *
+ * @param accountState - Base AccountState produced by a provider adapter.
+ * @param spotState - Raw spot clearinghouse response (HL-shaped); null or missing means no spot balance and the state is returned unchanged.
+ * @param options - See {@link AddSpotBalanceOptions}.
+ * @returns AccountState with spot folded into `totalBalance` always, and into spendable/withdrawable when `foldIntoCollateral` is true.
+ */
 export function addSpotBalanceToAccountState(
   accountState: AccountState,
   spotState?: SpotClearinghouseStateResponse | null,
@@ -149,12 +175,14 @@ export function addSpotBalanceToAccountState(
   // A caller that omits `options` should NOT silently fold spot — that would
   // over-report withdrawable funds for Standard / dexAbstraction users.
   const foldIntoCollateral = options?.foldIntoCollateral ?? false;
+
   const spotBalance = getSpotBalance(spotState);
   const spotHold = getSpotHold(spotState);
   const freeSpot = Math.max(0, spotBalance - spotHold);
 
   const currentTotal = parseFloat(accountState.totalBalance);
-  const currentAvailable = parseFloat(accountState.availableBalance);
+  const currentSpendable = parseFloat(accountState.spendableBalance);
+  const currentWithdrawable = parseFloat(accountState.withdrawableBalance);
 
   // Preserve sentinel totals (e.g. PERPS_CONSTANTS.FallbackDataDisplay '--')
   // rather than coercing them to NaN.
@@ -163,38 +191,63 @@ export function addSpotBalanceToAccountState(
   }
 
   if (spotBalance === 0) {
-    return {
-      ...accountState,
-      availableToTradeBalance: Number.isFinite(currentAvailable)
-        ? currentAvailable.toString()
-        : accountState.availableBalance,
-    };
+    // No spot wealth means no hold either in the HL payload shape, so the
+    // later totalBalance adjustment would also be a no-op.
+    return accountState;
   }
 
-  // Folding is gated strictly on the resolved abstraction mode. Standard /
-  // DEX-abstraction users keep perps and spot independent, so spot must NOT
-  // surface as a perps-withdrawable balance for them — withdraw3 only draws
-  // from the perps ledger in those modes. Unified / portfolio-margin users
-  // get the fold; live callers fail-CLOSED via `hyperLiquidModeFoldsSpot`
-  // when mode is unresolved (avoids over-reporting funds withdraw3 cannot
-  // actually draw during the initial subscription window).
-  let availableToTrade = accountState.availableBalance;
-  if (foldIntoCollateral) {
-    availableToTrade = Number.isFinite(currentAvailable)
-      ? (currentAvailable + freeSpot).toString()
-      : freeSpot.toString();
-  }
+  // Folding is gated strictly on the resolved abstraction mode (see callers'
+  // `foldIntoCollateral` argument). Standard / DEX-abstraction users keep
+  // perps and spot independent, so spot must NOT surface as a perps-
+  // withdrawable balance for them — withdraw3 only draws from the perps
+  // ledger in those modes. Unified / portfolio-margin users get the fold;
+  // live callers fail-CLOSED via `hyperLiquidModeFoldsSpot` when mode is
+  // unresolved.
+  const nextSpendable = resolveFoldedBalance(
+    currentSpendable,
+    accountState.spendableBalance,
+    freeSpot,
+    foldIntoCollateral,
+  );
+  const nextWithdrawable = resolveFoldedBalance(
+    currentWithdrawable,
+    accountState.withdrawableBalance,
+    freeSpot,
+    foldIntoCollateral,
+  );
 
-  // Subtract spotHold to avoid double-counting on Unified/PM accounts:
-  // marginSummary.accountValue already includes the margin that HL
-  // surfaces via spot.hold. Standard mode has spotHold = 0, no-op.
+  // Total always reflects combined wealth: subtract spotHold to avoid
+  // double-counting on Unified/PM accounts where marginSummary.accountValue
+  // already includes the margin that HL surfaces via spot.hold. Standard
+  // mode has spotHold = 0 by construction, so the subtraction is a no-op.
   const nextTotal = currentTotal + spotBalance - spotHold;
 
   return {
     ...accountState,
     totalBalance: nextTotal.toString(),
-    availableToTradeBalance: availableToTrade,
+    spendableBalance: nextSpendable,
+    withdrawableBalance: nextWithdrawable,
   };
+}
+
+function resolveFoldedBalance(
+  currentNumeric: number,
+  currentRaw: string,
+  freeSpot: number,
+  foldIntoCollateral: boolean,
+): string {
+  if (!foldIntoCollateral) {
+    return currentRaw;
+  }
+  if (Number.isFinite(currentNumeric)) {
+    return (currentNumeric + freeSpot).toString();
+  }
+  // Non-finite currentNumeric means the adapter passed a sentinel like
+  // `PERPS_CONSTANTS.FallbackDataDisplay` ("--") during loading. Preserve
+  // the sentinel rather than synthesising a numeric fold; the caller's
+  // UI treats "--" as "loading" and would otherwise show a misleading
+  // spot-only figure while the per-DEX perps fetch is still in flight.
+  return currentRaw;
 }
 
 /**
@@ -206,7 +259,8 @@ export function addSpotBalanceToAccountState(
  */
 export function aggregateAccountStates(states: AccountState[]): AccountState {
   const fallback: AccountState = {
-    availableBalance: PERPS_CONSTANTS.FallbackDataDisplay,
+    spendableBalance: PERPS_CONSTANTS.FallbackDataDisplay,
+    withdrawableBalance: PERPS_CONSTANTS.FallbackDataDisplay,
     totalBalance: PERPS_CONSTANTS.FallbackDataDisplay,
     marginUsed: PERPS_CONSTANTS.FallbackDataDisplay,
     unrealizedPnl: PERPS_CONSTANTS.FallbackDataDisplay,
@@ -221,25 +275,15 @@ export function aggregateAccountStates(states: AccountState[]): AccountState {
     if (index === 0) {
       return { ...state };
     }
-    const accAvailableToTrade = parseFloat(
-      acc.availableToTradeBalance ?? acc.availableBalance,
-    );
-    const stateAvailableToTrade = parseFloat(
-      state.availableToTradeBalance ?? state.availableBalance,
-    );
-    const availableToTradeSum =
-      Number.isFinite(accAvailableToTrade) &&
-      Number.isFinite(stateAvailableToTrade)
-        ? (accAvailableToTrade + stateAvailableToTrade).toString()
-        : undefined;
 
     return {
-      availableBalance: (
-        parseFloat(acc.availableBalance) + parseFloat(state.availableBalance)
+      spendableBalance: (
+        parseFloat(acc.spendableBalance) + parseFloat(state.spendableBalance)
       ).toString(),
-      ...(availableToTradeSum !== undefined && {
-        availableToTradeBalance: availableToTradeSum,
-      }),
+      withdrawableBalance: (
+        parseFloat(acc.withdrawableBalance) +
+        parseFloat(state.withdrawableBalance)
+      ).toString(),
       totalBalance: (
         parseFloat(acc.totalBalance) + parseFloat(state.totalBalance)
       ).toString(),

--- a/packages/perps-controller/src/utils/hyperLiquidAdapter.ts
+++ b/packages/perps-controller/src/utils/hyperLiquidAdapter.ts
@@ -290,9 +290,10 @@ export function adaptAccountStateFromSDK(
 
   const perpsBalance = parseFloat(perpsState.marginSummary.accountValue);
 
+  const withdrawable = perpsState.withdrawable || '0';
   const accountState: AccountState = {
-    availableBalance: perpsState.withdrawable || '0',
-    availableToTradeBalance: perpsState.withdrawable || '0',
+    spendableBalance: withdrawable,
+    withdrawableBalance: withdrawable,
     totalBalance: perpsBalance.toString() || '0',
     marginUsed: perpsState.marginSummary.totalMarginUsed || '0',
     unrealizedPnl: totalUnrealizedPnl.toString() || '0',

--- a/packages/perps-controller/src/utils/hyperLiquidValidation.ts
+++ b/packages/perps-controller/src/utils/hyperLiquidValidation.ts
@@ -288,30 +288,30 @@ export function validateAssetSupport(
  * Validate balance against withdrawal amount.
  *
  * @param withdrawAmount - The amount to withdraw
- * @param availableBalance - The available balance
+ * @param withdrawableBalance - Max USD that can leave the venue right now
  * @param debugLogger - Optional debug logger for detailed logging
  * @returns Validation result with isValid flag and optional error message
  */
 export function validateBalance(
   withdrawAmount: number,
-  availableBalance: number,
+  withdrawableBalance: number,
   debugLogger?: ValidationDebugLogger,
 ): { isValid: boolean; error?: string } {
   debugLogger?.log('validateBalance: Checking balance sufficiency', {
     withdrawAmount,
-    availableBalance,
-    difference: availableBalance - withdrawAmount,
+    withdrawableBalance,
+    difference: withdrawableBalance - withdrawAmount,
   });
 
-  if (withdrawAmount > availableBalance) {
-    const shortfall = withdrawAmount - availableBalance;
+  if (withdrawAmount > withdrawableBalance) {
+    const shortfall = withdrawAmount - withdrawableBalance;
 
     debugLogger?.log('validateBalance: Insufficient balance', {
       error: PERPS_ERROR_CODES.WITHDRAW_INSUFFICIENT_BALANCE,
       withdrawAmount,
-      availableBalance,
+      withdrawableBalance,
       shortfall,
-      percentageOfAvailable: `${((withdrawAmount / availableBalance) * 100).toFixed(2)}%`,
+      percentageOfAvailable: `${((withdrawAmount / withdrawableBalance) * 100).toFixed(2)}%`,
     });
 
     return {
@@ -320,12 +320,12 @@ export function validateBalance(
     };
   }
 
-  const remainingBalance = availableBalance - withdrawAmount;
+  const remainingBalance = withdrawableBalance - withdrawAmount;
   debugLogger?.log('validateBalance: Balance is sufficient', {
     withdrawAmount,
-    availableBalance,
+    withdrawableBalance,
     remainingBalance,
-    percentageUsed: `${((withdrawAmount / availableBalance) * 100).toFixed(2)}%`,
+    percentageUsed: `${((withdrawAmount / withdrawableBalance) * 100).toFixed(2)}%`,
   });
 
   return { isValid: true };

--- a/packages/perps-controller/src/utils/myxAdapter.ts
+++ b/packages/perps-controller/src/utils/myxAdapter.ts
@@ -462,10 +462,10 @@ export function adaptAccountStateFromMYX(
   const balance = walletBalance ? fromMYXCollateral(walletBalance) : 0;
 
   const totalBalance = balance + marginUsed + unrealizedPnl;
-  const availableBalance = balance;
 
   return {
-    availableBalance: availableBalance.toString(),
+    spendableBalance: balance.toString(),
+    withdrawableBalance: balance.toString(),
     totalBalance: totalBalance.toString(),
     marginUsed: marginUsed.toString(),
     unrealizedPnl: unrealizedPnl.toString(),

--- a/packages/perps-controller/src/utils/orderCalculations.ts
+++ b/packages/perps-controller/src/utils/orderCalculations.ts
@@ -30,7 +30,7 @@ type MarginRequiredParams = {
 };
 
 type MaxAllowedAmountParams = {
-  availableBalance: number;
+  spendableBalance: number;
   assetPrice: number;
   assetSzDecimals: number;
   leverage: number;
@@ -146,13 +146,13 @@ export function calculateMarginRequired(params: MarginRequiredParams): string {
 }
 
 export function getMaxAllowedAmount(params: MaxAllowedAmountParams): number {
-  const { availableBalance, assetPrice, assetSzDecimals, leverage } = params;
-  if (availableBalance === 0 || !assetPrice || assetSzDecimals === undefined) {
+  const { spendableBalance, assetPrice, assetSzDecimals, leverage } = params;
+  if (spendableBalance === 0 || !assetPrice || assetSzDecimals === undefined) {
     return 0;
   }
 
-  // The theoretical maximum is simply availableBalance * leverage
-  const theoreticalMax = availableBalance * leverage;
+  // The theoretical maximum is simply spendableBalance * leverage
+  const theoreticalMax = spendableBalance * leverage;
 
   // But we need to account for position size rounding
   // Find the largest whole dollar amount that fits within this limit
@@ -169,7 +169,7 @@ export function getMaxAllowedAmount(params: MaxAllowedAmountParams): number {
   const requiredMargin = actualNotionalValue / leverage;
 
   // If rounding caused us to exceed available balance, step down by one position increment
-  if (requiredMargin > availableBalance) {
+  if (requiredMargin > spendableBalance) {
     const minPositionSizeIncrement = 1 / Math.pow(10, assetSzDecimals);
     const positionSizeIncrementUsd = Math.ceil(
       minPositionSizeIncrement * assetPrice,


### PR DESCRIPTION
## Explanation

Syncs `app/controllers/perps/` from MetaMask Mobile commit `355c9b656b` to `packages/perps-controller/src/`.

### Key changes

- **BREAKING: AccountState balance rename** — `availableBalance` → `spendableBalance`, `availableToTradeBalance` → `withdrawableBalance` for clearer semantics across HL abstraction modes (Unified, Standard, Portfolio)
- **Mode-aware spot fold** — `addSpotBalanceToAccountState` now folds free spot USDC into both `spendableBalance` and `withdrawableBalance` for Unified/Portfolio modes, while Standard/DEX-abstraction modes keep spot separate
- **Throttled WS-driven `userAbstraction` refresh** — HL-web mode flips (Unified ↔ Standard) now propagate back without requiring a restart or account switch

### Mobile PRs included

- [refactor(perps): split AccountState balances + mode-aware spot fold (#29303)](https://github.com/MetaMask/metamask-mobile/pull/29303)
- [feat(perps): force unified account (#29492)](https://github.com/MetaMask/metamask-mobile/pull/29492)

### Files changed (12 source files)

- `constants/hyperLiquidConfig.ts` — minor config tweak
- `constants/perpsConfig.ts` — add `ABSTRACTION_MODE_REFRESH_THROTTLE_MS`
- `providers/HyperLiquidProvider.ts` — balance field renames, mode-aware fold
- `providers/MYXProvider.ts` — balance field renames
- `services/HyperLiquidSubscriptionService.ts` — per-user abstraction mode maps, throttled WS refresh, balance renames
- `types/hyperliquid-types.ts` — new types for abstraction mode handling
- `types/index.ts` — `AccountState` field renames with JSDoc
- `utils/accountUtils.ts` — `addSpotBalanceToAccountState` refactor with `resolveFoldedBalance` helper
- `utils/hyperLiquidAdapter.ts` — balance field renames
- `utils/hyperLiquidValidation.ts` — balance field renames
- `utils/myxAdapter.ts` — balance field renames
- `utils/orderCalculations.ts` — balance field renames

### Suppressions

1 new ESLint suppression: `@typescript-eslint/no-unused-vars` in `HyperLiquidSubscriptionService.ts` — caused by core's `no-unnecessary-type-assertion` rule removing a `as Promise<UserAbstractionResponse>` cast that mobile has, leaving the import unused. Total perps suppression count: 9.

## References

- Sync state: `.sync-state.json` updated to mobile commit `355c9b656b`
- Sync script: `scripts/perps/validate-core-sync.sh`

## Changelog

See `packages/perps-controller/CHANGELOG.md` — entries added under `## [Unreleased]`.

**Note:** CHANGELOG PR links use `#NNNN` placeholder — will be updated with this PR's number after creation.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces **breaking** changes to the `AccountState` contract and adjusts HyperLiquid balance/withdraw validation and spot-collateral folding based on abstraction mode, which can directly affect displayed balances and allowed withdrawals/orders.
> 
> **Overview**
> **BREAKING:** Renames `AccountState` balance fields to `spendableBalance` and `withdrawableBalance` and updates all perps providers/adapters/calculations/validation to use the new semantics (including per-subaccount breakdown and cache hashing).
> 
> Makes spot USDC folding *mode-aware*: `addSpotBalanceToAccountState` now always impacts `totalBalance`, and only contributes to `spendableBalance`/`withdrawableBalance` when `userAbstraction` indicates Unified/Portfolio mode; disk cache key is bumped to `PERPS_DISK_CACHE_USER_DATA_V2` to avoid stale legacy payloads.
> 
> Improves live mode handling by adding a throttled, per-user WS-triggered `userAbstraction` refresh in `HyperLiquidSubscriptionService` so HL-web mode flips propagate without restart/account switch, and adds a guard in `HyperLiquidProvider.updateIsolatedMargin` to ensure `spendableBalance` covers margin additions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a26383f78f9f52880b0b36ca2dc7feeb3554b526. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->