### PR TITLE
feat(snap-account-service): add `getLegacySnapKeyring`

### DIFF
--- a/packages/snap-account-service/CHANGELOG.md
+++ b/packages/snap-account-service/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Export `SnapAccountServiceGetSnapsAction` type.
   - The service now seeds its internal set from `SnapController:getRunnableSnaps` during `init()` and keeps it in sync via `SnapController` lifecycle events (`snapInstalled`, `snapEnabled`, `snapDisabled`, `snapBlocked`, `snapUninstalled`).
   - The service messenger now requires the `SnapController:getRunnableSnaps` action and the five lifecycle events listed above.
+- Add `getLegacySnapKeyring` ([#8757](https://github.com/MetaMask/core/pull/8757))
+  - This is a concurrent-safe variant of the existing `getSnapKeyring` function that exist on clients.
+  - The service messenger now requires the `KeyringController:withController` action.
 
 ### Changed
 

--- a/packages/snap-account-service/package.json
+++ b/packages/snap-account-service/package.json
@@ -63,6 +63,7 @@
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^6.1.0",
+    "@metamask/keyring-utils": "^3.2.1",
     "@ts-bridge/cli": "^0.6.4",
     "@types/jest": "^29.5.14",
     "deepmerge": "^4.2.2",

--- a/packages/snap-account-service/package.json
+++ b/packages/snap-account-service/package.json
@@ -53,6 +53,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
+    "@metamask/eth-snap-keyring": "^22.0.1",
     "@metamask/keyring-controller": "^25.5.0",
     "@metamask/messenger": "^1.2.0",
     "@metamask/snaps-controllers": "^19.0.0",

--- a/packages/snap-account-service/src/SnapAccountService-method-action-types.ts
+++ b/packages/snap-account-service/src/SnapAccountService-method-action-types.ts
@@ -33,8 +33,20 @@ export type SnapAccountServiceEnsureReadyAction = {
 };
 
 /**
+ * Atomically gets-or-creates the legacy (v1) Snap keyring — the keyring
+ * associated with {@link KeyringTypes.snap}.
+ *
+ * @returns The existing or newly-created Snap keyring instance.
+ */
+export type SnapAccountServiceGetLegacySnapKeyringAction = {
+  type: `SnapAccountService:getLegacySnapKeyring`;
+  handler: SnapAccountService['getLegacySnapKeyring'];
+};
+
+/**
  * Union of all SnapAccountService action types.
  */
 export type SnapAccountServiceMethodActions =
   | SnapAccountServiceGetSnapsAction
-  | SnapAccountServiceEnsureReadyAction;
+  | SnapAccountServiceEnsureReadyAction
+  | SnapAccountServiceGetLegacySnapKeyringAction;

--- a/packages/snap-account-service/src/SnapAccountService.test.ts
+++ b/packages/snap-account-service/src/SnapAccountService.test.ts
@@ -148,6 +148,51 @@ function buildSnap(id: string, hasKeyring: boolean): TruncatedSnap {
 }
 
 /**
+ * Builds a fake {@link KeyringEntry} with the given type.
+ *
+ * @param type - The keyring type.
+ * @returns A minimal KeyringEntry for tests.
+ */
+function buildKeyringEntry(type: string): KeyringEntry {
+  return {
+    keyring: { type } as KeyringEntry['keyring'],
+    metadata: { id: `id-${type}`, name: type },
+  };
+}
+
+/**
+ * Configures `mocks.KeyringController.withController` to invoke the
+ * operation with a controllable {@link RestrictedController}.
+ *
+ * @param mocks - The mocks object from {@link setup}.
+ * @param initialEntries - Entries exposed via `controller.keyrings`.
+ * @returns The mocked `addNewKeyring` jest fn for assertions.
+ */
+function mockWithController(
+  mocks: Mocks,
+  initialEntries: KeyringEntry[],
+): {
+  addNewKeyring: jest.MockedFunction<RestrictedController['addNewKeyring']>;
+} {
+  const entries = [...initialEntries];
+  const addNewKeyring = jest.fn(async (type: string) => {
+    const entry = buildKeyringEntry(type);
+    entries.push(entry);
+    return entry;
+  });
+  mocks.KeyringController.withController.mockImplementation(async (operation) =>
+    operation({
+      get keyrings() {
+        return Object.freeze([...entries]);
+      },
+      addNewKeyring,
+      removeKeyring: jest.fn(),
+    }),
+  );
+  return { addNewKeyring };
+}
+
+/**
  * Constructs the service under test with sensible defaults.
  *
  * @param args - The arguments to this function.
@@ -372,52 +417,6 @@ describe('SnapAccountService', () => {
   });
 
   describe('getLegacySnapKeyring', () => {
-    /**
-     * Builds a fake {@link KeyringEntry} with the given type.
-     *
-     * @param type - The keyring type.
-     * @returns A minimal KeyringEntry for tests.
-     */
-    function buildKeyringEntry(type: string): KeyringEntry {
-      return {
-        keyring: { type } as KeyringEntry['keyring'],
-        metadata: { id: `id-${type}`, name: type },
-      };
-    }
-
-    /**
-     * Configures `mocks.KeyringController.withController` to invoke the
-     * operation with a controllable {@link RestrictedController}.
-     *
-     * @param mocks - The mocks object from {@link setup}.
-     * @param initialEntries - Entries exposed via `controller.keyrings`.
-     * @returns The mocked `addNewKeyring` jest fn for assertions.
-     */
-    function mockWithController(
-      mocks: Mocks,
-      initialEntries: KeyringEntry[],
-    ): {
-      addNewKeyring: jest.MockedFunction<RestrictedController['addNewKeyring']>;
-    } {
-      const entries = [...initialEntries];
-      const addNewKeyring = jest.fn(async (type: string) => {
-        const entry = buildKeyringEntry(type);
-        entries.push(entry);
-        return entry;
-      });
-      mocks.KeyringController.withController.mockImplementation(
-        async (operation) =>
-          operation({
-            get keyrings() {
-              return Object.freeze([...entries]);
-            },
-            addNewKeyring,
-            removeKeyring: jest.fn(),
-          }),
-      );
-      return { addNewKeyring };
-    }
-
     it('returns the existing Snap keyring when one is already present', async () => {
       const { service, mocks } = setup();
       const existing = buildKeyringEntry(KeyringTypes.snap);

--- a/packages/snap-account-service/src/SnapAccountService.test.ts
+++ b/packages/snap-account-service/src/SnapAccountService.test.ts
@@ -47,6 +47,7 @@ type Mocks = {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   KeyringController: {
     getState: jest.MockedFunction<() => { keyrings: { type: string }[] }>;
+    withController: jest.Mock;
   };
 };
 
@@ -184,6 +185,7 @@ function setup({
     },
     KeyringController: {
       getState: jest.fn().mockReturnValue({ keyrings }),
+      withController: jest.fn(),
     },
   };
 
@@ -198,6 +200,10 @@ function setup({
   rootMessenger.registerActionHandler(
     'KeyringController:getState',
     mocks.KeyringController.getState,
+  );
+  rootMessenger.registerActionHandler(
+    'KeyringController:withController',
+    mocks.KeyringController.withController,
   );
 
   const service = new SnapAccountService({ messenger, config });
@@ -380,25 +386,26 @@ describe('SnapAccountService', () => {
     }
 
     /**
-     * Registers a fake `KeyringController:withController` handler that calls
-     * the operation with a controllable {@link RestrictedController}.
+     * Configures `mocks.KeyringController.withController` to invoke the
+     * operation with a controllable {@link RestrictedController}.
      *
-     * @param rootMessenger - The root messenger.
+     * @param mocks - The mocks object from {@link setup}.
      * @param initialEntries - Entries exposed via `controller.keyrings`.
      * @returns The mocked `addNewKeyring` jest fn for assertions.
      */
-    function registerWithController(
-      rootMessenger: RootMessenger,
+    function mockWithController(
+      mocks: Mocks,
       initialEntries: KeyringEntry[],
-    ): jest.MockedFunction<RestrictedController['addNewKeyring']> {
+    ): {
+      addNewKeyring: jest.MockedFunction<RestrictedController['addNewKeyring']>;
+    } {
       const entries = [...initialEntries];
       const addNewKeyring = jest.fn(async (type: string) => {
         const entry = buildKeyringEntry(type);
         entries.push(entry);
         return entry;
       });
-      rootMessenger.registerActionHandler(
-        'KeyringController:withController',
+      mocks.KeyringController.withController.mockImplementation(
         async (operation) =>
           operation({
             get keyrings() {
@@ -408,13 +415,13 @@ describe('SnapAccountService', () => {
             removeKeyring: jest.fn(),
           }),
       );
-      return addNewKeyring;
+      return { addNewKeyring };
     }
 
     it('returns the existing Snap keyring when one is already present', async () => {
-      const { service, rootMessenger } = setup();
+      const { service, mocks } = setup();
       const existing = buildKeyringEntry(KeyringTypes.snap);
-      const addNewKeyring = registerWithController(rootMessenger, [
+      const { addNewKeyring } = mockWithController(mocks, [
         buildKeyringEntry(KeyringTypes.hd),
         existing,
       ]);
@@ -426,8 +433,8 @@ describe('SnapAccountService', () => {
     });
 
     it('creates a new Snap keyring when none exists', async () => {
-      const { service, rootMessenger } = setup();
-      const addNewKeyring = registerWithController(rootMessenger, [
+      const { service, mocks } = setup();
+      const { addNewKeyring } = mockWithController(mocks, [
         buildKeyringEntry(KeyringTypes.hd),
       ]);
 
@@ -438,13 +445,10 @@ describe('SnapAccountService', () => {
     });
 
     it('propagates errors thrown by withController', async () => {
-      const { service, rootMessenger } = setup();
-      rootMessenger.registerActionHandler(
-        'KeyringController:withController',
-        async () => {
-          throw new Error('boom');
-        },
-      );
+      const { service, mocks } = setup();
+      mocks.KeyringController.withController.mockImplementation(async () => {
+        throw new Error('boom');
+      });
 
       await expect(service.getLegacySnapKeyring()).rejects.toThrow('boom');
     });

--- a/packages/snap-account-service/src/SnapAccountService.test.ts
+++ b/packages/snap-account-service/src/SnapAccountService.test.ts
@@ -1,6 +1,11 @@
+import type { SnapKeyring } from '@metamask/eth-snap-keyring';
 import {
   KeyringControllerState,
   KeyringTypes,
+} from '@metamask/keyring-controller';
+import type {
+  KeyringEntry,
+  RestrictedController,
 } from '@metamask/keyring-controller';
 import { Messenger, MOCK_ANY_NAMESPACE } from '@metamask/messenger';
 import type {
@@ -75,6 +80,7 @@ function getMessenger(
       'SnapController:getSnap',
       'SnapController:getRunnableSnaps',
       'KeyringController:getState',
+      'KeyringController:withController',
     ],
     events: [
       'SnapController:stateChange',
@@ -356,6 +362,91 @@ describe('SnapAccountService', () => {
 
       await ensurePromise;
       expect(resolved).toBe(true);
+    });
+  });
+
+  describe('getLegacySnapKeyring', () => {
+    /**
+     * Builds a fake {@link KeyringEntry} with the given type.
+     *
+     * @param type - The keyring type.
+     * @returns A minimal KeyringEntry for tests.
+     */
+    function buildKeyringEntry(type: string): KeyringEntry {
+      return {
+        keyring: { type } as KeyringEntry['keyring'],
+        metadata: { id: `id-${type}`, name: type },
+      };
+    }
+
+    /**
+     * Registers a fake `KeyringController:withController` handler that calls
+     * the operation with a controllable {@link RestrictedController}.
+     *
+     * @param rootMessenger - The root messenger.
+     * @param initialEntries - Entries exposed via `controller.keyrings`.
+     * @returns The mocked `addNewKeyring` jest fn for assertions.
+     */
+    function registerWithController(
+      rootMessenger: RootMessenger,
+      initialEntries: KeyringEntry[],
+    ): jest.MockedFunction<RestrictedController['addNewKeyring']> {
+      const entries = [...initialEntries];
+      const addNewKeyring = jest.fn(async (type: string) => {
+        const entry = buildKeyringEntry(type);
+        entries.push(entry);
+        return entry;
+      });
+      rootMessenger.registerActionHandler(
+        'KeyringController:withController',
+        async (operation) =>
+          operation({
+            get keyrings() {
+              return Object.freeze([...entries]);
+            },
+            addNewKeyring,
+            removeKeyring: jest.fn(),
+          }),
+      );
+      return addNewKeyring;
+    }
+
+    it('returns the existing Snap keyring when one is already present', async () => {
+      const { service, rootMessenger } = setup();
+      const existing = buildKeyringEntry(KeyringTypes.snap);
+      const addNewKeyring = registerWithController(rootMessenger, [
+        buildKeyringEntry(KeyringTypes.hd),
+        existing,
+      ]);
+
+      const result = await service.getLegacySnapKeyring();
+
+      expect(result).toBe(existing.keyring as unknown as SnapKeyring);
+      expect(addNewKeyring).not.toHaveBeenCalled();
+    });
+
+    it('creates a new Snap keyring when none exists', async () => {
+      const { service, rootMessenger } = setup();
+      const addNewKeyring = registerWithController(rootMessenger, [
+        buildKeyringEntry(KeyringTypes.hd),
+      ]);
+
+      const result = await service.getLegacySnapKeyring();
+
+      expect(addNewKeyring).toHaveBeenCalledWith(KeyringTypes.snap);
+      expect(result.type).toBe(KeyringTypes.snap);
+    });
+
+    it('propagates errors thrown by withController', async () => {
+      const { service, rootMessenger } = setup();
+      rootMessenger.registerActionHandler(
+        'KeyringController:withController',
+        async () => {
+          throw new Error('boom');
+        },
+      );
+
+      await expect(service.getLegacySnapKeyring()).rejects.toThrow('boom');
     });
   });
 });

--- a/packages/snap-account-service/src/SnapAccountService.ts
+++ b/packages/snap-account-service/src/SnapAccountService.ts
@@ -1,4 +1,4 @@
-import type { SnapKeyring } from '@metamask/eth-snap-keyring';
+import type { SnapKeyring as LegacySnapKeyring } from '@metamask/eth-snap-keyring';
 import type {
   KeyringControllerGetStateAction,
   KeyringControllerStateChangeEvent,
@@ -6,6 +6,7 @@ import type {
   KeyringEntry,
 } from '@metamask/keyring-controller';
 import { KeyringTypes } from '@metamask/keyring-controller';
+import type { EthKeyring } from '@metamask/keyring-utils';
 import type { Messenger } from '@metamask/messenger';
 import type {
   SnapControllerGetRunnableSnapsAction,
@@ -109,6 +110,18 @@ export type SnapAccountServiceOptions = {
 };
 
 /**
+ * Checks if a given keyring is a Snap keyring (v2).
+ *
+ * @param keyring - The keyring to check.
+ * @returns `true` if the keyring is a Snap keyring (v2), `false` otherwise.
+ */
+function isLegacySnapKeyring(
+  keyring: EthKeyring,
+): keyring is LegacySnapKeyring {
+  return keyring.type === KeyringTypes.snap;
+}
+
+/**
  * Service responsible for managing account management snaps.
  */
 export class SnapAccountService {
@@ -192,9 +205,9 @@ export class SnapAccountService {
    *
    * @returns The existing or newly-created Snap keyring instance.
    */
-  async getLegacySnapKeyring(): Promise<SnapKeyring> {
+  async getLegacySnapKeyring(): Promise<LegacySnapKeyring> {
     type Result = {
-      snapKeyring: SnapKeyring;
+      snapKeyring: LegacySnapKeyring;
     };
 
     // `KeyringController:withController` forbids returning a direct keyring
@@ -208,8 +221,8 @@ export class SnapAccountService {
       async (controller): Promise<Result> => {
         let snapKeyring: KeyringEntry['keyring'] | undefined;
 
-        const found = controller.keyrings.find(
-          ({ keyring }) => keyring.type === KeyringTypes.snap,
+        const found = controller.keyrings.find(({ keyring }) =>
+          isLegacySnapKeyring(keyring),
         );
         if (found) {
           snapKeyring = found.keyring;

--- a/packages/snap-account-service/src/SnapAccountService.ts
+++ b/packages/snap-account-service/src/SnapAccountService.ts
@@ -21,6 +21,7 @@ import type {
 } from '@metamask/snaps-controllers';
 import { SnapId } from '@metamask/snaps-sdk';
 
+import { projectLogger as log } from './logger';
 import type {
   SnapAccountServiceEnsureReadyAction,
   SnapAccountServiceGetLegacySnapKeyringAction,
@@ -215,10 +216,13 @@ export class SnapAccountService {
         }
 
         if (!snapKeyring) {
-          const { keyring: newSnapKeyring } = await controller.addNewKeyring(
-            KeyringTypes.snap,
-          );
+          const {
+            keyring: newSnapKeyring,
+            metadata: { id },
+          } = await controller.addNewKeyring(KeyringTypes.snap);
           snapKeyring = newSnapKeyring;
+
+          log(`Legacy Snap keyring created. ("${id}")`);
         }
 
         // The legacy Snap keyring is not compatible with `EthKeyring`, so we need to cast here.

--- a/packages/snap-account-service/src/SnapAccountService.ts
+++ b/packages/snap-account-service/src/SnapAccountService.ts
@@ -1,7 +1,11 @@
+import type { SnapKeyring } from '@metamask/eth-snap-keyring';
 import type {
   KeyringControllerGetStateAction,
   KeyringControllerStateChangeEvent,
+  KeyringControllerWithControllerAction,
+  KeyringEntry,
 } from '@metamask/keyring-controller';
+import { KeyringTypes } from '@metamask/keyring-controller';
 import type { Messenger } from '@metamask/messenger';
 import type {
   SnapControllerGetRunnableSnapsAction,
@@ -19,6 +23,7 @@ import { SnapId } from '@metamask/snaps-sdk';
 
 import type {
   SnapAccountServiceEnsureReadyAction,
+  SnapAccountServiceGetLegacySnapKeyringAction,
   SnapAccountServiceGetSnapsAction,
 } from './SnapAccountService-method-action-types';
 import { SnapPlatformWatcher } from './SnapPlatformWatcher';
@@ -35,14 +40,19 @@ export const serviceName = 'SnapAccountService';
  * All of the methods within {@link SnapAccountService} that are exposed via
  * the messenger.
  */
-const MESSENGER_EXPOSED_METHODS = ['ensureReady', 'getSnaps'] as const;
+const MESSENGER_EXPOSED_METHODS = [
+  'ensureReady',
+  'getSnaps',
+  'getLegacySnapKeyring',
+] as const;
 
 /**
  * Actions that {@link SnapAccountService} exposes to other consumers.
  */
 export type SnapAccountServiceActions =
   | SnapAccountServiceEnsureReadyAction
-  | SnapAccountServiceGetSnapsAction;
+  | SnapAccountServiceGetSnapsAction
+  | SnapAccountServiceGetLegacySnapKeyringAction;
 
 /**
  * Actions from other messengers that {@link SnapAccountService} calls.
@@ -51,7 +61,8 @@ type AllowedActions =
   | SnapControllerGetStateAction
   | SnapControllerGetSnapAction
   | SnapControllerGetRunnableSnapsAction
-  | KeyringControllerGetStateAction;
+  | KeyringControllerGetStateAction
+  | KeyringControllerWithControllerAction;
 
 /**
  * Events that {@link SnapAccountService} exposes to other consumers.
@@ -172,5 +183,49 @@ export class SnapAccountService {
     // Before doing anything with our Snap, we need to make sure the platform
     // is ready to process requests.
     await this.#watcher.ensureCanUseSnapPlatform();
+  }
+
+  /**
+   * Atomically gets-or-creates the legacy (v1) Snap keyring — the keyring
+   * associated with {@link KeyringTypes.snap}.
+   *
+   * @returns The existing or newly-created Snap keyring instance.
+   */
+  async getLegacySnapKeyring(): Promise<SnapKeyring> {
+    type Result = {
+      snapKeyring: SnapKeyring;
+    };
+
+    // `KeyringController:withController` forbids returning a direct keyring
+    // reference (it checks the result via `Object.is`), so we smuggle the
+    // instance out wrapped in an object and unwrap it after the call.
+    // NOTE: This violates the abstraction of `KeyringController:withController`, but this
+    // is how we currently interact with the legacy Snap keyring. Once we migrate it to
+    // the Snap keyring v2, we won't be using the same pattern.
+    const result = await this.#messenger.call(
+      'KeyringController:withController',
+      async (controller): Promise<Result> => {
+        let snapKeyring: KeyringEntry['keyring'] | undefined;
+
+        const found = controller.keyrings.find(
+          ({ keyring }) => keyring.type === KeyringTypes.snap,
+        );
+        if (found) {
+          snapKeyring = found.keyring;
+        }
+
+        if (!snapKeyring) {
+          const { keyring: newSnapKeyring } = await controller.addNewKeyring(
+            KeyringTypes.snap,
+          );
+          snapKeyring = newSnapKeyring;
+        }
+
+        // The legacy Snap keyring is not compatible with `EthKeyring`, so we need to cast here.
+        return { snapKeyring } as unknown as Result;
+      },
+    );
+
+    return (result as Result).snapKeyring;
   }
 }

--- a/packages/snap-account-service/src/SnapAccountService.ts
+++ b/packages/snap-account-service/src/SnapAccountService.ts
@@ -6,7 +6,7 @@ import type {
   KeyringEntry,
 } from '@metamask/keyring-controller';
 import { KeyringTypes } from '@metamask/keyring-controller';
-import type { EthKeyring } from '@metamask/keyring-utils';
+import type { BaseKeyring } from '@metamask/keyring-utils';
 import type { Messenger } from '@metamask/messenger';
 import type {
   SnapControllerGetRunnableSnapsAction,
@@ -113,11 +113,12 @@ export type SnapAccountServiceOptions = {
  * Checks if a given keyring is a Snap keyring (v2).
  *
  * @param keyring - The keyring to check.
+ * @param keyring.type - The type of the keyring.
  * @returns `true` if the keyring is a Snap keyring (v2), `false` otherwise.
  */
-function isLegacySnapKeyring(
-  keyring: EthKeyring,
-): keyring is LegacySnapKeyring {
+function isLegacySnapKeyring(keyring: {
+  type: BaseKeyring['type'];
+}): keyring is LegacySnapKeyring {
   return keyring.type === KeyringTypes.snap;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5433,6 +5433,7 @@ __metadata:
   resolution: "@metamask/snap-account-service@workspace:packages/snap-account-service"
   dependencies:
     "@metamask/auto-changelog": "npm:^6.1.0"
+    "@metamask/eth-snap-keyring": "npm:^22.0.1"
     "@metamask/keyring-controller": "npm:^25.5.0"
     "@metamask/messenger": "npm:^1.2.0"
     "@metamask/snaps-controllers": "npm:^19.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5435,6 +5435,7 @@ __metadata:
     "@metamask/auto-changelog": "npm:^6.1.0"
     "@metamask/eth-snap-keyring": "npm:^22.0.1"
     "@metamask/keyring-controller": "npm:^25.5.0"
+    "@metamask/keyring-utils": "npm:^3.2.1"
     "@metamask/messenger": "npm:^1.2.0"
     "@metamask/snaps-controllers": "npm:^19.0.0"
     "@metamask/snaps-sdk": "npm:^11.0.0"


### PR DESCRIPTION
## Explanation

Add a `getLegacySnapKeyring` to replace all use of `getSnapKeyring` in each clients.

## References

N/A

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new messenger-exposed method that can create a legacy Snap keyring via `KeyringController:withController`, which touches keyring management and could impact account/keyring state if misused. Scope is otherwise contained to the snap-account-service package with dedicated tests.
> 
> **Overview**
> Adds a new `SnapAccountService:getLegacySnapKeyring` messenger action that atomically returns the existing legacy Snap keyring (`KeyringTypes.snap`) or creates it via `KeyringController:withController`/`addNewKeyring`, with logging when creation occurs.
> 
> Updates action type unions and tests to cover existing-keyring, create-if-missing, and error propagation behavior, and adds `@metamask/eth-snap-keyring` (plus `@metamask/keyring-utils` for typing) dependencies alongside changelog entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74136a7d7309bf740d20633f4da6aaf0a32cda13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->