### PR TITLE
feat: use `defaultInfuraNetworks` as default networks list

### DIFF
--- a/packages/controller-utils/CHANGELOG.md
+++ b/packages/controller-utils/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `defaultInfuraNetworks` with Infura network names to be enabled by default ([#8767](https://github.com/MetaMask/core/pull/8767))
+
 ## [12.0.0]
 
 ### Changed

--- a/packages/controller-utils/CHANGELOG.md
+++ b/packages/controller-utils/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `defaultInfuraNetworks` with Infura network names to be enabled by default ([#8767](https://github.com/MetaMask/core/pull/8767))
+- Add `DEFAULT_INFURA_NETWORKS` with Infura network names to be enabled by default ([#8767](https://github.com/MetaMask/core/pull/8767))
 
 ## [12.0.0]
 

--- a/packages/controller-utils/src/index.test.ts
+++ b/packages/controller-utils/src/index.test.ts
@@ -81,6 +81,7 @@ describe('@metamask/controller-utils', () => {
         "weiHexToGweiDec",
         "isEqualCaseInsensitive",
         "InfuraNetworkType",
+        "defaultInfuraNetworks",
         "CustomNetworkType",
         "NetworkType",
         "isNetworkType",

--- a/packages/controller-utils/src/index.test.ts
+++ b/packages/controller-utils/src/index.test.ts
@@ -81,7 +81,7 @@ describe('@metamask/controller-utils', () => {
         "weiHexToGweiDec",
         "isEqualCaseInsensitive",
         "InfuraNetworkType",
-        "defaultInfuraNetworks",
+        "DEFAULT_INFURA_NETWORKS",
         "CustomNetworkType",
         "NetworkType",
         "isNetworkType",

--- a/packages/controller-utils/src/types.ts
+++ b/packages/controller-utils/src/types.ts
@@ -29,7 +29,7 @@ export type InfuraNetworkType =
  * This is a subset of the full list of {@link InfuraNetworkType}, and can be used to determine
  * which Infura networks to enable by default.
  */
-export const defaultInfuraNetworks: InfuraNetworkType[] = [
+export const DEFAULT_INFURA_NETWORKS = [
   InfuraNetworkType.mainnet,
   InfuraNetworkType.goerli,
   InfuraNetworkType.sepolia,
@@ -42,7 +42,7 @@ export const defaultInfuraNetworks: InfuraNetworkType[] = [
   InfuraNetworkType['optimism-mainnet'],
   InfuraNetworkType['polygon-mainnet'],
   InfuraNetworkType['monad-mainnet'],
-];
+] as const satisfies InfuraNetworkType[];
 
 /**
  * Custom network types that are not part of Infura.

--- a/packages/controller-utils/src/types.ts
+++ b/packages/controller-utils/src/types.ts
@@ -24,6 +24,27 @@ export type InfuraNetworkType =
   (typeof InfuraNetworkType)[keyof typeof InfuraNetworkType];
 
 /**
+ * The default set of Infura networks to include in the wallet.
+ *
+ * This is a subset of the full list of {@link InfuraNetworkType}, and can be used to determine
+ * which Infura networks to enable by default.
+ */
+export const defaultInfuraNetworks: InfuraNetworkType[] = [
+  InfuraNetworkType.mainnet,
+  InfuraNetworkType.goerli,
+  InfuraNetworkType.sepolia,
+  InfuraNetworkType['linea-goerli'],
+  InfuraNetworkType['linea-sepolia'],
+  InfuraNetworkType['linea-mainnet'],
+  InfuraNetworkType['base-mainnet'],
+  InfuraNetworkType['arbitrum-mainnet'],
+  InfuraNetworkType['bsc-mainnet'],
+  InfuraNetworkType['optimism-mainnet'],
+  InfuraNetworkType['polygon-mainnet'],
+  InfuraNetworkType['monad-mainnet'],
+];
+
+/**
  * Custom network types that are not part of Infura.
  */
 export const CustomNetworkType = {

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Use `defaultInfuraNetworks` from `controller-utils` as list of Infura networks ([#8767](https://github.com/MetaMask/core/pull/8767))
-  - The list of networks is used to determine which networks should be included in NetworkController's default state when constructed with an empty state.
+### Changed
+
+- **BREAKING:** Remove Sei, MegaETH, Avalanche, and ZKSync from list of default networks ([#8767](https://github.com/MetaMask/core/pull/8767))
+  - You will need to add them as network configurations first before switching to them. 
 
 ## [31.1.0]
 

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -9,8 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-### Changed
-
 - **BREAKING:** Remove Sei, MegaETH, Avalanche, and ZKSync from list of default networks ([#8767](https://github.com/MetaMask/core/pull/8767))
   - You will need to add them as network configurations first before switching to them. 
 

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use `defaultInfuraNetworks` from `controller-utils` as list of Infura networks ([#8767](https://github.com/MetaMask/core/pull/8767))
+  - The list of networks is used to determine which networks should be included in NetworkController's default state when constructed with an empty state.
+
 ## [31.1.0]
 
 ### Added

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **BREAKING:** Remove Sei, MegaETH, Avalanche, and ZKSync from list of default networks ([#8767](https://github.com/MetaMask/core/pull/8767))
-  - You will need to add them as network configurations first before switching to them. 
+  - You will need to add them as network configurations first before switching to them.
 
 ## [31.1.0]
 

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -16,6 +16,7 @@ import {
   NetworkNickname,
   BUILT_IN_CUSTOM_NETWORKS_RPC,
   BUILT_IN_NETWORKS,
+  defaultInfuraNetworks,
 } from '@metamask/controller-utils';
 import type { PollingBlockTrackerOptions } from '@metamask/eth-block-tracker';
 import EthQuery from '@metamask/eth-query';
@@ -807,37 +808,38 @@ function getDefaultInfuraNetworkConfigurationsByChainId(): Record<
   Hex,
   NetworkConfiguration
 > {
-  return Object.values(InfuraNetworkType).reduce<
-    Record<Hex, NetworkConfiguration>
-  >((obj, infuraNetworkType) => {
-    const chainId = ChainId[infuraNetworkType];
+  return defaultInfuraNetworks.reduce<Record<Hex, NetworkConfiguration>>(
+    (obj, infuraNetworkType) => {
+      const chainId = ChainId[infuraNetworkType];
 
-    // Skip deprecated network as default network.
-    if (DEPRECATED_NETWORKS.has(chainId)) {
-      return obj;
-    }
+      // Skip deprecated network as default network.
+      if (DEPRECATED_NETWORKS.has(chainId)) {
+        return obj;
+      }
 
-    const rpcEndpointUrl =
-      `https://${infuraNetworkType}.infura.io/v3/{infuraProjectId}` as const;
+      const rpcEndpointUrl =
+        `https://${infuraNetworkType}.infura.io/v3/{infuraProjectId}` as const;
 
-    const networkConfiguration: NetworkConfiguration = {
-      blockExplorerUrls: [],
-      chainId,
-      defaultRpcEndpointIndex: 0,
-      name: NetworkNickname[infuraNetworkType],
-      nativeCurrency: NetworksTicker[infuraNetworkType],
-      rpcEndpoints: [
-        {
-          failoverUrls: [],
-          networkClientId: infuraNetworkType,
-          type: RpcEndpointType.Infura,
-          url: rpcEndpointUrl,
-        },
-      ],
-    };
+      const networkConfiguration: NetworkConfiguration = {
+        blockExplorerUrls: [],
+        chainId,
+        defaultRpcEndpointIndex: 0,
+        name: NetworkNickname[infuraNetworkType],
+        nativeCurrency: NetworksTicker[infuraNetworkType],
+        rpcEndpoints: [
+          {
+            failoverUrls: [],
+            networkClientId: infuraNetworkType,
+            type: RpcEndpointType.Infura,
+            url: rpcEndpointUrl,
+          },
+        ],
+      };
 
-    return { ...obj, [chainId]: networkConfiguration };
-  }, {});
+      return { ...obj, [chainId]: networkConfiguration };
+    },
+    {},
+  );
 }
 
 /**

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -16,7 +16,7 @@ import {
   NetworkNickname,
   BUILT_IN_CUSTOM_NETWORKS_RPC,
   BUILT_IN_NETWORKS,
-  defaultInfuraNetworks,
+  DEFAULT_INFURA_NETWORKS,
 } from '@metamask/controller-utils';
 import type { PollingBlockTrackerOptions } from '@metamask/eth-block-tracker';
 import EthQuery from '@metamask/eth-query';
@@ -808,7 +808,7 @@ function getDefaultInfuraNetworkConfigurationsByChainId(): Record<
   Hex,
   NetworkConfiguration
 > {
-  return defaultInfuraNetworks.reduce<Record<Hex, NetworkConfiguration>>(
+  return DEFAULT_INFURA_NETWORKS.reduce<Record<Hex, NetworkConfiguration>>(
     (obj, infuraNetworkType) => {
       const chainId = ChainId[infuraNetworkType];
 

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -518,36 +518,6 @@ describe('NetworkController', () => {
                   },
                 ],
               },
-              "0x10e6": {
-                "blockExplorerUrls": [],
-                "chainId": "0x10e6",
-                "defaultRpcEndpointIndex": 0,
-                "name": "MegaETH Mainnet",
-                "nativeCurrency": "ETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "megaeth-mainnet",
-                    "type": "infura",
-                    "url": "https://megaeth-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0x144": {
-                "blockExplorerUrls": [],
-                "chainId": "0x144",
-                "defaultRpcEndpointIndex": 0,
-                "name": "ZKsync Era",
-                "nativeCurrency": "ETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "zksync-mainnet",
-                    "type": "infura",
-                    "url": "https://zksync-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
               "0x2105": {
                 "blockExplorerUrls": [],
                 "chainId": "0x2105",
@@ -575,21 +545,6 @@ describe('NetworkController', () => {
                     "networkClientId": "bsc-mainnet",
                     "type": "infura",
                     "url": "https://bsc-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0x531": {
-                "blockExplorerUrls": [],
-                "chainId": "0x531",
-                "defaultRpcEndpointIndex": 0,
-                "name": "Sei Mainnet",
-                "nativeCurrency": "SEI",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "sei-mainnet",
-                    "type": "infura",
-                    "url": "https://sei-mainnet.infura.io/v3/{infuraProjectId}",
                   },
                 ],
               },
@@ -650,21 +605,6 @@ describe('NetworkController', () => {
                     "networkClientId": "arbitrum-mainnet",
                     "type": "infura",
                     "url": "https://arbitrum-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0xa86a": {
-                "blockExplorerUrls": [],
-                "chainId": "0xa86a",
-                "defaultRpcEndpointIndex": 0,
-                "name": "Avalanche Mainnet",
-                "nativeCurrency": "AVAX",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "avalanche-mainnet",
-                    "type": "infura",
-                    "url": "https://avalanche-mainnet.infura.io/v3/{infuraProjectId}",
                   },
                 ],
               },
@@ -747,36 +687,6 @@ describe('NetworkController', () => {
                     },
                   ],
                 },
-                "0x10e6": {
-                  "blockExplorerUrls": [],
-                  "chainId": "0x10e6",
-                  "defaultRpcEndpointIndex": 0,
-                  "name": "MegaETH Mainnet",
-                  "nativeCurrency": "ETH",
-                  "rpcEndpoints": [
-                    {
-                      "failoverUrls": [],
-                      "networkClientId": "megaeth-mainnet",
-                      "type": "infura",
-                      "url": "https://megaeth-mainnet.infura.io/v3/{infuraProjectId}",
-                    },
-                  ],
-                },
-                "0x144": {
-                  "blockExplorerUrls": [],
-                  "chainId": "0x144",
-                  "defaultRpcEndpointIndex": 0,
-                  "name": "ZKsync Era",
-                  "nativeCurrency": "ETH",
-                  "rpcEndpoints": [
-                    {
-                      "failoverUrls": [],
-                      "networkClientId": "zksync-mainnet",
-                      "type": "infura",
-                      "url": "https://zksync-mainnet.infura.io/v3/{infuraProjectId}",
-                    },
-                  ],
-                },
                 "0x18c6": {
                   "blockExplorerUrls": [
                     "https://megaexplorer.xyz",
@@ -822,21 +732,6 @@ describe('NetworkController', () => {
                       "networkClientId": "bsc-mainnet",
                       "type": "infura",
                       "url": "https://bsc-mainnet.infura.io/v3/{infuraProjectId}",
-                    },
-                  ],
-                },
-                "0x531": {
-                  "blockExplorerUrls": [],
-                  "chainId": "0x531",
-                  "defaultRpcEndpointIndex": 0,
-                  "name": "Sei Mainnet",
-                  "nativeCurrency": "SEI",
-                  "rpcEndpoints": [
-                    {
-                      "failoverUrls": [],
-                      "networkClientId": "sei-mainnet",
-                      "type": "infura",
-                      "url": "https://sei-mainnet.infura.io/v3/{infuraProjectId}",
                     },
                   ],
                 },
@@ -897,21 +792,6 @@ describe('NetworkController', () => {
                       "networkClientId": "arbitrum-mainnet",
                       "type": "infura",
                       "url": "https://arbitrum-mainnet.infura.io/v3/{infuraProjectId}",
-                    },
-                  ],
-                },
-                "0xa86a": {
-                  "blockExplorerUrls": [],
-                  "chainId": "0xa86a",
-                  "defaultRpcEndpointIndex": 0,
-                  "name": "Avalanche Mainnet",
-                  "nativeCurrency": "AVAX",
-                  "rpcEndpoints": [
-                    {
-                      "failoverUrls": [],
-                      "networkClientId": "avalanche-mainnet",
-                      "type": "infura",
-                      "url": "https://avalanche-mainnet.infura.io/v3/{infuraProjectId}",
                     },
                   ],
                 },
@@ -2071,21 +1951,6 @@ describe('NetworkController', () => {
                 enableRpcFailover: expect.any(Function),
                 disableRpcFailover: expect.any(Function),
               },
-              'avalanche-mainnet': {
-                blockTracker: expect.anything(),
-                configuration: {
-                  type: NetworkClientType.Infura,
-                  failoverRpcUrls: [],
-                  infuraProjectId,
-                  chainId: '0xa86a',
-                  ticker: 'AVAX',
-                  network: InfuraNetworkType['avalanche-mainnet'],
-                },
-                provider: expect.anything(),
-                destroy: expect.any(Function),
-                enableRpcFailover: expect.any(Function),
-                disableRpcFailover: expect.any(Function),
-              },
               'base-mainnet': {
                 blockTracker: expect.anything(),
                 configuration: {
@@ -2161,21 +2026,6 @@ describe('NetworkController', () => {
                 enableRpcFailover: expect.any(Function),
                 disableRpcFailover: expect.any(Function),
               },
-              'megaeth-mainnet': {
-                blockTracker: expect.anything(),
-                configuration: {
-                  type: NetworkClientType.Infura,
-                  failoverRpcUrls: [],
-                  infuraProjectId,
-                  chainId: '0x10e6',
-                  ticker: 'ETH',
-                  network: InfuraNetworkType['megaeth-mainnet'],
-                },
-                provider: expect.anything(),
-                destroy: expect.any(Function),
-                enableRpcFailover: expect.any(Function),
-                disableRpcFailover: expect.any(Function),
-              },
               'monad-mainnet': {
                 blockTracker: expect.anything(),
                 configuration: {
@@ -2221,21 +2071,6 @@ describe('NetworkController', () => {
                 enableRpcFailover: expect.any(Function),
                 disableRpcFailover: expect.any(Function),
               },
-              'sei-mainnet': {
-                blockTracker: expect.anything(),
-                configuration: {
-                  type: NetworkClientType.Infura,
-                  failoverRpcUrls: [],
-                  infuraProjectId,
-                  chainId: '0x531',
-                  ticker: 'SEI',
-                  network: InfuraNetworkType['sei-mainnet'],
-                },
-                provider: expect.anything(),
-                destroy: expect.any(Function),
-                enableRpcFailover: expect.any(Function),
-                disableRpcFailover: expect.any(Function),
-              },
               sepolia: {
                 blockTracker: expect.anything(),
                 configuration: {
@@ -2245,21 +2080,6 @@ describe('NetworkController', () => {
                   chainId: '0xaa36a7',
                   ticker: 'SepoliaETH',
                   network: InfuraNetworkType.sepolia,
-                },
-                provider: expect.anything(),
-                destroy: expect.any(Function),
-                enableRpcFailover: expect.any(Function),
-                disableRpcFailover: expect.any(Function),
-              },
-              'zksync-mainnet': {
-                blockTracker: expect.anything(),
-                configuration: {
-                  type: NetworkClientType.Infura,
-                  failoverRpcUrls: [],
-                  infuraProjectId,
-                  chainId: '0x144',
-                  ticker: 'ETH',
-                  network: InfuraNetworkType['zksync-mainnet'],
                 },
                 provider: expect.anything(),
                 destroy: expect.any(Function),
@@ -15090,36 +14910,6 @@ describe('NetworkController', () => {
                   },
                 ],
               },
-              "0x10e6": {
-                "blockExplorerUrls": [],
-                "chainId": "0x10e6",
-                "defaultRpcEndpointIndex": 0,
-                "name": "MegaETH Mainnet",
-                "nativeCurrency": "ETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "megaeth-mainnet",
-                    "type": "infura",
-                    "url": "https://megaeth-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0x144": {
-                "blockExplorerUrls": [],
-                "chainId": "0x144",
-                "defaultRpcEndpointIndex": 0,
-                "name": "ZKsync Era",
-                "nativeCurrency": "ETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "zksync-mainnet",
-                    "type": "infura",
-                    "url": "https://zksync-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
               "0x2105": {
                 "blockExplorerUrls": [],
                 "chainId": "0x2105",
@@ -15147,21 +14937,6 @@ describe('NetworkController', () => {
                     "networkClientId": "bsc-mainnet",
                     "type": "infura",
                     "url": "https://bsc-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0x531": {
-                "blockExplorerUrls": [],
-                "chainId": "0x531",
-                "defaultRpcEndpointIndex": 0,
-                "name": "Sei Mainnet",
-                "nativeCurrency": "SEI",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "sei-mainnet",
-                    "type": "infura",
-                    "url": "https://sei-mainnet.infura.io/v3/{infuraProjectId}",
                   },
                 ],
               },
@@ -15222,21 +14997,6 @@ describe('NetworkController', () => {
                     "networkClientId": "arbitrum-mainnet",
                     "type": "infura",
                     "url": "https://arbitrum-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0xa86a": {
-                "blockExplorerUrls": [],
-                "chainId": "0xa86a",
-                "defaultRpcEndpointIndex": 0,
-                "name": "Avalanche Mainnet",
-                "nativeCurrency": "AVAX",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "avalanche-mainnet",
-                    "type": "infura",
-                    "url": "https://avalanche-mainnet.infura.io/v3/{infuraProjectId}",
                   },
                 ],
               },
@@ -15319,36 +15079,6 @@ describe('NetworkController', () => {
                   },
                 ],
               },
-              "0x10e6": {
-                "blockExplorerUrls": [],
-                "chainId": "0x10e6",
-                "defaultRpcEndpointIndex": 0,
-                "name": "MegaETH Mainnet",
-                "nativeCurrency": "ETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "megaeth-mainnet",
-                    "type": "infura",
-                    "url": "https://megaeth-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0x144": {
-                "blockExplorerUrls": [],
-                "chainId": "0x144",
-                "defaultRpcEndpointIndex": 0,
-                "name": "ZKsync Era",
-                "nativeCurrency": "ETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "zksync-mainnet",
-                    "type": "infura",
-                    "url": "https://zksync-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
               "0x2105": {
                 "blockExplorerUrls": [],
                 "chainId": "0x2105",
@@ -15376,21 +15106,6 @@ describe('NetworkController', () => {
                     "networkClientId": "bsc-mainnet",
                     "type": "infura",
                     "url": "https://bsc-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0x531": {
-                "blockExplorerUrls": [],
-                "chainId": "0x531",
-                "defaultRpcEndpointIndex": 0,
-                "name": "Sei Mainnet",
-                "nativeCurrency": "SEI",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "sei-mainnet",
-                    "type": "infura",
-                    "url": "https://sei-mainnet.infura.io/v3/{infuraProjectId}",
                   },
                 ],
               },
@@ -15451,21 +15166,6 @@ describe('NetworkController', () => {
                     "networkClientId": "arbitrum-mainnet",
                     "type": "infura",
                     "url": "https://arbitrum-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0xa86a": {
-                "blockExplorerUrls": [],
-                "chainId": "0xa86a",
-                "defaultRpcEndpointIndex": 0,
-                "name": "Avalanche Mainnet",
-                "nativeCurrency": "AVAX",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "avalanche-mainnet",
-                    "type": "infura",
-                    "url": "https://avalanche-mainnet.infura.io/v3/{infuraProjectId}",
                   },
                 ],
               },
@@ -15548,36 +15248,6 @@ describe('NetworkController', () => {
                   },
                 ],
               },
-              "0x10e6": {
-                "blockExplorerUrls": [],
-                "chainId": "0x10e6",
-                "defaultRpcEndpointIndex": 0,
-                "name": "MegaETH Mainnet",
-                "nativeCurrency": "ETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "megaeth-mainnet",
-                    "type": "infura",
-                    "url": "https://megaeth-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0x144": {
-                "blockExplorerUrls": [],
-                "chainId": "0x144",
-                "defaultRpcEndpointIndex": 0,
-                "name": "ZKsync Era",
-                "nativeCurrency": "ETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "zksync-mainnet",
-                    "type": "infura",
-                    "url": "https://zksync-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
               "0x2105": {
                 "blockExplorerUrls": [],
                 "chainId": "0x2105",
@@ -15605,21 +15275,6 @@ describe('NetworkController', () => {
                     "networkClientId": "bsc-mainnet",
                     "type": "infura",
                     "url": "https://bsc-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0x531": {
-                "blockExplorerUrls": [],
-                "chainId": "0x531",
-                "defaultRpcEndpointIndex": 0,
-                "name": "Sei Mainnet",
-                "nativeCurrency": "SEI",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "sei-mainnet",
-                    "type": "infura",
-                    "url": "https://sei-mainnet.infura.io/v3/{infuraProjectId}",
                   },
                 ],
               },
@@ -15680,21 +15335,6 @@ describe('NetworkController', () => {
                     "networkClientId": "arbitrum-mainnet",
                     "type": "infura",
                     "url": "https://arbitrum-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0xa86a": {
-                "blockExplorerUrls": [],
-                "chainId": "0xa86a",
-                "defaultRpcEndpointIndex": 0,
-                "name": "Avalanche Mainnet",
-                "nativeCurrency": "AVAX",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "avalanche-mainnet",
-                    "type": "infura",
-                    "url": "https://avalanche-mainnet.infura.io/v3/{infuraProjectId}",
                   },
                 ],
               },


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->
Some new Infura network have been added to `InfuraNetworkType` (#8680), but `NetworkController` uses the same list of networks to:
- Build the default list of networks when creating the initial default state
- Validate new Infura networks being enabled

This has been fine until now because additional networks that can be enabled by users were added as "custom" networks. However, with the addition of new Infura networks, we have some networks that can be enabled by users but are not included in the default list of networks. This causes validation to fail when users try to enable those networks (via the Additional Networks list). 

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the set of networks that are auto-included on initialization, which is a breaking behavioral change that can affect users’ ability to switch to previously-default networks without first adding configurations.
> 
> **Overview**
> Introduces `DEFAULT_INFURA_NETWORKS` (a curated subset of `InfuraNetworkType`) in `@metamask/controller-utils` and exports it for consumers.
> 
> Updates `NetworkController` to build its default `networkConfigurationsByChainId` from `DEFAULT_INFURA_NETWORKS` instead of `Object.values(InfuraNetworkType)`, effectively **removing Sei, MegaETH, Avalanche, and ZKSync from the default network set** while keeping them available as Infura-supported networks.
> 
> Adjusts controller-utils export snapshots and network-controller tests/changelogs to reflect the new default-network behavior (**breaking**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f8fa8c0705f5ceb9b629e9b831749e408f4e3d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->