### PR TITLE
fix(account-tree-controller): add support for new (v2) `KeyringType`

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -83,11 +83,6 @@
       "count": 1
     }
   },
-  "packages/account-tree-controller/src/rules/keyring.ts": {
-    "@typescript-eslint/explicit-function-return-type": {
-      "count": 2
-    }
-  },
   "packages/account-tree-controller/src/type-utils.ts": {
     "@typescript-eslint/naming-convention": {
       "count": 1

--- a/packages/account-tree-controller/CHANGELOG.md
+++ b/packages/account-tree-controller/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add group naming support for `KeyringType` (v2) ([#8885](https://github.com/MetaMask/core/pull/8885))
+- Add `KeyringType` (v2) in Snap matching rule ([#8885](https://github.com/MetaMask/core/pull/8885))
 
 ## [7.4.0]
 

--- a/packages/account-tree-controller/CHANGELOG.md
+++ b/packages/account-tree-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add group naming support for `KeyringType` (v2) ([#8885](https://github.com/MetaMask/core/pull/8885))
+
 ## [7.4.0]
 
 ### Added

--- a/packages/account-tree-controller/src/rules/keyring.test.ts
+++ b/packages/account-tree-controller/src/rules/keyring.test.ts
@@ -5,6 +5,7 @@ import {
   AccountWalletType,
 } from '@metamask/account-api';
 import { EthAccountType, EthMethod, EthScope } from '@metamask/keyring-api';
+import { KeyringType } from '@metamask/keyring-api/v2';
 import { KeyringTypes } from '@metamask/keyring-controller';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 
@@ -21,10 +22,12 @@ import { KeyringRule, getAccountWalletNameFromKeyringType } from './keyring';
 
 describe('keyring', () => {
   describe('getAccountWalletNameFromKeyringType', () => {
-    it.each(Object.values(KeyringTypes))(
+    it.each([...Object.values(KeyringTypes), ...Object.values(KeyringType)])(
       'computes wallet name from: %s',
       (type) => {
-        const name = getAccountWalletNameFromKeyringType(type as KeyringTypes);
+        const name = getAccountWalletNameFromKeyringType(
+          type as KeyringTypes | KeyringType,
+        );
 
         expect(name).toBeDefined();
         expect(name.length).toBeGreaterThan(0);
@@ -134,6 +137,14 @@ describe('keyring', () => {
         [KeyringTypes.qr, 'QR Account'],
         [KeyringTypes.trezor, 'Trezor Account'],
         [KeyringTypes.simple, 'Imported Account'],
+        [KeyringType.Lattice, 'Lattice Account'],
+        [KeyringType.Ledger, 'Ledger Account'],
+        [KeyringType.OneKey, 'OneKey Account'],
+        [KeyringType.Qr, 'QR Account'],
+        [KeyringType.Trezor, 'Trezor Account'],
+        [KeyringType.PrivateKey, 'Imported Account'],
+        [KeyringType.Hd, 'Account'],
+        [KeyringType.Snap, 'Snap Account'],
         ['unknown', 'Unknown Account'],
       ])(
         'returns default name prefix for "$0" to be "$1"',

--- a/packages/account-tree-controller/src/rules/keyring.ts
+++ b/packages/account-tree-controller/src/rules/keyring.ts
@@ -1,6 +1,7 @@
 import { AccountGroupType } from '@metamask/account-api';
 import { AccountWalletType } from '@metamask/account-api';
 import { toAccountGroupId, toAccountWalletId } from '@metamask/account-api';
+import { KeyringType } from '@metamask/keyring-api/v2';
 import { KeyringTypes } from '@metamask/keyring-controller';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 
@@ -15,31 +16,41 @@ import type { AccountWalletObjectOf } from '../wallet';
  * @param type - Keyring's type.
  * @returns Wallet name.
  */
-export function getAccountWalletNameFromKeyringType(type: KeyringTypes) {
+export function getAccountWalletNameFromKeyringType(
+  type: KeyringTypes | KeyringType,
+): string {
   switch (type) {
+    case KeyringType.PrivateKey:
     case KeyringTypes.simple: {
       return 'Imported accounts';
     }
+    case KeyringType.Trezor:
     case KeyringTypes.trezor: {
       return 'Trezor';
     }
+    case KeyringType.OneKey:
     case KeyringTypes.oneKey: {
       return 'OneKey';
     }
+    case KeyringType.Ledger:
     case KeyringTypes.ledger: {
       return 'Ledger';
     }
+    case KeyringType.Lattice:
     case KeyringTypes.lattice: {
       return 'Lattice';
     }
+    case KeyringType.Qr:
     case KeyringTypes.qr: {
       return 'QR';
     }
     // Those keyrings should never really be used in such context since they
     // should be used by other grouping rules.
+    case KeyringType.Hd:
     case KeyringTypes.hd: {
       return 'HD Wallet';
     }
+    case KeyringType.Snap:
     case KeyringTypes.snap: {
       return 'Snap Wallet';
     }
@@ -56,31 +67,41 @@ export function getAccountWalletNameFromKeyringType(type: KeyringTypes) {
  * @param type - Keyring's type.
  * @returns Wallet name.
  */
-export function getAccountGroupPrefixFromKeyringType(type: KeyringTypes) {
+export function getAccountGroupPrefixFromKeyringType(
+  type: KeyringTypes | KeyringType,
+): string {
   switch (type) {
+    case KeyringType.PrivateKey:
     case KeyringTypes.simple: {
       return 'Imported Account';
     }
+    case KeyringType.Trezor:
     case KeyringTypes.trezor: {
       return 'Trezor Account';
     }
+    case KeyringType.OneKey:
     case KeyringTypes.oneKey: {
       return 'OneKey Account';
     }
+    case KeyringType.Ledger:
     case KeyringTypes.ledger: {
       return 'Ledger Account';
     }
+    case KeyringType.Lattice:
     case KeyringTypes.lattice: {
       return 'Lattice Account';
     }
+    case KeyringType.Qr:
     case KeyringTypes.qr: {
       return 'QR Account';
     }
     // Those keyrings should never really be used in such context since they
     // should be used by other grouping rules.
+    case KeyringType.Hd:
     case KeyringTypes.hd: {
       return 'Account';
     }
+    case KeyringType.Snap:
     case KeyringTypes.snap: {
       return 'Snap Account';
     }

--- a/packages/account-tree-controller/src/rules/snap.test.ts
+++ b/packages/account-tree-controller/src/rules/snap.test.ts
@@ -5,6 +5,7 @@ import {
   AccountWalletType,
 } from '@metamask/account-api';
 import { EthAccountType, EthMethod, EthScope } from '@metamask/keyring-api';
+import { KeyringType } from '@metamask/keyring-api/v2';
 import { KeyringTypes } from '@metamask/keyring-controller';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 import type { SnapId } from '@metamask/snaps-sdk';
@@ -48,6 +49,22 @@ const MOCK_SNAP_ACCOUNT_1: InternalAccount = {
   metadata: {
     name: 'Snap Account 1',
     keyring: { type: KeyringTypes.snap },
+    snap: { id: MOCK_SNAP_1.id },
+    importTime: 0,
+    lastSelected: 0,
+  },
+};
+
+const MOCK_SNAP_ACCOUNT_V2: InternalAccount = {
+  id: 'mock-snap-account-id-v2',
+  address: '0xDEF',
+  options: {},
+  methods: [...ETH_EOA_METHODS],
+  type: EthAccountType.Eoa,
+  scopes: [EthScope.Eoa],
+  metadata: {
+    name: 'Snap Account V2',
+    keyring: { type: KeyringType.Snap },
     snap: { id: MOCK_SNAP_1.id },
     importTime: 0,
     lastSelected: 0,
@@ -98,6 +115,57 @@ describe('SnapRule', () => {
       );
 
       expect(rule.match(MOCK_SNAP_ACCOUNT_1)).toBeDefined();
+    });
+
+    it('returns a result for a v2 snap keyring type account', () => {
+      const messenger = getRootMessenger();
+      const accountTreeControllerMessenger =
+        getAccountTreeControllerMessenger(messenger);
+      const rule = new SnapRule(accountTreeControllerMessenger);
+
+      messenger.registerActionHandler(
+        'SnapController:getSnap',
+        () => MOCK_SNAP_1 as unknown as Snap,
+      );
+
+      expect(rule.match(MOCK_SNAP_ACCOUNT_V2)).toBeDefined();
+    });
+
+    it('returns undefined for a v2 snap keyring type account when snap is blocked', () => {
+      const messenger = getRootMessenger();
+      const accountTreeControllerMessenger =
+        getAccountTreeControllerMessenger(messenger);
+      const rule = new SnapRule(accountTreeControllerMessenger);
+
+      const blockedSnap = { ...MOCK_SNAP_1, enabled: true, blocked: true };
+      messenger.registerActionHandler(
+        'SnapController:getSnap',
+        () => blockedSnap as unknown as Snap,
+      );
+
+      expect(rule.match(MOCK_SNAP_ACCOUNT_V2)).toBeUndefined();
+    });
+
+    it('returns undefined for account with unknown keyring type', () => {
+      const messenger = getRootMessenger();
+      const accountTreeControllerMessenger =
+        getAccountTreeControllerMessenger(messenger);
+      const rule = new SnapRule(accountTreeControllerMessenger);
+
+      messenger.registerActionHandler(
+        'SnapController:getSnap',
+        () => MOCK_SNAP_1 as unknown as Snap,
+      );
+
+      const accountWithUnknownKeyring: InternalAccount = {
+        ...MOCK_SNAP_ACCOUNT_1,
+        metadata: {
+          ...MOCK_SNAP_ACCOUNT_1.metadata,
+          keyring: { type: 'unknown-keyring-type' },
+        },
+      };
+
+      expect(rule.match(accountWithUnknownKeyring)).toBeUndefined();
     });
   });
 

--- a/packages/account-tree-controller/src/rules/snap.ts
+++ b/packages/account-tree-controller/src/rules/snap.ts
@@ -1,5 +1,6 @@
 import { AccountGroupType, AccountWalletType } from '@metamask/account-api';
 import { toAccountWalletId, toAccountGroupId } from '@metamask/account-api';
+import { KeyringType } from '@metamask/keyring-api/v2';
 import { KeyringTypes } from '@metamask/keyring-controller';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 import type { SnapId } from '@metamask/snaps-sdk';
@@ -105,10 +106,10 @@ export class SnapRule
       return false;
     }
 
-    return (
-      account.metadata.keyring.type === (KeyringTypes.snap as string) &&
-      snap.enabled &&
-      !snap.blocked
-    );
+    const keyringType = account.metadata.keyring.type;
+    const hasSnapKeyringType =
+      keyringType === KeyringTypes.snap || keyringType === KeyringType.Snap;
+
+    return hasSnapKeyringType && snap.enabled && !snap.blocked;
   }
 }


### PR DESCRIPTION
## Explanation

We are integrating new keyring v2 slowly. So the group naming will have to support this.

This is required at least for the Snap keyring v2 support that will be seen as "real keyrings" (different from v2 wrappers).

## References

N/A

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes account grouping/naming logic and Snap account detection, which can affect how wallets/groups are organized in clients if keyring types are misidentified.
> 
> **Overview**
> Updates account-tree keyring naming helpers to accept both legacy `KeyringTypes` and new v2 `KeyringType`, mapping v2 values to the same wallet/group display names.
> 
> Extends `SnapRule` matching to treat `KeyringType.Snap` accounts as Snap accounts (in addition to `KeyringTypes.snap`) and adds tests/fixtures covering v2 Snap accounts, blocked snaps, and unknown keyring types; also records the change in the package changelog and removes an obsolete ESLint suppression entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 855431b5b7a35b5be423b25b5121858d402a213f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->