### PR TITLE
fix/mantle lack operator fee

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/accounts-controller` from `^38.1.1` to `^38.1.2` ([#8912](https://github.com/MetaMask/core/pull/8912))
 - Bump `@metamask/core-backend` from `^6.3.0` to `^6.3.1` ([#8912](https://github.com/MetaMask/core/pull/8912))
 
+### Fixed
+
+- Include Mantle operator fee in the displayed L1 gas estimate when simulated `gasUsed` is unavailable, by falling back to the transaction's gas limit ([#8837](https://github.com/MetaMask/core/pull/8837))
+  - Adds a `protected getOperatorFeeGas` hook on `OracleLayer1GasFeeFlow` that subclasses can override to supply a fallback value. The default behaviour is unchanged (returns `transactionMeta.gasUsed`).
+  - `MantleLayer1GasFeeFlow` overrides the hook with `gasUsed ?? txParams.gas ?? txParams.gasLimit`, so the operator-fee oracle is called with the gas limit when `gasUsed` is missing. Gas limit is an upper bound on actual gas used, so the operator fee is over-estimated rather than under-reported.
+
 ## [66.0.0]
 
 ### Changed

--- a/packages/transaction-controller/src/gas-flows/MantleLayer1GasFeeFlow.test.ts
+++ b/packages/transaction-controller/src/gas-flows/MantleLayer1GasFeeFlow.test.ts
@@ -180,7 +180,85 @@ describe('MantleLayer1GasFeeFlow', () => {
       });
     });
 
-    it('returns converted L1 fee when no gasUsed (no operator fee)', async () => {
+    it('falls back to txParams.gas for operator fee when gasUsed is missing', async () => {
+      contractGetOperatorFeeMock.mockResolvedValueOnce(
+        bnFromHex(OPERATOR_FEE_MOCK),
+      );
+
+      jest
+        .spyOn(TransactionFactory, 'fromTxData')
+        .mockReturnValueOnce(
+          createMockTypedTransaction(
+            Buffer.from(SERIALIZED_TRANSACTION_MOCK, 'hex'),
+          ),
+        );
+
+      const flow = new MantleLayer1GasFeeFlow();
+      const response = await flow.getLayer1Fee(request);
+
+      const expectedL1FeeInMnt = bnFromHex(L1_FEE_MOCK).mul(TOKEN_RATIO_MOCK);
+      const expectedTotal = expectedL1FeeInMnt.add(
+        bnFromHex(OPERATOR_FEE_MOCK),
+      );
+
+      expect(contractGetOperatorFeeMock).toHaveBeenCalledTimes(1);
+      expect(contractGetOperatorFeeMock).toHaveBeenCalledWith(
+        TRANSACTION_PARAMS_MOCK.gas,
+      );
+      expect(response).toStrictEqual({
+        layer1Fee: add0x(padHexToEvenLength(expectedTotal.toString(16))),
+      });
+    });
+
+    it('falls back to txParams.gasLimit for operator fee when gasUsed and txParams.gas are missing', async () => {
+      const gasLimit = '0x9999';
+      request = {
+        ...request,
+        transactionMeta: {
+          ...request.transactionMeta,
+          txParams: {
+            from: TRANSACTION_PARAMS_MOCK.from,
+            gasLimit,
+          },
+        },
+      };
+
+      contractGetOperatorFeeMock.mockResolvedValueOnce(
+        bnFromHex(OPERATOR_FEE_MOCK),
+      );
+
+      jest
+        .spyOn(TransactionFactory, 'fromTxData')
+        .mockReturnValueOnce(
+          createMockTypedTransaction(
+            Buffer.from(SERIALIZED_TRANSACTION_MOCK, 'hex'),
+          ),
+        );
+
+      const flow = new MantleLayer1GasFeeFlow();
+      const response = await flow.getLayer1Fee(request);
+
+      const expectedL1FeeInMnt = bnFromHex(L1_FEE_MOCK).mul(TOKEN_RATIO_MOCK);
+      const expectedTotal = expectedL1FeeInMnt.add(
+        bnFromHex(OPERATOR_FEE_MOCK),
+      );
+
+      expect(contractGetOperatorFeeMock).toHaveBeenCalledTimes(1);
+      expect(contractGetOperatorFeeMock).toHaveBeenCalledWith(gasLimit);
+      expect(response).toStrictEqual({
+        layer1Fee: add0x(padHexToEvenLength(expectedTotal.toString(16))),
+      });
+    });
+
+    it('skips operator fee when no gasUsed, txParams.gas, or txParams.gasLimit is available', async () => {
+      request = {
+        ...request,
+        transactionMeta: {
+          ...request.transactionMeta,
+          txParams: { from: TRANSACTION_PARAMS_MOCK.from },
+        },
+      };
+
       jest
         .spyOn(TransactionFactory, 'fromTxData')
         .mockReturnValueOnce(

--- a/packages/transaction-controller/src/gas-flows/MantleLayer1GasFeeFlow.ts
+++ b/packages/transaction-controller/src/gas-flows/MantleLayer1GasFeeFlow.ts
@@ -46,6 +46,16 @@ export class MantleLayer1GasFeeFlow extends OracleLayer1GasFeeFlow {
     return MANTLE_CHAIN_IDS.includes(transactionMeta.chainId);
   }
 
+  protected override getOperatorFeeGas(
+    transactionMeta: TransactionMeta,
+  ): string | undefined {
+    return (
+      transactionMeta.gasUsed ??
+      transactionMeta.txParams.gas ??
+      transactionMeta.txParams.gasLimit
+    );
+  }
+
   protected override async transformOracleFee(
     oracleFee: BN,
     request: Layer1GasFeeFlowRequest,

--- a/packages/transaction-controller/src/gas-flows/OracleLayer1GasFeeFlow.ts
+++ b/packages/transaction-controller/src/gas-flows/OracleLayer1GasFeeFlow.ts
@@ -174,18 +174,33 @@ export abstract class OracleLayer1GasFeeFlow implements Layer1GasFeeFlow {
     return toBN(result);
   }
 
+  /**
+   * Returns the gas value to pass to the operator-fee oracle, or undefined
+   * to skip the operator-fee call entirely. Defaults to the simulated
+   * `gasUsed` on the transaction. Subclasses can override to supply a
+   * fallback (e.g. estimated gas limit) when `gasUsed` is unavailable.
+   *
+   * @param transactionMeta - The transaction metadata.
+   * @returns The gas value, or undefined to skip the operator-fee call.
+   */
+  protected getOperatorFeeGas(
+    transactionMeta: TransactionMeta,
+  ): string | undefined {
+    return transactionMeta.gasUsed;
+  }
+
   async #getOperatorLayer1GasFee(
     contract: Contract,
     transactionMeta: TransactionMeta,
   ): Promise<BN> {
-    const { gasUsed } = transactionMeta;
+    const gas = this.getOperatorFeeGas(transactionMeta);
 
-    if (!gasUsed) {
+    if (!gas) {
       return ZERO;
     }
 
     try {
-      const result = await contract.getOperatorFee(gasUsed);
+      const result = await contract.getOperatorFee(gas);
 
       if (result === undefined) {
         return ZERO;


### PR DESCRIPTION
## Explanation

We observed the confirmation screen showing `0.10 MNT` for a transaction that ended up costing `0.12 MNT` — the ~0.02 MNT delta is the operator-fee component of Mantle's Arsia gas model, which never reached the displayed total.

Root cause is in `OracleLayer1GasFeeFlow.#getOperatorLayer1GasFee`: the method skips the operator-fee oracle call whenever `transactionMeta.gasUsed` is unset. That field is populated by the transaction simulation backend, and Mantle is not in its supported-networks list — `getBalanceChanges` throws `SimulationChainNotSupportedError`, the catch returns `gasUsed: undefined`, and the operator-fee path silently collapses to zero for the entire pre-confirmation lifecycle (initial render, gas-fee poller re-poll, edit-gas). The UI sums `layer1GasFee` straight into the displayed total in `useFeeCalculations.ts`, so the dropped operator fee flows directly to the user.

The fix introduces a `protected getOperatorFeeGas` hook on `OracleLayer1GasFeeFlow`. The base default returns `transactionMeta.gasUsed`, so `OptimismLayer1GasFeeFlow`, `ScrollLayer1GasFeeFlow`, and any other current or future subclass keep their existing behaviour. `MantleLayer1GasFeeFlow` overrides the hook to fall back to `txParams.gas ?? txParams.gasLimit` when `gasUsed` is unavailable.

The transaction's gas limit is an upper bound on actual gas used (it carries the `updateGas` buffer when populated by the controller, and is the caller-supplied value otherwise). Mantle's operator-fee oracle is strictly linear in its input gas (verified on-chain at `0x420000000000000000000000000000000000000F` — `getOperatorFee(21000) = 2.1e14`, `getOperatorFee(500000) = 5e15`, same per-gas rate), so the operator fee returned for a gas-limit input is an upper bound on the realised operator fee. The displayed total will be a hair above the actual on-chain cost rather than under-reporting it. This matches the over-estimate direction already used for the Optimism L1 data fee.

Caller coverage with the override in place:

- Confirmation screen (`addTransaction` flow): `updateGas` populates `txParams.gas` in `#updateGasProperties` before `updateTransactionLayer1GasFee` runs in the same method.
- `GasFeePoller` 10s re-poll: reads the same `txParams.gas` from state.
- `updateEditableParams` (user edits gas): uses the new `txParams.gas` after the edit.
- Bridge L1-fee path: `bridge-controller`'s `appendL1GasFees` is allowlisted to Optimism + Base only today, so Mantle quotes don't reach this code. The `?? gasLimit` arm future-proofs the bridge `getLayer1GasFee` call shape if Mantle is added later.

## References

Fixes the operator-fee under-reporting flagged by the Mantle team following the Arsia gas model rollout.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized gas-estimation change with default behavior unchanged for other chains; Mantle may show slightly high fees when using gas limit fallback.
> 
> **Overview**
> Fixes Mantle confirmation totals omitting the Arsia **operator fee** when `transactionMeta.gasUsed` is missing (e.g. Mantle unsupported by simulation), which previously skipped `getOperatorFee` and under-reported `layer1GasFee`.
> 
> `OracleLayer1GasFeeFlow` now routes operator-fee oracle input through a **`protected getOperatorFeeGas`** hook (default still `gasUsed`). **`MantleLayer1GasFeeFlow`** overrides it with `gasUsed ?? txParams.gas ?? txParams.gasLimit` so pre-confirmation estimates still call the oracle; using gas limit slightly **over-estimates** rather than under-shows the fee. Tests and changelog updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a0ebd5b47e4d2d21b2d613aace1646bd2fcd01c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->