### PR TITLE
Add Across Predict withdraw plumbing

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `predictAcrossWithdraw` to the `TransactionType` enum ([#8759](https://github.com/MetaMask/core/pull/8759))
+
 ### Changed
 
 - Bump `@metamask/network-controller` from `^31.0.0` to `^31.1.0` ([#8765](https://github.com/MetaMask/core/pull/8765))

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -846,6 +846,11 @@ export enum TransactionType {
   predictAcrossDeposit = 'predictAcrossDeposit',
 
   /**
+   * Withdraw funds for Across quote via Predict.
+   */
+  predictAcrossWithdraw = 'predictAcrossWithdraw',
+
+  /**
    * Buy a position via Predict.
    *
    * @deprecated Not used.

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `POLYGON_PUSD_ADDRESS` constant and treat Polymarket pUSD as a Polygon stablecoin in display/fiat-rate logic ([#8735](https://github.com/MetaMask/core/pull/8735))
+- Add Across strategy plumbing to identify post-quote Predict withdraw requests ([#8759](https://github.com/MetaMask/core/pull/8759))
 
 ### Fixed
 

--- a/packages/transaction-pay-controller/src/strategy/across/AcrossStrategy.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/across/AcrossStrategy.test.ts
@@ -197,6 +197,60 @@ describe('AcrossStrategy', () => {
     ).toBe(true);
   });
 
+  it('supports post-quote predict withdraw requests with source-chain authorization lists', () => {
+    const strategy = new AcrossStrategy();
+    expect(
+      strategy.supports({
+        ...baseRequest,
+        transaction: {
+          ...TRANSACTION_META_MOCK,
+          nestedTransactions: [{ type: TransactionType.predictWithdraw }],
+          txParams: {
+            ...TRANSACTION_META_MOCK.txParams,
+            authorizationList: [{ address: '0xabc' as Hex }],
+            data: '0x12345678' as Hex,
+            to: '0xdef' as Hex,
+          },
+        } as TransactionMeta,
+        requests: [
+          {
+            from: '0xabc' as Hex,
+            isPostQuote: true,
+            sourceBalanceRaw: '100',
+            sourceChainId: '0x1' as Hex,
+            sourceTokenAddress: '0xabc' as Hex,
+            sourceTokenAmount: '100',
+            targetAmountMinimum: '0',
+            targetChainId: '0x2' as Hex,
+            targetTokenAddress: '0xdef' as Hex,
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it('does not support post-quote requests outside predict withdraw', () => {
+    const strategy = new AcrossStrategy();
+    expect(
+      strategy.supports({
+        ...baseRequest,
+        requests: [
+          {
+            from: '0xabc' as Hex,
+            isPostQuote: true,
+            sourceBalanceRaw: '100',
+            sourceChainId: '0x1' as Hex,
+            sourceTokenAddress: '0xabc' as Hex,
+            sourceTokenAmount: '100',
+            targetAmountMinimum: '0',
+            targetChainId: '0x2' as Hex,
+            targetTokenAddress: '0xdef' as Hex,
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
+
   it('returns false for unsupported perps deposits', () => {
     const strategy = new AcrossStrategy();
     expect(

--- a/packages/transaction-pay-controller/src/strategy/across/AcrossStrategy.ts
+++ b/packages/transaction-pay-controller/src/strategy/across/AcrossStrategy.ts
@@ -8,9 +8,11 @@ import type {
   TransactionPayQuote,
 } from '../../types';
 import { getPayStrategiesConfig } from '../../utils/feature-flags';
+import { isPredictWithdrawTransaction } from '../../utils/transaction';
 import { getAcrossDestination } from './across-actions';
 import { getAcrossQuotes } from './across-quotes';
 import { submitAcrossQuotes } from './across-submit';
+import { hasUnsupportedTransactionAuthorizationList } from './authorization-list';
 import { isSupportedAcrossPerpsDepositRequest } from './perps';
 import { isAcrossQuoteRequest } from './requests';
 import type { AcrossQuote } from './types';
@@ -52,15 +54,20 @@ export class AcrossStrategy implements PayStrategy<AcrossQuote> {
       }
     }
 
-    // Across cannot submit EIP-7702 authorization lists. This pre-quote check
-    // catches transactions where the authorization list is already present.
-    // First-time 7702 upgrades discovered during gas planning are handled in
-    // `checkQuoteSupport` below.
-    if (request.transaction.txParams?.authorizationList?.length) {
+    if (
+      hasUnsupportedTransactionAuthorizationList(
+        request.transaction,
+        actionableRequests,
+      )
+    ) {
       return false;
     }
 
     return actionableRequests.every((singleRequest) => {
+      if (singleRequest.isPostQuote) {
+        return isPredictWithdrawTransaction(request.transaction);
+      }
+
       try {
         getAcrossDestination(request.transaction, singleRequest);
         return true;

--- a/packages/transaction-pay-controller/src/strategy/across/authorization-list.ts
+++ b/packages/transaction-pay-controller/src/strategy/across/authorization-list.ts
@@ -1,0 +1,30 @@
+import type { TransactionMeta } from '@metamask/transaction-controller';
+
+import type { QuoteRequest } from '../../types';
+import { isPredictWithdrawTransaction } from '../../utils/transaction';
+
+/**
+ * Check whether an authorization list on the original transaction is unsupported by Across.
+ *
+ * Predict withdraw post-quote requests do not use Across destination actions;
+ * the original withdrawal is submitted by MetaMask on the source chain before
+ * the Across deposit leg. That keeps a source-chain authorization list out of
+ * Across' post-swap action payload.
+ *
+ * @param transaction - Original transaction metadata.
+ * @param requests - Across quote requests.
+ * @returns `true` if the authorization list should block Across.
+ */
+export function hasUnsupportedTransactionAuthorizationList(
+  transaction: TransactionMeta,
+  requests: QuoteRequest[],
+): boolean {
+  if (!transaction.txParams?.authorizationList?.length) {
+    return false;
+  }
+
+  return (
+    !isPredictWithdrawTransaction(transaction) ||
+    requests.some((request) => request.isPostQuote !== true)
+  );
+}

--- a/packages/transaction-pay-controller/src/strategy/across/requests.ts
+++ b/packages/transaction-pay-controller/src/strategy/across/requests.ts
@@ -3,6 +3,7 @@ import type { QuoteRequest } from '../../types';
 export function isAcrossQuoteRequest(request: QuoteRequest): boolean {
   return (
     request.isMaxAmount === true ||
+    request.isPostQuote === true ||
     (request.targetAmountMinimum !== undefined &&
       request.targetAmountMinimum !== '0')
   );

--- a/packages/transaction-pay-controller/src/types.ts
+++ b/packages/transaction-pay-controller/src/types.ts
@@ -123,8 +123,8 @@ export type TransactionConfig = {
   isPostQuote?: boolean;
 
   /**
-   * Optional address to receive refunds if the Relay transaction fails.
-   * When set, overrides the default refund recipient (EOA) in the Relay quote
+   * Optional address to receive refunds if the quote provider transaction fails.
+   * When set, overrides the default refund recipient (EOA) in the quote
    * request. Use this for post-quote flows where the user's funds originate
    * from a smart contract account (e.g. Predict Safe proxy) so that refunds
    * go back to that account rather than the EOA.
@@ -224,8 +224,8 @@ export type TransactionData = {
   isHyperliquidSource?: boolean;
 
   /**
-   * Optional address to receive refunds if the Relay transaction fails.
-   * When set, overrides the default refund recipient (EOA) in the Relay quote
+   * Optional address to receive refunds if the quote provider transaction fails.
+   * When set, overrides the default refund recipient (EOA) in the quote
    * request.
    */
   refundTo?: Hex;
@@ -403,8 +403,8 @@ export type QuoteRequest = {
   isHyperliquidSource?: boolean;
 
   /**
-   * Optional address to receive refunds if the Relay transaction fails.
-   * When set, overrides the default refund recipient (EOA) in the Relay quote
+   * Optional address to receive refunds if the quote provider transaction fails.
+   * When set, overrides the default refund recipient (EOA) in the quote
    * request.
    */
   refundTo?: Hex;


### PR DESCRIPTION
## Summary

This is PR 1 of 4 in the core stack for Predict withdraws over Across.

- Adds `TransactionType.predictAcrossWithdraw`.
- Treats `isPostQuote` requests as actionable for Across support checks.
- Allows source-chain authorization lists only for post-quote Predict withdraw detection, where the original withdraw is not encoded as an Across destination action.
- Generalizes transaction-pay refund documentation from Relay-only language to quote-provider language.

## Stack

1. This PR: plumbing to identify Predict Across withdraws
2. #8760: quote support
3. #8761: submit support
4. #8762: gas payment edge cases

## Validation

- `yarn workspace @metamask/transaction-pay-controller run jest --no-coverage src/strategy/across/AcrossStrategy.test.ts`
- Full stack validation was run on the final stacked branch:
  - `yarn changelog:validate`
  - `yarn workspace @metamask/transaction-pay-controller run test`
  - `yarn workspace @metamask/transaction-controller run test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Across quote eligibility logic to treat `isPostQuote` requests as actionable and to allow EIP-7702 `authorizationList` only for a specific Predict-withdraw post-quote path; misclassification could incorrectly enable/disable Across quoting for some transactions.
> 
> **Overview**
> Introduces a new `TransactionType.predictAcrossWithdraw` to tag Predict withdraws that will use Across.
> 
> Updates `AcrossStrategy.supports` to treat `isPostQuote` quote requests as actionable and only accept them when the original transaction is a Predict withdraw, plus adds `hasUnsupportedTransactionAuthorizationList` to block EIP-7702 `authorizationList` usage except for the Predict-withdraw post-quote detection case. Tests were extended to cover post-quote Predict withdraw handling.
> 
> Minor docs/logic tweaks: `isAcrossQuoteRequest` now includes `isPostQuote`, and `refundTo` comments were generalized from Relay-specific wording to quote-provider wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc6f92e1547a7a24bf5f2b37f9ff00f4d11b2cb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->