### PR TITLE
feat(snap-account-service): track account management Snaps + add `:getSnaps`

### DIFF
--- a/packages/snap-account-service/CHANGELOG.md
+++ b/packages/snap-account-service/CHANGELOG.md
@@ -10,17 +10,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `SnapAccountService` ([#8414](https://github.com/MetaMask/core/pull/8414))
-- Add `SnapPlatformWatcher`, which waits for the Snap platform to be ready and for a Snap keyring to appear in `KeyringController` state before allowing Snap account operations ([#8715](https://github.com/MetaMask/core/pull/8715))
+- Add `SnapPlatformWatcher` and `SnapAccountService.ensureReady` ([#8715](https://github.com/MetaMask/core/pull/8715)), ([#8725](https://github.com/MetaMask/core/pull/8725))
+  - Waits for the Snap platform to be ready and for a Snap keyring to appear in `KeyringController` state before allowing Snap account operations.
+  - Callers must ensure `init()` has run and the Snap is currently installed, enabled, non-blocked, and declares `endowment:keyring`.
   - `SnapAccountService.ensureReady` now awaits the watcher, so it only resolves once both conditions hold (or rejects if the Snap keyring does not appear within the configured timeout).
+  - `SnapAccountService.ensureReady` now throws `Unknown snap: "<id>"` when called with a Snap ID that isn't tracked as an account-management Snap.
 - Add `config` option to `SnapAccountService` constructor with a `snapPlatformWatcher` field exposing `ensureOnboardingComplete` and `snapKeyringWaitTimeoutMs` ([#8715](https://github.com/MetaMask/core/pull/8715))
   - Export `SnapAccountServiceConfig` and `SnapPlatformWatcherConfig` types.
 - Add `@metamask/keyring-controller` dependency ([#8715](https://github.com/MetaMask/core/pull/8715))
   - The service messenger now requires the `KeyringController:getState` action and `KeyringController:stateChange` event.
+- Add `getSnaps` action to `SnapAccountService`, returning the IDs of installed, enabled, non-blocked Snaps that declare the `endowment:keyring` permission ([#8725](https://github.com/MetaMask/core/pull/8725))
+  - Export `SnapAccountServiceGetSnapsAction` type.
+  - The service now seeds its internal set from `SnapController:getRunnableSnaps` during `init()` and keeps it in sync via `SnapController` lifecycle events (`snapInstalled`, `snapEnabled`, `snapDisabled`, `snapBlocked`, `snapUninstalled`).
+  - The service messenger now requires the `SnapController:getRunnableSnaps` action and the five lifecycle events listed above.
 
 ### Changed
 
 - Bump `@metamask/messenger` from `^1.1.1` to `^1.2.0` ([#8632](https://github.com/MetaMask/core/pull/8632))
-- **BREAKING:** Remove the top-level `ensureOnboardingComplete` option from `SnapAccountServiceOptions` ([#8715](https://github.com/MetaMask/core/pull/8715))
-  - Pass the callback via `config.snapPlatformWatcher.ensureOnboardingComplete` instead.
 
 [Unreleased]: https://github.com/MetaMask/core/

--- a/packages/snap-account-service/src/SnapAccountService-method-action-types.ts
+++ b/packages/snap-account-service/src/SnapAccountService-method-action-types.ts
@@ -6,12 +6,26 @@
 import type { SnapAccountService } from './SnapAccountService';
 
 /**
+ * Returns the IDs of all currently tracked account-management Snaps —
+ * Snaps that are installed, enabled, not blocked, and have the
+ * `endowment:keyring` permission.
+ *
+ * @returns The IDs of tracked account-management Snaps.
+ */
+export type SnapAccountServiceGetSnapsAction = {
+  type: `SnapAccountService:getSnaps`;
+  handler: SnapAccountService['getSnaps'];
+};
+
+/**
  * Ensures everything is ready to use Snap accounts for the given Snap.
- * 1. Waits for the Snap platform to be fully started.
+ * 1. Validates that `snapId` is a tracked account-management Snap.
+ * 2. Waits for the Snap platform to be fully started.
  *
  * Safe to call concurrently — each step is idempotent or mutex-protected.
  *
- * @param _snapId - ID of the Snap to ensure readiness for.
+ * @param snapId - ID of the Snap to ensure readiness for.
+ * @throws If `snapId` is not a tracked account-management Snap.
  */
 export type SnapAccountServiceEnsureReadyAction = {
   type: `SnapAccountService:ensureReady`;
@@ -22,4 +36,5 @@ export type SnapAccountServiceEnsureReadyAction = {
  * Union of all SnapAccountService action types.
  */
 export type SnapAccountServiceMethodActions =
-  SnapAccountServiceEnsureReadyAction;
+  | SnapAccountServiceGetSnapsAction
+  | SnapAccountServiceEnsureReadyAction;

--- a/packages/snap-account-service/src/SnapAccountService.test.ts
+++ b/packages/snap-account-service/src/SnapAccountService.test.ts
@@ -18,10 +18,6 @@ import type {
 } from './SnapAccountService';
 import { SnapAccountService } from './SnapAccountService';
 
-/**
- * The type of the messenger populated with all external actions and events
- * required by the service under test.
- */
 type RootMessenger = Messenger<
   MockAnyNamespace,
   MessengerActions<SnapAccountServiceMessenger>,
@@ -34,14 +30,10 @@ type MockKeyringControllerState = Pick<KeyringControllerState, 'keyrings'>;
 /** Mock truncated snap type for tests. */
 type MockTruncatedSnap = Pick<TruncatedSnap, 'id' | 'initialPermissions'>;
 
-/**
- * Mock objects for all external dependencies of {@link SnapAccountService}.
- */
 type Mocks = {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   SnapController: {
     getState: jest.MockedFunction<() => SnapControllerState>;
-    getSnap: jest.MockedFunction<(snapId: string) => TruncatedSnap | null>;
     getRunnableSnaps: jest.MockedFunction<() => TruncatedSnap[]>;
   };
   // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -144,84 +136,6 @@ function buildSnap(id: string, hasKeyring: boolean): TruncatedSnap {
 }
 
 /**
- * Publishes a `SnapController:snapInstalled` event on the root messenger.
- *
- * @param rootMessenger - The root messenger.
- * @param snap - The Snap that was installed.
- */
-function publishSnapInstalled(
-  rootMessenger: RootMessenger,
-  snap: TruncatedSnap,
-): void {
-  rootMessenger.publish('SnapController:snapInstalled', snap, 'origin', false);
-}
-
-/**
- * Publishes a `SnapController:snapEnabled` event on the root messenger.
- *
- * @param rootMessenger - The root messenger.
- * @param snap - The Snap that was enabled.
- */
-function publishSnapEnabled(
-  rootMessenger: RootMessenger,
-  snap: TruncatedSnap,
-): void {
-  rootMessenger.publish('SnapController:snapEnabled', snap);
-}
-
-/**
- * Publishes a `SnapController:snapDisabled` event on the root messenger.
- *
- * @param rootMessenger - The root messenger.
- * @param snap - The Snap that was disabled.
- */
-function publishSnapDisabled(
-  rootMessenger: RootMessenger,
-  snap: TruncatedSnap,
-): void {
-  rootMessenger.publish('SnapController:snapDisabled', snap);
-}
-
-/**
- * Publishes a `SnapController:snapBlocked` event on the root messenger.
- *
- * @param rootMessenger - The root messenger.
- * @param snapId - The ID of the Snap that was blocked.
- */
-function publishSnapBlocked(
-  rootMessenger: RootMessenger,
-  snapId: string,
-): void {
-  rootMessenger.publish('SnapController:snapBlocked', snapId);
-}
-
-/**
- * Publishes a `SnapController:snapUnblocked` event on the root messenger.
- *
- * @param rootMessenger - The root messenger.
- * @param snapId - The ID of the Snap that was unblocked.
- */
-function publishSnapUnblocked(
-  rootMessenger: RootMessenger,
-  snapId: string,
-): void {
-  rootMessenger.publish('SnapController:snapUnblocked', snapId);
-}
-
-/**
- * Publishes a `SnapController:snapUninstalled` event on the root messenger.
- *
- * @param rootMessenger - The root messenger.
- * @param snap - The Snap that was uninstalled.
- */
-function publishSnapUninstalled(
-  rootMessenger: RootMessenger,
-  snap: TruncatedSnap,
-): void {
-  rootMessenger.publish('SnapController:snapUninstalled', snap);
-}
-
-/**
  * Constructs the service under test with sensible defaults.
  *
  * @param args - The arguments to this function.
@@ -255,7 +169,6 @@ function setup({
       getState: jest
         .fn()
         .mockReturnValue({ isReady: snapIsReady } as SnapControllerState),
-      getSnap: jest.fn().mockReturnValue(null),
       getRunnableSnaps: jest.fn().mockReturnValue(runnableSnaps),
     },
     KeyringController: {
@@ -266,10 +179,6 @@ function setup({
   rootMessenger.registerActionHandler(
     'SnapController:getState',
     mocks.SnapController.getState,
-  );
-  rootMessenger.registerActionHandler(
-    'SnapController:getSnap',
-    mocks.SnapController.getSnap as never,
   );
   rootMessenger.registerActionHandler(
     'SnapController:getRunnableSnaps',
@@ -286,7 +195,6 @@ function setup({
 }
 
 const MOCK_SNAP_ID = 'npm:@metamask/mock-snap' as SnapId;
-const MOCK_OTHER_SNAP_ID = 'npm:@metamask/other-snap' as SnapId;
 
 describe('SnapAccountService', () => {
   describe('init', () => {
@@ -295,185 +203,17 @@ describe('SnapAccountService', () => {
 
       expect(await service.init()).toBeUndefined();
     });
-
-    it('seeds tracked Snaps from getRunnableSnaps, filtering out non-keyring Snaps', async () => {
-      const { service } = setup({
-        runnableSnaps: [
-          buildSnap(MOCK_SNAP_ID, true),
-          buildSnap(MOCK_OTHER_SNAP_ID, false),
-        ],
-      });
-
-      await service.init();
-
-      expect(service.getSnaps()).toStrictEqual([MOCK_SNAP_ID]);
-    });
   });
 
   describe('getSnaps', () => {
-    it('returns an empty array before init', () => {
+    it('exposes tracked Snaps seeded by init', async () => {
       const { service } = setup({
         runnableSnaps: [buildSnap(MOCK_SNAP_ID, true)],
       });
 
-      expect(service.getSnaps()).toStrictEqual([]);
-    });
-  });
-
-  describe('lifecycle events', () => {
-    it('ignores add events received before init', async () => {
-      const { service, rootMessenger } = setup();
-
-      publishSnapInstalled(rootMessenger, buildSnap(MOCK_SNAP_ID, true));
-
-      await service.init();
-
-      expect(service.getSnaps()).toStrictEqual([]);
-    });
-
-    it('ignores remove events received before init', async () => {
-      const { service, rootMessenger } = setup({
-        runnableSnaps: [buildSnap(MOCK_SNAP_ID, true)],
-      });
-
-      // Publish a removal event *before* init: it must be ignored, so once
-      // init seeds from `getRunnableSnaps` the Snap is still tracked.
-      publishSnapUninstalled(rootMessenger, buildSnap(MOCK_SNAP_ID, true));
-
       await service.init();
 
       expect(service.getSnaps()).toStrictEqual([MOCK_SNAP_ID]);
-    });
-
-    it('adds a Snap on snapInstalled when it has the keyring endowment', async () => {
-      const { service, rootMessenger } = setup();
-
-      await service.init();
-      publishSnapInstalled(rootMessenger, buildSnap(MOCK_SNAP_ID, true));
-
-      expect(service.getSnaps()).toStrictEqual([MOCK_SNAP_ID]);
-    });
-
-    it('does not add a Snap on snapInstalled when it lacks the keyring endowment', async () => {
-      const { service, rootMessenger } = setup();
-
-      await service.init();
-      publishSnapInstalled(rootMessenger, buildSnap(MOCK_SNAP_ID, false));
-
-      expect(service.getSnaps()).toStrictEqual([]);
-    });
-
-    it('adds a Snap on snapEnabled when it has the keyring endowment', async () => {
-      const { service, rootMessenger } = setup();
-
-      await service.init();
-      publishSnapEnabled(rootMessenger, buildSnap(MOCK_SNAP_ID, true));
-
-      expect(service.getSnaps()).toStrictEqual([MOCK_SNAP_ID]);
-    });
-
-    it('removes a Snap on snapDisabled', async () => {
-      const { service, rootMessenger } = setup({
-        runnableSnaps: [buildSnap(MOCK_SNAP_ID, true)],
-      });
-
-      await service.init();
-      expect(service.getSnaps()).toStrictEqual([MOCK_SNAP_ID]);
-
-      publishSnapDisabled(rootMessenger, buildSnap(MOCK_SNAP_ID, true));
-
-      expect(service.getSnaps()).toStrictEqual([]);
-    });
-
-    it('removes a Snap on snapBlocked', async () => {
-      const { service, rootMessenger } = setup({
-        runnableSnaps: [buildSnap(MOCK_SNAP_ID, true)],
-      });
-
-      await service.init();
-      publishSnapBlocked(rootMessenger, MOCK_SNAP_ID);
-
-      expect(service.getSnaps()).toStrictEqual([]);
-    });
-
-    it('ignores snapUnblocked received before init', async () => {
-      const { service, rootMessenger, mocks } = setup();
-
-      mocks.SnapController.getSnap.mockReturnValue({
-        ...buildSnap(MOCK_SNAP_ID, true),
-        enabled: true,
-        blocked: false,
-      } as TruncatedSnap);
-      publishSnapUnblocked(rootMessenger, MOCK_SNAP_ID);
-
-      await service.init();
-
-      expect(service.getSnaps()).toStrictEqual([]);
-    });
-
-    it('re-adds a Snap on snapUnblocked when it is enabled and has the keyring endowment', async () => {
-      const { service, rootMessenger, mocks } = setup();
-
-      await service.init();
-      mocks.SnapController.getSnap.mockReturnValue({
-        ...buildSnap(MOCK_SNAP_ID, true),
-        enabled: true,
-        blocked: false,
-      } as TruncatedSnap);
-
-      publishSnapUnblocked(rootMessenger, MOCK_SNAP_ID);
-
-      expect(service.getSnaps()).toStrictEqual([MOCK_SNAP_ID]);
-    });
-
-    it('does not re-add a Snap on snapUnblocked when it is disabled', async () => {
-      const { service, rootMessenger, mocks } = setup();
-
-      await service.init();
-      mocks.SnapController.getSnap.mockReturnValue({
-        ...buildSnap(MOCK_SNAP_ID, true),
-        enabled: false,
-        blocked: false,
-      } as TruncatedSnap);
-
-      publishSnapUnblocked(rootMessenger, MOCK_SNAP_ID);
-
-      expect(service.getSnaps()).toStrictEqual([]);
-    });
-
-    it('does not re-add a Snap on snapUnblocked when it lacks the keyring endowment', async () => {
-      const { service, rootMessenger, mocks } = setup();
-
-      await service.init();
-      mocks.SnapController.getSnap.mockReturnValue({
-        ...buildSnap(MOCK_SNAP_ID, false),
-        enabled: true,
-        blocked: false,
-      } as TruncatedSnap);
-
-      publishSnapUnblocked(rootMessenger, MOCK_SNAP_ID);
-
-      expect(service.getSnaps()).toStrictEqual([]);
-    });
-
-    it('does not re-add a Snap on snapUnblocked when getSnap returns null', async () => {
-      const { service, rootMessenger } = setup();
-
-      await service.init();
-      publishSnapUnblocked(rootMessenger, MOCK_SNAP_ID);
-
-      expect(service.getSnaps()).toStrictEqual([]);
-    });
-
-    it('removes a Snap on snapUninstalled', async () => {
-      const { service, rootMessenger } = setup({
-        runnableSnaps: [buildSnap(MOCK_SNAP_ID, true)],
-      });
-
-      await service.init();
-      publishSnapUninstalled(rootMessenger, buildSnap(MOCK_SNAP_ID, true));
-
-      expect(service.getSnaps()).toStrictEqual([]);
     });
   });
 

--- a/packages/snap-account-service/src/SnapAccountService.test.ts
+++ b/packages/snap-account-service/src/SnapAccountService.test.ts
@@ -28,7 +28,10 @@ type RootMessenger = Messenger<
 type MockKeyringControllerState = Pick<KeyringControllerState, 'keyrings'>;
 
 /** Mock truncated snap type for tests. */
-type MockTruncatedSnap = Pick<TruncatedSnap, 'id' | 'initialPermissions'>;
+type MockTruncatedSnap = Pick<
+  TruncatedSnap,
+  'id' | 'initialPermissions' | 'enabled' | 'blocked'
+>;
 
 type Mocks = {
   // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -132,6 +135,8 @@ function buildSnap(id: string, hasKeyring: boolean): TruncatedSnap {
   return {
     id: id as SnapId,
     initialPermissions: hasKeyring ? { 'endowment:keyring': {} } : {},
+    enabled: true,
+    blocked: false,
   } as MockTruncatedSnap as TruncatedSnap;
 }
 

--- a/packages/snap-account-service/src/SnapAccountService.test.ts
+++ b/packages/snap-account-service/src/SnapAccountService.test.ts
@@ -6,6 +6,8 @@ import type {
   MessengerEvents,
 } from '@metamask/messenger';
 import type { SnapControllerState } from '@metamask/snaps-controllers';
+import type { SnapId } from '@metamask/snaps-sdk';
+import type { TruncatedSnap } from '@metamask/snaps-utils';
 
 import type {
   SnapAccountServiceMessenger,
@@ -30,6 +32,7 @@ type Mocks = {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   SnapController: {
     getState: jest.MockedFunction<() => SnapControllerState>;
+    getRunnableSnaps: jest.MockedFunction<() => TruncatedSnap[]>;
   };
   // eslint-disable-next-line @typescript-eslint/naming-convention
   KeyringController: {
@@ -62,8 +65,20 @@ function getMessenger(
   });
   rootMessenger.delegate({
     messenger,
-    actions: ['SnapController:getState', 'KeyringController:getState'],
-    events: ['SnapController:stateChange', 'KeyringController:stateChange'],
+    actions: [
+      'SnapController:getState',
+      'SnapController:getRunnableSnaps',
+      'KeyringController:getState',
+    ],
+    events: [
+      'SnapController:stateChange',
+      'SnapController:snapInstalled',
+      'SnapController:snapEnabled',
+      'SnapController:snapDisabled',
+      'SnapController:snapBlocked',
+      'SnapController:snapUninstalled',
+      'KeyringController:stateChange',
+    ],
   });
   return messenger;
 }
@@ -104,21 +119,104 @@ function publishKeyrings(
 }
 
 /**
+ * Builds a minimal `TruncatedSnap` for tests.
+ *
+ * @param id - The Snap ID.
+ * @param hasKeyring - Whether the Snap declares the `endowment:keyring` initial permission.
+ * @returns A minimal `TruncatedSnap`.
+ */
+function buildSnap(id: string, hasKeyring: boolean): TruncatedSnap {
+  return {
+    id: id as SnapId,
+    initialPermissions: hasKeyring ? { 'endowment:keyring': {} } : {},
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+/**
+ * Publishes a `SnapController:snapInstalled` event on the root messenger.
+ *
+ * @param rootMessenger - The root messenger.
+ * @param snap - The Snap that was installed.
+ */
+function publishSnapInstalled(
+  rootMessenger: RootMessenger,
+  snap: TruncatedSnap,
+): void {
+  rootMessenger.publish('SnapController:snapInstalled', snap, 'origin', false);
+}
+
+/**
+ * Publishes a `SnapController:snapEnabled` event on the root messenger.
+ *
+ * @param rootMessenger - The root messenger.
+ * @param snap - The Snap that was enabled.
+ */
+function publishSnapEnabled(
+  rootMessenger: RootMessenger,
+  snap: TruncatedSnap,
+): void {
+  rootMessenger.publish('SnapController:snapEnabled', snap);
+}
+
+/**
+ * Publishes a `SnapController:snapDisabled` event on the root messenger.
+ *
+ * @param rootMessenger - The root messenger.
+ * @param snap - The Snap that was disabled.
+ */
+function publishSnapDisabled(
+  rootMessenger: RootMessenger,
+  snap: TruncatedSnap,
+): void {
+  rootMessenger.publish('SnapController:snapDisabled', snap);
+}
+
+/**
+ * Publishes a `SnapController:snapBlocked` event on the root messenger.
+ *
+ * @param rootMessenger - The root messenger.
+ * @param snapId - The ID of the Snap that was blocked.
+ */
+function publishSnapBlocked(
+  rootMessenger: RootMessenger,
+  snapId: string,
+): void {
+  rootMessenger.publish('SnapController:snapBlocked', snapId);
+}
+
+/**
+ * Publishes a `SnapController:snapUninstalled` event on the root messenger.
+ *
+ * @param rootMessenger - The root messenger.
+ * @param snap - The Snap that was uninstalled.
+ */
+function publishSnapUninstalled(
+  rootMessenger: RootMessenger,
+  snap: TruncatedSnap,
+): void {
+  rootMessenger.publish('SnapController:snapUninstalled', snap);
+}
+
+/**
  * Constructs the service under test with sensible defaults.
  *
  * @param args - The arguments to this function.
  * @param args.snapIsReady - Initial value of `SnapController.isReady`.
  * @param args.keyrings - Initial keyrings returned by `KeyringController:getState`.
+ * @param args.runnableSnaps - Snaps returned by `SnapController:getRunnableSnaps`.
  * @param args.config - Optional service config.
  * @returns The new service, root messenger, service messenger, and mocks.
  */
 function setup({
   snapIsReady = true,
   keyrings = [{ type: KeyringTypes.snap }],
+  runnableSnaps = [],
   config,
 }: {
   snapIsReady?: boolean;
   keyrings?: { type: string }[];
+  runnableSnaps?: TruncatedSnap[];
   config?: SnapAccountServiceOptions['config'];
 } = {}): {
   service: SnapAccountService;
@@ -134,6 +232,7 @@ function setup({
       getState: jest
         .fn()
         .mockReturnValue({ isReady: snapIsReady } as SnapControllerState),
+      getRunnableSnaps: jest.fn().mockReturnValue(runnableSnaps),
     },
     KeyringController: {
       getState: jest.fn().mockReturnValue({ keyrings }),
@@ -145,6 +244,10 @@ function setup({
     mocks.SnapController.getState,
   );
   rootMessenger.registerActionHandler(
+    'SnapController:getRunnableSnaps',
+    mocks.SnapController.getRunnableSnaps,
+  );
+  rootMessenger.registerActionHandler(
     'KeyringController:getState',
     mocks.KeyringController.getState,
   );
@@ -154,7 +257,8 @@ function setup({
   return { service, rootMessenger, messenger, mocks };
 }
 
-const MOCK_SNAP_ID = 'npm:@metamask/mock-snap' as const;
+const MOCK_SNAP_ID = 'npm:@metamask/mock-snap' as SnapId;
+const MOCK_OTHER_SNAP_ID = 'npm:@metamask/other-snap' as SnapId;
 
 describe('SnapAccountService', () => {
   describe('init', () => {
@@ -163,17 +267,157 @@ describe('SnapAccountService', () => {
 
       expect(await service.init()).toBeUndefined();
     });
+
+    it('seeds tracked Snaps from getRunnableSnaps, filtering out non-keyring Snaps', async () => {
+      const { service } = setup({
+        runnableSnaps: [
+          buildSnap(MOCK_SNAP_ID, true),
+          buildSnap(MOCK_OTHER_SNAP_ID, false),
+        ],
+      });
+
+      await service.init();
+
+      expect(service.getSnaps()).toStrictEqual([MOCK_SNAP_ID]);
+    });
+  });
+
+  describe('getSnaps', () => {
+    it('returns an empty array before init', () => {
+      const { service } = setup({
+        runnableSnaps: [buildSnap(MOCK_SNAP_ID, true)],
+      });
+
+      expect(service.getSnaps()).toStrictEqual([]);
+    });
+  });
+
+  describe('lifecycle events', () => {
+    it('ignores add events received before init', async () => {
+      const { service, rootMessenger } = setup();
+
+      publishSnapInstalled(rootMessenger, buildSnap(MOCK_SNAP_ID, true));
+
+      await service.init();
+
+      expect(service.getSnaps()).toStrictEqual([]);
+    });
+
+    it('ignores remove events received before init', async () => {
+      const { service, rootMessenger } = setup({
+        runnableSnaps: [buildSnap(MOCK_SNAP_ID, true)],
+      });
+
+      // Publish a removal event *before* init: it must be ignored, so once
+      // init seeds from `getRunnableSnaps` the Snap is still tracked.
+      publishSnapUninstalled(rootMessenger, buildSnap(MOCK_SNAP_ID, true));
+
+      await service.init();
+
+      expect(service.getSnaps()).toStrictEqual([MOCK_SNAP_ID]);
+    });
+
+    it('adds a Snap on snapInstalled when it has the keyring endowment', async () => {
+      const { service, rootMessenger } = setup();
+
+      await service.init();
+      publishSnapInstalled(rootMessenger, buildSnap(MOCK_SNAP_ID, true));
+
+      expect(service.getSnaps()).toStrictEqual([MOCK_SNAP_ID]);
+    });
+
+    it('does not add a Snap on snapInstalled when it lacks the keyring endowment', async () => {
+      const { service, rootMessenger } = setup();
+
+      await service.init();
+      publishSnapInstalled(rootMessenger, buildSnap(MOCK_SNAP_ID, false));
+
+      expect(service.getSnaps()).toStrictEqual([]);
+    });
+
+    it('adds a Snap on snapEnabled when it has the keyring endowment', async () => {
+      const { service, rootMessenger } = setup();
+
+      await service.init();
+      publishSnapEnabled(rootMessenger, buildSnap(MOCK_SNAP_ID, true));
+
+      expect(service.getSnaps()).toStrictEqual([MOCK_SNAP_ID]);
+    });
+
+    it('removes a Snap on snapDisabled', async () => {
+      const { service, rootMessenger } = setup({
+        runnableSnaps: [buildSnap(MOCK_SNAP_ID, true)],
+      });
+
+      await service.init();
+      expect(service.getSnaps()).toStrictEqual([MOCK_SNAP_ID]);
+
+      publishSnapDisabled(rootMessenger, buildSnap(MOCK_SNAP_ID, true));
+
+      expect(service.getSnaps()).toStrictEqual([]);
+    });
+
+    it('removes a Snap on snapBlocked', async () => {
+      const { service, rootMessenger } = setup({
+        runnableSnaps: [buildSnap(MOCK_SNAP_ID, true)],
+      });
+
+      await service.init();
+      publishSnapBlocked(rootMessenger, MOCK_SNAP_ID);
+
+      expect(service.getSnaps()).toStrictEqual([]);
+    });
+
+    it('removes a Snap on snapUninstalled', async () => {
+      const { service, rootMessenger } = setup({
+        runnableSnaps: [buildSnap(MOCK_SNAP_ID, true)],
+      });
+
+      await service.init();
+      publishSnapUninstalled(rootMessenger, buildSnap(MOCK_SNAP_ID, true));
+
+      expect(service.getSnaps()).toStrictEqual([]);
+    });
   });
 
   describe('ensureReady', () => {
-    it('resolves when platform is already ready', async () => {
+    it('throws when the Snap is not tracked', async () => {
       const { service } = setup();
+
+      await service.init();
+
+      await expect(service.ensureReady(MOCK_SNAP_ID)).rejects.toThrow(
+        `Unknown snap: "${MOCK_SNAP_ID}"`,
+      );
+    });
+
+    it('throws before init even for runnable Snaps', async () => {
+      const { service } = setup({
+        runnableSnaps: [buildSnap(MOCK_SNAP_ID, true)],
+      });
+
+      await expect(service.ensureReady(MOCK_SNAP_ID)).rejects.toThrow(
+        `Unknown snap: "${MOCK_SNAP_ID}"`,
+      );
+    });
+
+    it('resolves when platform is already ready', async () => {
+      const { service } = setup({
+        runnableSnaps: [buildSnap(MOCK_SNAP_ID, true)],
+      });
+
+      await service.init();
 
       expect(await service.ensureReady(MOCK_SNAP_ID)).toBeUndefined();
     });
 
     it('waits for the Snap platform to become ready', async () => {
-      const { service, rootMessenger } = setup({ snapIsReady: false });
+      const { service, rootMessenger } = setup({
+        snapIsReady: false,
+        runnableSnaps: [buildSnap(MOCK_SNAP_ID, true)],
+      });
+
+      await service.init();
 
       let resolved = false;
       const ensurePromise = service.ensureReady(MOCK_SNAP_ID).then(() => {
@@ -190,7 +434,12 @@ describe('SnapAccountService', () => {
     });
 
     it('waits for the Snap keyring to appear via KeyringController:stateChange', async () => {
-      const { service, rootMessenger } = setup({ keyrings: [] });
+      const { service, rootMessenger } = setup({
+        keyrings: [],
+        runnableSnaps: [buildSnap(MOCK_SNAP_ID, true)],
+      });
+
+      await service.init();
 
       let resolved = false;
       const ensurePromise = service.ensureReady(MOCK_SNAP_ID).then(() => {
@@ -213,10 +462,13 @@ describe('SnapAccountService', () => {
     it('rejects if the Snap keyring does not appear within snapKeyringWaitTimeoutMs', async () => {
       const { service } = setup({
         keyrings: [],
+        runnableSnaps: [buildSnap(MOCK_SNAP_ID, true)],
         config: {
           snapPlatformWatcher: { snapKeyringWaitTimeoutMs: 1_000 },
         },
       });
+
+      await service.init();
 
       jest.useFakeTimers();
       const ensurePromise = service.ensureReady(MOCK_SNAP_ID);
@@ -242,8 +494,11 @@ describe('SnapAccountService', () => {
       );
 
       const { service } = setup({
+        runnableSnaps: [buildSnap(MOCK_SNAP_ID, true)],
         config: { snapPlatformWatcher: { ensureOnboardingComplete } },
       });
+
+      await service.init();
 
       let resolved = false;
       const ensurePromise = service.ensureReady(MOCK_SNAP_ID).then(() => {

--- a/packages/snap-account-service/src/SnapAccountService.test.ts
+++ b/packages/snap-account-service/src/SnapAccountService.test.ts
@@ -41,6 +41,7 @@ type Mocks = {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   SnapController: {
     getState: jest.MockedFunction<() => SnapControllerState>;
+    getSnap: jest.MockedFunction<(snapId: string) => TruncatedSnap | null>;
     getRunnableSnaps: jest.MockedFunction<() => TruncatedSnap[]>;
   };
   // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -76,6 +77,7 @@ function getMessenger(
     messenger,
     actions: [
       'SnapController:getState',
+      'SnapController:getSnap',
       'SnapController:getRunnableSnaps',
       'KeyringController:getState',
     ],
@@ -85,6 +87,7 @@ function getMessenger(
       'SnapController:snapEnabled',
       'SnapController:snapDisabled',
       'SnapController:snapBlocked',
+      'SnapController:snapUnblocked',
       'SnapController:snapUninstalled',
       'KeyringController:stateChange',
     ],
@@ -193,6 +196,19 @@ function publishSnapBlocked(
 }
 
 /**
+ * Publishes a `SnapController:snapUnblocked` event on the root messenger.
+ *
+ * @param rootMessenger - The root messenger.
+ * @param snapId - The ID of the Snap that was unblocked.
+ */
+function publishSnapUnblocked(
+  rootMessenger: RootMessenger,
+  snapId: string,
+): void {
+  rootMessenger.publish('SnapController:snapUnblocked', snapId);
+}
+
+/**
  * Publishes a `SnapController:snapUninstalled` event on the root messenger.
  *
  * @param rootMessenger - The root messenger.
@@ -239,6 +255,7 @@ function setup({
       getState: jest
         .fn()
         .mockReturnValue({ isReady: snapIsReady } as SnapControllerState),
+      getSnap: jest.fn().mockReturnValue(null),
       getRunnableSnaps: jest.fn().mockReturnValue(runnableSnaps),
     },
     KeyringController: {
@@ -249,6 +266,10 @@ function setup({
   rootMessenger.registerActionHandler(
     'SnapController:getState',
     mocks.SnapController.getState,
+  );
+  rootMessenger.registerActionHandler(
+    'SnapController:getSnap',
+    mocks.SnapController.getSnap as never,
   );
   rootMessenger.registerActionHandler(
     'SnapController:getRunnableSnaps',
@@ -371,6 +392,75 @@ describe('SnapAccountService', () => {
 
       await service.init();
       publishSnapBlocked(rootMessenger, MOCK_SNAP_ID);
+
+      expect(service.getSnaps()).toStrictEqual([]);
+    });
+
+    it('ignores snapUnblocked received before init', async () => {
+      const { service, rootMessenger, mocks } = setup();
+
+      mocks.SnapController.getSnap.mockReturnValue({
+        ...buildSnap(MOCK_SNAP_ID, true),
+        enabled: true,
+        blocked: false,
+      } as TruncatedSnap);
+      publishSnapUnblocked(rootMessenger, MOCK_SNAP_ID);
+
+      await service.init();
+
+      expect(service.getSnaps()).toStrictEqual([]);
+    });
+
+    it('re-adds a Snap on snapUnblocked when it is enabled and has the keyring endowment', async () => {
+      const { service, rootMessenger, mocks } = setup();
+
+      await service.init();
+      mocks.SnapController.getSnap.mockReturnValue({
+        ...buildSnap(MOCK_SNAP_ID, true),
+        enabled: true,
+        blocked: false,
+      } as TruncatedSnap);
+
+      publishSnapUnblocked(rootMessenger, MOCK_SNAP_ID);
+
+      expect(service.getSnaps()).toStrictEqual([MOCK_SNAP_ID]);
+    });
+
+    it('does not re-add a Snap on snapUnblocked when it is disabled', async () => {
+      const { service, rootMessenger, mocks } = setup();
+
+      await service.init();
+      mocks.SnapController.getSnap.mockReturnValue({
+        ...buildSnap(MOCK_SNAP_ID, true),
+        enabled: false,
+        blocked: false,
+      } as TruncatedSnap);
+
+      publishSnapUnblocked(rootMessenger, MOCK_SNAP_ID);
+
+      expect(service.getSnaps()).toStrictEqual([]);
+    });
+
+    it('does not re-add a Snap on snapUnblocked when it lacks the keyring endowment', async () => {
+      const { service, rootMessenger, mocks } = setup();
+
+      await service.init();
+      mocks.SnapController.getSnap.mockReturnValue({
+        ...buildSnap(MOCK_SNAP_ID, false),
+        enabled: true,
+        blocked: false,
+      } as TruncatedSnap);
+
+      publishSnapUnblocked(rootMessenger, MOCK_SNAP_ID);
+
+      expect(service.getSnaps()).toStrictEqual([]);
+    });
+
+    it('does not re-add a Snap on snapUnblocked when getSnap returns null', async () => {
+      const { service, rootMessenger } = setup();
+
+      await service.init();
+      publishSnapUnblocked(rootMessenger, MOCK_SNAP_ID);
 
       expect(service.getSnaps()).toStrictEqual([]);
     });

--- a/packages/snap-account-service/src/SnapAccountService.test.ts
+++ b/packages/snap-account-service/src/SnapAccountService.test.ts
@@ -1,4 +1,7 @@
-import { KeyringTypes } from '@metamask/keyring-controller';
+import {
+  KeyringControllerState,
+  KeyringTypes,
+} from '@metamask/keyring-controller';
 import { Messenger, MOCK_ANY_NAMESPACE } from '@metamask/messenger';
 import type {
   MockAnyNamespace,
@@ -24,6 +27,12 @@ type RootMessenger = Messenger<
   MessengerActions<SnapAccountServiceMessenger>,
   MessengerEvents<SnapAccountServiceMessenger>
 >;
+
+/** Mock keyring controller state type for tests. */
+type MockKeyringControllerState = Pick<KeyringControllerState, 'keyrings'>;
+
+/** Mock truncated snap type for tests. */
+type MockTruncatedSnap = Pick<TruncatedSnap, 'id' | 'initialPermissions'>;
 
 /**
  * Mock objects for all external dependencies of {@link SnapAccountService}.
@@ -112,8 +121,7 @@ function publishKeyrings(
 ): void {
   rootMessenger.publish(
     'KeyringController:stateChange',
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    { keyrings } as any,
+    { keyrings } as MockKeyringControllerState as KeyringControllerState,
     [],
   );
 }
@@ -129,8 +137,7 @@ function buildSnap(id: string, hasKeyring: boolean): TruncatedSnap {
   return {
     id: id as SnapId,
     initialPermissions: hasKeyring ? { 'endowment:keyring': {} } : {},
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } as any;
+  } as MockTruncatedSnap as TruncatedSnap;
 }
 
 /**

--- a/packages/snap-account-service/src/SnapAccountService.ts
+++ b/packages/snap-account-service/src/SnapAccountService.ts
@@ -16,6 +16,7 @@ import type {
 import { SnapId } from '@metamask/snaps-sdk';
 import type { TruncatedSnap } from '@metamask/snaps-utils';
 
+import { projectLogger as log } from './logger';
 import type {
   SnapAccountServiceEnsureReadyAction,
   SnapAccountServiceGetSnapsAction,
@@ -136,19 +137,19 @@ export class SnapAccountService {
     );
 
     this.#messenger.subscribe('SnapController:snapInstalled', (snap) =>
-      this.#handleSnapAdded(snap),
+      this.#handleSnapAdded(snap, 'installed'),
     );
     this.#messenger.subscribe('SnapController:snapEnabled', (snap) =>
-      this.#handleSnapAdded(snap),
+      this.#handleSnapAdded(snap, 'enabled'),
     );
     this.#messenger.subscribe('SnapController:snapDisabled', (snap) =>
-      this.#handleSnapRemoved(snap.id),
+      this.#handleSnapRemoved(snap.id, 'disabled'),
     );
     this.#messenger.subscribe('SnapController:snapBlocked', (snapId) =>
-      this.#handleSnapRemoved(snapId as SnapId),
+      this.#handleSnapRemoved(snapId as SnapId, 'blocked'),
     );
     this.#messenger.subscribe('SnapController:snapUninstalled', (snap) =>
-      this.#handleSnapRemoved(snap.id),
+      this.#handleSnapRemoved(snap.id, 'uninstalled'),
     );
 
     this.#messenger.registerMethodActionHandlers(
@@ -210,13 +211,16 @@ export class SnapAccountService {
    * account-management Snap, adds it to the internal set of tracked Snaps.
    *
    * @param snap - The Snap that was installed or enabled.
+   * @param reason - The reason the Snap was added.
    */
-  #handleSnapAdded(snap: TruncatedSnap): void {
+  #handleSnapAdded(snap: TruncatedSnap, reason: string): void {
     if (!this.#initialized) {
       return;
     }
 
-    if (isAccountManagementSnap(snap)) {
+    if (isAccountManagementSnap(snap) && !this.#snaps.has(snap.id)) {
+      log(`Added account management Snap: ${snap.id} (${reason})`);
+
       this.#snaps.add(snap.id);
     }
   }
@@ -226,12 +230,17 @@ export class SnapAccountService {
    * account-management Snap, removes it from the internal set of tracked Snaps.
    *
    * @param snapId - The Snap ID that was disabled, blocked, or uninstalled.
+   * @param reason - The reason the Snap was removed.
    */
-  #handleSnapRemoved(snapId: SnapId): void {
+  #handleSnapRemoved(snapId: SnapId, reason: string): void {
     if (!this.#initialized) {
       return;
     }
 
-    this.#snaps.delete(snapId);
+    if (this.#snaps.has(snapId)) {
+      log(`Removed account management Snap: ${snapId} (${reason})`);
+
+      this.#snaps.delete(snapId);
+    }
   }
 }

--- a/packages/snap-account-service/src/SnapAccountService.ts
+++ b/packages/snap-account-service/src/SnapAccountService.ts
@@ -168,7 +168,8 @@ export class SnapAccountService {
   async init(): Promise<void> {
     const runnable = this.#messenger.call('SnapController:getRunnableSnaps');
     for (const snap of runnable) {
-      if (isAccountManagementSnap(snap)) {
+      if (isAccountManagementSnap(snap) && !this.#snaps.has(snap.id)) {
+        log(`Found account management Snap: ${snap.id} (initialization)`);
         this.#snaps.add(snap.id);
       }
     }

--- a/packages/snap-account-service/src/SnapAccountService.ts
+++ b/packages/snap-account-service/src/SnapAccountService.ts
@@ -16,26 +16,14 @@ import type {
   SnapControllerStateChangeEvent,
 } from '@metamask/snaps-controllers';
 import { SnapId } from '@metamask/snaps-sdk';
-import type { TruncatedSnap } from '@metamask/snaps-utils';
 
-import { projectLogger as log } from './logger';
 import type {
   SnapAccountServiceEnsureReadyAction,
   SnapAccountServiceGetSnapsAction,
 } from './SnapAccountService-method-action-types';
 import { SnapPlatformWatcher } from './SnapPlatformWatcher';
 import type { SnapPlatformWatcherConfig } from './SnapPlatformWatcher';
-
-/**
- * Checks if a given Snap is an account management Snap.
- *
- * @param snap - The Snap to check.
- * @returns True if the Snap declares the `endowment:keyring` initial
- * permission.
- */
-function isAccountManagementSnap(snap: TruncatedSnap): boolean {
-  return snap.initialPermissions['endowment:keyring'] !== undefined;
-}
+import { SnapTracker } from './SnapTracker';
 
 /**
  * The name of the {@link SnapAccountService}, used to namespace the service's
@@ -121,9 +109,7 @@ export class SnapAccountService {
 
   readonly #watcher: SnapPlatformWatcher;
 
-  readonly #snaps: Set<SnapId> = new Set();
-
-  #initialized = false;
+  readonly #tracker: SnapTracker;
 
   /**
    * Constructs a new {@link SnapAccountService}.
@@ -139,25 +125,7 @@ export class SnapAccountService {
       messenger,
       config?.snapPlatformWatcher,
     );
-
-    this.#messenger.subscribe('SnapController:snapInstalled', (snap) =>
-      this.#handleSnapAdded(snap, 'installed'),
-    );
-    this.#messenger.subscribe('SnapController:snapUninstalled', (snap) =>
-      this.#handleSnapRemoved(snap.id, 'uninstalled'),
-    );
-    this.#messenger.subscribe('SnapController:snapEnabled', (snap) =>
-      this.#handleSnapAdded(snap, 'enabled'),
-    );
-    this.#messenger.subscribe('SnapController:snapDisabled', (snap) =>
-      this.#handleSnapRemoved(snap.id, 'disabled'),
-    );
-    this.#messenger.subscribe('SnapController:snapBlocked', (snapId) =>
-      this.#handleSnapRemoved(snapId as SnapId, 'blocked'),
-    );
-    this.#messenger.subscribe('SnapController:snapUnblocked', (snapId) =>
-      this.#handleSnapUnblocked(snapId as SnapId),
-    );
+    this.#tracker = new SnapTracker(messenger);
 
     this.#messenger.registerMethodActionHandlers(
       this,
@@ -173,15 +141,7 @@ export class SnapAccountService {
    * events.
    */
   async init(): Promise<void> {
-    const runnable = this.#messenger.call('SnapController:getRunnableSnaps');
-    for (const snap of runnable) {
-      if (isAccountManagementSnap(snap) && !this.#snaps.has(snap.id)) {
-        log(`Found account management Snap: ${snap.id} (initialization)`);
-        this.#snaps.add(snap.id);
-      }
-    }
-
-    this.#initialized = true;
+    await this.#tracker.init();
   }
 
   /**
@@ -192,7 +152,7 @@ export class SnapAccountService {
    * @returns The IDs of tracked account-management Snaps.
    */
   getSnaps(): SnapId[] {
-    return [...this.#snaps];
+    return this.#tracker.getSnaps();
   }
 
   /**
@@ -206,66 +166,11 @@ export class SnapAccountService {
    * @throws If `snapId` is not a tracked account-management Snap.
    */
   async ensureReady(snapId: SnapId): Promise<void> {
-    if (!this.#snaps.has(snapId)) {
+    if (!this.#tracker.has(snapId)) {
       throw new Error(`Unknown snap: "${snapId}"`);
     }
     // Before doing anything with our Snap, we need to make sure the platform
     // is ready to process requests.
     await this.#watcher.ensureCanUseSnapPlatform();
-  }
-
-  /**
-   * Handles a Snap being added (installed or enabled). If the Snap is an
-   * account-management Snap, adds it to the internal set of tracked Snaps.
-   *
-   * @param snap - The Snap that was installed or enabled.
-   * @param reason - The reason the Snap was added.
-   */
-  #handleSnapAdded(snap: TruncatedSnap, reason: string): void {
-    if (!this.#initialized) {
-      return;
-    }
-
-    if (isAccountManagementSnap(snap) && !this.#snaps.has(snap.id)) {
-      log(`Added account management Snap: ${snap.id} (${reason})`);
-
-      this.#snaps.add(snap.id);
-    }
-  }
-
-  /**
-   * Handles a Snap being unblocked. If the Snap is an enabled
-   * account-management Snap, re-adds it to the internal set of tracked Snaps.
-   *
-   * @param snapId - The Snap ID that was unblocked.
-   */
-  #handleSnapUnblocked(snapId: SnapId): void {
-    if (!this.#initialized) {
-      return;
-    }
-
-    const snap = this.#messenger.call('SnapController:getSnap', snapId);
-    if (snap && snap.enabled && !snap.blocked) {
-      this.#handleSnapAdded(snap, 'unblocked');
-    }
-  }
-
-  /**
-   * Handles a Snap being removed (disabled, blocked, or uninstalled). If the Snap is an
-   * account-management Snap, removes it from the internal set of tracked Snaps.
-   *
-   * @param snapId - The Snap ID that was disabled, blocked, or uninstalled.
-   * @param reason - The reason the Snap was removed.
-   */
-  #handleSnapRemoved(snapId: SnapId, reason: string): void {
-    if (!this.#initialized) {
-      return;
-    }
-
-    if (this.#snaps.has(snapId)) {
-      log(`Removed account management Snap: ${snapId} (${reason})`);
-
-      this.#snaps.delete(snapId);
-    }
   }
 }

--- a/packages/snap-account-service/src/SnapAccountService.ts
+++ b/packages/snap-account-service/src/SnapAccountService.ts
@@ -4,14 +4,35 @@ import type {
 } from '@metamask/keyring-controller';
 import type { Messenger } from '@metamask/messenger';
 import type {
+  SnapControllerGetRunnableSnapsAction,
   SnapControllerGetStateAction,
+  SnapControllerSnapBlockedEvent,
+  SnapControllerSnapDisabledEvent,
+  SnapControllerSnapEnabledEvent,
+  SnapControllerSnapInstalledEvent,
+  SnapControllerSnapUninstalledEvent,
   SnapControllerStateChangeEvent,
 } from '@metamask/snaps-controllers';
 import { SnapId } from '@metamask/snaps-sdk';
+import type { TruncatedSnap } from '@metamask/snaps-utils';
 
-import type { SnapAccountServiceEnsureReadyAction } from './SnapAccountService-method-action-types';
+import type {
+  SnapAccountServiceEnsureReadyAction,
+  SnapAccountServiceGetSnapsAction,
+} from './SnapAccountService-method-action-types';
 import { SnapPlatformWatcher } from './SnapPlatformWatcher';
 import type { SnapPlatformWatcherConfig } from './SnapPlatformWatcher';
+
+/**
+ * Checks if a given Snap is an account management Snap.
+ *
+ * @param snap - The Snap to check.
+ * @returns True if the Snap declares the `endowment:keyring` initial
+ * permission.
+ */
+function isAccountManagementSnap(snap: TruncatedSnap): boolean {
+  return snap.initialPermissions['endowment:keyring'] !== undefined;
+}
 
 /**
  * The name of the {@link SnapAccountService}, used to namespace the service's
@@ -23,18 +44,21 @@ export const serviceName = 'SnapAccountService';
  * All of the methods within {@link SnapAccountService} that are exposed via
  * the messenger.
  */
-const MESSENGER_EXPOSED_METHODS = ['ensureReady'] as const;
+const MESSENGER_EXPOSED_METHODS = ['ensureReady', 'getSnaps'] as const;
 
 /**
  * Actions that {@link SnapAccountService} exposes to other consumers.
  */
-export type SnapAccountServiceActions = SnapAccountServiceEnsureReadyAction;
+export type SnapAccountServiceActions =
+  | SnapAccountServiceEnsureReadyAction
+  | SnapAccountServiceGetSnapsAction;
 
 /**
  * Actions from other messengers that {@link SnapAccountService} calls.
  */
 type AllowedActions =
   | SnapControllerGetStateAction
+  | SnapControllerGetRunnableSnapsAction
   | KeyringControllerGetStateAction;
 
 /**
@@ -47,6 +71,11 @@ export type SnapAccountServiceEvents = never;
  */
 type AllowedEvents =
   | SnapControllerStateChangeEvent
+  | SnapControllerSnapInstalledEvent
+  | SnapControllerSnapEnabledEvent
+  | SnapControllerSnapDisabledEvent
+  | SnapControllerSnapBlockedEvent
+  | SnapControllerSnapUninstalledEvent
   | KeyringControllerStateChangeEvent;
 
 /**
@@ -87,6 +116,10 @@ export class SnapAccountService {
 
   readonly #watcher: SnapPlatformWatcher;
 
+  readonly #snaps: Set<SnapId> = new Set();
+
+  #initialized = false;
+
   /**
    * Constructs a new {@link SnapAccountService}.
    *
@@ -102,6 +135,22 @@ export class SnapAccountService {
       config?.snapPlatformWatcher,
     );
 
+    this.#messenger.subscribe('SnapController:snapInstalled', (snap) =>
+      this.#handleSnapAdded(snap),
+    );
+    this.#messenger.subscribe('SnapController:snapEnabled', (snap) =>
+      this.#handleSnapAdded(snap),
+    );
+    this.#messenger.subscribe('SnapController:snapDisabled', (snap) =>
+      this.#handleSnapRemoved(snap.id),
+    );
+    this.#messenger.subscribe('SnapController:snapBlocked', (snapId) =>
+      this.#handleSnapRemoved(snapId as SnapId),
+    );
+    this.#messenger.subscribe('SnapController:snapUninstalled', (snap) =>
+      this.#handleSnapRemoved(snap.id),
+    );
+
     this.#messenger.registerMethodActionHandlers(
       this,
       MESSENGER_EXPOSED_METHODS,
@@ -110,22 +159,79 @@ export class SnapAccountService {
 
   /**
    * Initializes the snap account service.
+   *
+   * Seeds the internal set of account-management Snaps from
+   * `SnapController:getRunnableSnaps`, then starts processing lifecycle
+   * events.
    */
   async init(): Promise<void> {
-    // TODO: Add initialization logic here.
+    const runnable = this.#messenger.call('SnapController:getRunnableSnaps');
+    for (const snap of runnable) {
+      if (isAccountManagementSnap(snap)) {
+        this.#snaps.add(snap.id);
+      }
+    }
+
+    this.#initialized = true;
+  }
+
+  /**
+   * Returns the IDs of all currently tracked account-management Snaps —
+   * Snaps that are installed, enabled, not blocked, and have the
+   * `endowment:keyring` permission.
+   *
+   * @returns The IDs of tracked account-management Snaps.
+   */
+  getSnaps(): SnapId[] {
+    return [...this.#snaps];
   }
 
   /**
    * Ensures everything is ready to use Snap accounts for the given Snap.
-   * 1. Waits for the Snap platform to be fully started.
+   * 1. Validates that `snapId` is a tracked account-management Snap.
+   * 2. Waits for the Snap platform to be fully started.
    *
    * Safe to call concurrently — each step is idempotent or mutex-protected.
    *
-   * @param _snapId - ID of the Snap to ensure readiness for.
+   * @param snapId - ID of the Snap to ensure readiness for.
+   * @throws If `snapId` is not a tracked account-management Snap.
    */
-  async ensureReady(_snapId: SnapId): Promise<void> {
-    // Lastly, before doing anything with our Snap, we need to make sure the
-    // platform is ready to process requests.
+  async ensureReady(snapId: SnapId): Promise<void> {
+    if (!this.#snaps.has(snapId)) {
+      throw new Error(`Unknown snap: "${snapId}"`);
+    }
+    // Before doing anything with our Snap, we need to make sure the platform
+    // is ready to process requests.
     await this.#watcher.ensureCanUseSnapPlatform();
+  }
+
+  /**
+   * Handles a Snap being added (installed or enabled). If the Snap is an
+   * account-management Snap, adds it to the internal set of tracked Snaps.
+   *
+   * @param snap - The Snap that was installed or enabled.
+   */
+  #handleSnapAdded(snap: TruncatedSnap): void {
+    if (!this.#initialized) {
+      return;
+    }
+
+    if (isAccountManagementSnap(snap)) {
+      this.#snaps.add(snap.id);
+    }
+  }
+
+  /**
+   * Handles a Snap being removed (disabled, blocked, or uninstalled). If the Snap is an
+   * account-management Snap, removes it from the internal set of tracked Snaps.
+   *
+   * @param snapId - The Snap ID that was disabled, blocked, or uninstalled.
+   */
+  #handleSnapRemoved(snapId: SnapId): void {
+    if (!this.#initialized) {
+      return;
+    }
+
+    this.#snaps.delete(snapId);
   }
 }

--- a/packages/snap-account-service/src/SnapAccountService.ts
+++ b/packages/snap-account-service/src/SnapAccountService.ts
@@ -166,7 +166,7 @@ export class SnapAccountService {
    * @throws If `snapId` is not a tracked account-management Snap.
    */
   async ensureReady(snapId: SnapId): Promise<void> {
-    if (!this.#tracker.has(snapId)) {
+    if (!this.#tracker.canUse(snapId)) {
       throw new Error(`Unknown snap: "${snapId}"`);
     }
     // Before doing anything with our Snap, we need to make sure the platform

--- a/packages/snap-account-service/src/SnapAccountService.ts
+++ b/packages/snap-account-service/src/SnapAccountService.ts
@@ -5,11 +5,13 @@ import type {
 import type { Messenger } from '@metamask/messenger';
 import type {
   SnapControllerGetRunnableSnapsAction,
+  SnapControllerGetSnapAction,
   SnapControllerGetStateAction,
   SnapControllerSnapBlockedEvent,
   SnapControllerSnapDisabledEvent,
   SnapControllerSnapEnabledEvent,
   SnapControllerSnapInstalledEvent,
+  SnapControllerSnapUnblockedEvent,
   SnapControllerSnapUninstalledEvent,
   SnapControllerStateChangeEvent,
 } from '@metamask/snaps-controllers';
@@ -59,6 +61,7 @@ export type SnapAccountServiceActions =
  */
 type AllowedActions =
   | SnapControllerGetStateAction
+  | SnapControllerGetSnapAction
   | SnapControllerGetRunnableSnapsAction
   | KeyringControllerGetStateAction;
 
@@ -76,6 +79,7 @@ type AllowedEvents =
   | SnapControllerSnapEnabledEvent
   | SnapControllerSnapDisabledEvent
   | SnapControllerSnapBlockedEvent
+  | SnapControllerSnapUnblockedEvent
   | SnapControllerSnapUninstalledEvent
   | KeyringControllerStateChangeEvent;
 
@@ -139,6 +143,9 @@ export class SnapAccountService {
     this.#messenger.subscribe('SnapController:snapInstalled', (snap) =>
       this.#handleSnapAdded(snap, 'installed'),
     );
+    this.#messenger.subscribe('SnapController:snapUninstalled', (snap) =>
+      this.#handleSnapRemoved(snap.id, 'uninstalled'),
+    );
     this.#messenger.subscribe('SnapController:snapEnabled', (snap) =>
       this.#handleSnapAdded(snap, 'enabled'),
     );
@@ -148,8 +155,8 @@ export class SnapAccountService {
     this.#messenger.subscribe('SnapController:snapBlocked', (snapId) =>
       this.#handleSnapRemoved(snapId as SnapId, 'blocked'),
     );
-    this.#messenger.subscribe('SnapController:snapUninstalled', (snap) =>
-      this.#handleSnapRemoved(snap.id, 'uninstalled'),
+    this.#messenger.subscribe('SnapController:snapUnblocked', (snapId) =>
+      this.#handleSnapUnblocked(snapId as SnapId),
     );
 
     this.#messenger.registerMethodActionHandlers(
@@ -223,6 +230,23 @@ export class SnapAccountService {
       log(`Added account management Snap: ${snap.id} (${reason})`);
 
       this.#snaps.add(snap.id);
+    }
+  }
+
+  /**
+   * Handles a Snap being unblocked. If the Snap is an enabled
+   * account-management Snap, re-adds it to the internal set of tracked Snaps.
+   *
+   * @param snapId - The Snap ID that was unblocked.
+   */
+  #handleSnapUnblocked(snapId: SnapId): void {
+    if (!this.#initialized) {
+      return;
+    }
+
+    const snap = this.#messenger.call('SnapController:getSnap', snapId);
+    if (snap && snap.enabled && !snap.blocked) {
+      this.#handleSnapAdded(snap, 'unblocked');
     }
   }
 

--- a/packages/snap-account-service/src/SnapTracker.test.ts
+++ b/packages/snap-account-service/src/SnapTracker.test.ts
@@ -16,7 +16,10 @@ type RootMessenger = Messenger<
   MessengerEvents<SnapAccountServiceMessenger>
 >;
 
-type MockTruncatedSnap = Pick<TruncatedSnap, 'id' | 'initialPermissions'>;
+type MockTruncatedSnap = Pick<
+  TruncatedSnap,
+  'id' | 'initialPermissions' | 'enabled' | 'blocked'
+>;
 
 type Mocks = {
   // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -75,6 +78,8 @@ function buildSnap(id: string, isKeyring: boolean): TruncatedSnap {
   return {
     id: id as SnapId,
     initialPermissions: isKeyring ? { 'endowment:keyring': {} } : {},
+    enabled: true,
+    blocked: false,
   } as MockTruncatedSnap as TruncatedSnap;
 }
 

--- a/packages/snap-account-service/src/SnapTracker.test.ts
+++ b/packages/snap-account-service/src/SnapTracker.test.ts
@@ -1,0 +1,417 @@
+import { Messenger, MOCK_ANY_NAMESPACE } from '@metamask/messenger';
+import type {
+  MockAnyNamespace,
+  MessengerActions,
+  MessengerEvents,
+} from '@metamask/messenger';
+import type { SnapId } from '@metamask/snaps-sdk';
+import type { TruncatedSnap } from '@metamask/snaps-utils';
+
+import type { SnapAccountServiceMessenger } from './SnapAccountService';
+import { SnapTracker } from './SnapTracker';
+
+type RootMessenger = Messenger<
+  MockAnyNamespace,
+  MessengerActions<SnapAccountServiceMessenger>,
+  MessengerEvents<SnapAccountServiceMessenger>
+>;
+
+type MockTruncatedSnap = Pick<TruncatedSnap, 'id' | 'initialPermissions'>;
+
+type Mocks = {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  SnapController: {
+    getSnap: jest.MockedFunction<(snapId: string) => TruncatedSnap | null>;
+    getRunnableSnaps: jest.MockedFunction<() => TruncatedSnap[]>;
+  };
+};
+
+/**
+ * Constructs the root messenger for the tracker under test.
+ *
+ * @returns The root messenger.
+ */
+function getRootMessenger(): RootMessenger {
+  return new Messenger({ namespace: MOCK_ANY_NAMESPACE });
+}
+
+/**
+ * Constructs the messenger for the tracker under test, and delegates all
+ * required external actions and events from the root messenger to it.
+ *
+ * @param rootMessenger - The root messenger.
+ * @returns The tracker messenger.
+ */
+function getMessenger(
+  rootMessenger: RootMessenger,
+): SnapAccountServiceMessenger {
+  const messenger = new Messenger({
+    namespace: 'SnapAccountService',
+    parent: rootMessenger,
+  });
+  rootMessenger.delegate({
+    messenger,
+    actions: ['SnapController:getSnap', 'SnapController:getRunnableSnaps'],
+    events: [
+      'SnapController:snapInstalled',
+      'SnapController:snapEnabled',
+      'SnapController:snapDisabled',
+      'SnapController:snapBlocked',
+      'SnapController:snapUnblocked',
+      'SnapController:snapUninstalled',
+    ],
+  });
+  return messenger;
+}
+
+/**
+ * Builds a minimal `TruncatedSnap` for tests.
+ *
+ * @param id - The Snap ID.
+ * @param hasKeyring - Whether the Snap declares the `endowment:keyring` initial permission.
+ * @returns A minimal `TruncatedSnap`.
+ */
+function buildSnap(id: string, hasKeyring: boolean): TruncatedSnap {
+  return {
+    id: id as SnapId,
+    initialPermissions: hasKeyring ? { 'endowment:keyring': {} } : {},
+  } as MockTruncatedSnap as TruncatedSnap;
+}
+
+/**
+ * Publishes a `SnapController:snapInstalled` event on the root messenger.
+ *
+ * @param rootMessenger - The root messenger.
+ * @param snap - The Snap that was installed.
+ */
+function publishSnapInstalled(
+  rootMessenger: RootMessenger,
+  snap: TruncatedSnap,
+): void {
+  rootMessenger.publish('SnapController:snapInstalled', snap, 'origin', false);
+}
+
+/**
+ * Publishes a `SnapController:snapEnabled` event on the root messenger.
+ *
+ * @param rootMessenger - The root messenger.
+ * @param snap - The Snap that was enabled.
+ */
+function publishSnapEnabled(
+  rootMessenger: RootMessenger,
+  snap: TruncatedSnap,
+): void {
+  rootMessenger.publish('SnapController:snapEnabled', snap);
+}
+
+/**
+ * Publishes a `SnapController:snapDisabled` event on the root messenger.
+ *
+ * @param rootMessenger - The root messenger.
+ * @param snap - The Snap that was disabled.
+ */
+function publishSnapDisabled(
+  rootMessenger: RootMessenger,
+  snap: TruncatedSnap,
+): void {
+  rootMessenger.publish('SnapController:snapDisabled', snap);
+}
+
+/**
+ * Publishes a `SnapController:snapBlocked` event on the root messenger.
+ *
+ * @param rootMessenger - The root messenger.
+ * @param snapId - The ID of the Snap that was blocked.
+ */
+function publishSnapBlocked(
+  rootMessenger: RootMessenger,
+  snapId: string,
+): void {
+  rootMessenger.publish('SnapController:snapBlocked', snapId);
+}
+
+/**
+ * Publishes a `SnapController:snapUnblocked` event on the root messenger.
+ *
+ * @param rootMessenger - The root messenger.
+ * @param snapId - The ID of the Snap that was unblocked.
+ */
+function publishSnapUnblocked(
+  rootMessenger: RootMessenger,
+  snapId: string,
+): void {
+  rootMessenger.publish('SnapController:snapUnblocked', snapId);
+}
+
+/**
+ * Publishes a `SnapController:snapUninstalled` event on the root messenger.
+ *
+ * @param rootMessenger - The root messenger.
+ * @param snap - The Snap that was uninstalled.
+ */
+function publishSnapUninstalled(
+  rootMessenger: RootMessenger,
+  snap: TruncatedSnap,
+): void {
+  rootMessenger.publish('SnapController:snapUninstalled', snap);
+}
+
+/**
+ * Constructs the tracker under test with sensible defaults.
+ *
+ * @param args - The arguments to this function.
+ * @param args.runnableSnaps - Snaps returned by `SnapController:getRunnableSnaps`.
+ * @returns The new tracker, root messenger, tracker messenger, and mocks.
+ */
+function setup({
+  runnableSnaps = [],
+}: {
+  runnableSnaps?: TruncatedSnap[];
+} = {}): {
+  tracker: SnapTracker;
+  rootMessenger: RootMessenger;
+  messenger: SnapAccountServiceMessenger;
+  mocks: Mocks;
+} {
+  const rootMessenger = getRootMessenger();
+  const messenger = getMessenger(rootMessenger);
+
+  const mocks: Mocks = {
+    SnapController: {
+      getSnap: jest.fn().mockReturnValue(null),
+      getRunnableSnaps: jest.fn().mockReturnValue(runnableSnaps),
+    },
+  };
+
+  rootMessenger.registerActionHandler(
+    'SnapController:getSnap',
+    mocks.SnapController.getSnap as never,
+  );
+  rootMessenger.registerActionHandler(
+    'SnapController:getRunnableSnaps',
+    mocks.SnapController.getRunnableSnaps,
+  );
+
+  const tracker = new SnapTracker(messenger);
+
+  return { tracker, rootMessenger, messenger, mocks };
+}
+
+const MOCK_SNAP_ID = 'npm:@metamask/mock-snap' as SnapId;
+const MOCK_OTHER_SNAP_ID = 'npm:@metamask/other-snap' as SnapId;
+
+describe('SnapTracker', () => {
+  describe('init', () => {
+    it('resolves without throwing', async () => {
+      const { tracker } = setup();
+
+      expect(await tracker.init()).toBeUndefined();
+    });
+
+    it('seeds tracked Snaps from getRunnableSnaps, filtering out non-keyring Snaps', async () => {
+      const { tracker } = setup({
+        runnableSnaps: [
+          buildSnap(MOCK_SNAP_ID, true),
+          buildSnap(MOCK_OTHER_SNAP_ID, false),
+        ],
+      });
+
+      await tracker.init();
+
+      expect(tracker.getSnaps()).toStrictEqual([MOCK_SNAP_ID]);
+    });
+  });
+
+  describe('getSnaps', () => {
+    it('returns an empty array before init', () => {
+      const { tracker } = setup({
+        runnableSnaps: [buildSnap(MOCK_SNAP_ID, true)],
+      });
+
+      expect(tracker.getSnaps()).toStrictEqual([]);
+    });
+  });
+
+  describe('has', () => {
+    it('returns false before init', () => {
+      const { tracker } = setup({
+        runnableSnaps: [buildSnap(MOCK_SNAP_ID, true)],
+      });
+
+      expect(tracker.has(MOCK_SNAP_ID)).toBe(false);
+    });
+
+    it('returns true for a tracked Snap', async () => {
+      const { tracker } = setup({
+        runnableSnaps: [buildSnap(MOCK_SNAP_ID, true)],
+      });
+
+      await tracker.init();
+
+      expect(tracker.has(MOCK_SNAP_ID)).toBe(true);
+    });
+
+    it('returns false for an untracked Snap', async () => {
+      const { tracker } = setup();
+
+      await tracker.init();
+
+      expect(tracker.has(MOCK_SNAP_ID)).toBe(false);
+    });
+  });
+
+  describe('lifecycle events', () => {
+    it('ignores add events received before init', async () => {
+      const { tracker, rootMessenger } = setup();
+
+      publishSnapInstalled(rootMessenger, buildSnap(MOCK_SNAP_ID, true));
+
+      await tracker.init();
+
+      expect(tracker.getSnaps()).toStrictEqual([]);
+    });
+
+    it('ignores remove events received before init', async () => {
+      const { tracker, rootMessenger } = setup({
+        runnableSnaps: [buildSnap(MOCK_SNAP_ID, true)],
+      });
+
+      publishSnapUninstalled(rootMessenger, buildSnap(MOCK_SNAP_ID, true));
+
+      await tracker.init();
+
+      expect(tracker.getSnaps()).toStrictEqual([MOCK_SNAP_ID]);
+    });
+
+    it('adds a Snap on snapInstalled when it has the keyring endowment', async () => {
+      const { tracker, rootMessenger } = setup();
+
+      await tracker.init();
+      publishSnapInstalled(rootMessenger, buildSnap(MOCK_SNAP_ID, true));
+
+      expect(tracker.getSnaps()).toStrictEqual([MOCK_SNAP_ID]);
+    });
+
+    it('does not add a Snap on snapInstalled when it lacks the keyring endowment', async () => {
+      const { tracker, rootMessenger } = setup();
+
+      await tracker.init();
+      publishSnapInstalled(rootMessenger, buildSnap(MOCK_SNAP_ID, false));
+
+      expect(tracker.getSnaps()).toStrictEqual([]);
+    });
+
+    it('adds a Snap on snapEnabled when it has the keyring endowment', async () => {
+      const { tracker, rootMessenger } = setup();
+
+      await tracker.init();
+      publishSnapEnabled(rootMessenger, buildSnap(MOCK_SNAP_ID, true));
+
+      expect(tracker.getSnaps()).toStrictEqual([MOCK_SNAP_ID]);
+    });
+
+    it('removes a Snap on snapDisabled', async () => {
+      const { tracker, rootMessenger } = setup({
+        runnableSnaps: [buildSnap(MOCK_SNAP_ID, true)],
+      });
+
+      await tracker.init();
+      expect(tracker.getSnaps()).toStrictEqual([MOCK_SNAP_ID]);
+
+      publishSnapDisabled(rootMessenger, buildSnap(MOCK_SNAP_ID, true));
+
+      expect(tracker.getSnaps()).toStrictEqual([]);
+    });
+
+    it('removes a Snap on snapBlocked', async () => {
+      const { tracker, rootMessenger } = setup({
+        runnableSnaps: [buildSnap(MOCK_SNAP_ID, true)],
+      });
+
+      await tracker.init();
+      publishSnapBlocked(rootMessenger, MOCK_SNAP_ID);
+
+      expect(tracker.getSnaps()).toStrictEqual([]);
+    });
+
+    it('ignores snapUnblocked received before init', async () => {
+      const { tracker, rootMessenger, mocks } = setup();
+
+      mocks.SnapController.getSnap.mockReturnValue({
+        ...buildSnap(MOCK_SNAP_ID, true),
+        enabled: true,
+        blocked: false,
+      } as TruncatedSnap);
+      publishSnapUnblocked(rootMessenger, MOCK_SNAP_ID);
+
+      await tracker.init();
+
+      expect(tracker.getSnaps()).toStrictEqual([]);
+    });
+
+    it('re-adds a Snap on snapUnblocked when it is enabled and has the keyring endowment', async () => {
+      const { tracker, rootMessenger, mocks } = setup();
+
+      await tracker.init();
+      mocks.SnapController.getSnap.mockReturnValue({
+        ...buildSnap(MOCK_SNAP_ID, true),
+        enabled: true,
+        blocked: false,
+      } as TruncatedSnap);
+
+      publishSnapUnblocked(rootMessenger, MOCK_SNAP_ID);
+
+      expect(tracker.getSnaps()).toStrictEqual([MOCK_SNAP_ID]);
+    });
+
+    it('does not re-add a Snap on snapUnblocked when it is disabled', async () => {
+      const { tracker, rootMessenger, mocks } = setup();
+
+      await tracker.init();
+      mocks.SnapController.getSnap.mockReturnValue({
+        ...buildSnap(MOCK_SNAP_ID, true),
+        enabled: false,
+        blocked: false,
+      } as TruncatedSnap);
+
+      publishSnapUnblocked(rootMessenger, MOCK_SNAP_ID);
+
+      expect(tracker.getSnaps()).toStrictEqual([]);
+    });
+
+    it('does not re-add a Snap on snapUnblocked when it lacks the keyring endowment', async () => {
+      const { tracker, rootMessenger, mocks } = setup();
+
+      await tracker.init();
+      mocks.SnapController.getSnap.mockReturnValue({
+        ...buildSnap(MOCK_SNAP_ID, false),
+        enabled: true,
+        blocked: false,
+      } as TruncatedSnap);
+
+      publishSnapUnblocked(rootMessenger, MOCK_SNAP_ID);
+
+      expect(tracker.getSnaps()).toStrictEqual([]);
+    });
+
+    it('does not re-add a Snap on snapUnblocked when getSnap returns null', async () => {
+      const { tracker, rootMessenger } = setup();
+
+      await tracker.init();
+      publishSnapUnblocked(rootMessenger, MOCK_SNAP_ID);
+
+      expect(tracker.getSnaps()).toStrictEqual([]);
+    });
+
+    it('removes a Snap on snapUninstalled', async () => {
+      const { tracker, rootMessenger } = setup({
+        runnableSnaps: [buildSnap(MOCK_SNAP_ID, true)],
+      });
+
+      await tracker.init();
+      publishSnapUninstalled(rootMessenger, buildSnap(MOCK_SNAP_ID, true));
+
+      expect(tracker.getSnaps()).toStrictEqual([]);
+    });
+  });
+});

--- a/packages/snap-account-service/src/SnapTracker.test.ts
+++ b/packages/snap-account-service/src/SnapTracker.test.ts
@@ -68,13 +68,13 @@ function getMessenger(
  * Builds a minimal `TruncatedSnap` for tests.
  *
  * @param id - The Snap ID.
- * @param hasKeyring - Whether the Snap declares the `endowment:keyring` initial permission.
+ * @param isKeyring - Whether the Snap declares the `endowment:keyring` initial permission.
  * @returns A minimal `TruncatedSnap`.
  */
-function buildSnap(id: string, hasKeyring: boolean): TruncatedSnap {
+function buildSnap(id: string, isKeyring: boolean): TruncatedSnap {
   return {
     id: id as SnapId,
-    initialPermissions: hasKeyring ? { 'endowment:keyring': {} } : {},
+    initialPermissions: isKeyring ? { 'endowment:keyring': {} } : {},
   } as MockTruncatedSnap as TruncatedSnap;
 }
 

--- a/packages/snap-account-service/src/SnapTracker.test.ts
+++ b/packages/snap-account-service/src/SnapTracker.test.ts
@@ -208,6 +208,16 @@ describe('SnapTracker', () => {
       expect(await tracker.init()).toBeUndefined();
     });
 
+    it('does not re-init if already initialized', async () => {
+      const { tracker, mocks } = setup();
+
+      expect(await tracker.init()).toBeUndefined();
+      expect(mocks.SnapController.getRunnableSnaps).toHaveBeenCalledTimes(1);
+
+      expect(await tracker.init()).toBeUndefined();
+      expect(mocks.SnapController.getRunnableSnaps).toHaveBeenCalledTimes(1); // Still only called once.
+    });
+
     it('seeds tracked Snaps from getRunnableSnaps, filtering out non-keyring Snaps', async () => {
       const { tracker } = setup({
         runnableSnaps: [

--- a/packages/snap-account-service/src/SnapTracker.test.ts
+++ b/packages/snap-account-service/src/SnapTracker.test.ts
@@ -242,13 +242,13 @@ describe('SnapTracker', () => {
     });
   });
 
-  describe('has', () => {
+  describe('canUse', () => {
     it('returns false before init', () => {
       const { tracker } = setup({
         runnableSnaps: [buildSnap(MOCK_SNAP_ID, true)],
       });
 
-      expect(tracker.has(MOCK_SNAP_ID)).toBe(false);
+      expect(tracker.canUse(MOCK_SNAP_ID)).toBe(false);
     });
 
     it('returns true for a tracked Snap', async () => {
@@ -258,7 +258,7 @@ describe('SnapTracker', () => {
 
       await tracker.init();
 
-      expect(tracker.has(MOCK_SNAP_ID)).toBe(true);
+      expect(tracker.canUse(MOCK_SNAP_ID)).toBe(true);
     });
 
     it('returns false for an untracked Snap', async () => {
@@ -266,7 +266,7 @@ describe('SnapTracker', () => {
 
       await tracker.init();
 
-      expect(tracker.has(MOCK_SNAP_ID)).toBe(false);
+      expect(tracker.canUse(MOCK_SNAP_ID)).toBe(false);
     });
   });
 

--- a/packages/snap-account-service/src/SnapTracker.ts
+++ b/packages/snap-account-service/src/SnapTracker.ts
@@ -106,6 +106,10 @@ export class SnapTracker {
       return;
     }
 
+    if (!snap.enabled || snap.blocked) {
+      return;
+    }
+
     if (isAccountManagementSnap(snap) && !this.#snaps.has(snap.id)) {
       log(`Added account management Snap: ${snap.id} (${reason})`);
 
@@ -125,7 +129,7 @@ export class SnapTracker {
     }
 
     const snap = this.#messenger.call('SnapController:getSnap', snapId);
-    if (snap && snap.enabled && !snap.blocked) {
+    if (snap) {
       this.#handleSnapAdded(snap, 'unblocked');
     }
   }

--- a/packages/snap-account-service/src/SnapTracker.ts
+++ b/packages/snap-account-service/src/SnapTracker.ts
@@ -85,12 +85,12 @@ export class SnapTracker {
   }
 
   /**
-   * Returns true if the given Snap ID is currently tracked.
+   * Returns true if the given Snap ID is currently tracked and can be used.
    *
    * @param snapId - The Snap ID to check.
-   * @returns True if the Snap is tracked.
+   * @returns True if the Snap is tracked and can be used.
    */
-  has(snapId: SnapId): boolean {
+  canUse(snapId: SnapId): boolean {
     return this.#snaps.has(snapId);
   }
 

--- a/packages/snap-account-service/src/SnapTracker.ts
+++ b/packages/snap-account-service/src/SnapTracker.ts
@@ -1,0 +1,143 @@
+import { SnapId } from '@metamask/snaps-sdk';
+import type { TruncatedSnap } from '@metamask/snaps-utils';
+
+import { projectLogger as log } from './logger';
+import type { SnapAccountServiceMessenger } from './SnapAccountService';
+
+/**
+ * Checks if a given Snap is an account management Snap.
+ *
+ * @param snap - The Snap to check.
+ * @returns True if the Snap declares the `endowment:keyring` initial
+ * permission.
+ */
+function isAccountManagementSnap(snap: TruncatedSnap): boolean {
+  return snap.initialPermissions['endowment:keyring'] !== undefined;
+}
+
+/**
+ * Tracks the set of installed, enabled, non-blocked account-management Snaps
+ * (Snaps declaring the `endowment:keyring` initial permission) by listening to
+ * `SnapController` lifecycle events.
+ */
+export class SnapTracker {
+  readonly #messenger: SnapAccountServiceMessenger;
+
+  readonly #snaps: Set<SnapId> = new Set();
+
+  #initialized = false;
+
+  constructor(messenger: SnapAccountServiceMessenger) {
+    this.#messenger = messenger;
+
+    this.#messenger.subscribe('SnapController:snapInstalled', (snap) =>
+      this.#handleSnapAdded(snap, 'installed'),
+    );
+    this.#messenger.subscribe('SnapController:snapUninstalled', (snap) =>
+      this.#handleSnapRemoved(snap.id, 'uninstalled'),
+    );
+    this.#messenger.subscribe('SnapController:snapEnabled', (snap) =>
+      this.#handleSnapAdded(snap, 'enabled'),
+    );
+    this.#messenger.subscribe('SnapController:snapDisabled', (snap) =>
+      this.#handleSnapRemoved(snap.id, 'disabled'),
+    );
+    this.#messenger.subscribe('SnapController:snapBlocked', (snapId) =>
+      this.#handleSnapRemoved(snapId as SnapId, 'blocked'),
+    );
+    this.#messenger.subscribe('SnapController:snapUnblocked', (snapId) =>
+      this.#handleSnapUnblocked(snapId as SnapId),
+    );
+  }
+
+  /**
+   * Seeds the internal set of account-management Snaps from
+   * `SnapController:getRunnableSnaps`, then starts processing lifecycle
+   * events.
+   */
+  async init(): Promise<void> {
+    const runnable = this.#messenger.call('SnapController:getRunnableSnaps');
+    for (const snap of runnable) {
+      if (isAccountManagementSnap(snap) && !this.#snaps.has(snap.id)) {
+        log(`Found account management Snap: ${snap.id} (initialization)`);
+        this.#snaps.add(snap.id);
+      }
+    }
+
+    this.#initialized = true;
+  }
+
+  /**
+   * Returns the IDs of all currently tracked account-management Snaps.
+   *
+   * @returns The IDs of tracked account-management Snaps.
+   */
+  getSnaps(): SnapId[] {
+    return [...this.#snaps];
+  }
+
+  /**
+   * Returns true if the given Snap ID is currently tracked.
+   *
+   * @param snapId - The Snap ID to check.
+   * @returns True if the Snap is tracked.
+   */
+  has(snapId: SnapId): boolean {
+    return this.#snaps.has(snapId);
+  }
+
+  /**
+   * Handles a Snap being added (installed or enabled). If the Snap is an
+   * account-management Snap, adds it to the internal set of tracked Snaps.
+   *
+   * @param snap - The Snap that was installed or enabled.
+   * @param reason - The reason the Snap was added.
+   */
+  #handleSnapAdded(snap: TruncatedSnap, reason: string): void {
+    if (!this.#initialized) {
+      return;
+    }
+
+    if (isAccountManagementSnap(snap) && !this.#snaps.has(snap.id)) {
+      log(`Added account management Snap: ${snap.id} (${reason})`);
+
+      this.#snaps.add(snap.id);
+    }
+  }
+
+  /**
+   * Handles a Snap being unblocked. If the Snap is an enabled
+   * account-management Snap, re-adds it to the internal set of tracked Snaps.
+   *
+   * @param snapId - The Snap ID that was unblocked.
+   */
+  #handleSnapUnblocked(snapId: SnapId): void {
+    if (!this.#initialized) {
+      return;
+    }
+
+    const snap = this.#messenger.call('SnapController:getSnap', snapId);
+    if (snap && snap.enabled && !snap.blocked) {
+      this.#handleSnapAdded(snap, 'unblocked');
+    }
+  }
+
+  /**
+   * Handles a Snap being removed (disabled, blocked, or uninstalled). If the Snap is an
+   * account-management Snap, removes it from the internal set of tracked Snaps.
+   *
+   * @param snapId - The Snap ID that was disabled, blocked, or uninstalled.
+   * @param reason - The reason the Snap was removed.
+   */
+  #handleSnapRemoved(snapId: SnapId, reason: string): void {
+    if (!this.#initialized) {
+      return;
+    }
+
+    if (this.#snaps.has(snapId)) {
+      log(`Removed account management Snap: ${snapId} (${reason})`);
+
+      this.#snaps.delete(snapId);
+    }
+  }
+}

--- a/packages/snap-account-service/src/SnapTracker.ts
+++ b/packages/snap-account-service/src/SnapTracker.ts
@@ -56,9 +56,17 @@ export class SnapTracker {
    * events.
    */
   async init(): Promise<void> {
+    if (this.#initialized) {
+      // Do not re-init, once setup we only rely on lifecycle events to update the set of
+      // tracked Snaps.
+      return;
+    }
+
+    this.#snaps.clear();
+
     const runnable = this.#messenger.call('SnapController:getRunnableSnaps');
     for (const snap of runnable) {
-      if (isAccountManagementSnap(snap) && !this.#snaps.has(snap.id)) {
+      if (isAccountManagementSnap(snap)) {
         log(`Found account management Snap: ${snap.id} (initialization)`);
         this.#snaps.add(snap.id);
       }

--- a/packages/snap-account-service/src/index.ts
+++ b/packages/snap-account-service/src/index.ts
@@ -6,6 +6,9 @@ export type {
   SnapAccountServiceMessenger,
   SnapAccountServiceOptions,
 } from './SnapAccountService';
-export type { SnapAccountServiceEnsureReadyAction } from './SnapAccountService-method-action-types';
+export type {
+  SnapAccountServiceEnsureReadyAction,
+  SnapAccountServiceGetSnapsAction,
+} from './SnapAccountService-method-action-types';
 export { SnapPlatformWatcher } from './SnapPlatformWatcher';
 export type { SnapPlatformWatcherConfig } from './SnapPlatformWatcher';


### PR DESCRIPTION
## Explanation

Tracking account management Snaps so we can "restrict" the use of this service only for those Snaps.

This will also be used later on to initialize their associated `SnapKeyring` v2.

## References

N/A

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `SnapAccountService.ensureReady` semantics to reject unknown/uninitialized Snap IDs and adds new messenger dependencies on `SnapController` lifecycle events, which could break existing consumers or event wiring if not updated.
> 
> **Overview**
> Adds `SnapTracker`, which seeds and maintains an in-memory set of *account-management Snaps* (installed/enabled, not blocked, and declaring `endowment:keyring`) based on `SnapController:getRunnableSnaps` plus `SnapController` lifecycle events.
> 
> `SnapAccountService` now initializes this tracker in `init()`, exposes a new `getSnaps()` messenger method, and updates `ensureReady(snapId)` to **throw `Unknown snap: "<id>"`** unless the snap is currently tracked (effectively requiring callers to run `init()` and only use eligible Snaps). Tests and exports/changelog are updated accordingly, and the service messenger contract expands to include the new `SnapController` actions/events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48b03c9d0053e1992c6080132ac0b405f54f9ee5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->