### PR TITLE
Fix update-changelogs workflow

### DIFF
--- a/.github/workflows/update-changelogs.yml
+++ b/.github/workflows/update-changelogs.yml
@@ -132,7 +132,7 @@ jobs:
         run: |
           git fetch --no-tags origin "$PR_HEAD_SHA"
           git fetch --no-tags origin "$PR_BASE_REF"
-          git checkout "$PR_HEAD_SHA" -- '**/CHANGELOG.md'
+          git checkout --detach "$PR_HEAD_SHA"
 
       - name: Ensure required dependency bump entries exist across all changelogs
         id: update-changelogs

--- a/.github/workflows/update-changelogs.yml
+++ b/.github/workflows/update-changelogs.yml
@@ -112,53 +112,91 @@ jobs:
     if: ${{ needs.is-release.outputs.is-release == 'true' }}
     runs-on: ubuntu-latest
     environment: default-branch
-    env:
-      PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
     steps:
-      - name: Checkout repository
+      - name: Check out the base ref
         uses: actions/checkout@v6
         with:
+          ref: ${{ needs.is-release.outputs.base-ref }}
           token: ${{ secrets.UPDATE_CHANGELOG_TOKEN }}
 
-      - name: Checkout pull request
-        env:
-          PR_HEAD_SHA: ${{ needs.is-release.outputs.head-sha }}
-          PR_BASE_REF: ${{ needs.is-release.outputs.base-ref }}
-        run: |
-          git fetch --no-tags origin "$PR_HEAD_SHA"
-          git fetch --no-tags origin "$PR_BASE_REF"
-          git checkout --detach "$PR_HEAD_SHA"
+      - name: Detach HEAD (to prevent accidental pushes)
+        run: git checkout --detach HEAD
 
       - name: Setup environment
         uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
 
+      - name: Overlay changelogs from current pull request
+        env:
+          PR_HEAD_SHA: ${{ needs.is-release.outputs.head-sha }}
+          PR_HEAD_REF: ${{ needs.is-release.outputs.head-ref }}
+        run: |
+          # These next two commands are also useful later when pushing
+          git fetch --no-tags origin "$PR_HEAD_SHA"
+          git fetch --no-tags origin "$PR_HEAD_REF"
+          git checkout "$PR_HEAD_SHA" -- '**/CHANGELOG.md'
+        shell: bash
+
+      - name: Configure Git with name and email
+        run: |
+          # This is necessary to make a commit
+          # Passing `token` to the `checkout` action does not do this for us
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        shell: bash
+
+      - name: Commit changelogs from current pull request
+        run: |
+          git add -- '**/CHANGELOG.md'
+          git commit -m "[Temporary] Add changelogs from current pull request"
+        shell: bash
+
       - name: Ensure required dependency bump entries exist across all changelogs
         id: update-changelogs
         env:
+          PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
           MERGE_BASE: ${{ needs.is-release.outputs.merge-base }}
-        run: yarn changelog:validate --checkDeps --fix --currentPr "$PR_NUMBER" --fromRef "$MERGE_BASE"
-        continue-on-error: true
-
-      - name: Commit and push updated changelogs
-        id: push-changes
-        env:
-          PR_HEAD_REF: ${{ needs.is-release.outputs.head-ref }}
         run: |
+          yarn changelog:validate --checkDeps --fix --currentPr "$PR_NUMBER" --fromRef "$MERGE_BASE"
           if git diff --quiet; then
-            echo "changes-pushed=false" >> "$GITHUB_OUTPUT"
+            echo "changelogs-updated=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          echo "changelogs-updated=true" >> "$GITHUB_OUTPUT"
+        shell: bash
 
-          git diff --stat
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - name: Commit updated changelogs
+        if: ${{ steps.update-changelogs.outputs.changelogs-updated == 'true' }}
+        id: commit-updated-changelogs
+        run: |
           git add -- '**/CHANGELOG.md'
           git commit -m "chore: Update dependency bump changelog entries"
-          git push origin "HEAD:$PR_HEAD_REF"
+          new_commit_id="$(git log -1 --pretty='format:%h')"
+          echo "new-commit-id=${new_commit_id}" >> "$GITHUB_OUTPUT"
+        shell: bash
 
-          echo "changes-pushed=true" >> "$GITHUB_OUTPUT"
+      - name: Check out pull request completely
+        env:
+          PR_HEAD_SHA: ${{ needs.is-release.outputs.head-sha }}
+        run: |
+          git checkout "$PR_HEAD_SHA"
+        shell: bash
+
+      - name: Cherry-pick new commit and push it
+        id: push-changes
+        env:
+          NEW_COMMIT_ID: ${{ steps.commit-updated-changelogs.outputs.new-commit-id }}
+          PR_HEAD_REF: ${{ needs.is-release.outputs.head-ref }}
+        run: |
+          if [[ -n "$NEW_COMMIT_ID" ]]; then
+            git cherry-pick "$NEW_COMMIT_ID"
+            git push origin "HEAD:$PR_HEAD_REF"
+            echo "changes-pushed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changes-pushed=false" >> "$GITHUB_OUTPUT"
+          fi
+        shell: bash
 
       - name: Comment result
         if: always()

--- a/.github/workflows/update-changelogs.yml
+++ b/.github/workflows/update-changelogs.yml
@@ -113,16 +113,16 @@ jobs:
     runs-on: ubuntu-latest
     environment: default-branch
     steps:
-      - name: Check out the base ref
+      - name: Check out the base branch
         uses: actions/checkout@v6
         with:
-          ref: ${{ needs.is-release.outputs.base-ref }}
+          ref: ${{ needs.is-release.outputs.merge-base }}
           token: ${{ secrets.UPDATE_CHANGELOG_TOKEN }}
 
       - name: Detach HEAD (to prevent accidental pushes)
         run: git checkout --detach HEAD
 
-      - name: Setup environment
+      - name: Set up environment
         uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false

--- a/.github/workflows/update-changelogs.yml
+++ b/.github/workflows/update-changelogs.yml
@@ -115,17 +115,12 @@ jobs:
     env:
       PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
     steps:
-      - name: Checkout main
+      - name: Checkout repository
         uses: actions/checkout@v6
         with:
           token: ${{ secrets.UPDATE_CHANGELOG_TOKEN }}
 
-      - name: Setup environment
-        uses: MetaMask/action-checkout-and-setup@v3
-        with:
-          is-high-risk-environment: false
-
-      - name: Overlay changelog files from current PR
+      - name: Checkout pull request
         env:
           PR_HEAD_SHA: ${{ needs.is-release.outputs.head-sha }}
           PR_BASE_REF: ${{ needs.is-release.outputs.base-ref }}
@@ -133,6 +128,11 @@ jobs:
           git fetch --no-tags origin "$PR_HEAD_SHA"
           git fetch --no-tags origin "$PR_BASE_REF"
           git checkout --detach "$PR_HEAD_SHA"
+
+      - name: Setup environment
+        uses: MetaMask/action-checkout-and-setup@v3
+        with:
+          is-high-risk-environment: false
 
       - name: Ensure required dependency bump entries exist across all changelogs
         id: update-changelogs

--- a/.github/workflows/update-changelogs.yml
+++ b/.github/workflows/update-changelogs.yml
@@ -183,6 +183,7 @@ jobs:
         id: push-changes
         env:
           NEW_COMMIT_ID: ${{ steps.commit-updated-changelogs.outputs.new-commit-id }}
+          PR_HEAD_SHA: ${{ needs.is-release.outputs.head-sha }}
           PR_HEAD_REF: ${{ needs.is-release.outputs.head-ref }}
         run: |
           if [[ -n "$NEW_COMMIT_ID" ]]; then

--- a/.github/workflows/update-changelogs.yml
+++ b/.github/workflows/update-changelogs.yml
@@ -159,37 +159,34 @@ jobs:
           MERGE_BASE: ${{ needs.is-release.outputs.merge-base }}
         run: |
           yarn changelog:validate --checkDeps --fix --currentPr "$PR_NUMBER" --fromRef "$MERGE_BASE"
-          if git diff --quiet; then
-            echo "changelogs-updated=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "changelogs-updated=true" >> "$GITHUB_OUTPUT"
         shell: bash
+        # If changelogs were updated but there were other validation errors
+        # found, we need to still create a commit below
+        continue-on-error: true
 
       - name: Commit updated changelogs
-        if: ${{ steps.update-changelogs.outputs.changelogs-updated == 'true' }}
         id: commit-updated-changelogs
         run: |
+          if git diff --quiet; then
+            # Nothing to commit; no changelogs updated
+            exit 0
+          fi
+
           git add -- '**/CHANGELOG.md'
           git commit -m "chore: Update dependency bump changelog entries"
+
           new_commit_id="$(git log -1 --pretty='format:%h')"
           echo "new-commit-id=${new_commit_id}" >> "$GITHUB_OUTPUT"
         shell: bash
 
-      - name: Check out pull request completely
-        env:
-          PR_HEAD_SHA: ${{ needs.is-release.outputs.head-sha }}
-        run: |
-          git checkout "$PR_HEAD_SHA"
-        shell: bash
-
-      - name: Cherry-pick new commit and push it
+      - name: Cherry-pick new commit on top of pull request branch and push it
         id: push-changes
         env:
           NEW_COMMIT_ID: ${{ steps.commit-updated-changelogs.outputs.new-commit-id }}
           PR_HEAD_REF: ${{ needs.is-release.outputs.head-ref }}
         run: |
           if [[ -n "$NEW_COMMIT_ID" ]]; then
+            git checkout "$PR_HEAD_SHA"
             git cherry-pick "$NEW_COMMIT_ID"
             git push origin "HEAD:$PR_HEAD_REF"
             echo "changes-pushed=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/update-changelogs.yml
+++ b/.github/workflows/update-changelogs.yml
@@ -4,11 +4,11 @@ on:
   issue_comment:
     types:
       - created
-#  pull_request:
-#    branches:
-#      - main
-#    types:
-#      - opened
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - opened
 
 permissions:
   contents: write
@@ -17,7 +17,7 @@ permissions:
 jobs:
   is-fork:
     name: Determine whether this PR is from a fork
-    if: github.event_name == 'pull_request' || (github.event.issue.pull_request && startsWith(github.event.comment.body, '@metamaskbot update-changelogs'))
+    if: github.event_name == 'pull_request_target' || (github.event.issue.pull_request && startsWith(github.event.comment.body, '@metamaskbot update-changelogs'))
     runs-on: ubuntu-latest
     outputs:
       is-fork: ${{ steps.is-fork.outputs.is-fork }}
@@ -115,24 +115,24 @@ jobs:
     env:
       PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
     steps:
-      - name: Checkout repository
+      - name: Checkout main
         uses: actions/checkout@v6
         with:
           token: ${{ secrets.UPDATE_CHANGELOG_TOKEN }}
 
-      - name: Checkout pull request
+      - name: Setup environment
+        uses: MetaMask/action-checkout-and-setup@v3
+        with:
+          is-high-risk-environment: false
+
+      - name: Overlay changelog files from current PR
         env:
           PR_HEAD_SHA: ${{ needs.is-release.outputs.head-sha }}
           PR_BASE_REF: ${{ needs.is-release.outputs.base-ref }}
         run: |
           git fetch --no-tags origin "$PR_HEAD_SHA"
           git fetch --no-tags origin "$PR_BASE_REF"
-          git checkout --detach "$PR_HEAD_SHA"
-
-      - name: Setup environment
-        uses: MetaMask/action-checkout-and-setup@v3
-        with:
-          is-high-risk-environment: false
+          git checkout "$PR_HEAD_SHA" -- '**/CHANGELOG.md'
 
       - name: Ensure required dependency bump entries exist across all changelogs
         id: update-changelogs


### PR DESCRIPTION
The `update-changelogs` workflow is designed to run automatically and manually (in response to a `metamaskbot` comment on a release PR).

Currently, the manual run succeeds, but the automatic run does not. We use the `default-branch` environment for commands in this workflow as we need a tightly-scoped token that to push to the PR branch. The problem is that our use of the `pull_request` event for automatic runs and our use of the `default-branch` environment conflict with each other and trigger our branch protection rules (the `default-branch` is scoped to the `main` branch, not pull request branches). 

To fix this, instead of `pull_request`, we use the `pull_request_target` event. This event runs against the default branch, and so it should match the same scope as the `default-branch` environment and satisfy the branch protection rules we have in place. However, as this is a dangerous event — [GitHub recommends against it](https://docs.github.com/en/enterprise-cloud@latest/actions/reference/security/secure-use#mitigating-the-risks-of-untrusted-code-checkout) — we have to be careful not to allow commands to run directly against a pull request branch.

So, we modify the workflow to follow this plan:

1. Check out the PR base branch (usually `main`)
2. Set up Node, install Yarn + dependencies
3. Overlay changelogs from the PR branch
4. Create a temporary commit to clear the working index
5. Update changelogs with dependency bumps as needed
6. Make a new commit
7. Check out the pull request branch completely (overwriting the base branch)
8. Cherry-pick the new commit on to it
9. Push the pull request branch
10. Done!

## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

https://consensyssoftware.atlassian.net/browse/WPC-997

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes a privileged `pull_request_target` workflow that checks out refs and pushes commits to PR branches; misconfiguration could create a security or branch-protection bypass.
> 
> **Overview**
> Updates `.github/workflows/update-changelogs.yml` to trigger on `pull_request_target` (instead of `pull_request`) so the workflow runs against `main` while using the `default-branch` environment/token.
> 
> Reworks the changelog update flow to **avoid running untrusted PR code**: check out the merge base, detach `HEAD`, overlay only `**/CHANGELOG.md` from the PR, commit those as a temporary baseline, run `yarn changelog:validate --checkDeps --fix` with `continue-on-error`, then commit any resulting changelog fixes and **cherry-pick/push** that commit onto the PR head SHA/ref.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68a9155ac56ed6c62f5381bc4490600b1e54fc59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->