### PR TITLE
Revert "Continue to retry failed requests when offline (#8623)"

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1523,7 +1523,7 @@
   },
   "packages/network-controller/src/rpc-service/rpc-service.ts": {
     "no-restricted-syntax": {
-      "count": 2
+      "count": 3
     }
   },
   "packages/network-controller/tests/NetworkController.provider.test.ts": {

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -51,10 +51,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deprecate `AbstractRpcService` and `RpcServiceRequestable` ([#8475](https://github.com/MetaMask/core/pull/8475))
   - There are no equivalents to these interfaces. If you need to take an "RPC-service-like" argument, it's best to declare which properties you're interested in rather than accepting the entire RPC service interface.
 
-### Fixed
-
-- Restore retries for failed requests even if the user is offline, preventing a bad user experience if the reported offline status is inaccurate or stuck ([#8623](https://github.com/MetaMask/core/pull/8623))
-
 ## [30.0.1]
 
 ### Changed

--- a/packages/network-controller/src/create-network-client-tests/rpc-endpoint-events.test.ts
+++ b/packages/network-controller/src/create-network-client-tests/rpc-endpoint-events.test.ts
@@ -266,7 +266,81 @@ describe('createNetworkClient - RPC endpoint events', () => {
           );
         });
 
-        it('does not publish the NetworkController:rpcEndpointUnavailable event when user is offline', async () => {
+        it('does not retry requests when user is offline', async () => {
+          const failoverEndpointUrl = 'https://failover.endpoint/';
+          const request = {
+            method: 'eth_gasPrice',
+            params: [],
+          };
+          const expectedError = createResourceUnavailableError(503);
+
+          await withMockedCommunications(
+            { providerType: networkClientType },
+            async (primaryComms) => {
+              await withMockedCommunications(
+                {
+                  providerType: 'custom',
+                  customRpcUrl: failoverEndpointUrl,
+                },
+                async () => {
+                  // Mock only one failure - if retries were happening, we'd need more
+                  primaryComms.mockRpcCall({
+                    request: {
+                      method: 'eth_blockNumber',
+                      params: [],
+                    },
+                    times: 1,
+                    response: {
+                      httpStatus: 503,
+                    },
+                  });
+
+                  const rootMessenger = buildRootMessenger({
+                    connectivityStatus: CONNECTIVITY_STATUSES.Offline,
+                  });
+
+                  const rpcEndpointRetriedEventHandler = jest.fn();
+                  rootMessenger.subscribe(
+                    'NetworkController:rpcEndpointRetried',
+                    rpcEndpointRetriedEventHandler,
+                  );
+
+                  await withNetworkClient(
+                    {
+                      providerType: networkClientType,
+                      networkClientId: 'AAAA-AAAA-AAAA-AAAA',
+                      isRpcFailoverEnabled: true,
+                      failoverRpcUrls: [failoverEndpointUrl],
+                      messenger: rootMessenger,
+                      getRpcServiceOptions: () => ({
+                        fetch,
+                        btoa,
+                        policyOptions: {
+                          backoff: new ConstantBackoff(backoffDuration),
+                        },
+                        isOffline: (): boolean => false,
+                      }),
+                    },
+                    async ({ makeRpcCall }) => {
+                      // When offline, errors are not retried, so the request
+                      // should fail immediately without retries
+                      await expect(makeRpcCall(request)).rejects.toThrow(
+                        expectedError,
+                      );
+
+                      // Verify that retry event was not published
+                      expect(
+                        rpcEndpointRetriedEventHandler,
+                      ).not.toHaveBeenCalled();
+                    },
+                  );
+                },
+              );
+            },
+          );
+        });
+
+        it('suppresses the NetworkController:rpcEndpointUnavailable event when user is offline', async () => {
           const failoverEndpointUrl = 'https://failover.endpoint/';
           const request = {
             method: 'eth_gasPrice',
@@ -1300,7 +1374,78 @@ describe('createNetworkClient - RPC endpoint events', () => {
           );
         });
 
-        it('does not publish the NetworkController:rpcEndpointDegraded event when user is offline', async () => {
+        it('does not retry requests when user is offline (degraded scenario)', async () => {
+          const request = {
+            method: 'eth_gasPrice',
+            params: [],
+          };
+          const expectedError = createResourceUnavailableError(503);
+
+          await withMockedCommunications(
+            { providerType: networkClientType },
+            async (comms) => {
+              // Mock only one failure - if retries were happening, we'd need more
+              comms.mockRpcCall({
+                request: {
+                  method: 'eth_blockNumber',
+                  params: [],
+                },
+                times: 1,
+                response: {
+                  httpStatus: 503,
+                },
+              });
+              comms.mockRpcCall({
+                request: {
+                  method: 'eth_gasPrice',
+                  params: [],
+                },
+                times: 1,
+                response: {
+                  httpStatus: 503,
+                },
+              });
+
+              const rootMessenger = buildRootMessenger({
+                connectivityStatus: CONNECTIVITY_STATUSES.Offline,
+              });
+
+              const rpcEndpointRetriedEventHandler = jest.fn();
+              rootMessenger.subscribe(
+                'NetworkController:rpcEndpointRetried',
+                rpcEndpointRetriedEventHandler,
+              );
+
+              await withNetworkClient(
+                {
+                  providerType: networkClientType,
+                  networkClientId: 'AAAA-AAAA-AAAA-AAAA',
+                  messenger: rootMessenger,
+                  getRpcServiceOptions: () => ({
+                    fetch,
+                    btoa,
+                    policyOptions: {
+                      backoff: new ConstantBackoff(backoffDuration),
+                    },
+                    isOffline: (): boolean => false,
+                  }),
+                },
+                async ({ makeRpcCall }) => {
+                  // When offline, errors are not retried, so the request
+                  // should fail immediately without retries
+                  await expect(makeRpcCall(request)).rejects.toThrow(
+                    expectedError,
+                  );
+
+                  // Verify that retry event was not published
+                  expect(rpcEndpointRetriedEventHandler).not.toHaveBeenCalled();
+                },
+              );
+            },
+          );
+        });
+
+        it('suppresses the NetworkController:rpcEndpointDegraded event when user is offline', async () => {
           const request = {
             method: 'eth_gasPrice',
             params: [],

--- a/packages/network-controller/src/rpc-service/rpc-service.test.ts
+++ b/packages/network-controller/src/rpc-service/rpc-service.test.ts
@@ -593,6 +593,109 @@ describe('RpcService', () => {
       },
     );
 
+    describe('when offline', () => {
+      it('does not retry when offline, only makes one fetch call', async () => {
+        const expectedError = new TypeError('Failed to fetch');
+        const mockFetch = jest.fn(() => {
+          throw expectedError;
+        });
+        const service = new RpcService({
+          fetch: mockFetch,
+          btoa,
+          endpointUrl: 'https://rpc.example.chain',
+          isOffline: (): boolean => true,
+        });
+        service.onRetry(() => {
+          jest.advanceTimersToNextTimer();
+        });
+
+        const jsonRpcRequest = {
+          id: 1,
+          jsonrpc: '2.0' as const,
+          method: 'eth_chainId',
+          params: [],
+        };
+        await expect(service.request(jsonRpcRequest)).rejects.toThrow(
+          expectedError,
+        );
+        // When offline, no retries should happen, so only 1 fetch call
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+      });
+
+      it('does not call onDegraded when offline', async () => {
+        const expectedError = new TypeError('Failed to fetch');
+        const mockFetch = jest.fn(() => {
+          throw expectedError;
+        });
+        const endpointUrl = 'https://rpc.example.chain';
+        const onDegradedListener = jest.fn();
+        const service = new RpcService({
+          fetch: mockFetch,
+          btoa,
+          endpointUrl,
+          isOffline: (): boolean => true,
+        });
+        service.onRetry(() => {
+          jest.advanceTimersToNextTimer();
+        });
+        service.onDegraded(onDegradedListener);
+
+        const jsonRpcRequest = {
+          id: 1,
+          jsonrpc: '2.0' as const,
+          method: 'eth_chainId',
+          params: [],
+        };
+        await expect(service.request(jsonRpcRequest)).rejects.toThrow(
+          expectedError,
+        );
+
+        // When offline, retries don't happen, so onDegraded should not be called
+        expect(onDegradedListener).not.toHaveBeenCalled();
+      });
+
+      it('does not call onBreak when offline', async () => {
+        const expectedError = new TypeError('Failed to fetch');
+        const mockFetch = jest.fn(() => {
+          throw expectedError;
+        });
+        const endpointUrl = 'https://rpc.example.chain';
+        const onBreakListener = jest.fn();
+        const service = new RpcService({
+          fetch: mockFetch,
+          btoa,
+          endpointUrl,
+          isOffline: (): boolean => true,
+        });
+        service.onRetry(() => {
+          jest.advanceTimersToNextTimer();
+        });
+        service.onBreak(onBreakListener);
+
+        const jsonRpcRequest = {
+          id: 1,
+          jsonrpc: '2.0' as const,
+          method: 'eth_chainId',
+          params: [],
+        };
+        // Make multiple requests - even though we'd normally break the circuit,
+        // when offline, no retries happen so circuit won't break
+        await expect(service.request(jsonRpcRequest)).rejects.toThrow(
+          expectedError,
+        );
+        await expect(service.request(jsonRpcRequest)).rejects.toThrow(
+          expectedError,
+        );
+        await expect(service.request(jsonRpcRequest)).rejects.toThrow(
+          expectedError,
+        );
+
+        // When offline, retries don't happen, so circuit won't break and onBreak
+        // should not be called
+        expect(onBreakListener).not.toHaveBeenCalled();
+      });
+    });
+
     it('removes non-JSON-RPC-compliant properties from the request body before sending it to the endpoint', async () => {
       const endpointUrl = 'https://rpc.example.chain';
       nock(endpointUrl)
@@ -1446,32 +1549,6 @@ function testsForRetriableFetchErrors({
     });
   });
 
-  it('still retries a failing request even if the user is offline', async () => {
-    const mockFetch = jest.fn(() => {
-      throw producedError;
-    });
-    const service = new RpcService({
-      fetch: mockFetch,
-      btoa,
-      endpointUrl: 'https://rpc.example.chain',
-      isOffline: (): boolean => true,
-    });
-    service.onRetry(() => {
-      jest.advanceTimersToNextTimer();
-    });
-
-    const jsonRpcRequest = {
-      id: 1,
-      jsonrpc: '2.0' as const,
-      method: 'eth_chainId',
-      params: [],
-    };
-    await expect(service.request(jsonRpcRequest)).rejects.toThrow(
-      expectedError,
-    );
-    expect(mockFetch).toHaveBeenCalledTimes(5);
-  });
-
   it('still re-throws the error even after the circuit breaks', async () => {
     const mockFetch = jest.fn(() => {
       throw producedError;
@@ -1533,37 +1610,6 @@ function testsForRetriableFetchErrors({
       error: expectedError,
       endpointUrl: `${endpointUrl}/`,
     });
-  });
-
-  it('does not call onBreak if the user is offline after the circuit breaks', async () => {
-    const mockFetch = jest.fn(() => {
-      throw producedError;
-    });
-    const endpointUrl = 'https://rpc.example.chain';
-    const onBreakListener = jest.fn();
-    const service = new RpcService({
-      fetch: mockFetch,
-      btoa,
-      endpointUrl,
-      isOffline: (): boolean => true,
-    });
-    service.onRetry(() => {
-      jest.advanceTimersToNextTimer();
-    });
-    service.onBreak(onBreakListener);
-
-    const jsonRpcRequest = {
-      id: 1,
-      jsonrpc: '2.0' as const,
-      method: 'eth_chainId',
-      params: [],
-    };
-    await ignoreRejection(service.request(jsonRpcRequest));
-    await ignoreRejection(service.request(jsonRpcRequest));
-    // The last retry breaks the circuit
-    await ignoreRejection(service.request(jsonRpcRequest));
-
-    expect(onBreakListener).not.toHaveBeenCalled();
   });
 
   it('throws an error that includes the number of minutes until the circuit is re-closed if a request is attempted while the circuit is open', async () => {
@@ -1789,37 +1835,6 @@ function testsForRetriableResponses({
     });
   });
 
-  it('still retries a failing request even if the user is offline', async () => {
-    nock('https://rpc.example.chain')
-      .post('/', {
-        id: 1,
-        jsonrpc: '2.0',
-        method: 'eth_chainId',
-        params: [],
-      })
-      .times(5)
-      .reply(httpStatus, responseBody);
-    const service = new RpcService({
-      fetch,
-      btoa,
-      endpointUrl: 'https://rpc.example.chain',
-      isOffline: (): boolean => true,
-    });
-    service.onRetry(() => {
-      jest.advanceTimersToNextTimer();
-    });
-
-    const jsonRpcRequest = {
-      id: 1,
-      jsonrpc: '2.0' as const,
-      method: 'eth_chainId',
-      params: [],
-    };
-    await expect(service.request(jsonRpcRequest)).rejects.toThrow(
-      expectedError,
-    );
-  });
-
   it('calls the onDegraded callback with a trace ID if one is available', async () => {
     nock('https://rpc.example.chain')
       .post('/', {
@@ -1994,43 +2009,6 @@ function testsForRetriableResponses({
     });
   });
 
-  it('does not call onBreak if the user is offline when the circuit breaks', async () => {
-    const endpointUrl = 'https://rpc.example.chain';
-    nock(endpointUrl)
-      .post('/', {
-        id: 1,
-        jsonrpc: '2.0',
-        method: 'eth_chainId',
-        params: [],
-      })
-      .times(15)
-      .reply(httpStatus, responseBody);
-    const onBreakListener = jest.fn();
-    const service = new RpcService({
-      fetch,
-      btoa,
-      endpointUrl,
-      isOffline: (): boolean => true,
-    });
-    service.onRetry(() => {
-      jest.advanceTimersToNextTimer();
-    });
-    service.onBreak(onBreakListener);
-
-    const jsonRpcRequest = {
-      id: 1,
-      jsonrpc: '2.0' as const,
-      method: 'eth_chainId',
-      params: [],
-    };
-    await ignoreRejection(service.request(jsonRpcRequest));
-    await ignoreRejection(service.request(jsonRpcRequest));
-    // The last retry breaks the circuit
-    await ignoreRejection(service.request(jsonRpcRequest));
-
-    expect(onBreakListener).not.toHaveBeenCalled();
-  });
-
   it('throws an error that includes the number of minutes until the circuit is re-closed if a request is attempted while the circuit is open', async () => {
     const endpointUrl = 'https://rpc.example.chain';
     nock(endpointUrl)
@@ -2118,6 +2096,86 @@ function testsForRetriableResponses({
         message: 'Execution prevented because the circuit breaker is open',
       }),
     );
+  });
+
+  it('does not retry when offline, only makes one request', async () => {
+    const scope = nock('https://rpc.example.chain')
+      .post('/', {
+        id: 1,
+        jsonrpc: '2.0',
+        method: 'eth_chainId',
+        params: [],
+      })
+      .times(1)
+      .reply(httpStatus, responseBody);
+    const service = new RpcService({
+      fetch,
+      btoa,
+      endpointUrl: 'https://rpc.example.chain',
+      isOffline: (): boolean => true,
+    });
+    service.onRetry(() => {
+      jest.advanceTimersToNextTimer();
+    });
+
+    const jsonRpcRequest = {
+      id: 1,
+      jsonrpc: '2.0' as const,
+      method: 'eth_chainId',
+      params: [],
+    };
+    await expect(service.request(jsonRpcRequest)).rejects.toThrow(
+      expectedError,
+    );
+    // When offline, no retries should happen, so only 1 request
+    expect(scope.isDone()).toBe(true);
+  });
+
+  it('does not call onBreak when offline', async () => {
+    const scope = nock('https://rpc.example.chain')
+      .post('/', {
+        id: 1,
+        jsonrpc: '2.0',
+        method: 'eth_chainId',
+        params: [],
+      })
+      .times(3)
+      .reply(httpStatus, responseBody);
+    const endpointUrl = 'https://rpc.example.chain';
+    const onBreakListener = jest.fn();
+    const service = new RpcService({
+      fetch,
+      btoa,
+      endpointUrl,
+      isOffline: (): boolean => true,
+    });
+    service.onRetry(() => {
+      jest.advanceTimersToNextTimer();
+    });
+    service.onBreak(onBreakListener);
+
+    const jsonRpcRequest = {
+      id: 1,
+      jsonrpc: '2.0' as const,
+      method: 'eth_chainId',
+      params: [],
+    };
+    // Make multiple requests - even though we'd normally break the circuit,
+    // when offline, no retries happen so circuit won't break
+    await expect(service.request(jsonRpcRequest)).rejects.toThrow(
+      expectedError,
+    );
+    await expect(service.request(jsonRpcRequest)).rejects.toThrow(
+      expectedError,
+    );
+    await expect(service.request(jsonRpcRequest)).rejects.toThrow(
+      expectedError,
+    );
+
+    // When offline, retries don't happen, so circuit won't break and onBreak
+    // should not be called
+    expect(onBreakListener).not.toHaveBeenCalled();
+    expect(scope.isDone()).toBe(true);
   });
 
   /* eslint-enable jest/require-top-level-describe,jest/no-identical-title */

--- a/packages/network-controller/src/rpc-service/rpc-service.ts
+++ b/packages/network-controller/src/rpc-service/rpc-service.ts
@@ -63,8 +63,9 @@ export type RpcServiceOptions = {
    */
   policyOptions?: Omit<CreateServicePolicyOptions, 'retryFilterPolicy'>;
   /**
-   * A function that checks if the user is currently offline. If it returns
-   * true, onDegraded and onBreak callbacks will not be called.
+   * A function that checks if the user is currently offline. If it returns true,
+   * connection errors will not be retried, preventing degraded and break
+   * callbacks from being triggered.
    */
   isOffline: () => boolean;
 };
@@ -321,12 +322,6 @@ export class RpcService {
   readonly #fetchOptions: FetchOptions;
 
   /**
-   * A function that checks if the user is currently offline. If it returns
-   * true, onDegraded and onBreak callbacks will not be called.
-   */
-  readonly #isOffline: () => boolean;
-
-  /**
    * A `loglevel` logger.
    */
   readonly #logger: RpcServiceOptions['logger'];
@@ -361,13 +356,18 @@ export class RpcService {
     );
     this.endpointUrl = stripCredentialsFromUrl(normalizedUrl);
     this.#logger = logger;
-    this.#isOffline = isOffline;
 
     this.#policy = createServicePolicy({
       maxRetries: DEFAULT_MAX_RETRIES,
       maxConsecutiveFailures: DEFAULT_MAX_CONSECUTIVE_FAILURES,
       ...policyOptions,
       retryFilterPolicy: handleWhen((error) => {
+        // If user is offline, don't retry any errors
+        // This prevents degraded/break callbacks from being triggered
+        if (isOffline()) {
+          return false;
+        }
+
         return (
           // Ignore errors where the request failed to establish
           isConnectionError(error) ||
@@ -451,7 +451,7 @@ export class RpcService {
       // doesn't function the way it is intended, at least in the context of an
       // RpcService. However, we are making a bet that we won't need to use it
       // other than how we are already using it.
-      if (!hasProperty(data, 'isolated') && !this.#isOffline()) {
+      if (!('isolated' in data)) {
         listener({
           ...data,
           endpointUrl: this.endpointUrl.toString(),
@@ -480,14 +480,12 @@ export class RpcService {
     >,
   ): ReturnType<ServicePolicy['onDegraded']> {
     return this.#policy.onDegraded((data) => {
-      if (!this.#isOffline()) {
-        listener({
-          ...data,
-          endpointUrl: this.endpointUrl.toString(),
-          rpcMethodName: this.#currentRpcMethodName,
-          traceId: this.#currentTraceId,
-        });
-      }
+      listener({
+        ...data,
+        endpointUrl: this.endpointUrl.toString(),
+        rpcMethodName: this.#currentRpcMethodName,
+        traceId: this.#currentTraceId,
+      });
     });
   }
 


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

This reverts commit 0caca271acf27ae4e65ee6af6e803741410b0579.

This PR is faulty, because although it does restore retries for failed requests, it also causes `onDegraded` and `onBreak` to be fired for `RpcServiceChain`, and hence causes `NetworkController:rpcEndpointChainDegraded` and `NetworkController:rpcEndpointChainUnavailable` to be fired as well.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `RpcService` retry/circuit-breaker behavior based on offline status, which can affect request reliability and when network degraded/unavailable events fire. Risk is mitigated by expanded unit/integration tests for offline scenarios.
> 
> **Overview**
> Reverts the previous behavior that continued retrying RPC requests while the user is offline by making `RpcService`'s retry filter short-circuit when `isOffline()` is true.
> 
> This prevents offline connection failures from triggering retries, circuit breaks, and downstream NetworkController retry/degraded/unavailable event emissions, with updated/added tests covering offline unavailable and degraded scenarios and updated ESLint suppression metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 263e1caf97cc8cb440e97cc631ef97a507e53011. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->