### PR TITLE
Initially run update-changelogs only for non-draft PRs

### DIFF
--- a/.github/workflows/update-changelogs.yml
+++ b/.github/workflows/update-changelogs.yml
@@ -16,16 +16,9 @@ permissions:
   pull-requests: write
 
 jobs:
-  check-event:
-    name: Check event conditions
-    if: (github.event_name == 'pull_request_target' && !github.event.pull_request.draft) || (github.event.issue.pull_request && startsWith(github.event.comment.body, '@metamaskbot update-changelogs'))
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Event conditions met, proceeding."
-
   is-fork:
     name: Determine whether this PR is from a fork
-    needs: check-event
+    if: (github.event_name == 'pull_request_target' && !github.event.pull_request.draft) || (github.event.issue.pull_request && startsWith(github.event.comment.body, '@metamaskbot update-changelogs'))
     runs-on: ubuntu-latest
     outputs:
       is-fork: ${{ steps.is-fork.outputs.is-fork }}

--- a/.github/workflows/update-changelogs.yml
+++ b/.github/workflows/update-changelogs.yml
@@ -9,15 +9,23 @@ on:
       - main
     types:
       - opened
+      - ready_for_review
 
 permissions:
   contents: write
   pull-requests: write
 
 jobs:
+  check-event:
+    name: Check event conditions
+    if: (github.event_name == 'pull_request_target' && !github.event.pull_request.draft) || (github.event.issue.pull_request && startsWith(github.event.comment.body, '@metamaskbot update-changelogs'))
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Event conditions met, proceeding."
+
   is-fork:
     name: Determine whether this PR is from a fork
-    if: github.event_name == 'pull_request_target' || (github.event.issue.pull_request && startsWith(github.event.comment.body, '@metamaskbot update-changelogs'))
+    needs: check-event
     runs-on: ubuntu-latest
     outputs:
       is-fork: ${{ steps.is-fork.outputs.is-fork }}


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

When an engineer opens a release PR, they may want to make additional changes to the release plan before they are ready to open the PR, and so they may not want to populate dependency bump entries across changelogs right away. To account for this, this commit modifies the `update-changelogs` workflow so that the initial run only occurs if the PR is created in non-draft status or is taken out of draft otherwise.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow gating change; it only adjusts when the GitHub Actions job runs and does not affect production code paths.
> 
> **Overview**
> Updates the `update-changelogs` GitHub Actions workflow to **not run automatically for draft PRs**.
> 
> The workflow now triggers on `pull_request_target` `ready_for_review` and tightens the `is-fork` job condition so the initial run only occurs when the PR is *not* a draft (while still allowing manual runs via `@metamaskbot update-changelogs` comments).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8a1fc0c488ce90dd0b4f8f61d6f4f28fe70cfb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->