### PR TITLE
feat(snap-account-service): handle `:accountGroup{Created,Updated,Removed}` events

### DIFF
--- a/packages/snap-account-service/CHANGELOG.md
+++ b/packages/snap-account-service/CHANGELOG.md
@@ -28,9 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The service messenger now requires the `KeyringController:withController` action.
 - Add `handleKeyringSnapMessage` ([#8758](https://github.com/MetaMask/core/pull/8758))
   - This will be the new entry point for consumer that needs to forward keyring events to a account management Snap (instead of using the legacy Snap keyring instance directly).
-- Forward selected account group accounts ([#8763](https://github.com/MetaMask/core/pull/8763))
+- Forward selected account group accounts ([#8763](https://github.com/MetaMask/core/pull/8763)), ([#8770](https://github.com/MetaMask/core/pull/8770))
   - This logic used to live on the clients.
-  - The service messenger now requires the `KeyringController:unlock`, `AccountTreeController:selectedAccountGroupChange` events and `AccountTreeController:getAccountGroupObject` action.
+  - The service messenger now requires the `KeyringController:unlock`, `AccountTreeController:selectedAccountGroupChange`, `AccountTreeController:accountGroup{Created,Updated,Removed}` events.
+  - The service messenger now requires the `AccountTreeController:getSelectedAccountGroup` and `AccountTreeController:getAccountGroupObject` actions.
 
 ### Changed
 

--- a/packages/snap-account-service/src/SnapAccountService.test.ts
+++ b/packages/snap-account-service/src/SnapAccountService.test.ts
@@ -40,6 +40,18 @@ type MockTruncatedSnap = Pick<
   'id' | 'initialPermissions' | 'enabled' | 'blocked'
 >;
 
+/** Mock account group type for tests. */
+type MockAccountGroup = Pick<AccountGroupObject, 'id' | 'accounts'>;
+
+/** Mock Snap keyring type for tests. */
+type MockSnapKeyring = {
+  type: KeyringTypes.snap;
+  handleKeyringSnapMessage?: jest.MockedFunction<
+    SnapKeyring['handleKeyringSnapMessage']
+  >;
+  setSelectedAccounts?: jest.MockedFunction<SnapKeyring['setSelectedAccounts']>;
+};
+
 type Mocks = {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   SnapController: {
@@ -213,7 +225,7 @@ function buildGroup(
   id: AccountGroupId,
   accounts: string[],
 ): AccountGroupObject {
-  return { id, accounts } as unknown as AccountGroupObject;
+  return { id, accounts } as MockAccountGroup as AccountGroupObject;
 }
 
 /**
@@ -326,7 +338,7 @@ function mockLegacySnapKeyring(
     >;
   },
 ): void {
-  const snapKeyring = {
+  const snapKeyring: MockSnapKeyring = {
     type: KeyringTypes.snap,
     handleKeyringSnapMessage,
     setSelectedAccounts,
@@ -336,7 +348,7 @@ function mockLegacySnapKeyring(
       get keyrings() {
         return Object.freeze([
           {
-            keyring: snapKeyring as unknown as KeyringEntry['keyring'],
+            keyring: snapKeyring as KeyringEntry['keyring'],
             metadata: { id: 'id-snap', name: KeyringTypes.snap },
           },
         ]);

--- a/packages/snap-account-service/src/SnapAccountService.test.ts
+++ b/packages/snap-account-service/src/SnapAccountService.test.ts
@@ -105,6 +105,9 @@ function getMessenger(
       'KeyringController:stateChange',
       'KeyringController:unlock',
       'AccountTreeController:selectedAccountGroupChange',
+      'AccountTreeController:accountGroupCreated',
+      'AccountTreeController:accountGroupUpdated',
+      'AccountTreeController:accountGroupRemoved',
     ],
   });
   return messenger;
@@ -202,11 +205,57 @@ function buildSnap(id: string, hasKeyring: boolean): TruncatedSnap {
 /**
  * Builds a minimal `AccountGroupObject` for tests.
  *
+ * @param id - The group ID.
  * @param accounts - The list of account IDs in the group.
  * @returns A minimal `AccountGroupObject`.
  */
-function buildGroup(accounts: string[]): AccountGroupObject {
-  return { accounts } as unknown as AccountGroupObject;
+function buildGroup(
+  id: AccountGroupId,
+  accounts: string[],
+): AccountGroupObject {
+  return { id, accounts } as unknown as AccountGroupObject;
+}
+
+/**
+ * Publishes an AccountTreeController accountGroupCreated event on the root
+ * messenger.
+ *
+ * @param rootMessenger - The root messenger.
+ * @param group - The created account group.
+ */
+function publishAccountGroupCreated(
+  rootMessenger: RootMessenger,
+  group: AccountGroupObject,
+): void {
+  rootMessenger.publish('AccountTreeController:accountGroupCreated', group);
+}
+
+/**
+ * Publishes an AccountTreeController accountGroupUpdated event on the root
+ * messenger.
+ *
+ * @param rootMessenger - The root messenger.
+ * @param group - The updated account group.
+ */
+function publishAccountGroupUpdated(
+  rootMessenger: RootMessenger,
+  group: AccountGroupObject,
+): void {
+  rootMessenger.publish('AccountTreeController:accountGroupUpdated', group);
+}
+
+/**
+ * Publishes an AccountTreeController accountGroupRemoved event on the root
+ * messenger.
+ *
+ * @param rootMessenger - The root messenger.
+ * @param groupId - The removed account group ID.
+ */
+function publishAccountGroupRemoved(
+  rootMessenger: RootMessenger,
+  groupId: AccountGroupId,
+): void {
+  rootMessenger.publish('AccountTreeController:accountGroupRemoved', groupId);
 }
 
 /**
@@ -642,7 +691,7 @@ describe('SnapAccountService', () => {
       const setSelectedAccounts = jest.fn().mockResolvedValue(undefined);
       mockLegacySnapKeyring(mocks, { setSelectedAccounts });
       mocks.AccountTreeController.getAccountGroupObject.mockReturnValue(
-        buildGroup(MOCK_ACCOUNTS),
+        buildGroup(MOCK_GROUP_ID, MOCK_ACCOUNTS),
       );
       expect(service).toBeDefined();
 
@@ -694,7 +743,7 @@ describe('SnapAccountService', () => {
       const setSelectedAccounts = jest.fn().mockRejectedValue(error);
       mockLegacySnapKeyring(mocks, { setSelectedAccounts });
       mocks.AccountTreeController.getAccountGroupObject.mockReturnValue(
-        buildGroup(MOCK_ACCOUNTS),
+        buildGroup(MOCK_GROUP_ID, MOCK_ACCOUNTS),
       );
       const consoleErrorSpy = jest
         .spyOn(console, 'error')
@@ -706,7 +755,7 @@ describe('SnapAccountService', () => {
 
       expect(setSelectedAccounts).toHaveBeenCalledWith(MOCK_ACCOUNTS);
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        'Error handling selected account group change:',
+        'Error forwarding selected accounts:',
         error,
       );
 
@@ -729,7 +778,7 @@ describe('SnapAccountService', () => {
         MOCK_GROUP_ID,
       );
       mocks.AccountTreeController.getAccountGroupObject.mockReturnValue(
-        buildGroup(MOCK_ACCOUNTS),
+        buildGroup(MOCK_GROUP_ID, MOCK_ACCOUNTS),
       );
       expect(service).toBeDefined();
 
@@ -770,7 +819,7 @@ describe('SnapAccountService', () => {
         MOCK_GROUP_ID,
       );
       mocks.AccountTreeController.getAccountGroupObject.mockReturnValue(
-        buildGroup(MOCK_ACCOUNTS),
+        buildGroup(MOCK_GROUP_ID, MOCK_ACCOUNTS),
       );
       const consoleErrorSpy = jest
         .spyOn(console, 'error')
@@ -782,11 +831,116 @@ describe('SnapAccountService', () => {
 
       expect(setSelectedAccounts).toHaveBeenCalledWith(MOCK_ACCOUNTS);
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        'Error forwarding selected account group on unlock:',
+        'Error forwarding selected accounts:',
         error,
       );
 
       consoleErrorSpy.mockRestore();
+    });
+  });
+
+  describe.each([
+    ['accountGroupCreated', publishAccountGroupCreated] as const,
+    ['accountGroupUpdated', publishAccountGroupUpdated] as const,
+  ])('on AccountTreeController:%s', (_eventName, publishEvent) => {
+    const MOCK_GROUP_ID = 'keyring:01JABC/group-1' as AccountGroupId;
+    const OTHER_GROUP_ID = 'keyring:01JABC/group-2' as AccountGroupId;
+    const MOCK_ACCOUNTS = [
+      '00000000-0000-0000-0000-000000000001',
+      '00000000-0000-0000-0000-000000000002',
+    ];
+
+    it('forwards the accounts from the event payload when the affected group is the selected one', async () => {
+      const { service, rootMessenger, mocks } = setup();
+      const setSelectedAccounts = jest.fn().mockResolvedValue(undefined);
+      mockLegacySnapKeyring(mocks, { setSelectedAccounts });
+      mocks.AccountTreeController.getSelectedAccountGroup.mockReturnValue(
+        MOCK_GROUP_ID,
+      );
+      expect(service).toBeDefined();
+
+      publishEvent(rootMessenger, buildGroup(MOCK_GROUP_ID, MOCK_ACCOUNTS));
+      await flushMicrotasks();
+
+      expect(
+        mocks.AccountTreeController.getAccountGroupObject,
+      ).not.toHaveBeenCalled();
+      expect(setSelectedAccounts).toHaveBeenCalledWith(MOCK_ACCOUNTS);
+    });
+
+    it('does nothing when the affected group is not the selected one', async () => {
+      const { service, rootMessenger, mocks } = setup();
+      const setSelectedAccounts = jest.fn().mockResolvedValue(undefined);
+      mockLegacySnapKeyring(mocks, { setSelectedAccounts });
+      mocks.AccountTreeController.getSelectedAccountGroup.mockReturnValue(
+        OTHER_GROUP_ID,
+      );
+      expect(service).toBeDefined();
+
+      publishEvent(rootMessenger, buildGroup(MOCK_GROUP_ID, MOCK_ACCOUNTS));
+      await flushMicrotasks();
+
+      expect(
+        mocks.AccountTreeController.getAccountGroupObject,
+      ).not.toHaveBeenCalled();
+      expect(setSelectedAccounts).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when no account group is selected', async () => {
+      const { service, rootMessenger, mocks } = setup();
+      const setSelectedAccounts = jest.fn().mockResolvedValue(undefined);
+      mockLegacySnapKeyring(mocks, { setSelectedAccounts });
+      mocks.AccountTreeController.getSelectedAccountGroup.mockReturnValue('');
+      expect(service).toBeDefined();
+
+      publishEvent(rootMessenger, buildGroup(MOCK_GROUP_ID, MOCK_ACCOUNTS));
+      await flushMicrotasks();
+
+      expect(
+        mocks.AccountTreeController.getAccountGroupObject,
+      ).not.toHaveBeenCalled();
+      expect(setSelectedAccounts).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('on AccountTreeController:accountGroupRemoved', () => {
+    const MOCK_GROUP_ID = 'keyring:01JABC/group-1' as AccountGroupId;
+    const OTHER_GROUP_ID = 'keyring:01JABC/group-2' as AccountGroupId;
+
+    it('clears the selected accounts when the removed group is the selected one', async () => {
+      const { service, rootMessenger, mocks } = setup();
+      const setSelectedAccounts = jest.fn().mockResolvedValue(undefined);
+      mockLegacySnapKeyring(mocks, { setSelectedAccounts });
+      mocks.AccountTreeController.getSelectedAccountGroup.mockReturnValue(
+        MOCK_GROUP_ID,
+      );
+      expect(service).toBeDefined();
+
+      publishAccountGroupRemoved(rootMessenger, MOCK_GROUP_ID);
+      await flushMicrotasks();
+
+      expect(
+        mocks.AccountTreeController.getAccountGroupObject,
+      ).not.toHaveBeenCalled();
+      expect(setSelectedAccounts).toHaveBeenCalledWith([]);
+    });
+
+    it('does nothing when the removed group is not the selected one', async () => {
+      const { service, rootMessenger, mocks } = setup();
+      const setSelectedAccounts = jest.fn().mockResolvedValue(undefined);
+      mockLegacySnapKeyring(mocks, { setSelectedAccounts });
+      mocks.AccountTreeController.getSelectedAccountGroup.mockReturnValue(
+        OTHER_GROUP_ID,
+      );
+      expect(service).toBeDefined();
+
+      publishAccountGroupRemoved(rootMessenger, MOCK_GROUP_ID);
+      await flushMicrotasks();
+
+      expect(
+        mocks.AccountTreeController.getAccountGroupObject,
+      ).not.toHaveBeenCalled();
+      expect(setSelectedAccounts).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/snap-account-service/src/SnapAccountService.ts
+++ b/packages/snap-account-service/src/SnapAccountService.ts
@@ -11,7 +11,7 @@ import type {
   KeyringEntry,
 } from '@metamask/keyring-controller';
 import { KeyringTypes } from '@metamask/keyring-controller';
-import type { BaseKeyring } from '@metamask/keyring-utils';
+import type { AccountId, BaseKeyring } from '@metamask/keyring-utils';
 import type { Messenger } from '@metamask/messenger';
 import type {
   SnapControllerGetRunnableSnapsAction,
@@ -42,6 +42,10 @@ import type {
   AccountTreeControllerGetAccountGroupObjectAction,
   AccountTreeControllerGetSelectedAccountGroupAction,
   AccountTreeControllerSelectedAccountGroupChangeEvent,
+  AccountTreeControllerAccountGroupCreatedEvent,
+  AccountTreeControllerAccountGroupUpdatedEvent,
+  AccountTreeControllerAccountGroupRemovedEvent,
+  AccountGroupObject,
 } from './types';
 
 /**
@@ -100,7 +104,10 @@ type AllowedEvents =
   | SnapControllerSnapUninstalledEvent
   | KeyringControllerStateChangeEvent
   | KeyringControllerUnlockEvent
-  | AccountTreeControllerSelectedAccountGroupChangeEvent;
+  | AccountTreeControllerSelectedAccountGroupChangeEvent
+  | AccountTreeControllerAccountGroupCreatedEvent
+  | AccountTreeControllerAccountGroupUpdatedEvent
+  | AccountTreeControllerAccountGroupRemovedEvent;
 
 /**
  * The messenger which is restricted to actions and events accessed by
@@ -181,6 +188,21 @@ export class SnapAccountService {
       (groupId) => this.#handleSelectedAccountGroupChange(groupId),
     );
 
+    this.#messenger.subscribe(
+      'AccountTreeController:accountGroupCreated',
+      (group) => this.#handleAccountGroupCreatedOrUpdated(group),
+    );
+
+    this.#messenger.subscribe(
+      'AccountTreeController:accountGroupUpdated',
+      (group) => this.#handleAccountGroupCreatedOrUpdated(group),
+    );
+
+    this.#messenger.subscribe(
+      'AccountTreeController:accountGroupRemoved',
+      (groupId) => this.#handleAccountGroupRemoved(groupId),
+    );
+
     this.#messenger.subscribe('KeyringController:unlock', () =>
       this.#handleUnlock(),
     );
@@ -193,9 +215,10 @@ export class SnapAccountService {
    * @param groupId - The ID of the newly selected account group.
    */
   #handleSelectedAccountGroupChange(groupId: AccountGroupId | ''): void {
-    this.#forwardSelectedAccountGroup(groupId).catch((error) => {
-      console.error('Error handling selected account group change:', error);
-    });
+    this.#forwardSelectedAccounts(
+      groupId,
+      this.#getAccountGroup(groupId)?.accounts,
+    );
   }
 
   /**
@@ -203,15 +226,38 @@ export class SnapAccountService {
    * selected account group's accounts to the Snap keyring.
    */
   #handleUnlock(): void {
-    const groupId = this.#messenger.call(
-      'AccountTreeController:getSelectedAccountGroup',
+    const groupId = this.#getSelectedAccountGroupId();
+    this.#forwardSelectedAccounts(
+      groupId,
+      this.#getAccountGroup(groupId)?.accounts,
     );
-    this.#forwardSelectedAccountGroup(groupId).catch((error) => {
-      console.error(
-        'Error forwarding selected account group on unlock:',
-        error,
+  }
+
+  /**
+   * Handles created or updated account groups by forwarding the accounts of the currently
+   * selected account group to the Snap keyring, if the created/updated group is currently selected.
+   *
+   * @param group - The account group being created or updated.
+   */
+  #handleAccountGroupCreatedOrUpdated(group: AccountGroupObject): void {
+    if (group.id === this.#getSelectedAccountGroupId()) {
+      this.#forwardSelectedAccounts(group.id, group.accounts);
+    }
+  }
+
+  /**
+   * Handles removed account groups by forwarding the accounts of the currently
+   * selected account group to the Snap keyring, if the removed group is currently selected.
+   *
+   * @param groupId - The ID of the account group being removed.
+   */
+  #handleAccountGroupRemoved(groupId: AccountGroupId): void {
+    if (groupId === this.#getSelectedAccountGroupId()) {
+      this.#forwardSelectedAccounts(
+        groupId,
+        [] /* Clearing accounts since the group is removed */,
       );
-    });
+    }
   }
 
   /**
@@ -322,24 +368,68 @@ export class SnapAccountService {
    *
    * @param groupId - The ID of the account group whose accounts should be
    * forwarded. If empty, this is a no-op.
+   * @param accounts - The accounts to forward. If not defined, this is a no-op.
    */
-  async #forwardSelectedAccountGroup(
+  #forwardSelectedAccounts(
     groupId: AccountGroupId | '',
-  ): Promise<void> {
-    if (groupId) {
-      const group = this.#messenger.call(
-        'AccountTreeController:getAccountGroupObject',
-        groupId,
+    accounts: AccountId[] | undefined,
+  ): void {
+    if (!groupId) {
+      log(
+        'No selected account group, skipping forwarding selected accounts to Snap keyring.',
       );
+      return;
+    }
 
-      if (group) {
-        log(
-          `Forwarding selected accounts (from "${groupId}") to Snap keyring: ${group.accounts.join(', ')}`,
-        );
+    const forwardSelectedAccounts = async (): Promise<void> => {
+      if (accounts) {
+        if (accounts.length) {
+          log(
+            `Forwarding selected accounts (from "${groupId}"): ${accounts.join(', ')}`,
+          );
+        } else {
+          log(`Cleearing selected accounts (from "${groupId}")`);
+        }
 
         const snapKeyring = await this.getLegacySnapKeyring();
-        await snapKeyring.setSelectedAccounts(group.accounts);
+        await snapKeyring.setSelectedAccounts(accounts);
       }
+    };
+
+    // There is nothing we can do if forwarding fails. This will auto-recover on the next relevant event.
+    forwardSelectedAccounts().catch((error) => {
+      console.error('Error forwarding selected accounts:', error);
+    });
+  }
+
+  /**
+   * Gets the account group object for the given group ID.
+   *
+   * @param groupId - The ID of the account group.
+   * @returns The account group object, or undefined if the group ID is empty or the group does not exist.
+   */
+  #getAccountGroup(
+    groupId: AccountGroupId | '',
+  ): AccountGroupObject | undefined {
+    if (!groupId) {
+      return undefined;
     }
+
+    return this.#messenger.call(
+      'AccountTreeController:getAccountGroupObject',
+      groupId,
+    );
+  }
+
+  /**
+   * Gets the currently selected account group ID.
+   *
+   * @returns The currently selected account group ID, or an empty string if
+   * there is no selected account group.
+   */
+  #getSelectedAccountGroupId(): AccountGroupId | '' {
+    return this.#messenger.call(
+      'AccountTreeController:getSelectedAccountGroup',
+    );
   }
 }

--- a/packages/snap-account-service/src/SnapAccountService.ts
+++ b/packages/snap-account-service/src/SnapAccountService.ts
@@ -388,7 +388,7 @@ export class SnapAccountService {
             `Forwarding selected accounts (from "${groupId}"): ${accounts.join(', ')}`,
           );
         } else {
-          log(`Cleearing selected accounts (from "${groupId}")`);
+          log(`Clearing selected accounts (from "${groupId}")`);
         }
 
         const snapKeyring = await this.getLegacySnapKeyring();

--- a/packages/snap-account-service/src/SnapAccountService.ts
+++ b/packages/snap-account-service/src/SnapAccountService.ts
@@ -255,7 +255,7 @@ export class SnapAccountService {
     if (groupId === this.#getSelectedAccountGroupId()) {
       this.#forwardSelectedAccounts(
         groupId,
-        [] /* Clearing accounts since the group is removed */,
+        [], // Clearing accounts since the group is removed
       );
     }
   }

--- a/packages/snap-account-service/src/SnapAccountService.ts
+++ b/packages/snap-account-service/src/SnapAccountService.ts
@@ -381,19 +381,24 @@ export class SnapAccountService {
       return;
     }
 
-    const forwardSelectedAccounts = async (): Promise<void> => {
-      if (accounts) {
-        if (accounts.length) {
-          log(
-            `Forwarding selected accounts (from "${groupId}"): ${accounts.join(', ')}`,
-          );
-        } else {
-          log(`Clearing selected accounts (from "${groupId}")`);
-        }
+    if (!accounts) {
+      log(
+        `Account group ("${groupId}") has no accounts, skipping forwarding selected accounts to Snap keyring.`,
+      );
+      return;
+    }
 
-        const snapKeyring = await this.getLegacySnapKeyring();
-        await snapKeyring.setSelectedAccounts(accounts);
+    const forwardSelectedAccounts = async (): Promise<void> => {
+      if (accounts.length) {
+        log(
+          `Forwarding selected accounts (from "${groupId}"): ${accounts.join(', ')}`,
+        );
+      } else {
+        log(`Clearing selected accounts (from "${groupId}")`);
       }
+
+      const snapKeyring = await this.getLegacySnapKeyring();
+      await snapKeyring.setSelectedAccounts(accounts);
     };
 
     // There is nothing we can do if forwarding fails. This will auto-recover on the next relevant event.

--- a/packages/snap-account-service/src/types.ts
+++ b/packages/snap-account-service/src/types.ts
@@ -25,6 +25,7 @@ import { AccountId } from '@metamask/keyring-utils';
  * narrow. See the note above.
  */
 export type AccountGroupObject = {
+  id: AccountGroupId;
   accounts: AccountId[];
 };
 
@@ -50,4 +51,28 @@ export type AccountTreeControllerGetSelectedAccountGroupAction = {
 export type AccountTreeControllerSelectedAccountGroupChangeEvent = {
   type: `AccountTreeController:selectedAccountGroupChange`;
   payload: [AccountGroupId | '', AccountGroupId | ''];
+};
+
+/**
+ * Mirror of `AccountTreeControllerAccountGroupCreatedEvent`.
+ */
+export type AccountTreeControllerAccountGroupCreatedEvent = {
+  type: `AccountTreeController:accountGroupCreated`;
+  payload: [AccountGroupObject];
+};
+
+/**
+ * Mirror of `AccountTreeControllerAccountGroupUpdatedEvent`.
+ */
+export type AccountTreeControllerAccountGroupUpdatedEvent = {
+  type: `AccountTreeController:accountGroupUpdated`;
+  payload: [AccountGroupObject];
+};
+
+/**
+ * Mirror of `AccountTreeControllerAccountGroupRemovedEvent`.
+ */
+export type AccountTreeControllerAccountGroupRemovedEvent = {
+  type: `AccountTreeController:accountGroupRemoved`;
+  payload: [AccountGroupId];
 };


### PR DESCRIPTION
## Explanation

Now handles all group updates in case groups gets created/updated or removed. We still filter those events with the currently selected account group before forwarding this to the Snaps.

## References

N/A

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how selected accounts are forwarded into the legacy Snap keyring by adding new AccountTreeController lifecycle event handlers; bugs here could desync Snap-selected accounts from the UI-selected group.
> 
> **Overview**
> Extends `SnapAccountService` to listen for `AccountTreeController:accountGroupCreated`, `:accountGroupUpdated`, and `:accountGroupRemoved` and update the legacy Snap keyring’s selected accounts when (and only when) the affected group is currently selected.
> 
> Refactors forwarding into `#forwardSelectedAccounts` with shared logging/error handling, adds helpers for fetching the selected group and group object, and updates mirrored types/tests/changelog to include group `id` and the new events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 866a677aa91329cc5bf3977e80365c3512a97f25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->