### PR TITLE
ci: Run changelog validation in a single job

### DIFF
--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -40,7 +40,6 @@ jobs:
           - lint:teams
           - messenger-action-types:check
           - readme-content:check
-          - changelog:validate
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v2
@@ -51,6 +50,39 @@ jobs:
         run: yarn "$SCRIPT"
         env:
           SCRIPT: ${{ matrix.script }}
+      - name: Require clean working directory
+        shell: bash
+        run: |
+          if ! git diff --exit-code; then
+            echo "Working tree dirty at end of job"
+            exit 1
+          fi
+
+  validate-changelogs:
+    name: Validate changelogs
+    runs-on: ubuntu-latest
+    needs: prepare
+    strategy:
+      matrix:
+        node-version: [24.x]
+    steps:
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v2
+        with:
+          is-high-risk-environment: false
+          node-version: ${{ matrix.node-version }}
+      - name: Validate changelogs
+        env:
+          CHILD_WORKSPACE_PACKAGE_NAMES: ${{ needs.prepare.outputs.child-workspace-package-names }}
+        run: |
+          EXIT_CODE=0
+          for package_name in $(echo "$CHILD_WORKSPACE_PACKAGE_NAMES" | jq --raw-output '.[]'); do
+            echo "Validating changelog for $package_name"
+            if ! yarn workspace "$package_name" run changelog:validate; then
+              EXIT_CODE=1
+            fi
+          done
+          exit "$EXIT_CODE"
       - name: Require clean working directory
         shell: bash
         run: |

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -58,21 +58,20 @@ jobs:
             exit 1
           fi
 
-  validate-changelog:
-    name: Validate changelog
+  validate-changelogs:
+    name: Validate changelogs
     runs-on: ubuntu-latest
     needs: prepare
     strategy:
       matrix:
         node-version: [24.x]
-        package-name: ${{ fromJson(needs.prepare.outputs.child-workspace-package-names) }}
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v2
         with:
           is-high-risk-environment: false
           node-version: ${{ matrix.node-version }}
-      - run: yarn workspace ${{ matrix.package-name }} changelog:validate
+      - run: yarn changelog:validate
       - name: Require clean working directory
         shell: bash
         run: |

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -40,6 +40,7 @@ jobs:
           - lint:teams
           - messenger-action-types:check
           - readme-content:check
+          - changelog:validate
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v2
@@ -50,28 +51,6 @@ jobs:
         run: yarn "$SCRIPT"
         env:
           SCRIPT: ${{ matrix.script }}
-      - name: Require clean working directory
-        shell: bash
-        run: |
-          if ! git diff --exit-code; then
-            echo "Working tree dirty at end of job"
-            exit 1
-          fi
-
-  validate-changelogs:
-    name: Validate changelogs
-    runs-on: ubuntu-latest
-    needs: prepare
-    strategy:
-      matrix:
-        node-version: [24.x]
-    steps:
-      - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v2
-        with:
-          is-high-risk-environment: false
-          node-version: ${{ matrix.node-version }}
-      - run: yarn changelog:validate
       - name: Require clean working directory
         shell: bash
         run: |


### PR DESCRIPTION
## Explanation

Instead of running 83 jobs for changelog validation, we can run it in a single job, which should not affect the total CI time much.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change; main risk is reduced parallelism and potential failures if the loop/jq parsing behaves differently than the previous matrix expansion.
> 
> **Overview**
> Reworks the `lint-build-test.yml` changelog validation to run in one `validate-changelogs` job instead of spawning a matrix job per workspace.
> 
> The new step reads the `child-workspace-package-names` JSON output and loops through each package, running `yarn workspace <pkg> changelog:validate` while aggregating failures into a single exit code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54f884dc0a220af75ad64dfa6a80931b32295b5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->