### PR TITLE
refactor(multichain-account-service): remove old unused event

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1304,11 +1304,6 @@
       "count": 7
     }
   },
-  "packages/multichain-account-service/src/tests/messenger.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "packages/multichain-api-middleware/src/handlers/types.ts": {
     "@typescript-eslint/naming-convention": {
       "count": 2

--- a/packages/multichain-account-service/CHANGELOG.md
+++ b/packages/multichain-account-service/CHANGELOG.md
@@ -10,12 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **BREAKING:** The service messenger now requires the `SnapAccountService:ensureReady` action to be declared ([#8715](https://github.com/MetaMask/core/pull/8715))
-- **BREAKING:** Delegate Snap platform readiness to `@metamask/snap-account-service` ([#8715](https://github.com/MetaMask/core/pull/8715))
+- **BREAKING:** Delegate Snap platform readiness to `@metamask/snap-account-service` ([#8715](https://github.com/MetaMask/core/pull/8715)), ([#8752](https://github.com/MetaMask/core/pull/8752))
   - Removed `MultichainAccountService.ensureCanUseSnapPlatform()` method and the corresponding `MultichainAccountService:ensureCanUseSnapPlatform` messenger action.
   - Removed the `MultichainAccountServiceEnsureCanUseSnapPlatformAction` type export.
   - Removed `MultichainAccountServiceOptions.ensureOnboardingComplete`. Configure it via `SnapAccountService`'s `config.snapPlatformWatcher.ensureOnboardingComplete` instead.
   - Removed `MultichainAccountServiceConfig.snapPlatformWatcher` and the `SnapPlatformWatcherConfig` type export. Configure the keyring-wait timeout via `SnapAccountService`'s `config.snapPlatformWatcher.snapKeyringWaitTimeoutMs` instead.
-  - The service messenger no longer needs `SnapController:getState` or `SnapController:stateChange`.
+  - The service messenger no longer needs `SnapController:getState`, `SnapController:stateChange` or `KeyringController:stateChange`.
 - **BREAKING:** Rename `SnapAccountProvider.ensureCanUseSnapPlatform()` to `ensureReady()` ([#8715](https://github.com/MetaMask/core/pull/8715))
 
 ## [9.0.0]

--- a/packages/multichain-account-service/src/tests/messenger.ts
+++ b/packages/multichain-account-service/src/tests/messenger.ts
@@ -78,7 +78,6 @@ export function getMultichainAccountServiceMessenger(
       ...(extra?.actions ?? []),
     ],
     events: [
-      'KeyringController:stateChange',
       'AccountsController:accountAdded',
       'AccountsController:accountRemoved',
       ...(extra?.events ?? []),

--- a/packages/multichain-account-service/src/types.ts
+++ b/packages/multichain-account-service/src/types.ts
@@ -21,7 +21,6 @@ import type {
   KeyringControllerGetKeyringsByTypeAction,
   KeyringControllerGetStateAction,
   KeyringControllerRemoveAccountAction,
-  KeyringControllerStateChangeEvent,
   KeyringControllerWithKeyringAction,
   KeyringControllerWithKeyringV2Action,
 } from '@metamask/keyring-controller';
@@ -95,8 +94,7 @@ type AllowedActions =
  */
 type AllowedEvents =
   | AccountsControllerAccountAddedEvent
-  | AccountsControllerAccountRemovedEvent
-  | KeyringControllerStateChangeEvent;
+  | AccountsControllerAccountRemovedEvent;
 
 /**
  * The messenger restricted to actions and events that


### PR DESCRIPTION
## Explanation

I forgot to remove this event in my previous PR:
- https://github.com/MetaMask/core/pull/8715

## References

N/A

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk cleanup that only tightens messenger event typings/delegations and updates related lint suppression/changelog entries; behavioral impact should be limited to consumers that still attempted to delegate/subscribe to `KeyringController:stateChange`.
> 
> **Overview**
> Removes the unused `KeyringController:stateChange` subscription from `multichain-account-service` by dropping it from the test messenger delegation list and from the service’s `AllowedEvents` type.
> 
> Updates supporting metadata: deletes the now-unneeded ESLint suppression for `src/tests/messenger.ts` and tweaks the changelog entry to reflect that `KeyringController:stateChange` is no longer required (and references the follow-up PR).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7eb0e90ddeb27ee5137685b1663e9f90b095bd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->