### PR TITLE
fix(keyring-controller)!: use `KeyringType` for `:withKeyringV2*`

### DIFF
--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING:** Change `KeyringSelectorV2` type selectors for `withKeyringV2` and `withKeyringV2Unsafe` to use `KeyringType` (v2 variant) ([#TODO](https://github.com/MetaMask/core/pull/TODO))
+  - Use values such as `KeyringType.Hd` instead of legacy `KeyringTypes.hd`.
+
 ## [25.5.0]
 
 ### Added

--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Change `KeyringSelectorV2` type selectors for `withKeyringV2` and `withKeyringV2Unsafe` to use `KeyringType` (v2 variant) ([#TODO](https://github.com/MetaMask/core/pull/TODO))
+- **BREAKING:** Change `KeyringSelectorV2` type selectors for `withKeyringV2` and `withKeyringV2Unsafe` to use `KeyringType` (v2 variant) ([#8901](https://github.com/MetaMask/core/pull/8901))
   - Use values such as `KeyringType.Hd` instead of legacy `KeyringTypes.hd`.
 
 ## [25.5.0]

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -4751,10 +4751,7 @@ describe('KeyringController', () => {
         { skipVaultCreation: true },
         async ({ controller }) => {
           await expect(
-            controller.withKeyringV2Unsafe(
-              { type: KeyringType.Hd },
-              jest.fn(),
-            ),
+            controller.withKeyringV2Unsafe({ type: KeyringType.Hd }, jest.fn()),
           ).rejects.toThrow(KeyringControllerErrorMessage.ControllerLocked);
         },
       );
@@ -4934,12 +4931,9 @@ describe('KeyringController', () => {
 
         // withKeyringV2Unsafe does not roll back — errors just propagate.
         await expect(
-          controller.withKeyringV2Unsafe(
-            { type: KeyringType.Hd },
-            async () => {
-              throw new Error('Oops');
-            },
-          ),
+          controller.withKeyringV2Unsafe({ type: KeyringType.Hd }, async () => {
+            throw new Error('Oops');
+          }),
         ).rejects.toThrow('Oops');
 
         // State is unchanged (no rollback to pre-withKeyringV2Unsafe state).

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -4499,7 +4499,7 @@ describe('KeyringController', () => {
     it('should wrap the V1 keyring using the default builder and call the operation', async () => {
       await withController(async ({ controller }) => {
         const fn = jest.fn();
-        await controller.withKeyringV2({ type: KeyringTypes.hd }, fn);
+        await controller.withKeyringV2({ type: KeyringType.Hd }, fn);
 
         expect(fn).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -4513,7 +4513,7 @@ describe('KeyringController', () => {
     it('should return the result of the operation', async () => {
       await withController(async ({ controller }) => {
         const result = await controller.withKeyringV2(
-          { type: KeyringTypes.hd },
+          { type: KeyringType.Hd },
           async () => 'result-value',
         );
 
@@ -4526,24 +4526,26 @@ describe('KeyringController', () => {
         const fn = jest.fn();
 
         await expect(
-          controller.withKeyringV2({ type: 'non-existent' }, fn),
+          controller.withKeyringV2({ type: KeyringType.Snap }, fn),
         ).rejects.toThrow(KeyringControllerErrorMessage.KeyringNotFound);
 
         expect(fn).not.toHaveBeenCalled();
       });
     });
 
-    it('should throw KeyringV2NotSupported when no builder is registered for the type', async () => {
+    it('should throw KeyringV2NotSupported when the selected keyring has no V2 adapter', async () => {
       await withController(
         {
           keyringBuilders: [keyringBuilderFactory(MockShallowKeyring)],
         },
         async ({ controller }) => {
-          await controller.addNewKeyring(MockShallowKeyring.type);
+          const metadata = await controller.addNewKeyring(
+            MockShallowKeyring.type,
+          );
 
           const fn = jest.fn();
           await expect(
-            controller.withKeyringV2({ type: MockShallowKeyring.type }, fn),
+            controller.withKeyringV2({ id: metadata.id }, fn),
           ).rejects.toThrow(
             KeyringControllerErrorMessage.KeyringV2NotSupported,
           );
@@ -4557,7 +4559,7 @@ describe('KeyringController', () => {
       await withController(async ({ controller }) => {
         await expect(
           controller.withKeyringV2(
-            { type: KeyringTypes.hd },
+            { type: KeyringType.Hd },
             async ({ keyring }) => keyring,
           ),
         ).rejects.toThrow(
@@ -4571,8 +4573,23 @@ describe('KeyringController', () => {
         await controller.setLocked();
 
         await expect(
-          controller.withKeyringV2({ type: KeyringTypes.hd }, jest.fn()),
+          controller.withKeyringV2({ type: KeyringType.Hd }, jest.fn()),
         ).rejects.toThrow(KeyringControllerErrorMessage.ControllerLocked);
+      });
+    });
+
+    it('should not match legacy KeyringTypes values in V2 type selectors', async () => {
+      await withController(async ({ controller }) => {
+        const fn = jest.fn();
+
+        await expect(
+          controller.withKeyringV2(
+            { type: KeyringTypes.hd } as unknown as KeyringSelectorV2,
+            fn,
+          ),
+        ).rejects.toThrow(KeyringControllerErrorMessage.KeyringNotFound);
+
+        expect(fn).not.toHaveBeenCalled();
       });
     });
 
@@ -4681,7 +4698,7 @@ describe('KeyringController', () => {
       it('should rollback the underlying V1 keyring if the operation throws', async () => {
         await withController(async ({ controller, initialState }) => {
           await expect(
-            controller.withKeyringV2({ type: KeyringTypes.hd }, async () => {
+            controller.withKeyringV2({ type: KeyringType.Hd }, async () => {
               throw new Error('Rollback test');
             }),
           ).rejects.toThrow('Rollback test');
@@ -4700,7 +4717,7 @@ describe('KeyringController', () => {
 
           await messenger.call(
             'KeyringController:withKeyringV2',
-            { type: KeyringTypes.hd },
+            { type: KeyringType.Hd },
             fn,
           );
 
@@ -4715,7 +4732,7 @@ describe('KeyringController', () => {
       await withController(async ({ controller, initialState }) => {
         const acquireSpy = jest.spyOn(Mutex.prototype, 'acquire');
         const fn = jest.fn().mockResolvedValue('result');
-        const selector = { type: KeyringTypes.hd };
+        const selector = { type: KeyringType.Hd };
         const { metadata } = initialState.keyrings[0];
 
         const result = await controller.withKeyringV2Unsafe(selector, fn);
@@ -4735,7 +4752,7 @@ describe('KeyringController', () => {
         async ({ controller }) => {
           await expect(
             controller.withKeyringV2Unsafe(
-              { type: KeyringTypes.hd },
+              { type: KeyringType.Hd },
               jest.fn(),
             ),
           ).rejects.toThrow(KeyringControllerErrorMessage.ControllerLocked);
@@ -4748,25 +4765,24 @@ describe('KeyringController', () => {
         const fn = jest.fn();
 
         await expect(
-          controller.withKeyringV2Unsafe({ type: 'NonExistentType' }, fn),
+          controller.withKeyringV2Unsafe({ type: KeyringType.Snap }, fn),
         ).rejects.toThrow(KeyringControllerErrorMessage.KeyringNotFound);
 
         expect(fn).not.toHaveBeenCalled();
       });
     });
 
-    it('throws KeyringV2NotSupported when no v2 builder is registered for the type', async () => {
+    it('throws KeyringV2NotSupported when the selected keyring has no V2 adapter', async () => {
       await withController(
         { keyringBuilders: [keyringBuilderFactory(MockShallowKeyring)] },
         async ({ controller }) => {
-          await controller.addNewKeyring(MockShallowKeyring.type);
+          const metadata = await controller.addNewKeyring(
+            MockShallowKeyring.type,
+          );
 
           const fn = jest.fn();
           await expect(
-            controller.withKeyringV2Unsafe(
-              { type: MockShallowKeyring.type },
-              fn,
-            ),
+            controller.withKeyringV2Unsafe({ id: metadata.id }, fn),
           ).rejects.toThrow(
             KeyringControllerErrorMessage.KeyringV2NotSupported,
           );
@@ -4780,12 +4796,27 @@ describe('KeyringController', () => {
       await withController(async ({ controller }) => {
         await expect(
           controller.withKeyringV2Unsafe(
-            { type: KeyringTypes.hd },
+            { type: KeyringType.Hd },
             async ({ keyring }) => keyring,
           ),
         ).rejects.toThrow(
           KeyringControllerErrorMessage.UnsafeDirectKeyringAccess,
         );
+      });
+    });
+
+    it('does not match legacy KeyringTypes values in V2 type selectors', async () => {
+      await withController(async ({ controller }) => {
+        const fn = jest.fn();
+
+        await expect(
+          controller.withKeyringV2Unsafe(
+            { type: KeyringTypes.hd } as unknown as KeyringSelectorV2,
+            fn,
+          ),
+        ).rejects.toThrow(KeyringControllerErrorMessage.KeyringNotFound);
+
+        expect(fn).not.toHaveBeenCalled();
       });
     });
 
@@ -4904,7 +4935,7 @@ describe('KeyringController', () => {
         // withKeyringV2Unsafe does not roll back — errors just propagate.
         await expect(
           controller.withKeyringV2Unsafe(
-            { type: KeyringTypes.hd },
+            { type: KeyringType.Hd },
             async () => {
               throw new Error('Oops');
             },
@@ -4928,7 +4959,7 @@ describe('KeyringController', () => {
 
           await messenger.call(
             'KeyringController:withKeyringV2Unsafe',
-            { type: KeyringTypes.hd },
+            { type: KeyringType.Hd },
             fn,
           );
 

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -15,7 +15,10 @@ import type {
   EthUserOperationPatch,
   KeyringAccount,
 } from '@metamask/keyring-api';
-import type { Keyring as KeyringV2 } from '@metamask/keyring-api/v2';
+import type {
+  Keyring as KeyringV2,
+  KeyringType,
+} from '@metamask/keyring-api/v2';
 import type { EthKeyring } from '@metamask/keyring-internal-api';
 import type { Keyring, KeyringClass } from '@metamask/keyring-utils';
 import type { Messenger } from '@metamask/messenger';
@@ -526,7 +529,7 @@ export type KeyringSelector<SelectedKeyring extends EthKeyring = EthKeyring> =
  */
 export type KeyringSelectorV2<SelectedKeyring extends KeyringV2 = KeyringV2> =
   | {
-      type: string;
+      type: `${KeyringType}`;
       index?: number;
     }
   | {
@@ -1217,12 +1220,27 @@ export class KeyringController<
    */
   getKeyringsByType(type: KeyringTypes | string): unknown[] {
     this.#assertIsUnlocked();
-    return this.#getKeyringEntriesByType(type).map(({ keyring }) => keyring);
+    return this.#getKeyringEntriesByType({ v2: false, type }).map(
+      ({ keyring }) => keyring,
+    );
   }
 
-  #getKeyringEntriesByType(type: KeyringTypes | string): KeyringEntry[] {
+  #getKeyringEntriesByType({
+    v2,
+    type,
+  }:
+    | {
+        v2: false;
+        type: KeyringTypes | string;
+      }
+    | {
+        v2: true;
+        type: `${KeyringType}`;
+      }): KeyringEntry[] {
     this.#assertIsUnlocked();
-    return this.#keyrings.filter(({ keyring }) => keyring.type === type);
+    return this.#keyrings.filter(({ keyring, keyringV2 }) =>
+      v2 ? keyringV2?.type === type : keyring.type === type,
+    );
   }
 
   /**
@@ -2270,7 +2288,10 @@ export class KeyringController<
     if ('address' in selector) {
       entry = await this.#getKeyringEntryForAccount(selector.address);
     } else if ('type' in selector) {
-      entry = this.#getKeyringEntriesByType(selector.type)[selector.index ?? 0];
+      const entries = v2
+        ? this.#getKeyringEntriesByType({ v2: true, type: selector.type })
+        : this.#getKeyringEntriesByType({ v2: false, type: selector.type });
+      entry = entries[selector.index ?? 0];
     } else if ('id' in selector) {
       entry = this.#getKeyringEntryById(selector.id);
     } else if ('filter' in selector) {


### PR DESCRIPTION
## Explanation

We were wrongly using the old `KeyringTypes` enum values instead of the new v2 enum values `KeyringType` (from `keyring-api/v2`).

## References

N/A

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking API change in keyring selection for signing/account operations; incorrect consumer updates could fail to find keyrings or target the wrong adapter at runtime.
> 
> **Overview**
> **BREAKING:** `withKeyringV2` and `withKeyringV2Unsafe` now require v2 **`KeyringType`** values in type selectors (e.g. `KeyringType.Hd`), not legacy **`KeyringTypes`** strings.
> 
> `KeyringSelectorV2`’s `type` field is typed as `` `${KeyringType}` ``. Type-based lookup for V2 paths filters on **`keyringV2.type`** via a refactored `#getKeyringEntriesByType` that distinguishes v1 (`keyring.type`) from v2 (`keyringV2?.type`). Legacy values such as `KeyringTypes.hd` no longer match and yield **KeyringNotFound**.
> 
> Tests and changelog reflect the migration; “no V2 adapter” cases are exercised with **`id`** selectors where appropriate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5bcf745dc5cf88407d68dc556bb581ac3456ce4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->