### PR TITLE
feat(perps-controller): expose subpath exports for constants, types, utils

### DIFF
--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add slippage controls so users can configure per-order slippage tolerance for market trades ([#8871](https://github.com/MetaMask/core/pull/8871))
 - Track `vip_tier` and `vip_discount` properties on perps trading events for fee analytics ([#8871](https://github.com/MetaMask/core/pull/8871))
 - Surface an in-app banner during an ongoing HyperLiquid outage so users see degraded trading status ([#8871](https://github.com/MetaMask/core/pull/8871))
-- Expose subpath `exports` for `./constants`, `./constants/*`, `./types`, and `./utils/*` so consumers using legacy `node` module resolution can deep-import compiled entry points without losing tree-shaking ([#NNNN](https://github.com/MetaMask/core/pull/NNNN))
+- Expose subpath `exports` for `./constants`, `./constants/*`, `./types`, and `./utils/*` so consumers using legacy `node` module resolution can deep-import compiled entry points without losing tree-shaking ([#8883](https://github.com/MetaMask/core/pull/8883))
 
 ### Fixed
 

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add slippage controls so users can configure per-order slippage tolerance for market trades ([#8871](https://github.com/MetaMask/core/pull/8871))
 - Track `vip_tier` and `vip_discount` properties on perps trading events for fee analytics ([#8871](https://github.com/MetaMask/core/pull/8871))
 - Surface an in-app banner during an ongoing HyperLiquid outage so users see degraded trading status ([#8871](https://github.com/MetaMask/core/pull/8871))
+- Expose subpath `exports` for `./constants`, `./constants/*`, `./types`, and `./utils/*` so consumers using legacy `node` module resolution can deep-import compiled entry points without losing tree-shaking ([#NNNN](https://github.com/MetaMask/core/pull/NNNN))
 
 ### Fixed
 

--- a/packages/perps-controller/package.json
+++ b/packages/perps-controller/package.json
@@ -35,6 +35,46 @@
         "default": "./dist/index.cjs"
       }
     },
+    "./constants": {
+      "import": {
+        "types": "./dist/constants/index.d.mts",
+        "default": "./dist/constants/index.mjs"
+      },
+      "require": {
+        "types": "./dist/constants/index.d.cts",
+        "default": "./dist/constants/index.cjs"
+      }
+    },
+    "./constants/*": {
+      "import": {
+        "types": "./dist/constants/*.d.mts",
+        "default": "./dist/constants/*.mjs"
+      },
+      "require": {
+        "types": "./dist/constants/*.d.cts",
+        "default": "./dist/constants/*.cjs"
+      }
+    },
+    "./types": {
+      "import": {
+        "types": "./dist/types/index.d.mts",
+        "default": "./dist/types/index.mjs"
+      },
+      "require": {
+        "types": "./dist/types/index.d.cts",
+        "default": "./dist/types/index.cjs"
+      }
+    },
+    "./utils/*": {
+      "import": {
+        "types": "./dist/utils/*.d.mts",
+        "default": "./dist/utils/*.mjs"
+      },
+      "require": {
+        "types": "./dist/utils/*.d.cts",
+        "default": "./dist/utils/*.cjs"
+      }
+    },
     "./package.json": "./package.json"
   },
   "publishConfig": {


### PR DESCRIPTION
## Explanation

Follow-up to #8871 (the perps-controller source-of-truth migration into core).

Mobile (`@metamask/metamask-mobile`) and other consumers that still rely on TypeScript's legacy `moduleResolution: "node"` cannot resolve deep package imports through the package.json `exports` field. Declaring explicit subpath entries lets imports such as

- `@metamask/perps-controller/constants`
- `@metamask/perps-controller/constants/perpsConfig`
- `@metamask/perps-controller/constants/hyperLiquidConfig`
- `@metamask/perps-controller/utils/coalescePerpsRestRequest`
- `@metamask/perps-controller/utils/perpsDiskPersistence`
- `@metamask/perps-controller/utils/hyperLiquidAdapter`
- `@metamask/perps-controller/types`

map back to the compiled artifacts in `dist/` while preserving tree-shaking — each subpath points at its own emitted file rather than going through the barrel.

This change was authored locally during #8871 but never committed before merge. Splitting it out so the new entry points are reviewed on their own and the CHANGELOG entry is clearly attributable.

## References

- Follow-up to: #8871
- Mobile consumer using these subpaths: https://github.com/MetaMask/metamask-mobile

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because this only changes package export maps and documentation; main behavior changes are limited to how consumers resolve deep imports at build/runtime.
> 
> **Overview**
> Adds explicit `package.json` subpath `exports` for `./constants`, `./constants/*`, `./types`, and `./utils/*`, mapping both ESM/CJS and type entries directly to `dist/` artifacts to support consumers using legacy Node/TypeScript module resolution while preserving tree-shaking.
> 
> Updates the perps-controller changelog to record the new deep-import entry points.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd98053e95c53c44226e50421ba97cce22b7b915. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->