### PR TITLE
Simplify logic in recursivelyFindMessengerCapabilityTypeDeclarations

### DIFF
--- a/packages/platform-api-docs/src/extraction.ts
+++ b/packages/platform-api-docs/src/extraction.ts
@@ -457,8 +457,10 @@ function recursivelyFindMessengerCapabilityTypeDeclarations(
   //                  ^^^^^^^
   //   // Good
   //   type Actions = FooControllerSomeAction;
+  //                  ^^^^^^^^^^^^^^^^^^^^^^^
   //   // Good
   //   type Actions = ControllerGetStateAction<...>;
+  //                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   if (!NodeGuards.isTypeReference(node)) {
     return result;
   }
@@ -501,42 +503,24 @@ function recursivelyFindMessengerCapabilityTypeDeclarations(
     // If we have a type alias, then we have to handle a few scenarios.
     // EXAMPLES:
     //   type FooControllerMethodActions = ...
+    //   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     //   type FooControllerSomeAction = ...
+    //   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     if (NodeGuards.isTypeAliasDeclaration(declaration)) {
       const body = declaration.getTypeNode();
 
-      // If we have a union type, then walk each type in the union.
-      // EXAMPLE:
+      // If the body is a union type or a plain type reference (not a utility
+      // type), walk it.
+      // EXAMPLES:
       //   type FooControllerMethodActions = FooControllerSomeAction | FooControllerSomeOtherAction
-      //                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      if (body && NodeGuards.isUnionTypeNode(body)) {
-        const innerResult = recursivelyFindMessengerCapabilityTypeDeclarations(
-          body,
-          kind,
-          result.visitedTypeDeclarations,
-        );
-        result.capabilityTypeDeclarations.push(
-          ...innerResult.capabilityTypeDeclarations,
-        );
-        for (const typeDeclaration of innerResult.visitedTypeDeclarations) {
-          result.visitedTypeDeclarations.add(typeDeclaration);
-        }
-        continue;
-      }
-
-      // A bare TypeReference body with no type arguments is a single-member
-      // umbrella or plain re-export — walk into the referenced type so we
-      // still reach the underlying capability. This is what makes
-      // auto-generated `*MethodActions` aliases work when they only wrap a
-      // single action (e.g.
-      // `type DelegationControllerMethodActions = DelegationControllerSignDelegationAction`).
-      // TypeReferences *with* type arguments are capability-type-constructor
-      // invocations (e.g. `ControllerGetStateAction<typeof name, State>`)
-      // and are recorded directly below.
+      //   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      //   type DelegationControllerMethodActions = DelegationControllerSignDelegationAction
+      //   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       if (
         body &&
-        NodeGuards.isTypeReference(body) &&
-        body.getTypeArguments().length === 0
+        (NodeGuards.isUnionTypeNode(body) ||
+          (NodeGuards.isTypeReference(body) &&
+            body.getTypeArguments().length === 0))
       ) {
         const innerResult = recursivelyFindMessengerCapabilityTypeDeclarations(
           body,
@@ -784,7 +768,7 @@ function getMessengerCapabilityTypeString(
   //   }
   //   type FooControllerSomeAction = {
   //     type: `${typeof CONTROLLER_NAME}:someAction`;
-  //           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  //           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   //   }
   const resolvedType = typeNode.getType();
   if (resolvedType.isStringLiteral()) {


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

We're doing the same thing twice — we can collapse a conditional.

Also look through the examples and fix any accuracy issues.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only change in docs extraction AST walking; logic is consolidated, not altered, and risk is low unless tests were not run.
> 
> **Overview**
> In **`packages/platform-api-docs/src/extraction.ts`**, **`recursivelyFindMessengerCapabilityTypeDeclarations`** no longer uses two separate blocks that both recurse into a type-alias body. **Union** bodies and **plain type references** (no type arguments) are handled by one shared condition and the same recursive walk, so umbrella aliases like `*MethodActions` and multi-action unions follow one code path.
> 
> Comment-only updates clarify which `Actions` / alias shapes are valid, add examples for single-action re-exports and constructor references, and fix caret alignment in the template-literal `type` example in **`getMessengerCapabilityTypeString`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3395e5c2a2f2e582f8314b8fcd6f08c2a4312783. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->