### PR TITLE
Remove unnecessary istanbul-ignore in tryToExtractFromCapabilityTypeConstructor

### DIFF
--- a/packages/platform-api-docs/src/extraction.test.ts
+++ b/packages/platform-api-docs/src/extraction.test.ts
@@ -1535,6 +1535,47 @@ export interface FooAction {
     });
   });
 
+  it('skips a capability-type-constructor alias whose body is a qualified-name constructor reference', async () => {
+    expect.assertions(1);
+
+    await withinSandbox(async ({ directoryPath }) => {
+      await fs.promises.writeFile(
+        path.join(directoryPath, 'helpers.ts'),
+        `
+export type ControllerGetStateAction<T, S> = {
+  type: \`\${T & string}:getState\`;
+  handler: () => S;
+};
+`,
+      );
+
+      const filePath = path.join(directoryPath, 'types.ts');
+      // A namespace import produces a qualified-name reference on the right-
+      // hand side of the alias body (`Helpers.ControllerGetStateAction<...>`).
+      // The walker cannot resolve qualified-name constructor references and
+      // should skip the slot without crashing, leaving no items.
+
+      const items = await extractFromWrittenFile(
+        filePath,
+        `
+import * as Helpers from './helpers';
+
+export type LocalAction = {
+  type: 'Local:do';
+  handler: () => void;
+};
+
+export type QualifiedAction = Helpers.ControllerGetStateAction<'Foo', object>;
+
+export type LocalMessenger = Messenger<'Local', LocalAction | QualifiedAction, never>;
+`,
+        directoryPath,
+      );
+
+      expect(items).toHaveLength(1);
+    });
+  });
+
   it('ignores capability-type-constructor aliases whose name does not match', async () => {
     expect.assertions(1);
 

--- a/packages/platform-api-docs/src/extraction.ts
+++ b/packages/platform-api-docs/src/extraction.ts
@@ -1,5 +1,6 @@
 import * as path from 'node:path';
 import type {
+  Identifier,
   InterfaceDeclaration,
   JSDocableNode,
   JSDocTag,
@@ -200,7 +201,8 @@ function findClassMethodDeclaration(
   }
   const methodName = indexLiteral.getLiteralValue();
 
-  // Reject qualified-name type references, as we can't follow those.
+  // Reject qualified-name type names, as we need a plain identifier to
+  // resolve the symbol.
   // EXAMPLE:
   //   import * as somePackage from '...';
   //   somePackage.FooController['someMethod']
@@ -285,6 +287,7 @@ type ConstructorMessengerCapabilityTypeDeclaration = {
   kind: 'action' | 'event';
   declaration: TypeAliasDeclaration;
   body: TypeReferenceNode;
+  typeName: Identifier;
 };
 
 /**
@@ -462,7 +465,8 @@ function recursivelyFindMessengerCapabilityTypeDeclarations(
 
   const nameNode = node.getTypeName();
 
-  // Reject qualified-name type references, as we can't follow those.
+  // Reject qualified-name type names, as we need a plain identifier to
+  // resolve the symbol.
   // EXAMPLE:
   //   import * as somePackage from '...';
   //   type Actions = somePackage.FooControllerSomeAction;
@@ -556,12 +560,23 @@ function recursivelyFindMessengerCapabilityTypeDeclarations(
       //   type FooControllerSomeAction = ControllerGetStateAction<...>
       //                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       if (body && NodeGuards.isTypeReference(body)) {
-        result.capabilityTypeDeclarations.push({
-          bodyShape: 'constructor',
-          kind,
-          declaration,
-          body,
-        });
+        // Reject qualified-name constructor type names, as we need a plain
+        // identifier to match the constructor by name.
+        // EXAMPLE:
+        //   // Bad
+        //   import * as somePackage from '...';
+        //   type FooControllerSomeAction = somePackage.ControllerGetStateAction<...>
+        //                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        const constructorTypeName = body.getTypeName();
+        if (NodeGuards.isIdentifier(constructorTypeName)) {
+          result.capabilityTypeDeclarations.push({
+            bodyShape: 'constructor',
+            kind,
+            declaration,
+            body,
+            typeName: constructorTypeName,
+          });
+        }
         continue;
       }
 
@@ -830,19 +845,7 @@ function tryToExtractFromCapabilityTypeConstructor(
   capabilityTypeDeclaration: ConstructorMessengerCapabilityTypeDeclaration,
   projectPath: string,
 ): MessengerCapabilityPacket | null {
-  const { declaration, kind, body } = capabilityTypeDeclaration;
-
-  // `body.getTypeName()` returns an `EntityName` — either an `Identifier`
-  // (the common case, e.g. `ControllerGetStateAction`) or a `QualifiedName`
-  // (a namespace-imported reference, e.g. `someNs.ControllerGetStateAction`).
-  // The latter doesn't appear in MetaMask messenger types in practice, but
-  // we can't recognize the constructor by name without an identifier.
-  const typeName = body.getTypeName();
-  // istanbul ignore next: qualified-name constructor references aren't used
-  // in messenger capability types.
-  if (!NodeGuards.isIdentifier(typeName)) {
-    return null;
-  }
+  const { declaration, kind, body, typeName } = capabilityTypeDeclaration;
 
   // The name of the utility type should be either `ControllerGetStateAction`
   // (for actions) or `ControllerStateChangeEvent` (for events).


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

In `tryToExtractFromCapabilityTypeConstructor`, we look up the name of the action/event type that is being declared, and we use a type guard to ensure that it is an `Identifier` before proceeding. But we already know that, because we determined it in `recursivelyFindMessengerCapabilityTypeDeclarations`. Currently we are using `istanbul-ignore` so we don't have to test the redundant check. But a better fix would be to modify `recursivelyFindMessengerCapabilityTypeDeclarations` so that it returns the `typeName` that it's encountered. This way we can use it directly without having to look it up, and we can remove the redundant check along with the `istanbul-ignore`.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs extraction-only refactor with added test coverage; behavior for qualified constructor aliases remains skip-without-crash.
> 
> **Overview**
> **platform-api-docs** messenger extraction now records the constructor utility name (`ControllerGetStateAction` / `ControllerStateChangeEvent`) when walking type aliases, but only when the alias body is a **plain identifier** reference—not a namespace-qualified name like `Helpers.ControllerGetStateAction<...>`.
> 
> That lets `tryToExtractFromCapabilityTypeConstructor` use the pre-validated `typeName` instead of re-reading `body.getTypeName()` and dropping an `istanbul-ignore` for unreachable qualified-name handling. Qualified constructor aliases are skipped during the walk (same behavior as before, without redundant checks).
> 
> A regression test covers a messenger union with both a local inline action and a qualified constructor alias: only the local action is documented.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd8e9d7a5c4fa5082f984dfdd30f677299ada798. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->