### PR TITLE
fix: Rename gasless feature flag

### DIFF
--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add Polymarket deposit-wallet support to the Relay strategy for `predictWithdraw` transactions, routed via the `isPolymarketDepositWallet` flag on `TransactionConfig` ([#8754](https://github.com/MetaMask/core/pull/8754))
 
+### Changed
+
+- Rename Relay gasless execution feature flag from `gaslessEnabled` to `isGaslessEnabled` ([#8801](https://github.com/MetaMask/core/pull/8801))
+
 ## [22.4.0]
 
 ### Added

--- a/packages/transaction-pay-controller/src/utils/feature-flags.test.ts
+++ b/packages/transaction-pay-controller/src/utils/feature-flags.test.ts
@@ -464,14 +464,14 @@ describe('Feature Flags Utils', () => {
       expect(isRelayExecuteEnabled(messenger)).toBe(false);
     });
 
-    it('returns true when gaslessEnabled is true', () => {
+    it('returns true when isGaslessEnabled is true', () => {
       getRemoteFeatureFlagControllerStateMock.mockReturnValue({
         ...getDefaultRemoteFeatureFlagControllerState(),
         remoteFeatureFlags: {
           confirmations_pay: {
             payStrategies: {
               relay: {
-                gaslessEnabled: true,
+                isGaslessEnabled: true,
               },
             },
           },
@@ -481,14 +481,14 @@ describe('Feature Flags Utils', () => {
       expect(isRelayExecuteEnabled(messenger)).toBe(true);
     });
 
-    it('returns false when gaslessEnabled is false', () => {
+    it('returns false when isGaslessEnabled is false', () => {
       getRemoteFeatureFlagControllerStateMock.mockReturnValue({
         ...getDefaultRemoteFeatureFlagControllerState(),
         remoteFeatureFlags: {
           confirmations_pay: {
             payStrategies: {
               relay: {
-                gaslessEnabled: false,
+                isGaslessEnabled: false,
               },
             },
           },

--- a/packages/transaction-pay-controller/src/utils/feature-flags.ts
+++ b/packages/transaction-pay-controller/src/utils/feature-flags.ts
@@ -133,7 +133,7 @@ export type PayStrategiesConfigRaw = {
   across?: AcrossConfigRaw;
   relay?: {
     enabled?: boolean;
-    gaslessEnabled?: boolean;
+    isGaslessEnabled?: boolean;
     originGasOverhead?: string;
     pollingInterval?: number;
     pollingTimeout?: number;
@@ -496,7 +496,7 @@ export function isRelayExecuteEnabled(
     (state.remoteFeatureFlags?.confirmations_pay as
       | FeatureFlagsRaw
       | undefined) ?? {};
-  return featureFlags.payStrategies?.relay?.gaslessEnabled ?? false;
+  return featureFlags.payStrategies?.relay?.isGaslessEnabled ?? false;
 }
 
 /**


### PR DESCRIPTION
## What changed

- Renamed the Relay execute feature flag in `transaction-pay-controller` from `gaslessEnabled` to `isGaslessEnabled`.
- Updated feature flag tests to use the new key for both enabled and disabled cases.
- Added an Unreleased changelog entry referencing this PR.

## Why

This separates the new gasless toggle from the prior release flag so rollout can use one flag up to a given release and another flag starting with this release.

## Validation

- `yarn workspace @metamask/transaction-pay-controller run jest --no-coverage src/utils/feature-flags.test.ts`
- `yarn workspace @metamask/transaction-pay-controller run test`
- `yarn workspace @metamask/transaction-pay-controller run changelog:validate`
- `yarn build`
- `yarn lint`

Note: `yarn validate:changelog` is not defined at the repo root in this checkout, so I used the package changelog validation script.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a straightforward rename of a remote feature-flag key used to gate Relay `/execute` gasless behavior, with tests updated accordingly. Main risk is rollout/config mismatch if any clients or flag payloads still send `gaslessEnabled`.
> 
> **Overview**
> Renames the Relay gasless execution remote feature flag key from `gaslessEnabled` to `isGaslessEnabled` and updates `isRelayExecuteEnabled` (and its `PayStrategiesConfigRaw` typing) to read the new key.
> 
> Updates unit tests to assert the new flag name and adds an Unreleased changelog entry documenting the rename.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f79da17d07d13c59ffffeee75287af79721da2e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->