### PR TITLE
chore: Expose missing `AssetsController` methods through the messenger

### DIFF
--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Expose missing `AssetsController:setSelectedCurrency` action through its messenger ([#8719](https://github.com/MetaMask/core/pull/8719))
+  - Corresponding action type is available as well.
 - Bump `@metamask/transaction-controller` from `^65.0.0` to `^65.1.0` ([#8691](https://github.com/MetaMask/core/pull/8691))
 - Bump `@metamask/network-enablement-controller` from `^5.0.2` to `^5.1.0` ([#8665](https://github.com/MetaMask/core/pull/8665))
 - Bump `@metamask/keyring-controller` from `^25.3.0` to `^25.4.0` ([#8665](https://github.com/MetaMask/core/pull/8665))

--- a/packages/assets-controller/src/AssetsController-method-action-types.ts
+++ b/packages/assets-controller/src/AssetsController-method-action-types.ts
@@ -116,6 +116,16 @@ export type AssetsControllerUnhideAssetAction = {
 };
 
 /**
+ * Set the current currency.
+ *
+ * @param selectedCurrency - The ISO 4217 currency code to set.
+ */
+export type AssetsControllerSetSelectedCurrencyAction = {
+  type: `AssetsController:setSelectedCurrency`;
+  handler: AssetsController['setSelectedCurrency'];
+};
+
+/**
  * Union of all AssetsController action types.
  */
 export type AssetsControllerMethodActions =
@@ -129,4 +139,5 @@ export type AssetsControllerMethodActions =
   | AssetsControllerRemoveCustomAssetAction
   | AssetsControllerGetCustomAssetsAction
   | AssetsControllerHideAssetAction
-  | AssetsControllerUnhideAssetAction;
+  | AssetsControllerUnhideAssetAction
+  | AssetsControllerSetSelectedCurrencyAction;

--- a/packages/assets-controller/src/AssetsController.ts
+++ b/packages/assets-controller/src/AssetsController.ts
@@ -175,6 +175,7 @@ const MESSENGER_EXPOSED_METHODS = [
   'getCustomAssets',
   'hideAsset',
   'unhideAsset',
+  'setSelectedCurrency',
 ] as const;
 
 /** Default polling interval hint for data sources (30 seconds) */

--- a/packages/assets-controller/src/AssetsController.ts
+++ b/packages/assets-controller/src/AssetsController.ts
@@ -3166,5 +3166,8 @@ export class AssetsController extends BaseController<
     this.messenger.unregisterActionHandler('AssetsController:getCustomAssets');
     this.messenger.unregisterActionHandler('AssetsController:hideAsset');
     this.messenger.unregisterActionHandler('AssetsController:unhideAsset');
+    this.messenger.unregisterActionHandler(
+      'AssetsController:setSelectedCurrency',
+    );
   }
 }

--- a/packages/assets-controller/src/index.ts
+++ b/packages/assets-controller/src/index.ts
@@ -39,6 +39,7 @@ export type {
   AssetsControllerUnhideAssetAction,
   AssetsControllerGetExchangeRatesForBridgeAction,
   AssetsControllerGetStateForTransactionPayAction,
+  AssetsControllerSetSelectedCurrencyAction,
 } from './AssetsController-method-action-types';
 
 // Core types


### PR DESCRIPTION
## Explanation
This exposes missing methods used in the clients through the messenger.

## References
Progresses https://consensyssoftware.atlassian.net/browse/WPC-989

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only expands the messenger-exposed API surface to include an existing `setSelectedCurrency` method, with no changes to business logic or data handling.
> 
> **Overview**
> **Exposes `AssetsController.setSelectedCurrency` via the messenger.** This adds the `AssetsController:setSelectedCurrency` action type, includes `setSelectedCurrency` in the controller’s `MESSENGER_EXPOSED_METHODS`, exports the new action type from `index.ts`, and unregisters the handler on `destroy()`.
> 
> Updates the `@metamask/assets-controller` changelog to document the newly exposed action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ae3b436392c032264a14fa4f23b1d0cb0324c34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->