### PR TITLE
feat: add rwas support

### DIFF
--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -3118,9 +3118,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial release
-
   - As a result of converting our shared controllers repo into a monorepo ([#831](https://github.com/MetaMask/core/pull/831)), we've created this package from select parts of [`@metamask/controllers` v33.0.0](https://github.com/MetaMask/core/tree/v33.0.0), namely:
-
     - Everything in `src/assets`
     - Asset-related functions from `src/util.ts` and accompanying tests
 

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `fetchRwas` to fetch real-world asset tokens from the Token API ([#8931](https://github.com/MetaMask/core/pull/8931))
+
 ### Changed
 
 - Bump `@metamask/account-tree-controller` from `^7.4.0` to `^7.5.0` ([#8912](https://github.com/MetaMask/core/pull/8912))
@@ -3114,7 +3118,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial release
+
   - As a result of converting our shared controllers repo into a monorepo ([#831](https://github.com/MetaMask/core/pull/831)), we've created this package from select parts of [`@metamask/controllers` v33.0.0](https://github.com/MetaMask/core/tree/v33.0.0), namely:
+
     - Everything in `src/assets`
     - Asset-related functions from `src/util.ts` and accompanying tests
 

--- a/packages/assets-controllers/src/index.ts
+++ b/packages/assets-controllers/src/index.ts
@@ -178,6 +178,7 @@ export {
   SPOT_PRICES_SUPPORT_INFO,
 } from './token-prices-service';
 export {
+  fetchRwas,
   searchTokens,
   getTrendingTokens,
   fetchTokenAssets,
@@ -304,4 +305,10 @@ export type {
   TokenSecurityFees,
   TokenSecurityFinancialStats,
   TokenSecurityMetadata,
+  RwaMarket,
+  RwaTokenData,
+  RwaToken,
+  RwasResponse,
+  RwaSortBy,
+  FetchRwasParams,
 } from './token-service';

--- a/packages/assets-controllers/src/token-service.test.ts
+++ b/packages/assets-controllers/src/token-service.test.ts
@@ -1885,7 +1885,7 @@ describe('Token service', () => {
     it('passes unknown query params through to the URL', async () => {
       nock(TOKEN_END_POINT_API)
         .get(
-          '/v1/rwas?chainIds=eip155%3A1&foo=bar&enabled=true&page=2&limit=100',
+          '/v1/rwas?chainIds=eip155%3A1&limit=100&foo=bar&enabled=true&page=2',
         )
         .reply(200, sampleRwasResponse)
         .persist();

--- a/packages/assets-controllers/src/token-service.test.ts
+++ b/packages/assets-controllers/src/token-service.test.ts
@@ -5,6 +5,7 @@ import nock from 'nock';
 
 import type { SortTrendingBy } from './token-service';
 import {
+  fetchRwas,
   fetchTokenAssets,
   fetchTokenListByChainId,
   fetchTokenMetadata,
@@ -1796,6 +1797,114 @@ describe('Token service', () => {
       setupNock();
       const result = await fetchTokenAssets([oneInchAssetId]);
       expect(result).toStrictEqual([]);
+    });
+  });
+
+  describe('fetchRwas', () => {
+    const sampleRwasResponse = {
+      data: [
+        {
+          id: 'eip155:1/erc20:0x1234567890123456789012345678901234567890',
+          assetId:
+            'eip155:1/erc20:0x1234567890123456789012345678901234567890',
+          symbol: 'TSLAx',
+          decimals: 18,
+          name: 'Tesla xStock',
+          rwaData: {
+            price: '342.13',
+            priceChange: '1.23',
+            marketCap: 1090000000000,
+            aggregatedUsdVolume: 1234567,
+            active: true,
+            ticker: 'TSLA',
+            instrumentType: 'stock',
+            custodians: ['ondo'],
+            industry: ['consumer discretionary'],
+            market: {
+              nextOpen: '2026-05-29T13:30:00.000Z',
+              nextClose: '2026-05-29T20:00:00.000Z',
+            },
+          },
+        },
+      ],
+      count: 1,
+      totalCount: 1,
+      pageInfo: {
+        nextCursor: null,
+        hasNextPage: false,
+      },
+    };
+
+    it('fetches RWAs with default params', async () => {
+      nock(TOKEN_END_POINT_API)
+        .get('/v1/rwas?limit=100')
+        .reply(200, sampleRwasResponse)
+        .persist();
+
+      const result = await fetchRwas();
+
+      expect(result).toStrictEqual(sampleRwasResponse);
+    });
+
+    it('includes supported query params and trims the search query', async () => {
+      nock(TOKEN_END_POINT_API)
+        .get(
+          '/v1/rwas?chainIds=eip155%3A1%2Ceip155%3A137&query=Tesla&active=true&custodian=ondo&type=stock&industry=consumer+discretionary&sortBy=market_cap_desc&limit=25&after=cursor-1',
+        )
+        .reply(200, sampleRwasResponse)
+        .persist();
+
+      const result = await fetchRwas({
+        chainIds: ['eip155:1', 'eip155:137'],
+        query: '  Tesla  ',
+        sortBy: 'market_cap_desc',
+        limit: 25,
+        after: 'cursor-1',
+        active: true,
+        custodian: 'ondo',
+        type: 'stock',
+        industry: 'consumer discretionary',
+      });
+
+      expect(result).toStrictEqual(sampleRwasResponse);
+    });
+
+    it('omits blank and undefined query params', async () => {
+      nock(TOKEN_END_POINT_API)
+        .get('/v1/rwas?active=false&limit=100')
+        .reply(200, sampleRwasResponse)
+        .persist();
+
+      const result = await fetchRwas({
+        query: '   ',
+        active: false,
+      });
+
+      expect(result).toStrictEqual(sampleRwasResponse);
+    });
+
+    it('passes unknown query params through to the URL', async () => {
+      nock(TOKEN_END_POINT_API)
+        .get('/v1/rwas?chainIds=eip155%3A1&foo=bar&enabled=true&page=2&limit=100')
+        .reply(200, sampleRwasResponse)
+        .persist();
+
+      const result = await fetchRwas({
+        chainIds: ['eip155:1'],
+        foo: 'bar',
+        enabled: true,
+        page: 2,
+      });
+
+      expect(result).toStrictEqual(sampleRwasResponse);
+    });
+
+    it('throws if the fetch fails', async () => {
+      nock(TOKEN_END_POINT_API).get('/v1/rwas?limit=100').reply(500);
+
+      await expect(fetchRwas()).rejects.toThrow(
+        "Fetch failed with status '500'",
+      );
     });
   });
 });

--- a/packages/assets-controllers/src/token-service.test.ts
+++ b/packages/assets-controllers/src/token-service.test.ts
@@ -1805,8 +1805,7 @@ describe('Token service', () => {
       data: [
         {
           id: 'eip155:1/erc20:0x1234567890123456789012345678901234567890',
-          assetId:
-            'eip155:1/erc20:0x1234567890123456789012345678901234567890',
+          assetId: 'eip155:1/erc20:0x1234567890123456789012345678901234567890',
           symbol: 'TSLAx',
           decimals: 18,
           name: 'Tesla xStock',
@@ -1885,7 +1884,9 @@ describe('Token service', () => {
 
     it('passes unknown query params through to the URL', async () => {
       nock(TOKEN_END_POINT_API)
-        .get('/v1/rwas?chainIds=eip155%3A1&foo=bar&enabled=true&page=2&limit=100')
+        .get(
+          '/v1/rwas?chainIds=eip155%3A1&foo=bar&enabled=true&page=2&limit=100',
+        )
         .reply(200, sampleRwasResponse)
         .persist();
 

--- a/packages/assets-controllers/src/token-service.ts
+++ b/packages/assets-controllers/src/token-service.ts
@@ -140,6 +140,57 @@ function getTokenAssetsURL(options: {
 }
 
 /**
+ * Get the RWAs URL for the given query params.
+ *
+ * @param options - Options for getting RWAs.
+ * @returns The RWAs URL.
+ */
+function getRwasURL(options: FetchRwasParams): string {
+  const {
+    chainIds,
+    query: searchQuery,
+    active,
+    custodian,
+    type,
+    industry,
+    sortBy,
+    limit = 100,
+    after,
+    ...additionalParams
+  } = options;
+  const trimmedSearchQuery = searchQuery?.trim();
+  const queryParams = new URLSearchParams();
+
+  Object.entries({
+    ...(chainIds?.length ? { chainIds } : {}),
+    ...(trimmedSearchQuery && { query: trimmedSearchQuery }),
+    ...(active === undefined ? {} : { active }),
+    ...(custodian && { custodian }),
+    ...(type && { type }),
+    ...(industry && { industry }),
+    ...(sortBy && { sortBy }),
+    limit,
+    ...(after && { after }),
+    ...additionalParams,
+  }).forEach(([key, value]) => {
+    if (value === undefined || value === '') {
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      if (value.length > 0) {
+        queryParams.append(key, value.join(','));
+      }
+      return;
+    }
+
+    queryParams.append(key, String(value));
+  });
+
+  return `${TOKEN_END_POINT_API}/v1/rwas?${queryParams.toString()}`;
+}
+
+/**
  * Shared query-parameter type for the v3 trending tokens endpoint.
  *
  * Known parameters are explicitly typed for autocomplete and documentation.
@@ -239,6 +290,78 @@ export type TokenRwaData = {
   };
   ticker?: string;
   instrumentType?: string;
+};
+
+export type RwaMarket = {
+  nextOpen?: string;
+  nextClose?: string;
+};
+
+export type RwaTokenData = {
+  price: string;
+  priceChange: string;
+  marketCap: number;
+  aggregatedUsdVolume: number;
+  active: boolean;
+  ticker: string;
+  instrumentType: string;
+  custodians: string[];
+  industry: string[];
+  market?: RwaMarket;
+  nextPause?: Record<string, unknown>;
+  sharesOutstanding?: number;
+  restrictedCountries?: string[];
+  updatedAt?: string;
+  addressType?: string;
+};
+
+export type RwaToken = {
+  id: string;
+  assetId: CaipAssetType;
+  symbol: string;
+  decimals: number;
+  name: string;
+  rwaData: RwaTokenData;
+};
+
+export type RwasResponse = {
+  data: RwaToken[];
+  count: number;
+  totalCount: number;
+  pageInfo: {
+    nextCursor: string | null;
+    hasNextPage: boolean;
+  };
+};
+
+export type RwaSortBy =
+  | 'price_change_asc'
+  | 'price_change_desc'
+  | 'volume_asc'
+  | 'volume_desc'
+  | 'market_cap_asc'
+  | 'market_cap_desc';
+
+export type FetchRwasParams = {
+  chainIds?: CaipChainId[];
+  query?: string;
+  sortBy?: RwaSortBy;
+  limit?: number;
+  after?: string;
+  active?: boolean;
+  custodian?: 'ondo';
+  type?: 'stock' | 'etf';
+  industry?:
+    | 'industrials'
+    | 'technology'
+    | 'healthcare'
+    | 'consumer discretionary'
+    | 'financials'
+    | 'materials'
+    | 'utilities'
+    | 'energy'
+    | 'real estate';
+  [key: string]: string | number | boolean | string[] | undefined;
 };
 
 export type TokenSecurityFeature = {
@@ -543,6 +666,18 @@ export async function fetchTokenAssets(
   } catch {
     return [];
   }
+}
+
+/**
+ * Fetch real-world asset tokens.
+ *
+ * @param params - Query params used to filter, sort, and paginate RWAs.
+ * @returns The paginated RWA response.
+ */
+export async function fetchRwas(
+  params: FetchRwasParams = {},
+): Promise<RwasResponse> {
+  return handleFetch(getRwasURL(params), { headers: { accept: '*/*' } });
 }
 
 /**


### PR DESCRIPTION
## Explanation
Add RWAs endpoint support
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References
https://consensyssoftware.atlassian.net/browse/ASSETS-2957
<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive read-only HTTP client and types with unit tests; no changes to auth, persistence, or existing token fetch behavior.
> 
> **Overview**
> Adds a **Token API** client in `assets-controllers` for listing **real-world asset (RWA)** tokens via `fetchRwas`, calling `GET /v1/rwas` on the existing token service host.
> 
> Callers can filter and paginate with typed options (chains, search text, `active`, custodian, instrument type, industry, `sortBy`, `limit`, `after`), with **trimmed** search queries and **omission** of blank/undefined params; extra keys are still forwarded for forward-compatible API params. New **`RwaToken`**, **`RwasResponse`**, and related types describe paginated results and `rwaData` (price, market cap, custodians, market hours, etc.). The helper is **re-exported** from the package entrypoint, documented in the changelog, and covered by **nock** tests for default params, full query strings, param omission, passthrough params, and HTTP errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd7ecc357eca416f3bd4a8045ed4cc954fd82595. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->