### PR TITLE
chore: Expose missing `GasFeeController` methods through the messenger

### DIFF
--- a/packages/gas-fee-controller/CHANGELOG.md
+++ b/packages/gas-fee-controller/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Expose missing public `GasFeeController` methods through its messenger ([#8699](https://github.com/MetaMask/core/pull/8699))
+  - The following actions are now available:
+    - `GasFeeController:enableNonRPCGasFeeApis`
+    - `GasFeeController:disableNonRPCGasFeeApis`
+  - Corresponding action types are available as well.
 - Bump `@metamask/messenger` from `^1.1.0` to `^1.2.0` ([#8373](https://github.com/MetaMask/core/pull/8373), [#8632](https://github.com/MetaMask/core/pull/8632))
 - Add missing `@metamask/messenger` dependency ([#8318](https://github.com/MetaMask/core/pull/8318), [#8364](https://github.com/MetaMask/core/pull/8364))
 - Bump `@metamask/controller-utils` from `^11.19.0` to `^11.20.0` ([#8344](https://github.com/MetaMask/core/pull/8344))

--- a/packages/gas-fee-controller/src/GasFeeController-method-action-types.ts
+++ b/packages/gas-fee-controller/src/GasFeeController-method-action-types.ts
@@ -68,6 +68,16 @@ export type GasFeeControllerGetTimeEstimateAction = {
   handler: GasFeeController['getTimeEstimate'];
 };
 
+export type GasFeeControllerEnableNonRPCGasFeeApisAction = {
+  type: `GasFeeController:enableNonRPCGasFeeApis`;
+  handler: GasFeeController['enableNonRPCGasFeeApis'];
+};
+
+export type GasFeeControllerDisableNonRPCGasFeeApisAction = {
+  type: `GasFeeController:disableNonRPCGasFeeApis`;
+  handler: GasFeeController['disableNonRPCGasFeeApis'];
+};
+
 /**
  * Union of all GasFeeController action types.
  */
@@ -77,4 +87,6 @@ export type GasFeeControllerMethodActions =
   | GasFeeControllerGetGasFeeEstimatesAndStartPollingAction
   | GasFeeControllerDisconnectPollerAction
   | GasFeeControllerStopPollingAction
-  | GasFeeControllerGetTimeEstimateAction;
+  | GasFeeControllerGetTimeEstimateAction
+  | GasFeeControllerEnableNonRPCGasFeeApisAction
+  | GasFeeControllerDisableNonRPCGasFeeApisAction;

--- a/packages/gas-fee-controller/src/GasFeeController.ts
+++ b/packages/gas-fee-controller/src/GasFeeController.ts
@@ -252,7 +252,9 @@ export type GasFeeState = GasFeeEstimatesByChainId &
 const name = 'GasFeeController';
 
 const MESSENGER_EXPOSED_METHODS = [
+  'disableNonRPCGasFeeApis',
   'disconnectPoller',
+  'enableNonRPCGasFeeApis',
   'fetchGasFeeEstimates',
   'getGasFeeEstimatesAndStartPolling',
   'getTimeEstimate',

--- a/packages/gas-fee-controller/src/index.ts
+++ b/packages/gas-fee-controller/src/index.ts
@@ -6,4 +6,6 @@ export type {
   GasFeeControllerDisconnectPollerAction,
   GasFeeControllerStopPollingAction,
   GasFeeControllerGetTimeEstimateAction,
+  GasFeeControllerEnableNonRPCGasFeeApisAction,
+  GasFeeControllerDisableNonRPCGasFeeApisAction,
 } from './GasFeeController-method-action-types';


### PR DESCRIPTION
## Explanation
This exposes missing methods used in the clients through the messenger after https://github.com/MetaMask/core/pull/8183

## References
Progresses https://consensyssoftware.atlassian.net/browse/WPC-989

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only expands the messenger-exposed surface area and exported types, without changing gas estimation logic; main risk is downstream callers relying on the new action names/types.
> 
> **Overview**
> **Exposes two previously-unavailable `GasFeeController` methods via the messenger** by adding `GasFeeController:enableNonRPCGasFeeApis` and `GasFeeController:disableNonRPCGasFeeApis` to the registered `MESSENGER_EXPOSED_METHODS`.
> 
> Adds new method action type definitions for these actions and re-exports them from `src/index.ts`, and documents the new messenger actions in the `gas-fee-controller` changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b41d3326a6eac87972ca6d26093d591ddf0393f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->