### PR TITLE
Fix update-changelogs workflow

### DIFF
--- a/.github/workflows/update-changelogs.yml
+++ b/.github/workflows/update-changelogs.yml
@@ -127,7 +127,7 @@ jobs:
         with:
           is-high-risk-environment: false
 
-      - name: Overlay changelogs from current pull request
+      - name: Overlay relevant files from current pull request
         env:
           PR_HEAD_SHA: ${{ needs.is-release.outputs.head-sha }}
           PR_HEAD_REF: ${{ needs.is-release.outputs.head-ref }}
@@ -135,7 +135,7 @@ jobs:
           # These next two commands are also useful later when pushing
           git fetch --no-tags origin "$PR_HEAD_SHA"
           git fetch --no-tags origin "$PR_HEAD_REF"
-          git checkout "$PR_HEAD_SHA" -- '**/CHANGELOG.md'
+          git checkout "$PR_HEAD_SHA" -- '**/CHANGELOG.md' '**/package.json'
         shell: bash
 
       - name: Configure Git with name and email
@@ -146,9 +146,9 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
         shell: bash
 
-      - name: Commit changelogs from current pull request
+      - name: Commit relevant files from current pull request
         run: |
-          git add -- '**/CHANGELOG.md'
+          git add -- '**/CHANGELOG.md' '**/package.json'
           git commit -m "[Temporary] Add changelogs from current pull request"
         shell: bash
 
@@ -175,7 +175,7 @@ jobs:
           git add -- '**/CHANGELOG.md'
           git commit -m "chore: Update dependency bump changelog entries"
 
-          new_commit_id="$(git log -1 --pretty='format:%h')"
+          new_commit_id="$(git log -1 --pretty='format:%H')"
           echo "new-commit-id=${new_commit_id}" >> "$GITHUB_OUTPUT"
         shell: bash
 


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

A recent commit changed the `update-changelog` workflow so that instead of checking out the release PR branch directly, it checks out the base branch and then overlays files from the release PR that are necessary to run `auto-changelog validate`.

Currently, only changelogs are copied from the release PR. However, to determine which dependency bump changelog entries are missing, the `auto-changelog validate` command needs not only changelogs but also package manifests.

This commit fixes the `update-changelog` workflow accordingly.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that adjusts which files are checked out/committed and how a commit SHA is captured; main risk is unintended CI behavior or pushes to PR branches.
> 
> **Overview**
> Fixes the `update-changelogs` GitHub Actions workflow to overlay and temporarily commit both `**/CHANGELOG.md` *and* `**/package.json` from the PR branch before running `yarn changelog:validate --checkDeps`, ensuring dependency-bump validation uses the PR’s manifests.
> 
> Also updates the workflow to output the full commit SHA (`%H`) for the generated changelog-fix commit, and renames the related steps to reflect the broader file overlay/commit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd502470e25458d1b5820acfdbfc04d695b12887. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->