### PR TITLE
fix(corebackend): update HTTP headers

### DIFF
--- a/packages/core-backend/CHANGELOG.md
+++ b/packages/core-backend/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/controller-utils` from `^12.0.0` to `^12.1.0` ([#8774](https://github.com/MetaMask/core/pull/8774))
 - Bump `@metamask/profile-sync-controller` from `^28.0.2` to `^28.1.0` ([#8783](https://github.com/MetaMask/core/pull/8783))
 
+### Fixed
+
+- Update HTTP headers from `X-Client-Product`/`X-Client-Version` to `x-metamask-clientproduct`/`x-metamask-clientversion` ([#8798](https://github.com/MetaMask/core/pull/8798))
+- Remove default `clientVersion` value of `1.0.0`; the `x-metamask-clientversion` header is now only sent when `clientVersion` is explicitly provided ([#8798](https://github.com/MetaMask/core/pull/8798))
+
 ## [6.2.2]
 
 ### Changed

--- a/packages/core-backend/src/api/ApiPlatformClient.test.ts
+++ b/packages/core-backend/src/api/ApiPlatformClient.test.ts
@@ -91,7 +91,7 @@ describe('ApiPlatformClient', () => {
       expect(instance.tokens.queryClient).toBe(customQueryClient);
     });
 
-    it('uses default version when not provided', async () => {
+    it('omits clientversion header when not provided', async () => {
       const instance = new ApiPlatformClient({
         clientProduct: 'test-client',
         queryClient: new QueryClient({
@@ -108,8 +108,8 @@ describe('ApiPlatformClient', () => {
       expect(mockFetch).toHaveBeenCalledWith(
         expect.any(String),
         expect.objectContaining({
-          headers: expect.objectContaining({
-            'X-Client-Version': '1.0.0',
+          headers: expect.not.objectContaining({
+            'x-metamask-clientversion': expect.any(String),
           }),
         }),
       );
@@ -145,8 +145,8 @@ describe('ApiPlatformClient', () => {
           method: 'GET',
           headers: {
             'Content-Type': 'application/json',
-            'X-Client-Product': 'test-client',
-            'X-Client-Version': '1.0.0',
+            'x-metamask-clientproduct': 'test-client',
+            'x-metamask-clientversion': '1.0.0',
           },
         }),
       );

--- a/packages/core-backend/src/api/base-client.ts
+++ b/packages/core-backend/src/api/base-client.ts
@@ -40,7 +40,7 @@ export type InternalFetchOptions = {
 export class BaseApiClient {
   protected readonly clientProduct: string;
 
-  protected readonly clientVersion: string;
+  protected readonly clientVersion?: string;
 
   protected readonly getBearerToken?: () => Promise<string | undefined>;
 
@@ -71,7 +71,7 @@ export class BaseApiClient {
 
   constructor(options: ApiPlatformClientOptions) {
     this.clientProduct = options.clientProduct;
-    this.clientVersion = options.clientVersion ?? '1.0.0';
+    this.clientVersion = options.clientVersion;
     this.getBearerToken = options.getBearerToken;
 
     this.#queryClientInstance =
@@ -121,9 +121,12 @@ export class BaseApiClient {
 
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
-      'X-Client-Product': this.clientProduct,
-      'X-Client-Version': this.clientVersion,
+      'x-metamask-clientproduct': this.clientProduct,
     };
+
+    if (this.clientVersion) {
+      headers['x-metamask-clientversion'] = this.clientVersion;
+    }
 
     // Get bearer token using fetchQuery for automatic deduplication
     if (this.getBearerToken) {


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request header names and makes `clientVersion` optional, which could break backend compatibility or analytics if consumers/backends still expect the old headers or a default version.
> 
> **Overview**
> `BaseApiClient` now sends `x-metamask-clientproduct` and (optionally) `x-metamask-clientversion` instead of the previous `X-Client-Product`/`X-Client-Version` headers, and it no longer defaults `clientVersion` to `1.0.0`.
> 
> Tests and the `core-backend` changelog are updated to reflect the new header contract, including verifying the version header is *omitted* when `clientVersion` is not provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09cc23a5fcec2d62293a496491bc580c55148a4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->