### PR TITLE
normalize assetIds for native assets

### DIFF
--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `buildNativeAssetsFromConstant` now normalizes each native asset ID via `normalizeAssetId`, ensuring ERC20 addresses are EIP-55 checksummed and consistent with IDs written by data sources ([#8789](https://github.com/MetaMask/core/pull/8789))
 - `RpcDataSource` no longer writes `{ amount: "NaN" }` entries into `assetsBalance` when state holds malformed native metadata ([#8781](https://github.com/MetaMask/core/pull/8781))
   - Existing native metadata in `assetsInfo` is now only reused when its `decimals` field is a finite, non-negative number (via a new `#hasValidDecimals` guard). Stale entries like `{ type: 'native', decimals: null, name: '', symbol: '' }` or `{ decimals: -1, ... }` are replaced with the chain-status stub (`{ type: 'native', symbol/name: chainStatus.nativeCurrency, decimals: 18 }`) so balance conversion has a usable `decimals` and consumers never see a negative `decimals` in `assetsInfo`.
   - `decimals: 0` is treated as valid; `name` and `symbol` are not required.

--- a/packages/assets-controller/src/utils/native-assets.test.ts
+++ b/packages/assets-controller/src/utils/native-assets.test.ts
@@ -5,6 +5,7 @@ import {
   buildNativeAssetsFromConstant,
   buildNativeAssetsFromApi,
 } from './native-assets';
+import { normalizeAssetId } from './normalizeAssetId';
 
 jest.mock('@metamask/controller-utils', () => ({
   ...jest.requireActual('@metamask/controller-utils'),
@@ -14,12 +15,12 @@ jest.mock('@metamask/controller-utils', () => ({
 const fetchWithErrorHandlingMock = jest.mocked(fetchWithErrorHandling);
 
 describe('buildNativeAssetsFromConstant', () => {
-  it('includes an entry for every value in SPOT_PRICES_SUPPORT_INFO', () => {
+  it('includes a normalized entry for every value in SPOT_PRICES_SUPPORT_INFO', () => {
     const result = buildNativeAssetsFromConstant();
     const supportInfoValues = Object.values(SPOT_PRICES_SUPPORT_INFO);
 
     for (const assetId of supportInfoValues) {
-      expect(Object.values(result)).toContain(assetId);
+      expect(Object.values(result)).toContain(normalizeAssetId(assetId));
     }
   });
 });

--- a/packages/assets-controller/src/utils/native-assets.ts
+++ b/packages/assets-controller/src/utils/native-assets.ts
@@ -3,6 +3,7 @@ import { fetchWithErrorHandling } from '@metamask/controller-utils';
 import { parseCaipAssetType } from '@metamask/utils';
 
 import type { Caip19AssetId, ChainId } from '../types';
+import { normalizeAssetId } from './normalizeAssetId';
 
 const CHAINID_NETWORK_URL = 'https://chainid.network/chains.json';
 
@@ -23,7 +24,7 @@ export function buildNativeAssetsFromConstant(): Record<
   const nativeAssetsMap: Record<ChainId, Caip19AssetId> = {};
   for (const nativeAssetId of Object.values(SPOT_PRICES_SUPPORT_INFO)) {
     const { chainId } = parseCaipAssetType(nativeAssetId);
-    nativeAssetsMap[chainId] = nativeAssetId;
+    nativeAssetsMap[chainId] = normalizeAssetId(nativeAssetId);
   }
   return nativeAssetsMap;
 }


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Normalizes native asset addresses.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [X] I've updated the test suite for new or updated code as appropriate
- [X] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [X] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [X] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the canonical native asset IDs produced by `buildNativeAssetsFromConstant`, which can affect cache/state keys and lookups if any consumers relied on the previous un-normalized IDs. Logic is small and test-covered, with normalization limited to EVM `erc20` CAIP-19 IDs.
> 
> **Overview**
> Native-asset seeding now normalizes each CAIP-19 native asset ID returned by `buildNativeAssetsFromConstant` using `normalizeAssetId`, aligning the seed map with IDs produced by other data sources (e.g., EIP-55 checksummed ERC-20 addresses).
> 
> Tests were updated to assert the normalized IDs, and the package changelog documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00b8711ae7ce1c7daa4459abde9ae7047d681550. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->