### PR TITLE
Update Release 1005.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "1004.0.0",
+  "version": "1005.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {

--- a/packages/compliance-controller/CHANGELOG.md
+++ b/packages/compliance-controller/CHANGELOG.md
@@ -7,10 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0]
+
+### Uncategorized
+
+- Revert "chore(compliance-controller): release 2.1.0 (#8899)" ([#8899](https://github.com/MetaMask/core/pull/8899))
+- Revert "Release/1001.0.0" ([#8904](https://github.com/MetaMask/core/pull/8904))
+- Release/1001.0.0 ([#8900](https://github.com/MetaMask/core/pull/8900))
+- chore(compliance-controller): release 2.1.0 ([#8899](https://github.com/MetaMask/core/pull/8899))
+
 ### Added
 
-- Add `ComplianceService` support for an explicit Compliance API URL ([#8820](https://github.com/MetaMask/core/pull/8820)).
-- Add `selectAreAnyWalletsBlocked` ([#8820](https://github.com/MetaMask/core/pull/8820)).
+- Add `ComplianceService` support for an explicit Compliance API URL. ([#8820](https://github.com/MetaMask/core/pull/8820))
+- Add `selectAreAnyWalletsBlocked`. ([#8820](https://github.com/MetaMask/core/pull/8820))
 
 ### Changed
 
@@ -18,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Match EVM address casing consistently when reading cached wallet compliance statuses ([#8820](https://github.com/MetaMask/core/pull/8820)).
+- Match EVM address casing consistently when reading cached wallet compliance statuses. ([#8820](https://github.com/MetaMask/core/pull/8820))
 
 ## [2.0.1]
 
@@ -69,7 +78,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/controller-utils` from `^11.18.0` to `^11.19.0` ([#7995](https://github.com/MetaMask/core/pull/7995))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/compliance-controller@2.0.1...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/compliance-controller@2.1.0...HEAD
+[2.1.0]: https://github.com/MetaMask/core/compare/@metamask/compliance-controller@2.0.1...@metamask/compliance-controller@2.1.0
 [2.0.1]: https://github.com/MetaMask/core/compare/@metamask/compliance-controller@2.0.0...@metamask/compliance-controller@2.0.1
 [2.0.0]: https://github.com/MetaMask/core/compare/@metamask/compliance-controller@1.0.2...@metamask/compliance-controller@2.0.0
 [1.0.2]: https://github.com/MetaMask/core/compare/@metamask/compliance-controller@1.0.1...@metamask/compliance-controller@1.0.2

--- a/packages/compliance-controller/package.json
+++ b/packages/compliance-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/compliance-controller",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Manages OFAC compliance checks for wallet addresses",
   "keywords": [
     "Ethereum",


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

This release publishes `@metamask/compliance-controller` `2.1.0`.

The package currently has unreleased compliance changes on `main` from #8820. Those changes need to be published so downstream clients can consume the updated compliance API support.

This release includes:

- `ComplianceService` support for configuring an explicit Compliance API URL.
- A new `selectAreAnyWalletsBlocked` selector.
- Case-insensitive cached compliance lookups for valid EVM addresses.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Related to #8820

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog edits only; no runtime code changes in the diff.
> 
> **Overview**
> **Release 1005.0.0** bumps the monorepo root from `1004.0.0` to `1005.0.0` and publishes **`@metamask/compliance-controller` `2.1.0`**.
> 
> The package changelog is finalized for `2.1.0`: entries move out of `[Unreleased]`, compare links are updated, and an **Uncategorized** section records prior release/revert PRs. Documented consumer-facing changes for this version (already landed via #8820) include configurable Compliance API URL on `ComplianceService`, `selectAreAnyWalletsBlocked`, and consistent EVM address casing for cached compliance lookups.
> 
> There is **no application source change** in this diff—only version and changelog metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b18874cfaac8b3752e6e30d75997d9ef5a7e1d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->