### PR TITLE
Revert "chore(compliance-controller): release 2.1.0 (#8899)"

### DIFF
--- a/packages/compliance-controller/CHANGELOG.md
+++ b/packages/compliance-controller/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.1.0]
-
 ### Added
 
 - Add `ComplianceService` support for an explicit Compliance API URL ([#8820](https://github.com/MetaMask/core/pull/8820)).
@@ -20,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Match EVM addresses case-insensitively when reading cached wallet compliance statuses ([#8820](https://github.com/MetaMask/core/pull/8820)).
+- Match EVM address casing consistently when reading cached wallet compliance statuses ([#8820](https://github.com/MetaMask/core/pull/8820)).
 
 ## [2.0.1]
 
@@ -71,8 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/controller-utils` from `^11.18.0` to `^11.19.0` ([#7995](https://github.com/MetaMask/core/pull/7995))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/compliance-controller@2.1.0...HEAD
-[2.1.0]: https://github.com/MetaMask/core/compare/@metamask/compliance-controller@2.0.1...@metamask/compliance-controller@2.1.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/compliance-controller@2.0.1...HEAD
 [2.0.1]: https://github.com/MetaMask/core/compare/@metamask/compliance-controller@2.0.0...@metamask/compliance-controller@2.0.1
 [2.0.0]: https://github.com/MetaMask/core/compare/@metamask/compliance-controller@1.0.2...@metamask/compliance-controller@2.0.0
 [1.0.2]: https://github.com/MetaMask/core/compare/@metamask/compliance-controller@1.0.1...@metamask/compliance-controller@1.0.2

--- a/packages/compliance-controller/package.json
+++ b/packages/compliance-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/compliance-controller",
-  "version": "2.1.0",
+  "version": "2.0.1",
   "description": "Manages OFAC compliance checks for wallet addresses",
   "keywords": [
     "Ethereum",


### PR DESCRIPTION
This reverts commit 2face14f76174740dd3c5ceadb54602a2d36ded4.

## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only revert of version and changelog links; no application logic changes.
> 
> **Overview**
> Reverts the **2.1.0** release bookkeeping for `@metamask/compliance-controller` (undoing #8899).
> 
> `package.json` **version** goes from `2.1.0` back to **`2.0.1`**. The changelog drops the published **`## [2.1.0]`** section and keeps those notes under **`## [Unreleased]`** (including a small wording tweak on the EVM casing fix). Compare links at the bottom are updated so **`[Unreleased]`** again points at `2.0.1...HEAD` and the `2.1.0` link is removed.
> 
> No runtime or API code changes—only release metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dd66f1584af06db32877dae8d9379fa5dca3e47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->