### PR TITLE
fix: route fiat payment method through strategy selection to enable fiat strategy

### DIFF
--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/transaction-controller` from `^65.0.0` to `^65.1.0` ([#8691](https://github.com/MetaMask/core/pull/8691))
 - Bump `@metamask/ramps-controller` from `^13.2.0` to `^13.3.0` ([#8698](https://github.com/MetaMask/core/pull/8698))
 
+### Fixed
+
+- Fix fiat strategy never being selected by routing fiat payment method through `getStrategyOrder` and allowing quote retrieval when no crypto payment token is set ([#8720](https://github.com/MetaMask/core/pull/8720))
+
 ## [21.0.0]
 
 ### Added

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix fiat strategy never being selected by routing fiat payment method through `getStrategyOrder` and allowing quote retrieval when no crypto payment token is set ([#8720](https://github.com/MetaMask/core/pull/8720))
+
 ## [21.1.0]
 
 ### Added
@@ -21,10 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/ramps-controller` from `^13.2.0` to `^13.3.0` ([#8698](https://github.com/MetaMask/core/pull/8698))
 - Bump `@metamask/assets-controller` from `^6.3.0` to `^6.4.0` ([#8721](https://github.com/MetaMask/core/pull/8721))
 - Bump `@metamask/assets-controllers` from `^105.1.0` to `^106.0.0` ([#8721](https://github.com/MetaMask/core/pull/8721))
-
-### Fixed
-
-- Fix fiat strategy never being selected by routing fiat payment method through `getStrategyOrder` and allowing quote retrieval when no crypto payment token is set ([#8720](https://github.com/MetaMask/core/pull/8720))
 
 ## [21.0.0]
 

--- a/packages/transaction-pay-controller/src/TransactionPayController.test.ts
+++ b/packages/transaction-pay-controller/src/TransactionPayController.test.ts
@@ -540,6 +540,48 @@ describe('TransactionPayController', () => {
         CHAIN_ID_MOCK,
         TOKEN_ADDRESS_MOCK,
         'perpsDeposit',
+        undefined,
+      );
+    });
+
+    it('passes fiat payment method ID into getStrategyOrder', async () => {
+      const controller = createController();
+
+      controller.updatePaymentToken({
+        transactionId: TRANSACTION_ID_MOCK,
+        tokenAddress: TOKEN_ADDRESS_MOCK,
+        chainId: CHAIN_ID_MOCK,
+      });
+
+      const { updateTransactionData } = updatePaymentTokenMock.mock.calls[0][1];
+
+      updateTransactionData(TRANSACTION_ID_MOCK, (data) => {
+        data.paymentToken = {
+          address: TOKEN_ADDRESS_MOCK,
+          balanceFiat: '1',
+          balanceHuman: '1',
+          balanceRaw: '1',
+          balanceUsd: '1',
+          chainId: CHAIN_ID_MOCK,
+          decimals: 6,
+          symbol: 'USDC',
+        };
+        data.fiatPayment = { selectedPaymentMethodId: 'card-123' };
+      });
+
+      const transactionMeta = {
+        id: TRANSACTION_ID_MOCK,
+        type: 'perpsDeposit',
+      } as TransactionMeta;
+
+      messenger.call('TransactionPayController:getStrategy', transactionMeta);
+
+      expect(getStrategyOrderMock).toHaveBeenCalledWith(
+        messenger,
+        CHAIN_ID_MOCK,
+        TOKEN_ADDRESS_MOCK,
+        'perpsDeposit',
+        'card-123',
       );
     });
   });

--- a/packages/transaction-pay-controller/src/TransactionPayController.ts
+++ b/packages/transaction-pay-controller/src/TransactionPayController.ts
@@ -324,14 +324,15 @@ export class TransactionPayController extends BaseController<
       return validStrategies;
     }
 
-    const paymentToken =
-      this.state.transactionData[transaction.id]?.paymentToken;
+    const transactionData = this.state.transactionData[transaction.id];
+    const paymentToken = transactionData?.paymentToken;
 
     return getStrategyOrder(
       this.messenger,
       paymentToken?.chainId,
       paymentToken?.address,
       transaction.type,
+      transactionData?.fiatPayment?.selectedPaymentMethodId,
     );
   }
 }

--- a/packages/transaction-pay-controller/src/utils/feature-flags.test.ts
+++ b/packages/transaction-pay-controller/src/utils/feature-flags.test.ts
@@ -809,6 +809,49 @@ describe('Feature Flags Utils', () => {
         TransactionPayStrategy.Relay,
       ]);
     });
+
+    it('returns only Fiat strategy when fiatPaymentMethodId is provided', () => {
+      const strategyOrder = getStrategyOrder(
+        messenger,
+        undefined,
+        undefined,
+        undefined,
+        'card-123',
+      );
+
+      expect(strategyOrder).toStrictEqual([TransactionPayStrategy.Fiat]);
+    });
+
+    it('returns only Fiat strategy regardless of other routing config when fiatPaymentMethodId is provided', () => {
+      getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+        ...getDefaultRemoteFeatureFlagControllerState(),
+        remoteFeatureFlags: {
+          confirmations_pay: {
+            strategyOrder: [
+              TransactionPayStrategy.Relay,
+              TransactionPayStrategy.Across,
+            ],
+            strategyOverrides: {
+              default: {
+                chains: {
+                  [CHAIN_ID_MOCK]: [TransactionPayStrategy.Bridge],
+                },
+              },
+            },
+          },
+        },
+      });
+
+      const strategyOrder = getStrategyOrder(
+        messenger,
+        CHAIN_ID_MOCK,
+        TOKEN_ADDRESS_MOCK,
+        'perpsDeposit',
+        '/payments/debit-credit-card',
+      );
+
+      expect(strategyOrder).toStrictEqual([TransactionPayStrategy.Fiat]);
+    });
   });
 
   describe('getStrategyOrder route-aware resolution', () => {

--- a/packages/transaction-pay-controller/src/utils/feature-flags.ts
+++ b/packages/transaction-pay-controller/src/utils/feature-flags.ts
@@ -312,6 +312,7 @@ function getDefaultOverrideStrategies(
  * @param tokenAddress - Optional token address used to match route overrides.
  * @param transactionType - Optional transaction type used to match route
  * overrides.
+ * @param fiatPaymentMethodId - Optional fiat payment method ID used to match route overrides.
  * @returns Ordered strategy list.
  */
 export function getStrategyOrder(
@@ -319,7 +320,13 @@ export function getStrategyOrder(
   chainId?: Hex,
   tokenAddress?: Hex,
   transactionType?: string,
+  fiatPaymentMethodId?: string,
 ): StrategyOrder {
+  // If fiat payment method is selected, use Fiat strategy only
+  if (fiatPaymentMethodId) {
+    return [TransactionPayStrategy.Fiat];
+  }
+
   const routingConfig = getStrategyRoutingConfig(messenger);
   const normalizedChainId = normalizeHex(chainId);
   const normalizedTokenAddress = normalizeHex(tokenAddress);

--- a/packages/transaction-pay-controller/src/utils/quotes.test.ts
+++ b/packages/transaction-pay-controller/src/utils/quotes.test.ts
@@ -589,6 +589,42 @@ describe('Quotes Utils', () => {
       });
     });
 
+    it('still invokes strategies when no payment token but fiat payment method is set', async () => {
+      await run({
+        transactionData: {
+          ...TRANSACTION_DATA_MOCK,
+          paymentToken: undefined,
+          fiatPayment: { selectedPaymentMethodId: 'card-123' },
+        },
+      });
+
+      expect(getQuotesMock).toHaveBeenCalled();
+    });
+
+    it('does not invoke strategies when no payment token and no fiat payment method', async () => {
+      await run({
+        transactionData: {
+          ...TRANSACTION_DATA_MOCK,
+          paymentToken: undefined,
+          fiatPayment: {},
+        },
+      });
+
+      const transactionDataMock = {
+        quotes: [QUOTE_MOCK],
+        quotesLastUpdated: undefined,
+      };
+
+      updateTransactionDataMock.mock.calls.map((call) =>
+        call[1](transactionDataMock),
+      );
+
+      expect(transactionDataMock).toMatchObject({
+        quotes: [],
+        quotesLastUpdated: expect.any(Number),
+      });
+    });
+
     it('gets quotes from strategy', async () => {
       await run();
 

--- a/packages/transaction-pay-controller/src/utils/quotes.ts
+++ b/packages/transaction-pay-controller/src/utils/quotes.ts
@@ -571,7 +571,7 @@ async function getQuotes(
     },
   );
 
-  if (!requests?.length) {
+  if (!requests?.length && !fiatPaymentMethod) {
     return {
       batchTransactions: [],
       quotes: [],


### PR DESCRIPTION
## Explanation

The fiat strategy was never selected during quote retrieval because of two issues:

1. **`getStrategyOrder` never included `Fiat`** — The default strategy order only contained `Relay` and `Across`. The fiat payment method ID was not passed into the strategy routing function, so `TransactionPayStrategy.Fiat` was never part of the strategy list.

2. **`getQuotes` bailed early on empty requests** — When a fiat payment method is selected without a crypto payment token, `buildQuoteRequests` returns an empty array (no `paymentToken`). The guard `if (!requests?.length)` short-circuited before any strategy could run. The fiat strategy doesn't need these requests — it derives its own relay request from `amountFiat` internally.

### Changes

- **`getStrategyOrder`** — Added optional `fiatPaymentMethodId` parameter. When provided, early returns `[TransactionPayStrategy.Fiat]` so only the fiat strategy is used.
- **`#getStrategiesWithFallback`** — Now passes `transactionData.fiatPayment.selectedPaymentMethodId` through to `getStrategyOrder`.
- **`getQuotes`** — Changed the empty-requests guard from `!requests?.length` to `!requests?.length && !fiatPaymentMethod` so the strategy loop runs when a fiat payment method is active.

## References

- Related to CONF-1065

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes strategy routing and quote retrieval guard logic, which can affect which pay strategy executes and when quotes are fetched, but scope is limited to the transaction-pay controller and covered by new unit tests.
> 
> **Overview**
> Fixes fiat pay quote retrieval by threading `fiatPayment.selectedPaymentMethodId` into strategy selection and ensuring it can drive the `Fiat` strategy.
> 
> `getStrategyOrder` now accepts an optional fiat payment method ID and short-circuits to **Fiat-only** strategy ordering when present, and `TransactionPayController` passes this value through during fallback strategy resolution. Quote retrieval no longer bails early on empty request sets when a fiat payment method is selected, allowing fiat quotes even without a crypto `paymentToken`.
> 
> Adds targeted test coverage for the new routing behavior and updates the package changelog under **Fixed**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e81276d5177364894df56c0b33b9679f8ab6666. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->