### PR TITLE
fix(snap-account-service): fix missing exports

### DIFF
--- a/packages/snap-account-service/CHANGELOG.md
+++ b/packages/snap-account-service/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `SnapAccountService{GetLegacySnapKeyring,HandleKeyringSnapMessage}Action` ([#8842](https://github.com/MetaMask/core/pull/8842))
+
 ## [0.1.0]
 
 ### Added

--- a/packages/snap-account-service/src/index.ts
+++ b/packages/snap-account-service/src/index.ts
@@ -9,6 +9,8 @@ export type {
 export type {
   SnapAccountServiceEnsureReadyAction,
   SnapAccountServiceGetSnapsAction,
+  SnapAccountServiceGetLegacySnapKeyringAction,
+  SnapAccountServiceHandleKeyringSnapMessageAction,
 } from './SnapAccountService-method-action-types';
 export { SnapPlatformWatcher } from './SnapPlatformWatcher';
 export type { SnapPlatformWatcherConfig } from './SnapPlatformWatcher';


### PR DESCRIPTION
## Explanation

Fix missing exports.

## References

N/A

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates public exports and the changelog, with no runtime logic changes.
> 
> **Overview**
> Fixes missing TypeScript exports from `@metamask/snap-account-service` by re-exporting `SnapAccountServiceGetLegacySnapKeyringAction` and `SnapAccountServiceHandleKeyringSnapMessageAction` from `src/index.ts`.
> 
> Updates the package changelog to document the newly exported action types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16749daa5b3eb5c2087caee3ec3a436a83495be7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->