### PR TITLE
chore: Expose missing `AccountTrackerController` and `TokenBalanceController` methods through the messenger

### DIFF
--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Expose missing public `AccountTrackerController` methods through its messenger ([#8693](https://github.com/MetaMask/core/pull/8693))
+  - The following actions are now available:
+    - `AccountTrackerController:refresh`
+    - `AccountTrackerController:syncBalanceWithAddresses`
+  - Corresponding action types are available as well.
+- Expose missing public `TokenBalancesController` methods through its messenger ([#8693](https://github.com/MetaMask/core/pull/8693))
+  - The following actions are now available:
+    - `TokenBalancesController:updateBalances`
+    - `TokenBalancesController:resetState`
+  - Corresponding action types are available as well.
+
 ### Changed
 
 - Bump `@metamask/network-enablement-controller` from `^5.0.2` to `^5.1.0` ([#8665](https://github.com/MetaMask/core/pull/8665))

--- a/packages/assets-controllers/src/AccountTrackerController-method-action-types.ts
+++ b/packages/assets-controllers/src/AccountTrackerController-method-action-types.ts
@@ -6,6 +6,31 @@
 import type { AccountTrackerController } from './AccountTrackerController';
 
 /**
+ * Refreshes the balances of the accounts depending on the multi-account setting.
+ * If multi-account is disabled, only updates the selected account balance.
+ * If multi-account is enabled, updates balances for all accounts.
+ *
+ * @param networkClientIds - Optional network client IDs to fetch a network client with
+ * @param queryAllAccounts - Whether to query all accounts or just the selected account
+ */
+export type AccountTrackerControllerRefreshAction = {
+  type: `AccountTrackerController:refresh`;
+  handler: AccountTrackerController['refresh'];
+};
+
+/**
+ * Sync accounts balances with some additional addresses.
+ *
+ * @param addresses - the additional addresses, may be hardware wallet addresses.
+ * @param networkClientId - Optional networkClientId to fetch a network client with.
+ * @returns accounts - addresses with synced balance
+ */
+export type AccountTrackerControllerSyncBalanceWithAddressesAction = {
+  type: `AccountTrackerController:syncBalanceWithAddresses`;
+  handler: AccountTrackerController['syncBalanceWithAddresses'];
+};
+
+/**
  * Updates the balances of multiple native tokens in a single batch operation.
  * This is more efficient than calling updateNativeToken multiple times as it
  * triggers only one state update.
@@ -33,5 +58,7 @@ export type AccountTrackerControllerUpdateStakedBalancesAction = {
  * Union of all AccountTrackerController action types.
  */
 export type AccountTrackerControllerMethodActions =
+  | AccountTrackerControllerRefreshAction
+  | AccountTrackerControllerSyncBalanceWithAddressesAction
   | AccountTrackerControllerUpdateNativeBalancesAction
   | AccountTrackerControllerUpdateStakedBalancesAction;

--- a/packages/assets-controllers/src/AccountTrackerController.ts
+++ b/packages/assets-controllers/src/AccountTrackerController.ts
@@ -234,6 +234,8 @@ type AccountTrackerPollingInput = {
 const MESSENGER_EXPOSED_METHODS = [
   'updateNativeBalances',
   'updateStakedBalances',
+  'refresh',
+  'syncBalanceWithAddresses',
 ] as const;
 
 /**

--- a/packages/assets-controllers/src/TokenBalancesController-method-action-types.ts
+++ b/packages/assets-controllers/src/TokenBalancesController-method-action-types.ts
@@ -15,9 +15,21 @@ export type TokenBalancesControllerUpdateChainPollingConfigsAction = {
   handler: TokenBalancesController['updateChainPollingConfigs'];
 };
 
+export type TokenBalancesControllerUpdateBalancesAction = {
+  type: `TokenBalancesController:updateBalances`;
+  handler: TokenBalancesController['updateBalances'];
+};
+
+export type TokenBalancesControllerResetStateAction = {
+  type: `TokenBalancesController:resetState`;
+  handler: TokenBalancesController['resetState'];
+};
+
 /**
  * Union of all TokenBalancesController action types.
  */
 export type TokenBalancesControllerMethodActions =
   | TokenBalancesControllerGetChainPollingConfigAction
-  | TokenBalancesControllerUpdateChainPollingConfigsAction;
+  | TokenBalancesControllerUpdateChainPollingConfigsAction
+  | TokenBalancesControllerUpdateBalancesAction
+  | TokenBalancesControllerResetStateAction;

--- a/packages/assets-controllers/src/TokenBalancesController.ts
+++ b/packages/assets-controllers/src/TokenBalancesController.ts
@@ -289,7 +289,9 @@ type StakedBalanceUpdate = {
 const MESSENGER_EXPOSED_METHODS = [
   'updateChainPollingConfigs',
   'getChainPollingConfig',
-] as const;
+  'updateBalances',
+  'resetState',
+];
 
 export class TokenBalancesController extends StaticIntervalPollingController<{
   chainIds: ChainIdHex[];

--- a/packages/assets-controllers/src/TokenBalancesController.ts
+++ b/packages/assets-controllers/src/TokenBalancesController.ts
@@ -291,7 +291,7 @@ const MESSENGER_EXPOSED_METHODS = [
   'getChainPollingConfig',
   'updateBalances',
   'resetState',
-];
+] as const;
 
 export class TokenBalancesController extends StaticIntervalPollingController<{
   chainIds: ChainIdHex[];

--- a/packages/assets-controllers/src/index.ts
+++ b/packages/assets-controllers/src/index.ts
@@ -11,6 +11,8 @@ export { AccountTrackerController } from './AccountTrackerController';
 export type {
   AccountTrackerControllerUpdateNativeBalancesAction,
   AccountTrackerControllerUpdateStakedBalancesAction,
+  AccountTrackerControllerRefreshAction,
+  AccountTrackerControllerSyncBalanceWithAddressesAction,
 } from './AccountTrackerController-method-action-types';
 export type {
   AssetsContractControllerActions,
@@ -95,6 +97,8 @@ export { TokenBalancesController } from './TokenBalancesController';
 export type {
   TokenBalancesControllerUpdateChainPollingConfigsAction,
   TokenBalancesControllerGetChainPollingConfigAction,
+  TokenBalancesControllerUpdateBalancesAction,
+  TokenBalancesControllerResetStateAction,
 } from './TokenBalancesController-method-action-types';
 export type {
   TokenDetectionControllerMessenger,


### PR DESCRIPTION
## Explanation
This exposes missing methods used in the clients through the messenger after https://github.com/MetaMask/core/pull/8164

## References
Progresses https://consensyssoftware.atlassian.net/browse/WPC-989

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk API-surface change: it only exposes existing controller methods via the messenger and adds corresponding action types/exports, with minimal behavioral impact beyond enabling new calls.
> 
> **Overview**
> **Exposes additional controller methods via the messenger** by adding `AccountTrackerController:refresh` and `AccountTrackerController:syncBalanceWithAddresses`, plus `TokenBalancesController:updateBalances` and `TokenBalancesController:resetState`.
> 
> Updates the auto-generated `*-method-action-types` unions and package exports so consumers can type and invoke these newly exposed actions, and documents the additions in the `assets-controllers` changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00c2c6f0c5d9ed19dabb06510076ee47b4e679e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->