### PR TITLE
feat: Add legacy `createOriginMiddleware`

### DIFF
--- a/packages/json-rpc-engine/CHANGELOG.md
+++ b/packages/json-rpc-engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add legacy `createOriginMiddleware` utility ([#8734](https://github.com/MetaMask/core/pull/8734))
+
 ## [10.3.0]
 
 ### Added

--- a/packages/json-rpc-engine/src/createOriginMiddleware.test.ts
+++ b/packages/json-rpc-engine/src/createOriginMiddleware.test.ts
@@ -1,20 +1,27 @@
-import { JsonRpcRequest } from "@metamask/utils";
-import { makeRequest } from "../tests/utils";
-import { JsonRpcEngine } from "./JsonRpcEngine"
-import { createOriginMiddleware } from "./createOriginMiddleware";
+import { JsonRpcRequest } from '@metamask/utils';
+
+import { makeRequest } from '../tests/utils';
+import { createOriginMiddleware } from './createOriginMiddleware';
+import { JsonRpcEngine } from './JsonRpcEngine';
 
 describe('createOriginMiddleware', () => {
-    it('adds the origin property to the request', async () => {
-            const origin = 'https://metamask.io';
-        const engine = new JsonRpcEngine();
+  it('adds the origin property to the request', async () => {
+    const origin = 'https://metamask.io';
+    const engine = new JsonRpcEngine();
 
-        engine.push(createOriginMiddleware(origin));
+    engine.push(createOriginMiddleware(origin));
 
-        engine.push((request, response, _next, end) => {
-            response.result = (request as unknown as JsonRpcRequest & { origin: string }).origin;
-            end();
-        })
+    engine.push((request, response, _next, end) => {
+      response.result = (
+        request as unknown as JsonRpcRequest & { origin: string }
+      ).origin;
+      end();
+    });
 
-        expect(await engine.handle(makeRequest())).toStrictEqual({"id": "1", "jsonrpc": "2.0", result: origin});
-    })
-})
+    expect(await engine.handle(makeRequest())).toStrictEqual({
+      id: '1',
+      jsonrpc: '2.0',
+      result: origin,
+    });
+  });
+});

--- a/packages/json-rpc-engine/src/createOriginMiddleware.test.ts
+++ b/packages/json-rpc-engine/src/createOriginMiddleware.test.ts
@@ -1,0 +1,20 @@
+import { JsonRpcRequest } from "@metamask/utils";
+import { makeRequest } from "../tests/utils";
+import { JsonRpcEngine } from "./JsonRpcEngine"
+import { createOriginMiddleware } from "./createOriginMiddleware";
+
+describe('createOriginMiddleware', () => {
+    it('adds the origin property to the request', async () => {
+            const origin = 'https://metamask.io';
+        const engine = new JsonRpcEngine();
+
+        engine.push(createOriginMiddleware(origin));
+
+        engine.push((request, response, _next, end) => {
+            response.result = (request as unknown as JsonRpcRequest & { origin: string }).origin;
+            end();
+        })
+
+        expect(await engine.handle(makeRequest())).toStrictEqual({"id": "1", "jsonrpc": "2.0", result: origin});
+    })
+})

--- a/packages/json-rpc-engine/src/createOriginMiddleware.ts
+++ b/packages/json-rpc-engine/src/createOriginMiddleware.ts
@@ -1,0 +1,16 @@
+import { Json, JsonRpcRequest } from "@metamask/utils";
+import { JsonRpcMiddleware } from "./JsonRpcEngine";
+
+/**
+ * Create a middleware function that adds `origin` to the request object.
+ * 
+ * @deprecated Use the v2 `createOriginMiddleware` instead.
+ * @param origin - The origin.
+ * @returns The middleware.
+ */
+export function createOriginMiddleware(origin: string): JsonRpcMiddleware<JsonRpcRequest, Json> {
+  return (request, _result, next) => {
+    (request as unknown as JsonRpcRequest & { origin: string }).origin = origin;
+    next();
+  };
+}

--- a/packages/json-rpc-engine/src/createOriginMiddleware.ts
+++ b/packages/json-rpc-engine/src/createOriginMiddleware.ts
@@ -1,14 +1,17 @@
-import { Json, JsonRpcRequest } from "@metamask/utils";
-import { JsonRpcMiddleware } from "./JsonRpcEngine";
+import { Json, JsonRpcRequest } from '@metamask/utils';
+
+import { JsonRpcMiddleware } from './JsonRpcEngine';
 
 /**
  * Create a middleware function that adds `origin` to the request object.
- * 
+ *
  * @deprecated Use the v2 `createOriginMiddleware` instead.
  * @param origin - The origin.
  * @returns The middleware.
  */
-export function createOriginMiddleware(origin: string): JsonRpcMiddleware<JsonRpcRequest, Json> {
+export function createOriginMiddleware(
+  origin: string,
+): JsonRpcMiddleware<JsonRpcRequest, Json> {
   return (request, _result, next) => {
     (request as unknown as JsonRpcRequest & { origin: string }).origin = origin;
     next();

--- a/packages/json-rpc-engine/src/index.test.ts
+++ b/packages/json-rpc-engine/src/index.test.ts
@@ -7,6 +7,7 @@ describe('@metamask/json-rpc-engine', () => {
         "asV2Middleware",
         "createAsyncMiddleware",
         "createMethodMiddleware",
+        "createOriginMiddleware",
         "createScaffoldMiddleware",
         "getUniqueId",
         "createIdRemapMiddleware",

--- a/packages/json-rpc-engine/src/index.ts
+++ b/packages/json-rpc-engine/src/index.ts
@@ -10,6 +10,7 @@ export type {
   MethodHandlerImplementation,
 } from './createMethodMiddleware';
 export { createMethodMiddleware } from './createMethodMiddleware';
+export { createOriginMiddleware } from './createOriginMiddleware';
 export { createScaffoldMiddleware } from './createScaffoldMiddleware';
 export { getUniqueId } from './getUniqueId';
 export { createIdRemapMiddleware } from './idRemapMiddleware';


### PR DESCRIPTION
## Explanation

Recently we added `createOriginMiddleware` to `v2` for usage in the clients. Though using it via `asLegacyMiddleware` introduces some complications, so for the time being we introduce the same middleware using the legacy API.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk additive change: introduces a new legacy middleware and export without altering existing middleware behavior, with a small chance of conflicts for consumers that already attach an `origin` field to requests.
> 
> **Overview**
> Adds a legacy `createOriginMiddleware` for `@metamask/json-rpc-engine` that mutates the JSON-RPC request object to include an `origin` string (marked *deprecated* in favor of the v2 API).
> 
> Exports the new utility from the package entrypoint, updates export snapshot tests, adds a unit test verifying `origin` is set, and records the addition in the package changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 710f93151161cea848d66925e5158708ba21daf5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->