### PR TITLE
fix(transaction-controller): pass isInternal when submitting extra transactions batch

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Include Mantle operator fee in the displayed L1 gas estimate when simulated `gasUsed` is unavailable, by falling back to the transaction's gas limit ([#8837](https://github.com/MetaMask/core/pull/8837))
   - Adds a `protected getOperatorFeeGas` hook on `OracleLayer1GasFeeFlow` that subclasses can override to supply a fallback value. The default behaviour is unchanged (returns `transactionMeta.gasUsed`).
   - `MantleLayer1GasFeeFlow` overrides the hook with `gasUsed ?? txParams.gas ?? txParams.gasLimit`, so the operator-fee oracle is called with the gas limit when `gasUsed` is missing. Gas limit is an upper bound on actual gas used, so the operator fee is over-estimated rather than under-reported.
+- Fix `ExtraTransactionsPublishHook` not passing `isInternal: true` when calling `addTransactionBatch`, causing the duplicate-batch-ID guard to incorrectly throw `DuplicateBundleId` (error 5720) for nested ERC-20 gas-fee-token transfers that share a `batchId` with their parent batch ([#8884](https://github.com/MetaMask/core/pull/8884))
 
 ## [66.0.0]
 

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -3739,6 +3739,36 @@ describe('TransactionController', () => {
           networkClientId: NETWORK_CLIENT_ID_MOCK,
         });
       });
+
+      it('does not throw if duplicate and isInternal is true', async () => {
+        const { controller } = setupController({
+          options: {
+            state: {
+              transactions: [
+                {
+                  batchId: BATCH_ID_MOCK,
+                } as unknown as TransactionMeta,
+              ],
+            },
+          },
+          updateToInitialState: true,
+        });
+
+        const txParams = {
+          from: ACCOUNT_MOCK,
+          to: ACCOUNT_MOCK,
+        };
+
+        const { result } = await controller.addTransaction(txParams, {
+          batchId: BATCH_ID_MOCK,
+          isInternal: true,
+          networkClientId: NETWORK_CLIENT_ID_MOCK,
+          origin: ORIGIN_MOCK,
+          requireApproval: false,
+        });
+
+        await result.catch(() => undefined);
+      });
     });
   });
 

--- a/packages/transaction-controller/src/hooks/ExtraTransactionsPublishHook.test.ts
+++ b/packages/transaction-controller/src/hooks/ExtraTransactionsPublishHook.test.ts
@@ -121,6 +121,7 @@ describe('ExtraTransactionsPublishHook', () => {
       disable7702: true,
       disableHook: false,
       disableSequential: true,
+      isInternal: true,
       requireApproval: false,
     });
   });

--- a/packages/transaction-controller/src/hooks/ExtraTransactionsPublishHook.ts
+++ b/packages/transaction-controller/src/hooks/ExtraTransactionsPublishHook.ts
@@ -164,6 +164,7 @@ export class ExtraTransactionsPublishHook {
 
     await this.#addTransactionBatch({
       from,
+      isInternal: true,
       networkClientId,
       requireApproval: false,
       transactions,


### PR DESCRIPTION
## Explanation

`ExtraTransactionsPublishHook` calls `addTransactionBatch` to submit an ERC-20 gas-fee-token payment alongside a Smart Transaction, but was not passing `isInternal: true`. The duplicate-batch-ID guard introduced in #8633 then threw `DuplicateBundleId` (error 5720) because the shared `batchId` looked like an untrusted external call.

Fix: pass `isInternal: true` at the `ExtraTransactionsPublishHook` call site.

## References

* Follows #8633

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single call-site flag fix with tests; no auth or API surface changes beyond correcting internal batch submission.
> 
> **Overview**
> Marks nested **ERC-20 gas-fee-token** batches submitted by `ExtraTransactionsPublishHook` as trusted internal work by passing **`isInternal: true`** into `addTransactionBatch`.
> 
> After the explicit internal-flag change in v66, that hook reused the parent **`batchId`** without the flag, so the duplicate-batch guard treated it like an external caller and threw **`DuplicateBundleId` (5720)**. Tests and the changelog document the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e22f8d1cf5e24ac1c5f69d21f0867e4762a1741. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->