### PR TITLE
Revert "Release 1001.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "1001.0.0",
+  "version": "1000.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {

--- a/packages/wallet/CHANGELOG.md
+++ b/packages/wallet/CHANGELOG.md
@@ -7,11 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0]
-
 ### Added
 
 - Initial release ([#8838](https://github.com/MetaMask/core/pull/8838))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/wallet@1.0.0...HEAD
-[1.0.0]: https://github.com/MetaMask/core/releases/tag/@metamask/wallet@1.0.0
+[Unreleased]: https://github.com/MetaMask/core/

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/wallet",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "Provides a shared framework for building MetaMask wallets",
   "keywords": [
     "Ethereum",


### PR DESCRIPTION
Reverts MetaMask/core#8902

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only rollback with no runtime or API logic changes.
> 
> **Overview**
> Reverts the **Release 1001.0.0** changes from #8902 by rolling back version bumps and changelog release metadata.
> 
> The root monorepo `package.json` version goes from **1001.0.0** back to **1000.0.0**. **`@metamask/wallet`** is reset from **1.0.0** to **0.0.0**, and its `CHANGELOG.md` drops the published **1.0.0** section and compare links so the initial-release note stays under **[Unreleased]** only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8c527e93b13d2003dec4792929d2068712ca8d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->