### PR TITLE
fix: perps flip position and suppress transient HL SDK sentry errors

### DIFF
--- a/packages/perps-controller/.sync-state.json
+++ b/packages/perps-controller/.sync-state.json
@@ -1,8 +1,8 @@
 {
-  "lastSyncedMobileCommit": "355c9b656b9b51e154212666275f6d83ccb60fc5",
-  "lastSyncedMobileBranch": "main",
-  "lastSyncedCoreCommit": "fe175509d6f54207a06ebc710a9e5c07c5bc2cd8",
-  "lastSyncedCoreBranch": "feat/perps/sync-4-may-2026",
-  "lastSyncedDate": "2026-05-04T14:25:52Z",
-  "sourceChecksum": "2e7e9eab35667ca1bed2e2c3cd2f59361467910574b428ec47e9c6a7d0958bf5"
+  "lastSyncedMobileCommit": "106369c46bd01ee87faeaf51530fe67ad03ca178",
+  "lastSyncedMobileBranch": "fix/perps/flip-position-tat-2123",
+  "lastSyncedCoreCommit": "db4cc9ec8ff8530d8e9e0e3737b358e3269ce1b2",
+  "lastSyncedCoreBranch": "feat/perps/controller-sync-may-5",
+  "lastSyncedDate": "2026-05-05T20:50:44Z",
+  "sourceChecksum": "894eb0960741e569f1f025dbaaff6e1ffcab2489a80ad71e74cdf43af98aa764"
 }

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** Rename `AccountState.availableBalance` to `spendableBalance` and `AccountState.availableToTradeBalance` to `withdrawableBalance` for clearer semantics across abstraction modes ([#8678](https://github.com/MetaMask/core/pull/8678))
 - Mode-aware spot fold: `addSpotBalanceToAccountState` now folds free spot USDC into both `spendableBalance` and `withdrawableBalance` for Unified/Portfolio modes, while Standard/DEX-abstraction modes keep spot separate ([#8678](https://github.com/MetaMask/core/pull/8678))
 - Add throttled WS-driven `userAbstraction` refresh so HL-web mode flips propagate back without requiring a restart or account switch ([#8678](https://github.com/MetaMask/core/pull/8678))
-- Fix position direction display for flipped positions ([#NNNN](https://github.com/MetaMask/core/pull/NNNN))
+- Fix position direction display for flipped positions ([#8707](https://github.com/MetaMask/core/pull/8707))
 
 ## [5.0.0]
 

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** Rename `AccountState.availableBalance` to `spendableBalance` and `AccountState.availableToTradeBalance` to `withdrawableBalance` for clearer semantics across abstraction modes ([#8678](https://github.com/MetaMask/core/pull/8678))
 - Mode-aware spot fold: `addSpotBalanceToAccountState` now folds free spot USDC into both `spendableBalance` and `withdrawableBalance` for Unified/Portfolio modes, while Standard/DEX-abstraction modes keep spot separate ([#8678](https://github.com/MetaMask/core/pull/8678))
 - Add throttled WS-driven `userAbstraction` refresh so HL-web mode flips propagate back without requiring a restart or account switch ([#8678](https://github.com/MetaMask/core/pull/8678))
+- Fix position direction display for flipped positions ([#NNNN](https://github.com/MetaMask/core/pull/NNNN))
 
 ## [5.0.0]
 

--- a/packages/perps-controller/src/providers/HyperLiquidProvider.ts
+++ b/packages/perps-controller/src/providers/HyperLiquidProvider.ts
@@ -3543,6 +3543,9 @@ export class HyperLiquidProvider implements PerpsProvider {
    * @returns A promise that resolves to the result.
    */
   async placeOrder(params: OrderParams, retryCount = 0): Promise<OrderResult> {
+    // Hoisted so the retry path in the catch block can use the fetched price
+    // even when the caller (e.g. flipPosition) omits currentPrice from params.
+    let effectivePrice: number | undefined;
     try {
       this.#deps.debugLogger.log('Placing order via HyperLiquid SDK:', params);
 
@@ -3557,10 +3560,42 @@ export class HyperLiquidProvider implements PerpsProvider {
         throw new Error(validation.error);
       }
 
-      // Validate order at provider level (enforces USD validation rules)
-      await this.#validateOrderBeforePlacement(params);
+      // Extract DEX name for API calls (main DEX = null)
+      const { dex: dexName } = parseAssetName(params.symbol);
 
-      // Ensure provider is ready for trading (includes signing operations)
+      // 1. Get asset info and current price before validation so price-less
+      // callers (e.g. flipPosition) can validate against the live fetched price.
+      const { assetInfo, currentPrice, meta } = await this.#getAssetInfo({
+        symbol: params.symbol,
+        dexName,
+      });
+
+      // Allow override with UI-provided price (optimization to avoid API call).
+      effectivePrice =
+        params.currentPrice && params.currentPrice > 0
+          ? params.currentPrice
+          : currentPrice;
+
+      if (params.currentPrice && params.currentPrice > 0) {
+        this.#deps.debugLogger.log('Using provided current price:', {
+          coin: params.symbol,
+          providedPrice: effectivePrice,
+          source: 'UI price feed',
+        });
+      }
+
+      // Validate order at provider level (enforces USD validation rules).
+      // Pass effectivePrice so price-less market orders (e.g. flipPosition)
+      // validate against the live fetched price instead of failing with
+      // ORDER_PRICE_REQUIRED.
+      await this.#validateOrderBeforePlacement({
+        ...params,
+        currentPrice: effectivePrice,
+      });
+
+      // Ensure provider is ready for trading (includes signing operations).
+      // Kept after validation so invalid orders never trigger signature prompts
+      // (builder-fee approval, DEX abstraction enablement, etc.).
       await this.#ensureReadyForTrading();
 
       // Debug: Log asset map state before order placement
@@ -3577,29 +3612,6 @@ export class HyperLiquidProvider implements PerpsProvider {
         allowlistMarkets: this.#allowlistMarkets,
         blocklistMarkets: this.#blocklistMarkets,
       });
-
-      // Extract DEX name for API calls (main DEX = null)
-      const { dex: dexName } = parseAssetName(params.symbol);
-
-      // 1. Get asset info and current price
-      const { assetInfo, currentPrice, meta } = await this.#getAssetInfo({
-        symbol: params.symbol,
-        dexName,
-      });
-
-      // Allow override with UI-provided price (optimization to avoid API call)
-      const effectivePrice =
-        params.currentPrice && params.currentPrice > 0
-          ? params.currentPrice
-          : currentPrice;
-
-      if (params.currentPrice && params.currentPrice > 0) {
-        this.#deps.debugLogger.log('Using provided current price:', {
-          coin: params.symbol,
-          providedPrice: effectivePrice,
-          source: 'UI price feed',
-        });
-      }
 
       // 2. Calculate final position size with USD reconciliation
       const { finalPositionSize } = calculateFinalPositionSize({
@@ -3706,10 +3718,13 @@ export class HyperLiquidProvider implements PerpsProvider {
           // USD-based order: adjust the USD amount directly
           originalValue = params.usdAmount;
           adjustedUsdAmount = (parseFloat(params.usdAmount) * 1.015).toFixed(2);
-        } else if (params.currentPrice) {
-          // Size-based order: calculate USD from size and adjust
+        } else if (effectivePrice) {
+          // Size-based order: calculate USD from size and adjust.
+          // Use the hoisted effectivePrice (fetched live price) so callers that
+          // omit currentPrice (e.g. flipPosition) can still recover from the
+          // $10-minimum edge case.
           const sizeValue = parseFloat(params.size);
-          const estimatedUsd = sizeValue * params.currentPrice;
+          const estimatedUsd = sizeValue * effectivePrice;
           originalValue = `${estimatedUsd.toFixed(2)} (calculated from size ${params.size})`;
           adjustedUsdAmount = (estimatedUsd * 1.015).toFixed(2);
         } else {

--- a/packages/perps-controller/src/services/HyperLiquidSubscriptionService.ts
+++ b/packages/perps-controller/src/services/HyperLiquidSubscriptionService.ts
@@ -353,13 +353,44 @@ export class HyperLiquidSubscriptionService {
     if (this.#isClearing) {
       return;
     }
+    if (this.#isTransientSdkError(error)) {
+      // Expected SDK lifecycle: reconnect churn, intentional terminations, or
+      // request-side aborts. Forwarding these to Sentry pollutes the error
+      // budget with handled events the SDK already recovers from. Keep them
+      // visible locally via debugLogger for diagnosis.
+      this.#deps.debugLogger.log(
+        `[Perps transient SDK error] ${(context?.context?.data?.method as string) ?? 'unknown'}: ${error.message}`,
+      );
+      return;
+    }
     this.#deps.logger.error(error, context);
   }
 
-  #isTransientAssetCtxsError(error: unknown): boolean {
+  /**
+   * Detects transient SDK errors that are part of normal WebSocket / HTTP
+   * lifecycle and should not surface to Sentry. The Hyperliquid SDK
+   * (`@nktkas/hyperliquid`) and its `@nktkas/rews` v2 transport surface several
+   * error classes that are caught and recovered automatically by the SDK or
+   * by our own teardown paths.
+   *
+   * Returns true for `WebSocketRequestError` (rews queue rejection on close),
+   * `ReconnectingWebSocketError` (rews v2 lifecycle: RECONNECTION_LIMIT,
+   * TERMINATED_BY_USER, UNKNOWN_ERROR — v1 silently hung), `TimeoutError`
+   * with "Signal timed out" message (AbortSignal.timeout shim firing inside
+   * the SDK transport as designed), and reconnect-churn fallbacks (unknown
+   * or undefined errors while in Connecting / Disconnected states).
+   *
+   * Used both to drop these from Sentry (`#logErrorUnlessClearing`) and to
+   * decide whether to retry on the assetCtxs subscription path.
+   *
+   * @param error - The error thrown by the SDK or rews transport.
+   * @returns True if the error is part of normal SDK lifecycle and should
+   * be downgraded from Sentry capture to debug logging.
+   */
+  #isTransientSdkError(error: unknown): boolean {
     const ensuredError = ensureError(
       error,
-      'HyperLiquidSubscriptionService.createAssetCtxsSubscription',
+      'HyperLiquidSubscriptionService.isTransientSdkError',
     );
     const connectionState = this.#clientService.getConnectionState?.();
     const messageParts = [
@@ -377,6 +408,9 @@ export class HyperLiquidSubscriptionService {
     return (
       messageParts.includes('websocketrequesterror') ||
       messageParts.includes('unknown error while making a websocket request') ||
+      messageParts.includes('reconnectingwebsocketerror') ||
+      (messageParts.includes('timeouterror') &&
+        messageParts.includes('signal timed out')) ||
       (isReconnectChurn &&
         (messageParts.includes('unknown error (no details provided)') ||
           messageParts.includes('undefined')))
@@ -3482,10 +3516,7 @@ export class HyperLiquidSubscriptionService {
               'HyperLiquidSubscriptionService.createAssetCtxsSubscription',
             );
             const isLastAttempt = attempt === maxAttempts;
-            if (
-              isLastAttempt ||
-              !this.#isTransientAssetCtxsError(ensuredError)
-            ) {
+            if (isLastAttempt || !this.#isTransientSdkError(ensuredError)) {
               throw ensuredError;
             }
 


### PR DESCRIPTION
## Explanation

There was a regression that got introduced with flipping position. This change to the controller fixes it properly. Also adds a change to mitigate SDK sentry errors

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Mobile PRs:
1. https://github.com/MetaMask/metamask-mobile/pull/29691
2. https://github.com/MetaMask/metamask-mobile/pull/29642

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches HyperLiquid order placement and subscription error handling; mistakes could block trades or hide real connectivity issues, but changes are localized and mainly adjust validation/logging behavior.
> 
> **Overview**
> Fixes a flip-position regression by restructuring `HyperLiquidProvider.placeOrder()` to fetch a live price up front, validate market orders against that `effectivePrice`, and reuse it in the $10-minimum retry path when `currentPrice` is omitted.
> 
> Reduces Sentry noise in `HyperLiquidSubscriptionService` by classifying additional Hyperliquid/`rews` lifecycle errors as transient (e.g., reconnect/timeout/termination cases), logging them to `debugLogger` instead of Sentry, and reusing the same transient detector to decide when to retry `assetCtxs` subscription reconnects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 938a7fe613d17f6959ab8cb564fe211f3f038775. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->