### PR TITLE
Release 969.0.0 (TEST)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "968.0.0",
+  "version": "969.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {
@@ -55,7 +55,7 @@
     "@metamask/eth-block-tracker": "^15.0.1",
     "@metamask/eth-json-rpc-provider": "^6.0.1",
     "@metamask/json-rpc-engine": "^10.3.0",
-    "@metamask/network-controller": "^30.1.0",
+    "@metamask/network-controller": "^30.1.1",
     "@metamask/utils": "^11.9.0",
     "@ts-bridge/cli": "^0.6.4",
     "@types/jest": "^29.5.14",

--- a/packages/accounts-controller/package.json
+++ b/packages/accounts-controller/package.json
@@ -62,7 +62,7 @@
     "@metamask/keyring-sdk": "^2.1.1",
     "@metamask/keyring-utils": "^3.2.1",
     "@metamask/messenger": "^1.2.0",
-    "@metamask/network-controller": "^30.1.0",
+    "@metamask/network-controller": "^30.1.1",
     "@metamask/superstruct": "^3.1.0",
     "@metamask/utils": "^11.9.0",
     "deepmerge": "^4.2.2",

--- a/packages/assets-controller/package.json
+++ b/packages/assets-controller/package.json
@@ -68,7 +68,7 @@
     "@metamask/keyring-internal-api": "^11.0.1",
     "@metamask/keyring-snap-client": "^9.0.2",
     "@metamask/messenger": "^1.2.0",
-    "@metamask/network-controller": "^30.1.0",
+    "@metamask/network-controller": "^30.1.1",
     "@metamask/network-enablement-controller": "^5.1.0",
     "@metamask/permission-controller": "^13.1.0",
     "@metamask/phishing-controller": "^17.1.1",

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -73,7 +73,7 @@
     "@metamask/messenger": "^1.2.0",
     "@metamask/metamask-eth-abis": "^3.1.1",
     "@metamask/multichain-account-service": "^9.0.0",
-    "@metamask/network-controller": "^30.1.0",
+    "@metamask/network-controller": "^30.1.1",
     "@metamask/network-enablement-controller": "^5.1.0",
     "@metamask/permission-controller": "^13.1.0",
     "@metamask/phishing-controller": "^17.1.1",

--- a/packages/bridge-controller/package.json
+++ b/packages/bridge-controller/package.json
@@ -67,7 +67,7 @@
     "@metamask/messenger": "^1.2.0",
     "@metamask/metamask-eth-abis": "^3.1.1",
     "@metamask/multichain-network-controller": "^3.1.0",
-    "@metamask/network-controller": "^30.1.0",
+    "@metamask/network-controller": "^30.1.1",
     "@metamask/polling-controller": "^16.0.4",
     "@metamask/profile-sync-controller": "^28.0.2",
     "@metamask/remote-feature-flag-controller": "^4.2.0",

--- a/packages/bridge-status-controller/package.json
+++ b/packages/bridge-status-controller/package.json
@@ -59,7 +59,7 @@
     "@metamask/gas-fee-controller": "^26.2.0",
     "@metamask/keyring-controller": "^25.5.0",
     "@metamask/messenger": "^1.2.0",
-    "@metamask/network-controller": "^30.1.0",
+    "@metamask/network-controller": "^30.1.1",
     "@metamask/polling-controller": "^16.0.4",
     "@metamask/profile-sync-controller": "^28.0.2",
     "@metamask/snaps-controllers": "^19.0.0",

--- a/packages/earn-controller/package.json
+++ b/packages/earn-controller/package.json
@@ -60,7 +60,7 @@
     "@metamask/controller-utils": "^11.20.0",
     "@metamask/keyring-api": "^23.1.0",
     "@metamask/messenger": "^1.2.0",
-    "@metamask/network-controller": "^30.1.0",
+    "@metamask/network-controller": "^30.1.1",
     "@metamask/stake-sdk": "^3.2.1",
     "reselect": "^5.1.1"
   },

--- a/packages/ens-controller/package.json
+++ b/packages/ens-controller/package.json
@@ -57,7 +57,7 @@
     "@metamask/base-controller": "^9.1.0",
     "@metamask/controller-utils": "^11.20.0",
     "@metamask/messenger": "^1.2.0",
-    "@metamask/network-controller": "^30.1.0",
+    "@metamask/network-controller": "^30.1.1",
     "@metamask/utils": "^11.9.0",
     "punycode": "^2.1.1"
   },

--- a/packages/eth-json-rpc-middleware/package.json
+++ b/packages/eth-json-rpc-middleware/package.json
@@ -71,7 +71,7 @@
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^6.1.0",
-    "@metamask/network-controller": "^30.1.0",
+    "@metamask/network-controller": "^30.1.1",
     "@ts-bridge/cli": "^0.6.4",
     "@types/deep-freeze-strict": "^1.1.0",
     "@types/jest": "^29.5.14",

--- a/packages/gas-fee-controller/package.json
+++ b/packages/gas-fee-controller/package.json
@@ -58,7 +58,7 @@
     "@metamask/eth-query": "^4.0.0",
     "@metamask/ethjs-unit": "^0.3.0",
     "@metamask/messenger": "^1.2.0",
-    "@metamask/network-controller": "^30.1.0",
+    "@metamask/network-controller": "^30.1.1",
     "@metamask/polling-controller": "^16.0.4",
     "@metamask/utils": "^11.9.0",
     "@types/bn.js": "^5.1.5",

--- a/packages/gator-permissions-controller/package.json
+++ b/packages/gator-permissions-controller/package.json
@@ -59,7 +59,7 @@
     "@metamask/delegation-core": "^2.0.0",
     "@metamask/delegation-deployments": "^1.3.0",
     "@metamask/messenger": "^1.2.0",
-    "@metamask/network-controller": "^30.1.0",
+    "@metamask/network-controller": "^30.1.1",
     "@metamask/snaps-controllers": "^19.0.0",
     "@metamask/snaps-sdk": "^11.0.0",
     "@metamask/snaps-utils": "^12.1.2",

--- a/packages/money-account-balance-service/package.json
+++ b/packages/money-account-balance-service/package.json
@@ -59,7 +59,7 @@
     "@metamask/controller-utils": "^11.20.0",
     "@metamask/messenger": "^1.2.0",
     "@metamask/metamask-eth-abis": "^3.1.1",
-    "@metamask/network-controller": "^30.1.0",
+    "@metamask/network-controller": "^30.1.1",
     "@metamask/superstruct": "^3.1.0",
     "@metamask/utils": "^11.9.0"
   },

--- a/packages/money-account-upgrade-controller/package.json
+++ b/packages/money-account-upgrade-controller/package.json
@@ -57,7 +57,7 @@
     "@metamask/chomp-api-service": "^3.0.0",
     "@metamask/keyring-controller": "^25.5.0",
     "@metamask/messenger": "^1.2.0",
-    "@metamask/network-controller": "^30.1.0",
+    "@metamask/network-controller": "^30.1.1",
     "@metamask/utils": "^11.9.0"
   },
   "devDependencies": {

--- a/packages/multichain-api-middleware/package.json
+++ b/packages/multichain-api-middleware/package.json
@@ -56,7 +56,7 @@
     "@metamask/chain-agnostic-permission": "^1.5.0",
     "@metamask/controller-utils": "^11.20.0",
     "@metamask/json-rpc-engine": "^10.3.0",
-    "@metamask/network-controller": "^30.1.0",
+    "@metamask/network-controller": "^30.1.1",
     "@metamask/permission-controller": "^13.1.0",
     "@metamask/rpc-errors": "^7.0.2",
     "@metamask/snaps-controllers": "^19.0.0",

--- a/packages/multichain-network-controller/package.json
+++ b/packages/multichain-network-controller/package.json
@@ -59,7 +59,7 @@
     "@metamask/keyring-api": "^23.1.0",
     "@metamask/keyring-internal-api": "^11.0.1",
     "@metamask/messenger": "^1.2.0",
-    "@metamask/network-controller": "^30.1.0",
+    "@metamask/network-controller": "^30.1.1",
     "@metamask/superstruct": "^3.1.0",
     "@metamask/utils": "^11.9.0",
     "@solana/addresses": "^2.0.0",

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [30.1.1]
+
 ### Added
 
 - **BREAKING:** Add `duration` and `traceId` to `NetworkController:rpcEndpointDegraded` and `NetworkController:rpcEndpointChainDegraded` event payloads ([#8455](https://github.com/MetaMask/core/pull/8455))
@@ -1168,7 +1170,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
     All changes listed after this point were applied to this package following the monorepo conversion.
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/network-controller@30.1.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/network-controller@30.1.1...HEAD
+[30.1.1]: https://github.com/MetaMask/core/compare/@metamask/network-controller@30.1.0...@metamask/network-controller@30.1.1
 [30.1.0]: https://github.com/MetaMask/core/compare/@metamask/network-controller@30.0.1...@metamask/network-controller@30.1.0
 [30.0.1]: https://github.com/MetaMask/core/compare/@metamask/network-controller@30.0.0...@metamask/network-controller@30.0.1
 [30.0.0]: https://github.com/MetaMask/core/compare/@metamask/network-controller@29.0.0...@metamask/network-controller@30.0.0

--- a/packages/network-controller/package.json
+++ b/packages/network-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/network-controller",
-  "version": "30.1.0",
+  "version": "30.1.1",
   "description": "Provides an interface to the currently selected network via a MetaMask-compatible provider object",
   "keywords": [
     "Ethereum",

--- a/packages/network-enablement-controller/package.json
+++ b/packages/network-enablement-controller/package.json
@@ -58,7 +58,7 @@
     "@metamask/keyring-api": "^23.1.0",
     "@metamask/messenger": "^1.2.0",
     "@metamask/multichain-network-controller": "^3.1.0",
-    "@metamask/network-controller": "^30.1.0",
+    "@metamask/network-controller": "^30.1.1",
     "@metamask/slip44": "^4.3.0",
     "@metamask/transaction-controller": "^65.2.0",
     "@metamask/utils": "^11.9.0",

--- a/packages/perps-controller/package.json
+++ b/packages/perps-controller/package.json
@@ -72,7 +72,7 @@
     "@metamask/geolocation-controller": "^0.1.2",
     "@metamask/keyring-controller": "^25.5.0",
     "@metamask/keyring-internal-api": "^11.0.1",
-    "@metamask/network-controller": "^30.1.0",
+    "@metamask/network-controller": "^30.1.1",
     "@metamask/profile-sync-controller": "^28.0.2",
     "@metamask/remote-feature-flag-controller": "^4.2.0",
     "@metamask/transaction-controller": "^65.2.0",

--- a/packages/polling-controller/package.json
+++ b/packages/polling-controller/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@metamask/base-controller": "^9.1.0",
     "@metamask/controller-utils": "^11.20.0",
-    "@metamask/network-controller": "^30.1.0",
+    "@metamask/network-controller": "^30.1.1",
     "@metamask/utils": "^11.9.0",
     "@types/uuid": "^8.3.0",
     "fast-json-stable-stringify": "^2.1.0",

--- a/packages/sample-controllers/package.json
+++ b/packages/sample-controllers/package.json
@@ -56,7 +56,7 @@
     "@metamask/base-controller": "^9.1.0",
     "@metamask/base-data-service": "^0.1.1",
     "@metamask/messenger": "^1.2.0",
-    "@metamask/network-controller": "^30.1.0",
+    "@metamask/network-controller": "^30.1.1",
     "@metamask/superstruct": "^3.1.0",
     "@metamask/utils": "^11.9.0",
     "@tanstack/query-core": "^4.43.0"

--- a/packages/selected-network-controller/package.json
+++ b/packages/selected-network-controller/package.json
@@ -56,7 +56,7 @@
     "@metamask/base-controller": "^9.1.0",
     "@metamask/json-rpc-engine": "^10.3.0",
     "@metamask/messenger": "^1.2.0",
-    "@metamask/network-controller": "^30.1.0",
+    "@metamask/network-controller": "^30.1.1",
     "@metamask/permission-controller": "^13.1.0",
     "@metamask/swappable-obj-proxy": "^2.3.0",
     "@metamask/utils": "^11.9.0"

--- a/packages/signature-controller/package.json
+++ b/packages/signature-controller/package.json
@@ -62,7 +62,7 @@
     "@metamask/keyring-controller": "^25.5.0",
     "@metamask/logging-controller": "^8.0.1",
     "@metamask/messenger": "^1.2.0",
-    "@metamask/network-controller": "^30.1.0",
+    "@metamask/network-controller": "^30.1.1",
     "@metamask/utils": "^11.9.0",
     "jsonschema": "^1.4.1",
     "lodash": "^4.17.21",

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -68,7 +68,7 @@
     "@metamask/gas-fee-controller": "^26.2.0",
     "@metamask/messenger": "^1.2.0",
     "@metamask/metamask-eth-abis": "^3.1.1",
-    "@metamask/network-controller": "^30.1.0",
+    "@metamask/network-controller": "^30.1.1",
     "@metamask/nonce-tracker": "^6.0.0",
     "@metamask/remote-feature-flag-controller": "^4.2.0",
     "@metamask/rpc-errors": "^7.0.2",

--- a/packages/transaction-pay-controller/package.json
+++ b/packages/transaction-pay-controller/package.json
@@ -66,7 +66,7 @@
     "@metamask/gas-fee-controller": "^26.2.0",
     "@metamask/messenger": "^1.2.0",
     "@metamask/metamask-eth-abis": "^3.1.1",
-    "@metamask/network-controller": "^30.1.0",
+    "@metamask/network-controller": "^30.1.1",
     "@metamask/ramps-controller": "^13.3.0",
     "@metamask/remote-feature-flag-controller": "^4.2.0",
     "@metamask/transaction-controller": "^65.2.0",

--- a/packages/user-operation-controller/package.json
+++ b/packages/user-operation-controller/package.json
@@ -61,7 +61,7 @@
     "@metamask/gas-fee-controller": "^26.2.0",
     "@metamask/keyring-controller": "^25.5.0",
     "@metamask/messenger": "^1.2.0",
-    "@metamask/network-controller": "^30.1.0",
+    "@metamask/network-controller": "^30.1.1",
     "@metamask/polling-controller": "^16.0.4",
     "@metamask/rpc-errors": "^7.0.2",
     "@metamask/superstruct": "^3.1.0",


### PR DESCRIPTION
(This is a PR to test the `update-changelog` workflow. I don't intend on merging this.)