### PR TITLE
Clean up resolveIndexedAccessMethod

### DIFF
--- a/packages/platform-api-docs/src/extraction.test.ts
+++ b/packages/platform-api-docs/src/extraction.test.ts
@@ -2160,4 +2160,172 @@ export type FooEvent = {
       expect(items).toStrictEqual([]);
     });
   });
+
+  it('falls back to the raw handler text when the handler object type is not a simple type reference', async () => {
+    expect.assertions(2);
+
+    await withinSandbox(async ({ directoryPath }) => {
+      const filePath = path.join(directoryPath, 'types.ts');
+      // When the object side of an indexed-access handler type is not a plain
+      // type reference (e.g. it is an object-literal type or a built-in keyword
+      // type), `resolveIndexedAccessMethod` cannot walk to a class declaration
+      // and must return null. The extractor should fall back to rendering the
+      // raw syntax instead.
+      await fs.promises.writeFile(
+        filePath,
+        withMessenger(
+          `
+export type FooAction = {
+  type: 'Foo:do';
+  handler: { doStuff(): void }['doStuff'];
+};
+`,
+          { actions: ['FooAction'] },
+        ),
+      );
+
+      const items = await extractFromFile(filePath, directoryPath);
+
+      expect(items).toHaveLength(1);
+      expect(items[0].handlerOrPayload).toContain("{ doStuff(): void }['doStuff']");
+    });
+  });
+
+  it('falls back to the raw handler text when the handler index is not a literal type node', async () => {
+    expect.assertions(2);
+
+    await withinSandbox(async ({ directoryPath }) => {
+      const filePath = path.join(directoryPath, 'types.ts');
+      // When the index side of an indexed-access handler type is not a literal
+      // (e.g. it is `keyof T`), `resolveIndexedAccessMethod` cannot determine
+      // the method name and must return null. The extractor should fall back to
+      // rendering the raw syntax instead.
+      await fs.promises.writeFile(
+        filePath,
+        withMessenger(
+          `
+class FooController {
+  doStuff(): void {}
+}
+
+export type FooAction = {
+  type: 'Foo:do';
+  handler: FooController[keyof FooController];
+};
+`,
+          { actions: ['FooAction'] },
+        ),
+      );
+
+      const items = await extractFromFile(filePath, directoryPath);
+
+      expect(items).toHaveLength(1);
+      expect(items[0].handlerOrPayload).toContain('FooController[keyof FooController]');
+    });
+  });
+
+  it('falls back to the raw handler text when the handler index is a numeric literal', async () => {
+    expect.assertions(2);
+
+    await withinSandbox(async ({ directoryPath }) => {
+      const filePath = path.join(directoryPath, 'types.ts');
+      // When the index of an indexed-access handler type is a numeric literal
+      // (e.g. `Class[0]`), the method name cannot be a valid identifier, so
+      // `resolveIndexedAccessMethod` returns null and the extractor falls back
+      // to the raw type text.
+      await fs.promises.writeFile(
+        filePath,
+        withMessenger(
+          `
+type Tuple = [() => void];
+
+export type FooAction = {
+  type: 'Foo:do';
+  handler: Tuple[0];
+};
+`,
+          { actions: ['FooAction'] },
+        ),
+      );
+
+      const items = await extractFromFile(filePath, directoryPath);
+
+      expect(items).toHaveLength(1);
+      expect(items[0].handlerOrPayload).toContain('Tuple[0]');
+    });
+  });
+
+  it('falls back to the raw handler text when the handler class reference is a qualified name', async () => {
+    expect.assertions(2);
+
+    await withinSandbox(async ({ directoryPath }) => {
+      await fs.promises.writeFile(
+        path.join(directoryPath, 'controller.ts'),
+        `
+export class FooController {
+  doStuff(): void {}
+}
+`,
+      );
+
+      const filePath = path.join(directoryPath, 'types.ts');
+      // When the class side of a handler indexed-access type is accessed via a
+      // namespace import (e.g. `NS.FooController['doStuff']`), the type name is
+      // a qualified name rather than a plain identifier.
+      // `resolveIndexedAccessMethod` cannot follow qualified names and returns
+      // null, so the extractor falls back to the raw syntax.
+      await fs.promises.writeFile(
+        filePath,
+        withMessenger(
+          `
+import * as NS from './controller';
+
+export type FooAction = {
+  type: 'Foo:do';
+  handler: NS.FooController['doStuff'];
+};
+`,
+          { actions: ['FooAction'] },
+        ),
+      );
+
+      const items = await extractFromFile(filePath, directoryPath);
+
+      expect(items).toHaveLength(1);
+      expect(items[0].handlerOrPayload).toContain("NS.FooController['doStuff']");
+    });
+  });
+
+  it('falls back to the raw handler text when the indexed method does not exist on the class', async () => {
+    expect.assertions(2);
+
+    await withinSandbox(async ({ directoryPath }) => {
+      const filePath = path.join(directoryPath, 'types.ts');
+      // When the method name in an indexed-access handler type does not match
+      // any method declared on the class, `resolveIndexedAccessMethod` exhausts
+      // all class declarations and returns null. The extractor falls back to
+      // the raw type text instead of crashing.
+      await fs.promises.writeFile(
+        filePath,
+        withMessenger(
+          `
+class FooController {
+  doStuff(): void {}
+}
+
+export type FooAction = {
+  type: 'Foo:do';
+  handler: FooController['nonExistentMethod'];
+};
+`,
+          { actions: ['FooAction'] },
+        ),
+      );
+
+      const items = await extractFromFile(filePath, directoryPath);
+
+      expect(items).toHaveLength(1);
+      expect(items[0].handlerOrPayload).toContain("FooController['nonExistentMethod']");
+    });
+  });
 });

--- a/packages/platform-api-docs/src/extraction.test.ts
+++ b/packages/platform-api-docs/src/extraction.test.ts
@@ -2187,7 +2187,9 @@ export type FooAction = {
       const items = await extractFromFile(filePath, directoryPath);
 
       expect(items).toHaveLength(1);
-      expect(items[0].handlerOrPayload).toContain("{ doStuff(): void }['doStuff']");
+      expect(items[0].handlerOrPayload).toContain(
+        "{ doStuff(): void }['doStuff']",
+      );
     });
   });
 
@@ -2220,7 +2222,9 @@ export type FooAction = {
       const items = await extractFromFile(filePath, directoryPath);
 
       expect(items).toHaveLength(1);
-      expect(items[0].handlerOrPayload).toContain('FooController[keyof FooController]');
+      expect(items[0].handlerOrPayload).toContain(
+        'FooController[keyof FooController]',
+      );
     });
   });
 
@@ -2292,7 +2296,9 @@ export type FooAction = {
       const items = await extractFromFile(filePath, directoryPath);
 
       expect(items).toHaveLength(1);
-      expect(items[0].handlerOrPayload).toContain("NS.FooController['doStuff']");
+      expect(items[0].handlerOrPayload).toContain(
+        "NS.FooController['doStuff']",
+      );
     });
   });
 
@@ -2325,7 +2331,9 @@ export type FooAction = {
       const items = await extractFromFile(filePath, directoryPath);
 
       expect(items).toHaveLength(1);
-      expect(items[0].handlerOrPayload).toContain("FooController['nonExistentMethod']");
+      expect(items[0].handlerOrPayload).toContain(
+        "FooController['nonExistentMethod']",
+      );
     });
   });
 });

--- a/packages/platform-api-docs/src/extraction.ts
+++ b/packages/platform-api-docs/src/extraction.ts
@@ -158,37 +158,40 @@ function hasDeprecatedJsDocTag(node: JSDocableNode): boolean {
 // ---------------------------------------------------------------------------
 
 /**
- * If `typeNode` is `Class['method']`, resolve `Class` to its declaration
- * (across files if needed via the type checker) and look up the method by
- * name. Returns the method declaration when found.
+ * Locates the type that represents a method on a class (e.g.
+ * `Class['method']`), which itself comes from a messenger action handler.
  *
- * @param typeNode - The handler's type node.
- * @returns The method declaration, or null.
+ * @param typeNode - The node that represents the indexed access.
+ * @returns The found method declaration, or null.
  */
-function resolveIndexedAccessMethod(
+function findClassMethodDeclaration(
   typeNode: TypeNode | undefined,
 ): MethodDeclaration | null {
-  if (!typeNode || !NodeGuards.isIndexedAccessTypeNode(typeNode)) {
+  // Fundamental check: if we don't have `Class['method']`, we can't do anything.
+  if (!NodeGuards.isIndexedAccessTypeNode(typeNode)) {
     return null;
   }
+
+  // The type that represents the class being accessed.
+  // EXAMPLE:
+  //   FooController['someMethod']
+  //   ^^^^^^^^^^^^^
   const objectType = typeNode.getObjectTypeNode();
+  // The type that represents the property being accessed.
+  // EXAMPLE:
+  //   FooController['someMethod']
+  //                 ^^^^^^^^^^^^
   const indexType = typeNode.getIndexTypeNode();
 
-  // istanbul ignore next: handler indexed-access types in messenger fixtures
-  // always reference a class via TypeReference.
-  if (!NodeGuards.isTypeReference(objectType)) {
-    return null;
-  }
-  // istanbul ignore next: the index in `Class['method']` is always a literal
-  // type node in valid handler syntax.
-  if (!NodeGuards.isLiteralTypeNode(indexType)) {
+  // To access a property on a type, it must be a type we can access properties of.
+  if (
+    !NodeGuards.isTypeReference(objectType) ||
+    !NodeGuards.isLiteralTypeNode(indexType)
+  ) {
     return null;
   }
   const indexLiteral = indexType.getLiteral();
-  // The index can be written as `'method'`, `"method"`, or `` `method` ``.
-  // The first two land as `StringLiteral`; the bare template literal is a
-  // `NoSubstitutionTemplateLiteral`.
-  // istanbul ignore next: numeric/boolean indices aren't valid method names.
+  // Names of methods must be static strings; they cannot be template strings.
   if (
     !NodeGuards.isStringLiteral(indexLiteral) &&
     !NodeGuards.isNoSubstitutionTemplateLiteral(indexLiteral)
@@ -197,25 +200,31 @@ function resolveIndexedAccessMethod(
   }
   const methodName = indexLiteral.getLiteralValue();
 
+  // Reject qualified-name type references, as we can't follow those.
+  // EXAMPLE:
+  //   import * as somePackage from '...';
+  //   somePackage.FooController['someMethod']
+  //   ^^^^^^^^^^^^^^^^^^^^^^^^^
   const classNameNode = objectType.getTypeName();
-  // istanbul ignore next: qualified-name class references aren't used in
-  // messenger handler types.
   if (!NodeGuards.isIdentifier(classNameNode)) {
     return null;
   }
-  const localSymbol = classNameNode.getSymbol();
-  // istanbul ignore next: a referenced class name always resolves to a symbol
-  // in a typechecked project.
-  if (!localSymbol) {
-    return null;
-  }
-  // Follow the import alias (if any) so we can find the class declaration in
-  // its home file.
+
+  // Since we know we have a type reference, we can assume that we have a symbol.
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const localSymbol = classNameNode.getSymbol()!;
+  // If we have a type imported from another file, ensure that when we access
+  // the declaration, it's the type declaration in the other file, not the
+  // import declaration in this file.
+  // EXAMPLE:
+  //   import { FooController } from '@metamask/foo-controller';
+  //   FooController['someMethod']
+  //   ^^^^^^^^^^^^^
   const symbol = localSymbol.getAliasedSymbol() ?? localSymbol;
 
-  // istanbul ignore next: a resolved symbol always exposes its declarations
-  // array in a typechecked project.
-  for (const declaration of symbol.getDeclarations() ?? []) {
+  for (const declaration of symbol.getDeclarations()) {
+    // We must have a class to treat the property on the object type as a
+    // method.
     if (NodeGuards.isClassDeclaration(declaration)) {
       const method = declaration.getMethod(methodName);
       if (method) {
@@ -223,9 +232,7 @@ function resolveIndexedAccessMethod(
       }
     }
   }
-  // istanbul ignore next: only reached if the indexed method isn't declared
-  // on any of the resolved class declarations, which doesn't happen in valid
-  // handler types.
+
   return null;
 }
 
@@ -468,8 +475,8 @@ function recursivelyFindMessengerCapabilityTypeDeclarations(
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const localSymbol = nameNode.getSymbol()!;
   // If we have a type imported from another file, ensure that when we access
-  // the declaration, it's the *type* declaration in the other file, not the
-  // *import* declaration in this file.
+  // the declaration, it's the type declaration in the other file, not the
+  // import declaration in this file.
   // EXAMPLE:
   //   import { FooControllerSomeAction } from '@metamask/foo-controller';
   //   type Actions = FooControllerSomeAction;
@@ -641,7 +648,7 @@ function tryToExtractFromMessengerCapabilityTypeLiteral(
 ): MessengerCapabilityPacket | null {
   const { declaration, kind } = capabilityTypeDeclaration;
 
-  // Reject empty type aliases or interfaces.
+  // We must have a object type alias or an interface, and the body must not be empty.
   // EXAMPLES:
   //   // Good
   //   type FooControllerSomeAction = {
@@ -699,16 +706,15 @@ function tryToExtractFromMessengerCapabilityTypeLiteral(
 
   const { description: jsDoc, params, returns } = extractJsDoc(declaration);
 
-  // For actions, render `Class['method']` handlers as the method's actual
-  // signature (e.g. `(id: number) => Promise<string>`) instead of leaving the
-  // raw indexed-access syntax in the docs. JSDoc lives on the type alias
-  // itself, so we don't pull anything else from the class method.
+  // For actions that represent methods (e.g. `Class['method']`), walk the
+  // handler type to find the underlying handler signature
+  // (e.g. `(id: number) => Promise<string>`).
   if (kind === 'action') {
-    const resolvedMethod = resolveIndexedAccessMethod(
+    const methodDeclaration = findClassMethodDeclaration(
       handlerOrPayloadPropertyTypeNode,
     );
-    if (resolvedMethod) {
-      handlerOrPayloadSignature = buildMethodSignature(resolvedMethod);
+    if (methodDeclaration) {
+      handlerOrPayloadSignature = buildMethodSignature(methodDeclaration);
     }
   }
 


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

`resolveIndexedAccessMethod` still contains `istanbul ignore` comments. Most of these are unnecessary, and the logic actually ought to be tested.

This commit cleans up these `istanbul ignore` comments, and also adds new ones to clarify the existing logic. It also renames `resolveIndexedAccessMethod` to `findClassMethodDeclaration` so that it's easier to understand the purpose of this function at a glance.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation extraction only; behavior is clarified and covered by new tests, with no runtime product surface change.
> 
> **Overview**
> Refactors messenger **action handler** resolution in `platform-api-docs` extraction: **`resolveIndexedAccessMethod`** is renamed to **`findClassMethodDeclaration`**, with clearer guards, inline examples, and removal of **`istanbul ignore`** coverage skips on paths that are now meant to run in production.
> 
> Adds **five tests** that assert when `Class['method']` cannot be resolved (object-literal type, `keyof`, numeric index, namespace-qualified class, missing method), docs still show the **raw handler type text** instead of failing or inventing a signature. Successful resolution behavior is unchanged; only naming, comments, and test coverage for fallbacks differ.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 561b1c63983e7a558f9a42ebed9697966c26bf59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->