### PR TITLE
chore: Expose missing `AccountTreeController` methods through the messenger

### DIFF
--- a/packages/account-tree-controller/CHANGELOG.md
+++ b/packages/account-tree-controller/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Expose missing public `AccountTreeController` methods through its messenger ([#8716](https://github.com/MetaMask/core/pull/8716))
+  - The following actions are now available:
+    - `AccountTreeController:init`
+    - `AccountTreeController:reinit`
+  - Corresponding action types are available as well.
+
 ## [7.2.0]
 
 ### Changed

--- a/packages/account-tree-controller/src/AccountTreeController-method-action-types.ts
+++ b/packages/account-tree-controller/src/AccountTreeController-method-action-types.ts
@@ -6,6 +6,29 @@
 import type { AccountTreeController } from './AccountTreeController';
 
 /**
+ * Initialize the controller's state.
+ *
+ * It constructs the initial state of the account tree (tree nodes, nodes
+ * names, metadata, etc..) and will automatically update the controller's
+ * state with it.
+ */
+export type AccountTreeControllerInitAction = {
+  type: `AccountTreeController:init`;
+  handler: AccountTreeController['init'];
+};
+
+/**
+ * Re-initialize the controller's state.
+ *
+ * This is done in one single (atomic) `update` block to avoid having a temporary
+ * cleared state. Use this when you need to force a full re-init even if already initialized.
+ */
+export type AccountTreeControllerReinitAction = {
+  type: `AccountTreeController:reinit`;
+  handler: AccountTreeController['reinit'];
+};
+
+/**
  * Gets the account wallet object from its ID.
  *
  * @param walletId - Account wallet ID.
@@ -180,6 +203,8 @@ export type AccountTreeControllerSyncWithUserStorageAtLeastOnceAction = {
  * Union of all AccountTreeController action types.
  */
 export type AccountTreeControllerMethodActions =
+  | AccountTreeControllerInitAction
+  | AccountTreeControllerReinitAction
   | AccountTreeControllerGetAccountWalletObjectAction
   | AccountTreeControllerGetAccountWalletObjectsAction
   | AccountTreeControllerGetAccountsFromSelectedAccountGroupAction

--- a/packages/account-tree-controller/src/AccountTreeController.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.ts
@@ -59,6 +59,8 @@ const MESSENGER_EXPOSED_METHODS = [
   'clearState',
   'syncWithUserStorage',
   'syncWithUserStorageAtLeastOnce',
+  'init',
+  'reinit',
 ] as const;
 
 const accountTreeControllerMetadata: StateMetadata<AccountTreeControllerState> =

--- a/packages/account-tree-controller/src/index.ts
+++ b/packages/account-tree-controller/src/index.ts
@@ -33,6 +33,8 @@ export type {
   AccountTreeControllerClearStateAction,
   AccountTreeControllerSyncWithUserStorageAction,
   AccountTreeControllerSyncWithUserStorageAtLeastOnceAction,
+  AccountTreeControllerInitAction,
+  AccountTreeControllerReinitAction,
 } from './AccountTreeController-method-action-types';
 
 export type { AccountContext } from './AccountTreeController';


### PR DESCRIPTION
## Explanation
This exposes missing methods used in the clients through the messenger after https://github.com/MetaMask/core/pull/7976

## References
Progresses https://consensyssoftware.atlassian.net/browse/WPC-989

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, additive API surface change that only exposes existing `AccountTreeController` lifecycle methods (`init`, `reinit`) through the messenger without altering controller behavior or persistence logic.
> 
> **Overview**
> **Exposes `AccountTreeController` lifecycle methods via the messenger.** The controller now registers `init` and `reinit` in `MESSENGER_EXPOSED_METHODS`, and the auto-generated method action union adds `AccountTreeController:init`/`AccountTreeController:reinit` (with exported action types).
> 
> Updates the package changelog to document the newly available messenger actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 618ad509c8ab84f841d8f95e0bf56aadbbe47012. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->