### PR TITLE
fix: batch sell value in currency sometimes missing

### DIFF
--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix EVM token exchange-rate lookups when asset ID address casing differs from `marketData` keys, restoring Batch Sell network fee fiat values.
+- Fix EVM token exchange-rate lookups when asset ID address casing differs from `marketData` keys, restoring Batch Sell network fee fiat values ([#8928](https://github.com/MetaMask/core/pull/8928))
 
 ## [73.1.0]
 

--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/assets-controller` from `^8.0.2` to `^8.1.0` ([#8919](https://github.com/MetaMask/core/pull/8919))
 
+### Fixed
+
+- Fix EVM token exchange-rate lookups when asset ID address casing differs from `marketData` keys, restoring Batch Sell network fee fiat values.
+
 ## [73.1.0]
 
 ### Added

--- a/packages/bridge-controller/src/selectors.test.ts
+++ b/packages/bridge-controller/src/selectors.test.ts
@@ -173,6 +173,21 @@ describe('Bridge Selectors', () => {
         usdExchangeRate: '36.4650017017000806',
       });
     });
+
+    it('should not throw when EVM token rate asset ID has a malformed hex address', () => {
+      expect(() =>
+        selectExchangeRateByAssetId(
+          mockExchangeRateSources,
+          'eip155:1/erc20:0x123',
+        ),
+      ).not.toThrow();
+      expect(
+        selectExchangeRateByAssetId(
+          mockExchangeRateSources,
+          'eip155:1/erc20:0x123',
+        ),
+      ).toStrictEqual({});
+    });
   });
 
   describe('selectIsAssetExchangeRateInState', () => {

--- a/packages/bridge-controller/src/selectors.test.ts
+++ b/packages/bridge-controller/src/selectors.test.ts
@@ -1,3 +1,4 @@
+import { getAddress } from '@ethersproject/address';
 import { AddressZero } from '@ethersproject/constants';
 import type { MarketDataDetails } from '@metamask/assets-controllers';
 import { toHex } from '@metamask/controller-utils';
@@ -155,6 +156,17 @@ describe('Bridge Selectors', () => {
       const result = selectExchangeRateByAssetId(
         mockExchangeRateSources,
         formatAddressToAssetId(MOCK_MUSD_ADDRESS.toLowerCase(), '1'),
+      );
+      expect(result).toStrictEqual({
+        exchangeRate: '50.00000000000000162804',
+        usdExchangeRate: '36.4650017017000806',
+      });
+    });
+
+    it('should handle EVM token rates when the asset ID address is lowercase and market data is checksummed', () => {
+      const result = selectExchangeRateByAssetId(
+        mockExchangeRateSources,
+        `eip155:1/erc20:${MOCK_MUSD_ADDRESS.toLowerCase()}`,
       );
       expect(result).toStrictEqual({
         exchangeRate: '50.00000000000000162804',
@@ -1704,6 +1716,45 @@ describe('Bridge Selectors', () => {
           },
           "usd": "0.05",
           "valueInCurrency": "2",
+        }
+      `);
+      expect(result.isBatchSellTradeAvailable).toBe(true);
+    });
+
+    it('should return total network fee value when fee asset ID address is lowercase and market data is checksummed', () => {
+      const result = selectBatchSellTrades({
+        ...mockState,
+        currencyRates: {
+          ETH: {
+            conversionRate: 1,
+            usdConversionRate: 1,
+          },
+        },
+        marketData: {
+          '0x89': {
+            [getAddress(mockBatchSellTrades.fee.asset.address)]: {
+              price: 1,
+              currency: 'ETH',
+            },
+          },
+        },
+        batchSellTradesLoadingStatus: RequestStatus.FETCHED,
+        batchSellTrades: mockBatchSellTrades,
+      });
+
+      expect(result.totalNetworkFee).toMatchInlineSnapshot(`
+        {
+          "amount": "0.01",
+          "asset": {
+            "address": "0x3c499c542cef5e3811e1192ce70d8cc03d5c3359",
+            "assetId": "eip155:137/erc20:0x3c499c542cef5e3811e1192ce70d8cc03d5c3359",
+            "chainId": 137,
+            "decimals": 6,
+            "name": "USD Coin",
+            "symbol": "USDC",
+          },
+          "usd": "0.01",
+          "valueInCurrency": "0.01",
         }
       `);
       expect(result.isBatchSellTradeAvailable).toBe(true);

--- a/packages/bridge-controller/src/selectors.ts
+++ b/packages/bridge-controller/src/selectors.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { getAddress } from '@ethersproject/address';
 import type {
   CurrencyRateState,
   MultichainAssetsRatesControllerState,
@@ -232,7 +233,8 @@ export const selectExchangeRateByAssetId = (
     const evmTokenExchangeRates =
       marketDataByChain[formatChainIdToHex(chainId)];
     const evmTokenExchangeRateForAddress = isStrictHexString(address)
-      ? evmTokenExchangeRates?.[address]
+      ? evmTokenExchangeRates?.[getAddress(address)] ??
+        evmTokenExchangeRates?.[address.toLowerCase()]
       : null;
     const currencyKey = evmTokenExchangeRateForAddress?.currency;
     const nativeCurrencyRate =

--- a/packages/bridge-controller/src/selectors.ts
+++ b/packages/bridge-controller/src/selectors.ts
@@ -112,6 +112,9 @@ type BridgeQuotesClientParams = {
   selectedQuote: (QuoteResponse & QuoteMetadata) | null;
 };
 
+type EvmTokenExchangeRate = { price?: number; currency?: string };
+type EvmTokenExchangeRates = Record<string, EvmTokenExchangeRate>;
+
 const createFeatureFlagsSelector =
   createSelector_.withTypes<RemoteFeatureFlagControllerState>();
 
@@ -140,6 +143,20 @@ export const selectBridgeFeatureFlags = createFeatureFlagsSelector(
   [(state) => state.remoteFeatureFlags.bridgeConfig],
   (bridgeConfig: unknown) => processFeatureFlags(bridgeConfig),
 );
+
+const getEvmTokenExchangeRateForAddress = (
+  evmTokenExchangeRates: EvmTokenExchangeRates | undefined,
+  address: string,
+): EvmTokenExchangeRate | null | undefined => {
+  try {
+    return isStrictHexString(address)
+      ? (evmTokenExchangeRates?.[getAddress(address)] ??
+          evmTokenExchangeRates?.[address.toLowerCase()])
+      : null;
+  } catch {
+    return null;
+  }
+};
 
 /**
  * Selects the asset exchange rate for a given chain and address
@@ -227,15 +244,13 @@ export const selectExchangeRateByAssetId = (
   // If the chain is an EVM chain and the asset is not the native asset, use the conversion rate from the token rates controller
   if (!isNonEvmChainId(chainId)) {
     const marketDataByChain =
-      (marketData as
-        | Record<string, Record<string, { price?: number; currency?: string }>>
-        | undefined) ?? {};
+      (marketData as Record<string, EvmTokenExchangeRates> | undefined) ?? {};
     const evmTokenExchangeRates =
       marketDataByChain[formatChainIdToHex(chainId)];
-    const evmTokenExchangeRateForAddress = isStrictHexString(address)
-      ? (evmTokenExchangeRates?.[getAddress(address)] ??
-        evmTokenExchangeRates?.[address.toLowerCase()])
-      : null;
+    const evmTokenExchangeRateForAddress = getEvmTokenExchangeRateForAddress(
+      evmTokenExchangeRates,
+      address,
+    );
     const currencyKey = evmTokenExchangeRateForAddress?.currency;
     const nativeCurrencyRate =
       currencyKey !== undefined && currencyKey !== null

--- a/packages/bridge-controller/src/selectors.ts
+++ b/packages/bridge-controller/src/selectors.ts
@@ -233,8 +233,8 @@ export const selectExchangeRateByAssetId = (
     const evmTokenExchangeRates =
       marketDataByChain[formatChainIdToHex(chainId)];
     const evmTokenExchangeRateForAddress = isStrictHexString(address)
-      ? evmTokenExchangeRates?.[getAddress(address)] ??
-        evmTokenExchangeRates?.[address.toLowerCase()]
+      ? (evmTokenExchangeRates?.[getAddress(address)] ??
+        evmTokenExchangeRates?.[address.toLowerCase()])
       : null;
     const currencyKey = evmTokenExchangeRateForAddress?.currency;
     const nativeCurrencyRate =


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

`selectExchangeRateByAssetId` previously looked up EVM token `marketData` using only the address casing extracted from the provided asset ID. Batch Sell fee assets can arrive from `obtainGaslessBatch` with a lowercase ERC-20 address, while Mobile provides token rates keyed by checksummed addresses. That mismatch caused `selectBatchSellTrades(...).totalNetworkFee.amount` to be present while `valueInCurrency` and `usd` were `null`.

This updates the EVM token exchange-rate lookup to try the checksummed address first and then fall back to the lowercase address. That keeps existing checksummed quote metadata behavior working while allowing Batch Sell fee asset IDs with lowercase addresses to resolve against checksummed `marketData` keys.

Regression tests cover both the low-level `selectExchangeRateByAssetId` casing behavior and the full `selectBatchSellTrades` path for Batch Sell network fee fiat values.

https://github.com/user-attachments/assets/b9850d2e-b7df-4b46-ab9b-b50cf7d96ecf

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Related to https://github.com/MetaMask/metamask-mobile/pull/30710/

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small selector lookup fix with new tests; no auth, persistence, or API contract changes.
> 
> **Overview**
> Fixes **Batch Sell** network fee fiat display when the fee token’s ERC-20 address in the asset ID is **lowercase** but `marketData` is keyed by **checksummed** addresses.
> 
> `selectExchangeRateByAssetId` now resolves EVM token rates via a shared helper that looks up **`getAddress(address)` first**, then **lowercase**, and returns safely on invalid hex instead of failing the lookup. That restores `selectBatchSellTrades` **`totalNetworkFee`** `valueInCurrency` and `usd` when rates were previously missing. Regression tests cover the selector and the full Batch Sell fee path; the package changelog records the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 156b42cdeb8d9154b0cb96f0ed569c876f2b28c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->