### PR TITLE
fix: for postquote payments payment token for MM Pay transaction should not be reset when accountOverride is changed

### DIFF
--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Derive fiat order source amount from on-chain transaction data (`order.txHash`) with fallback to `order.cryptoAmount` ([#8694](https://github.com/MetaMask/core/pull/8694))
 - Persist fiat order ID and provider code on `transaction.metamaskPay` before polling, so activity views can query order status after controller state cleanup ([#8694](https://github.com/MetaMask/core/pull/8694))
 
+### Fixed
+
+- For postquote payments payment token for MM Pay transaction should not be reset when accountOverride is changed ([#8787](https://github.com/MetaMask/core/pull/8787)).
+
 ## [22.3.1]
 
 ### Changed

--- a/packages/transaction-pay-controller/src/TransactionPayController.test.ts
+++ b/packages/transaction-pay-controller/src/TransactionPayController.test.ts
@@ -372,6 +372,49 @@ describe('TransactionPayController', () => {
       ).toBeDefined();
     });
 
+    it('does not clear paymentToken when accountOverride changes if isPostQuote is true', () => {
+      const controller = createController();
+      const accountOverride =
+        '0xdeadbeef00000000000000000000000000000002' as Hex;
+
+      controller.setTransactionConfig(TRANSACTION_ID_MOCK, (config) => {
+        config.isPostQuote = true;
+      });
+
+      controller.updatePaymentToken({
+        transactionId: TRANSACTION_ID_MOCK,
+        tokenAddress: TOKEN_ADDRESS_MOCK,
+        chainId: CHAIN_ID_MOCK,
+      });
+
+      const { updateTransactionData } = updatePaymentTokenMock.mock.calls[0][1];
+
+      updateTransactionData(TRANSACTION_ID_MOCK, (data) => {
+        data.paymentToken = {
+          address: TOKEN_ADDRESS_MOCK,
+          balanceFiat: '1',
+          balanceHuman: '1',
+          balanceRaw: '1',
+          balanceUsd: '1',
+          chainId: CHAIN_ID_MOCK,
+          decimals: 6,
+          symbol: 'USDC',
+        };
+      });
+
+      expect(
+        controller.state.transactionData[TRANSACTION_ID_MOCK].paymentToken,
+      ).toBeDefined();
+
+      controller.setTransactionConfig(TRANSACTION_ID_MOCK, (config) => {
+        config.accountOverride = accountOverride;
+      });
+
+      expect(
+        controller.state.transactionData[TRANSACTION_ID_MOCK].paymentToken,
+      ).toBeDefined();
+    });
+
     it('updates multiple config properties at once', () => {
       const controller = createController();
       const refundTo = '0xdeadbeef00000000000000000000000000000001' as Hex;

--- a/packages/transaction-pay-controller/src/TransactionPayController.ts
+++ b/packages/transaction-pay-controller/src/TransactionPayController.ts
@@ -144,7 +144,10 @@ export class TransactionPayController extends BaseController<
       transactionData.isHyperliquidSource = config.isHyperliquidSource;
       transactionData.refundTo = config.refundTo;
 
-      if (config.accountOverride !== previousAccountOverride) {
+      if (
+        !config.isPostQuote &&
+        config.accountOverride !== previousAccountOverride
+      ) {
         transactionData.paymentToken = undefined;
       }
     });


### PR DESCRIPTION
## Explanation

For postquote payments payment token for MM Pay transaction should not be reset when accountOverride is changed. This is ensure on UI token selection is not reset when account selection is changes.

## References

Related to https://consensyssoftware.atlassian.net/browse/CONF-1381

## Checklist

- [X] I've updated the test suite for new or updated code as appropriate
- [X] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [X] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [X] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small conditional change to when `paymentToken` is cleared, limited to post-quote flows and covered by a new unit test.
> 
> **Overview**
> Prevents `TransactionPayController.setTransactionConfig` from clearing `transactionData.paymentToken` when `accountOverride` changes in **post-quote** flows (`isPostQuote: true`), avoiding UI token selection resets.
> 
> Adds a regression test covering the new behavior, and documents the fix in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 681171979a5f694484b8d3cb884e75a41c0e51f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->