### PR TITLE
Release/959.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "958.0.0",
+  "version": "959.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {

--- a/packages/ramps-controller/CHANGELOG.md
+++ b/packages/ramps-controller/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [13.3.0]
+
 ### Changed
 
 - Bump `@metamask/messenger` from `^1.1.1` to `^1.2.0` ([#8632](https://github.com/MetaMask/core/pull/8632))
@@ -330,7 +332,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add `OnRampService` for interacting with the OnRamp API
   - Add geolocation detection via IP address lookup
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/ramps-controller@13.2.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/ramps-controller@13.3.0...HEAD
+[13.3.0]: https://github.com/MetaMask/core/compare/@metamask/ramps-controller@13.2.0...@metamask/ramps-controller@13.3.0
 [13.2.0]: https://github.com/MetaMask/core/compare/@metamask/ramps-controller@13.1.0...@metamask/ramps-controller@13.2.0
 [13.1.0]: https://github.com/MetaMask/core/compare/@metamask/ramps-controller@13.0.0...@metamask/ramps-controller@13.1.0
 [13.0.0]: https://github.com/MetaMask/core/compare/@metamask/ramps-controller@12.1.0...@metamask/ramps-controller@13.0.0

--- a/packages/ramps-controller/package.json
+++ b/packages/ramps-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/ramps-controller",
-  "version": "13.2.0",
+  "version": "13.3.0",
   "description": "A controller for managing cryptocurrency on/off ramps functionality",
   "keywords": [
     "Ethereum",

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `@metamask/transaction-controller` from `^65.0.0` to `^65.1.0` ([#8691](https://github.com/MetaMask/core/pull/8691))
+- Bump `@metamask/ramps-controller` from `^13.2.0` to `^13.3.0` ([#PLACEHOLDER](https://github.com/MetaMask/core/pull/PLACEHOLDER))
 
 ## [21.0.0]
 

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `@metamask/transaction-controller` from `^65.0.0` to `^65.1.0` ([#8691](https://github.com/MetaMask/core/pull/8691))
-- Bump `@metamask/ramps-controller` from `^13.2.0` to `^13.3.0` ([#PLACEHOLDER](https://github.com/MetaMask/core/pull/PLACEHOLDER))
+- Bump `@metamask/ramps-controller` from `^13.2.0` to `^13.3.0` ([#8698](https://github.com/MetaMask/core/pull/8698))
 
 ## [21.0.0]
 

--- a/packages/transaction-pay-controller/package.json
+++ b/packages/transaction-pay-controller/package.json
@@ -67,7 +67,7 @@
     "@metamask/messenger": "^1.2.0",
     "@metamask/metamask-eth-abis": "^3.1.1",
     "@metamask/network-controller": "^30.1.0",
-    "@metamask/ramps-controller": "^13.2.0",
+    "@metamask/ramps-controller": "^13.3.0",
     "@metamask/remote-feature-flag-controller": "^4.2.0",
     "@metamask/transaction-controller": "^65.1.0",
     "@metamask/utils": "^11.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5153,7 +5153,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/ramps-controller@npm:^13.2.0, @metamask/ramps-controller@workspace:packages/ramps-controller":
+"@metamask/ramps-controller@npm:^13.3.0, @metamask/ramps-controller@workspace:packages/ramps-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/ramps-controller@workspace:packages/ramps-controller"
   dependencies:
@@ -5740,7 +5740,7 @@ __metadata:
     "@metamask/messenger": "npm:^1.2.0"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
     "@metamask/network-controller": "npm:^30.1.0"
-    "@metamask/ramps-controller": "npm:^13.2.0"
+    "@metamask/ramps-controller": "npm:^13.3.0"
     "@metamask/remote-feature-flag-controller": "npm:^4.2.0"
     "@metamask/transaction-controller": "npm:^65.1.0"
     "@metamask/utils": "npm:^11.9.0"


### PR DESCRIPTION
## Summary

This release PR publishes `@metamask/ramps-controller@13.3.0`, which includes the circuit-breaker error-key fix from [#8596](https://github.com/MetaMask/core/pull/8596) and the other unreleased ramps-controller changes accumulated since `13.2.0`.

## Why this is separate

This is the successor to [#8692](https://github.com/MetaMask/core/pull/8692). That PR was originally cut as `Release/958.0.0`, but [#8691](https://github.com/MetaMask/core/pull/8691) merged first and consumed `958.0.0`, so this re-cuts the same content as `Release/959.0.0` from current `main`.

## What changed

- bump the monorepo release version to `959.0.0`
- publish `@metamask/ramps-controller@13.3.0`
- move the current ramps-controller unreleased entries into the `13.3.0` changelog section
- update `@metamask/transaction-pay-controller` to depend on `@metamask/ramps-controller@^13.3.0`

## Why the transaction-pay-controller range update is included

`transaction-pay-controller` is the in-repo consumer of `@metamask/ramps-controller`. Once ramps-controller is versioned to `13.3.0`, the monorepo dependency constraints require the internal dependency range to move from `^13.2.0` to `^13.3.0` as well. This keeps the repo internally consistent without broadening the published package scope.

## Validation

- `yarn install` (regenerates `yarn.lock`)
- `yarn constraints`
- `yarn lint:dependencies`
- `yarn lint:misc:check`
- `yarn workspace @metamask/ramps-controller changelog:validate`
- `yarn workspace @metamask/transaction-pay-controller changelog:validate`
- `yarn workspace @metamask/ramps-controller build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping: version bumps, changelog cut, and an internal dependency range update with no functional code changes in this diff.
> 
> **Overview**
> Bumps the monorepo version to `959.0.0` and publishes `@metamask/ramps-controller@13.3.0` by cutting the existing *Unreleased* changelog entries into a new `13.3.0` section.
> 
> Updates `@metamask/transaction-pay-controller` to depend on `@metamask/ramps-controller@^13.3.0`, with corresponding `yarn.lock` changes to keep workspace constraints consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90e73f150dc6d090ac25c9d6d2288a74a51e0cf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->