### PR TITLE
feat: add `RampsController:ensureProviderForAsset` for MM Pay fiat surfaces

### DIFF
--- a/packages/ramps-controller/CHANGELOG.md
+++ b/packages/ramps-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `ensureProviderForAsset` method and `RampsController:ensureProviderForAsset` messenger action that auto-selects a provider supporting a given CAIP asset ID when the current provider does not ([#8926](https://github.com/MetaMask/core/pull/8926))
+
 ### Changed
 
 - Bump `@metamask/profile-sync-controller` from `^28.1.0` to `^28.1.1` ([#8912](https://github.com/MetaMask/core/pull/8912))

--- a/packages/ramps-controller/src/RampsController-method-action-types.ts
+++ b/packages/ramps-controller/src/RampsController-method-action-types.ts
@@ -88,6 +88,24 @@ export type RampsControllerSetSelectedProviderAction = {
 };
 
 /**
+ * Ensures the currently selected provider supports the given asset.
+ *
+ * If no provider is selected, or the selected provider does not list the
+ * asset in its `supportedCryptoCurrencies`, this method searches the
+ * available providers for the first one that does and auto-selects it.
+ *
+ * This is a no-op when the current provider already supports the asset,
+ * when no providers are loaded, or when no provider supports the asset.
+ *
+ * @param assetId - CAIP-19 asset type identifier
+ * (e.g. `"eip155:42161/erc20:0xaf88d065e77c8cC2239327C5EDb3A432268e5831"`).
+ */
+export type RampsControllerEnsureProviderForAssetAction = {
+  type: `RampsController:ensureProviderForAsset`;
+  handler: RampsController['ensureProviderForAsset'];
+};
+
+/**
  * Initializes the controller by fetching the user's region from geolocation.
  * This should be called once at app startup to set up the initial region.
  *
@@ -621,6 +639,7 @@ export type RampsControllerMethodActions =
   | RampsControllerGetRequestStateAction
   | RampsControllerSetUserRegionAction
   | RampsControllerSetSelectedProviderAction
+  | RampsControllerEnsureProviderForAssetAction
   | RampsControllerInitAction
   | RampsControllerGetCountriesAction
   | RampsControllerGetTokensAction

--- a/packages/ramps-controller/src/RampsController.test.ts
+++ b/packages/ramps-controller/src/RampsController.test.ts
@@ -3495,6 +3495,155 @@ describe('RampsController', () => {
     });
   });
 
+  describe('ensureProviderForAsset', () => {
+    const ASSET_ETH = 'eip155:1/slip44:60';
+    const ASSET_USDC =
+      'eip155:42161/erc20:0xaf88d065e77c8cc2239327c5edb3a432268e5831';
+
+    const providerA = createMockProvider({
+      id: '/providers/provider-a',
+      name: 'Provider A',
+      supportedCryptoCurrencies: { [ASSET_ETH]: true },
+    });
+
+    const providerB = createMockProvider({
+      id: '/providers/provider-b',
+      name: 'Provider B',
+      supportedCryptoCurrencies: { [ASSET_USDC]: true },
+    });
+
+    it('is a no-op when the selected provider already supports the asset', async () => {
+      await withController(
+        {
+          options: {
+            state: {
+              userRegion: createMockUserRegion('us-ca'),
+              providers: createResourceState([providerA], providerA),
+            },
+          },
+        },
+        ({ controller, rootMessenger }) => {
+          rootMessenger.call(
+            'RampsController:ensureProviderForAsset',
+            ASSET_ETH,
+          );
+
+          expect(controller.state.providers.selected).toStrictEqual(providerA);
+        },
+      );
+    });
+
+    it('selects the first supporting provider when none is selected', async () => {
+      await withController(
+        {
+          options: {
+            state: {
+              userRegion: createMockUserRegion('us-ca'),
+              providers: createResourceState([providerA, providerB], null),
+            },
+          },
+        },
+        ({ controller, rootMessenger }) => {
+          rootMessenger.call(
+            'RampsController:ensureProviderForAsset',
+            ASSET_USDC,
+          );
+
+          expect(controller.state.providers.selected).toStrictEqual(providerB);
+          expect(controller.state.providerAutoSelected).toBe(true);
+        },
+      );
+    });
+
+    it('switches to a supporting provider when the selected one does not support the asset', async () => {
+      await withController(
+        {
+          options: {
+            state: {
+              userRegion: createMockUserRegion('us-ca'),
+              providers: createResourceState([providerA, providerB], providerA),
+            },
+          },
+        },
+        ({ controller, rootMessenger }) => {
+          rootMessenger.call(
+            'RampsController:ensureProviderForAsset',
+            ASSET_USDC,
+          );
+
+          expect(controller.state.providers.selected).toStrictEqual(providerB);
+          expect(controller.state.providerAutoSelected).toBe(true);
+        },
+      );
+    });
+
+    it('is a no-op when no provider supports the asset', async () => {
+      await withController(
+        {
+          options: {
+            state: {
+              userRegion: createMockUserRegion('us-ca'),
+              providers: createResourceState([providerA, providerB], providerA),
+            },
+          },
+        },
+        ({ controller, rootMessenger }) => {
+          rootMessenger.call(
+            'RampsController:ensureProviderForAsset',
+            'eip155:999/slip44:0',
+          );
+
+          expect(controller.state.providers.selected).toStrictEqual(providerA);
+        },
+      );
+    });
+
+    it('is a no-op when providers list is empty', async () => {
+      await withController(
+        {
+          options: {
+            state: {
+              userRegion: createMockUserRegion('us-ca'),
+              providers: createResourceState([], null),
+            },
+          },
+        },
+        ({ controller, rootMessenger }) => {
+          rootMessenger.call(
+            'RampsController:ensureProviderForAsset',
+            ASSET_ETH,
+          );
+
+          expect(controller.state.providers.selected).toBeNull();
+        },
+      );
+    });
+
+    it('matches asset ID case-insensitively', async () => {
+      const checksummedAsset =
+        'eip155:42161/erc20:0xAF88d065e77c8cC2239327C5EDb3A432268e5831';
+
+      await withController(
+        {
+          options: {
+            state: {
+              userRegion: createMockUserRegion('us-ca'),
+              providers: createResourceState([providerB], null),
+            },
+          },
+        },
+        ({ controller, rootMessenger }) => {
+          rootMessenger.call(
+            'RampsController:ensureProviderForAsset',
+            checksummedAsset,
+          );
+
+          expect(controller.state.providers.selected).toStrictEqual(providerB);
+        },
+      );
+    });
+  });
+
   describe('setSelectedToken', () => {
     const mockToken: RampsToken = {
       assetId: 'eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',

--- a/packages/ramps-controller/src/RampsController.test.ts
+++ b/packages/ramps-controller/src/RampsController.test.ts
@@ -3642,6 +3642,79 @@ describe('RampsController', () => {
         },
       );
     });
+
+    it('prefers a Transak provider over others when multiple support the asset', async () => {
+      const transakProvider = createMockProvider({
+        id: '/providers/transak-native',
+        name: 'Transak Native',
+        supportedCryptoCurrencies: { [ASSET_ETH]: true },
+      });
+
+      const otherProvider = createMockProvider({
+        id: '/providers/moonpay',
+        name: 'MoonPay',
+        supportedCryptoCurrencies: { [ASSET_ETH]: true },
+      });
+
+      await withController(
+        {
+          options: {
+            state: {
+              userRegion: createMockUserRegion('us-ca'),
+              providers: createResourceState(
+                [otherProvider, transakProvider],
+                null,
+              ),
+            },
+          },
+        },
+        ({ controller, rootMessenger }) => {
+          rootMessenger.call(
+            'RampsController:ensureProviderForAsset',
+            ASSET_ETH,
+          );
+
+          expect(controller.state.providers.selected).toStrictEqual(
+            transakProvider,
+          );
+          expect(controller.state.providerAutoSelected).toBe(false);
+        },
+      );
+    });
+
+    it('falls back to first supporting provider when no Transak provider supports the asset', async () => {
+      const moonpay = createMockProvider({
+        id: '/providers/moonpay',
+        name: 'MoonPay',
+        supportedCryptoCurrencies: { [ASSET_USDC]: true },
+      });
+
+      const paypal = createMockProvider({
+        id: '/providers/paypal',
+        name: 'PayPal',
+        supportedCryptoCurrencies: { [ASSET_USDC]: true },
+      });
+
+      await withController(
+        {
+          options: {
+            state: {
+              userRegion: createMockUserRegion('us-ca'),
+              providers: createResourceState([moonpay, paypal], null),
+            },
+          },
+        },
+        ({ controller, rootMessenger }) => {
+          rootMessenger.call(
+            'RampsController:ensureProviderForAsset',
+            ASSET_USDC,
+          );
+
+          expect(controller.state.providers.selected).toStrictEqual(moonpay);
+          expect(controller.state.providerAutoSelected).toBe(true);
+        },
+      );
+    });
   });
 
   describe('setSelectedToken', () => {

--- a/packages/ramps-controller/src/RampsController.ts
+++ b/packages/ramps-controller/src/RampsController.ts
@@ -1383,11 +1383,26 @@ export class RampsController extends BaseController<
       return;
     }
 
-    const supporting = providers?.find((provider) => supports(provider));
+    const supportingProviders = providers?.filter((provider) =>
+      supports(provider),
+    );
 
-    if (supporting) {
-      this.setSelectedProvider(supporting, { autoSelected: true });
+    if (!supportingProviders?.length) {
+      return;
     }
+
+    const transakProvider = supportingProviders.find(
+      (provider) =>
+        provider.id?.toLowerCase().includes('transak') ||
+        provider.name?.toLowerCase().includes('transak'),
+    );
+
+    if (transakProvider) {
+      this.setSelectedProvider(transakProvider, { autoSelected: false });
+      return;
+    }
+
+    this.setSelectedProvider(supportingProviders[0], { autoSelected: true });
   }
 
   /**

--- a/packages/ramps-controller/src/RampsController.ts
+++ b/packages/ramps-controller/src/RampsController.ts
@@ -771,6 +771,7 @@ const MESSENGER_EXPOSED_METHODS = [
   'getRequestState',
   'setUserRegion',
   'setSelectedProvider',
+  'ensureProviderForAsset',
   'init',
   'getCountries',
   'getTokens',
@@ -1350,6 +1351,42 @@ export class RampsController extends BaseController<
         state.providers.selected = provider;
         state.providerAutoSelected = options?.autoSelected ?? false;
       });
+    }
+  }
+
+  /**
+   * Ensures the currently selected provider supports the given asset.
+   *
+   * If no provider is selected, or the selected provider does not list the
+   * asset in its `supportedCryptoCurrencies`, this method searches the
+   * available providers for the first one that does and auto-selects it.
+   *
+   * This is a no-op when the current provider already supports the asset,
+   * when no providers are loaded, or when no provider supports the asset.
+   *
+   * @param assetId - CAIP-19 asset type identifier
+   *   (e.g. `"eip155:42161/erc20:0xaf88d065e77c8cC2239327C5EDb3A432268e5831"`).
+   */
+  ensureProviderForAsset(assetId: string): void {
+    const { selected, data: providers } = this.state.providers;
+    const lowerId = assetId.toLowerCase();
+
+    const supports = (provider: Provider | null): provider is Provider => {
+      const map = provider?.supportedCryptoCurrencies;
+      if (!map) {
+        return false;
+      }
+      return Boolean(map[assetId]) || Boolean(map[lowerId]);
+    };
+
+    if (supports(selected)) {
+      return;
+    }
+
+    const supporting = providers?.find((provider) => supports(provider));
+
+    if (supporting) {
+      this.setSelectedProvider(supporting, { autoSelected: true });
     }
   }
 

--- a/packages/ramps-controller/src/index.ts
+++ b/packages/ramps-controller/src/index.ts
@@ -18,6 +18,7 @@ export type {
   RampsControllerGetRequestStateAction,
   RampsControllerSetUserRegionAction,
   RampsControllerSetSelectedProviderAction,
+  RampsControllerEnsureProviderForAssetAction,
   RampsControllerInitAction,
   RampsControllerGetCountriesAction,
   RampsControllerGetTokensAction,

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Ensure the selected Ramps provider supports the fiat asset when transaction data is first created, by calling `RampsController:ensureProviderForAsset` with the feature-flag-derived CAIP asset ID ([#8926](https://github.com/MetaMask/core/pull/8926))
+- Extract fiat-related utilities (`ensureProviderForFiatAsset`, `updateFiatAssetId`) into `utils/fiat.ts` ([#8926](https://github.com/MetaMask/core/pull/8926))
+
 ### Changed
 
 - Bump `@metamask/assets-controllers` from `^108.1.0` to `^108.2.0` ([#8911](https://github.com/MetaMask/core/pull/8911))

--- a/packages/transaction-pay-controller/src/TransactionPayController.test.ts
+++ b/packages/transaction-pay-controller/src/TransactionPayController.test.ts
@@ -7,7 +7,6 @@ import { TransactionPayController } from '.';
 import { updateFiatPayment } from './actions/update-fiat-payment';
 import { updatePaymentToken } from './actions/update-payment-token';
 import { PaymentOverride, TransactionPayStrategy } from './constants';
-import { deriveFiatAssetForFiatPayment } from './strategy/fiat/utils';
 import { getMessengerMock } from './tests/messenger-mock';
 import type {
   TransactionPayControllerMessenger,
@@ -15,17 +14,17 @@ import type {
   UpdateTransactionDataCallback,
 } from './types';
 import { getStrategyOrder } from './utils/feature-flags';
+import { ensureProviderForFiatAsset, updateFiatAssetId } from './utils/fiat';
 import { updateQuotes } from './utils/quotes';
 import { updateSourceAmounts } from './utils/source-amounts';
 import {
-  getTransaction,
   subscribeAssetChanges,
   subscribeTransactionChanges,
 } from './utils/transaction';
 
 jest.mock('./actions/update-fiat-payment');
 jest.mock('./actions/update-payment-token');
-jest.mock('./strategy/fiat/utils');
+jest.mock('./utils/fiat');
 jest.mock('./utils/source-amounts');
 jest.mock('./utils/quotes');
 jest.mock('./utils/transaction');
@@ -39,10 +38,10 @@ const CHAIN_ID_MOCK = '0x1' as Hex;
 describe('TransactionPayController', () => {
   const updateFiatPaymentMock = jest.mocked(updateFiatPayment);
   const updatePaymentTokenMock = jest.mocked(updatePaymentToken);
-  const deriveFiatAssetForFiatPaymentMock = jest.mocked(
-    deriveFiatAssetForFiatPayment,
+  const ensureProviderForFiatAssetMock = jest.mocked(
+    ensureProviderForFiatAsset,
   );
-  const getTransactionMock = jest.mocked(getTransaction);
+  const updateFiatAssetIdMock = jest.mocked(updateFiatAssetId);
   const updateSourceAmountsMock = jest.mocked(updateSourceAmounts);
   const updateQuotesMock = jest.mocked(updateQuotes);
   const subscribeTransactionChangesMock = jest.mocked(
@@ -850,12 +849,6 @@ describe('TransactionPayController', () => {
   });
 
   describe('fiat token selection', () => {
-    const CAIP_ASSET_ID_MOCK = 'eip155:137/slip44:966';
-    const FIAT_ASSET_MOCK = {
-      address: '0x0000000000000000000000000000000000001010' as Hex,
-      chainId: '0x89' as Hex,
-    };
-
     function getControllerAndUpdateTransactionData(): {
       controller: TransactionPayController;
       updateTransactionData: UpdateTransactionDataCallback;
@@ -873,44 +866,43 @@ describe('TransactionPayController', () => {
       };
     }
 
-    it('does not set caipAssetId when only fiat amount changes', () => {
-      getTransactionMock.mockReturnValue(TRANSACTION_META_MOCK);
-      deriveFiatAssetForFiatPaymentMock.mockReturnValue(FIAT_ASSET_MOCK);
-
-      const { controller, updateTransactionData } =
-        getControllerAndUpdateTransactionData();
-
-      updateTransactionData(TRANSACTION_ID_MOCK, (data) => {
-        data.fiatPayment = { amountFiat: '100' };
-      });
-
-      expect(
-        controller.state.transactionData[TRANSACTION_ID_MOCK]?.fiatPayment
-          ?.caipAssetId,
-      ).toBeUndefined();
-    });
-
-    it('stores caipAssetId in fiatPayment when payment method changes', () => {
-      getTransactionMock.mockReturnValue(TRANSACTION_META_MOCK);
-      deriveFiatAssetForFiatPaymentMock.mockReturnValue(FIAT_ASSET_MOCK);
-
-      const { controller, updateTransactionData } =
-        getControllerAndUpdateTransactionData();
+    it('calls updateFiatAssetId when payment method changes', () => {
+      const { updateTransactionData } = getControllerAndUpdateTransactionData();
 
       updateTransactionData(TRANSACTION_ID_MOCK, (data) => {
         data.fiatPayment = { selectedPaymentMethodId: 'card-123' };
       });
 
-      expect(
-        controller.state.transactionData[TRANSACTION_ID_MOCK]?.fiatPayment
-          ?.caipAssetId,
-      ).toBe(CAIP_ASSET_ID_MOCK);
+      expect(updateFiatAssetIdMock).toHaveBeenCalledWith({
+        transactionId: TRANSACTION_ID_MOCK,
+        messenger,
+        updateTransactionData: expect.any(Function),
+      });
+    });
+
+    it('does not call updateFiatAssetId when only fiat amount changes', () => {
+      const { updateTransactionData } = getControllerAndUpdateTransactionData();
+
+      updateTransactionData(TRANSACTION_ID_MOCK, (data) => {
+        data.fiatPayment = { amountFiat: '100' };
+      });
+
+      expect(updateFiatAssetIdMock).not.toHaveBeenCalled();
+    });
+
+    it('does not call updateFiatAssetId when fiat payment does not change', () => {
+      const { updateTransactionData } = getControllerAndUpdateTransactionData();
+
+      updateTransactionData(TRANSACTION_ID_MOCK, (data) => {
+        data.sourceAmounts = [
+          { sourceAmountHuman: '1.23' } as TransactionPaySourceAmount,
+        ];
+      });
+
+      expect(updateFiatAssetIdMock).not.toHaveBeenCalled();
     });
 
     it('triggers quote update when fiat payment changes', () => {
-      getTransactionMock.mockReturnValue(TRANSACTION_META_MOCK);
-      deriveFiatAssetForFiatPaymentMock.mockReturnValue(FIAT_ASSET_MOCK);
-
       const { updateTransactionData } = getControllerAndUpdateTransactionData();
 
       updateTransactionData(TRANSACTION_ID_MOCK, (data) => {
@@ -919,57 +911,53 @@ describe('TransactionPayController', () => {
 
       expect(updateQuotesMock).toHaveBeenCalledTimes(1);
     });
+  });
 
-    it('does not set caipAssetId when transaction is not found', () => {
-      getTransactionMock.mockReturnValue(undefined);
+  describe('provider auto-selection on new transaction', () => {
+    function getControllerAndUpdateTransactionData(): {
+      controller: TransactionPayController;
+      updateTransactionData: UpdateTransactionDataCallback;
+    } {
+      const controller = createController();
+      controller.updatePaymentToken({
+        transactionId: TRANSACTION_ID_MOCK,
+        tokenAddress: TOKEN_ADDRESS_MOCK,
+        chainId: CHAIN_ID_MOCK,
+      });
+      return {
+        controller,
+        updateTransactionData:
+          updatePaymentTokenMock.mock.calls[0][1].updateTransactionData,
+      };
+    }
 
-      const { controller, updateTransactionData } =
-        getControllerAndUpdateTransactionData();
+    it('calls ensureProviderForFiatAsset when transaction data is first created', () => {
+      const { updateTransactionData } = getControllerAndUpdateTransactionData();
 
       updateTransactionData(TRANSACTION_ID_MOCK, (data) => {
-        data.fiatPayment = { selectedPaymentMethodId: 'card-123' };
+        data.tokens = [];
       });
 
-      expect(
-        controller.state.transactionData[TRANSACTION_ID_MOCK]?.fiatPayment
-          ?.caipAssetId,
-      ).toBeUndefined();
+      expect(ensureProviderForFiatAssetMock).toHaveBeenCalledWith({
+        transactionId: TRANSACTION_ID_MOCK,
+        messenger,
+      });
     });
 
-    it('does not set caipAssetId when fiat asset cannot be derived', () => {
-      getTransactionMock.mockReturnValue(TRANSACTION_META_MOCK);
-      deriveFiatAssetForFiatPaymentMock.mockReturnValue(undefined as never);
-
-      const { controller, updateTransactionData } =
-        getControllerAndUpdateTransactionData();
+    it('does not call ensureProviderForFiatAsset on subsequent updates', () => {
+      const { updateTransactionData } = getControllerAndUpdateTransactionData();
 
       updateTransactionData(TRANSACTION_ID_MOCK, (data) => {
-        data.fiatPayment = { selectedPaymentMethodId: 'card-123' };
+        data.tokens = [];
       });
 
-      expect(
-        controller.state.transactionData[TRANSACTION_ID_MOCK]?.fiatPayment
-          ?.caipAssetId,
-      ).toBeUndefined();
-    });
-
-    it('does not set caipAssetId when fiat payment does not change', () => {
-      getTransactionMock.mockReturnValue(TRANSACTION_META_MOCK);
-      deriveFiatAssetForFiatPaymentMock.mockReturnValue(FIAT_ASSET_MOCK);
-
-      const { controller, updateTransactionData } =
-        getControllerAndUpdateTransactionData();
+      ensureProviderForFiatAssetMock.mockClear();
 
       updateTransactionData(TRANSACTION_ID_MOCK, (data) => {
-        data.sourceAmounts = [
-          { sourceAmountHuman: '1.23' } as TransactionPaySourceAmount,
-        ];
+        data.fiatPayment = { amountFiat: '50' };
       });
 
-      expect(
-        controller.state.transactionData[TRANSACTION_ID_MOCK]?.fiatPayment
-          ?.caipAssetId,
-      ).toBeUndefined();
+      expect(ensureProviderForFiatAssetMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/transaction-pay-controller/src/TransactionPayController.ts
+++ b/packages/transaction-pay-controller/src/TransactionPayController.ts
@@ -12,7 +12,6 @@ import {
   TransactionPayStrategy,
 } from './constants';
 import { QuoteRefresher } from './helpers/QuoteRefresher';
-import { deriveFiatAssetForFiatPayment } from './strategy/fiat/utils';
 import type {
   GetDelegationTransactionCallback,
   PolymarketCallbacks,
@@ -25,11 +24,10 @@ import type {
   UpdatePaymentTokenRequest,
 } from './types';
 import { getStrategyOrder } from './utils/feature-flags';
+import { ensureProviderForFiatAsset, updateFiatAssetId } from './utils/fiat';
 import { updateQuotes } from './utils/quotes';
 import { updateSourceAmounts } from './utils/source-amounts';
-import { buildCaipAssetType } from './utils/token';
 import {
-  getTransaction,
   subscribeAssetChanges,
   subscribeTransactionChanges,
 } from './utils/transaction';
@@ -276,6 +274,7 @@ export class TransactionPayController extends BaseController<
   ): void {
     let shouldUpdateQuotes = false;
     let shouldUpdateFiatToken = false;
+    let isNewTransaction = false;
 
     this.update((state) => {
       const { transactionData } = state;
@@ -297,6 +296,7 @@ export class TransactionPayController extends BaseController<
         };
 
         current = transactionData[transactionId];
+        isNewTransaction = true;
       }
 
       fn(current);
@@ -338,25 +338,19 @@ export class TransactionPayController extends BaseController<
       }
     });
 
-    if (shouldUpdateFiatToken) {
-      const transaction = getTransaction(
+    if (isNewTransaction) {
+      ensureProviderForFiatAsset({
         transactionId,
-        this.messenger,
-      ) as TransactionMeta;
-      const fiatAsset = deriveFiatAssetForFiatPayment(
-        transaction,
-        this.messenger,
-      );
-      if (fiatAsset) {
-        this.#updateTransactionData(transactionId, (data) => {
-          if (data.fiatPayment) {
-            data.fiatPayment.caipAssetId = buildCaipAssetType(
-              fiatAsset.chainId,
-              fiatAsset.address,
-            );
-          }
-        });
-      }
+        messenger: this.messenger,
+      });
+    }
+
+    if (shouldUpdateFiatToken) {
+      updateFiatAssetId({
+        transactionId,
+        messenger: this.messenger,
+        updateTransactionData: this.#updateTransactionData.bind(this),
+      });
     }
 
     if (shouldUpdateQuotes) {

--- a/packages/transaction-pay-controller/src/types.ts
+++ b/packages/transaction-pay-controller/src/types.ts
@@ -33,6 +33,7 @@ import type { NetworkControllerFindNetworkClientIdByChainIdAction } from '@metam
 import type { NetworkControllerGetNetworkClientByIdAction } from '@metamask/network-controller';
 import type { Quote as RampsQuote } from '@metamask/ramps-controller';
 import type {
+  RampsControllerEnsureProviderForAssetAction,
   RampsControllerGetOrderAction,
   RampsControllerGetQuotesAction,
   RampsControllerGetStateAction,
@@ -77,6 +78,7 @@ export type AllowedActions =
   | KeyringControllerSignTypedMessageAction
   | NetworkControllerFindNetworkClientIdByChainIdAction
   | NetworkControllerGetNetworkClientByIdAction
+  | RampsControllerEnsureProviderForAssetAction
   | RampsControllerGetOrderAction
   | RampsControllerGetQuotesAction
   | RampsControllerGetStateAction

--- a/packages/transaction-pay-controller/src/utils/fiat.test.ts
+++ b/packages/transaction-pay-controller/src/utils/fiat.test.ts
@@ -1,0 +1,134 @@
+import type { TransactionMeta } from '@metamask/transaction-controller';
+import type { Hex } from '@metamask/utils';
+
+import { deriveFiatAssetForFiatPayment } from '../strategy/fiat/utils';
+import { getMessengerMock } from '../tests/messenger-mock';
+import type { TransactionPayControllerMessenger } from '../types';
+import { ensureProviderForFiatAsset, updateFiatAssetId } from './fiat';
+import { getTransaction } from './transaction';
+
+jest.mock('../strategy/fiat/utils');
+jest.mock('./transaction');
+
+const TRANSACTION_ID_MOCK = '123-456';
+const TRANSACTION_META_MOCK = {
+  id: TRANSACTION_ID_MOCK,
+} as TransactionMeta;
+
+const FIAT_ASSET_MOCK = {
+  address: '0x0000000000000000000000000000000000001010' as Hex,
+  chainId: '0x89' as Hex,
+};
+
+describe('fiat utils', () => {
+  const deriveFiatAssetMock = jest.mocked(deriveFiatAssetForFiatPayment);
+  const getTransactionMock = jest.mocked(getTransaction);
+  let messenger: TransactionPayControllerMessenger;
+  let ensureProviderForAssetMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    const mocks = getMessengerMock();
+    messenger = mocks.messenger;
+
+    ensureProviderForAssetMock = jest.fn();
+    jest
+      .spyOn(messenger as never, 'call')
+      .mockImplementation((action: string, ...args: unknown[]) => {
+        if (action === 'RampsController:ensureProviderForAsset') {
+          return ensureProviderForAssetMock(...args) as never;
+        }
+        return undefined as never;
+      });
+  });
+
+  describe('ensureProviderForFiatAsset', () => {
+    it('calls RampsController:ensureProviderForAsset with derived CAIP asset ID', () => {
+      getTransactionMock.mockReturnValue(TRANSACTION_META_MOCK);
+      deriveFiatAssetMock.mockReturnValue(FIAT_ASSET_MOCK);
+
+      ensureProviderForFiatAsset({
+        transactionId: TRANSACTION_ID_MOCK,
+        messenger,
+      });
+
+      expect(ensureProviderForAssetMock).toHaveBeenCalledWith(
+        'eip155:137/slip44:966',
+      );
+    });
+
+    it('does not call RampsController when transaction is not found', () => {
+      getTransactionMock.mockReturnValue(undefined);
+
+      ensureProviderForFiatAsset({
+        transactionId: TRANSACTION_ID_MOCK,
+        messenger,
+      });
+
+      expect(ensureProviderForAssetMock).not.toHaveBeenCalled();
+    });
+
+    it('does not call RampsController when fiat asset cannot be derived', () => {
+      getTransactionMock.mockReturnValue(TRANSACTION_META_MOCK);
+      deriveFiatAssetMock.mockReturnValue(undefined as never);
+
+      ensureProviderForFiatAsset({
+        transactionId: TRANSACTION_ID_MOCK,
+        messenger,
+      });
+
+      expect(ensureProviderForAssetMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateFiatAssetId', () => {
+    it('stores caipAssetId in fiat payment data', () => {
+      getTransactionMock.mockReturnValue(TRANSACTION_META_MOCK);
+      deriveFiatAssetMock.mockReturnValue(FIAT_ASSET_MOCK);
+
+      const updateTransactionData = jest.fn();
+      updateFiatAssetId({
+        transactionId: TRANSACTION_ID_MOCK,
+        messenger,
+        updateTransactionData,
+      });
+
+      expect(updateTransactionData).toHaveBeenCalledWith(
+        TRANSACTION_ID_MOCK,
+        expect.any(Function),
+      );
+
+      const fiatPayment = { caipAssetId: undefined as string | undefined };
+      updateTransactionData.mock.calls[0][1]({ fiatPayment });
+
+      expect(fiatPayment.caipAssetId).toBe('eip155:137/slip44:966');
+    });
+
+    it('does not call updateTransactionData when transaction is not found', () => {
+      getTransactionMock.mockReturnValue(undefined);
+
+      const updateTransactionData = jest.fn();
+      updateFiatAssetId({
+        transactionId: TRANSACTION_ID_MOCK,
+        messenger,
+        updateTransactionData,
+      });
+
+      expect(updateTransactionData).not.toHaveBeenCalled();
+    });
+
+    it('does not call updateTransactionData when fiat asset cannot be derived', () => {
+      getTransactionMock.mockReturnValue(TRANSACTION_META_MOCK);
+      deriveFiatAssetMock.mockReturnValue(undefined as never);
+
+      const updateTransactionData = jest.fn();
+      updateFiatAssetId({
+        transactionId: TRANSACTION_ID_MOCK,
+        messenger,
+        updateTransactionData,
+      });
+
+      expect(updateTransactionData).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/transaction-pay-controller/src/utils/fiat.ts
+++ b/packages/transaction-pay-controller/src/utils/fiat.ts
@@ -1,0 +1,81 @@
+import { deriveFiatAssetForFiatPayment } from '../strategy/fiat/utils';
+import type {
+  TransactionPayControllerMessenger,
+  UpdateTransactionDataCallback,
+} from '../types';
+import { buildCaipAssetType } from './token';
+import { getTransaction } from './transaction';
+
+/**
+ * Ensures the selected Ramps provider supports the fiat asset
+ * required by the given transaction.
+ *
+ * Derives the fiat asset from the transaction type and feature flags,
+ * then delegates to `RampsController:ensureProviderForAsset` which
+ * auto-selects a supporting provider when the current one cannot
+ * fulfill the asset.
+ *
+ * @param options - The options.
+ * @param options.transactionId - ID of the transaction.
+ * @param options.messenger - Controller messenger.
+ */
+export function ensureProviderForFiatAsset({
+  transactionId,
+  messenger,
+}: {
+  transactionId: string;
+  messenger: TransactionPayControllerMessenger;
+}): void {
+  const transaction = getTransaction(transactionId, messenger);
+
+  if (!transaction) {
+    return;
+  }
+
+  const fiatAsset = deriveFiatAssetForFiatPayment(transaction, messenger);
+
+  if (fiatAsset) {
+    messenger.call(
+      'RampsController:ensureProviderForAsset',
+      buildCaipAssetType(fiatAsset.chainId, fiatAsset.address),
+    );
+  }
+}
+
+/**
+ * Updates the CAIP asset ID stored in the transaction's fiat payment
+ * state based on the transaction type and feature flags.
+ *
+ * @param options - The options.
+ * @param options.transactionId - ID of the transaction.
+ * @param options.messenger - Controller messenger.
+ * @param options.updateTransactionData - Callback to update transaction data.
+ */
+export function updateFiatAssetId({
+  transactionId,
+  messenger,
+  updateTransactionData,
+}: {
+  transactionId: string;
+  messenger: TransactionPayControllerMessenger;
+  updateTransactionData: UpdateTransactionDataCallback;
+}): void {
+  const transaction = getTransaction(transactionId, messenger);
+
+  if (!transaction) {
+    return;
+  }
+
+  const fiatAsset = deriveFiatAssetForFiatPayment(transaction, messenger);
+
+  if (fiatAsset) {
+    updateTransactionData(transactionId, (data) => {
+      if (data.fiatPayment) {
+        data.fiatPayment.caipAssetId = buildCaipAssetType(
+          fiatAsset.chainId,
+          fiatAsset.address,
+        );
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Explanation

When MM Pay surfaces (Perps deposit, Predict deposit) open the confirmation screen, the Ramp bootstrap may have selected a provider that does not support the fiat asset required by the transaction type - or may have failed to select any provider at all (e.g. first-time user in `us-ny` with no Transak Native). This leaves the user with an empty payment methods state and no recovery path.

### Solution

Instead of duplicating provider auto-selection in client-side React hooks (as proposed in metamask-mobile#30719), this PR moves the logic to the controller layer:

1. **New `RampsController.ensureProviderForAsset(assetId)`** - a generic, reusable action that checks if the currently selected provider supports the given CAIP asset. If not (or if no provider is selected), it finds the first available provider that does and auto-selects it.

2. **`TransactionPayController` integration** - when transaction data is first created (`isNewTransaction`), the controller derives the correct fiat asset via `deriveFiatAssetForFiatPayment` (feature-flag-driven, per-transaction-type) and calls `RampsController:ensureProviderForAsset` with the resulting CAIP ID.

3. **`utils/fiat.ts` extraction** - fiat-related utilities (`ensureProviderForFiatAsset`, `updateFiatAssetId`) are extracted from the controller into a dedicated utils file, following the same pattern as `utils/source-amounts.ts`.

### Why controller-side instead of client-side hooks?

- **Correct asset derivation**: The controller uses `deriveFiatAssetForFiatPayment` which resolves the asset from feature flags, not from `requiredTokens`. For `perpsDeposit`, the Ramp should buy ETH on Arbitrum (native token), not USDC - the Relay strategy handles the swap.
- **Single source of truth**: No need to duplicate provider selection logic across BuildQuote, CustomAmountInfo, and future MM Pay surfaces.

## References

- Related to https://github.com/MetaMask/metamask-mobile/pull/30719 (client-side approach for the same problem)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default ramps provider selection (including Transak preference) at transaction start, which affects buy/payment-method UX but is scoped to provider state and covered by new unit tests.
> 
> **Overview**
> Adds **`RampsController.ensureProviderForAsset`** and the **`RampsController:ensureProviderForAsset`** messenger action so ramps can auto-pick a provider whose `supportedCryptoCurrencies` includes a given CAIP-19 asset when none is selected or the current one does not. Matching is case-insensitive; when several providers qualify, **Transak** is preferred (with `providerAutoSelected: false`); otherwise the first match is chosen with **`autoSelected: true`**.
> 
> **`TransactionPayController`** now calls **`ensureProviderForFiatAsset`** once when transaction data is first created, deriving the fiat asset via feature flags and delegating to ramps. Fiat CAIP ID updates on payment-method change are moved into new **`utils/fiat.ts`** (`ensureProviderForFiatAsset`, `updateFiatAssetId`), with messenger types and tests updated in both packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f9af5ad04cfdb1c57752fe0c2fee65e0de2f292. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->