### PR TITLE
chore(keyring-controller): deprecate `KeyringTypes`

### DIFF
--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **BREAKING:** Change `KeyringSelectorV2` type selectors for `withKeyringV2` and `withKeyringV2Unsafe` to use `KeyringType` (v2 variant) ([#8901](https://github.com/MetaMask/core/pull/8901))
   - Use values such as `KeyringType.Hd` instead of legacy `KeyringTypes.hd`.
+- Deprecate `KeyringTypes` ([#TODO](https://github.com/MetaMask/core/pull/TODO))
+  - Use `KeyringTypes` from `@metamask/keyring-api/v2` if your keyring has a v2 builder.
 
 ## [25.5.0]
 

--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **BREAKING:** Change `KeyringSelectorV2` type selectors for `withKeyringV2` and `withKeyringV2Unsafe` to use `KeyringType` (v2 variant) ([#8901](https://github.com/MetaMask/core/pull/8901))
   - Use values such as `KeyringType.Hd` instead of legacy `KeyringTypes.hd`.
-- Deprecate `KeyringTypes` ([#TODO](https://github.com/MetaMask/core/pull/TODO))
+- Deprecate `KeyringTypes` ([#8907](https://github.com/MetaMask/core/pull/8907))
   - Use `KeyringTypes` from `@metamask/keyring-api/v2` if your keyring has a v2 builder.
 
 ## [25.5.0]

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -94,6 +94,10 @@ const MESSENGER_EXPOSED_METHODS = [
 
 /**
  * Available keyring types
+ *
+ * @deprecated Use `KeyringType` from `@metamask/keyring-api/v2` instead. This enum will be removed
+ * in a future release once V2 is fully adopted. Only use it if the keyring you are trying to access
+ * has no V2 builder available yet.
  */
 export enum KeyringTypes {
   // Changing this would be a breaking change, and not worth the effort at this


### PR DESCRIPTION
## Explanation

Deprecating `KeyringTypes` in favor of the new v2 type.

## References

N/A

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only deprecation with no removal or behavior change; consumers keep compiling against the existing enum until a future major release.
> 
> **Overview**
> Marks the exported **`KeyringTypes`** enum in `@metamask/keyring-controller` as **deprecated** via JSDoc, steering integrators toward **`KeyringType`** from `@metamask/keyring-api/v2` (and the v2 **`KeyringTypes`** where a V2 builder exists). The enum values and runtime behavior are unchanged.
> 
> The package **changelog** records the deprecation under **Unreleased**, aligned with the recent breaking move of **`withKeyringV2`** selectors to v2 types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b472f9a63c66c502be9828a8509ec8b0454ea1f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->