### PR TITLE
feat(STX-575): add has_sufficient_gas_for_quote to quote received event

### DIFF
--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add optional `has_sufficient_gas_for_quote` property to `QuotesReceived` event and `getQuotesReceivedProperties` utility to allow clients to pass whether the user has sufficient gas to submit the quote ([#8895](https://github.com/MetaMask/core/pull/8895))
+
 ## [73.1.0]
 
 ### Added
@@ -15,7 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Add optional `has_sufficient_gas_for_quote` property to `QuotesReceived` event and `getQuotesReceivedProperties` utility to allow clients to pass whether the user has sufficient gas to submit the quote ([#8895](https://github.com/MetaMask/core/pull/8895))
 - Bump `@metamask/assets-controller` from `^8.0.0` to `^8.0.2` ([#8874](https://github.com/MetaMask/core/pull/8874), [#8912](https://github.com/MetaMask/core/pull/8912))
 - Bump `@metamask/assets-controllers` from `^108.1.0` to `^108.2.0` ([#8911](https://github.com/MetaMask/core/pull/8911))
 - Bump `@metamask/accounts-controller` from `^38.1.1` to `^38.1.2` ([#8912](https://github.com/MetaMask/core/pull/8912))

--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Add optional `has_sufficient_gas_for_quote` property to `QuotesReceived` event and `getQuotesReceivedProperties` utility to allow clients to pass whether the user has sufficient gas to submit the quote ([#8895](https://github.com/MetaMask/core/pull/8895))
 - Bump `@metamask/assets-controller` from `^8.0.0` to `^8.0.2` ([#8874](https://github.com/MetaMask/core/pull/8874), [#8912](https://github.com/MetaMask/core/pull/8912))
 - Bump `@metamask/assets-controllers` from `^108.1.0` to `^108.2.0` ([#8911](https://github.com/MetaMask/core/pull/8911))
 - Bump `@metamask/accounts-controller` from `^38.1.1` to `^38.1.2` ([#8912](https://github.com/MetaMask/core/pull/8912))

--- a/packages/bridge-controller/src/utils/metrics/properties.ts
+++ b/packages/bridge-controller/src/utils/metrics/properties.ts
@@ -160,6 +160,7 @@ export const getQuotesReceivedProperties = (
   isSubmittable: boolean = true,
   recommendedQuote?: null | (QuoteResponse & Partial<QuoteMetadata>),
   usdBalanceSource?: number,
+  hasSufficientGasForQuote?: boolean | null,
 ) => {
   const provider = activeQuote ? formatProviderLabel(activeQuote.quote) : '_';
   return {
@@ -178,5 +179,8 @@ export const getQuotesReceivedProperties = (
     provider,
     warnings,
     price_impact: Number(activeQuote?.quote.priceData?.priceImpact ?? 0),
+    ...(hasSufficientGasForQuote !== undefined && {
+      has_sufficient_gas_for_quote: hasSufficientGasForQuote,
+    }),
   };
 };

--- a/packages/bridge-controller/src/utils/metrics/types.ts
+++ b/packages/bridge-controller/src/utils/metrics/types.ts
@@ -140,6 +140,7 @@ type RequiredEventContextFromClientBase = {
     price_impact: QuoteFetchData['price_impact'];
     can_submit: QuoteFetchData['can_submit'];
     usd_balance_source?: number;
+    has_sufficient_gas_for_quote?: boolean | null;
   };
   [UnifiedSwapBridgeEventName.QuotesError]: Pick<
     RequestMetadata,


### PR DESCRIPTION
## Explanation

Add optional `has_sufficient_gas_for_quote` property to `QuotesReceived` event and `getQuotesReceivedProperties` utility to allow clients to pass whether the user has sufficient gas to submit the quote.

Context: https://docs.google.com/document/d/1EFG4E-5_U8DPAcxWFtNbemgB4e5e22pXxIFx5Pf37n8/edit?tab=t.0

This property will allow us to measure the perception of the user that they have enough native assets to cover the gas, but are presented incorrectly with a gasless swap quote

Why not using the warnings as a warning is added when the user has insufficient gas for quote. The warning is not emitted in the case of a `gasIncluded` quote. Adding the warning when it is not shown to the user for the quote would break the semantic of the existing warning property. 

This is aimed at being populated by the calculation of `useHasSufficientGas` hook in Mobile (irrespective of whether the quote is gasIncluded or not). This hook does compare the fee that is displayed to the user and the native balance so it's essentially the same mental calculation a user is susceptible to do.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional analytics fields only; no runtime swap/bridge logic changes. Clients must pass the new argument when they want the metric populated.
> 
> **Overview**
> Adds an optional **`has_sufficient_gas_for_quote`** field to Unified Swap/Bridge **`QuotesReceived`** analytics so clients (e.g. Mobile via `useHasSufficientGas`) can record whether the user’s native balance covers the gas shown for the quote—even when the quote is gas-included and existing **`insufficient_gas_*`** warnings are not emitted.
> 
> **`getQuotesReceivedProperties`** gains a sixth optional argument; the property is included in the payload only when that argument is not `undefined`. Event typings in **`types.ts`** and the package changelog are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 552e73500a2d6c81688a6e4fa2f677272865dd56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->