### PR TITLE
feat: integrate AuthenticationController for bearer token handling in…

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,7 @@ linkStyle default opacity:0.5
   ramps_controller --> base_controller;
   ramps_controller --> controller_utils;
   ramps_controller --> messenger;
+  ramps_controller --> profile_sync_controller;
   rate_limit_controller --> base_controller;
   rate_limit_controller --> messenger;
   react_data_query --> base_data_service;

--- a/packages/ramps-controller/CHANGELOG.md
+++ b/packages/ramps-controller/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Authenticate ramps requests by sourcing a bearer token from `AuthenticationController:getBearerToken` and sending it as an `Authorization: Bearer <token>` header for `getBuyWidgetUrl` ([#8843](https://github.com/MetaMask/core/pull/8843))
+- Add `@metamask/profile-sync-controller` `^28.1.0` as a runtime dependency ([#8843](https://github.com/MetaMask/core/pull/8843))
+
 ### Changed
 
+- **BREAKING:** `RampsServiceMessenger` now requires the `AuthenticationController:getBearerToken` action to be delegated to it; consumers must register this action handler before calling `getBuyWidgetUrl`, otherwise the call will throw ([#8843](https://github.com/MetaMask/core/pull/8843))
 - Bump `@metamask/controller-utils` from `^12.0.0` to `^12.1.0` ([#8774](https://github.com/MetaMask/core/pull/8774))
 
 ## [13.3.1]

--- a/packages/ramps-controller/package.json
+++ b/packages/ramps-controller/package.json
@@ -56,7 +56,8 @@
   "dependencies": {
     "@metamask/base-controller": "^9.1.0",
     "@metamask/controller-utils": "^12.1.0",
-    "@metamask/messenger": "^1.2.0"
+    "@metamask/messenger": "^1.2.0",
+    "@metamask/profile-sync-controller": "^28.1.0"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^6.1.0",

--- a/packages/ramps-controller/src/RampsService.test.ts
+++ b/packages/ramps-controller/src/RampsService.test.ts
@@ -4,7 +4,7 @@ import type {
   MessengerActions,
   MessengerEvents,
 } from '@metamask/messenger';
-import nock from 'nock';
+import nock, { cleanAll } from 'nock';
 
 import { flushPromises } from '../../../tests/helpers';
 import packageJson from '../package.json';
@@ -2468,7 +2468,11 @@ describe('RampsService', () => {
 
   describe('RampsService:getBuyWidgetUrl', () => {
     it('returns buy widget data from the buy URL endpoint', async () => {
-      nock('https://on-ramp.uat-api.cx.metamask.io')
+      nock('https://on-ramp.uat-api.cx.metamask.io', {
+        reqheaders: {
+          Authorization: 'Bearer mock-bearer-token',
+        },
+      })
         .get('/providers/transak-staging/buy-widget')
         .query({
           sdk: '2.1.6',
@@ -2498,7 +2502,11 @@ describe('RampsService', () => {
     });
 
     it('throws when the response is not ok', async () => {
-      nock('https://on-ramp.uat-api.cx.metamask.io')
+      nock('https://on-ramp.uat-api.cx.metamask.io', {
+        reqheaders: {
+          Authorization: 'Bearer mock-bearer-token',
+        },
+      })
         .get('/providers/transak-staging/buy-widget')
         .query({
           sdk: '2.1.6',
@@ -2524,7 +2532,11 @@ describe('RampsService', () => {
     });
 
     it('throws when the response does not contain url field', async () => {
-      nock('https://on-ramp.uat-api.cx.metamask.io')
+      nock('https://on-ramp.uat-api.cx.metamask.io', {
+        reqheaders: {
+          Authorization: 'Bearer mock-bearer-token',
+        },
+      })
         .get('/providers/transak-staging/buy-widget')
         .query({
           sdk: '2.1.6',
@@ -2547,6 +2559,101 @@ describe('RampsService', () => {
       await expect(buyWidgetPromise).rejects.toThrow(
         'Malformed response received from buy widget URL API',
       );
+    });
+
+    it('requests a bearer token exactly once per call', async () => {
+      nock('https://on-ramp.uat-api.cx.metamask.io', {
+        reqheaders: {
+          Authorization: 'Bearer mock-bearer-token',
+        },
+      })
+        .get('/providers/transak-staging/buy-widget')
+        .query({
+          sdk: '2.1.6',
+          controller: CONTROLLER_VERSION,
+          context: 'mobile-ios',
+        })
+        .reply(200, {
+          url: 'https://global.transak.com/?apiKey=test',
+          browser: 'APP_BROWSER',
+          orderId: null,
+        });
+      const { service, mockGetBearerToken } = getService();
+
+      const buyWidgetPromise = service.getBuyWidgetUrl(
+        'https://on-ramp.uat-api.cx.metamask.io/providers/transak-staging/buy-widget',
+      );
+      await jest.runAllTimersAsync();
+      await flushPromises();
+      await buyWidgetPromise;
+
+      expect(mockGetBearerToken).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects without making an HTTP call when the bearer token cannot be retrieved', async () => {
+      const interceptor = nock('https://on-ramp.uat-api.cx.metamask.io')
+        .get('/providers/transak-staging/buy-widget')
+        .query(true)
+        .reply(200, {
+          url: 'https://global.transak.com/?apiKey=test',
+          browser: 'APP_BROWSER',
+          orderId: null,
+        });
+      const { service } = getService({
+        mockGetBearerToken: jest
+          .fn()
+          .mockRejectedValue(new Error('Wallet is locked')),
+      });
+
+      await expect(
+        service.getBuyWidgetUrl(
+          'https://on-ramp.uat-api.cx.metamask.io/providers/transak-staging/buy-widget',
+        ),
+      ).rejects.toThrow('Wallet is locked');
+      expect(interceptor.isDone()).toBe(false);
+      cleanAll();
+    });
+  });
+
+  describe('RampsService bearer auth scope', () => {
+    it('does not request a bearer token for getGeolocation', async () => {
+      nock('https://on-ramp.uat-api.cx.metamask.io')
+        .get('/geolocation')
+        .query({
+          sdk: '2.1.6',
+          controller: CONTROLLER_VERSION,
+          context: 'mobile-ios',
+        })
+        .reply(200, 'US');
+      const { service, mockGetBearerToken } = getService();
+
+      const geolocationPromise = service.getGeolocation();
+      await jest.runAllTimersAsync();
+      await flushPromises();
+      await geolocationPromise;
+
+      expect(mockGetBearerToken).not.toHaveBeenCalled();
+    });
+
+    it('does not send an Authorization header for getGeolocation', async () => {
+      const scope = nock('https://on-ramp.uat-api.cx.metamask.io', {
+        badheaders: ['authorization'],
+      })
+        .get('/geolocation')
+        .query({
+          sdk: '2.1.6',
+          controller: CONTROLLER_VERSION,
+          context: 'mobile-ios',
+        })
+        .reply(200, 'US');
+      const { service } = getService();
+
+      const geolocationPromise = service.getGeolocation();
+      await jest.runAllTimersAsync();
+      await flushPromises();
+      await geolocationPromise;
+
+      expect(scope.isDone()).toBe(true);
     });
   });
 
@@ -2917,10 +3024,16 @@ function getRootMessenger(): RootMessenger {
  * @returns The service-specific messenger.
  */
 function getMessenger(rootMessenger: RootMessenger): RampsServiceMessenger {
-  return new Messenger({
+  const messenger: RampsServiceMessenger = new Messenger({
     namespace: 'RampsService',
     parent: rootMessenger,
   });
+  rootMessenger.delegate({
+    actions: ['AuthenticationController:getBearerToken'],
+    events: [],
+    messenger,
+  });
+  return messenger;
 }
 
 /**
@@ -2930,18 +3043,31 @@ function getMessenger(rootMessenger: RootMessenger): RampsServiceMessenger {
  * @param args.options - The options that the service constructor takes. All are
  * optional and will be filled in with defaults in as needed (including
  * `messenger`).
- * @returns The new service, root messenger, and service messenger.
+ * @param args.mockGetBearerToken - Optional override for the
+ * `AuthenticationController:getBearerToken` handler. Defaults to a jest mock
+ * that resolves with `'mock-bearer-token'`.
+ * @returns The new service, root messenger, service messenger, and the bearer
+ * token mock so tests can inspect or override its behavior.
  */
 function getService({
   options = {},
+  mockGetBearerToken,
 }: {
   options?: Partial<ConstructorParameters<typeof RampsService>[0]>;
+  mockGetBearerToken?: jest.Mock;
 } = {}): {
   service: RampsService;
   rootMessenger: RootMessenger;
   messenger: RampsServiceMessenger;
+  mockGetBearerToken: jest.Mock;
 } {
   const rootMessenger = getRootMessenger();
+  const getBearerTokenMock =
+    mockGetBearerToken ?? jest.fn().mockResolvedValue('mock-bearer-token');
+  rootMessenger.registerActionHandler(
+    'AuthenticationController:getBearerToken',
+    getBearerTokenMock,
+  );
   const messenger = getMessenger(rootMessenger);
   const service = new RampsService({
     fetch,
@@ -2950,5 +3076,10 @@ function getService({
     ...options,
   });
 
-  return { service, rootMessenger, messenger };
+  return {
+    service,
+    rootMessenger,
+    messenger,
+    mockGetBearerToken: getBearerTokenMock,
+  };
 }

--- a/packages/ramps-controller/src/RampsService.ts
+++ b/packages/ramps-controller/src/RampsService.ts
@@ -4,6 +4,7 @@ import type {
 } from '@metamask/controller-utils';
 import { createServicePolicy, HttpError } from '@metamask/controller-utils';
 import type { Messenger } from '@metamask/messenger';
+import type { AuthenticationController } from '@metamask/profile-sync-controller';
 
 import packageJson from '../package.json';
 import type { RampsServiceMethodActions } from './RampsService-method-action-types';
@@ -684,7 +685,8 @@ export type RampsServiceActions = RampsServiceMethodActions;
 /**
  * Actions from other messengers that {@link RampsService} calls.
  */
-type AllowedActions = never;
+type AllowedActions =
+  AuthenticationController.AuthenticationControllerGetBearerTokenAction;
 
 /**
  * Events that {@link RampsService} exposes to other consumers.
@@ -889,6 +891,24 @@ export class RampsService {
       return this.#baseUrlOverride;
     }
     return getBaseUrl(this.#environment, service);
+  }
+
+  /**
+   * Builds the request headers for authenticated ramps API calls.
+   *
+   * Fetches a bearer token from `AuthenticationController` and returns it as
+   * an `Authorization` header. Throws if the token is unavailable (e.g. the
+   * wallet is locked or the user is signed out).
+   *
+   * @returns Headers containing the `Authorization: Bearer <token>` entry.
+   */
+  async #getRequestHeaders(): Promise<Record<string, string>> {
+    const bearerToken = await this.#messenger.call(
+      'AuthenticationController:getBearerToken',
+    );
+    return {
+      Authorization: `Bearer ${bearerToken}`,
+    };
   }
 
   /**
@@ -1324,8 +1344,10 @@ export class RampsService {
     const url = new URL(buyUrl);
     this.#addCommonParams(url);
 
+    const headers = await this.#getRequestHeaders();
+
     const response = await this.#policy.execute(async () => {
-      const fetchResponse = await this.#fetch(url);
+      const fetchResponse = await this.#fetch(url, { headers });
       if (!fetchResponse.ok) {
         throw new HttpError(
           fetchResponse.status,

--- a/packages/ramps-controller/tsconfig.build.json
+++ b/packages/ramps-controller/tsconfig.build.json
@@ -15,6 +15,9 @@
     },
     {
       "path": "../messenger/tsconfig.build.json"
+    },
+    {
+      "path": "../profile-sync-controller/tsconfig.build.json"
     }
   ],
   "include": ["../../types", "./src"]

--- a/packages/ramps-controller/tsconfig.json
+++ b/packages/ramps-controller/tsconfig.json
@@ -4,6 +4,10 @@
     "baseUrl": "./",
     "resolveJsonModule": true
   },
-  "references": [{ "path": "../base-controller" }, { "path": "../messenger" }],
+  "references": [
+    { "path": "../base-controller" },
+    { "path": "../messenger" },
+    { "path": "../profile-sync-controller" }
+  ],
   "include": ["../../types", "./src"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5194,6 +5194,7 @@ __metadata:
     "@metamask/base-controller": "npm:^9.1.0"
     "@metamask/controller-utils": "npm:^12.1.0"
     "@metamask/messenger": "npm:^1.2.0"
+    "@metamask/profile-sync-controller": "npm:^28.1.0"
     "@ts-bridge/cli": "npm:^0.6.4"
     "@types/jest": "npm:^29.5.14"
     deepmerge: "npm:^4.2.2"


### PR DESCRIPTION
## Explanation

`RampsService.getBuyWidgetUrl` previously issued unauthenticated requests to the ramps API (`/providers/<provider>/buy-widget`). The upstream API is being gated behind authentication, so without a bearer token the call will start to fail and break the Buy flow for every consumer (mobile, extension).

This PR makes `getBuyWidgetUrl` authenticated by sourcing a bearer token from `AuthenticationController` via the messenger and attaching it as an `Authorization: Bearer <token>` header on the outgoing request.

**How it works:**

- A new private method `RampsService.#getRequestHeaders` calls the messenger action `AuthenticationController:getBearerToken` and returns the `Authorization` header. It is awaited once per `getBuyWidgetUrl` invocation (verified by a new test) before the request is dispatched through the existing `#policy.execute` wrapper, so token retrieval happens outside the retry/circuit-breaker loop. If the token call rejects (e.g. wallet is locked, user signed out), the rejection propagates and no HTTP call is made — also covered by a new test.
- `RampsServiceMessenger`'s `AllowedActions` is widened from `never` to `AuthenticationController.AuthenticationControllerGetBearerTokenAction`. This is a **breaking change** to the messenger contract: consumers must delegate the `AuthenticationController:getBearerToken` action into the ramps messenger before calling `getBuyWidgetUrl`.
- The scope of the auth requirement is deliberately narrow — only `getBuyWidgetUrl` is authenticated in this PR. Other endpoints (e.g. `getGeolocation`) remain unauthenticated and explicitly do not request a bearer token; this is locked in by tests that assert `getBearerToken` is not called and that no `Authorization` header is sent for those endpoints.

**Dependency added:**

`@metamask/profile-sync-controller@^28.1.0` is added as a runtime dependency solely for its `AuthenticationController` type export (the `AuthenticationControllerGetBearerTokenAction` action type). It is not instantiated by `ramps-controller`; the implementing controller lives in the consuming app and is wired up via the messenger.

**Demo:**

https://github.com/user-attachments/assets/87d4d146-1ce4-4582-a27a-4e60760fae7b


**Test updates:**

- Existing happy-path tests for `getBuyWidgetUrl` now assert the `Authorization: Bearer mock-bearer-token` header is present on the nock interceptor.
- New tests cover: bearer token is fetched exactly once per call; rejection from `getBearerToken` short-circuits before any HTTP request; and the scope assertion that `getGeolocation` remains unauthenticated.
- The `getRootMessenger`/`getService` test helpers now delegate the `AuthenticationController:getBearerToken` action and expose a `mockGetBearerToken` jest mock so individual tests can override the resolution behavior.

## References

- Fixes [TRAM-3502](https://consensyssoftware.atlassian.net/browse/TRAM-3502)
- Consumer adoption (mobile): https://github.com/MetaMask/metamask-mobile/pull/30319

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


[TRAM-3502]: https://consensyssoftware.atlassian.net/browse/TRAM-3502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to a **breaking** messenger contract change requiring consumers to delegate `AuthenticationController:getBearerToken`, and because it changes how `getBuyWidgetUrl` performs network requests by adding auth headers and failing early when tokens are unavailable.
> 
> **Overview**
> `RampsService.getBuyWidgetUrl` now authenticates buy-widget requests by retrieving a bearer token via the messenger action `AuthenticationController:getBearerToken` and sending `Authorization: Bearer <token>` on the HTTP call.
> 
> This widens `RampsServiceMessenger` allowed actions (a **breaking change** for consumers that must delegate/register the new action), adds `@metamask/profile-sync-controller` as a runtime dependency for the action type, updates TS project references, and extends tests to assert auth header behavior, token fetch call counts, and that unrelated endpoints (e.g. `getGeolocation`) remain unauthenticated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdad7425cc6906bef947041f93a2375715e89e79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->