### PR TITLE
fix: Move gasless flag to extended pay config

### DIFF
--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Move the Relay gasless execution feature flag to `confirmations_pay_extended.payStrategies.relay.gaslessEnabled` ([#8801](https://github.com/MetaMask/core/pull/8801))
+- Move the Relay gasless execution feature flag to `confirmations_pay_extended.payStrategies.relay.gaslessEnabled` ([#8810](https://github.com/MetaMask/core/pull/8810))
 
 ## [22.4.0]
 

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Rename Relay gasless execution feature flag from `gaslessEnabled` to `isGaslessEnabled` ([#8801](https://github.com/MetaMask/core/pull/8801))
 - Move the Relay gasless execution feature flag to `confirmations_pay_extended.payStrategies.relay.gaslessEnabled` ([#8810](https://github.com/MetaMask/core/pull/8810))
 
 ## [22.4.0]

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Rename Relay gasless execution feature flag from `gaslessEnabled` to `isGaslessEnabled` ([#8801](https://github.com/MetaMask/core/pull/8801))
+- Move the Relay gasless execution feature flag to `confirmations_pay_extended.payStrategies.relay.gaslessEnabled` ([#8801](https://github.com/MetaMask/core/pull/8801))
 
 ## [22.4.0]
 

--- a/packages/transaction-pay-controller/src/utils/feature-flags.test.ts
+++ b/packages/transaction-pay-controller/src/utils/feature-flags.test.ts
@@ -464,14 +464,14 @@ describe('Feature Flags Utils', () => {
       expect(isRelayExecuteEnabled(messenger)).toBe(false);
     });
 
-    it('returns true when isGaslessEnabled is true', () => {
+    it('returns true when gaslessEnabled is true', () => {
       getRemoteFeatureFlagControllerStateMock.mockReturnValue({
         ...getDefaultRemoteFeatureFlagControllerState(),
         remoteFeatureFlags: {
-          confirmations_pay: {
+          confirmations_pay_extended: {
             payStrategies: {
               relay: {
-                isGaslessEnabled: true,
+                gaslessEnabled: true,
               },
             },
           },
@@ -481,14 +481,14 @@ describe('Feature Flags Utils', () => {
       expect(isRelayExecuteEnabled(messenger)).toBe(true);
     });
 
-    it('returns false when isGaslessEnabled is false', () => {
+    it('returns false when gaslessEnabled is false', () => {
       getRemoteFeatureFlagControllerStateMock.mockReturnValue({
         ...getDefaultRemoteFeatureFlagControllerState(),
         remoteFeatureFlags: {
-          confirmations_pay: {
+          confirmations_pay_extended: {
             payStrategies: {
               relay: {
-                isGaslessEnabled: false,
+                gaslessEnabled: false,
               },
             },
           },

--- a/packages/transaction-pay-controller/src/utils/feature-flags.ts
+++ b/packages/transaction-pay-controller/src/utils/feature-flags.ts
@@ -133,17 +133,10 @@ export type PayStrategiesConfigRaw = {
   across?: AcrossConfigRaw;
   relay?: {
     enabled?: boolean;
+    gaslessEnabled?: boolean;
     originGasOverhead?: string;
     pollingInterval?: number;
     pollingTimeout?: number;
-  };
-};
-
-type FeatureFlagsExtendedRaw = {
-  payStrategies?: {
-    relay?: {
-      gaslessEnabled?: boolean;
-    };
   };
 };
 
@@ -501,7 +494,7 @@ export function isRelayExecuteEnabled(
   const state = messenger.call('RemoteFeatureFlagController:getState');
   const featureFlags =
     (state.remoteFeatureFlags?.confirmations_pay_extended as
-      | FeatureFlagsExtendedRaw
+      | FeatureFlagsRaw
       | undefined) ?? {};
   return featureFlags.payStrategies?.relay?.gaslessEnabled ?? false;
 }

--- a/packages/transaction-pay-controller/src/utils/feature-flags.ts
+++ b/packages/transaction-pay-controller/src/utils/feature-flags.ts
@@ -143,11 +143,9 @@ export type PayStrategiesConfigRaw = {
 type FeatureFlagsExtendedRaw = {
   payStrategies?: {
     relay?: {
-      enabled?: boolean;
       gaslessEnabled?: boolean;
     };
   };
-  strategyOrder?: string[];
 };
 
 export type PayStrategiesConfig = {

--- a/packages/transaction-pay-controller/src/utils/feature-flags.ts
+++ b/packages/transaction-pay-controller/src/utils/feature-flags.ts
@@ -133,10 +133,17 @@ export type PayStrategiesConfigRaw = {
   across?: AcrossConfigRaw;
   relay?: {
     enabled?: boolean;
-    isGaslessEnabled?: boolean;
     originGasOverhead?: string;
     pollingInterval?: number;
     pollingTimeout?: number;
+  };
+};
+
+type FeatureFlagsExtendedRaw = {
+  payStrategies?: {
+    relay?: {
+      gaslessEnabled?: boolean;
+    };
   };
 };
 
@@ -493,10 +500,10 @@ export function isRelayExecuteEnabled(
 ): boolean {
   const state = messenger.call('RemoteFeatureFlagController:getState');
   const featureFlags =
-    (state.remoteFeatureFlags?.confirmations_pay as
-      | FeatureFlagsRaw
+    (state.remoteFeatureFlags?.confirmations_pay_extended as
+      | FeatureFlagsExtendedRaw
       | undefined) ?? {};
-  return featureFlags.payStrategies?.relay?.isGaslessEnabled ?? false;
+  return featureFlags.payStrategies?.relay?.gaslessEnabled ?? false;
 }
 
 /**

--- a/packages/transaction-pay-controller/src/utils/feature-flags.ts
+++ b/packages/transaction-pay-controller/src/utils/feature-flags.ts
@@ -133,7 +133,6 @@ export type PayStrategiesConfigRaw = {
   across?: AcrossConfigRaw;
   relay?: {
     enabled?: boolean;
-    isGaslessEnabled?: boolean;
     originGasOverhead?: string;
     pollingInterval?: number;
     pollingTimeout?: number;

--- a/packages/transaction-pay-controller/src/utils/feature-flags.ts
+++ b/packages/transaction-pay-controller/src/utils/feature-flags.ts
@@ -133,11 +133,21 @@ export type PayStrategiesConfigRaw = {
   across?: AcrossConfigRaw;
   relay?: {
     enabled?: boolean;
-    gaslessEnabled?: boolean;
+    isGaslessEnabled?: boolean;
     originGasOverhead?: string;
     pollingInterval?: number;
     pollingTimeout?: number;
   };
+};
+
+type FeatureFlagsExtendedRaw = {
+  payStrategies?: {
+    relay?: {
+      enabled?: boolean;
+      gaslessEnabled?: boolean;
+    };
+  };
+  strategyOrder?: string[];
 };
 
 export type PayStrategiesConfig = {
@@ -494,7 +504,7 @@ export function isRelayExecuteEnabled(
   const state = messenger.call('RemoteFeatureFlagController:getState');
   const featureFlags =
     (state.remoteFeatureFlags?.confirmations_pay_extended as
-      | FeatureFlagsRaw
+      | FeatureFlagsExtendedRaw
       | undefined) ?? {};
   return featureFlags.payStrategies?.relay?.gaslessEnabled ?? false;
 }


### PR DESCRIPTION
## What changed

- Moved the Relay execute toggle to `confirmations_pay_extended.payStrategies.relay.gaslessEnabled`.
- Renamed the flag back to `gaslessEnabled` and removed transaction-pay-controller source/test references to `isGaslessEnabled`.
- Updated feature flag tests for the new remote flag namespace.
- Updated the transaction-pay-controller changelog entry to reference this PR.

## Why

This keeps `confirmations_pay` available for the existing release-scoped flag while allowing the new release behavior to be controlled from `confirmations_pay_extended`.

## Validation

- `yarn workspace @metamask/transaction-pay-controller run jest --no-coverage src/utils/feature-flags.test.ts`
- `yarn workspace @metamask/transaction-pay-controller run test`
- `yarn workspace @metamask/transaction-pay-controller run changelog:validate`
- `yarn build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the remote feature-flag lookup path/name that gates the Relay `/execute` gasless flow; misconfiguration could unintentionally enable/disable gasless execution.
> 
> **Overview**
> Updates the Relay gasless execute toggle to read from `remoteFeatureFlags.confirmations_pay_extended.payStrategies.relay.gaslessEnabled` (renaming from `isGaslessEnabled` and removing the old `confirmations_pay` location).
> 
> Adjusts `isRelayExecuteEnabled` unit tests to match the new namespace/key, and updates the changelog to document the flag move.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b57908519602e11dec32f1bc0c3f8cc6fac7908. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->