### PR TITLE
Revert "Release/993.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "993.0.0",
+  "version": "992.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {

--- a/packages/gator-permissions-controller/CHANGELOG.md
+++ b/packages/gator-permissions-controller/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [4.2.0]
-
 ### Added
 
 - Add `token-approval-revocation` execution permission type decoding ([#8823](https://github.com/MetaMask/core/pull/8823))
@@ -256,8 +254,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release ([#6033](https://github.com/MetaMask/core/pull/6033))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/gator-permissions-controller@4.2.0...HEAD
-[4.2.0]: https://github.com/MetaMask/core/compare/@metamask/gator-permissions-controller@4.1.2...@metamask/gator-permissions-controller@4.2.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/gator-permissions-controller@4.1.2...HEAD
 [4.1.2]: https://github.com/MetaMask/core/compare/@metamask/gator-permissions-controller@4.1.1...@metamask/gator-permissions-controller@4.1.2
 [4.1.1]: https://github.com/MetaMask/core/compare/@metamask/gator-permissions-controller@4.1.0...@metamask/gator-permissions-controller@4.1.1
 [4.1.0]: https://github.com/MetaMask/core/compare/@metamask/gator-permissions-controller@4.0.0...@metamask/gator-permissions-controller@4.1.0

--- a/packages/gator-permissions-controller/package.json
+++ b/packages/gator-permissions-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/gator-permissions-controller",
-  "version": "4.2.0",
+  "version": "4.1.2",
   "description": "Controller for managing gator permissions with profile sync integration",
   "keywords": [
     "Ethereum",

--- a/packages/signature-controller/CHANGELOG.md
+++ b/packages/signature-controller/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- Bump `@metamask/gator-permissions-controller` from `^4.1.2` to `^4.2.0` ([#8855](https://github.com/MetaMask/core/pull/8855))
-
 ## [39.2.2]
 
 ### Changed

--- a/packages/signature-controller/package.json
+++ b/packages/signature-controller/package.json
@@ -58,7 +58,7 @@
     "@metamask/base-controller": "^9.1.0",
     "@metamask/controller-utils": "^12.1.0",
     "@metamask/eth-sig-util": "^8.2.0",
-    "@metamask/gator-permissions-controller": "^4.2.0",
+    "@metamask/gator-permissions-controller": "^4.1.2",
     "@metamask/keyring-controller": "^25.5.0",
     "@metamask/logging-controller": "^8.0.2",
     "@metamask/messenger": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4122,7 +4122,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/gator-permissions-controller@npm:^4.2.0, @metamask/gator-permissions-controller@workspace:packages/gator-permissions-controller":
+"@metamask/gator-permissions-controller@npm:^4.1.2, @metamask/gator-permissions-controller@workspace:packages/gator-permissions-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/gator-permissions-controller@workspace:packages/gator-permissions-controller"
   dependencies:
@@ -5430,7 +5430,7 @@ __metadata:
     "@metamask/base-controller": "npm:^9.1.0"
     "@metamask/controller-utils": "npm:^12.1.0"
     "@metamask/eth-sig-util": "npm:^8.2.0"
-    "@metamask/gator-permissions-controller": "npm:^4.2.0"
+    "@metamask/gator-permissions-controller": "npm:^4.1.2"
     "@metamask/keyring-controller": "npm:^25.5.0"
     "@metamask/logging-controller": "npm:^8.0.2"
     "@metamask/messenger": "npm:^1.2.0"


### PR DESCRIPTION
Reverts MetaMask/core#8855.

CI didn't trigger on `main`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only reverts release bookkeeping (package versions, changelog entries, and a dependency version), with no runtime logic changes.
> 
> **Overview**
> Reverts the `993.0.0` release bookkeeping by downgrading the root monorepo version back to `992.0.0`.
> 
> Rolls back `@metamask/gator-permissions-controller` from `4.2.0` to `4.1.2`, including undoing the `@metamask/signature-controller` dependency bump to `^4.2.0` and removing the corresponding changelog entry/compare links; `yarn.lock` is updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73896e15bfa2992dc3d18b1dec756d662cca5f7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->