### PR TITLE
feat(wallet): add injectable logger for per-controller init diagnostics

### DIFF
--- a/packages/wallet/CHANGELOG.md
+++ b/packages/wallet/CHANGELOG.md
@@ -15,5 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Passed to `RemoteFeatureFlagController` to trigger cache invalidation when the client version changes.
 - Add optional `fetch` field to `WalletOptions` ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
   - Overrides the `fetch` implementation used by `NetworkController`'s RPC service. Defaults to `globalThis.fetch`. Allows platform-specific fetch implementations (e.g. React Native) to be injected.
+- Add optional `logger` field to `WalletOptions` ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
+  - When provided, emits an `info`-level log after each controller finishes initializing: `[wallet] ${ControllerName}: initialized`. Defaults to no-op (no output). Pass `console` during development to observe initialization order.
 
 [Unreleased]: https://github.com/MetaMask/core/

--- a/packages/wallet/src/initialization/initialization.ts
+++ b/packages/wallet/src/initialization/initialization.ts
@@ -32,6 +32,7 @@ export function initialize({
     });
 
     instances[name] = instance as Record<string, unknown>;
+    options.logger?.info(`[wallet] ${name}: initialized`);
   }
 
   return instances as DefaultInstances;

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -10,4 +10,5 @@ export type WalletOptions = {
   showApprovalRequest: () => void;
   clientConfigApiService: ClientConfigApiService;
   getMetaMetricsId: () => string;
+  logger?: Pick<Console, 'info'>;
 };


### PR DESCRIPTION
## Summary

Part of a stack on top of #8879.

- Adds optional `logger?: Pick<Console, 'info'>` to `WalletOptions`. When provided, emits an `info`-level line after each controller finishes initializing: `[wallet] ${ControllerName}: initialized`. Defaults to no-op.
- Pass `console` during development to observe initialization order. Useful for diagnosing startup timing or confirming which controllers are included.

Closes #8791

## Test plan

- [ ] `yarn workspace @metamask/wallet run test` passes
- [ ] `yarn constraints` passes
- [ ] `yarn validate:changelog` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)