### PR TITLE
chore: Expose missing `MoneyAccountService` methods through the messenger

### DIFF
--- a/packages/money-account-controller/CHANGELOG.md
+++ b/packages/money-account-controller/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Expose missing `MoneyAccountController:init` action through its messenger ([#8718](https://github.com/MetaMask/core/pull/8718))
+  - Corresponding action type is available as well.
+
 ## [0.2.0]
 
 ### Changed

--- a/packages/money-account-controller/src/MoneyAccountController-method-action-types.ts
+++ b/packages/money-account-controller/src/MoneyAccountController-method-action-types.ts
@@ -6,6 +6,15 @@
 import type { MoneyAccountController } from './MoneyAccountController';
 
 /**
+ * Initializes the controller by creating a money account for the primary
+ * entropy source if one does not already exist.
+ */
+export type MoneyAccountControllerInitAction = {
+  type: `MoneyAccountController:init`;
+  handler: MoneyAccountController['init'];
+};
+
+/**
  * Creates a money account for the given entropy source. If an account
  * already exists for that entropy source, it is returned as-is (idempotent).
  *
@@ -46,6 +55,7 @@ export type MoneyAccountControllerClearStateAction = {
  * Union of all MoneyAccountController action types.
  */
 export type MoneyAccountControllerMethodActions =
+  | MoneyAccountControllerInitAction
   | MoneyAccountControllerCreateMoneyAccountAction
   | MoneyAccountControllerGetMoneyAccountAction
   | MoneyAccountControllerClearStateAction;

--- a/packages/money-account-controller/src/MoneyAccountController.ts
+++ b/packages/money-account-controller/src/MoneyAccountController.ts
@@ -59,6 +59,7 @@ const MESSENGER_EXPOSED_METHODS = [
   'createMoneyAccount',
   'getMoneyAccount',
   'clearState',
+  'init',
 ] as const;
 
 export type MoneyAccountControllerGetStateAction = ControllerGetStateAction<

--- a/packages/money-account-controller/src/index.ts
+++ b/packages/money-account-controller/src/index.ts
@@ -17,4 +17,5 @@ export type {
   MoneyAccountControllerClearStateAction,
   MoneyAccountControllerCreateMoneyAccountAction,
   MoneyAccountControllerGetMoneyAccountAction,
+  MoneyAccountControllerInitAction,
 } from './MoneyAccountController-method-action-types';


### PR DESCRIPTION
## Explanation
This exposes missing methods used in the clients through the messenger.

## References
Progresses https://consensyssoftware.atlassian.net/browse/WPC-989

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only exposes an existing `MoneyAccountController.init` method via the messenger and adds the corresponding action type, without changing account/keyring logic.
> 
> **Overview**
> Exposes the previously unexposed `MoneyAccountController:init` method through the controller messenger by adding `init` to `MESSENGER_EXPOSED_METHODS`.
> 
> Adds the corresponding `MoneyAccountControllerInitAction` type, exports it from the package entrypoint, and documents the new exposed action in the changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1a4ad5b1bf848daf79b3faa765320dfbae51838. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->