### PR TITLE
feat: added mainnet monad to default getDefaultNetworkEnablementControllerState in network-enablement-controller

### DIFF
--- a/packages/network-enablement-controller/CHANGELOG.md
+++ b/packages/network-enablement-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add Monad mainnet (`0x8f`, chain ID 143) to the default enabled network map for new users ([#8743](https://github.com/MetaMask/core/pull/8743))
+
 ## [5.1.1]
 
 ### Changed

--- a/packages/network-enablement-controller/src/NetworkEnablementController.test.ts
+++ b/packages/network-enablement-controller/src/NetworkEnablementController.test.ts
@@ -195,6 +195,7 @@ describe('NetworkEnablementController', () => {
           [ChainId[BuiltInNetworkName.OptimismMainnet]]: true,
           [ChainId[BuiltInNetworkName.PolygonMainnet]]: true,
           [ChainId[BuiltInNetworkName.SeiMainnet]]: true,
+          [ChainId[BuiltInNetworkName.MonadMainnet]]: true,
         },
         [KnownCaipNamespace.Solana]: {
           [SolScope.Mainnet]: true,
@@ -250,6 +251,7 @@ describe('NetworkEnablementController', () => {
           [ChainId[BuiltInNetworkName.OptimismMainnet]]: true,
           [ChainId[BuiltInNetworkName.PolygonMainnet]]: true,
           [ChainId[BuiltInNetworkName.SeiMainnet]]: true,
+          [ChainId[BuiltInNetworkName.MonadMainnet]]: true,
           '0xa86a': true, // Avalanche network added and enabled (keeps current selection)
         },
         [KnownCaipNamespace.Solana]: {
@@ -314,6 +316,7 @@ describe('NetworkEnablementController', () => {
           [ChainId[BuiltInNetworkName.OptimismMainnet]]: true,
           [ChainId[BuiltInNetworkName.PolygonMainnet]]: true,
           [ChainId[BuiltInNetworkName.SeiMainnet]]: true,
+          [ChainId[BuiltInNetworkName.MonadMainnet]]: true,
         },
         [KnownCaipNamespace.Solana]: {
           [SolScope.Mainnet]: true,
@@ -418,6 +421,7 @@ describe('NetworkEnablementController', () => {
     controller.disableNetwork('0xa'); // Optimism Mainnet
     controller.disableNetwork('0x89'); // Polygon Mainnet
     controller.disableNetwork('0x531'); // Sei Mainnet
+    controller.disableNetwork('0x8f'); // Monad Mainnet
 
     // Publish an update with linea network removed
     rootMessenger.publish('NetworkController:networkRemoved', {
@@ -455,6 +459,7 @@ describe('NetworkEnablementController', () => {
           [ChainId[BuiltInNetworkName.OptimismMainnet]]: false,
           [ChainId[BuiltInNetworkName.PolygonMainnet]]: false,
           [ChainId[BuiltInNetworkName.SeiMainnet]]: false,
+          [ChainId[BuiltInNetworkName.MonadMainnet]]: false,
         },
         [KnownCaipNamespace.Solana]: {
           [SolScope.Mainnet]: true,
@@ -555,6 +560,7 @@ describe('NetworkEnablementController', () => {
             [ChainId[BuiltInNetworkName.OptimismMainnet]]: true,
             [ChainId[BuiltInNetworkName.PolygonMainnet]]: true,
             [ChainId[BuiltInNetworkName.SeiMainnet]]: true,
+            [ChainId[BuiltInNetworkName.MonadMainnet]]: true,
           },
           [KnownCaipNamespace.Solana]: {
             [SolScope.Mainnet]: true, // Solana Mainnet (exists in multichain config)
@@ -1197,6 +1203,7 @@ describe('NetworkEnablementController', () => {
             [ChainId[BuiltInNetworkName.OptimismMainnet]]: true,
             [ChainId[BuiltInNetworkName.PolygonMainnet]]: true,
             [ChainId[BuiltInNetworkName.SeiMainnet]]: true,
+            [ChainId[BuiltInNetworkName.MonadMainnet]]: true,
           },
           [KnownCaipNamespace.Solana]: {
             [SolScope.Mainnet]: true,
@@ -1231,6 +1238,7 @@ describe('NetworkEnablementController', () => {
             [ChainId[BuiltInNetworkName.OptimismMainnet]]: false, // Not in mocked config
             [ChainId[BuiltInNetworkName.PolygonMainnet]]: false, // Not in mocked config
             [ChainId[BuiltInNetworkName.SeiMainnet]]: false, // Not in mocked config
+            [ChainId[BuiltInNetworkName.MonadMainnet]]: false, // Not in mocked config
           },
           [KnownCaipNamespace.Solana]: {
             [SolScope.Mainnet]: true, // Solana
@@ -1494,6 +1502,7 @@ describe('NetworkEnablementController', () => {
             [ChainId[BuiltInNetworkName.OptimismMainnet]]: true,
             [ChainId[BuiltInNetworkName.PolygonMainnet]]: true,
             [ChainId[BuiltInNetworkName.SeiMainnet]]: true,
+            [ChainId[BuiltInNetworkName.MonadMainnet]]: true,
           },
           [KnownCaipNamespace.Solana]: {
             [SolScope.Mainnet]: true,
@@ -1528,6 +1537,7 @@ describe('NetworkEnablementController', () => {
             [ChainId[BuiltInNetworkName.OptimismMainnet]]: false,
             [ChainId[BuiltInNetworkName.PolygonMainnet]]: false,
             [ChainId[BuiltInNetworkName.SeiMainnet]]: false,
+            [ChainId[BuiltInNetworkName.MonadMainnet]]: false,
           },
           [KnownCaipNamespace.Solana]: {
             [SolScope.Mainnet]: false, // Now disabled (cross-namespace behavior)
@@ -1582,6 +1592,7 @@ describe('NetworkEnablementController', () => {
             [ChainId[BuiltInNetworkName.OptimismMainnet]]: false,
             [ChainId[BuiltInNetworkName.PolygonMainnet]]: false,
             [ChainId[BuiltInNetworkName.SeiMainnet]]: false,
+            [ChainId[BuiltInNetworkName.MonadMainnet]]: false,
           },
           [KnownCaipNamespace.Solana]: {
             [SolScope.Mainnet]: false, // Disabled due to cross-namespace behavior
@@ -1620,6 +1631,7 @@ describe('NetworkEnablementController', () => {
             [ChainId[BuiltInNetworkName.OptimismMainnet]]: false,
             [ChainId[BuiltInNetworkName.PolygonMainnet]]: false,
             [ChainId[BuiltInNetworkName.SeiMainnet]]: false,
+            [ChainId[BuiltInNetworkName.MonadMainnet]]: false,
           },
           [KnownCaipNamespace.Solana]: {
             [SolScope.Mainnet]: false, // Now disabled (cross-namespace behavior)
@@ -1658,6 +1670,7 @@ describe('NetworkEnablementController', () => {
             [ChainId[BuiltInNetworkName.OptimismMainnet]]: false,
             [ChainId[BuiltInNetworkName.PolygonMainnet]]: false,
             [ChainId[BuiltInNetworkName.SeiMainnet]]: false,
+            [ChainId[BuiltInNetworkName.MonadMainnet]]: false,
           },
           [KnownCaipNamespace.Solana]: {
             [SolScope.Mainnet]: false, // Now disabled (cross-namespace behavior)
@@ -1707,6 +1720,7 @@ describe('NetworkEnablementController', () => {
             [ChainId[BuiltInNetworkName.OptimismMainnet]]: false,
             [ChainId[BuiltInNetworkName.PolygonMainnet]]: false,
             [ChainId[BuiltInNetworkName.SeiMainnet]]: false,
+            [ChainId[BuiltInNetworkName.MonadMainnet]]: false,
           },
           [KnownCaipNamespace.Solana]: {
             [SolScope.Mainnet]: false, // Disabled due to cross-namespace behavior
@@ -1753,6 +1767,7 @@ describe('NetworkEnablementController', () => {
             [ChainId[BuiltInNetworkName.OptimismMainnet]]: false,
             [ChainId[BuiltInNetworkName.PolygonMainnet]]: false,
             [ChainId[BuiltInNetworkName.SeiMainnet]]: false,
+            [ChainId[BuiltInNetworkName.MonadMainnet]]: false,
           },
           [KnownCaipNamespace.Solana]: {
             [SolScope.Mainnet]: false,
@@ -1802,6 +1817,7 @@ describe('NetworkEnablementController', () => {
             [ChainId[BuiltInNetworkName.OptimismMainnet]]: false,
             [ChainId[BuiltInNetworkName.PolygonMainnet]]: false,
             [ChainId[BuiltInNetworkName.SeiMainnet]]: false,
+            [ChainId[BuiltInNetworkName.MonadMainnet]]: false,
           },
           [KnownCaipNamespace.Solana]: {
             [SolScope.Mainnet]: false, // Disabled due to cross-namespace behavior
@@ -1848,6 +1864,7 @@ describe('NetworkEnablementController', () => {
             [ChainId[BuiltInNetworkName.OptimismMainnet]]: true,
             [ChainId[BuiltInNetworkName.PolygonMainnet]]: true,
             [ChainId[BuiltInNetworkName.SeiMainnet]]: true,
+            [ChainId[BuiltInNetworkName.MonadMainnet]]: true,
           },
           [KnownCaipNamespace.Solana]: {
             [SolScope.Mainnet]: true,
@@ -1896,6 +1913,7 @@ describe('NetworkEnablementController', () => {
             [ChainId[BuiltInNetworkName.OptimismMainnet]]: true,
             [ChainId[BuiltInNetworkName.PolygonMainnet]]: true,
             [ChainId[BuiltInNetworkName.SeiMainnet]]: true,
+            [ChainId[BuiltInNetworkName.MonadMainnet]]: true,
           },
           [KnownCaipNamespace.Solana]: {
             [SolScope.Mainnet]: true,

--- a/packages/network-enablement-controller/src/NetworkEnablementController.ts
+++ b/packages/network-enablement-controller/src/NetworkEnablementController.ts
@@ -167,6 +167,7 @@ const getDefaultNetworkEnablementControllerState =
         [ChainId[BuiltInNetworkName.OptimismMainnet]]: true,
         [ChainId[BuiltInNetworkName.PolygonMainnet]]: true,
         [ChainId[BuiltInNetworkName.SeiMainnet]]: true,
+        [ChainId[BuiltInNetworkName.MonadMainnet]]: true,
       },
       [KnownCaipNamespace.Solana]: {
         [SolScope.Mainnet]: true,


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Adds mainnet Monad as a default enabled network. 

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

- [MUSD-784: Mobile: Add Monad to default enabled networks](https://consensyssoftware.atlassian.net/browse/MUSD-784)

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes the default enabled network list and updates tests/changelog, with no behavioral logic changes beyond initial state defaults for new users.
> 
> **Overview**
> Adds Monad mainnet (`0x8f`, chain ID 143) to `NetworkEnablementController`’s default `enabledNetworkMap` so new users start with Monad enabled.
> 
> Updates the unit test expectations (and related disable/fallback scenarios) plus the package changelog to reflect the new default network.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54f74860beb654c18f60452ce9e37a4278971f99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->