### PR TITLE
Optimize type params for Messenger.delegate/revoke

### DIFF
--- a/packages/messenger/CHANGELOG.md
+++ b/packages/messenger/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `Messenger.delegate` and `Messenger.revoke` to reduce the chance of TS2590 errors when delegatee has large number of actions/events or a large number of actions/events are being delegated
+
 ## [1.2.0]
 
 ### Added

--- a/packages/messenger/CHANGELOG.md
+++ b/packages/messenger/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix `Messenger.delegate` and `Messenger.revoke` to reduce the chance of TS2590 errors when delegatee has large number of actions/events or a large number of actions/events are being delegated
+- Fix `Messenger.delegate` and `Messenger.revoke` to reduce the chance of TS2590 errors when delegatee has large number of actions/events or a large number of actions/events are being delegated ([#8748](https://github.com/MetaMask/core/pull/8748))
 
 ## [1.2.0]
 

--- a/packages/messenger/src/Messenger.ts
+++ b/packages/messenger/src/Messenger.ts
@@ -969,8 +969,10 @@ export class Messenger<
    */
   delegate<
     Delegatee extends Messenger<string, ActionConstraint, EventConstraint>,
-    DelegatedActions extends (MessengerActions<Delegatee> & Action)['type'][],
-    DelegatedEvents extends (MessengerEvents<Delegatee> & Event)['type'][],
+    DelegatedActions extends (MessengerActions<Delegatee>['type'] &
+      Action['type'])[],
+    DelegatedEvents extends (MessengerEvents<Delegatee>['type'] &
+      Event['type'])[],
   >({
     actions,
     events,
@@ -1084,8 +1086,10 @@ export class Messenger<
    */
   revoke<
     Delegatee extends Messenger<string, ActionConstraint, EventConstraint>,
-    DelegatedActions extends (MessengerActions<Delegatee> & Action)['type'][],
-    DelegatedEvents extends (MessengerEvents<Delegatee> & Event)['type'][],
+    DelegatedActions extends (MessengerActions<Delegatee>['type'] &
+      Action['type'])[],
+    DelegatedEvents extends (MessengerEvents<Delegatee>['type'] &
+      Event['type'])[],
   >({
     actions,
     events,


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

When TypeScript type-checks arguments to `Messenger.delegate` and `Messenger.revoke` it can produce the error "Expression produces a union type that is too complex to represent" if the delegatee contains a large number of capabilities and/or there are large number of capabilities being delegated or revoked. This happens because when TypeScript evaluates `MessengerActions<Delegatee> & Action` or `MessengerEvents<Delegatee> & Event` it needs to recursively compute every combination of action/event type — handlers, types used within handlers, everything. The possibility of this error has always been present, but was excerbated by recent changes to the `InternalAccount` type in `keyring-api`, which added support for Tron and Stellar.

All of this computing is wasteful. All we really need is an intersection of action/event type strings. This commit changes the types for `DelegatedActions` and `DelegatedEvents` to reflect this fact. These changes should be type-compatible since the end result is still the same.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Recently a change was made in Mobile to work around this problem. See: https://github.com/MetaMask/metamask-mobile/pull/29621

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public TypeScript API typings for `Messenger.delegate`/`Messenger.revoke` change, which could affect downstream type-checking even though runtime behavior is untouched. Risk is limited to compile-time compatibility and inference/regression in complex consumer typings.
> 
> **Overview**
> Reduces TypeScript type-checker blowups in `Messenger.delegate` and `Messenger.revoke` by narrowing `DelegatedActions`/`DelegatedEvents` to intersections of action/event **type strings** (rather than intersecting full action/event unions), aiming to avoid TS2590 “union type too complex” errors.
> 
> Updates the messenger package changelog to note the fix under *Unreleased*.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdf1305bba0a250376cb261091f2e1f948363459. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->