### PR TITLE
chore: Expose missing `TransactionController` methods through the messenger

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Expose missing public `TransactionController` methods through its messenger ([#8690](https://github.com/MetaMask/core/pull/8690))
+  - The following actions are now available:
+    - `TransactionController:updateSecurityAlertResponse`
+    - `TransactionController:updatePreviousGasParams`
+    - `TransactionController:updateRequiredTransactionIds`
+    - `TransactionController:updateSelectedGasFeeToken`
+    - `TransactionController:updateTransactionGasFees`
+  - Corresponding action types are available as well.
 - Allow EIP-7702 authorizations from accounts in the Money keyring ([#8687](https://github.com/MetaMask/core/pull/8687)).
 - Export `decodeAuthorizationSignature` utility that decodes a 65-byte EIP-7702 authorization signature into RLP-canonical `r`, `s`, and `yParity` ([#8656](https://github.com/MetaMask/core/pull/8656))
   - All `eth_sendRawTransaction` failures are prefixed `RPC submit:` for failure-surface attribution in error metrics

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [65.1.0]
-
 ### Added
 
 - Expose missing public `TransactionController` methods through its messenger ([#8690](https://github.com/MetaMask/core/pull/8690))
@@ -19,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `TransactionController:updateSelectedGasFeeToken`
     - `TransactionController:updateTransactionGasFees`
   - Corresponding action types are available as well.
+
+## [65.1.0]
+
+### Added
+
 - Allow EIP-7702 authorizations from accounts in the Money keyring ([#8687](https://github.com/MetaMask/core/pull/8687)).
 - Export `decodeAuthorizationSignature` utility that decodes a 65-byte EIP-7702 authorization signature into RLP-canonical `r`, `s`, and `yParity` ([#8656](https://github.com/MetaMask/core/pull/8656))
   - All `eth_sendRawTransaction` failures are prefixed `RPC submit:` for failure-surface attribution in error metrics

--- a/packages/transaction-controller/src/TransactionController-method-action-types.ts
+++ b/packages/transaction-controller/src/TransactionController-method-action-types.ts
@@ -162,6 +162,17 @@ export type TransactionControllerUpdateTransactionAction = {
 };
 
 /**
+ * Update the security alert response for a transaction.
+ *
+ * @param transactionId - ID of the transaction.
+ * @param securityAlertResponse - The new security alert response for the transaction.
+ */
+export type TransactionControllerUpdateSecurityAlertResponseAction = {
+  type: `TransactionController:updateSecurityAlertResponse`;
+  handler: TransactionController['updateSecurityAlertResponse'];
+};
+
+/**
  * Remove transactions from state.
  *
  * @param options - The options bag.
@@ -183,6 +194,44 @@ export type TransactionControllerWipeTransactionsAction = {
 export type TransactionControllerConfirmExternalTransactionAction = {
   type: `TransactionController:confirmExternalTransaction`;
   handler: TransactionController['confirmExternalTransaction'];
+};
+
+/**
+ * Update the gas values of a transaction.
+ *
+ * @param transactionId - The ID of the transaction to update.
+ * @param gasValues - Gas values to update.
+ * @param gasValues.gas - Same as transaction.gasLimit.
+ * @param gasValues.gasLimit - Maxmimum number of units of gas to use for this transaction.
+ * @param gasValues.gasPrice - Price per gas for legacy transactions.
+ * @param gasValues.maxPriorityFeePerGas - Maximum amount per gas to give to validator as incentive.
+ * @param gasValues.maxFeePerGas - Maximum amount per gas to pay for the transaction, including the priority fee.
+ * @param gasValues.estimateUsed - Which estimate level was used.
+ * @param gasValues.estimateSuggested - Which estimate level that the API suggested.
+ * @param gasValues.defaultGasEstimates - The default estimate for gas.
+ * @param gasValues.originalGasEstimate - Original estimate for gas.
+ * @param gasValues.userEditedGasLimit - The gas limit supplied by user.
+ * @param gasValues.userFeeLevel - Estimate level user selected.
+ * @returns The updated transactionMeta.
+ */
+export type TransactionControllerUpdateTransactionGasFeesAction = {
+  type: `TransactionController:updateTransactionGasFees`;
+  handler: TransactionController['updateTransactionGasFees'];
+};
+
+/**
+ * Update the previous gas values of a transaction.
+ *
+ * @param transactionId - The ID of the transaction to update.
+ * @param previousGas - Previous gas values to update.
+ * @param previousGas.gasLimit - Maximum number of units of gas to use for this transaction.
+ * @param previousGas.maxFeePerGas - Maximum amount per gas to pay for the transaction, including the priority fee.
+ * @param previousGas.maxPriorityFeePerGas - Maximum amount per gas to give to validator as incentive.
+ * @returns The updated transactionMeta.
+ */
+export type TransactionControllerUpdatePreviousGasParamsAction = {
+  type: `TransactionController:updatePreviousGasParams`;
+  handler: TransactionController['updatePreviousGasParams'];
 };
 
 /**
@@ -332,6 +381,30 @@ export type TransactionControllerUpdateAtomicBatchDataAction = {
 };
 
 /**
+ * Update the selected gas fee token for a transaction.
+ *
+ * @param transactionId - The ID of the transaction to update.
+ * @param contractAddress - The contract address of the selected gas fee token.
+ */
+export type TransactionControllerUpdateSelectedGasFeeTokenAction = {
+  type: `TransactionController:updateSelectedGasFeeToken`;
+  handler: TransactionController['updateSelectedGasFeeToken'];
+};
+
+/**
+ * Update the required transaction IDs for a transaction.
+ *
+ * @param request - The request object.
+ * @param request.transactionId - The ID of the transaction to update.
+ * @param request.requiredTransactionIds - The additional required transaction IDs.
+ * @param request.append - Whether to append the IDs to any existing values. Defaults to true.
+ */
+export type TransactionControllerUpdateRequiredTransactionIdsAction = {
+  type: `TransactionController:updateRequiredTransactionIds`;
+  handler: TransactionController['updateRequiredTransactionIds'];
+};
+
+/**
  * Emulate a new transaction.
  *
  * @param transactionId - The transaction ID.
@@ -379,8 +452,11 @@ export type TransactionControllerMethodActions =
   | TransactionControllerEstimateGasBatchAction
   | TransactionControllerEstimateGasBufferedAction
   | TransactionControllerUpdateTransactionAction
+  | TransactionControllerUpdateSecurityAlertResponseAction
   | TransactionControllerWipeTransactionsAction
   | TransactionControllerConfirmExternalTransactionAction
+  | TransactionControllerUpdateTransactionGasFeesAction
+  | TransactionControllerUpdatePreviousGasParamsAction
   | TransactionControllerGetNonceLockAction
   | TransactionControllerUpdateEditableParamsAction
   | TransactionControllerSetTransactionActiveAction
@@ -392,6 +468,8 @@ export type TransactionControllerMethodActions =
   | TransactionControllerClearUnapprovedTransactionsAction
   | TransactionControllerAbortTransactionSigningAction
   | TransactionControllerUpdateAtomicBatchDataAction
+  | TransactionControllerUpdateSelectedGasFeeTokenAction
+  | TransactionControllerUpdateRequiredTransactionIdsAction
   | TransactionControllerEmulateNewTransactionAction
   | TransactionControllerEmulateTransactionUpdateAction
   | TransactionControllerGetGasFeeTokensAction;

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -763,13 +763,13 @@ const MESSENGER_EXPOSED_METHODS = [
   'updateCustodialTransaction',
   'updateEditableParams',
   'updateIncomingTransactions',
-  'updateTransaction',
-  'wipeTransactions',
-  'updateSecurityAlertResponse',
   'updatePreviousGasParams',
   'updateRequiredTransactionIds',
+  'updateSecurityAlertResponse',
   'updateSelectedGasFeeToken',
+  'updateTransaction',
   'updateTransactionGasFees',
+  'wipeTransactions',
 ] as const;
 
 /**

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -765,6 +765,11 @@ const MESSENGER_EXPOSED_METHODS = [
   'updateIncomingTransactions',
   'updateTransaction',
   'wipeTransactions',
+  'updateSecurityAlertResponse',
+  'updatePreviousGasParams',
+  'updateRequiredTransactionIds',
+  'updateSelectedGasFeeToken',
+  'updateTransactionGasFees',
 ] as const;
 
 /**

--- a/packages/transaction-controller/src/index.ts
+++ b/packages/transaction-controller/src/index.ts
@@ -54,6 +54,11 @@ export type {
   TransactionControllerAbortTransactionSigningAction,
   TransactionControllerUpdateAtomicBatchDataAction,
   TransactionControllerWipeTransactionsAction,
+  TransactionControllerUpdateSecurityAlertResponseAction,
+  TransactionControllerUpdateTransactionGasFeesAction,
+  TransactionControllerUpdatePreviousGasParamsAction,
+  TransactionControllerUpdateSelectedGasFeeTokenAction,
+  TransactionControllerUpdateRequiredTransactionIdsAction,
 } from './TransactionController-method-action-types';
 export {
   CANCEL_RATE,


### PR DESCRIPTION
## Explanation
This exposes missing methods used in the clients through the messenger after https://github.com/MetaMask/core/pull/8183
## References
Progresses https://consensyssoftware.atlassian.net/browse/WPC-989

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only expands the TransactionController messenger/public API surface (types + exposed method list) without changing transaction processing logic, but it may require downstream consumers to update allowed actions/imports.
> 
> **Overview**
> **Exposes additional `TransactionController` methods via the messenger** by adding new messenger action type definitions and including these methods in `MESSENGER_EXPOSED_METHODS`.
> 
> Adds/exports actions for `updateSecurityAlertResponse`, `updateTransactionGasFees`, `updatePreviousGasParams`, `updateSelectedGasFeeToken`, and `updateRequiredTransactionIds`, and documents the new messenger actions in the `transaction-controller` `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58c619d22e2b5069cd90022c14b287f216e05ec5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->