### PR TITLE
chore: expose batchSell trades loading state

### DIFF
--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Expose gasless batch loading state through selectBatchSellTrades's `isLoading` value
+- Expose gasless batch loading state through selectBatchSellTrades's `isLoading` value ([#8913](https://github.com/MetaMask/core/pull/8913))
 
 ### Changed
 

--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Expose gasless batch loading state through selectBatchSellTrades's `isLoading` value
+
 ### Changed
 
 - Bump `@metamask/assets-controller` from `^8.0.0` to `^8.0.2` ([#8874](https://github.com/MetaMask/core/pull/8874), [#8912](https://github.com/MetaMask/core/pull/8912))

--- a/packages/bridge-controller/src/selectors.test.ts
+++ b/packages/bridge-controller/src/selectors.test.ts
@@ -1742,6 +1742,7 @@ describe('Bridge Selectors', () => {
         }
       `);
       expect(result.isBatchSellTradeAvailable).toBe(true);
+      expect(result.isLoading).toBe(false);
     });
 
     it('should return empty data when batch sell trades are not defined', () => {
@@ -1763,6 +1764,7 @@ describe('Bridge Selectors', () => {
 
       expect(result.totalNetworkFee).toMatchInlineSnapshot(`undefined`);
       expect(result.isBatchSellTradeAvailable).toBe(false);
+      expect(result.isLoading).toBe(false);
     });
 
     it.each([
@@ -1782,6 +1784,7 @@ describe('Bridge Selectors', () => {
           },
         ],
         expectedResult: false,
+        expectedLoadingResult: true,
       },
       {
         status: RequestStatus.FETCHED,
@@ -1799,26 +1802,30 @@ describe('Bridge Selectors', () => {
           },
         ],
         expectedResult: true,
+        expectedLoadingResult: false,
       },
       {
         status: RequestStatus.FETCHED,
         transactions: undefined,
         expectedResult: false,
+        expectedLoadingResult: false,
       },
       {
         status: RequestStatus.FETCHED,
         transactions: [],
         expectedResult: false,
+        expectedLoadingResult: false,
       },
       {
         status: RequestStatus.ERROR,
         transactions: undefined,
         expectedResult: false,
+        expectedLoadingResult: false,
       },
     ])(
       'should return loading state when status is $status',
-      ({ status, transactions, expectedResult }) => {
-        const { isBatchSellTradeAvailable } = selectBatchSellTrades({
+      ({ status, transactions, expectedResult, expectedLoadingResult }) => {
+        const { isBatchSellTradeAvailable, isLoading } = selectBatchSellTrades({
           ...mockState,
           batchSellTradesLoadingStatus: status,
           // @ts-expect-error - test data
@@ -1843,6 +1850,7 @@ describe('Bridge Selectors', () => {
         });
 
         expect(isBatchSellTradeAvailable).toBe(expectedResult);
+        expect(isLoading).toBe(expectedLoadingResult);
       },
     );
   });

--- a/packages/bridge-controller/src/selectors.ts
+++ b/packages/bridge-controller/src/selectors.ts
@@ -528,8 +528,8 @@ export const selectIsQuoteExpired = createBridgeSelector(
   (isQuoteGoingToRefresh, quotesLastFetched, refreshRate, currentTimeInMs) =>
     Boolean(
       !isQuoteGoingToRefresh &&
-      quotesLastFetched &&
-      currentTimeInMs - quotesLastFetched > refreshRate,
+        quotesLastFetched &&
+        currentTimeInMs - quotesLastFetched > refreshRate,
     ),
 );
 
@@ -672,8 +672,9 @@ export const selectBatchSellTrades = createBridgeSelector(
     (state) => state.batchSellTradesLoadingStatus === RequestStatus.FETCHED,
     (state) => state.batchSellTrades,
     selectBatchSellFees,
+    (state) => state.batchSellTradesLoadingStatus === RequestStatus.LOADING,
   ],
-  (isBatchSellTradeAvailable, batchSellTrades, batchFees) => {
+  (isBatchSellTradeAvailable, batchSellTrades, batchFees, isLoading) => {
     return {
       totalNetworkFee: batchFees,
       /**
@@ -682,6 +683,7 @@ export const selectBatchSellTrades = createBridgeSelector(
       isBatchSellTradeAvailable:
         isBatchSellTradeAvailable &&
         Boolean(batchSellTrades?.transactions?.length),
+      isLoading,
     };
   },
 );

--- a/packages/bridge-controller/src/selectors.ts
+++ b/packages/bridge-controller/src/selectors.ts
@@ -528,8 +528,8 @@ export const selectIsQuoteExpired = createBridgeSelector(
   (isQuoteGoingToRefresh, quotesLastFetched, refreshRate, currentTimeInMs) =>
     Boolean(
       !isQuoteGoingToRefresh &&
-        quotesLastFetched &&
-        currentTimeInMs - quotesLastFetched > refreshRate,
+      quotesLastFetched &&
+      currentTimeInMs - quotesLastFetched > refreshRate,
     ),
 );
 


### PR DESCRIPTION
## Explanation

Update selectBatchSellTrades to return `isLoading=true` while the batch sell trades are being fetched

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive selector field only; no auth, persistence, or transaction submission logic changes.
> 
> **Overview**
> **`selectBatchSellTrades`** now returns an **`isLoading`** flag that is **true** while **`batchSellTradesLoadingStatus`** is **`RequestStatus.LOADING`**, so UIs can show a loading state while gasless batch sell trades are being fetched (aligned with **`selectBridgeQuotes`** / **`selectBatchSellQuotes`**).
> 
> Tests cover **`isLoading`** for fetched, empty, loading, and error cases; the unreleased changelog documents the new field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 461b305244b25d6a91b0e6568dd8aa11a0670ad6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->