### PR TITLE
feat(wallet): add injectable fetch and prevClientVersion options

### DIFF
--- a/packages/wallet/CHANGELOG.md
+++ b/packages/wallet/CHANGELOG.md
@@ -11,5 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `Wallet` class with a bundled controller ensemble (AccountsController, ApprovalController, ConnectivityController, KeyringController, NetworkController, RemoteFeatureFlagController, TransactionController) ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
   - Pass `state` keyed by controller name to the constructor to hydrate from a stored snapshot. Subscribe to `${ControllerName}:stateChanged` events on `wallet.messenger` to write changes back to your storage backend. See the README for details.
+- Add optional `prevClientVersion` field to `WalletOptions` ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
+  - Passed to `RemoteFeatureFlagController` to trigger cache invalidation when the client version changes.
+- Add optional `fetch` field to `WalletOptions` ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
+  - Overrides the `fetch` implementation used by `NetworkController`'s RPC service. Defaults to `globalThis.fetch`. Allows platform-specific fetch implementations (e.g. React Native) to be injected.
 
 [Unreleased]: https://github.com/MetaMask/core/

--- a/packages/wallet/src/initialization/instances/network-controller.ts
+++ b/packages/wallet/src/initialization/instances/network-controller.ts
@@ -24,7 +24,7 @@ export const networkController: InitializationConfiguration<
 > = {
   name: 'NetworkController',
   init: ({ state, messenger, options }) => {
-    const fetchFn = globalThis.fetch.bind(globalThis);
+    const fetchFn = options.fetch ?? globalThis.fetch.bind(globalThis);
 
     const getRpcServiceOptions: NetworkControllerOptions['getRpcServiceOptions'] =
       () => {

--- a/packages/wallet/src/initialization/instances/remote-feature-flag-controller.ts
+++ b/packages/wallet/src/initialization/instances/remote-feature-flag-controller.ts
@@ -16,6 +16,7 @@ export const remoteFeatureFlagController: InitializationConfiguration<
       state,
       messenger,
       clientVersion: options.clientVersion,
+      prevClientVersion: options.prevClientVersion,
       clientConfigApiService: options.clientConfigApiService,
       getMetaMetricsId: options.getMetaMetricsId,
     });

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -5,6 +5,8 @@ export type WalletOptions = {
   state?: Record<string, Record<string, Json>>;
   infuraProjectId: string;
   clientVersion: string;
+  prevClientVersion?: string;
+  fetch?: typeof globalThis.fetch;
   showApprovalRequest: () => void;
   clientConfigApiService: ClientConfigApiService;
   getMetaMetricsId: () => string;


### PR DESCRIPTION
## Summary

Part of a stack on top of #8853.

- Adds optional `fetch` field to `WalletOptions` — overrides the `fetch` implementation used by `NetworkController`'s RPC service. Defaults to `globalThis.fetch`. Allows platform-specific fetch implementations (e.g. React Native) to be injected without subclassing.
- Adds optional `prevClientVersion` field to `WalletOptions` — passed to `RemoteFeatureFlagController` to trigger feature-flag cache invalidation when the client version changes between sessions.

Closes #8793, #8794

## Test plan

- [ ] `yarn workspace @metamask/wallet run test` passes
- [ ] `yarn constraints` passes
- [ ] `yarn validate:changelog` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)