### PR TITLE
feat: add IoTeX Mainnet to Price API supported chains

### DIFF
--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add IoTeX Mainnet (chain 4689) support ([#__PRNUM__](https://github.com/MetaMask/core/pull/__PRNUM__))
+  - Add `0x1251` to `SPOT_PRICES_SUPPORT_INFO` in `codefi-v2.ts`
+  - Add `0x1251` to `chainIdToNativeTokenAddress` in `codefi-v2.ts`
+  - Add `0x1251` to `MULTICALL_CONTRACT_BY_CHAINID` in `multicall.ts`
+
 ### Changed
 
 - Bump `@metamask/account-tree-controller` from `^7.4.0` to `^7.5.0` ([#8912](https://github.com/MetaMask/core/pull/8912))

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add IoTeX Mainnet (chain 4689) support ([#8930](https://github.com/MetaMask/core/pull/8930))
   - Add `0x1251` to `SPOT_PRICES_SUPPORT_INFO` in `codefi-v2.ts`
   - Add `0x1251` to `chainIdToNativeTokenAddress` in `codefi-v2.ts`
-  - Add `0x1251` to `MULTICALL_CONTRACT_BY_CHAINID` in `multicall.ts`
 
 ### Changed
 

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add IoTeX Mainnet (chain 4689) support ([#__PRNUM__](https://github.com/MetaMask/core/pull/__PRNUM__))
+- Add IoTeX Mainnet (chain 4689) support ([#8930](https://github.com/MetaMask/core/pull/8930))
   - Add `0x1251` to `SPOT_PRICES_SUPPORT_INFO` in `codefi-v2.ts`
   - Add `0x1251` to `chainIdToNativeTokenAddress` in `codefi-v2.ts`
   - Add `0x1251` to `MULTICALL_CONTRACT_BY_CHAINID` in `multicall.ts`

--- a/packages/assets-controllers/src/multicall.ts
+++ b/packages/assets-controllers/src/multicall.ts
@@ -315,8 +315,6 @@ const MULTICALL_CONTRACT_BY_CHAINID = {
   '0xa5bf': '0xcA11bde05977b3631167028862bE2a173976CA11',
   // Tempo Mainnet (4217)
   '0x1079': '0xcA11bde05977b3631167028862bE2a173976CA11',
-  // IoTeX Mainnet (4689)
-  '0x1251': '0xcA11bde05977b3631167028862bE2a173976CA11',
 } as Record<Hex, Hex>;
 
 const multicallAbi = [

--- a/packages/assets-controllers/src/multicall.ts
+++ b/packages/assets-controllers/src/multicall.ts
@@ -315,6 +315,8 @@ const MULTICALL_CONTRACT_BY_CHAINID = {
   '0xa5bf': '0xcA11bde05977b3631167028862bE2a173976CA11',
   // Tempo Mainnet (4217)
   '0x1079': '0xcA11bde05977b3631167028862bE2a173976CA11',
+  // IoTeX Mainnet (4689)
+  '0x1251': '0xcA11bde05977b3631167028862bE2a173976CA11',
 } as Record<Hex, Hex>;
 
 const multicallAbi = [

--- a/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
+++ b/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
@@ -232,6 +232,7 @@ const chainIdToNativeTokenAddress: Record<Hex, Hex> = {
   '0x64': '0xe91d153e0b41518a2ce8dd3d7944fa863463a97d', // Gnosis
   '0x3dc': '0x779ded0c9e1022225f8e0630b35a9b54be713736', // Stable - Native symbol: USDT0
   '0x440': '0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000', // Metis Andromeda
+  '0x1251': '0xa00744882684c3e4747faefd68d283ea44099d03', // IoTeX Mainnet - native IOTX via WIOTX
   '0x1388': '0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000', // Mantle
 };
 
@@ -292,6 +293,7 @@ export const SPOT_PRICES_SUPPORT_INFO = {
   '0xab5': 'eip155:2741/erc20:0x0000000000000000000000000000000000000000', // Abstract - Native symbol: ETH
   '0x1079': 'eip155:4217/slip44:60', // Tempo Mainnet - No native asset
   '0x10e6': 'eip155:4326/erc20:0x0000000000000000000000000000000000000000', // MegaETH Mainnet - Native symbol: ETH
+  '0x1251': 'eip155:4689/erc20:0xa00744882684c3e4747faefd68d283ea44099d03', // IoTeX Mainnet - native IOTX (via WIOTX, == coingecko "iotex")
   '0x1388': 'eip155:5000/erc20:0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000', // Mantle - Native symbol: MNT
   '0x1b58': 'eip155:7000/slip44:7000', // ZetaChain - Native symbol: ZETA
   '0x2105': 'eip155:8453/slip44:60', // Base - Native symbol: ETH


### PR DESCRIPTION
## Explanation

Native IOTX (and IoTeX ERC20s) show no price in MetaMask today. `eip155:4689` (IoTeX Mainnet) is absent from the Price API's `/v2/supportedNetworks` allowlist (`fullSupport`, `spotPricesV2`, `spotPricesV3`), so `CodefiTokenPricesServiceV2.fetchTokenPrices` filters IoTeX assets out before any price request is made — the wallet UI shows no conversion rate for IOTX or any IoTeX token.

This PR adds the client-side mapping for IoTeX, following the exact pattern used for the Stable network in #8185. Native IOTX has no direct CoinGecko native-coin mapping via slip44, but its canonical price equals wrapped IOTX (WIOTX), so we route native IOTX through the WIOTX ERC20 contract:

- `SPOT_PRICES_SUPPORT_INFO['0x1251'] = 'eip155:4689/erc20:0xa00744882684c3e4747faefd68d283ea44099d03'`
- `chainIdToNativeTokenAddress['0x1251'] = '0xa00744882684c3e4747faefd68d283ea44099d03'`
- `MULTICALL_CONTRACT_BY_CHAINID['0x1251'] = '0xcA11bde05977b3631167028862bE2a173976CA11'` (canonical Multicall3, verified deployed on IoTeX)

The Price API backend already resolves the WIOTX contract price today:

```
GET /v3/spot-prices?assetIds=eip155:4689/erc20:0xa00744882684c3e4747faefd68d283ea44099d03&vsCurrency=usd  -> WIOTX $0.00398  (== coingecko "iotex")
GET /v3/spot-prices?assetIds=eip155:4689/slip44:304&vsCurrency=usd                                         -> null  (native not mapped)
```

CoinGecko also already indexes IoTeX as an asset platform (`{ id: "iotex", chain_identifier: 4689, native_coin_id: "iotex" }`).

The `it.each(SUPPORTED_CHAIN_IDS)` parameterized test in `codefi-v2.test.ts` automatically covers the new entry.

### Companion backend request (required for prices to surface)

Since #7716, the supported-chain filter uses the live `/v2/supportedNetworks` list, not the hardcoded `SPOT_PRICES_SUPPORT_INFO`. For native IOTX prices to actually show, `eip155:4689` must be added to `supportedNetworks.partialSupport.spotPricesV2` and `spotPricesV3` in the Price API (`va-mmcx-price-api`). The evidence above shows the price path already works end-to-end via the WIOTX contract — this is a zero-risk allowlist entry, not new plumbing. Same companion-PR workflow as #8487 (Injective) and #8524 (Forma).

## References

- Pattern precedent (native priced via a contract address): #8185 (Stable → USDT0)
- Companion-PR precedents: #8487 (Injective), #8524 (Forma), #8627 (ZetaChain)
- Chain: https://chainlist.org/chain/4689
- CoinGecko coin: https://www.coingecko.com/en/coins/iotex

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive config entries in existing maps; no auth, transaction, or business-logic changes. Full pricing still gated by backend allowlist.
> 
> **Overview**
> Adds **IoTeX Mainnet** (`0x1251` / chain 4689) to the Codefi v2 token price mappings in `codefi-v2.ts` so native IOTX and IoTeX assets can be priced like other supported networks.
> 
> Native IOTX is routed through the **WIOTX** ERC-20 contract (`0xa007…9d03`) in both `SPOT_PRICES_SUPPORT_INFO` and `chainIdToNativeTokenAddress`, matching the Stable/USDT0 pattern when slip44 native pricing is unavailable. The assets-controllers changelog records the new chain support.
> 
> End-user spot prices still depend on the Price API allowing `eip155:4689` on `/v2/supportedNetworks` (companion backend change, as noted in the PR).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 408fdf5641431799ccbdd273f4fbdd6ab70a28f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->