### PR TITLE
chore: Expose missing `MultichainAccountService` methods through the messenger

### DIFF
--- a/packages/multichain-account-service/CHANGELOG.md
+++ b/packages/multichain-account-service/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Expose missing `MultichainAccountService:init` action through its messenger ([#8717](https://github.com/MetaMask/core/pull/8717))
+  - Corresponding action type is available as well.
 - Filter out `KeyringController` locked errors from sentry reporting ([#8619](https://github.com/MetaMask/core/pull/8619))
 
 ### Changed

--- a/packages/multichain-account-service/src/MultichainAccountService-method-action-types.ts
+++ b/packages/multichain-account-service/src/MultichainAccountService-method-action-types.ts
@@ -6,6 +6,15 @@
 import type { MultichainAccountService } from './MultichainAccountService';
 
 /**
+ * Initialize the service and constructs the internal reprensentation of
+ * multichain accounts and wallets.
+ */
+export type MultichainAccountServiceInitAction = {
+  type: `MultichainAccountService:init`;
+  handler: MultichainAccountService['init'];
+};
+
+/**
  * Re-synchronize MetaMask accounts and the providers accounts if needed.
  *
  * NOTE: This is mostly required if one of the providers (keyrings or Snaps)
@@ -190,6 +199,7 @@ export type MultichainAccountServiceAlignWalletAction = {
  * Union of all MultichainAccountService action types.
  */
 export type MultichainAccountServiceMethodActions =
+  | MultichainAccountServiceInitAction
   | MultichainAccountServiceResyncAccountsAction
   | MultichainAccountServiceEnsureCanUseSnapPlatformAction
   | MultichainAccountServiceGetMultichainAccountWalletAction

--- a/packages/multichain-account-service/src/MultichainAccountService.ts
+++ b/packages/multichain-account-service/src/MultichainAccountService.ts
@@ -117,6 +117,7 @@ const MESSENGER_EXPOSED_METHODS = [
   'resyncAccounts',
   'removeMultichainAccountWallet',
   'ensureCanUseSnapPlatform',
+  'init',
 ] as const;
 
 /**

--- a/packages/multichain-account-service/src/index.ts
+++ b/packages/multichain-account-service/src/index.ts
@@ -21,6 +21,7 @@ export type {
   MultichainAccountServiceSetBasicFunctionalityAction,
   MultichainAccountServiceAlignWalletsAction,
   MultichainAccountServiceAlignWalletAction,
+  MultichainAccountServiceInitAction,
 } from './MultichainAccountService-method-action-types';
 export {
   AccountProviderWrapper,


### PR DESCRIPTION
## Explanation
This exposes missing methods used in the clients through the messenger after https://github.com/MetaMask/core/pull/7976

## References
Progresses https://consensyssoftware.atlassian.net/browse/WPC-989

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only exposes an existing `init` method through the messenger and updates exported types/changelog, without changing initialization behavior or data handling.
> 
> **Overview**
> Exposes `MultichainAccountService:init` through the service messenger by adding it to `MESSENGER_EXPOSED_METHODS` and introducing the corresponding `MultichainAccountServiceInitAction` type.
> 
> Updates public exports (`src/index.ts`) and the package changelog to reflect the newly available messenger action and action type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit daa46d938d21bb0b9a9c820551fe4da9251e1366. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->