### PR TITLE
refactor: update notification services to use AUS preferences for feature announcements

### DIFF
--- a/packages/notification-services-controller/CHANGELOG.md
+++ b/packages/notification-services-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Fetch feature announcements based on AUS `marketing.inAppNotificationsEnabled` preferences instead of the deprecated `isFeatureAnnouncementsEnabled` controller state.
+- Fetch feature announcements based on AUS `marketing.inAppNotificationsEnabled` preferences instead of the deprecated `isFeatureAnnouncementsEnabled` controller state. ([#8861](https://github.com/MetaMask/core/pull/8861))
 
 ## [24.1.0]
 

--- a/packages/notification-services-controller/CHANGELOG.md
+++ b/packages/notification-services-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Fetch feature announcements based on AUS `marketing.inAppNotificationsEnabled` preferences instead of the deprecated `isFeatureAnnouncementsEnabled` controller state.
+
 ## [24.1.0]
 
 ### Added

--- a/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.test.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.test.ts
@@ -107,6 +107,17 @@ const prefsFromAddresses = (
   },
 });
 
+const prefsFromAddressesWithMarketingInAppNotifications = (
+  accounts: { address: string; enabled: boolean }[],
+  inAppNotificationsEnabled: boolean,
+): NotificationPreferences => ({
+  ...prefsFromAddresses(accounts),
+  marketing: {
+    inAppNotificationsEnabled,
+    pushNotificationsEnabled: false,
+  },
+});
+
 describe('NotificationServicesController', () => {
   afterEach(() => {
     clearAPICache();
@@ -125,11 +136,9 @@ describe('NotificationServicesController', () => {
         env: { featureAnnouncements: featureAnnouncementsEnv },
         state: {
           ...defaultState,
-          isFeatureAnnouncementsEnabled: true,
           isNotificationServicesEnabled: true,
         },
       });
-      expect(controller2.state.isFeatureAnnouncementsEnabled).toBe(true);
       expect(controller2.state.isNotificationServicesEnabled).toBe(true);
     });
   });
@@ -467,23 +476,6 @@ describe('NotificationServicesController', () => {
         [ADDRESS_1]: true,
         [ADDRESS_2]: false,
       });
-    });
-  });
-
-  describe('setFeatureAnnouncementsEnabled', () => {
-    it('flips state when the method is called', async () => {
-      const { messenger, mockIsSignedIn } = mockNotificationMessenger();
-      mockIsSignedIn.mockReturnValue(true);
-
-      const controller = new NotificationServicesController({
-        messenger,
-        env: { featureAnnouncements: featureAnnouncementsEnv },
-        state: { ...defaultState, isFeatureAnnouncementsEnabled: false },
-      });
-
-      await controller.setFeatureAnnouncementsEnabled(true);
-
-      expect(controller.state.isFeatureAnnouncementsEnabled).toBe(true);
     });
   });
 
@@ -1039,6 +1031,12 @@ describe('NotificationServicesController', () => {
       mockOnChainNotificationsAPI: nock.Scope;
     } => {
       const messengerMocks = mockNotificationMessenger();
+      messengerMocks.mockGetNotificationPreferences.mockResolvedValue(
+        prefsFromAddressesWithMarketingInAppNotifications(
+          [{ address: '0xTestAddress', enabled: true }],
+          true,
+        ),
+      );
 
       const mockFeatureAnnouncementAPIResult =
         createMockFeatureAnnouncementAPIResult();
@@ -1144,11 +1142,30 @@ describe('NotificationServicesController', () => {
       expect(mocks.mockOnChainNotificationsAPI.isDone()).toBe(false);
     });
 
-    it('should not fetch feature announcements if disabled', async () => {
+    it('should fetch feature announcements if AUS marketing in-app notifications are enabled', async () => {
       const { messenger, ...mocks } = arrangeMocks();
-      const controller = arrangeController(messenger, {
-        isFeatureAnnouncementsEnabled: false,
-      });
+      const controller = arrangeController(messenger);
+
+      const result = await controller.fetchAndUpdateMetamaskNotifications();
+
+      expect(
+        result.filter(
+          (notification) =>
+            notification.type === TRIGGER_TYPES.FEATURES_ANNOUNCEMENT,
+        ),
+      ).toHaveLength(1);
+      expect(mocks.mockFeatureAnnouncementsAPI.isDone()).toBe(true);
+    });
+
+    it('should not fetch feature announcements if AUS marketing in-app notifications are disabled', async () => {
+      const { messenger, ...mocks } = arrangeMocks();
+      mocks.mockGetNotificationPreferences.mockResolvedValue(
+        prefsFromAddressesWithMarketingInAppNotifications(
+          [{ address: '0xTestAddress', enabled: true }],
+          false,
+        ),
+      );
+      const controller = arrangeController(messenger);
 
       const result = await controller.fetchAndUpdateMetamaskNotifications();
 
@@ -1165,7 +1182,14 @@ describe('NotificationServicesController', () => {
     });
 
     it('should handle errors gracefully when fetching notifications', async () => {
-      const { messenger } = mockNotificationMessenger();
+      const { messenger, mockGetNotificationPreferences } =
+        mockNotificationMessenger();
+      mockGetNotificationPreferences.mockResolvedValue(
+        prefsFromAddressesWithMarketingInAppNotifications(
+          [{ address: '0xTestAddress', enabled: true }],
+          true,
+        ),
+      );
 
       // Mock APIs to fail
       mockFetchFeatureAnnouncementNotifications({ status: 500 });

--- a/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.ts
@@ -1255,10 +1255,16 @@ export class NotificationServicesController extends BaseController<
       // This is used by Feature Announcement & On Chain
       // Not used by Snaps
       const isGlobalNotifsEnabled = this.state.isNotificationServicesEnabled;
+      const notificationPreferences = isGlobalNotifsEnabled
+        ? await this.messenger
+            .call('AuthenticatedUserStorageService:getNotificationPreferences')
+            .catch(() => null)
+        : null;
 
       // Raw Feature Notifications
       const rawAnnouncements =
-        isGlobalNotifsEnabled && this.state.isFeatureAnnouncementsEnabled
+        isGlobalNotifsEnabled &&
+        notificationPreferences?.marketing.inAppNotificationsEnabled
           ? await getFeatureAnnouncementNotifications(
               this.#featureAnnouncementEnv,
               previewToken,
@@ -1270,11 +1276,8 @@ export class NotificationServicesController extends BaseController<
       if (isGlobalNotifsEnabled) {
         try {
           const { bearerToken } = await this.#getBearerToken();
-          const preferences = await this.messenger.call(
-            'AuthenticatedUserStorageService:getNotificationPreferences',
-          );
           const addressesWithNotifications = (
-            preferences?.walletActivity.accounts ?? []
+            notificationPreferences?.walletActivity.accounts ?? []
           )
             .filter((account) => account.enabled)
             .map((account) => account.address);


### PR DESCRIPTION
## Explanation

Related PR discussion: https://github.com/MetaMask/metamask-mobile/pull/30106#discussion_r3250763417

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->
Fixes: https://consensyssoftware.atlassian.net/browse/GE-244

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the gating logic for fetching feature-announcement notifications to rely on AUS `marketing.inAppNotificationsEnabled`, which could alter when users see announcements if preferences are missing or inconsistent. Scope is limited to notification fetching behavior and associated tests/changelog updates.
> 
> **Overview**
> Feature announcement fetching in `fetchAndUpdateMetamaskNotifications` now depends on AUS notification preferences (`marketing.inAppNotificationsEnabled`) rather than the controller’s `isFeatureAnnouncementsEnabled` state, and it reuses a single preferences read for both announcements and on-chain notification address selection.
> 
> Tests were updated to mock AUS marketing preference and assert announcements are fetched/not fetched accordingly, and the changelog documents the switch away from the deprecated controller flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bb79b1d8a524d40a2efb2a2a6d5c765d543b0a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->