### PR TITLE
fix: clear analytics queue on callback errors

### DIFF
--- a/packages/analytics-controller/CHANGELOG.md
+++ b/packages/analytics-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Clear persisted analytics event queue entries after the delivery callback runs, including when the callback reports an error. ([#8934](https://github.com/MetaMask/core/pull/8934))
+
 ## [1.1.0]
 
 ### Added

--- a/packages/analytics-controller/src/AnalyticsController.test.ts
+++ b/packages/analytics-controller/src/AnalyticsController.test.ts
@@ -1301,7 +1301,7 @@ describe('AnalyticsController', () => {
       expect(controller.state.eventQueue).toStrictEqual({});
     });
 
-    it('keeps queued payloads when the adapter callback receives an error', async () => {
+    it('clears queued payloads when the adapter callback receives an error', async () => {
       const mockAdapter = createMockAdapter();
       const { controller } = await setupController({
         state: {
@@ -1317,14 +1317,7 @@ describe('AnalyticsController', () => {
       const deliveryOptions = getDeliveryOptions(mockAdapter.track);
       deliveryOptions.callback?.(new Error('Segment failed'));
 
-      const [messageId] = Object.keys(controller.state.eventQueue ?? {});
-
-      expect(controller.state.eventQueue).toHaveProperty(messageId);
-      expect(controller.state.eventQueue?.[messageId]).toMatchObject({
-        type: 'track',
-        eventName: 'test_event',
-        properties: { prop: 'value' },
-      });
+      expect(controller.state.eventQueue).toStrictEqual({});
     });
 
     it('keeps queued payloads when the platform adapter throws', async () => {
@@ -1360,7 +1353,7 @@ describe('AnalyticsController', () => {
       let adapterMutationCompleted = false;
       jest
         .spyOn(mockAdapter, 'track')
-        .mockImplementation((_eventName, properties, context, options) => {
+        .mockImplementation((_eventName, properties, context) => {
           (
             properties as { nested: { adapterNormalized?: boolean } }
           ).nested.adapterNormalized = true;
@@ -1368,9 +1361,6 @@ describe('AnalyticsController', () => {
             context as { page: { adapterNormalized?: boolean } }
           ).page.adapterNormalized = true;
           adapterMutationCompleted = true;
-          (options as AnalyticsDeliveryOptions).callback?.(
-            new Error('Segment failed'),
-          );
         });
       const { controller } = await setupController({
         state: {

--- a/packages/analytics-controller/src/AnalyticsController.ts
+++ b/packages/analytics-controller/src/AnalyticsController.ts
@@ -555,7 +555,6 @@ export class AnalyticsController extends BaseController<
             messageId: queuedEvent.messageId,
             error,
           });
-          return;
         }
 
         this.#removeQueuedEvent(queuedEvent.messageId);


### PR DESCRIPTION
## Explanation

Clear persisted analytics queue entries once the platform adapter delivery callback fires, even when the callback receives an error. This aligns queue cleanup behavior with the previous Segment-backed MetaMetrics flow and avoids repeatedly replaying malformed or permanently failing events on restart.

## References

NA

For example:

* Needed for https://github.com/MetaMask/MetaMask-planning/issues/7193

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when persisted analytics events are dropped versus retried; events reported as failed by the adapter will not be re-sent after restart, which is intentional but affects delivery reliability semantics.
> 
> **Overview**
> When persisted event-queue delivery runs, **`AnalyticsController` now removes queued entries as soon as the platform adapter’s delivery callback fires**, including when the callback passes an error. Failed deliveries are still logged; the queue is no longer left intact for those cases.
> 
> That matches prior Segment-backed MetaMetrics behavior and stops **replaying events that already failed delivery** (for example malformed or permanently rejected payloads) on the next startup. **Queued items are still retained if the adapter throws synchronously** before the callback runs.
> 
> Tests and the package changelog were updated for the new cleanup behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18ab987f59336848c2dc1d45b7cd5059ba103b48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->