### PR TITLE
fix: add mUSD to assets controllers

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -471,6 +471,9 @@
     }
   },
   "packages/assets-controllers/src/TokensController.test.ts": {
+    "@typescript-eslint/explicit-function-return-type": {
+      "count": 6
+    },
     "no-restricted-syntax": {
       "count": 4
     }

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Switch the default mUSD asset from upfront `allTokens` state seeding to detection-based discovery on Ethereum mainnet (`0x1`), Linea (`0xe708`), and Monad mainnet (`0x8f`)
+- Switch the default mUSD asset from upfront `allTokens` state seeding to detection-based discovery on Ethereum mainnet (`0x1`), Linea (`0xe708`), and Monad mainnet (`0x8f`) ([#8688](https://github.com/MetaMask/core/pull/8688))
   - `TokenDetectionController` now merges mUSD into the in-memory token list cache for these chains so it is treated as a regular detection candidate, replacing the previous `start()`-time `TokensController:addTokens` call and the per-event re-seed runs.
   - `TokenBalancesController` schedules mUSD for import on the same chains even when the Accounts API returns a zero balance, so users without a current mUSD balance still see the token.
   - Drops Monad testnet (`0x279f`) from the default mUSD chain list.
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- Stop seeding mUSD directly into `TokensController` state and remove the related event subscriptions
+- Stop seeding mUSD directly into `TokensController` state and remove the related event subscriptions ([#8688](https://github.com/MetaMask/core/pull/8688))
   - `TokensController` no longer subscribes to `KeyringController:unlock`, `AccountsController:accountAdded`, `AccountsController:selectedEvmAccountChange`, `NetworkController:networkAdded`, or `NetworkController:stateChange` for mUSD seeding purposes.
   - `TokensControllerMessenger` no longer requires `NetworkControllerNetworkAddedEvent`, `AccountsControllerAccountAddedEvent`, or `KeyringControllerUnlockEvent` as allowed events.
   - Detection-based discovery (see Changed) covers the same user-facing behavior on supported chains.

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -9,15 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Switch the default mUSD asset from upfront `allTokens` state seeding to detection-based discovery on Ethereum mainnet (`0x1`), Linea (`0xe708`), and Monad mainnet (`0x8f`)
+  - `TokenDetectionController` now merges mUSD into the in-memory token list cache for these chains so it is treated as a regular detection candidate, replacing the previous `start()`-time `TokensController:addTokens` call and the per-event re-seed runs.
+  - `TokenBalancesController` schedules mUSD for import on the same chains even when the Accounts API returns a zero balance, so users without a current mUSD balance still see the token.
+  - Drops Monad testnet (`0x279f`) from the default mUSD chain list.
 - Bump `@metamask/network-enablement-controller` from `^5.0.2` to `^5.1.0` ([#8665](https://github.com/MetaMask/core/pull/8665))
 - Bump `@metamask/keyring-controller` from `^25.3.0` to `^25.4.0` ([#8665](https://github.com/MetaMask/core/pull/8665))
 - Bump `@metamask/accounts-controller` from `^37.2.0` to `^38.0.0` ([#8665](https://github.com/MetaMask/core/pull/8665))
 - Bump `@metamask/account-tree-controller` from `^7.1.0` to `^7.2.0` ([#8665](https://github.com/MetaMask/core/pull/8665))
 
+### Removed
+
+- Stop seeding mUSD directly into `TokensController` state and remove the related event subscriptions
+  - `TokensController` no longer subscribes to `KeyringController:unlock`, `AccountsController:accountAdded`, `AccountsController:selectedEvmAccountChange`, `NetworkController:networkAdded`, or `NetworkController:stateChange` for mUSD seeding purposes.
+  - `TokensControllerMessenger` no longer requires `NetworkControllerNetworkAddedEvent`, `AccountsControllerAccountAddedEvent`, or `KeyringControllerUnlockEvent` as allowed events.
+  - Detection-based discovery (see Changed) covers the same user-facing behavior on supported chains.
+
 ## [105.1.0]
 
 ### Added
 
+- Seed mUSD (`0xaca92e438df0b2401ff60da7e4337b687a2435da`) into `allTokens` state as a default tracked asset on Ethereum mainnet (`0x1`), Linea (`0xe708`), Monad mainnet (`0x8f`), and Monad testnet (`0x279f`) ([#8620](https://github.com/MetaMask/core/pull/8620))
+  - `TokenDetectionController.start()` now calls `TokensController:addTokens` for mUSD on every supported chain that is configured in `NetworkController` — this is the primary trigger and uses the proven `addTokens` API. Re-runs on `AccountsController:selectedEvmAccountChange` (since `addTokens` only seeds for the currently selected account).
+  - `TokensController` also seeds mUSD directly into state as a defense-in-depth measure: at startup for existing EVM accounts, on accounts already in persisted `allTokens` state, on `AccountsController:accountAdded`, on `AccountsController:selectedEvmAccountChange`, on `KeyringController:unlock`, on `NetworkController:networkAdded`, and on `NetworkController:stateChange` add patches.
+  - `TokensControllerMessenger` now requires `NetworkControllerNetworkAddedEvent`, `AccountsControllerAccountAddedEvent`, and `KeyringControllerUnlockEvent` as allowed events.
 - Add ZetaChain network support (`7000`/`0x1b58`) ([#8627](https://github.com/MetaMask/core/pull/8627))
 
 ### Changed
@@ -28,6 +43,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/messenger` from `^1.1.1` to `^1.2.0` ([#8632](https://github.com/MetaMask/core/pull/8632))
 - Bump `@metamask/keyring-controller` from `^25.2.0` to `^25.3.0` ([#8634](https://github.com/MetaMask/core/pull/8634))
 - Bump `@metamask/network-controller` from `^30.0.1` to `^30.1.0` ([#8636](https://github.com/MetaMask/core/pull/8636))
+
+### Fixed
+
+- Correct the seeded mUSD token decimals from `18` to `6` in `TokensController` and `TokenDetectionController` defaults so tracked token metadata matches contract precision ([#8664](https://github.com/MetaMask/core/pull/8664))
 
 ## [105.0.0]
 

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -18,10 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Seed mUSD (`0xaca92e438df0b2401ff60da7e4337b687a2435da`) into `allTokens` state as a default tracked asset on Ethereum mainnet (`0x1`), Linea (`0xe708`), Monad mainnet (`0x8f`), and Monad testnet (`0x279f`) ([#8620](https://github.com/MetaMask/core/pull/8620))
-  - `TokenDetectionController.start()` now calls `TokensController:addTokens` for mUSD on every supported chain that is configured in `NetworkController` — this is the primary trigger and uses the proven `addTokens` API. Re-runs on `AccountsController:selectedEvmAccountChange` (since `addTokens` only seeds for the currently selected account).
-  - `TokensController` also seeds mUSD directly into state as a defense-in-depth measure: at startup for existing EVM accounts, on accounts already in persisted `allTokens` state, on `AccountsController:accountAdded`, on `AccountsController:selectedEvmAccountChange`, on `KeyringController:unlock`, on `NetworkController:networkAdded`, and on `NetworkController:stateChange` add patches.
-  - `TokensControllerMessenger` now requires `NetworkControllerNetworkAddedEvent`, `AccountsControllerAccountAddedEvent`, and `KeyringControllerUnlockEvent` as allowed events.
 - Add ZetaChain network support (`7000`/`0x1b58`) ([#8627](https://github.com/MetaMask/core/pull/8627))
 
 ### Changed
@@ -32,10 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/messenger` from `^1.1.1` to `^1.2.0` ([#8632](https://github.com/MetaMask/core/pull/8632))
 - Bump `@metamask/keyring-controller` from `^25.2.0` to `^25.3.0` ([#8634](https://github.com/MetaMask/core/pull/8634))
 - Bump `@metamask/network-controller` from `^30.0.1` to `^30.1.0` ([#8636](https://github.com/MetaMask/core/pull/8636))
-
-### Fixed
-
-- Correct the seeded mUSD token decimals from `18` to `6` in `TokensController` and `TokenDetectionController` defaults so tracked token metadata matches contract precision ([#8664](https://github.com/MetaMask/core/pull/8664))
 
 ## [105.0.0]
 

--- a/packages/assets-controllers/src/TokenBalancesController.ts
+++ b/packages/assets-controllers/src/TokenBalancesController.ts
@@ -11,6 +11,7 @@ import type {
 } from '@metamask/base-controller';
 import {
   BNToHex,
+  isEqualCaseInsensitive,
   isValidHexAddress,
   safelyExecuteWithTimeout,
   toChecksumHexAddress,
@@ -80,7 +81,10 @@ import type {
   TokensControllerState,
   TokensControllerStateChangeEvent,
 } from './TokensController';
+import { MUSD_ERC20_ADDRESS_LOWER, MUSD_TOKEN_DETECTION_CHAIN_IDS } from './constants';
 import { createBatchedHandler } from './utils/create-batch-handler';
+
+const MUSD_IMPORT_CHAIN_ID_SET = new Set<Hex>(MUSD_TOKEN_DETECTION_CHAIN_IDS);
 
 export type ChainIdHex = Hex;
 export type ChecksumAddress = Hex;
@@ -821,7 +825,7 @@ export class TokenBalancesController extends StaticIntervalPollingController<{
       }
     }
 
-    await this.#importUntrackedTokens(filteredAggregated);
+    await this.#importUntrackedTokens(filteredAggregated, targetChains);
   }
 
   #getTargetChains(chainIds?: ChainIdHex[]): ChainIdHex[] {
@@ -1156,14 +1160,20 @@ export class TokenBalancesController extends StaticIntervalPollingController<{
   /**
    * Import untracked tokens that have non-zero balances.
    * This mirrors the v2 behavior where only tokens with actual balances are added.
+   * For mUSD default networks, the mUSD contract is also scheduled for import when
+   * balance is zero (Accounts API omits it like the single-call contract).
    * Delegates to TokenDetectionController:addDetectedTokensViaPolling which handles:
    * - Checking if useTokenDetection preference is enabled
    * - Filtering tokens already in allTokens or allIgnoredTokens
    * - Token metadata lookup and addition via TokensController
    *
    * @param balances - Array of processed balance results from fetchers
+   * @param targetChainIds - Chains included in this balance update (for mUSD zero-balance import)
    */
-  async #importUntrackedTokens(balances: ProcessedBalance[]): Promise<void> {
+  async #importUntrackedTokens(
+    balances: ProcessedBalance[],
+    targetChainIds: ChainIdHex[],
+  ): Promise<void> {
     const tokensByChain = new Map<ChainIdHex, string[]>();
 
     for (const balance of balances) {
@@ -1183,6 +1193,22 @@ export class TokenBalancesController extends StaticIntervalPollingController<{
         existing.push(tokenAddress);
         tokensByChain.set(balance.chainId, existing);
       }
+    }
+
+    for (const chainId of targetChainIds) {
+      if (!MUSD_IMPORT_CHAIN_ID_SET.has(chainId)) {
+        continue;
+      }
+      const existing = tokensByChain.get(chainId) ?? [];
+      if (
+        existing.some((addr) =>
+          isEqualCaseInsensitive(addr, MUSD_ERC20_ADDRESS_LOWER),
+        )
+      ) {
+        continue;
+      }
+      const next = [...existing, MUSD_ERC20_ADDRESS_LOWER];
+      tokensByChain.set(chainId, next);
     }
 
     // Add detected tokens via TokenDetectionController (handles preference check,

--- a/packages/assets-controllers/src/TokenBalancesController.ts
+++ b/packages/assets-controllers/src/TokenBalancesController.ts
@@ -63,6 +63,10 @@ import type {
   AccountTrackerControllerUpdateStakedBalancesAction,
 } from './AccountTrackerController-method-action-types';
 import { STAKING_CONTRACT_ADDRESS_BY_CHAINID } from './AssetsContractController';
+import {
+  MUSD_ERC20_ADDRESS_LOWER,
+  MUSD_TOKEN_DETECTION_CHAIN_IDS,
+} from './constants';
 import { AccountsApiBalanceFetcher } from './multi-chain-accounts-service/api-balance-fetcher';
 import type {
   BalanceFetcher,
@@ -81,7 +85,6 @@ import type {
   TokensControllerState,
   TokensControllerStateChangeEvent,
 } from './TokensController';
-import { MUSD_ERC20_ADDRESS_LOWER, MUSD_TOKEN_DETECTION_CHAIN_IDS } from './constants';
 import { createBatchedHandler } from './utils/create-batch-handler';
 
 const MUSD_IMPORT_CHAIN_ID_SET = new Set<Hex>(MUSD_TOKEN_DETECTION_CHAIN_IDS);

--- a/packages/assets-controllers/src/TokenBalancesController.ts
+++ b/packages/assets-controllers/src/TokenBalancesController.ts
@@ -1203,15 +1203,12 @@ export class TokenBalancesController extends StaticIntervalPollingController<{
         continue;
       }
       const existing = tokensByChain.get(chainId) ?? [];
-      if (
-        existing.some((addr) =>
-          isEqualCaseInsensitive(addr, MUSD_ERC20_ADDRESS_LOWER),
-        )
-      ) {
-        continue;
+      const alreadyHasMusd = existing.some((addr) =>
+        isEqualCaseInsensitive(addr, MUSD_ERC20_ADDRESS_LOWER),
+      );
+      if (!alreadyHasMusd) {
+        tokensByChain.set(chainId, [...existing, MUSD_ERC20_ADDRESS_LOWER]);
       }
-      const next = [...existing, MUSD_ERC20_ADDRESS_LOWER];
-      tokensByChain.set(chainId, next);
     }
 
     // Add detected tokens via TokenDetectionController (handles preference check,

--- a/packages/assets-controllers/src/TokenDetectionController.test.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.test.ts
@@ -3511,7 +3511,11 @@ describe('TokenDetectionController', () => {
             },
           },
         },
-        async ({ controller, callActionSpy, mockFindNetworkClientIdByChainId }) => {
+        async ({
+          controller,
+          callActionSpy,
+          mockFindNetworkClientIdByChainId,
+        }) => {
           mockFindNetworkClientIdByChainId(() => 'mainnet');
           await controller.addDetectedTokensViaWs({
             tokensSlice: [],
@@ -3837,7 +3841,11 @@ describe('TokenDetectionController', () => {
             },
           },
         },
-        async ({ controller, callActionSpy, mockFindNetworkClientIdByChainId }) => {
+        async ({
+          controller,
+          callActionSpy,
+          mockFindNetworkClientIdByChainId,
+        }) => {
           mockFindNetworkClientIdByChainId(() => 'mainnet');
           await controller.addDetectedTokensViaPolling({
             tokensSlice: [],

--- a/packages/assets-controllers/src/TokenDetectionController.test.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.test.ts
@@ -3,6 +3,7 @@ import {
   NetworkType,
   convertHexToDecimal,
   InfuraNetworkType,
+  toChecksumHexAddress,
 } from '@metamask/controller-utils';
 import type { KeyringControllerState } from '@metamask/keyring-controller';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
@@ -37,6 +38,7 @@ import {
   buildInfuraNetworkConfiguration,
 } from '../../network-controller/tests/helpers';
 import { formatAggregatorNames } from './assetsUtil';
+import { MUSD_ERC20_ADDRESS_LOWER } from './constants';
 import { TOKEN_END_POINT_API } from './token-service';
 import type { TokenDetectionControllerMessenger } from './TokenDetectionController';
 import {
@@ -299,25 +301,6 @@ describe('TokenDetectionController', () => {
           expect(mockTokens).not.toHaveBeenCalledTimes(2);
         },
       );
-    });
-
-    it('seeds mUSD with contract decimals when starting', async () => {
-      await withController(async ({ controller, callActionSpy }) => {
-        await controller.start();
-
-        expect(callActionSpy).toHaveBeenCalledWith(
-          'TokensController:addTokens',
-          [
-            expect.objectContaining({
-              address: '0xaca92e438df0b2401ff60da7e4337b687a2435da',
-              decimals: 6,
-              symbol: 'mUSD',
-              name: 'MetaMask USD',
-            }),
-          ],
-          expect.any(String),
-        );
-      });
     });
 
     it('should not poll if the controller is not active', async () => {
@@ -3168,6 +3151,94 @@ describe('TokenDetectionController', () => {
         },
       );
     });
+
+    it('adds mUSD from the token list cache when RPC reports zero balance', async () => {
+      const mockGetBalancesInSingleCall = jest.fn().mockResolvedValue({});
+      const selectedAccount = createMockInternalAccount({
+        address: '0x0000000000000000000000000000000000000001',
+      });
+      await withController(
+        {
+          options: {
+            disabled: false,
+            getBalancesInSingleCall: mockGetBalancesInSingleCall,
+          },
+          mocks: {
+            getSelectedAccount: selectedAccount,
+            getAccount: selectedAccount,
+          },
+        },
+        async ({
+          controller,
+          mockNetworkState,
+          mockFindNetworkClientIdByChainId,
+          mockTokenListGetState,
+          triggerPreferencesStateChange,
+          callActionSpy,
+        }) => {
+          const defaultState = getDefaultNetworkControllerState();
+          mockNetworkState({
+            ...defaultState,
+            selectedNetworkClientId: 'mainnet',
+            networkConfigurationsByChainId: {
+              ...defaultState.networkConfigurationsByChainId,
+              '0x1': {
+                chainId: '0x1',
+                name: 'Ethereum Mainnet',
+                nativeCurrency: 'ETH',
+                blockExplorerUrls: [],
+                defaultBlockExplorerUrlIndex: 0,
+                defaultRpcEndpointIndex: 0,
+                rpcEndpoints: [
+                  {
+                    networkClientId: 'mainnet',
+                    type: RpcEndpointType.Custom,
+                    url: 'https://mainnet.infura.io/v3/test',
+                    failoverUrls: [],
+                  },
+                ],
+              },
+            },
+          });
+          mockFindNetworkClientIdByChainId(() => 'mainnet');
+
+          mockTokenListGetState({
+            ...getDefaultTokenListState(),
+            tokensChainsCache: {
+              '0x1': {
+                timestamp: 0,
+                data: {},
+              },
+            },
+          });
+
+          triggerPreferencesStateChange({
+            ...getDefaultPreferencesState(),
+            useTokenDetection: true,
+          });
+
+          await controller.detectTokens({
+            chainIds: [ChainId.mainnet],
+            selectedAddress: selectedAccount.address,
+            forceRpc: true,
+          });
+
+          expect(mockGetBalancesInSingleCall).toHaveBeenCalled();
+          expect(callActionSpy).toHaveBeenCalledWith(
+            'TokensController:addTokens',
+            expect.arrayContaining([
+              expect.objectContaining({
+                address: MUSD_ERC20_ADDRESS_LOWER,
+                name: 'MetaMask USD',
+                symbol: 'MUSD',
+                decimals: 6,
+              }),
+            ]),
+            'mainnet',
+          );
+        },
+      );
+    });
   });
 
   describe('mapChainIdWithTokenListMap', () => {
@@ -3422,6 +3493,41 @@ describe('TokenDetectionController', () => {
               },
             ],
             'avalanche',
+          );
+        },
+      );
+    });
+
+    it('adds mUSD from merged token list when WebSocket provides no token addresses (zero balance)', async () => {
+      await withController(
+        {
+          options: { disabled: false },
+          mockTokenListState: {
+            tokensChainsCache: {
+              [ChainId.mainnet]: {
+                timestamp: 0,
+                data: {},
+              },
+            },
+          },
+        },
+        async ({ controller, callActionSpy, mockFindNetworkClientIdByChainId }) => {
+          mockFindNetworkClientIdByChainId(() => 'mainnet');
+          await controller.addDetectedTokensViaWs({
+            tokensSlice: [],
+            chainId: ChainId.mainnet,
+          });
+          expect(callActionSpy).toHaveBeenCalledWith(
+            'TokensController:addTokens',
+            expect.arrayContaining([
+              expect.objectContaining({
+                address: toChecksumHexAddress(MUSD_ERC20_ADDRESS_LOWER),
+                name: 'MetaMask USD',
+                symbol: 'MUSD',
+                decimals: 6,
+              }),
+            ]),
+            'mainnet',
           );
         },
       );
@@ -3713,6 +3819,41 @@ describe('TokenDetectionController', () => {
               },
             ],
             'avalanche',
+          );
+        },
+      );
+    });
+
+    it('adds mUSD from merged token list when polling has no other token addresses (zero balance)', async () => {
+      await withController(
+        {
+          options: { disabled: false, useTokenDetection: () => true },
+          mockTokenListState: {
+            tokensChainsCache: {
+              [ChainId.mainnet]: {
+                timestamp: 0,
+                data: {},
+              },
+            },
+          },
+        },
+        async ({ controller, callActionSpy, mockFindNetworkClientIdByChainId }) => {
+          mockFindNetworkClientIdByChainId(() => 'mainnet');
+          await controller.addDetectedTokensViaPolling({
+            tokensSlice: [],
+            chainId: ChainId.mainnet,
+          });
+          expect(callActionSpy).toHaveBeenCalledWith(
+            'TokensController:addTokens',
+            expect.arrayContaining([
+              expect.objectContaining({
+                address: toChecksumHexAddress(MUSD_ERC20_ADDRESS_LOWER),
+                name: 'MetaMask USD',
+                symbol: 'MUSD',
+                decimals: 6,
+              }),
+            ]),
+            'mainnet',
           );
         },
       );

--- a/packages/assets-controllers/src/TokenDetectionController.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.ts
@@ -813,7 +813,9 @@ export class TokenDetectionController extends StaticIntervalPollingController<To
       return tokensSlice;
     }
     if (
-      tokensSlice.some((a) => isEqualCaseInsensitive(a, MUSD_ERC20_ADDRESS_LOWER))
+      tokensSlice.some((a) =>
+        isEqualCaseInsensitive(a, MUSD_ERC20_ADDRESS_LOWER),
+      )
     ) {
       return tokensSlice;
     }
@@ -884,9 +886,7 @@ export class TokenDetectionController extends StaticIntervalPollingController<To
           if (musdListToken) {
             const { decimals, symbol, aggregators, iconUrl, name, rwaData } =
               musdListToken;
-            eventTokensDetails.push(
-              `${symbol} - ${MUSD_ERC20_ADDRESS_LOWER}`,
-            );
+            eventTokensDetails.push(`${symbol} - ${MUSD_ERC20_ADDRESS_LOWER}`);
             tokensWithBalance.push({
               address: MUSD_ERC20_ADDRESS_LOWER,
               decimals,

--- a/packages/assets-controllers/src/TokenDetectionController.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.ts
@@ -29,7 +29,6 @@ import type {
   NetworkControllerGetNetworkClientByIdAction,
   NetworkControllerGetNetworkConfigurationByNetworkClientId,
   NetworkControllerGetStateAction,
-  NetworkControllerNetworkAddedEvent,
   NetworkControllerNetworkDidChangeEvent,
 } from '@metamask/network-controller';
 import { StaticIntervalPollingController } from '@metamask/polling-controller';
@@ -43,13 +42,22 @@ import type { Hex } from '@metamask/utils';
 import { isEqual, mapValues, isObject, get } from 'lodash';
 
 import type { AssetsContractController } from './AssetsContractController';
-import { isTokenDetectionSupportedForNetwork } from './assetsUtil';
-import { SUPPORTED_NETWORKS_ACCOUNTS_API_V4 } from './constants';
+import {
+  formatIconUrlWithProxy,
+  isTokenDetectionSupportedForNetwork,
+} from './assetsUtil';
+import {
+  MUSD_ERC20_ADDRESS_LOWER,
+  MUSD_TOKEN_DETECTION_CHAIN_IDS,
+  MUSD_TOKEN_METADATA_BY_CHAIN,
+  SUPPORTED_NETWORKS_ACCOUNTS_API_V4,
+} from './constants';
 import type { TokenDetectionControllerMethodActions } from './TokenDetectionController-method-action-types';
 import type {
   GetTokenListState,
   TokenListMap,
   TokenListStateChange,
+  TokenListToken,
   TokensChainsCache,
 } from './TokenListController';
 import type { Token } from './TokenRatesController';
@@ -60,36 +68,6 @@ import type {
 } from './TokensController-method-action-types';
 
 const DEFAULT_INTERVAL = 180000;
-
-/**
- * Canonical contract address for MetaMask USD (mUSD) — same across every
- * chain we deploy it to.
- */
-const MUSD_ADDRESS = '0xaca92e438df0b2401ff60da7e4337b687a2435da';
-
-/**
- * Pre-built Token entry for mUSD — used when seeding default state.
- */
-const MUSD_TOKEN: Token = {
-  address: MUSD_ADDRESS,
-  decimals: 6,
-  symbol: 'mUSD',
-  name: 'MetaMask USD',
-};
-
-/**
- * Hex chain IDs on which mUSD is deployed and should be added by default.
- * - 0x1     — Ethereum mainnet (1)
- * - 0xe708  — Linea (59144)
- * - 0x8f    — Monad mainnet (143)
- * - 0x279f  — Monad testnet (10143)
- */
-const MUSD_SUPPORTED_CHAIN_IDS: ReadonlySet<Hex> = new Set<Hex>([
-  '0x1',
-  '0xe708',
-  '0x8f',
-  '0x279f',
-]);
 
 type LegacyToken = {
   name: string;
@@ -123,6 +101,10 @@ export const STATIC_MAINNET_TOKEN_LIST = Object.entries<LegacyToken>(
     },
   };
 }, {});
+
+const MUSD_TOKEN_DETECTION_CHAIN_ID_SET = new Set<Hex>(
+  MUSD_TOKEN_DETECTION_CHAIN_IDS,
+);
 
 /**
  * Function that takes a TokensChainsCache object and maps chainId with TokenListMap.
@@ -177,7 +159,6 @@ export type TokenDetectionControllerEvents =
 
 export type AllowedEvents =
   | AccountsControllerSelectedEvmAccountChangeEvent
-  | NetworkControllerNetworkAddedEvent
   | NetworkControllerNetworkDidChangeEvent
   | TokenListStateChange
   | KeyringControllerLockEvent
@@ -243,9 +224,6 @@ export class TokenDetectionController extends StaticIntervalPollingController<To
   readonly #useTokenDetection: () => boolean;
 
   readonly #useExternalServices: () => boolean;
-
-  /** Tracks whether default tokens (mUSD) have been seeded for the current session. */
-  #defaultTokensSeeded = false;
 
   readonly #getBalancesInSingleCall: AssetsContractController['getBalancesInSingleCall'];
 
@@ -400,13 +378,6 @@ export class TokenDetectionController extends StaticIntervalPollingController<To
           this.#selectedAccountId !== selectedAccount.id;
         if (isSelectedAccountIdChanged) {
           this.#selectedAccountId = selectedAccount.id;
-          // Re-seed mUSD for the newly selected account. addTokens only adds
-          // tokens for the currently selected account, so we need to re-run
-          // it whenever the active account changes.
-          this.#defaultTokensSeeded = false;
-          this.#seedDefaultTokens().catch(() => {
-            // Silently handle default-token seeding errors
-          });
           this.#restartTokenDetection({
             selectedAddress: selectedAccount.address,
             chainIds,
@@ -424,23 +395,6 @@ export class TokenDetectionController extends StaticIntervalPollingController<To
           chainIds: [transactionMeta.chainId],
         }).catch(() => {
           // Silently handle token detection errors
-        });
-      },
-    );
-
-    // Re-seed mUSD whenever a network is added. Covers the case where the
-    // user adds a supported chain (e.g. Monad testnet) after the controller
-    // has already started — the chain wasn't configured at start() time so
-    // findNetworkClientIdByChainId would have skipped it.
-    this.messenger.subscribe(
-      'NetworkController:networkAdded',
-      ({ chainId }) => {
-        if (!MUSD_SUPPORTED_CHAIN_IDS.has(chainId)) {
-          return;
-        }
-        this.#defaultTokensSeeded = false;
-        this.#seedDefaultTokens().catch(() => {
-          // Silently handle default-token seeding errors
         });
       },
     );
@@ -474,9 +428,6 @@ export class TokenDetectionController extends StaticIntervalPollingController<To
    */
   async start(): Promise<void> {
     this.enable();
-    // Seed mUSD as a default token via TokensController:addTokens. Runs
-    // once per session; idempotent because addTokens dedupes on address.
-    await this.#seedDefaultTokens();
     await this.#startPolling();
   }
 
@@ -619,7 +570,10 @@ export class TokenDetectionController extends StaticIntervalPollingController<To
       const { tokensChainsCache } = this.messenger.call(
         'TokenListController:getState',
       );
-      this.#tokensChainsCache = tokensChainsCache ?? {};
+      this.#tokensChainsCache = this.#applyMusdDefaultToTokensChainsCache(
+        chainId,
+        tokensChainsCache ?? {},
+      );
     }
 
     return true;
@@ -766,55 +720,114 @@ export class TokenDetectionController extends StaticIntervalPollingController<To
       }),
       {},
     );
+    const dataWithMusd = this.#mergeMusdIntoTokenListMap(ChainId.mainnet, data);
     return {
       '0x1': {
-        data,
+        data: dataWithMusd,
         timestamp: 0,
       },
     };
   }
 
   /**
-   * Seed mUSD into `TokensController.allTokens` via the public `addTokens`
-   * action for every supported chain that is currently configured in
-   * `NetworkController`.
+   * mUSD token list row derived from Tokens API v3/assets (baked in for offline detection).
    *
-   * Runs once per session (idempotent guard via `#defaultTokensSeeded`), but
-   * `addTokens` itself dedupes by contract address so re-running is safe.
-   *
-   * @returns Promise that resolves once seeding has been attempted on every
-   * supported chain.
+   * @param chainId - Hex chain id (mainnet, Linea, or Monad).
+   * @returns Token list entry for the detection cache.
    */
-  async #seedDefaultTokens(): Promise<void> {
-    if (this.#defaultTokensSeeded) {
-      return;
-    }
-    this.#defaultTokensSeeded = true;
+  #buildMusdTokenListToken(chainId: Hex): TokenListToken {
+    const meta =
+      MUSD_TOKEN_METADATA_BY_CHAIN[
+        chainId as (typeof MUSD_TOKEN_DETECTION_CHAIN_IDS)[number]
+      ];
+    return {
+      address: MUSD_ERC20_ADDRESS_LOWER,
+      name: meta.name,
+      symbol: meta.symbol,
+      decimals: meta.decimals,
+      aggregators: [...meta.aggregators],
+      iconUrl: formatIconUrlWithProxy({
+        chainId,
+        tokenAddress: MUSD_ERC20_ADDRESS_LOWER,
+      }),
+      occurrences: 999,
+    };
+  }
 
-    const { networkConfigurationsByChainId } = this.messenger.call(
-      'NetworkController:getState',
+  /**
+   * Merge mUSD into a flat token map when the chain is one of the default mUSD networks.
+   *
+   * @param chainId - Network being detected.
+   * @param data - Existing token map for that chain.
+   * @returns New map including mUSD when applicable.
+   */
+  #mergeMusdIntoTokenListMap(chainId: Hex, data: TokenListMap): TokenListMap {
+    if (!MUSD_TOKEN_DETECTION_CHAIN_ID_SET.has(chainId)) {
+      return data;
+    }
+    return {
+      ...data,
+      [MUSD_ERC20_ADDRESS_LOWER]: this.#buildMusdTokenListToken(chainId),
+    };
+  }
+
+  /**
+   * Shallow-clone the token list cache for the current chain and merge mUSD so we never
+   * mutate `TokenListController` state by reference.
+   *
+   * @param chainId - Network being detected.
+   * @param cache - Full tokens-by-chain cache from `TokenListController`.
+   * @returns Cache object safe to read and mutate for this detection pass.
+   */
+  #applyMusdDefaultToTokensChainsCache(
+    chainId: Hex,
+    cache: TokensChainsCache,
+  ): TokensChainsCache {
+    if (!MUSD_TOKEN_DETECTION_CHAIN_ID_SET.has(chainId)) {
+      return cache;
+    }
+    const existing = cache[chainId];
+    return {
+      ...cache,
+      [chainId]: {
+        data: this.#mergeMusdIntoTokenListMap(chainId, existing?.data ?? {}),
+        timestamp: existing?.timestamp ?? 0,
+      },
+    };
+  }
+
+  /**
+   * If mUSD is in the (possibly merged) token list for this chain, include its address
+   * in the slice so we still run detection when balance is zero (single-call / Accounts API
+   * / WebSocket do not list the contract when balance is zero).
+   *
+   * @param tokensSlice - Address batch from the caller.
+   * @param chainId - Network being updated.
+   * @returns The slice, possibly with mUSD appended.
+   */
+  #includeMusdInTokenDetectionSlice(
+    tokensSlice: string[],
+    chainId: Hex,
+  ): string[] {
+    if (!MUSD_TOKEN_DETECTION_CHAIN_ID_SET.has(chainId)) {
+      return tokensSlice;
+    }
+    if (
+      tokensSlice.some((a) => isEqualCaseInsensitive(a, MUSD_ERC20_ADDRESS_LOWER))
+    ) {
+      return tokensSlice;
+    }
+    const listData = this.#tokensChainsCache[chainId]?.data;
+    if (!listData) {
+      return tokensSlice;
+    }
+    const hasMusd = Object.keys(listData).some((k) =>
+      isEqualCaseInsensitive(k, MUSD_ERC20_ADDRESS_LOWER),
     );
-
-    for (const supportedChainId of MUSD_SUPPORTED_CHAIN_IDS) {
-      if (!networkConfigurationsByChainId[supportedChainId]) {
-        continue;
-      }
-
-      try {
-        const networkClientId = this.messenger.call(
-          'NetworkController:findNetworkClientIdByChainId',
-          supportedChainId,
-        );
-        await this.messenger.call(
-          'TokensController:addTokens',
-          [MUSD_TOKEN],
-          networkClientId,
-        );
-      } catch {
-        // Silently handle per-chain seeding errors so one failure does not
-        // block seeding on the remaining supported chains.
-      }
+    if (!hasMusd) {
+      return tokensSlice;
     }
+    return [...tokensSlice, MUSD_ERC20_ADDRESS_LOWER];
   }
 
   async #addDetectedTokens({
@@ -851,6 +864,41 @@ export class TokenDetectionController extends StaticIntervalPollingController<To
           name,
           ...(rwaData && { rwaData }),
         });
+      }
+
+      // mUSD is always in the chain token cache on supported networks, but
+      // getBalancesInSingleCall omits zero balances; still add mUSD so the wallet
+      // shows the asset (balance updates via the usual balance pipeline).
+      if (MUSD_TOKEN_DETECTION_CHAIN_ID_SET.has(chainId)) {
+        const musdInSlice = tokensSlice.some((addr) =>
+          isEqualCaseInsensitive(addr, MUSD_ERC20_ADDRESS_LOWER),
+        );
+        const musdHasNonZeroFromRpc = Object.keys(balances).some((addr) =>
+          isEqualCaseInsensitive(addr, MUSD_ERC20_ADDRESS_LOWER),
+        );
+        if (musdInSlice && !musdHasNonZeroFromRpc) {
+          const listData = this.#tokensChainsCache[chainId].data;
+          const musdListToken = Object.entries(listData).find(([key]) =>
+            isEqualCaseInsensitive(key, MUSD_ERC20_ADDRESS_LOWER),
+          )?.[1];
+          if (musdListToken) {
+            const { decimals, symbol, aggregators, iconUrl, name, rwaData } =
+              musdListToken;
+            eventTokensDetails.push(
+              `${symbol} - ${MUSD_ERC20_ADDRESS_LOWER}`,
+            );
+            tokensWithBalance.push({
+              address: MUSD_ERC20_ADDRESS_LOWER,
+              decimals,
+              symbol,
+              aggregators,
+              image: iconUrl,
+              isERC721: false,
+              name,
+              ...(rwaData && { rwaData }),
+            });
+          }
+        }
       }
 
       if (tokensWithBalance.length) {
@@ -909,12 +957,20 @@ export class TokenDetectionController extends StaticIntervalPollingController<To
     const { tokensChainsCache } = this.messenger.call(
       'TokenListController:getState',
     );
-    this.#tokensChainsCache = tokensChainsCache ?? {};
+    this.#tokensChainsCache = this.#applyMusdDefaultToTokensChainsCache(
+      chainId,
+      tokensChainsCache ?? {},
+    );
+
+    const effectiveSlice = this.#includeMusdInTokenDetectionSlice(
+      tokensSlice,
+      chainId,
+    );
 
     const tokensWithBalance: Token[] = [];
     const eventTokensDetails: string[] = [];
 
-    for (const tokenAddress of tokensSlice) {
+    for (const tokenAddress of effectiveSlice) {
       // Normalize addresses explicitly (don't assume input format)
       const lowercaseTokenAddress = tokenAddress.toLowerCase();
       const checksummedTokenAddress = toChecksumHexAddress(tokenAddress);
@@ -1005,7 +1061,10 @@ export class TokenDetectionController extends StaticIntervalPollingController<To
     const { tokensChainsCache } = this.messenger.call(
       'TokenListController:getState',
     );
-    this.#tokensChainsCache = tokensChainsCache ?? {};
+    this.#tokensChainsCache = this.#applyMusdDefaultToTokensChainsCache(
+      chainId,
+      tokensChainsCache ?? {},
+    );
 
     const selectedAddress = this.#getSelectedAddress();
 
@@ -1022,10 +1081,15 @@ export class TokenDetectionController extends StaticIntervalPollingController<To
       allIgnoredTokens[chainId]?.[selectedAddress] ?? []
     ).map((address) => address.toLowerCase());
 
+    const effectiveSlice = this.#includeMusdInTokenDetectionSlice(
+      tokensSlice,
+      chainId,
+    );
+
     const tokensWithBalance: Token[] = [];
     const eventTokensDetails: string[] = [];
 
-    for (const tokenAddress of tokensSlice) {
+    for (const tokenAddress of effectiveSlice) {
       const lowercaseTokenAddress = tokenAddress.toLowerCase();
       const checksummedTokenAddress = toChecksumHexAddress(tokenAddress);
 

--- a/packages/assets-controllers/src/TokenDetectionController.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.ts
@@ -762,9 +762,6 @@ export class TokenDetectionController extends StaticIntervalPollingController<To
    * @returns New map including mUSD when applicable.
    */
   #mergeMusdIntoTokenListMap(chainId: Hex, data: TokenListMap): TokenListMap {
-    if (!MUSD_TOKEN_DETECTION_CHAIN_ID_SET.has(chainId)) {
-      return data;
-    }
     return {
       ...data,
       [MUSD_ERC20_ADDRESS_LOWER]: this.#buildMusdTokenListToken(chainId),
@@ -817,16 +814,6 @@ export class TokenDetectionController extends StaticIntervalPollingController<To
         isEqualCaseInsensitive(a, MUSD_ERC20_ADDRESS_LOWER),
       )
     ) {
-      return tokensSlice;
-    }
-    const listData = this.#tokensChainsCache[chainId]?.data;
-    if (!listData) {
-      return tokensSlice;
-    }
-    const hasMusd = Object.keys(listData).some((k) =>
-      isEqualCaseInsensitive(k, MUSD_ERC20_ADDRESS_LOWER),
-    );
-    if (!hasMusd) {
       return tokensSlice;
     }
     return [...tokensSlice, MUSD_ERC20_ADDRESS_LOWER];

--- a/packages/assets-controllers/src/TokensController.test.ts
+++ b/packages/assets-controllers/src/TokensController.test.ts
@@ -1467,31 +1467,6 @@ describe('TokensController', () => {
           expect(result.isERC721).toBe(false);
         });
       });
-
-      it('should add isERC721 = false when supportsInterface rejects and token is not in contract-metadata repo', async () => {
-        await withController(async ({ controller }) => {
-          ContractMock.mockReturnValue(
-            buildMockEthersERC721Contract({
-              supportsInterface: true,
-              supportsInterfaceThrows: true,
-            }),
-          );
-          const tokenAddress = '0xda5584cc586d07c7141aa427224a4bd58e64af7d';
-
-          await controller.addToken({
-            address: tokenAddress,
-            symbol: 'TESTNFT',
-            decimals: 0,
-            networkClientId: 'mainnet',
-          });
-
-          const result = await controller.updateTokenType(
-            tokenAddress,
-            'mainnet',
-          );
-          expect(result.isERC721).toBe(false);
-        });
-      });
     });
 
     describe('addToken method', () => {
@@ -1707,56 +1682,6 @@ describe('TokensController', () => {
       });
     });
 
-    it('updates an already-imported token when addDetectedTokens includes the same contract address', async () => {
-      await withController(async ({ controller }) => {
-        ContractMock.mockReturnValue(
-          buildMockEthersERC721Contract({ supportsInterface: false }),
-        );
-        const address = '0x0000000000000000000000000000000000000b01';
-
-        await controller.addToken({
-          address,
-          symbol: 'OLD',
-          decimals: 18,
-          networkClientId: 'mainnet',
-        });
-
-        await controller.addDetectedTokens(
-          [
-            {
-              address,
-              symbol: 'NEW',
-              decimals: 6,
-              aggregators: ['aave'],
-              image: 'https://example.com/icon.png',
-              isERC721: false,
-              name: 'Updated name',
-            },
-          ],
-          {
-            selectedAddress: defaultMockInternalAccount.address,
-            chainId: ChainId.mainnet,
-          },
-        );
-
-        const list =
-          controller.state.allTokens[ChainId.mainnet][
-            defaultMockInternalAccount.address
-          ];
-        expect(list).toHaveLength(1);
-        expect(list[0]).toStrictEqual(
-          expect.objectContaining({
-            symbol: 'NEW',
-            decimals: 6,
-            name: 'Updated name',
-            aggregators: ['aave'],
-            image: 'https://example.com/icon.png',
-            isERC721: false,
-          }),
-        );
-      });
-    });
-
     it('should add tokens to the correct chainId/selectedAddress on which they were detected even if its not the currently configured chainId/selectedAddress', async () => {
       const CONFIGURED_ADDRESS = '0xConfiguredAddress';
       const configuredAccount = createMockInternalAccount({
@@ -1787,18 +1712,16 @@ describe('TokensController', () => {
           const OTHER_ADDRESS = '0xOtherAddress';
 
           // Mock some tokens to add
-          const generateTokens = (len: number): Token[] =>
-            [...Array(len)].map(
-              (_, i): Token => ({
-                address: `0x${i}`,
-                symbol: String.fromCharCode(65 + i),
-                decimals: 2,
-                aggregators: [],
-                name: undefined,
-                isERC721: false,
-                image: `https://static.cx.metamask.io/api/v1/tokenIcons/11155111/0x${i}.png`,
-              }),
-            );
+          const generateTokens = (len: number) =>
+            [...Array(len)].map((_, i) => ({
+              address: `0x${i}`,
+              symbol: String.fromCharCode(65 + i),
+              decimals: 2,
+              aggregators: [],
+              name: undefined,
+              isERC721: false,
+              image: `https://static.cx.metamask.io/api/v1/tokenIcons/11155111/0x${i}.png`,
+            }));
 
           const [
             addedTokenConfiguredAccount,
@@ -2575,43 +2498,6 @@ describe('TokensController', () => {
       });
     });
 
-    it('includes pageMeta on the approval request when provided', async () => {
-      await withController(async ({ controller, approvalController }) => {
-        const requestId = 'page-meta-req';
-        const addAndShowApprovalRequestSpy = jest
-          .spyOn(approvalController, 'addAndShowApprovalRequest')
-          .mockResolvedValue(undefined);
-        const asset = buildToken();
-        ContractMock.mockReturnValue(
-          buildMockEthersERC721Contract({ supportsInterface: false }),
-        );
-        uuidV1Mock.mockReturnValue(requestId);
-        const pageMeta = { title: 'Test Dapp' };
-
-        await controller.watchAsset({
-          asset,
-          type: 'ERC20',
-          networkClientId: 'mainnet',
-          pageMeta,
-        });
-
-        expect(addAndShowApprovalRequestSpy).toHaveBeenCalledTimes(1);
-        expect(addAndShowApprovalRequestSpy.mock.calls[0][0]).toStrictEqual(
-          expect.objectContaining({
-            id: requestId,
-            origin: ORIGIN_METAMASK,
-            type: ApprovalType.WatchAsset,
-            requestData: expect.objectContaining({
-              id: requestId,
-              interactingAddress: '0x1',
-              asset,
-              metadata: { pageMeta },
-            }),
-          }),
-        );
-      });
-    });
-
     it('falls back to ORIGIN_METAMASK when origin is empty string', async () => {
       await withController(async ({ controller, approvalController }) => {
         const requestId = '12345';
@@ -2887,7 +2773,7 @@ describe('TokensController', () => {
           ).mockReturnValueOnce(buildMockERC20StandardFromToken(anotherAsset));
 
           const promiseForApprovals = new Promise<void>((resolve) => {
-            const listener = (state: ApprovalControllerState): void => {
+            const listener = (state: ApprovalControllerState) => {
               if (state.pendingApprovalCount === 2) {
                 messenger.unsubscribe(
                   'ApprovalController:stateChange',
@@ -3684,52 +3570,6 @@ describe('TokensController', () => {
         },
       );
     });
-
-    it('does not mutate token state when patches omit networkConfigurationsByChainId', async () => {
-      const initialState = {
-        allTokens: {
-          '0x1': {
-            '0x134': [
-              {
-                address: '0x01',
-                symbol: 'TKN1',
-                decimals: 18,
-                aggregators: [],
-                name: 'Token 1',
-              },
-            ],
-          },
-        },
-        tokens: [],
-        ignoredTokens: [],
-        detectedTokens: [],
-        allIgnoredTokens: {},
-        allDetectedTokens: {},
-      };
-
-      await withController(
-        { options: { state: initialState } },
-        ({ controller, triggerNetworkStateChange }) => {
-          const before = controller.state;
-
-          triggerNetworkStateChange({} as NetworkState, [
-            {
-              op: 'replace',
-              path: ['selectedNetworkClientId'],
-              value: 'sepolia',
-            } as Patch,
-          ]);
-
-          expect(controller.state.allTokens).toStrictEqual(before.allTokens);
-          expect(controller.state.allIgnoredTokens).toStrictEqual(
-            before.allIgnoredTokens,
-          );
-          expect(controller.state.allDetectedTokens).toStrictEqual(
-            before.allDetectedTokens,
-          );
-        },
-      );
-    });
   });
 
   describe('resetState', () => {
@@ -3794,6 +3634,12 @@ describe('TokensController', () => {
     it('removes the list of tokens for the removed account', async () => {
       const firstAddress = '0xA73d9021f67931563fDfe3E8f66261086319a1FC';
       const secondAddress = '0xB73d9021f67931563fDfe3E8f66261086319a1FK';
+      const firstAccount = createMockInternalAccount({
+        address: firstAddress,
+      });
+      const secondAccount = createMockInternalAccount({
+        address: secondAddress,
+      });
       const initialState: TokensControllerState = {
         allTokens: {
           [ChainId.mainnet]: {
@@ -3832,79 +3678,48 @@ describe('TokensController', () => {
           options: {
             state: initialState,
           },
+          listAccounts: [firstAccount, secondAccount],
         },
         ({ controller, triggerAccountRemoved }) => {
-          triggerAccountRemoved(firstAddress);
+          expect(controller.state).toStrictEqual(initialState);
 
-          // firstAddress is removed from all chains; only secondAddress remains
-          expect(controller.state.allTokens[ChainId.mainnet]).toStrictEqual({
-            [secondAddress]: [
-              {
-                address: '0x04',
-                symbol: 'barD',
-                decimals: 2,
-                aggregators: [],
-                image: undefined,
-                name: undefined,
+          triggerAccountRemoved(firstAccount.address);
+
+          expect(controller.state).toStrictEqual({
+            allTokens: {
+              [ChainId.mainnet]: {
+                [secondAddress]: [
+                  {
+                    address: '0x04',
+                    symbol: 'barD',
+                    decimals: 2,
+                    aggregators: [],
+                    image: undefined,
+                    name: undefined,
+                  },
+                ],
               },
-            ],
-          });
-          expect(
-            controller.state.allTokens[ChainId.mainnet]?.[firstAddress],
-          ).toBeUndefined();
-          expect(controller.state.allIgnoredTokens).toStrictEqual({});
-          expect(controller.state.allDetectedTokens).toStrictEqual({
-            [ChainId.mainnet]: { [secondAddress]: [] },
-          });
-        },
-      );
-    });
-
-    it('removes ignored-token lists for the removed account across chains', async () => {
-      const firstAddress = '0xA73d9021f67931563fDfe3E8f66261086319a1FC';
-      const secondAddress = '0xB73d9021f67931563fDfe3E8f66261086319a1FK';
-      const initialState: TokensControllerState = {
-        allTokens: {},
-        allIgnoredTokens: {
-          [ChainId.mainnet]: {
-            [firstAddress]: ['0x01', '0x02'],
-            [secondAddress]: ['0x03'],
-          },
-          [ChainId.sepolia]: {
-            [firstAddress]: ['0x04'],
-          },
-        },
-        allDetectedTokens: {},
-      };
-
-      await withController(
-        {
-          options: {
-            state: initialState,
-          },
-        },
-        ({ controller, triggerAccountRemoved }) => {
-          triggerAccountRemoved(firstAddress);
-
-          expect(controller.state.allIgnoredTokens).toStrictEqual({
-            [ChainId.mainnet]: {
-              [secondAddress]: ['0x03'],
             },
-            [ChainId.sepolia]: {},
+            allIgnoredTokens: {},
+            allDetectedTokens: {
+              [ChainId.mainnet]: {
+                [secondAddress]: [],
+              },
+            },
           });
-          expect(
-            controller.state.allIgnoredTokens[ChainId.mainnet]?.[firstAddress],
-          ).toBeUndefined();
-          expect(
-            controller.state.allIgnoredTokens[ChainId.sepolia]?.[firstAddress],
-          ).toBeUndefined();
         },
       );
     });
 
     it('removes an account with no tokens', async () => {
       const firstAddress = '0xA73d9021f67931563fDfe3E8f66261086319a1FC';
-      const nonEvmAddress = '0xB73d9021f67931563fDfe3E8f66261086319a1FK';
+      const secondAddress = '0xB73d9021f67931563fDfe3E8f66261086319a1FK';
+      const firstAccount = createMockInternalAccount({
+        address: firstAddress,
+      });
+      const secondAccount = createMockInternalAccount({
+        address: secondAddress,
+      });
       const initialState: TokensControllerState = {
         allTokens: {
           [ChainId.mainnet]: {
@@ -3932,19 +3747,14 @@ describe('TokensController', () => {
           options: {
             state: initialState,
           },
+          listAccounts: [firstAccount, secondAccount],
         },
         ({ controller, triggerAccountRemoved }) => {
-          // Removing a non-EVM address is a no-op; firstAddress should be untouched
-          triggerAccountRemoved(nonEvmAddress);
+          expect(controller.state).toStrictEqual(initialState);
 
-          expect(
-            controller.state.allTokens[ChainId.mainnet]?.[firstAddress],
-          ).toStrictEqual(
-            expect.arrayContaining([
-              expect.objectContaining({ address: '0x03' }),
-            ]),
-          );
-          expect(controller.state.allIgnoredTokens).toStrictEqual({});
+          triggerAccountRemoved(secondAccount.address);
+
+          expect(controller.state).toStrictEqual(initialState);
         },
       );
     });
@@ -4011,372 +3821,6 @@ describe('TokensController', () => {
       });
     });
   });
-
-  // ---------------------------------------------------------------------------
-  // mUSD default token seeding
-  // ---------------------------------------------------------------------------
-
-  const MUSD_ADDRESS = '0xaca92e438df0b2401ff60da7e4337b687a2435da';
-  const MUSD_TOKEN = {
-    address: MUSD_ADDRESS,
-    decimals: 6,
-    symbol: 'mUSD',
-    name: 'MetaMask USD',
-  };
-
-  describe('mUSD default token seeding', () => {
-    describe('at startup', () => {
-      it('seeds mUSD into allTokens for every existing EVM account on supported chains', async () => {
-        const account1 = createMockInternalAccount({
-          address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-        });
-        const account2 = createMockInternalAccount({
-          address: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
-        });
-
-        await withController(
-          { listAccounts: [account1, account2] },
-          ({ controller }) => {
-            // Ethereum mainnet
-            expect(
-              controller.state.allTokens['0x1'][account1.address],
-            ).toContainEqual(MUSD_TOKEN);
-            expect(
-              controller.state.allTokens['0x1'][account2.address],
-            ).toContainEqual(MUSD_TOKEN);
-
-            // Linea
-            expect(
-              controller.state.allTokens['0xe708'][account1.address],
-            ).toContainEqual(MUSD_TOKEN);
-            expect(
-              controller.state.allTokens['0xe708'][account2.address],
-            ).toContainEqual(MUSD_TOKEN);
-
-            // Monad testnet
-            expect(
-              controller.state.allTokens['0x8f'][account1.address],
-            ).toContainEqual(MUSD_TOKEN);
-            expect(
-              controller.state.allTokens['0x8f'][account2.address],
-            ).toContainEqual(MUSD_TOKEN);
-          },
-        );
-      });
-
-      it('does not seed mUSD on chains that are not in the supported list', async () => {
-        const account = createMockInternalAccount({
-          address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-        });
-
-        await withController({ listAccounts: [account] }, ({ controller }) => {
-          expect(controller.state.allTokens['0x5']).toBeUndefined();
-          expect(controller.state.allTokens['0xa']).toBeUndefined();
-        });
-      });
-
-      it('does not duplicate mUSD when initial state already contains it', async () => {
-        const account = createMockInternalAccount({
-          address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-        });
-
-        const existingState: Partial<TokensControllerState> = {
-          allTokens: {
-            '0x1': { [account.address]: [MUSD_TOKEN] },
-          },
-        };
-
-        await withController(
-          { listAccounts: [account], options: { state: existingState } },
-          ({ controller }) => {
-            const mainnetTokens =
-              controller.state.allTokens['0x1'][account.address];
-            const musdCount = mainnetTokens.filter(
-              (token) =>
-                token.address.toLowerCase() === MUSD_ADDRESS.toLowerCase(),
-            ).length;
-            expect(musdCount).toBe(1);
-          },
-        );
-      });
-
-      it('does not seed mUSD when there are no accounts', async () => {
-        await withController({ listAccounts: [] }, ({ controller }) => {
-          expect(controller.state.allTokens).toStrictEqual({});
-        });
-      });
-
-      it('seeds mUSD for accounts already present in persisted allTokens state, without needing AccountsController', async () => {
-        const existingAddress = '0xcccccccccccccccccccccccccccccccccccccccc';
-        const existingToken = {
-          address: '0x01',
-          symbol: 'TKN',
-          decimals: 18,
-          aggregators: [],
-        };
-        const persistedState: Partial<TokensControllerState> = {
-          allTokens: {
-            // Only mainnet is in persisted state — Linea and Monad are absent
-            '0x1': { [existingAddress]: [existingToken] },
-          },
-        };
-
-        // listAccounts returns [] to simulate AccountsController not ready yet
-        await withController(
-          { listAccounts: [], options: { state: persistedState } },
-          ({ controller }) => {
-            // mUSD should be seeded on 0x1 (address was in persisted state)
-            expect(
-              controller.state.allTokens['0x1'][existingAddress],
-            ).toContainEqual(MUSD_TOKEN);
-            // mUSD should be seeded on Linea and Monad too
-            expect(
-              controller.state.allTokens['0xe708'][existingAddress],
-            ).toContainEqual(MUSD_TOKEN);
-            expect(
-              controller.state.allTokens['0x8f'][existingAddress],
-            ).toContainEqual(MUSD_TOKEN);
-            // Original token is preserved
-            expect(
-              controller.state.allTokens['0x1'][existingAddress],
-            ).toContainEqual(existingToken);
-          },
-        );
-      });
-    });
-
-    describe('when AccountsController:accountAdded is published', () => {
-      it('seeds mUSD for the newly added account on every supported chain', async () => {
-        const newAccount = createMockInternalAccount({
-          address: '0xffffffffffffffffffffffffffffffffffffffff',
-        });
-
-        await withController(
-          { listAccounts: [] },
-          ({ controller, triggerAccountAdded }) => {
-            // Nothing seeded at startup since listAccounts returned []
-            expect(controller.state.allTokens).toStrictEqual({});
-
-            triggerAccountAdded(newAccount);
-
-            expect(
-              controller.state.allTokens['0x1'][newAccount.address],
-            ).toContainEqual(MUSD_TOKEN);
-            expect(
-              controller.state.allTokens['0xe708'][newAccount.address],
-            ).toContainEqual(MUSD_TOKEN);
-            expect(
-              controller.state.allTokens['0x8f'][newAccount.address],
-            ).toContainEqual(MUSD_TOKEN);
-          },
-        );
-      });
-
-      it('does not seed mUSD for non-EVM addresses', async () => {
-        const nonEvmAccount = createMockInternalAccount({
-          address: 'bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh',
-        });
-
-        await withController(
-          { listAccounts: [] },
-          ({ controller, triggerAccountAdded }) => {
-            triggerAccountAdded(nonEvmAccount);
-
-            expect(controller.state.allTokens).toStrictEqual({});
-          },
-        );
-      });
-    });
-
-    describe('when KeyringController:unlock is published', () => {
-      it('seeds mUSD for all accounts available at unlock time', async () => {
-        const account1 = createMockInternalAccount({
-          address: '0x1111111111111111111111111111111111111111',
-        });
-        const account2 = createMockInternalAccount({
-          address: '0x2222222222222222222222222222222222222222',
-        });
-
-        await withController(
-          // listAccounts is empty at construction; will be populated by the
-          // time KeyringController:unlock fires
-          { listAccounts: [] },
-          ({ controller, triggerKeyringUnlock, messenger }) => {
-            expect(controller.state.allTokens).toStrictEqual({});
-
-            // Simulate AccountsController having loaded accounts after
-            // construction by re-registering the action handler
-            messenger.unregisterActionHandler(
-              'AccountsController:listAccounts',
-            );
-            messenger.registerActionHandler(
-              'AccountsController:listAccounts',
-              () => [account1, account2],
-            );
-
-            triggerKeyringUnlock();
-
-            expect(
-              controller.state.allTokens['0x1'][account1.address],
-            ).toContainEqual(MUSD_TOKEN);
-            expect(
-              controller.state.allTokens['0x1'][account2.address],
-            ).toContainEqual(MUSD_TOKEN);
-          },
-        );
-      });
-    });
-
-    describe('when AccountsController:selectedEvmAccountChange is published', () => {
-      it('seeds mUSD for the newly selected account', async () => {
-        const newAccount = createMockInternalAccount({
-          address: '0xcccccccccccccccccccccccccccccccccccccccc',
-        });
-
-        await withController(
-          { listAccounts: [] },
-          ({ controller, triggerSelectedAccountChange }) => {
-            expect(controller.state.allTokens['0x1']).toBeUndefined();
-
-            triggerSelectedAccountChange(newAccount);
-
-            expect(
-              controller.state.allTokens['0x1'][newAccount.address],
-            ).toContainEqual(MUSD_TOKEN);
-            expect(
-              controller.state.allTokens['0xe708'][newAccount.address],
-            ).toContainEqual(MUSD_TOKEN);
-            expect(
-              controller.state.allTokens['0x8f'][newAccount.address],
-            ).toContainEqual(MUSD_TOKEN);
-          },
-        );
-      });
-
-      it('does not duplicate mUSD when the account already has it', async () => {
-        const account = createMockInternalAccount({
-          address: '0xcccccccccccccccccccccccccccccccccccccccc',
-        });
-
-        const existingState: Partial<TokensControllerState> = {
-          allTokens: {
-            '0x1': { [account.address]: [MUSD_TOKEN] },
-          },
-        };
-
-        await withController(
-          { listAccounts: [account], options: { state: existingState } },
-          ({ controller, triggerSelectedAccountChange }) => {
-            triggerSelectedAccountChange(account);
-
-            const mainnetTokens =
-              controller.state.allTokens['0x1'][account.address];
-            const musdCount = mainnetTokens.filter(
-              (token) =>
-                token.address.toLowerCase() === MUSD_ADDRESS.toLowerCase(),
-            ).length;
-            expect(musdCount).toBe(1);
-          },
-        );
-      });
-    });
-
-    describe('when NetworkController:networkAdded is published', () => {
-      it('seeds mUSD for all accounts when a supported chain is added', async () => {
-        const account = createMockInternalAccount({
-          address: '0xdddddddddddddddddddddddddddddddddddddddd',
-        });
-
-        await withController(
-          { listAccounts: [account] },
-          ({ controller, triggerNetworkAdded }) => {
-            // Clear state manually to simulate the account not yet having Monad seeded
-            controller.update((state) => {
-              delete state.allTokens['0x8f'];
-            });
-            expect(controller.state.allTokens['0x8f']).toBeUndefined();
-
-            triggerNetworkAdded('0x8f');
-
-            expect(
-              controller.state.allTokens['0x8f'][account.address],
-            ).toContainEqual(MUSD_TOKEN);
-          },
-        );
-      });
-
-      it('does not seed mUSD when an unsupported chain is added', async () => {
-        const account = createMockInternalAccount({
-          address: '0xdddddddddddddddddddddddddddddddddddddddd',
-        });
-
-        await withController(
-          { listAccounts: [account] },
-          ({ controller, triggerNetworkAdded }) => {
-            const tokensBefore = { ...controller.state.allTokens };
-
-            triggerNetworkAdded('0x5'); // Goerli — not supported
-
-            // Only the pre-seeded mUSD chains should be present; no Goerli entry
-            expect(controller.state.allTokens).toStrictEqual(tokensBefore);
-          },
-        );
-      });
-    });
-
-    describe('when NetworkController:stateChange patch adds a supported chain', () => {
-      it('seeds mUSD for all accounts', async () => {
-        const account = createMockInternalAccount({
-          address: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
-        });
-
-        await withController(
-          { listAccounts: [account] },
-          ({ controller, triggerNetworkStateChange }) => {
-            // Simulate adding Monad via a state patch
-            controller.update((state) => {
-              delete state.allTokens['0x8f'];
-            });
-
-            triggerNetworkStateChange({} as NetworkState, [
-              {
-                op: 'add',
-                path: ['networkConfigurationsByChainId', '0x8f'],
-                value: {},
-              },
-            ]);
-
-            expect(
-              controller.state.allTokens['0x8f'][account.address],
-            ).toContainEqual(MUSD_TOKEN);
-          },
-        );
-      });
-
-      it('does not seed mUSD when an unsupported chain is added via state patch', async () => {
-        const account = createMockInternalAccount({
-          address: '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
-        });
-
-        await withController(
-          { listAccounts: [account] },
-          ({ controller, triggerNetworkStateChange }) => {
-            const tokensBefore = { ...controller.state.allTokens };
-
-            triggerNetworkStateChange({} as NetworkState, [
-              {
-                op: 'add',
-                path: ['networkConfigurationsByChainId', '0x5'],
-                value: {},
-              },
-            ]);
-
-            expect(controller.state.allTokens).toStrictEqual(tokensBefore);
-          },
-        );
-      });
-    });
-  });
 });
 
 type WithControllerCallback<ReturnValue> = ({
@@ -4399,9 +3843,6 @@ type WithControllerCallback<ReturnValue> = ({
     networkState: NetworkState,
     patches: Patch[],
   ) => void;
-  triggerNetworkAdded: (chainId: string) => void;
-  triggerAccountAdded: (account: InternalAccount) => void;
-  triggerKeyringUnlock: () => void;
   getAccountHandler: jest.Mock;
   getSelectedAccountHandler: jest.Mock;
 }) => Promise<ReturnValue> | ReturnValue;
@@ -4491,13 +3932,10 @@ async function withController<ReturnValue>(
     ],
     events: [
       'NetworkController:networkDidChange',
-      'NetworkController:networkAdded',
       'NetworkController:stateChange',
-      'AccountsController:accountAdded',
       'AccountsController:selectedEvmAccountChange',
       'TokenListController:stateChange',
       'KeyringController:accountRemoved',
-      'KeyringController:unlock',
     ],
   });
 
@@ -4534,9 +3972,7 @@ async function withController<ReturnValue>(
     ...options,
   });
 
-  const triggerSelectedAccountChange = (
-    internalAccount: InternalAccount,
-  ): void => {
+  const triggerSelectedAccountChange = (internalAccount: InternalAccount) => {
     getAccountHandler.mockReturnValue(internalAccount);
     messenger.publish(
       'AccountsController:selectedEvmAccountChange',
@@ -4544,7 +3980,7 @@ async function withController<ReturnValue>(
     );
   };
 
-  const triggerAccountRemoved = (accountAddress: string): void => {
+  const triggerAccountRemoved = (accountAddress: string) => {
     messenger.publish('KeyringController:accountRemoved', accountAddress);
   };
 
@@ -4552,7 +3988,7 @@ async function withController<ReturnValue>(
     selectedNetworkClientId,
   }: {
     selectedNetworkClientId: NetworkClientId;
-  }): void => {
+  }) => {
     messenger.publish('NetworkController:networkDidChange', {
       ...getDefaultNetworkControllerState(),
       selectedNetworkClientId,
@@ -4570,27 +4006,8 @@ async function withController<ReturnValue>(
   const triggerNetworkStateChange = (
     networkState: NetworkState,
     patches: Patch[],
-  ): void => {
+  ) => {
     messenger.publish('NetworkController:stateChange', networkState, patches);
-  };
-
-  const triggerNetworkAdded = (chainId: string): void => {
-    messenger.publish('NetworkController:networkAdded', {
-      chainId,
-      blockExplorerUrls: [],
-      name: 'Test Network',
-      nativeCurrency: 'ETH',
-      defaultRpcEndpointIndex: 0,
-      rpcEndpoints: [],
-    } as never);
-  };
-
-  const triggerAccountAdded = (account: InternalAccount): void => {
-    messenger.publish('AccountsController:accountAdded', account);
-  };
-
-  const triggerKeyringUnlock = (): void => {
-    messenger.publish('KeyringController:unlock');
   };
 
   return await fn({
@@ -4600,9 +4017,6 @@ async function withController<ReturnValue>(
     approvalController,
     triggerSelectedAccountChange,
     triggerNetworkStateChange,
-    triggerNetworkAdded,
-    triggerAccountAdded,
-    triggerKeyringUnlock,
     triggerAccountRemoved,
     getAccountHandler,
     getSelectedAccountHandler,
@@ -4727,25 +4141,16 @@ function buildMockERC1155Standard({
  * @param args - The arguments to this function.
  * @param args.supportsInterface - Whether the contract will report as supporting
  * the given ERC721 ABI.
- * @param args.supportsInterfaceThrows - When true, `supportsInterface` rejects
- * instead of returning a boolean (simulates a contract revert).
  * @returns The mock contract.
  */
 function buildMockEthersERC721Contract({
   supportsInterface,
-  supportsInterfaceThrows = false,
 }: {
   supportsInterface: boolean;
-  supportsInterfaceThrows?: boolean;
 }): Contract {
   // @ts-expect-error This intentionally does not support all of the methods
   // for the contract, only the ones we care about
   return {
-    supportsInterface: async (): Promise<boolean> => {
-      if (supportsInterfaceThrows) {
-        throw new Error('supportsInterface reverted');
-      }
-      return supportsInterface;
-    },
+    supportsInterface: async () => supportsInterface,
   };
 }

--- a/packages/assets-controllers/src/TokensController.ts
+++ b/packages/assets-controllers/src/TokensController.ts
@@ -1,7 +1,6 @@
 import { Contract } from '@ethersproject/contracts';
 import { Web3Provider } from '@ethersproject/providers';
 import type {
-  AccountsControllerAccountAddedEvent,
   AccountsControllerGetAccountAction,
   AccountsControllerGetSelectedAccountAction,
   AccountsControllerListAccountsAction,
@@ -26,17 +25,13 @@ import {
   isValidHexAddress,
   safelyExecute,
 } from '@metamask/controller-utils';
-import type {
-  KeyringControllerAccountRemovedEvent,
-  KeyringControllerUnlockEvent,
-} from '@metamask/keyring-controller';
+import type { KeyringControllerAccountRemovedEvent } from '@metamask/keyring-controller';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 import type { Messenger } from '@metamask/messenger';
 import { abiERC721 } from '@metamask/metamask-eth-abis';
 import type {
   NetworkClientId,
   NetworkControllerGetNetworkClientByIdAction,
-  NetworkControllerNetworkAddedEvent,
   NetworkControllerNetworkDidChangeEvent,
   NetworkControllerStateChangeEvent,
   NetworkState,
@@ -166,12 +161,9 @@ export type TokensControllerEvents = TokensControllerStateChangeEvent;
 export type AllowedEvents =
   | NetworkControllerStateChangeEvent
   | NetworkControllerNetworkDidChangeEvent
-  | NetworkControllerNetworkAddedEvent
   | TokenListStateChange
-  | AccountsControllerAccountAddedEvent
   | AccountsControllerSelectedEvmAccountChangeEvent
-  | KeyringControllerAccountRemovedEvent
-  | KeyringControllerUnlockEvent;
+  | KeyringControllerAccountRemovedEvent;
 
 /**
  * The messenger of the {@link TokensController}.
@@ -181,34 +173,6 @@ export type TokensControllerMessenger = Messenger<
   TokensControllerActions | AllowedActions,
   TokensControllerEvents | AllowedEvents
 >;
-
-/**
- * Canonical contract address for MetaMask USD (mUSD) — same across every
- * chain we deploy it to.
- */
-const MUSD_ADDRESS = '0xaca92e438df0b2401ff60da7e4337b687a2435da';
-
-/**
- * Pre-built Token entry for mUSD — used when seeding default state.
- */
-const MUSD_TOKEN: Token = {
-  address: MUSD_ADDRESS,
-  decimals: 6,
-  symbol: 'mUSD',
-  name: 'MetaMask USD',
-};
-
-/**
- * Hex chain IDs on which mUSD is deployed and should be shown by default.
- * - 0x1     — Ethereum mainnet (1)
- * - 0xe708  — Linea (59144)
- * - 0x8f    — Monad mainnet (143)
- */
-const MUSD_SUPPORTED_CHAIN_IDS: ReadonlySet<Hex> = new Set<Hex>([
-  '0x1',
-  '0xe708',
-  '0x8f',
-]);
 
 export const getDefaultTokensState = (): TokensControllerState => {
   return {
@@ -298,38 +262,6 @@ export class TokensController extends BaseController<
     );
 
     this.messenger.subscribe(
-      'NetworkController:networkAdded',
-      (networkConfiguration) => {
-        this.#onNetworkAdded(networkConfiguration.chainId);
-      },
-    );
-
-    // Seed mUSD for accounts already known to AccountsController (may return
-    // empty on first start if AccountsController hasn't loaded yet).
-    this.#seedMusdForAllAccounts();
-
-    // Also seed from existing persisted allTokens state so returning users see
-    // mUSD immediately without waiting for KeyringController:unlock.
-    this.#seedMusdFromExistingState();
-
-    // Re-seed mUSD after unlock, because accounts may not be available during
-    // construction (e.g. on restart before AccountsController has finished loading).
-    this.messenger.subscribe('KeyringController:unlock', () => {
-      this.#seedMusdForAllAccounts();
-    });
-
-    // Re-seed mUSD whenever a new account is added. This is the most reliable
-    // trigger when AccountsController populates accounts asynchronously after
-    // TokensController construction — it fires once per account as each one
-    // becomes available.
-    this.messenger.subscribe(
-      'AccountsController:accountAdded',
-      (account: InternalAccount) => {
-        this.#seedMusdForAccount(account.address);
-      },
-    );
-
-    this.messenger.subscribe(
       'TokenListController:stateChange',
       ({ tokensChainsCache }) => {
         const { allTokens } = this.state;
@@ -414,39 +346,20 @@ export class TokensController extends BaseController<
    * @param _ - The network state.
    * @param patches - An array of patch operations performed on the network state.
    */
-  /**
-   * Handles the `NetworkController:networkAdded` event. Seeds mUSD for all
-   * EVM accounts immediately when the user adds a supported chain (e.g. Monad
-   * testnet) — without waiting for the `stateChange` patch cycle.
-   *
-   * @param chainId - The hex chain ID of the newly added network.
-   */
-  #onNetworkAdded(chainId: Hex): void {
-    if (MUSD_SUPPORTED_CHAIN_IDS.has(chainId)) {
-      this.#seedMusdForAllAccounts();
-    }
-  }
-
   #onNetworkStateChange(_: NetworkState, patches: Patch[]) {
+    // Remove state for deleted networks
     for (const patch of patches) {
-      if (patch.path[0] !== 'networkConfigurationsByChainId') {
-        continue;
-      }
-
-      if (patch.op === 'remove') {
-        // Remove state for deleted networks
+      if (
+        patch.op === 'remove' &&
+        patch.path[0] === 'networkConfigurationsByChainId'
+      ) {
         const removedChainId = patch.path[1] as Hex;
+
         this.update((state) => {
           delete state.allTokens[removedChainId];
           delete state.allIgnoredTokens[removedChainId];
           delete state.allDetectedTokens[removedChainId];
         });
-      } else if (patch.op === 'add') {
-        // When a new chain is added, seed mUSD if it is a supported chain.
-        const addedChainId = patch.path[1] as Hex;
-        if (MUSD_SUPPORTED_CHAIN_IDS.has(addedChainId)) {
-          this.#seedMusdForAllAccounts();
-        }
       }
     }
   }
@@ -458,9 +371,6 @@ export class TokensController extends BaseController<
    */
   #onSelectedAccountChange(selectedAccount: InternalAccount) {
     this.#selectedAccountId = selectedAccount.id;
-    // Ensure mUSD is seeded for the newly active account (e.g. freshly
-    // created account that has never been the selected account before).
-    this.#seedMusdForAccount(selectedAccount.address);
   }
 
   /**
@@ -1227,68 +1137,6 @@ export class TokensController extends BaseController<
       },
       true,
     );
-  }
-
-  /**
-   * Ensure mUSD appears in `allTokens` for the given EVM account address on
-   * every chain where mUSD is a default tracked asset. Does nothing if the
-   * address is not a valid EVM address or if mUSD is already present.
-   *
-   * @param accountAddress - Lowercase hex address of the account.
-   */
-  #seedMusdForAccount(accountAddress: string): void {
-    if (
-      !isStrictHexString(accountAddress.toLowerCase()) ||
-      !isValidHexAddress(accountAddress)
-    ) {
-      return;
-    }
-
-    this.update((state) => {
-      for (const chainId of MUSD_SUPPORTED_CHAIN_IDS) {
-        state.allTokens[chainId] ??= {};
-        const accountTokens = state.allTokens[chainId][accountAddress] ?? [];
-        const alreadyPresent = accountTokens.some(
-          (token) => token.address.toLowerCase() === MUSD_ADDRESS,
-        );
-        if (!alreadyPresent) {
-          state.allTokens[chainId][accountAddress] = [
-            ...accountTokens,
-            MUSD_TOKEN,
-          ];
-        }
-      }
-    });
-  }
-
-  /**
-   * Seed mUSD for every existing EVM account via AccountsController.
-   * Called on KeyringController:unlock and on network/account events.
-   */
-  #seedMusdForAllAccounts(): void {
-    const accounts = this.messenger.call('AccountsController:listAccounts');
-    for (const account of accounts) {
-      this.#seedMusdForAccount(account.address);
-    }
-  }
-
-  /**
-   * Seed mUSD for every account address that already has an entry in the
-   * persisted `allTokens` state. This runs at construction time without
-   * relying on AccountsController being ready — it derives account addresses
-   * directly from state so that returning users see mUSD immediately, even
-   * before the keyring unlocks.
-   */
-  #seedMusdFromExistingState(): void {
-    const addresses = new Set<string>();
-    for (const chainTokens of Object.values(this.state.allTokens)) {
-      for (const address of Object.keys(chainTokens)) {
-        addresses.add(address);
-      }
-    }
-    for (const address of addresses) {
-      this.#seedMusdForAccount(address);
-    }
   }
 
   #getSelectedAccount() {

--- a/packages/assets-controllers/src/constants.ts
+++ b/packages/assets-controllers/src/constants.ts
@@ -1,4 +1,8 @@
-import { CHAIN_IDS_WITH_NO_NATIVE_TOKEN } from '@metamask/controller-utils';
+import {
+  CHAIN_IDS_WITH_NO_NATIVE_TOKEN,
+  ChainId,
+} from '@metamask/controller-utils';
+import type { Hex } from '@metamask/utils';
 
 export enum Source {
   Custom = 'custom',
@@ -20,6 +24,52 @@ export const SUPPORTED_NETWORKS_ACCOUNTS_API_V4 = [
   '0x8f', // 143
   '0x3e7', // 999 HyperEVM
 ];
+
+/** Lowercase ERC-20 address for MetaMask USD (mUSD), same contract on listed chains. */
+export const MUSD_ERC20_ADDRESS_LOWER =
+  '0xaca92e438df0b2401ff60da7e4337b687a2435da';
+
+/**
+ * EVM chains where mUSD is always merged into the token-detection candidate list.
+ * Metadata matches `GET /v3/assets` on `tokens.api.cx.metamask.io` (assetIds CAIP-19).
+ */
+export const MUSD_TOKEN_DETECTION_CHAIN_IDS: readonly Hex[] = [
+  ChainId.mainnet,
+  ChainId['linea-mainnet'],
+  '0x8f', // Monad mainnet (eip155:143)
+] as const;
+
+/** Raw `aggregators` keys from the Tokens API (same shape as token list cache). */
+export type MusdTokenDetectionMetadata = {
+  name: string;
+  symbol: string;
+  decimals: number;
+  aggregators: string[];
+};
+
+export const MUSD_TOKEN_METADATA_BY_CHAIN: Record<
+  (typeof MUSD_TOKEN_DETECTION_CHAIN_IDS)[number],
+  MusdTokenDetectionMetadata
+> = {
+  [ChainId.mainnet]: {
+    name: 'MetaMask USD',
+    symbol: 'MUSD',
+    decimals: 6,
+    aggregators: ['metamask', 'liFi', 'socket', 'rubic', 'rango'],
+  },
+  [ChainId['linea-mainnet']]: {
+    name: 'MetaMask USD',
+    symbol: 'MUSD',
+    decimals: 6,
+    aggregators: ['metamask', 'liFi', 'socket', 'rubic', 'squid', 'rango'],
+  },
+  '0x8f': {
+    name: 'MetaMask USD',
+    symbol: 'mUSD',
+    decimals: 6,
+    aggregators: ['dynamic'],
+  },
+};
 
 /**
  * Determines if native token fetching should be included for the given chain.

--- a/packages/assets-controllers/src/constants.ts
+++ b/packages/assets-controllers/src/constants.ts
@@ -1,7 +1,4 @@
-import {
-  CHAIN_IDS_WITH_NO_NATIVE_TOKEN,
-  ChainId,
-} from '@metamask/controller-utils';
+import { CHAIN_IDS_WITH_NO_NATIVE_TOKEN } from '@metamask/controller-utils';
 import type { Hex } from '@metamask/utils';
 
 export enum Source {
@@ -33,11 +30,11 @@ export const MUSD_ERC20_ADDRESS_LOWER =
  * EVM chains where mUSD is always merged into the token-detection candidate list.
  * Metadata matches `GET /v3/assets` on `tokens.api.cx.metamask.io` (assetIds CAIP-19).
  */
-export const MUSD_TOKEN_DETECTION_CHAIN_IDS: readonly Hex[] = [
-  ChainId.mainnet,
-  ChainId['linea-mainnet'],
+export const MUSD_TOKEN_DETECTION_CHAIN_IDS = [
+  '0x1', // Ethereum mainnet (eip155:1)
+  '0xe708', // Linea (eip155:59144)
   '0x8f', // Monad mainnet (eip155:143)
-] as const;
+] as const satisfies readonly Hex[];
 
 /** Raw `aggregators` keys from the Tokens API (same shape as token list cache). */
 export type MusdTokenDetectionMetadata = {
@@ -51,13 +48,13 @@ export const MUSD_TOKEN_METADATA_BY_CHAIN: Record<
   (typeof MUSD_TOKEN_DETECTION_CHAIN_IDS)[number],
   MusdTokenDetectionMetadata
 > = {
-  [ChainId.mainnet]: {
+  '0x1': {
     name: 'MetaMask USD',
     symbol: 'MUSD',
     decimals: 6,
     aggregators: ['metamask', 'liFi', 'socket', 'rubic', 'rango'],
   },
-  [ChainId['linea-mainnet']]: {
+  '0xe708': {
     name: 'MetaMask USD',
     symbol: 'MUSD',
     decimals: 6,


### PR DESCRIPTION
## Explanation

UI PR: https://github.com/MetaMask/metamask-extension/pull/42390

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes token discovery/import behavior for mUSD across multiple chains, which could impact whether the asset appears by default and how it is re-added across account/network changes. Risk is mitigated by added unit tests, but regressions could affect token visibility/import timing.
> 
> **Overview**
> Switches **default mUSD handling** from upfront `TokensController` state seeding to **detection-based discovery** on Ethereum mainnet (`0x1`), Linea (`0xe708`), and Monad mainnet (`0x8f`), and drops Monad testnet from the default list.
> 
> `TokenDetectionController` now merges mUSD metadata into the in-memory token list cache and ensures mUSD is included in detection slices (polling/WS/RPC), including a special case to add mUSD even when RPC returns a zero balance. `TokenBalancesController` now also schedules mUSD for import on those chains even when balances are zero.
> 
> Removes the prior mUSD seeding/event-subscription paths from `TokensController` (and related messenger allowed events), updates tests accordingly, and adds shared mUSD constants/metadata plus changelog and lint-suppression updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fa961b2428880ed89753f1c1cb1b4f03c0f7529. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->