### PR TITLE
fix non-evm token type detection

### DIFF
--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/transaction-controller` from `^65.3.0` to `^65.4.0` ([#8796](https://github.com/MetaMask/core/pull/8796))
 
+### Fixed
+
+- Non-EVM assets with a `slip44` asset namespace (e.g. Bitcoin, Solana native, TRON) are now correctly typed as `native` instead of `erc20` in `assetsInfo` ([#8811](https://github.com/MetaMask/core/pull/8811))
+- Solana SPL tokens (CAIP-19 `solana:.../token:<address>`) are now correctly typed as `spl` instead of `erc20` in `assetsInfo` ([#8811](https://github.com/MetaMask/core/pull/8811))
+
 ## [7.1.2]
 
 ### Changed

--- a/packages/assets-controller/src/AssetsController.ts
+++ b/packages/assets-controller/src/AssetsController.ts
@@ -57,6 +57,7 @@ import type { Hex } from '@metamask/utils';
 import {
   isCaipChainId,
   isStrictHexString,
+  KnownCaipNamespace,
   parseCaipAssetType,
   parseCaipChainId,
 } from '@metamask/utils';
@@ -82,7 +83,10 @@ import type { AccountsControllerAccountBalancesUpdatedEvent } from './data-sourc
 import { SnapDataSource } from './data-sources/SnapDataSource';
 import type { StakedBalanceDataSourceConfig } from './data-sources/StakedBalanceDataSource';
 import { StakedBalanceDataSource } from './data-sources/StakedBalanceDataSource';
-import { TokenDataSource } from './data-sources/TokenDataSource';
+import {
+  CaipAssetNamespace,
+  TokenDataSource,
+} from './data-sources/TokenDataSource';
 import {
   CHAINS_WITH_DEFAULT_TRACKED_ASSETS,
   DEFAULT_TRACKED_ASSETS_BY_CHAIN,
@@ -1663,7 +1667,10 @@ export class AssetsController extends BaseController<
         let tokenType: FungibleAssetMetadata['type'] = 'erc20';
         if (this.#isNativeAsset(normalizedAssetId)) {
           tokenType = 'native';
-        } else if (parsed.assetNamespace === 'spl') {
+        } else if (
+          parsed.chain.namespace === KnownCaipNamespace.Solana &&
+          parsed.assetNamespace === CaipAssetNamespace.Token
+        ) {
           tokenType = 'spl';
         }
 

--- a/packages/assets-controller/src/README.md
+++ b/packages/assets-controller/src/README.md
@@ -653,7 +653,7 @@ type Caip19AssetId = string;
 // - Native ETH: "eip155:1/slip44:60"
 // - USDC on Ethereum: "eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
 // - SOL: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501"
-// - SPL Token: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/spl:EPjFWdd5..."
+// - SPL Token: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5..."
 
 // CAIP-2 chain identifier
 type ChainId = string;

--- a/packages/assets-controller/src/data-sources/TokenDataSource.test.ts
+++ b/packages/assets-controller/src/data-sources/TokenDataSource.test.ts
@@ -20,8 +20,13 @@ const MOCK_ADDRESS = '0x1234567890123456789012345678901234567890';
 const MOCK_TOKEN_ASSET =
   'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as Caip19AssetId;
 const MOCK_NATIVE_ASSET = 'eip155:1/slip44:60' as Caip19AssetId;
+const MOCK_BTC_ASSET =
+  'bip122:000000000019d6689c085ae165831e93/slip44:0' as Caip19AssetId;
+const MOCK_SOL_NATIVE_ASSET =
+  'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501' as Caip19AssetId;
+const MOCK_TRX_ASSET = 'tron:728126428/slip44:195' as Caip19AssetId;
 const MOCK_SPL_ASSET =
-  'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/spl:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v' as Caip19AssetId;
+  'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v' as Caip19AssetId;
 
 type MockApiClient = {
   tokens: {
@@ -515,6 +520,57 @@ describe('TokenDataSource', () => {
 
     expect(context.response.assetsInfo?.[MOCK_SPL_ASSET]?.type).toBe('spl');
   });
+
+  it.each([
+    {
+      label: 'Bitcoin (bip122/slip44)',
+      assetId: MOCK_BTC_ASSET,
+      chainId: 'bip122:000000000019d6689c085ae165831e93',
+      name: 'Bitcoin',
+      symbol: 'BTC',
+      decimals: 8,
+    },
+    {
+      label: 'SOL native (solana/slip44)',
+      assetId: MOCK_SOL_NATIVE_ASSET,
+      chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+      name: 'Solana',
+      symbol: 'SOL',
+      decimals: 9,
+    },
+    {
+      label: 'TRX native (tron/slip44)',
+      assetId: MOCK_TRX_ASSET,
+      chainId: 'tron:728126428',
+      name: 'TRON',
+      symbol: 'TRX',
+      decimals: 6,
+    },
+  ])(
+    'middleware types non-EVM slip44 asset as native: $label',
+    async ({ assetId, chainId, name, symbol, decimals }) => {
+      const { controller } = setupController({
+        messenger: createTestMessenger(),
+        supportedNetworks: [chainId],
+        assetsResponse: [
+          createMockAssetResponse(assetId, { name, symbol, decimals }),
+        ],
+      });
+
+      const next = jest.fn().mockResolvedValue(undefined);
+      const context = createMiddlewareContext({
+        response: {
+          detectedAssets: {
+            'mock-account-id': [assetId],
+          },
+        },
+      });
+
+      await controller.assetsMiddleware(context, next);
+
+      expect(context.response.assetsInfo?.[assetId]?.type).toBe('native');
+    },
+  );
 
   it('middleware merges metadata into existing response', async () => {
     const anotherAsset =

--- a/packages/assets-controller/src/data-sources/TokenDataSource.ts
+++ b/packages/assets-controller/src/data-sources/TokenDataSource.ts
@@ -45,7 +45,7 @@ const BULK_SCAN_BATCH_SIZE = 100;
 const MIN_TOKEN_OCCURRENCES = 3;
 
 /** CAIP-19 `assetNamespace` segments used across filtering logic. */
-enum CaipAssetNamespace {
+export enum CaipAssetNamespace {
   Slip44 = 'slip44',
   Erc20 = 'erc20',
   Token = 'token',
@@ -102,11 +102,18 @@ function transformV3AssetResponseToMetadata(
   const parsed = parseCaipAssetType(assetId);
   let tokenType: 'native' | 'erc20' | 'spl' = 'erc20';
 
-  if (nativeAssetIds.has(assetId.toLowerCase())) {
+  if (
+    nativeAssetIds.has(assetId.toLowerCase()) ||
+    parsed.assetNamespace === CaipAssetNamespace.Slip44
+  ) {
     tokenType = 'native';
-  } else if (parsed.assetNamespace === 'spl') {
+  } else if (
+    parsed.chain.namespace === KnownCaipNamespace.Solana &&
+    parsed.assetNamespace === CaipAssetNamespace.Token
+  ) {
     tokenType = 'spl';
   }
+  // TODO: Add support for Tron trc20 standard
 
   const metadata: FungibleAssetMetadata = {
     // Type derived from assetId

--- a/packages/assets-controller/src/types.ts
+++ b/packages/assets-controller/src/types.ts
@@ -9,7 +9,7 @@ import type { CaipAssetType, CaipChainId, Json } from '@metamask/utils';
  * - Native: "eip155:1/slip44:60" (ETH)
  * - ERC20: "eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" (USDC)
  * - ERC721: "eip155:1/erc721:0xBC4CA0EdA7647A8aB7C2061c2E118A18a936f13D/1234" (BAYC #1234)
- * - SPL: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/spl:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+ * - SPL: "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
  */
 export type Caip19AssetId = CaipAssetType;
 

--- a/packages/bridge-controller/src/selectors.test.ts
+++ b/packages/bridge-controller/src/selectors.test.ts
@@ -39,7 +39,7 @@ describe('Bridge Selectors', () => {
           exchangeRate: '2.5',
           usdExchangeRate: '1.5',
         },
-        'solana:101/spl:456': {
+        'solana:101/token:456': {
           exchangeRate: '3.0',
         },
       },

--- a/packages/bridge-controller/src/selectors.test.ts
+++ b/packages/bridge-controller/src/selectors.test.ts
@@ -39,7 +39,7 @@ describe('Bridge Selectors', () => {
           exchangeRate: '2.5',
           usdExchangeRate: '1.5',
         },
-        'solana:101/token:456': {
+        'solana:101/spl:456': {
           exchangeRate: '3.0',
         },
       },


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Currently, all non-evm tokens are being stored as 'erc20', which is wrong. It is not causing any issues in the client, but needs to be corrected.

This fixes it.

<img width="735" height="427" alt="image" src="https://github.com/user-attachments/assets/bfb7b917-fec4-4689-81cb-29315de2be5e" />


## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts asset-type classification logic used to populate `assetsInfo`, which could affect downstream rendering/formatting for non-EVM assets if CAIP-19 parsing assumptions are wrong, but scope is limited and covered by updated unit tests.
> 
> **Overview**
> Fixes incorrect `assetsInfo.type` classification for non-EVM assets by treating any CAIP-19 `*/slip44:*` identifier as `native` (not `erc20`), and by recognizing Solana SPL tokens as `spl` when the chain namespace is Solana and the asset namespace is `token`.
> 
> Updates both the token-metadata transform (`TokenDataSource`) and the `addCustomAsset` pending-metadata path (`AssetsController`) to use the same namespace-aware rules, exports the shared `CaipAssetNamespace` enum, and refreshes docs/tests (including switching examples/fixtures from `solana:.../spl:` to `solana:.../token:`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe92f4bb32439400c23a5edb86000320ff2f47fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->