### PR TITLE
feat(analytics-controller): add optional context parameter for track, identify, view

### DIFF
--- a/packages/analytics-controller/CHANGELOG.md
+++ b/packages/analytics-controller/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add optional analytics context on `trackEvent`, `identify`, and `trackView` to forward platform-specific context to `AnalyticsPlatformAdapter` implementations ([#8835](https://github.com/MetaMask/core/pull/8835))
 - Optional `skipUUIDv4Check` on `AnalyticsPlatformAdapter` to allow non-UUIDv4 `analyticsId` strings when constructing `AnalyticsController` ([#8543](https://github.com/MetaMask/core/pull/8543))
 
 ### Changed

--- a/packages/analytics-controller/src/AnalyticsController-method-action-types.ts
+++ b/packages/analytics-controller/src/AnalyticsController-method-action-types.ts
@@ -11,6 +11,7 @@ import type { AnalyticsController } from './AnalyticsController';
  * Events are only tracked if analytics is enabled.
  *
  * @param event - Analytics event with properties and sensitive properties
+ * @param context - Optional platform-specific context forwarded to the platform adapter.
  */
 export type AnalyticsControllerTrackEventAction = {
   type: `AnalyticsController:trackEvent`;
@@ -21,6 +22,7 @@ export type AnalyticsControllerTrackEventAction = {
  * Identify a user for analytics.
  *
  * @param traits - User traits/properties
+ * @param context - Optional platform-specific context forwarded to the platform adapter.
  */
 export type AnalyticsControllerIdentifyAction = {
   type: `AnalyticsController:identify`;
@@ -32,6 +34,7 @@ export type AnalyticsControllerIdentifyAction = {
  *
  * @param name - The identifier/name of the page or screen being viewed (e.g., "home", "settings", "wallet")
  * @param properties - Optional properties associated with the view
+ * @param context - Optional platform-specific context forwarded to the platform adapter.
  */
 export type AnalyticsControllerTrackViewAction = {
   type: `AnalyticsController:trackView`;

--- a/packages/analytics-controller/src/AnalyticsController.test.ts
+++ b/packages/analytics-controller/src/AnalyticsController.test.ts
@@ -15,6 +15,7 @@ import type {
   AnalyticsPlatformAdapter,
   AnalyticsTrackingEvent,
   AnalyticsControllerState,
+  AnalyticsContext,
 } from '.';
 import { isValidUUIDv4 } from './analyticsControllerStateValidator';
 
@@ -692,6 +693,54 @@ describe('AnalyticsController', () => {
       });
     });
 
+    it('forwards context to the platform adapter', async () => {
+      const mockAdapter = createMockAdapter();
+      const { controller } = await setupController({
+        state: {
+          optedIn: true,
+          analyticsId: '77777777-7777-4777-b777-777777777777',
+        },
+        platformAdapter: mockAdapter,
+      });
+
+      const event = createTestEvent('test_event', { prop: 'value' });
+      const context: AnalyticsContext = {
+        page: { title: 'Unit test' },
+      };
+
+      controller.trackEvent(event, context);
+
+      expect(mockAdapter.track).toHaveBeenCalledWith(
+        'test_event',
+        { prop: 'value' },
+        context,
+      );
+    });
+
+    it('forwards context when tracking an event without properties', async () => {
+      const mockAdapter = createMockAdapter();
+      const { controller } = await setupController({
+        state: {
+          optedIn: true,
+          analyticsId: '77777777-7777-4777-9777-777777777777',
+        },
+        platformAdapter: mockAdapter,
+      });
+
+      const event = createTestEvent('test_event', {}, {}, true);
+      const context: AnalyticsContext = {
+        page: { path: '/background-process' },
+      };
+
+      controller.trackEvent(event, context);
+
+      expect(mockAdapter.track).toHaveBeenCalledWith(
+        'test_event',
+        undefined,
+        context,
+      );
+    });
+
     it('tracks event without properties when event has no properties', async () => {
       const mockAdapter = createMockAdapter();
       const { controller } = await setupController({
@@ -805,6 +854,47 @@ describe('AnalyticsController', () => {
         });
       });
 
+      it('forwards context to both events when splitting sensitive events', async () => {
+        const mockAdapter = createMockAdapter();
+        const { controller } = await setupController({
+          state: {
+            optedIn: true,
+            analyticsId: '11111111-1111-4111-9111-111111111111',
+          },
+          platformAdapter: mockAdapter,
+          isAnonymousEventsFeatureEnabled: true,
+        });
+
+        const event = createTestEvent(
+          'test_event',
+          { prop: 'value' },
+          { sensitive_prop: 'sensitive value' },
+        );
+        const context: AnalyticsContext = {
+          app: { name: 'MetaMask' },
+        };
+
+        controller.trackEvent(event, context);
+
+        expect(mockAdapter.track).toHaveBeenCalledTimes(2);
+        expect(mockAdapter.track).toHaveBeenNthCalledWith(
+          1,
+          'test_event',
+          { prop: 'value' },
+          context,
+        );
+        expect(mockAdapter.track).toHaveBeenNthCalledWith(
+          2,
+          'test_event',
+          {
+            prop: 'value',
+            sensitive_prop: 'sensitive value',
+            anonymous: true,
+          },
+          context,
+        );
+      });
+
       it('tracks regular properties first, then combined event when only sensitive properties are present', async () => {
         const mockAdapter = createMockAdapter();
         const { controller } = await setupController({
@@ -912,6 +1002,31 @@ describe('AnalyticsController', () => {
       expect(mockAdapter.identify).toHaveBeenCalledWith(analyticsId, undefined);
     });
 
+    it('forwards context to the platform adapter', async () => {
+      const mockAdapter = createMockAdapter();
+      const analyticsId = 'dddddddd-dddd-4ddd-9ddd-dddddddddddd';
+      const { controller } = await setupController({
+        state: {
+          analyticsId,
+          optedIn: true,
+        },
+        platformAdapter: mockAdapter,
+      });
+
+      const traits = { PLAN: 'pro' };
+      const context: AnalyticsContext = {
+        locale: 'en',
+      };
+
+      controller.identify(traits, context);
+
+      expect(mockAdapter.identify).toHaveBeenCalledWith(
+        analyticsId,
+        traits,
+        context,
+      );
+    });
+
     it('does not identify when disabled', async () => {
       const mockAdapter = createMockAdapter();
       const { controller } = await setupController({
@@ -949,6 +1064,29 @@ describe('AnalyticsController', () => {
       expect(mockAdapter.view).toHaveBeenCalledWith('home', {
         referrer: 'test',
       });
+    });
+
+    it('forwards context to the platform adapter', async () => {
+      const mockAdapter = createMockAdapter();
+      const { controller } = await setupController({
+        state: {
+          optedIn: true,
+          analyticsId: 'ffffffff-ffff-4fff-afff-ffffffffffff',
+        },
+        platformAdapter: mockAdapter,
+      });
+
+      const context: AnalyticsContext = {
+        page: { title: 'Settings' },
+      };
+
+      controller.trackView('settings', { section: 'security' }, context);
+
+      expect(mockAdapter.view).toHaveBeenCalledWith(
+        'settings',
+        { section: 'security' },
+        context,
+      );
     });
 
     it('does not call platform adapter when disabled', async () => {

--- a/packages/analytics-controller/src/AnalyticsController.ts
+++ b/packages/analytics-controller/src/AnalyticsController.ts
@@ -11,6 +11,7 @@ import { validateAnalyticsControllerState } from './analyticsControllerStateVali
 import { projectLogger as log } from './AnalyticsLogger';
 import type {
   AnalyticsPlatformAdapter,
+  AnalyticsContext,
   AnalyticsEventProperties,
   AnalyticsUserTraits,
   AnalyticsTrackingEvent,
@@ -273,8 +274,9 @@ export class AnalyticsController extends BaseController<
    * Events are only tracked if analytics is enabled.
    *
    * @param event - Analytics event with properties and sensitive properties
+   * @param context - Optional platform-specific context forwarded to the platform adapter.
    */
-  trackEvent(event: AnalyticsTrackingEvent): void {
+  trackEvent(event: AnalyticsTrackingEvent, context?: AnalyticsContext): void {
     // Don't track if analytics is disabled
     if (!analyticsControllerSelectors.selectEnabled(this.state)) {
       return;
@@ -283,7 +285,11 @@ export class AnalyticsController extends BaseController<
     // if event does not have properties, send event without properties
     // and return to prevent any additional processing
     if (!event.hasProperties) {
-      this.#platformAdapter.track(event.name);
+      if (context) {
+        this.#platformAdapter.track(event.name, undefined, context);
+      } else {
+        this.#platformAdapter.track(event.name);
+      }
       return;
     }
 
@@ -291,20 +297,30 @@ export class AnalyticsController extends BaseController<
     if (this.#isAnonymousEventsFeatureEnabled) {
       // Note: Even if regular properties object is empty, we still send it to ensure
       // an event with user ID is tracked.
-      this.#platformAdapter.track(event.name, {
+      const properties = {
         ...event.properties,
-      });
+      };
+      if (context) {
+        this.#platformAdapter.track(event.name, properties, context);
+      } else {
+        this.#platformAdapter.track(event.name, properties);
+      }
     }
 
     const hasSensitiveProperties =
       Object.keys(event.sensitiveProperties).length > 0;
 
     if (!this.#isAnonymousEventsFeatureEnabled || hasSensitiveProperties) {
-      this.#platformAdapter.track(event.name, {
+      const properties = {
         ...event.properties,
         ...event.sensitiveProperties,
         ...(hasSensitiveProperties && { anonymous: true }),
-      });
+      };
+      if (context) {
+        this.#platformAdapter.track(event.name, properties, context);
+      } else {
+        this.#platformAdapter.track(event.name, properties);
+      }
     }
   }
 
@@ -312,14 +328,19 @@ export class AnalyticsController extends BaseController<
    * Identify a user for analytics.
    *
    * @param traits - User traits/properties
+   * @param context - Optional platform-specific context forwarded to the platform adapter.
    */
-  identify(traits?: AnalyticsUserTraits): void {
+  identify(traits?: AnalyticsUserTraits, context?: AnalyticsContext): void {
     if (!analyticsControllerSelectors.selectEnabled(this.state)) {
       return;
     }
 
     // Delegate to platform adapter using the current analytics ID
-    this.#platformAdapter.identify(this.state.analyticsId, traits);
+    if (context) {
+      this.#platformAdapter.identify(this.state.analyticsId, traits, context);
+    } else {
+      this.#platformAdapter.identify(this.state.analyticsId, traits);
+    }
   }
 
   /**
@@ -327,14 +348,23 @@ export class AnalyticsController extends BaseController<
    *
    * @param name - The identifier/name of the page or screen being viewed (e.g., "home", "settings", "wallet")
    * @param properties - Optional properties associated with the view
+   * @param context - Optional platform-specific context forwarded to the platform adapter.
    */
-  trackView(name: string, properties?: AnalyticsEventProperties): void {
+  trackView(
+    name: string,
+    properties?: AnalyticsEventProperties,
+    context?: AnalyticsContext,
+  ): void {
     if (!analyticsControllerSelectors.selectEnabled(this.state)) {
       return;
     }
 
     // Delegate to platform adapter
-    this.#platformAdapter.view(name, properties);
+    if (context) {
+      this.#platformAdapter.view(name, properties, context);
+    } else {
+      this.#platformAdapter.view(name, properties);
+    }
   }
 
   /**

--- a/packages/analytics-controller/src/AnalyticsPlatformAdapter.types.ts
+++ b/packages/analytics-controller/src/AnalyticsPlatformAdapter.types.ts
@@ -29,6 +29,11 @@ export type AnalyticsTrackingEvent = {
 };
 
 /**
+ * Optional analytics context payload (for example Segment-style context).
+ */
+export type AnalyticsContext = Record<string, Json>;
+
+/**
  * Platform adapter interface for analytics tracking
  * Implementations should handle platform-specific details (Segment SDK, etc.)
  */
@@ -47,16 +52,26 @@ export type AnalyticsPlatformAdapter = {
    * @param eventName - The name of the event
    * @param properties - Event properties. If not provided, the event has no properties.
    * The privacy plugin should check for `isSensitive === true` to determine if an event contains sensitive data.
+   * @param context - Optional platform-specific context attached to the invocation.
    */
-  track(eventName: string, properties?: AnalyticsEventProperties): void;
+  track(
+    eventName: string,
+    properties?: AnalyticsEventProperties,
+    context?: AnalyticsContext,
+  ): void;
 
   /**
    * Identify a user with traits.
    *
    * @param userId - The user identifier (e.g., metametrics ID)
    * @param traits - User traits/properties
+   * @param context - Optional platform-specific context attached to the invocation.
    */
-  identify(userId: string, traits?: AnalyticsUserTraits): void;
+  identify(
+    userId: string,
+    traits?: AnalyticsUserTraits,
+    context?: AnalyticsContext,
+  ): void;
 
   /**
    * Track a UI unit (page or screen) view depending on the platform
@@ -67,8 +82,13 @@ export type AnalyticsPlatformAdapter = {
    *
    * @param name - The identifier/name of the page or screen being viewed (e.g., "home", "settings", "wallet")
    * @param properties - Optional properties associated with the view
+   * @param context - Optional platform-specific context attached to the invocation.
    */
-  view(name: string, properties?: AnalyticsEventProperties): void;
+  view(
+    name: string,
+    properties?: AnalyticsEventProperties,
+    context?: AnalyticsContext,
+  ): void;
 
   /**
    * Lifecycle hook called after the AnalyticsController is fully initialized.

--- a/packages/analytics-controller/src/index.ts
+++ b/packages/analytics-controller/src/index.ts
@@ -10,6 +10,7 @@ export { AnalyticsPlatformAdapterSetupError } from './AnalyticsPlatformAdapterSe
 
 // Export types
 export type {
+  AnalyticsContext,
   AnalyticsEventProperties,
   AnalyticsUserTraits,
   AnalyticsPlatformAdapter,


### PR DESCRIPTION
## Explanation

Add the possibility to forward context to AnalyticsController for trackEvent, identify, and trackView functions, as this is needed in Extension.

## Validation

- `yarn workspace @metamask/analytics-controller run jest --no-coverage packages/analytics-controller/src/AnalyticsController.test.ts`
- `yarn workspace @metamask/analytics-controller run messenger-action-types:check`
- `yarn workspace @metamask/analytics-controller run changelog:validate`
- `yarn workspace @metamask/analytics-controller run build`
- `yarn eslint packages/analytics-controller/src/AnalyticsController.ts packages/analytics-controller/src/AnalyticsController.test.ts packages/analytics-controller/src/AnalyticsPlatformAdapter.types.ts packages/analytics-controller/src/AnalyticsController-method-action-types.ts packages/analytics-controller/src/index.ts`

## References

Replaces #8701 which is no longer needed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an optional `context` payload and forwards it to adapters without changing existing behavior when omitted; main risk is downstream TypeScript/interface compatibility for `AnalyticsPlatformAdapter` implementations.
> 
> **Overview**
> Adds an optional `AnalyticsContext` parameter to `AnalyticsController` methods `trackEvent`, `identify`, and `trackView`, and forwards it through to the underlying `AnalyticsPlatformAdapter` (`track`/`identify`/`view`).
> 
> Updates the adapter type definitions and public exports to include `AnalyticsContext`, and extends unit tests plus changelog to cover context forwarding (including event-splitting behavior and events without properties).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3dcf3e664535aac75275a7ecb5f9e9cc91bf759. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->