### PR TITLE
chore: Add missing decsriptions for profile metrics controller package

### DIFF
--- a/packages/profile-metrics-controller/README.md
+++ b/packages/profile-metrics-controller/README.md
@@ -1,5 +1,7 @@
 # `@metamask/profile-metrics-controller`
 
+Manages user profile metrics. For users who opt-in to metrics, this controller and service will ensure we have metrics about their user profile (metrics ID and accounts).
+
 ## Installation
 
 `yarn add @metamask/profile-metrics-controller`

--- a/packages/profile-metrics-controller/package.json
+++ b/packages/profile-metrics-controller/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@metamask/profile-metrics-controller",
   "version": "3.1.4",
-  "description": "Sample package to illustrate best practices for controllers",
+  "description": "Manages user profile metrics",
   "keywords": [
     "Ethereum",
     "MetaMask"

--- a/packages/profile-metrics-controller/src/ProfileMetricsController.ts
+++ b/packages/profile-metrics-controller/src/ProfileMetricsController.ts
@@ -159,6 +159,12 @@ export type ProfileMetricsControllerMessenger = Messenger<
   ProfileMetricsControllerEvents | AllowedEvents
 >;
 
+/**
+ * Manages user profile metrics.
+ *
+ * For users who opt-in to metrics, this controller ensures we have metrics about their user
+ * profile (metrics ID and accounts).
+ */
 export class ProfileMetricsController extends StaticIntervalPollingController()<
   typeof controllerName,
   ProfileMetricsControllerState,

--- a/packages/profile-metrics-controller/src/ProfileMetricsService.ts
+++ b/packages/profile-metrics-controller/src/ProfileMetricsService.ts
@@ -73,6 +73,9 @@ export type ProfileMetricsServiceMessenger = Messenger<
 
 // === SERVICE DEFINITION ===
 
+/**
+ * A service for submitting user profile metrics (metrics ID and accounts).
+ */
 export class ProfileMetricsService {
   /**
    * The name of the service.


### PR DESCRIPTION
## Explanation

The manifest for `profile-metrics-controller` had an invalid description leftover from the example package, and decsriptions were also missing from the inline docs and README. A minimal description has been added in all of these places.

## References

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/metadata-only updates with no runtime behavior changes.
> 
> **Overview**
> Adds a short functional description of `@metamask/profile-metrics-controller` to the README, replaces the placeholder `package.json` description, and introduces missing JSDoc summaries on `ProfileMetricsController` and `ProfileMetricsService`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1dbee8a55e3a61515b7e5091658d6b212fe6d09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->