### PR TITLE
Revert "Release/1001.0.0"

### DIFF
--- a/packages/compliance-controller/CHANGELOG.md
+++ b/packages/compliance-controller/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.1.1]
+## [2.1.0]
 
 ### Added
 
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Match valid EVM addresses case-insensitively when reading cached wallet compliance statuses ([#8820](https://github.com/MetaMask/core/pull/8820)).
+- Match EVM addresses case-insensitively when reading cached wallet compliance statuses ([#8820](https://github.com/MetaMask/core/pull/8820)).
 
 ## [2.0.1]
 
@@ -71,8 +71,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/controller-utils` from `^11.18.0` to `^11.19.0` ([#7995](https://github.com/MetaMask/core/pull/7995))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/compliance-controller@2.1.1...HEAD
-[2.1.1]: https://github.com/MetaMask/core/compare/@metamask/compliance-controller@2.0.1...@metamask/compliance-controller@2.1.1
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/compliance-controller@2.1.0...HEAD
+[2.1.0]: https://github.com/MetaMask/core/compare/@metamask/compliance-controller@2.0.1...@metamask/compliance-controller@2.1.0
 [2.0.1]: https://github.com/MetaMask/core/compare/@metamask/compliance-controller@2.0.0...@metamask/compliance-controller@2.0.1
 [2.0.0]: https://github.com/MetaMask/core/compare/@metamask/compliance-controller@1.0.2...@metamask/compliance-controller@2.0.0
 [1.0.2]: https://github.com/MetaMask/core/compare/@metamask/compliance-controller@1.0.1...@metamask/compliance-controller@1.0.2

--- a/packages/compliance-controller/package.json
+++ b/packages/compliance-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/compliance-controller",
-  "version": "2.1.1",
+  "version": "2.1.0",
   "description": "Manages OFAC compliance checks for wallet addresses",
   "keywords": [
     "Ethereum",


### PR DESCRIPTION
Reverts MetaMask/core#8900

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only revert with no changes to compliance logic or published artifacts beyond semver metadata.
> 
> **Overview**
> Reverts the **`@metamask/compliance-controller`** release metadata from **2.1.1** back to **2.1.0**, as part of undoing **Release/1001.0.0** (revert of [#8900](https://github.com/MetaMask/core/pull/8900)).
> 
> **`package.json`** sets the published version to `2.1.0` again. **`CHANGELOG.md`** renames the unreleased section from `[2.1.1]` to `[2.1.0]`, tweaks the fixed-entry wording for case-insensitive EVM cache lookup, and updates compare links so `[Unreleased]` and `[2.1.0]` point at the correct tags. No runtime or API code changes appear in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a00ddfe5b2c4cc093a5404c8c6c9cce21b5e9e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->