### PR TITLE
Revert "Update Release 1005.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "1005.0.0",
+  "version": "1004.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {

--- a/packages/compliance-controller/CHANGELOG.md
+++ b/packages/compliance-controller/CHANGELOG.md
@@ -7,19 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.1.0]
-
-### Uncategorized
-
-- Revert "chore(compliance-controller): release 2.1.0 (#8899)" ([#8899](https://github.com/MetaMask/core/pull/8899))
-- Revert "Release/1001.0.0" ([#8904](https://github.com/MetaMask/core/pull/8904))
-- Release/1001.0.0 ([#8900](https://github.com/MetaMask/core/pull/8900))
-- chore(compliance-controller): release 2.1.0 ([#8899](https://github.com/MetaMask/core/pull/8899))
-
 ### Added
 
-- Add `ComplianceService` support for an explicit Compliance API URL. ([#8820](https://github.com/MetaMask/core/pull/8820))
-- Add `selectAreAnyWalletsBlocked`. ([#8820](https://github.com/MetaMask/core/pull/8820))
+- Add `ComplianceService` support for an explicit Compliance API URL ([#8820](https://github.com/MetaMask/core/pull/8820)).
+- Add `selectAreAnyWalletsBlocked` ([#8820](https://github.com/MetaMask/core/pull/8820)).
 
 ### Changed
 
@@ -27,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Match EVM address casing consistently when reading cached wallet compliance statuses. ([#8820](https://github.com/MetaMask/core/pull/8820))
+- Match EVM address casing consistently when reading cached wallet compliance statuses ([#8820](https://github.com/MetaMask/core/pull/8820)).
 
 ## [2.0.1]
 
@@ -78,8 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/controller-utils` from `^11.18.0` to `^11.19.0` ([#7995](https://github.com/MetaMask/core/pull/7995))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/compliance-controller@2.1.0...HEAD
-[2.1.0]: https://github.com/MetaMask/core/compare/@metamask/compliance-controller@2.0.1...@metamask/compliance-controller@2.1.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/compliance-controller@2.0.1...HEAD
 [2.0.1]: https://github.com/MetaMask/core/compare/@metamask/compliance-controller@2.0.0...@metamask/compliance-controller@2.0.1
 [2.0.0]: https://github.com/MetaMask/core/compare/@metamask/compliance-controller@1.0.2...@metamask/compliance-controller@2.0.0
 [1.0.2]: https://github.com/MetaMask/core/compare/@metamask/compliance-controller@1.0.1...@metamask/compliance-controller@1.0.2

--- a/packages/compliance-controller/package.json
+++ b/packages/compliance-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/compliance-controller",
-  "version": "2.1.0",
+  "version": "2.0.1",
   "description": "Manages OFAC compliance checks for wallet addresses",
   "keywords": [
     "Ethereum",


### PR DESCRIPTION
Reverts MetaMask/core#8917

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only revert with no runtime code changes in the diff; main risk is publish/consume confusion if tags or npm versions were already advanced.
> 
> **Overview**
> Reverts the **Release 1005.0.0** update (MetaMask/core#8917) by rolling back release metadata only—no application source changes appear in this diff.
> 
> The root monorepo version in `package.json` goes from `1005.0.0` back to `1004.0.0`. **`@metamask/compliance-controller`** is reset from `2.1.0` to `2.0.1`, and its `CHANGELOG.md` drops the published `## [2.1.0]` section and related compare links while keeping the same feature/fix bullets under **`[Unreleased]`** (with minor punctuation tweaks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf984e04a497409c88cd0e2a55a46dbf2eebe00f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->