### PR TITLE
fix(transaction-pay-controller): use Infura endpoint for live token balance queries

### DIFF
--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `getLiveTokenBalance` now prefers the Infura RPC endpoint for a chain when querying live token balances, falling back to the chain's default endpoint if no Infura endpoint is configured ([#8839](https://github.com/MetaMask/core/pull/8839))
+- `rpcRequest` now accepts a single options object instead of positional parameters, and supports a generic type parameter for typed responses ([#8839](https://github.com/MetaMask/core/pull/8839))
 - Bump `@metamask/assets-controllers` from `^108.1.0` to `^108.2.0` ([#8911](https://github.com/MetaMask/core/pull/8911))
 - Bump `@metamask/assets-controller` from `^8.0.1` to `^8.1.0` ([#8912](https://github.com/MetaMask/core/pull/8912), [#8919](https://github.com/MetaMask/core/pull/8919))
 - Bump `@metamask/bridge-status-controller` from `^71.2.0` to `^72.0.0` ([#8912](https://github.com/MetaMask/core/pull/8912), [#8935](https://github.com/MetaMask/core/pull/8935))

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/bridge-status-controller` from `^71.1.4` to `^71.2.0` ([#8848](https://github.com/MetaMask/core/pull/8848))
 - Bump `@metamask/transaction-controller` from `^65.4.0` to `^66.0.0` ([#8848](https://github.com/MetaMask/core/pull/8848))
 - Bump `@metamask/gas-fee-controller` from `^26.2.1` to `^26.2.2` ([#8834](https://github.com/MetaMask/core/pull/8834))
+- `getLiveTokenBalance` now prefers the Infura RPC endpoint for a chain when querying live token balances, falling back to the chain's default endpoint if no Infura endpoint is configured ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
 
 ### Fixed
 

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -20,8 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `getLiveTokenBalance` now prefers the Infura RPC endpoint for a chain when querying live token balances, falling back to the chain's default endpoint if no Infura endpoint is configured ([#8839](https://github.com/MetaMask/core/pull/8839))
-- `rpcRequest` now accepts a single options object instead of positional parameters, and supports a generic type parameter for typed responses ([#8839](https://github.com/MetaMask/core/pull/8839))
+- `getLiveTokenBalance` now prefers the chain's Infura endpoint when querying live token balances, falling back to the default endpoint if no Infura endpoint is configured ([#8839](https://github.com/MetaMask/core/pull/8839))
+  - Introduces a new `provider` utility module with `getNetworkClientId` and a refactored `rpcRequest` that accepts a single options object and supports a generic response type.
 - Bump `@metamask/assets-controllers` from `^108.1.0` to `^108.2.0` ([#8911](https://github.com/MetaMask/core/pull/8911))
 - Bump `@metamask/assets-controller` from `^8.0.1` to `^8.1.0` ([#8912](https://github.com/MetaMask/core/pull/8912), [#8919](https://github.com/MetaMask/core/pull/8919))
 - Bump `@metamask/bridge-status-controller` from `^71.2.0` to `^72.0.0` ([#8912](https://github.com/MetaMask/core/pull/8912), [#8935](https://github.com/MetaMask/core/pull/8935))
@@ -69,8 +69,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/bridge-status-controller` from `^71.1.4` to `^71.2.0` ([#8848](https://github.com/MetaMask/core/pull/8848))
 - Bump `@metamask/transaction-controller` from `^65.4.0` to `^66.0.0` ([#8848](https://github.com/MetaMask/core/pull/8848))
 - Bump `@metamask/gas-fee-controller` from `^26.2.1` to `^26.2.2` ([#8834](https://github.com/MetaMask/core/pull/8834))
-- `getLiveTokenBalance` now prefers the Infura RPC endpoint for a chain when querying live token balances, falling back to the chain's default endpoint if no Infura endpoint is configured ([#8839](https://github.com/MetaMask/core/pull/8839))
-- `rpcRequest` now accepts a single options object instead of positional parameters, and supports a generic type parameter for typed responses ([#8839](https://github.com/MetaMask/core/pull/8839))
 
 ### Fixed
 

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -67,7 +67,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/bridge-status-controller` from `^71.1.4` to `^71.2.0` ([#8848](https://github.com/MetaMask/core/pull/8848))
 - Bump `@metamask/transaction-controller` from `^65.4.0` to `^66.0.0` ([#8848](https://github.com/MetaMask/core/pull/8848))
 - Bump `@metamask/gas-fee-controller` from `^26.2.1` to `^26.2.2` ([#8834](https://github.com/MetaMask/core/pull/8834))
-- `getLiveTokenBalance` now prefers the Infura RPC endpoint for a chain when querying live token balances, falling back to the chain's default endpoint if no Infura endpoint is configured ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
+- `getLiveTokenBalance` now prefers the Infura RPC endpoint for a chain when querying live token balances, falling back to the chain's default endpoint if no Infura endpoint is configured ([#8839](https://github.com/MetaMask/core/pull/8839))
+- `rpcRequest` now accepts a single options object instead of positional parameters, and supports a generic type parameter for typed responses ([#8839](https://github.com/MetaMask/core/pull/8839))
 
 ### Fixed
 

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `getLiveTokenBalance` now prefers the chain's Infura endpoint when querying live token balances, falling back to the default endpoint if no Infura endpoint is configured ([#8839](https://github.com/MetaMask/core/pull/8839))
+- Live token balance queries now prefer the chain's Infura endpoint, falling back to the default endpoint if no Infura endpoint is configured ([#8839](https://github.com/MetaMask/core/pull/8839))
 - Bump `@metamask/assets-controllers` from `^108.1.0` to `^108.2.0` ([#8911](https://github.com/MetaMask/core/pull/8911))
 - Bump `@metamask/assets-controller` from `^8.0.1` to `^8.1.0` ([#8912](https://github.com/MetaMask/core/pull/8912), [#8919](https://github.com/MetaMask/core/pull/8919))
 - Bump `@metamask/bridge-status-controller` from `^71.2.0` to `^72.0.0` ([#8912](https://github.com/MetaMask/core/pull/8912), [#8935](https://github.com/MetaMask/core/pull/8935))

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Live token balance queries now prefer the chain's Infura endpoint, falling back to the default endpoint if no Infura endpoint is configured ([#8839](https://github.com/MetaMask/core/pull/8839))
 - Bump `@metamask/assets-controllers` from `^108.2.0` to `^108.3.0` ([#8941](https://github.com/MetaMask/core/pull/8941))
 
 ## [22.8.0]
@@ -20,7 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Live token balance queries now prefer the chain's Infura endpoint, falling back to the default endpoint if no Infura endpoint is configured ([#8839](https://github.com/MetaMask/core/pull/8839))
 - Bump `@metamask/assets-controllers` from `^108.1.0` to `^108.2.0` ([#8911](https://github.com/MetaMask/core/pull/8911))
 - Bump `@metamask/assets-controller` from `^8.0.1` to `^8.1.0` ([#8912](https://github.com/MetaMask/core/pull/8912), [#8919](https://github.com/MetaMask/core/pull/8919))
 - Bump `@metamask/bridge-status-controller` from `^71.2.0` to `^72.0.0` ([#8912](https://github.com/MetaMask/core/pull/8912), [#8935](https://github.com/MetaMask/core/pull/8935))

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -21,7 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `getLiveTokenBalance` now prefers the chain's Infura endpoint when querying live token balances, falling back to the default endpoint if no Infura endpoint is configured ([#8839](https://github.com/MetaMask/core/pull/8839))
-  - Introduces a new `provider` utility module with `getNetworkClientId` and a refactored `rpcRequest` that accepts a single options object and supports a generic response type.
 - Bump `@metamask/assets-controllers` from `^108.1.0` to `^108.2.0` ([#8911](https://github.com/MetaMask/core/pull/8911))
 - Bump `@metamask/assets-controller` from `^8.0.1` to `^8.1.0` ([#8912](https://github.com/MetaMask/core/pull/8912), [#8919](https://github.com/MetaMask/core/pull/8919))
 - Bump `@metamask/bridge-status-controller` from `^71.2.0` to `^72.0.0` ([#8912](https://github.com/MetaMask/core/pull/8912), [#8935](https://github.com/MetaMask/core/pull/8935))

--- a/packages/transaction-pay-controller/src/strategy/across/across-submit.ts
+++ b/packages/transaction-pay-controller/src/strategy/across/across-submit.ts
@@ -21,6 +21,7 @@ import type {
 import { accountSupports7702 } from '../../utils/7702';
 import { getPayStrategiesConfig } from '../../utils/feature-flags';
 import { getGasBuffer } from '../../utils/feature-flags';
+import { getNetworkClientId } from '../../utils/provider';
 import {
   collectTransactionIds,
   getTransaction,
@@ -141,10 +142,7 @@ async function submitTransactions(
   const transactionCount =
     orderedTransactions.length + (shouldPrependOriginalTransaction ? 1 : 0);
 
-  const networkClientId = messenger.call(
-    'NetworkController:findNetworkClientIdByChainId',
-    chainId,
-  );
+  const networkClientId = getNetworkClientId(messenger, chainId);
 
   const is7702Batch = is7702 && transactionCount > 1;
   const canUseQuotedBatchGasLimit =

--- a/packages/transaction-pay-controller/src/strategy/fiat/utils.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/utils.test.ts
@@ -1,4 +1,3 @@
-import { Web3Provider } from '@ethersproject/providers';
 import type { RampsOrder } from '@metamask/ramps-controller';
 import type { TransactionMeta } from '@metamask/transaction-controller';
 import { TransactionType } from '@metamask/transaction-controller';
@@ -14,11 +13,6 @@ import {
   getRawSourceAmountFromOrderCryptoAmount,
   resolveSourceAmountRaw,
 } from './utils';
-
-jest.mock('@ethersproject/providers', () => ({
-  ...jest.requireActual('@ethersproject/providers'),
-  Web3Provider: jest.fn(),
-}));
 
 const TX_HASH_MOCK = '0xabc123';
 const WALLET_ADDRESS_MOCK = '0x1111111111111111111111111111111111111111' as Hex;
@@ -210,23 +204,17 @@ describe('Fiat Utils', () => {
       messenger: resolveMessenger,
       findNetworkClientIdByChainIdMock,
       getNetworkClientByIdMock,
+      getNetworkConfigurationByChainIdMock,
       getTokensControllerStateMock,
       getRemoteFeatureFlagControllerStateMock:
         resolveRemoteFeatureFlagControllerStateMock,
     } = getMessengerMock();
 
-    let mockGetTransactionReceipt: jest.Mock;
-    let mockSend: jest.Mock;
-    let mockGetTransaction: jest.Mock;
-
     beforeEach(() => {
       jest.resetAllMocks();
 
-      mockGetTransactionReceipt = jest.fn();
-      mockSend = jest.fn();
-      mockGetTransaction = jest.fn();
-
       findNetworkClientIdByChainIdMock.mockReturnValue(NETWORK_CLIENT_ID_MOCK);
+      getNetworkConfigurationByChainIdMock.mockReturnValue(undefined);
       getNetworkClientByIdMock.mockReturnValue({
         provider: PROVIDER_MOCK,
       } as never);
@@ -255,16 +243,10 @@ describe('Fiat Utils', () => {
         allIgnoredTokens: {},
         allDetectedTokens: {},
       } as never);
-
-      (Web3Provider as unknown as jest.Mock).mockImplementation(() => ({
-        getTransactionReceipt: mockGetTransactionReceipt,
-        send: mockSend,
-        getTransaction: mockGetTransaction,
-      }));
     });
 
     it('returns on-chain ERC-20 amount from receipt logs', async () => {
-      mockGetTransactionReceipt.mockResolvedValue({
+      (PROVIDER_MOCK.request as jest.Mock).mockResolvedValue({
         logs: [
           {
             address: ERC20_ADDRESS_MOCK,
@@ -297,11 +279,11 @@ describe('Fiat Utils', () => {
       });
 
       expect(result).toBe('1500000');
-      expect(mockGetTransactionReceipt).not.toHaveBeenCalled();
+      expect(PROVIDER_MOCK.request).not.toHaveBeenCalled();
     });
 
     it('falls back to cryptoAmount when receipt is null', async () => {
-      mockGetTransactionReceipt.mockResolvedValue(null);
+      (PROVIDER_MOCK.request as jest.Mock).mockResolvedValue(null);
 
       const result = await resolveSourceAmountRaw({
         messenger: resolveMessenger,
@@ -314,7 +296,9 @@ describe('Fiat Utils', () => {
     });
 
     it('falls back to cryptoAmount when on-chain read throws', async () => {
-      mockGetTransactionReceipt.mockRejectedValue(new Error('Network error'));
+      (PROVIDER_MOCK.request as jest.Mock).mockRejectedValue(
+        new Error('Network error'),
+      );
 
       const result = await resolveSourceAmountRaw({
         messenger: resolveMessenger,
@@ -327,7 +311,7 @@ describe('Fiat Utils', () => {
     });
 
     it('returns native amount from debug_traceTransaction', async () => {
-      mockSend.mockResolvedValue({
+      (PROVIDER_MOCK.request as jest.Mock).mockResolvedValue({
         to: WALLET_ADDRESS_MOCK.toLowerCase(),
         value: '0x1bc16d674ec80000',
         calls: [],
@@ -344,11 +328,17 @@ describe('Fiat Utils', () => {
     });
 
     it('falls back to tx.value for native when trace is unsupported', async () => {
-      mockSend.mockRejectedValue(new Error('Method not found'));
-      mockGetTransaction.mockResolvedValue({
-        to: WALLET_ADDRESS_MOCK.toLowerCase(),
-        value: { toString: () => '2000000000000000000' },
-      });
+      (PROVIDER_MOCK.request as jest.Mock).mockImplementation(
+        ({ method }: { method: string }) => {
+          if (method === 'debug_traceTransaction') {
+            return Promise.reject(new Error('Method not found'));
+          }
+          return Promise.resolve({
+            to: WALLET_ADDRESS_MOCK.toLowerCase(),
+            value: '0x1bc16d674ec80000',
+          });
+        },
+      );
 
       const result = await resolveSourceAmountRaw({
         messenger: resolveMessenger,

--- a/packages/transaction-pay-controller/src/strategy/fiat/utils.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/utils.test.ts
@@ -246,7 +246,7 @@ describe('Fiat Utils', () => {
     });
 
     it('returns on-chain ERC-20 amount from receipt logs', async () => {
-      (PROVIDER_MOCK.request as jest.Mock).mockResolvedValue({
+      PROVIDER_MOCK.request.mockResolvedValue({
         logs: [
           {
             address: ERC20_ADDRESS_MOCK,
@@ -283,7 +283,7 @@ describe('Fiat Utils', () => {
     });
 
     it('falls back to cryptoAmount when receipt is null', async () => {
-      (PROVIDER_MOCK.request as jest.Mock).mockResolvedValue(null);
+      PROVIDER_MOCK.request.mockResolvedValue(null);
 
       const result = await resolveSourceAmountRaw({
         messenger: resolveMessenger,
@@ -296,9 +296,7 @@ describe('Fiat Utils', () => {
     });
 
     it('falls back to cryptoAmount when on-chain read throws', async () => {
-      (PROVIDER_MOCK.request as jest.Mock).mockRejectedValue(
-        new Error('Network error'),
-      );
+      PROVIDER_MOCK.request.mockRejectedValue(new Error('Network error'));
 
       const result = await resolveSourceAmountRaw({
         messenger: resolveMessenger,
@@ -311,7 +309,7 @@ describe('Fiat Utils', () => {
     });
 
     it('returns native amount from debug_traceTransaction', async () => {
-      (PROVIDER_MOCK.request as jest.Mock).mockResolvedValue({
+      PROVIDER_MOCK.request.mockResolvedValue({
         to: WALLET_ADDRESS_MOCK.toLowerCase(),
         value: '0x1bc16d674ec80000',
         calls: [],
@@ -328,7 +326,7 @@ describe('Fiat Utils', () => {
     });
 
     it('falls back to tx.value for native when trace is unsupported', async () => {
-      (PROVIDER_MOCK.request as jest.Mock).mockImplementation(
+      PROVIDER_MOCK.request.mockImplementation(
         ({ method }: { method: string }) => {
           if (method === 'debug_traceTransaction') {
             return Promise.reject(new Error('Method not found'));

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-submit.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-submit.ts
@@ -20,6 +20,7 @@ import {
   getRelayPollingInterval,
   getRelayPollingTimeout,
 } from '../../utils/feature-flags';
+import { getNetworkClientId } from '../../utils/provider';
 import {
   getLiveTokenBalance,
   normalizeTokenAddress,
@@ -508,10 +509,7 @@ async function submitViaRelayExecute(
   const { from, sourceChainId } = quote.request;
   const { requestId } = quote.original.steps[0];
 
-  const networkClientId = messenger.call(
-    'NetworkController:findNetworkClientIdByChainId',
-    sourceChainId,
-  );
+  const networkClientId = getNetworkClientId(messenger, sourceChainId);
 
   const sourceCallTransaction = {
     ...transaction,
@@ -600,10 +598,7 @@ async function submitViaTransactionController(
   const { from, sourceChainId, sourceTokenAddress } = quote.request;
   const { isPostQuote } = quote.request;
 
-  const networkClientId = messenger.call(
-    'NetworkController:findNetworkClientIdByChainId',
-    sourceChainId,
-  );
+  const networkClientId = getNetworkClientId(messenger, sourceChainId);
 
   log('Adding transactions', {
     normalizedParams: allParams,

--- a/packages/transaction-pay-controller/src/tests/messenger-mock.ts
+++ b/packages/transaction-pay-controller/src/tests/messenger-mock.ts
@@ -15,6 +15,7 @@ import type {
 import { Messenger, MOCK_ANY_NAMESPACE } from '@metamask/messenger';
 import type { NetworkControllerGetNetworkClientByIdAction } from '@metamask/network-controller';
 import type { NetworkControllerFindNetworkClientIdByChainIdAction } from '@metamask/network-controller';
+import type { NetworkControllerGetNetworkConfigurationByChainIdAction } from '@metamask/network-controller';
 import type { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
 import type {
   TransactionControllerAddTransactionAction,
@@ -115,6 +116,10 @@ export function getMessengerMock({
 
   const getNetworkClientByIdMock: jest.MockedFn<
     NetworkControllerGetNetworkClientByIdAction['handler']
+  > = jest.fn();
+
+  const getNetworkConfigurationByChainIdMock: jest.MockedFn<
+    NetworkControllerGetNetworkConfigurationByChainIdAction['handler']
   > = jest.fn();
 
   const getDelegationTransactionMock: jest.MockedFn<
@@ -256,6 +261,11 @@ export function getMessengerMock({
     );
 
     messenger.registerActionHandler(
+      'NetworkController:getNetworkConfigurationByChainId',
+      getNetworkConfigurationByChainIdMock,
+    );
+
+    messenger.registerActionHandler(
       'TransactionPayController:getDelegationTransaction',
       getDelegationTransactionMock,
     );
@@ -321,6 +331,7 @@ export function getMessengerMock({
     getGasFeeTokensMock,
     getKeyringControllerStateMock,
     getNetworkClientByIdMock,
+    getNetworkConfigurationByChainIdMock,
     getRemoteFeatureFlagControllerStateMock,
     getStrategyMock,
     getTokenBalanceControllerStateMock,

--- a/packages/transaction-pay-controller/src/types.ts
+++ b/packages/transaction-pay-controller/src/types.ts
@@ -31,6 +31,7 @@ import type {
 import type { Messenger } from '@metamask/messenger';
 import type { NetworkControllerFindNetworkClientIdByChainIdAction } from '@metamask/network-controller';
 import type { NetworkControllerGetNetworkClientByIdAction } from '@metamask/network-controller';
+import type { NetworkControllerGetNetworkConfigurationByChainIdAction } from '@metamask/network-controller';
 import type { Quote as RampsQuote } from '@metamask/ramps-controller';
 import type {
   RampsControllerGetOrderAction,
@@ -78,6 +79,7 @@ export type AllowedActions =
   | KeyringControllerSignTypedMessageAction
   | NetworkControllerFindNetworkClientIdByChainIdAction
   | NetworkControllerGetNetworkClientByIdAction
+  | NetworkControllerGetNetworkConfigurationByChainIdAction
   | RampsControllerGetOrderAction
   | RampsControllerGetQuotesAction
   | RampsControllerGetStateAction

--- a/packages/transaction-pay-controller/src/utils/gas.ts
+++ b/packages/transaction-pay-controller/src/utils/gas.ts
@@ -11,6 +11,7 @@ import type { TransactionPayControllerMessenger } from '..';
 import { createModuleLogger, projectLogger } from '../logger';
 import type { Amount } from '../types';
 import { getFallbackGas, getGasBuffer } from './feature-flags';
+import { getNetworkClientId } from './provider';
 import { getNativeToken, getTokenBalance, getTokenFiatRate } from './token';
 
 const log = createModuleLogger(projectLogger, 'gas');
@@ -227,10 +228,7 @@ export async function estimateGasLimit({
   error?: unknown;
 }> {
   const gasBuffer = getGasBuffer(messenger, chainId);
-  const networkClientId = messenger.call(
-    'NetworkController:findNetworkClientIdByChainId',
-    chainId,
-  );
+  const networkClientId = getNetworkClientId(messenger, chainId);
 
   let estimateGasError: unknown;
   let simulationError: Error | undefined;

--- a/packages/transaction-pay-controller/src/utils/provider.test.ts
+++ b/packages/transaction-pay-controller/src/utils/provider.test.ts
@@ -138,7 +138,11 @@ describe('provider utils', () => {
         provider: { request: requestMock },
       } as never);
 
-      await rpcRequest({ messenger, chainId: CHAIN_ID_MOCK, method: 'eth_blockNumber' });
+      await rpcRequest({
+        messenger,
+        chainId: CHAIN_ID_MOCK,
+        method: 'eth_blockNumber',
+      });
 
       expect(requestMock).toHaveBeenCalledWith({
         method: 'eth_blockNumber',
@@ -154,7 +158,11 @@ describe('provider utils', () => {
       } as never);
 
       await expect(
-        rpcRequest({ messenger, chainId: CHAIN_ID_MOCK, method: 'eth_blockNumber' }),
+        rpcRequest({
+          messenger,
+          chainId: CHAIN_ID_MOCK,
+          method: 'eth_blockNumber',
+        }),
       ).rejects.toBe(error);
     });
 

--- a/packages/transaction-pay-controller/src/utils/provider.test.ts
+++ b/packages/transaction-pay-controller/src/utils/provider.test.ts
@@ -1,0 +1,186 @@
+import type { Provider } from '@metamask/network-controller';
+import { RpcEndpointType } from '@metamask/network-controller';
+import type { NetworkConfiguration } from '@metamask/network-controller';
+import type { Hex } from '@metamask/utils';
+
+import { getMessengerMock } from '../tests/messenger-mock';
+import { getNetworkClientId, rpcRequest } from './provider';
+
+const CHAIN_ID_MOCK = '0x1' as Hex;
+const DEFAULT_NETWORK_CLIENT_ID_MOCK = 'default-client-id';
+const INFURA_NETWORK_CLIENT_ID_MOCK = 'mainnet';
+const PROVIDER_MOCK = { request: jest.fn() } as unknown as Provider;
+
+describe('provider utils', () => {
+  const {
+    messenger,
+    findNetworkClientIdByChainIdMock,
+    getNetworkClientByIdMock,
+    getNetworkConfigurationByChainIdMock,
+  } = getMessengerMock();
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    findNetworkClientIdByChainIdMock.mockReturnValue(
+      DEFAULT_NETWORK_CLIENT_ID_MOCK,
+    );
+
+    getNetworkClientByIdMock.mockReturnValue({
+      provider: PROVIDER_MOCK,
+    } as never);
+
+    getNetworkConfigurationByChainIdMock.mockReturnValue(undefined);
+  });
+
+  describe('getNetworkClientId', () => {
+    it('returns default network client ID when preferInfura is false', () => {
+      const result = getNetworkClientId(messenger, CHAIN_ID_MOCK);
+
+      expect(result).toBe(DEFAULT_NETWORK_CLIENT_ID_MOCK);
+      expect(findNetworkClientIdByChainIdMock).toHaveBeenCalledWith(
+        CHAIN_ID_MOCK,
+      );
+      expect(getNetworkConfigurationByChainIdMock).not.toHaveBeenCalled();
+    });
+
+    it('returns Infura network client ID when preferInfura is true and Infura endpoint exists', () => {
+      getNetworkConfigurationByChainIdMock.mockReturnValue({
+        rpcEndpoints: [
+          {
+            type: RpcEndpointType.Infura,
+            networkClientId: INFURA_NETWORK_CLIENT_ID_MOCK,
+          },
+        ],
+      } as NetworkConfiguration);
+
+      const result = getNetworkClientId(messenger, CHAIN_ID_MOCK, {
+        preferInfura: true,
+      });
+
+      expect(result).toBe(INFURA_NETWORK_CLIENT_ID_MOCK);
+      expect(findNetworkClientIdByChainIdMock).not.toHaveBeenCalled();
+    });
+
+    it('falls back to default network client ID when preferInfura is true but no Infura endpoint exists', () => {
+      getNetworkConfigurationByChainIdMock.mockReturnValue({
+        rpcEndpoints: [
+          {
+            type: RpcEndpointType.Custom,
+            networkClientId: 'custom-rpc-id',
+          },
+        ],
+      } as NetworkConfiguration);
+
+      const result = getNetworkClientId(messenger, CHAIN_ID_MOCK, {
+        preferInfura: true,
+      });
+
+      expect(result).toBe(DEFAULT_NETWORK_CLIENT_ID_MOCK);
+      expect(findNetworkClientIdByChainIdMock).toHaveBeenCalledWith(
+        CHAIN_ID_MOCK,
+      );
+    });
+
+    it('falls back to default network client ID when preferInfura is true but getNetworkConfigurationByChainId throws', () => {
+      getNetworkConfigurationByChainIdMock.mockImplementation(() => {
+        throw new Error('Configuration not found');
+      });
+
+      const result = getNetworkClientId(messenger, CHAIN_ID_MOCK, {
+        preferInfura: true,
+      });
+
+      expect(result).toBe(DEFAULT_NETWORK_CLIENT_ID_MOCK);
+      expect(findNetworkClientIdByChainIdMock).toHaveBeenCalledWith(
+        CHAIN_ID_MOCK,
+      );
+    });
+
+    it('falls back to default network client ID when preferInfura is true but network configuration is undefined', () => {
+      getNetworkConfigurationByChainIdMock.mockReturnValue(undefined);
+
+      const result = getNetworkClientId(messenger, CHAIN_ID_MOCK, {
+        preferInfura: true,
+      });
+
+      expect(result).toBe(DEFAULT_NETWORK_CLIENT_ID_MOCK);
+      expect(findNetworkClientIdByChainIdMock).toHaveBeenCalledWith(
+        CHAIN_ID_MOCK,
+      );
+    });
+  });
+
+  describe('rpcRequest', () => {
+    it('calls provider.request with method and params', async () => {
+      const requestMock = jest.fn().mockResolvedValue('0xabc');
+      getNetworkClientByIdMock.mockReturnValue({
+        provider: { request: requestMock },
+      } as never);
+
+      const result = await rpcRequest(messenger, CHAIN_ID_MOCK, 'eth_chainId', [
+        'latest',
+      ]);
+
+      expect(result).toBe('0xabc');
+      expect(requestMock).toHaveBeenCalledWith({
+        method: 'eth_chainId',
+        params: ['latest'],
+      });
+    });
+
+    it('calls provider.request without params when omitted', async () => {
+      const requestMock = jest.fn().mockResolvedValue('0x10');
+      getNetworkClientByIdMock.mockReturnValue({
+        provider: { request: requestMock },
+      } as never);
+
+      await rpcRequest(messenger, CHAIN_ID_MOCK, 'eth_blockNumber');
+
+      expect(requestMock).toHaveBeenCalledWith({
+        method: 'eth_blockNumber',
+        params: undefined,
+      });
+    });
+
+    it('propagates provider errors', async () => {
+      const error = new Error('RPC failed');
+      const requestMock = jest.fn().mockRejectedValue(error);
+      getNetworkClientByIdMock.mockReturnValue({
+        provider: { request: requestMock },
+      } as never);
+
+      await expect(
+        rpcRequest(messenger, CHAIN_ID_MOCK, 'eth_blockNumber'),
+      ).rejects.toBe(error);
+    });
+
+    it('uses Infura network client when preferInfura is true', async () => {
+      getNetworkConfigurationByChainIdMock.mockReturnValue({
+        rpcEndpoints: [
+          {
+            type: RpcEndpointType.Infura,
+            networkClientId: INFURA_NETWORK_CLIENT_ID_MOCK,
+          },
+        ],
+      } as NetworkConfiguration);
+
+      const requestMock = jest.fn().mockResolvedValue('0x1');
+      getNetworkClientByIdMock.mockReturnValue({
+        provider: { request: requestMock },
+      } as never);
+
+      await rpcRequest(
+        messenger,
+        CHAIN_ID_MOCK,
+        'eth_chainId',
+        [],
+        { preferInfura: true },
+      );
+
+      expect(getNetworkClientByIdMock).toHaveBeenCalledWith(
+        INFURA_NETWORK_CLIENT_ID_MOCK,
+      );
+    });
+  });
+});

--- a/packages/transaction-pay-controller/src/utils/provider.test.ts
+++ b/packages/transaction-pay-controller/src/utils/provider.test.ts
@@ -118,9 +118,12 @@ describe('provider utils', () => {
         provider: { request: requestMock },
       } as never);
 
-      const result = await rpcRequest(messenger, CHAIN_ID_MOCK, 'eth_chainId', [
-        'latest',
-      ]);
+      const result = await rpcRequest({
+        messenger,
+        chainId: CHAIN_ID_MOCK,
+        method: 'eth_chainId',
+        params: ['latest'],
+      });
 
       expect(result).toBe('0xabc');
       expect(requestMock).toHaveBeenCalledWith({
@@ -135,7 +138,7 @@ describe('provider utils', () => {
         provider: { request: requestMock },
       } as never);
 
-      await rpcRequest(messenger, CHAIN_ID_MOCK, 'eth_blockNumber');
+      await rpcRequest({ messenger, chainId: CHAIN_ID_MOCK, method: 'eth_blockNumber' });
 
       expect(requestMock).toHaveBeenCalledWith({
         method: 'eth_blockNumber',
@@ -151,7 +154,7 @@ describe('provider utils', () => {
       } as never);
 
       await expect(
-        rpcRequest(messenger, CHAIN_ID_MOCK, 'eth_blockNumber'),
+        rpcRequest({ messenger, chainId: CHAIN_ID_MOCK, method: 'eth_blockNumber' }),
       ).rejects.toBe(error);
     });
 
@@ -170,13 +173,13 @@ describe('provider utils', () => {
         provider: { request: requestMock },
       } as never);
 
-      await rpcRequest(
+      await rpcRequest({
         messenger,
-        CHAIN_ID_MOCK,
-        'eth_chainId',
-        [],
-        { preferInfura: true },
-      );
+        chainId: CHAIN_ID_MOCK,
+        method: 'eth_chainId',
+        params: [],
+        options: { preferInfura: true },
+      });
 
       expect(getNetworkClientByIdMock).toHaveBeenCalledWith(
         INFURA_NETWORK_CLIENT_ID_MOCK,

--- a/packages/transaction-pay-controller/src/utils/provider.ts
+++ b/packages/transaction-pay-controller/src/utils/provider.ts
@@ -86,15 +86,20 @@ export function getNetworkClientId(
  * Send an RPC request to the network for the specified chain.
  *
  * @param request - Request parameters.
- * @returns The RPC response typed as `T`.
+ * @param request.messenger - The TransactionPayController messenger.
+ * @param request.chainId - The chain ID to resolve.
+ * @param request.method - The JSON-RPC method name.
+ * @param request.params - Optional parameters for the RPC call.
+ * @param request.options - Resolution options forwarded to {@link getNetworkClientId}.
+ * @returns The RPC response typed as `TResponse`.
  */
-export async function rpcRequest<T = unknown>({
+export async function rpcRequest<TResponse = unknown>({
   messenger,
   chainId,
   method,
   params,
   options,
-}: RpcRequestParams): Promise<T> {
+}: RpcRequestParams): Promise<TResponse> {
   const networkClientId = getNetworkClientId(messenger, chainId, options);
 
   const { provider } = messenger.call(
@@ -106,5 +111,5 @@ export async function rpcRequest<T = unknown>({
 
   log(method, { params, response });
 
-  return response as T;
+  return response as TResponse;
 }

--- a/packages/transaction-pay-controller/src/utils/provider.ts
+++ b/packages/transaction-pay-controller/src/utils/provider.ts
@@ -23,6 +23,22 @@ export type GetNetworkClientIdOptions = {
 };
 
 /**
+ * Parameters for {@link rpcRequest}.
+ */
+export type RpcRequestParams = {
+  /** The TransactionPayController messenger. */
+  messenger: TransactionPayControllerMessenger;
+  /** The chain ID to resolve. */
+  chainId: Hex;
+  /** The JSON-RPC method name. */
+  method: string;
+  /** Optional parameters for the RPC call. */
+  params?: ProviderRequestParams;
+  /** Resolution options forwarded to {@link getNetworkClientId}. */
+  options?: GetNetworkClientIdOptions;
+};
+
+/**
  * Resolve the network client ID for a chain.
  *
  * When `preferInfura` is true the method tries to locate an Infura endpoint
@@ -69,20 +85,16 @@ export function getNetworkClientId(
 /**
  * Send an RPC request to the network for the specified chain.
  *
- * @param messenger - The TransactionPayController messenger.
- * @param chainId - The chain ID to resolve.
- * @param method - The JSON-RPC method name.
- * @param params - Optional parameters for the RPC call.
- * @param options - Resolution options (forwarded to {@link getNetworkClientId}).
- * @returns The RPC response.
+ * @param request - Request parameters.
+ * @returns The RPC response typed as `T`.
  */
-export async function rpcRequest(
-  messenger: TransactionPayControllerMessenger,
-  chainId: Hex,
-  method: string,
-  params?: ProviderRequestParams,
-  options?: GetNetworkClientIdOptions,
-): Promise<unknown> {
+export async function rpcRequest<T = unknown>({
+  messenger,
+  chainId,
+  method,
+  params,
+  options,
+}: RpcRequestParams): Promise<T> {
   const networkClientId = getNetworkClientId(messenger, chainId, options);
 
   const { provider } = messenger.call(
@@ -94,5 +106,5 @@ export async function rpcRequest(
 
   log(method, { params, response });
 
-  return response;
+  return response as T;
 }

--- a/packages/transaction-pay-controller/src/utils/provider.ts
+++ b/packages/transaction-pay-controller/src/utils/provider.ts
@@ -1,0 +1,98 @@
+import type { NetworkClientId, Provider } from '@metamask/network-controller';
+import { RpcEndpointType } from '@metamask/network-controller';
+import type { Hex } from '@metamask/utils';
+import { createModuleLogger } from '@metamask/utils';
+
+import { projectLogger } from '../logger';
+import type { TransactionPayControllerMessenger } from '../types';
+
+const log = createModuleLogger(projectLogger, 'provider');
+
+type ProviderRequestParams = Parameters<Provider['request']>[0]['params'];
+
+/**
+ * Options for network client resolution.
+ */
+export type GetNetworkClientIdOptions = {
+  /**
+   * When true, attempts to resolve to an Infura endpoint for the chain before
+   * falling back to the default selected endpoint. Useful for calls that use
+   * block tags (e.g. `pending`) that may not be supported by custom RPCs.
+   */
+  preferInfura?: boolean;
+};
+
+/**
+ * Resolve the network client ID for a chain.
+ *
+ * When `preferInfura` is true the method tries to locate an Infura endpoint
+ * in the chain's network configuration and returns its `networkClientId`.
+ * If no Infura endpoint is configured, or if the configuration lookup throws,
+ * it falls back to `findNetworkClientIdByChainId`.
+ *
+ * @param messenger - The TransactionPayController messenger.
+ * @param chainId - The chain ID to resolve.
+ * @param options - Resolution options.
+ * @param options.preferInfura - Prefer the Infura endpoint when available.
+ * @returns The resolved network client ID.
+ */
+export function getNetworkClientId(
+  messenger: TransactionPayControllerMessenger,
+  chainId: Hex,
+  { preferInfura = false }: GetNetworkClientIdOptions = {},
+): NetworkClientId {
+  if (preferInfura) {
+    try {
+      const networkConfiguration = messenger.call(
+        'NetworkController:getNetworkConfigurationByChainId',
+        chainId,
+      );
+
+      const infuraEndpoint = networkConfiguration?.rpcEndpoints.find(
+        (endpoint) => endpoint.type === RpcEndpointType.Infura,
+      );
+
+      if (infuraEndpoint) {
+        return infuraEndpoint.networkClientId;
+      }
+    } catch {
+      // empty
+    }
+  }
+
+  return messenger.call(
+    'NetworkController:findNetworkClientIdByChainId',
+    chainId,
+  );
+}
+
+/**
+ * Send an RPC request to the network for the specified chain.
+ *
+ * @param messenger - The TransactionPayController messenger.
+ * @param chainId - The chain ID to resolve.
+ * @param method - The JSON-RPC method name.
+ * @param params - Optional parameters for the RPC call.
+ * @param options - Resolution options (forwarded to {@link getNetworkClientId}).
+ * @returns The RPC response.
+ */
+export async function rpcRequest(
+  messenger: TransactionPayControllerMessenger,
+  chainId: Hex,
+  method: string,
+  params?: ProviderRequestParams,
+  options?: GetNetworkClientIdOptions,
+): Promise<unknown> {
+  const networkClientId = getNetworkClientId(messenger, chainId, options);
+
+  const { provider } = messenger.call(
+    'NetworkController:getNetworkClientById',
+    networkClientId,
+  );
+
+  const response = await provider.request({ method, params });
+
+  log(method, { params, response });
+
+  return response;
+}

--- a/packages/transaction-pay-controller/src/utils/provider.ts
+++ b/packages/transaction-pay-controller/src/utils/provider.ts
@@ -71,8 +71,13 @@ export function getNetworkClientId(
       if (infuraEndpoint) {
         return infuraEndpoint.networkClientId;
       }
-    } catch {
-      // empty
+
+      log('No Infura endpoint found for chain', {
+        chainId,
+        rpcEndpoints: networkConfiguration?.rpcEndpoints,
+      });
+    } catch (error) {
+      log('Error looking up Infura endpoint', { chainId, error });
     }
   }
 
@@ -109,7 +114,7 @@ export async function rpcRequest<TResponse = unknown>({
 
   const response = await provider.request({ method, params });
 
-  log(method, { params, response });
+  log(method, { chainId, networkClientId, params, response });
 
   return response as TResponse;
 }

--- a/packages/transaction-pay-controller/src/utils/token.test.ts
+++ b/packages/transaction-pay-controller/src/utils/token.test.ts
@@ -613,7 +613,7 @@ describe('Token Utils', () => {
 
   describe('getLiveTokenBalance', () => {
     it('returns ERC-20 balance via eth_call', async () => {
-      (PROVIDER_MOCK.request as jest.Mock).mockResolvedValue('0x4C4B40');
+      PROVIDER_MOCK.request.mockResolvedValue('0x4C4B40');
 
       const result = await getLiveTokenBalance(
         messenger,
@@ -644,9 +644,7 @@ describe('Token Utils', () => {
     });
 
     it('returns native balance via eth_getBalance', async () => {
-      (PROVIDER_MOCK.request as jest.Mock).mockResolvedValue(
-        '0xde0b6b3a7640000',
-      );
+      PROVIDER_MOCK.request.mockResolvedValue('0xde0b6b3a7640000');
 
       const result = await getLiveTokenBalance(
         messenger,
@@ -663,9 +661,7 @@ describe('Token Utils', () => {
     });
 
     it('returns native balance for polygon native address', async () => {
-      (PROVIDER_MOCK.request as jest.Mock).mockResolvedValue(
-        '0x1bc16d674ec80000',
-      );
+      PROVIDER_MOCK.request.mockResolvedValue('0x1bc16d674ec80000');
 
       const result = await getLiveTokenBalance(
         messenger,
@@ -682,7 +678,7 @@ describe('Token Utils', () => {
     });
 
     it('treats native address comparison as case-insensitive', async () => {
-      (PROVIDER_MOCK.request as jest.Mock).mockResolvedValue('0x1f4');
+      PROVIDER_MOCK.request.mockResolvedValue('0x1f4');
 
       const result = await getLiveTokenBalance(
         messenger,
@@ -699,7 +695,7 @@ describe('Token Utils', () => {
     });
 
     it('uses Infura network client when Infura endpoint is available', async () => {
-      (PROVIDER_MOCK.request as jest.Mock).mockResolvedValue('0x895440');
+      PROVIDER_MOCK.request.mockResolvedValue('0x895440');
 
       getNetworkConfigurationByChainIdMock.mockReturnValue({
         rpcEndpoints: [
@@ -728,7 +724,7 @@ describe('Token Utils', () => {
     });
 
     it('falls back to default network client when no Infura endpoint is configured', async () => {
-      (PROVIDER_MOCK.request as jest.Mock).mockResolvedValue('0x6ACFC0');
+      PROVIDER_MOCK.request.mockResolvedValue('0x6ACFC0');
 
       getNetworkConfigurationByChainIdMock.mockReturnValue({
         rpcEndpoints: [
@@ -756,7 +752,7 @@ describe('Token Utils', () => {
     });
 
     it('falls back to default network client when getNetworkConfigurationByChainId throws', async () => {
-      (PROVIDER_MOCK.request as jest.Mock).mockResolvedValue('0x2DC6C0');
+      PROVIDER_MOCK.request.mockResolvedValue('0x2DC6C0');
 
       getNetworkConfigurationByChainIdMock.mockImplementation(() => {
         throw new Error('Network configuration not found');

--- a/packages/transaction-pay-controller/src/utils/token.test.ts
+++ b/packages/transaction-pay-controller/src/utils/token.test.ts
@@ -1,8 +1,10 @@
-import { Contract } from '@ethersproject/contracts';
-import { Web3Provider } from '@ethersproject/providers';
+import { Interface } from '@ethersproject/abi';
 import type { TokensControllerState } from '@metamask/assets-controllers';
 import type { AccountTrackerControllerState } from '@metamask/assets-controllers';
 import type { TokenRatesControllerState } from '@metamask/assets-controllers';
+import { abiERC20 } from '@metamask/metamask-eth-abis';
+import { RpcEndpointType } from '@metamask/network-controller';
+import type { NetworkConfiguration } from '@metamask/network-controller';
 import type { Hex } from '@metamask/utils';
 
 import { getDefaultRemoteFeatureFlagControllerState } from '../../../remote-feature-flag-controller/src/remote-feature-flag-controller';
@@ -26,15 +28,6 @@ import {
   TokenAddressTarget,
 } from './token';
 
-jest.mock('@ethersproject/contracts', () => ({
-  ...jest.requireActual('@ethersproject/contracts'),
-  Contract: jest.fn(),
-}));
-
-jest.mock('@ethersproject/providers', () => ({
-  ...jest.requireActual('@ethersproject/providers'),
-  Web3Provider: jest.fn(),
-}));
 
 const TOKEN_ADDRESS_MOCK = '0x559B65722aD62AD6DAC4Fa5a1c6B23A2e8ce57Ec' as Hex;
 const TOKEN_ADDRESS_2_MOCK = '0x123456789abcdef1234567890abcdef12345678' as Hex;
@@ -43,6 +36,7 @@ const DECIMALS_MOCK = 6;
 const BALANCE_MOCK = '0x123' as Hex;
 const FROM_MOCK = '0x456' as Hex;
 const NETWORK_CLIENT_ID_MOCK = '123-456';
+const INFURA_NETWORK_CLIENT_ID_MOCK = 'mainnet';
 const TICKER_MOCK = 'TST';
 const SYMBOL_MOCK = 'TEST';
 const ACCOUNT_MOCK = '0x1234567890abcdef1234567890abcdef12345678' as Hex;
@@ -56,6 +50,7 @@ describe('Token Utils', () => {
     getRemoteFeatureFlagControllerStateMock,
     getTokensControllerStateMock,
     getNetworkClientByIdMock,
+    getNetworkConfigurationByChainIdMock,
     getTokenBalanceControllerStateMock,
     getAccountTrackerControllerStateMock,
     getTokenRatesControllerStateMock,
@@ -63,33 +58,20 @@ describe('Token Utils', () => {
     findNetworkClientIdByChainIdMock,
   } = getMessengerMock();
 
-  let mockBalanceOf: jest.Mock;
-  let mockGetBalance: jest.Mock;
-
   beforeEach(() => {
     jest.resetAllMocks();
-
-    mockBalanceOf = jest.fn();
-    mockGetBalance = jest.fn();
 
     getRemoteFeatureFlagControllerStateMock.mockReturnValue({
       ...getDefaultRemoteFeatureFlagControllerState(),
     });
 
     findNetworkClientIdByChainIdMock.mockReturnValue(NETWORK_CLIENT_ID_MOCK);
+    getNetworkConfigurationByChainIdMock.mockReturnValue(undefined);
 
     getNetworkClientByIdMock.mockReturnValue({
       configuration: { ticker: TICKER_MOCK },
       provider: PROVIDER_MOCK,
     } as never);
-
-    (Contract as unknown as jest.Mock).mockImplementation(() => ({
-      balanceOf: mockBalanceOf,
-    }));
-
-    (Web3Provider as unknown as jest.Mock).mockImplementation(() => ({
-      getBalance: mockGetBalance,
-    }));
   });
 
   function enableAssetsUnifyState(): void {
@@ -631,8 +613,8 @@ describe('Token Utils', () => {
   });
 
   describe('getLiveTokenBalance', () => {
-    it('returns ERC-20 balance via contract balanceOf', async () => {
-      mockBalanceOf.mockResolvedValue({ toString: () => '5000000' });
+    it('returns ERC-20 balance via eth_call', async () => {
+      (PROVIDER_MOCK.request as jest.Mock).mockResolvedValue('0x4C4B40');
 
       const result = await getLiveTokenBalance(
         messenger,
@@ -648,21 +630,22 @@ describe('Token Utils', () => {
       expect(getNetworkClientByIdMock).toHaveBeenCalledWith(
         NETWORK_CLIENT_ID_MOCK,
       );
-      expect(Web3Provider).toHaveBeenCalledWith(PROVIDER_MOCK);
-      expect(Contract).toHaveBeenCalledWith(
-        ERC20_ADDRESS_MOCK,
-        expect.anything(),
-        expect.anything(),
-      );
-      expect(mockBalanceOf).toHaveBeenCalledWith(ACCOUNT_MOCK, {
-        blockTag: 'pending',
+      expect(PROVIDER_MOCK.request).toHaveBeenCalledWith({
+        method: 'eth_call',
+        params: [
+          {
+            to: ERC20_ADDRESS_MOCK,
+            data: new Interface(abiERC20).encodeFunctionData('balanceOf', [
+              ACCOUNT_MOCK,
+            ]),
+          },
+          'pending',
+        ],
       });
     });
 
-    it('returns native balance via ethersProvider.getBalance', async () => {
-      mockGetBalance.mockResolvedValue({
-        toString: () => '1000000000000000000',
-      });
+    it('returns native balance via eth_getBalance', async () => {
+      (PROVIDER_MOCK.request as jest.Mock).mockResolvedValue('0xde0b6b3a7640000');
 
       const result = await getLiveTokenBalance(
         messenger,
@@ -672,14 +655,14 @@ describe('Token Utils', () => {
       );
 
       expect(result).toBe('1000000000000000000');
-      expect(mockGetBalance).toHaveBeenCalledWith(ACCOUNT_MOCK, 'pending');
-      expect(Contract).not.toHaveBeenCalled();
+      expect(PROVIDER_MOCK.request).toHaveBeenCalledWith({
+        method: 'eth_getBalance',
+        params: [ACCOUNT_MOCK, 'pending'],
+      });
     });
 
     it('returns native balance for polygon native address', async () => {
-      mockGetBalance.mockResolvedValue({
-        toString: () => '2000000000000000000',
-      });
+      (PROVIDER_MOCK.request as jest.Mock).mockResolvedValue('0x1bc16d674ec80000');
 
       const result = await getLiveTokenBalance(
         messenger,
@@ -689,12 +672,14 @@ describe('Token Utils', () => {
       );
 
       expect(result).toBe('2000000000000000000');
-      expect(mockGetBalance).toHaveBeenCalledWith(ACCOUNT_MOCK, 'pending');
-      expect(Contract).not.toHaveBeenCalled();
+      expect(PROVIDER_MOCK.request).toHaveBeenCalledWith({
+        method: 'eth_getBalance',
+        params: [ACCOUNT_MOCK, 'pending'],
+      });
     });
 
     it('treats native address comparison as case-insensitive', async () => {
-      mockGetBalance.mockResolvedValue({ toString: () => '500' });
+      (PROVIDER_MOCK.request as jest.Mock).mockResolvedValue('0x1f4');
 
       const result = await getLiveTokenBalance(
         messenger,
@@ -704,8 +689,90 @@ describe('Token Utils', () => {
       );
 
       expect(result).toBe('500');
-      expect(mockGetBalance).toHaveBeenCalledWith(ACCOUNT_MOCK, 'pending');
-      expect(Contract).not.toHaveBeenCalled();
+      expect(PROVIDER_MOCK.request).toHaveBeenCalledWith({
+        method: 'eth_getBalance',
+        params: [ACCOUNT_MOCK, 'pending'],
+      });
+    });
+
+    it('uses Infura network client when Infura endpoint is available', async () => {
+      (PROVIDER_MOCK.request as jest.Mock).mockResolvedValue('0x895440');
+
+      getNetworkConfigurationByChainIdMock.mockReturnValue({
+        rpcEndpoints: [
+          {
+            type: RpcEndpointType.Infura,
+            networkClientId: INFURA_NETWORK_CLIENT_ID_MOCK,
+          },
+        ],
+      } as NetworkConfiguration);
+
+      const result = await getLiveTokenBalance(
+        messenger,
+        ACCOUNT_MOCK,
+        CHAIN_ID_MOCK,
+        ERC20_ADDRESS_MOCK,
+      );
+
+      expect(result).toBe('9000000');
+      expect(getNetworkConfigurationByChainIdMock).toHaveBeenCalledWith(
+        CHAIN_ID_MOCK,
+      );
+      expect(getNetworkClientByIdMock).toHaveBeenCalledWith(
+        INFURA_NETWORK_CLIENT_ID_MOCK,
+      );
+      expect(findNetworkClientIdByChainIdMock).not.toHaveBeenCalled();
+    });
+
+    it('falls back to default network client when no Infura endpoint is configured', async () => {
+      (PROVIDER_MOCK.request as jest.Mock).mockResolvedValue('0x6ACFC0');
+
+      getNetworkConfigurationByChainIdMock.mockReturnValue({
+        rpcEndpoints: [
+          {
+            type: RpcEndpointType.Custom,
+            networkClientId: 'custom-rpc-id',
+          },
+        ],
+      } as NetworkConfiguration);
+
+      const result = await getLiveTokenBalance(
+        messenger,
+        ACCOUNT_MOCK,
+        CHAIN_ID_MOCK,
+        ERC20_ADDRESS_MOCK,
+      );
+
+      expect(result).toBe('7000000');
+      expect(findNetworkClientIdByChainIdMock).toHaveBeenCalledWith(
+        CHAIN_ID_MOCK,
+      );
+      expect(getNetworkClientByIdMock).toHaveBeenCalledWith(
+        NETWORK_CLIENT_ID_MOCK,
+      );
+    });
+
+    it('falls back to default network client when getNetworkConfigurationByChainId throws', async () => {
+      (PROVIDER_MOCK.request as jest.Mock).mockResolvedValue('0x2DC6C0');
+
+      getNetworkConfigurationByChainIdMock.mockImplementation(() => {
+        throw new Error('Network configuration not found');
+      });
+
+      const result = await getLiveTokenBalance(
+        messenger,
+        ACCOUNT_MOCK,
+        CHAIN_ID_MOCK,
+        ERC20_ADDRESS_MOCK,
+      );
+
+      expect(result).toBe('3000000');
+      expect(findNetworkClientIdByChainIdMock).toHaveBeenCalledWith(
+        CHAIN_ID_MOCK,
+      );
+      expect(getNetworkClientByIdMock).toHaveBeenCalledWith(
+        NETWORK_CLIENT_ID_MOCK,
+      );
     });
   });
 

--- a/packages/transaction-pay-controller/src/utils/token.test.ts
+++ b/packages/transaction-pay-controller/src/utils/token.test.ts
@@ -28,7 +28,6 @@ import {
   TokenAddressTarget,
 } from './token';
 
-
 const TOKEN_ADDRESS_MOCK = '0x559B65722aD62AD6DAC4Fa5a1c6B23A2e8ce57Ec' as Hex;
 const TOKEN_ADDRESS_2_MOCK = '0x123456789abcdef1234567890abcdef12345678' as Hex;
 const CHAIN_ID_MOCK = '0x1' as Hex;
@@ -645,7 +644,9 @@ describe('Token Utils', () => {
     });
 
     it('returns native balance via eth_getBalance', async () => {
-      (PROVIDER_MOCK.request as jest.Mock).mockResolvedValue('0xde0b6b3a7640000');
+      (PROVIDER_MOCK.request as jest.Mock).mockResolvedValue(
+        '0xde0b6b3a7640000',
+      );
 
       const result = await getLiveTokenBalance(
         messenger,
@@ -662,7 +663,9 @@ describe('Token Utils', () => {
     });
 
     it('returns native balance for polygon native address', async () => {
-      (PROVIDER_MOCK.request as jest.Mock).mockResolvedValue('0x1bc16d674ec80000');
+      (PROVIDER_MOCK.request as jest.Mock).mockResolvedValue(
+        '0x1bc16d674ec80000',
+      );
 
       const result = await getLiveTokenBalance(
         messenger,

--- a/packages/transaction-pay-controller/src/utils/token.ts
+++ b/packages/transaction-pay-controller/src/utils/token.ts
@@ -1,5 +1,4 @@
-import { Contract } from '@ethersproject/contracts';
-import { Web3Provider } from '@ethersproject/providers';
+import { Interface } from '@ethersproject/abi';
 import { TokensControllerState } from '@metamask/assets-controllers';
 import { toChecksumHexAddress } from '@metamask/controller-utils';
 import { abiERC20 } from '@metamask/metamask-eth-abis';
@@ -15,6 +14,7 @@ import {
 } from '../constants';
 import type { FiatRates, TransactionPayControllerMessenger } from '../types';
 import { getAssetsUnifyStateFeature } from './feature-flags';
+import { getNetworkClientId, rpcRequest } from './provider';
 
 /**
  * Check if two tokens are the same (same address and chain).
@@ -306,6 +306,10 @@ export function getNativeToken(chainId: Hex): Hex {
  * Unlike {@link getTokenBalance}, this bypasses the cached state in
  * `TokenBalancesController` and reads directly from the chain.
  *
+ * Uses the Infura RPC endpoint for the chain when one is configured, falling
+ * back to the chain's default endpoint. This avoids errors on custom mainnet
+ * RPC endpoints that may not support pending block queries.
+ *
  * @param messenger - Controller messenger.
  * @param account - Address of the account.
  * @param chainId - Chain ID.
@@ -318,31 +322,35 @@ export async function getLiveTokenBalance(
   chainId: Hex,
   tokenAddress: Hex,
 ): Promise<string> {
-  const networkClientId = messenger.call(
-    'NetworkController:findNetworkClientIdByChainId',
-    chainId,
-  );
-
-  const { provider } = messenger.call(
-    'NetworkController:getNetworkClientById',
-    networkClientId,
-  );
-
-  const ethersProvider = new Web3Provider(provider);
+  const options = { preferInfura: true };
   const isNative =
     tokenAddress.toLowerCase() === getNativeToken(chainId).toLowerCase();
 
-  // Use `pending` blockTag to bypass the RPC block-cache middleware so callers
-  // always observe the latest balance instead of a value pinned to the last
-  // polled block.
   if (isNative) {
-    const balance = await ethersProvider.getBalance(account, 'pending');
-    return balance.toString();
+    const result = await rpcRequest(
+      messenger,
+      chainId,
+      'eth_getBalance',
+      [account, 'pending'],
+      options,
+    );
+
+    return new BigNumber(result as string, 16).toString(10);
   }
 
-  const contract = new Contract(tokenAddress, abiERC20, ethersProvider);
-  const balance = await contract.balanceOf(account, { blockTag: 'pending' });
-  return balance.toString();
+  const calldata = new Interface(abiERC20).encodeFunctionData('balanceOf', [
+    account,
+  ]) as Hex;
+
+  const result = await rpcRequest(
+    messenger,
+    chainId,
+    'eth_call',
+    [{ to: tokenAddress, data: calldata }, 'pending'],
+    options,
+  );
+
+  return new BigNumber(result as string, 16).toString(10);
 }
 
 /**
@@ -385,17 +393,12 @@ function getTicker(
   messenger: TransactionPayControllerMessenger,
 ): string | undefined {
   try {
-    const networkClientId = messenger.call(
-      'NetworkController:findNetworkClientIdByChainId',
-      chainId,
-    );
+    const networkClientId = getNetworkClientId(messenger, chainId);
 
-    const networkConfiguration = messenger.call(
+    return messenger.call(
       'NetworkController:getNetworkClientById',
       networkClientId,
-    );
-
-    return networkConfiguration.configuration.ticker;
+    ).configuration.ticker;
   } catch {
     return undefined;
   }
@@ -447,3 +450,5 @@ export function normalizeTokenAddress(
 
   return tokenAddress;
 }
+
+

--- a/packages/transaction-pay-controller/src/utils/token.ts
+++ b/packages/transaction-pay-controller/src/utils/token.ts
@@ -450,5 +450,3 @@ export function normalizeTokenAddress(
 
   return tokenAddress;
 }
-
-

--- a/packages/transaction-pay-controller/src/utils/token.ts
+++ b/packages/transaction-pay-controller/src/utils/token.ts
@@ -327,30 +327,30 @@ export async function getLiveTokenBalance(
     tokenAddress.toLowerCase() === getNativeToken(chainId).toLowerCase();
 
   if (isNative) {
-    const result = await rpcRequest(
+    const result = await rpcRequest<string>({
       messenger,
       chainId,
-      'eth_getBalance',
-      [account, 'pending'],
+      method: 'eth_getBalance',
+      params: [account, 'pending'],
       options,
-    );
+    });
 
-    return new BigNumber(result as string, 16).toString(10);
+    return new BigNumber(result, 16).toString(10);
   }
 
   const calldata = new Interface(abiERC20).encodeFunctionData('balanceOf', [
     account,
   ]) as Hex;
 
-  const result = await rpcRequest(
+  const result = await rpcRequest<string>({
     messenger,
     chainId,
-    'eth_call',
-    [{ to: tokenAddress, data: calldata }, 'pending'],
+    method: 'eth_call',
+    params: [{ to: tokenAddress, data: calldata }, 'pending'],
     options,
-  );
+  });
 
-  return new BigNumber(result as string, 16).toString(10);
+  return new BigNumber(result, 16).toString(10);
 }
 
 /**

--- a/packages/transaction-pay-controller/src/utils/transaction.test.ts
+++ b/packages/transaction-pay-controller/src/utils/transaction.test.ts
@@ -1,5 +1,4 @@
 import { Interface } from '@ethersproject/abi';
-import { Web3Provider } from '@ethersproject/providers';
 import { abiERC20 } from '@metamask/metamask-eth-abis';
 import {
   TransactionStatus,
@@ -33,10 +32,6 @@ import {
 
 jest.mock('./feature-flags');
 jest.mock('./required-tokens');
-jest.mock('@ethersproject/providers', () => ({
-  ...jest.requireActual('@ethersproject/providers'),
-  Web3Provider: jest.fn(),
-}));
 
 const TRANSACTION_ID_MOCK = '123-456';
 const ERROR_MESSAGE_MOCK = 'Test error';
@@ -707,32 +702,18 @@ describe('getTransferredAmountFromTxHash', () => {
     getNetworkClientByIdMock: receiptGetNetworkMock,
   } = getMessengerMock();
 
-  let mockGetTransactionReceipt: jest.Mock;
-  let mockSend: jest.Mock;
-  let mockGetTx: jest.Mock;
-
   beforeEach(() => {
     jest.resetAllMocks();
-
-    mockGetTransactionReceipt = jest.fn();
-    mockSend = jest.fn();
-    mockGetTx = jest.fn();
 
     receiptFindNetworkMock.mockReturnValue(NETWORK_CLIENT_ID_RECEIPT_MOCK);
     receiptGetNetworkMock.mockReturnValue({
       provider: PROVIDER_RECEIPT_MOCK,
     } as never);
-
-    (Web3Provider as unknown as jest.Mock).mockImplementation(() => ({
-      getTransactionReceipt: mockGetTransactionReceipt,
-      send: mockSend,
-      getTransaction: mockGetTx,
-    }));
   });
 
   describe('native token', () => {
     it('returns amount from debug_traceTransaction for direct transfer', async () => {
-      mockSend.mockResolvedValue({
+      PROVIDER_RECEIPT_MOCK.request.mockResolvedValue({
         to: WALLET_ADDRESS_RECEIPT_MOCK.toLowerCase(),
         value: '0xde0b6b3a7640000',
         calls: [],
@@ -747,14 +728,14 @@ describe('getTransferredAmountFromTxHash', () => {
       });
 
       expect(result).toBe('1000000000000000000');
-      expect(mockSend).toHaveBeenCalledWith('debug_traceTransaction', [
-        TX_HASH_MOCK,
-        { tracer: 'callTracer' },
-      ]);
+      expect(PROVIDER_RECEIPT_MOCK.request).toHaveBeenCalledWith({
+        method: 'debug_traceTransaction',
+        params: [TX_HASH_MOCK, { tracer: 'callTracer' }],
+      });
     });
 
     it('sums native value from nested internal calls', async () => {
-      mockSend.mockResolvedValue({
+      PROVIDER_RECEIPT_MOCK.request.mockResolvedValue({
         to: '0xcontract',
         value: '0x0',
         calls: [
@@ -788,11 +769,17 @@ describe('getTransferredAmountFromTxHash', () => {
     });
 
     it('falls back to tx.value when debug_traceTransaction is unsupported', async () => {
-      mockSend.mockRejectedValue(new Error('Method not found'));
-      mockGetTx.mockResolvedValue({
-        to: WALLET_ADDRESS_RECEIPT_MOCK.toLowerCase(),
-        value: { toString: () => '1500000000000000000' },
-      });
+      PROVIDER_RECEIPT_MOCK.request.mockImplementation(
+        ({ method }: { method: string }) => {
+          if (method === 'debug_traceTransaction') {
+            return Promise.reject(new Error('Method not found'));
+          }
+          return Promise.resolve({
+            to: WALLET_ADDRESS_RECEIPT_MOCK.toLowerCase(),
+            value: '0x14d1120d7b160000',
+          });
+        },
+      );
 
       const result = await getTransferredAmountFromTxHash({
         messenger: receiptMessenger,
@@ -806,14 +793,17 @@ describe('getTransferredAmountFromTxHash', () => {
     });
 
     it('returns undefined when trace returns zero value and tx.to does not match wallet', async () => {
-      mockSend.mockResolvedValue({
-        to: '0xcontract',
-        value: '0x0',
-      });
-      mockGetTx.mockResolvedValue({
-        to: '0xcontract',
-        value: { toString: () => '1000000000000000000' },
-      });
+      PROVIDER_RECEIPT_MOCK.request.mockImplementation(
+        ({ method }: { method: string }) => {
+          if (method === 'debug_traceTransaction') {
+            return Promise.resolve({ to: '0xcontract', value: '0x0' });
+          }
+          return Promise.resolve({
+            to: '0xcontract',
+            value: '0xde0b6b3a7640000',
+          });
+        },
+      );
 
       const result = await getTransferredAmountFromTxHash({
         messenger: receiptMessenger,
@@ -827,8 +817,14 @@ describe('getTransferredAmountFromTxHash', () => {
     });
 
     it('returns undefined when trace is unsupported and transaction is not found', async () => {
-      mockSend.mockRejectedValue(new Error('Method not found'));
-      mockGetTx.mockResolvedValue(null);
+      PROVIDER_RECEIPT_MOCK.request.mockImplementation(
+        ({ method }: { method: string }) => {
+          if (method === 'debug_traceTransaction') {
+            return Promise.reject(new Error('Method not found'));
+          }
+          return Promise.resolve(null);
+        },
+      );
 
       const result = await getTransferredAmountFromTxHash({
         messenger: receiptMessenger,
@@ -842,11 +838,17 @@ describe('getTransferredAmountFromTxHash', () => {
     });
 
     it('returns undefined when trace is unsupported and native tx.value is zero', async () => {
-      mockSend.mockRejectedValue(new Error('Method not found'));
-      mockGetTx.mockResolvedValue({
-        to: WALLET_ADDRESS_RECEIPT_MOCK.toLowerCase(),
-        value: { toString: () => '0' },
-      });
+      PROVIDER_RECEIPT_MOCK.request.mockImplementation(
+        ({ method }: { method: string }) => {
+          if (method === 'debug_traceTransaction') {
+            return Promise.reject(new Error('Method not found'));
+          }
+          return Promise.resolve({
+            to: WALLET_ADDRESS_RECEIPT_MOCK.toLowerCase(),
+            value: '0x0',
+          });
+        },
+      );
 
       const result = await getTransferredAmountFromTxHash({
         messenger: receiptMessenger,
@@ -860,14 +862,20 @@ describe('getTransferredAmountFromTxHash', () => {
     });
 
     it('ignores trace value with 0x0', async () => {
-      mockSend.mockResolvedValue({
-        to: WALLET_ADDRESS_RECEIPT_MOCK.toLowerCase(),
-        value: '0x0',
-      });
-      mockGetTx.mockResolvedValue({
-        to: WALLET_ADDRESS_RECEIPT_MOCK.toLowerCase(),
-        value: { toString: () => '500' },
-      });
+      PROVIDER_RECEIPT_MOCK.request.mockImplementation(
+        ({ method }: { method: string }) => {
+          if (method === 'debug_traceTransaction') {
+            return Promise.resolve({
+              to: WALLET_ADDRESS_RECEIPT_MOCK.toLowerCase(),
+              value: '0x0',
+            });
+          }
+          return Promise.resolve({
+            to: WALLET_ADDRESS_RECEIPT_MOCK.toLowerCase(),
+            value: '0x1f4',
+          });
+        },
+      );
 
       const result = await getTransferredAmountFromTxHash({
         messenger: receiptMessenger,
@@ -883,7 +891,7 @@ describe('getTransferredAmountFromTxHash', () => {
 
   describe('ERC-20 token', () => {
     it('decodes transfer amount from receipt logs', async () => {
-      mockGetTransactionReceipt.mockResolvedValue({
+      PROVIDER_RECEIPT_MOCK.request.mockResolvedValue({
         logs: [encodeTransferLog(WALLET_ADDRESS_RECEIPT_MOCK, '5000000')],
       });
 
@@ -899,7 +907,7 @@ describe('getTransferredAmountFromTxHash', () => {
     });
 
     it('sums multiple Transfer events to the same wallet', async () => {
-      mockGetTransactionReceipt.mockResolvedValue({
+      PROVIDER_RECEIPT_MOCK.request.mockResolvedValue({
         logs: [
           encodeTransferLog(WALLET_ADDRESS_RECEIPT_MOCK, '3000000'),
           encodeTransferLog(WALLET_ADDRESS_RECEIPT_MOCK, '2000000'),
@@ -919,7 +927,7 @@ describe('getTransferredAmountFromTxHash', () => {
 
     it('ignores Transfer events to other addresses', async () => {
       const otherAddress = '0x3333333333333333333333333333333333333333' as Hex;
-      mockGetTransactionReceipt.mockResolvedValue({
+      PROVIDER_RECEIPT_MOCK.request.mockResolvedValue({
         logs: [
           encodeTransferLog(otherAddress, '9000000'),
           encodeTransferLog(WALLET_ADDRESS_RECEIPT_MOCK, '1000000'),
@@ -943,7 +951,7 @@ describe('getTransferredAmountFromTxHash', () => {
         WALLET_ADDRESS_RECEIPT_MOCK,
         '5000000',
       );
-      mockGetTransactionReceipt.mockResolvedValue({
+      PROVIDER_RECEIPT_MOCK.request.mockResolvedValue({
         logs: [
           { ...transferLog, address: otherToken },
           encodeTransferLog(WALLET_ADDRESS_RECEIPT_MOCK, '1000000'),
@@ -962,7 +970,7 @@ describe('getTransferredAmountFromTxHash', () => {
     });
 
     it('ignores logs with non-Transfer event topics', async () => {
-      mockGetTransactionReceipt.mockResolvedValue({
+      PROVIDER_RECEIPT_MOCK.request.mockResolvedValue({
         logs: [
           {
             address: ERC20_ADDRESS_RECEIPT_MOCK,
@@ -989,7 +997,7 @@ describe('getTransferredAmountFromTxHash', () => {
     });
 
     it('returns undefined when receipt is not found', async () => {
-      mockGetTransactionReceipt.mockResolvedValue(null);
+      PROVIDER_RECEIPT_MOCK.request.mockResolvedValue(null);
 
       const result = await getTransferredAmountFromTxHash({
         messenger: receiptMessenger,
@@ -1003,9 +1011,7 @@ describe('getTransferredAmountFromTxHash', () => {
     });
 
     it('returns undefined when no matching Transfer logs exist', async () => {
-      mockGetTransactionReceipt.mockResolvedValue({
-        logs: [],
-      });
+      PROVIDER_RECEIPT_MOCK.request.mockResolvedValue({ logs: [] });
 
       const result = await getTransferredAmountFromTxHash({
         messenger: receiptMessenger,
@@ -1019,7 +1025,7 @@ describe('getTransferredAmountFromTxHash', () => {
     });
 
     it('skips malformed log entries gracefully', async () => {
-      mockGetTransactionReceipt.mockResolvedValue({
+      PROVIDER_RECEIPT_MOCK.request.mockResolvedValue({
         logs: [
           {
             address: ERC20_ADDRESS_RECEIPT_MOCK,
@@ -1042,7 +1048,7 @@ describe('getTransferredAmountFromTxHash', () => {
     });
 
     it('returns undefined when all Transfer amounts are zero', async () => {
-      mockGetTransactionReceipt.mockResolvedValue({
+      PROVIDER_RECEIPT_MOCK.request.mockResolvedValue({
         logs: [encodeTransferLog(WALLET_ADDRESS_RECEIPT_MOCK, '0')],
       });
 
@@ -1059,7 +1065,7 @@ describe('getTransferredAmountFromTxHash', () => {
   });
 
   it('propagates provider errors for ERC-20', async () => {
-    mockGetTransactionReceipt.mockRejectedValue(new Error('RPC error'));
+    PROVIDER_RECEIPT_MOCK.request.mockRejectedValue(new Error('RPC error'));
 
     await expect(
       getTransferredAmountFromTxHash({
@@ -1073,8 +1079,7 @@ describe('getTransferredAmountFromTxHash', () => {
   });
 
   it('propagates provider errors for native when both trace and getTransaction fail', async () => {
-    mockSend.mockRejectedValue(new Error('Trace failed'));
-    mockGetTx.mockRejectedValue(new Error('RPC error'));
+    PROVIDER_RECEIPT_MOCK.request.mockRejectedValue(new Error('RPC error'));
 
     await expect(
       getTransferredAmountFromTxHash({

--- a/packages/transaction-pay-controller/src/utils/transaction.ts
+++ b/packages/transaction-pay-controller/src/utils/transaction.ts
@@ -400,7 +400,12 @@ export async function getTransferredAmountFromTxHash({
     tokenAddress.toLowerCase() === getNativeToken(chainId).toLowerCase();
 
   if (isNative) {
-    return await getNativeTransferAmount(messenger, chainId, txHash, walletAddress);
+    return await getNativeTransferAmount(
+      messenger,
+      chainId,
+      txHash,
+      walletAddress,
+    );
   }
 
   return await getErc20TransferAmount(

--- a/packages/transaction-pay-controller/src/utils/transaction.ts
+++ b/packages/transaction-pay-controller/src/utils/transaction.ts
@@ -433,12 +433,14 @@ async function getNativeTransferAmount(
   walletAddress: Hex,
 ): Promise<string | undefined> {
   try {
-    const trace = await rpcRequest(messenger, chainId, 'debug_traceTransaction', [
-      txHash,
-      { tracer: 'callTracer' },
-    ]);
+    const trace = await rpcRequest<CallTrace>({
+      messenger,
+      chainId,
+      method: 'debug_traceTransaction',
+      params: [txHash, { tracer: 'callTracer' }],
+    });
 
-    const amount = sumNativeValueFromTrace(trace as CallTrace, walletAddress);
+    const amount = sumNativeValueFromTrace(trace, walletAddress);
     if (amount.gt(0)) {
       return amount.toFixed(0);
     }
@@ -446,10 +448,12 @@ async function getNativeTransferAmount(
     // debug_traceTransaction not supported — fall through to tx.value
   }
 
-  const tx = await rpcRequest(messenger, chainId, 'eth_getTransactionByHash', [txHash]) as {
-    to?: string;
-    value: string;
-  } | null;
+  const tx = await rpcRequest<{ to?: string; value: string } | null>({
+    messenger,
+    chainId,
+    method: 'eth_getTransactionByHash',
+    params: [txHash],
+  });
 
   if (!tx) {
     return undefined;
@@ -480,9 +484,14 @@ async function getErc20TransferAmount(
   tokenAddress: Hex,
   walletAddress: Hex,
 ): Promise<string | undefined> {
-  const receipt = await rpcRequest(messenger, chainId, 'eth_getTransactionReceipt', [txHash]) as {
+  const receipt = await rpcRequest<{
     logs: { address: string; topics: string[]; data: string }[];
-  } | null;
+  } | null>({
+    messenger,
+    chainId,
+    method: 'eth_getTransactionReceipt',
+    params: [txHash],
+  });
 
   if (!receipt) {
     return undefined;

--- a/packages/transaction-pay-controller/src/utils/transaction.ts
+++ b/packages/transaction-pay-controller/src/utils/transaction.ts
@@ -1,5 +1,4 @@
 import { Interface } from '@ethersproject/abi';
-import { Web3Provider } from '@ethersproject/providers';
 import { abiERC20 } from '@metamask/metamask-eth-abis';
 import {
   TransactionStatus,
@@ -19,6 +18,7 @@ import type {
   UpdateTransactionDataCallback,
 } from '../types';
 import { getAssetsUnifyStateFeature } from './feature-flags';
+import { getNetworkClientId, rpcRequest } from './provider';
 import { parseRequiredTokens } from './required-tokens';
 import { getNativeToken } from './token';
 
@@ -396,17 +396,16 @@ export async function getTransferredAmountFromTxHash({
   tokenAddress: Hex;
   walletAddress: Hex;
 }): Promise<string | undefined> {
-  const provider = getEthersProvider(messenger, chainId);
-
   const isNative =
     tokenAddress.toLowerCase() === getNativeToken(chainId).toLowerCase();
 
   if (isNative) {
-    return await getNativeTransferAmount(provider, txHash, walletAddress);
+    return await getNativeTransferAmount(messenger, chainId, txHash, walletAddress);
   }
 
   return await getErc20TransferAmount(
-    provider,
+    messenger,
+    chainId,
     txHash,
     tokenAddress,
     walletAddress,
@@ -421,23 +420,25 @@ export async function getTransferredAmountFromTxHash({
  * 2. Falls back to the top-level `tx.value` when the wallet is the direct
  *    recipient and the trace RPC is unavailable or errors.
  *
- * @param provider - Ethers Web3Provider.
+ * @param messenger - Controller messenger.
+ * @param chainId - Chain ID where the transaction was executed.
  * @param txHash - Transaction hash.
  * @param walletAddress - Recipient wallet address.
  * @returns Raw amount as a decimal string, or `undefined`.
  */
 async function getNativeTransferAmount(
-  provider: Web3Provider,
+  messenger: TransactionPayControllerMessenger,
+  chainId: Hex,
   txHash: string,
   walletAddress: Hex,
 ): Promise<string | undefined> {
   try {
-    const trace = await provider.send('debug_traceTransaction', [
+    const trace = await rpcRequest(messenger, chainId, 'debug_traceTransaction', [
       txHash,
       { tracer: 'callTracer' },
     ]);
 
-    const amount = sumNativeValueFromTrace(trace, walletAddress);
+    const amount = sumNativeValueFromTrace(trace as CallTrace, walletAddress);
     if (amount.gt(0)) {
       return amount.toFixed(0);
     }
@@ -445,7 +446,11 @@ async function getNativeTransferAmount(
     // debug_traceTransaction not supported — fall through to tx.value
   }
 
-  const tx = await provider.getTransaction(txHash);
+  const tx = await rpcRequest(messenger, chainId, 'eth_getTransactionByHash', [txHash]) as {
+    to?: string;
+    value: string;
+  } | null;
+
   if (!tx) {
     return undefined;
   }
@@ -454,26 +459,30 @@ async function getNativeTransferAmount(
     return undefined;
   }
 
-  return positiveOrUndefined(tx.value.toString());
+  return positiveOrUndefined(new BigNumber(tx.value).toFixed(0));
 }
 
 /**
  * Resolves the ERC-20 token amount received by a wallet from a transaction
  * by decoding `Transfer` event logs from the transaction receipt.
  *
- * @param provider - Ethers Web3Provider.
+ * @param messenger - Controller messenger.
+ * @param chainId - Chain ID where the transaction was executed.
  * @param txHash - Transaction hash.
  * @param tokenAddress - ERC-20 token contract address.
  * @param walletAddress - Recipient wallet address.
  * @returns Raw amount as a decimal string, or `undefined`.
  */
 async function getErc20TransferAmount(
-  provider: Web3Provider,
+  messenger: TransactionPayControllerMessenger,
+  chainId: Hex,
   txHash: string,
   tokenAddress: Hex,
   walletAddress: Hex,
 ): Promise<string | undefined> {
-  const receipt = await provider.getTransactionReceipt(txHash);
+  const receipt = await rpcRequest(messenger, chainId, 'eth_getTransactionReceipt', [txHash]) as {
+    logs: { address: string; topics: string[]; data: string }[];
+  } | null;
 
   if (!receipt) {
     return undefined;
@@ -542,23 +551,6 @@ function sumNativeValueFromTrace(
   }
 
   return total;
-}
-
-function getEthersProvider(
-  messenger: TransactionPayControllerMessenger,
-  chainId: Hex,
-): Web3Provider {
-  const networkClientId = messenger.call(
-    'NetworkController:findNetworkClientIdByChainId',
-    chainId,
-  );
-
-  const { provider } = messenger.call(
-    'NetworkController:getNetworkClientById',
-    networkClientId,
-  );
-
-  return new Web3Provider(provider);
 }
 
 function positiveOrUndefined(amount: string): string | undefined {

--- a/packages/transaction-pay-controller/src/utils/transaction.ts
+++ b/packages/transaction-pay-controller/src/utils/transaction.ts
@@ -18,7 +18,7 @@ import type {
   UpdateTransactionDataCallback,
 } from '../types';
 import { getAssetsUnifyStateFeature } from './feature-flags';
-import { getNetworkClientId, rpcRequest } from './provider';
+import { rpcRequest } from './provider';
 import { parseRequiredTokens } from './required-tokens';
 import { getNativeToken } from './token';
 


### PR DESCRIPTION
## Explanation

When querying a live on-chain token balance, the controller previously resolved the network client using `findNetworkClientIdByChainId`, which returns whatever endpoint is currently selected for that chain — including custom RPC endpoints. Custom RPC endpoints may not support the `pending` block tag used by these calls, causing the query to fail.

This change adds a preference for the chain's Infura endpoint when one is configured, falling back to the existing `findNetworkClientIdByChainId` behaviour if no Infura endpoint is configured or if the lookup throws.

## References

<!--
Are there any issues that this pull request is tied to?
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which RPC endpoint serves balance checks and on-chain amount reads before Relay submit; wrong endpoint selection could block or mis-validate pay deposits, though Infura preference falls back to the default client.
> 
> **Overview**
> Introduces shared **`provider` utilities** (`getNetworkClientId`, `rpcRequest`) so chain RPC calls go through the controller messenger’s `provider.request` instead of **ethers `Web3Provider` / `Contract`**.
> 
> **Live token balances** (`getLiveTokenBalance`) now call `eth_getBalance` / `eth_call` with the **`pending`** block tag and pass **`preferInfura: true`**, picking the chain’s Infura `networkClientId` when configured and otherwise using `findNetworkClientIdByChainId`—addressing failures on custom RPCs that don’t support pending queries.
> 
> The same RPC helper path is used for **fiat source amount resolution** and **transfer amount from tx hash** (receipt logs, `debug_traceTransaction`, `eth_getTransactionByHash`). **Across**, **Relay**, and **gas** estimation call sites switch to `getNetworkClientId` for consistency.
> 
> Messenger **`AllowedActions`** and test mocks register **`NetworkController:getNetworkConfigurationByChainId`**. Changelog documents the Infura preference for live balance queries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ca536424a5502e118637de884c44654fe3c962d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->