### PR TITLE
feat: Add batch sell stablecoin feature flag

### DIFF
--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add optional `batchSellDestStablecoins` chain-level feature flag to bridge configuration.
+- Add optional `batchSellDestStablecoins` chain-level feature flag to bridge configuration ([#8705](https://github.com/MetaMask/core/pull/8705))
 
 ### Changed
 

--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add optional `batchSellDestStablecoins` chain-level feature flag to bridge configuration.
+
 ### Changed
 
 - Bump `@metamask/transaction-controller` from `^65.0.0` to `^65.1.0` ([#8691](https://github.com/MetaMask/core/pull/8691))

--- a/packages/bridge-controller/src/selectors.test.ts
+++ b/packages/bridge-controller/src/selectors.test.ts
@@ -1362,6 +1362,10 @@ describe('Bridge Selectors', () => {
         '1': {
           isActiveSrc: true,
           isActiveDest: true,
+          batchSellDestStablecoins: [
+            'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            'eip155:1/slip44:60',
+          ],
         },
         '10': {
           isActiveSrc: true,
@@ -1414,6 +1418,10 @@ describe('Bridge Selectors', () => {
           'eip155:1': {
             isActiveSrc: true,
             isActiveDest: true,
+            batchSellDestStablecoins: [
+              'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+              'eip155:1/slip44:60',
+            ],
           },
           'eip155:10': {
             isActiveSrc: true,

--- a/packages/bridge-controller/src/utils/feature-flags.test.ts
+++ b/packages/bridge-controller/src/utils/feature-flags.test.ts
@@ -21,6 +21,10 @@ describe('feature-flags', () => {
           '1': {
             isActiveSrc: true,
             isActiveDest: true,
+            batchSellDestStablecoins: [
+              'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+              'eip155:1/slip44:60',
+            ],
           },
           '10': {
             isActiveSrc: true,
@@ -62,6 +66,10 @@ describe('feature-flags', () => {
           'eip155:1': {
             isActiveSrc: true,
             isActiveDest: true,
+            batchSellDestStablecoins: [
+              'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+              'eip155:1/slip44:60',
+            ],
           },
           'eip155:10': {
             isActiveSrc: true,
@@ -407,6 +415,10 @@ describe('feature-flags', () => {
           '1': {
             isActiveSrc: true,
             isActiveDest: true,
+            batchSellDestStablecoins: [
+              'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+              'eip155:1/slip44:60',
+            ],
           },
         },
         chainRanking: [],
@@ -450,6 +462,10 @@ describe('feature-flags', () => {
           'eip155:1': {
             isActiveSrc: true,
             isActiveDest: true,
+            batchSellDestStablecoins: [
+              'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+              'eip155:1/slip44:60',
+            ],
           },
         },
         chainRanking: [...DEFAULT_CHAIN_RANKING],

--- a/packages/bridge-controller/src/utils/validators.test.ts
+++ b/packages/bridge-controller/src/utils/validators.test.ts
@@ -16,6 +16,45 @@ describe('validators', () => {
             '1': {
               isActiveDest: true,
               isActiveSrc: true,
+              batchSellDestStablecoins: [
+                'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+                'eip155:1/slip44:60',
+              ],
+            },
+          },
+          maxRefreshCount: 5,
+          refreshRate: 30000,
+          support: true,
+          minimumVersion: '0.0.0',
+          chainRanking: [{ chainId: 'eip155:1', name: 'Ethereum' }],
+        },
+        type: 'batch sell destination stablecoins',
+        expected: true,
+      },
+      {
+        response: {
+          chains: {
+            '1': {
+              isActiveDest: true,
+              isActiveSrc: true,
+              batchSellDestStablecoins: ['not-a-caip-asset-type'],
+            },
+          },
+          maxRefreshCount: 5,
+          refreshRate: 30000,
+          support: true,
+          minimumVersion: '0.0.0',
+          chainRanking: [{ chainId: 'eip155:1', name: 'Ethereum' }],
+        },
+        type: 'malformed batch sell destination stablecoins',
+        expected: false,
+      },
+      {
+        response: {
+          chains: {
+            '1': {
+              isActiveDest: true,
+              isActiveSrc: true,
               isGaslessSwapEnabled: true,
             },
             '10': { isActiveDest: true, isActiveSrc: true },

--- a/packages/bridge-controller/src/utils/validators.ts
+++ b/packages/bridge-controller/src/utils/validators.ts
@@ -128,6 +128,7 @@ export const ChainConfigurationSchema = type({
   refreshRate: optional(number()),
   topAssets: optional(array(string())),
   stablecoins: optional(array(string())),
+  batchSellDestStablecoins: optional(array(CaipAssetTypeStruct)),
   isUnifiedUIEnabled: optional(boolean()),
   isSingleSwapBridgeButtonEnabled: optional(boolean()),
   isGaslessSwapEnabled: optional(boolean()),


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Adds an optional `batchSellDestStablecoins` field to bridge feature flag chain configuration. The field accepts CAIP asset types and lets clients configure destination stablecoins for batch sell flows through the existing bridge feature flag payload.

The new field is validated as `CaipAssetType[]`, preserved when feature flags are formatted, and covered by selector, formatter, and validator tests.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Related to SWAPS-4437

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new optional field to the bridge feature-flag validation schema; main risk is rejecting/accepting remote configs incorrectly if clients/providers send unexpected values.
> 
> **Overview**
> Adds an optional chain-level `batchSellDestStablecoins` feature flag to the bridge remote config, validated as an array of CAIP asset types via `ChainConfigurationSchema`.
> 
> Updates selector/feature-flag formatting tests to ensure the new field is preserved when formatting chain IDs to CAIP, and adds validator test coverage for valid vs malformed `batchSellDestStablecoins` payloads. Also records the addition in the `bridge-controller` changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81d696ddda6943f630f316c41707b9eeb08d4b66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->