### PR TITLE
fix(assets-controllers): only seed mUSD on chains configured in NetworkController

### DIFF
--- a/packages/assets-controllers/src/TokensController.test.ts
+++ b/packages/assets-controllers/src/TokensController.test.ts
@@ -26,6 +26,7 @@ import type {
   NetworkState,
 } from '@metamask/network-controller';
 import { getDefaultNetworkControllerState } from '@metamask/network-controller';
+import type { Hex } from '@metamask/utils';
 import type { Patch } from 'immer';
 import nock from 'nock';
 import { v1 as uuidV1 } from 'uuid';
@@ -4324,6 +4325,73 @@ describe('TokensController', () => {
       });
     });
 
+    describe('when NetworkController has not configured every supported chain', () => {
+      it('only seeds mUSD on chains currently configured in NetworkController', async () => {
+        const account = createMockInternalAccount({
+          address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        });
+
+        await withController(
+          // Only mainnet is configured in NetworkController
+          { listAccounts: [account], configuredChainIds: ['0x1'] },
+          ({ controller }) => {
+            expect(
+              controller.state.allTokens['0x1'][account.address],
+            ).toContainEqual(MUSD_TOKEN);
+            expect(controller.state.allTokens['0xe708']).toBeUndefined();
+            expect(controller.state.allTokens['0x8f']).toBeUndefined();
+          },
+        );
+      });
+
+      it('does not seed mUSD when none of the supported chains are configured', async () => {
+        const account = createMockInternalAccount({
+          address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        });
+
+        await withController(
+          { listAccounts: [account], configuredChainIds: [] },
+          ({ controller }) => {
+            expect(controller.state.allTokens).toStrictEqual({});
+          },
+        );
+      });
+
+      it('does not seed mUSD when NetworkController state lacks networkConfigurationsByChainId', async () => {
+        const account = createMockInternalAccount({
+          address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        });
+
+        await withController(
+          { listAccounts: [account], configuredChainIds: null },
+          ({ controller }) => {
+            expect(controller.state.allTokens).toStrictEqual({});
+          },
+        );
+      });
+
+      it('does not seed a supported chainId fired via networkAdded when NetworkController has not configured it yet', async () => {
+        const account = createMockInternalAccount({
+          address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        });
+
+        await withController(
+          // Only Linea is configured in NetworkController.
+          { listAccounts: [account], configuredChainIds: ['0xe708'] },
+          ({ controller, triggerNetworkAdded }) => {
+            expect(
+              controller.state.allTokens['0xe708'][account.address],
+            ).toContainEqual(MUSD_TOKEN);
+
+            // Even though `0x1` is in MUSD_SUPPORTED_CHAIN_IDS, seeding
+            // respects the configured chain set reported by NetworkController.
+            triggerNetworkAdded('0x1');
+            expect(controller.state.allTokens['0x1']).toBeUndefined();
+          },
+        );
+      });
+    });
+
     describe('when NetworkController:stateChange patch adds a supported chain', () => {
       it('seeds mUSD for all accounts', async () => {
         const account = createMockInternalAccount({
@@ -4422,6 +4490,16 @@ type WithControllerArgs<ReturnValue> =
         >;
         mocks?: WithControllerMockArgs;
         listAccounts?: InternalAccount[];
+        /**
+         * The set of chain IDs to report as currently configured in
+         * `NetworkController` when the `NetworkController:getState` action is
+         * invoked. Defaults to all mUSD-supported chains so existing tests
+         * see seeding behave as if every chain is configured.
+         *
+         * Pass `null` to simulate `NetworkController:getState` returning a
+         * state object without a `networkConfigurationsByChainId` property.
+         */
+        configuredChainIds?: Hex[] | null;
       },
       WithControllerCallback<ReturnValue>,
     ];
@@ -4448,6 +4526,7 @@ async function withController<ReturnValue>(
       mockNetworkClientConfigurationsByNetworkClientId = {},
       mocks = {} as WithControllerMockArgs,
       listAccounts = [],
+      configuredChainIds = ['0x1', '0xe708', '0x8f'],
     },
     fn,
   ] = args.length === 2 ? args : [{}, args[0]];
@@ -4485,6 +4564,7 @@ async function withController<ReturnValue>(
     actions: [
       'ApprovalController:addRequest',
       'NetworkController:getNetworkClientById',
+      'NetworkController:getState',
       'AccountsController:getAccount',
       'AccountsController:getSelectedAccount',
       'AccountsController:listAccounts',
@@ -4521,6 +4601,37 @@ async function withController<ReturnValue>(
   messenger.registerActionHandler(
     'AccountsController:listAccounts',
     mockListAccounts,
+  );
+
+  const networkControllerStateMock: NetworkState =
+    configuredChainIds === null
+      ? // Simulate a NetworkController state object that is missing the
+        // `networkConfigurationsByChainId` property altogether.
+        ({
+          ...getDefaultNetworkControllerState(),
+          networkConfigurationsByChainId:
+            undefined as unknown as NetworkState['networkConfigurationsByChainId'],
+        } as NetworkState)
+      : {
+          ...getDefaultNetworkControllerState(),
+          networkConfigurationsByChainId:
+            configuredChainIds.reduce<
+              NetworkState['networkConfigurationsByChainId']
+            >((acc, chainId) => {
+              acc[chainId] = {
+                chainId,
+                blockExplorerUrls: [],
+                defaultRpcEndpointIndex: 0,
+                name: `Network ${chainId}`,
+                nativeCurrency: 'ETH',
+                rpcEndpoints: [],
+              } as never;
+              return acc;
+            }, {}),
+        };
+  messenger.registerActionHandler(
+    'NetworkController:getState',
+    () => networkControllerStateMock,
   );
 
   const controller = new TokensController({

--- a/packages/assets-controllers/src/TokensController.ts
+++ b/packages/assets-controllers/src/TokensController.ts
@@ -36,6 +36,7 @@ import { abiERC721 } from '@metamask/metamask-eth-abis';
 import type {
   NetworkClientId,
   NetworkControllerGetNetworkClientByIdAction,
+  NetworkControllerGetStateAction,
   NetworkControllerNetworkAddedEvent,
   NetworkControllerNetworkDidChangeEvent,
   NetworkControllerStateChangeEvent,
@@ -152,6 +153,7 @@ export type TokensControllerActions =
 export type AllowedActions =
   | ApprovalControllerAddRequestAction
   | NetworkControllerGetNetworkClientByIdAction
+  | NetworkControllerGetStateAction
   | AccountsControllerGetAccountAction
   | AccountsControllerGetSelectedAccountAction
   | AccountsControllerListAccountsAction;
@@ -1244,8 +1246,18 @@ export class TokensController extends BaseController<
       return;
     }
 
+    // Only seed for chains that are actually configured in NetworkController.
+    // The `NetworkController:networkAdded` subscriber re-runs seeding when a
+    // supported chain is added later, so this preserves correctness without
+    // emitting state changes for chainIds downstream subscribers (e.g.
+    // TokenRatesController) cannot resolve.
+    const configuredChainIds = this.#getConfiguredMusdChainIds();
+    if (configuredChainIds.length === 0) {
+      return;
+    }
+
     this.update((state) => {
-      for (const chainId of MUSD_SUPPORTED_CHAIN_IDS) {
+      for (const chainId of configuredChainIds) {
         state.allTokens[chainId] ??= {};
         const accountTokens = state.allTokens[chainId][accountAddress] ?? [];
         const alreadyPresent = accountTokens.some(
@@ -1259,6 +1271,36 @@ export class TokensController extends BaseController<
         }
       }
     });
+  }
+
+  /**
+   * Returns the subset of `MUSD_SUPPORTED_CHAIN_IDS` that are currently
+   * configured in `NetworkController`. Returns an empty array if the
+   * NetworkController state is unavailable.
+   * 
+   * @returns The subset of `MUSD_SUPPORTED_CHAIN_IDS` that are currently configured in `NetworkController`.
+   */
+  #getConfiguredMusdChainIds(): Hex[] {
+    let networkConfigurationsByChainId:
+      | NetworkState['networkConfigurationsByChainId']
+      | undefined;
+    try {
+      ({ networkConfigurationsByChainId } = this.messenger.call(
+        'NetworkController:getState',
+      ));
+    } catch {
+      return [];
+    }
+    if (!networkConfigurationsByChainId) {
+      return [];
+    }
+    const configured: Hex[] = [];
+    for (const chainId of MUSD_SUPPORTED_CHAIN_IDS) {
+      if (networkConfigurationsByChainId[chainId]) {
+        configured.push(chainId);
+      }
+    }
+    return configured;
   }
 
   /**


### PR DESCRIPTION
…rkController

`TokensController` previously seeded mUSD into `allTokens` for every chain in `MUSD_SUPPORTED_CHAIN_IDS` regardless of whether `NetworkController` had actually configured that chain. This caused state updates with chainIds that downstream subscribers (e.g. `TokenRatesController`) could not resolve.

Look up the configured chain set via the new `NetworkController:getState` allowed action and intersect it with `MUSD_SUPPORTED_CHAIN_IDS` before seeding. The existing `NetworkController:networkAdded` and `NetworkController:stateChange` subscribers continue to re-run seeding so newly added supported chains are picked up automatically.

The test harness now registers a `NetworkController:getState` handler returning all three supported chains by default, with an opt-in `configuredChainIds` option (incl. `null` for missing `networkConfigurationsByChainId`) to drive the new behavior in tests.

## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them
