### PR TITLE
fix(keyring-controller): auto-remove keyrings emptied during `withKeyring` callbacks

### DIFF
--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Automatically remove and destroy non-primary keyrings whose last account is removed during a `withKeyring` or `withKeyringV2` callback ([#XXX](https://github.com/MetaMask/core/pull/XXXX))
+  - Previously, draining a keyring of all its accounts via these APIs left an empty keyring entry in `state.keyrings` and persisted it in the vault.
+  - Pre-existing empty keyrings (e.g. those created intentionally via `addNewKeyring` without subsequent account creation) are still preserved, matching the behavior of `removeAccount`.
+  - The primary keyring is never auto-removed, even if drained; this preserves the existing `removeAccount` invariant against losing the primary keyring.
+
 ## [26.0.0]
 
 ### Changed

--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Automatically remove and destroy non-primary keyrings whose last account is removed during a `withKeyring` or `withKeyringV2` callback ([#XXX](https://github.com/MetaMask/core/pull/XXXX))
+- Automatically remove and destroy non-primary keyrings whose last account is removed during a `withKeyring` or `withKeyringV2` callback ([#8951](https://github.com/MetaMask/core/pull/8951))
   - Previously, draining a keyring of all its accounts via these APIs left an empty keyring entry in `state.keyrings` and persisted it in the vault.
   - Pre-existing empty keyrings (e.g. those created intentionally via `addNewKeyring` without subsequent account creation) are still preserved, matching the behavior of `removeAccount`.
   - The primary keyring is never auto-removed, even if drained; this preserves the existing `removeAccount` invariant against losing the primary keyring.

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -4895,6 +4895,61 @@ describe('KeyringController', () => {
           expect(controller.state.keyrings[0].type).toBe(KeyringTypes.hd);
         });
       });
+
+      it('destroys the drained keyring, including its V2 instance', async () => {
+        await withController(async ({ controller }) => {
+          await controller.importAccountWithStrategy(
+            AccountImportStrategy.privateKey,
+            [privateKey],
+          );
+
+          // The V2 adapter for simple keyrings has no native `destroy`, so we
+          // attach one to assert the cleanup tears down the V2 instance too.
+          const destroyV2 = jest.fn();
+          await controller.withController(async (restrictedController) => {
+            const { keyringV2 } = restrictedController.keyrings[1];
+            (keyringV2 as { destroy?: () => void }).destroy = destroyV2;
+          });
+
+          await controller.withKeyringV2(
+            { type: KeyringType.PrivateKey },
+            async ({ keyring }) => {
+              const [account] = await keyring.getAccounts();
+              await keyring.deleteAccount(account.id);
+            },
+          );
+
+          expect(controller.state.keyrings).toHaveLength(1);
+          expect(destroyV2).toHaveBeenCalled();
+        });
+      });
+
+      it('does not remove keyrings if the operation rolls back', async () => {
+        await withController(async ({ controller }) => {
+          const importedAccount = await controller.importAccountWithStrategy(
+            AccountImportStrategy.privateKey,
+            [privateKey],
+          );
+          expect(controller.state.keyrings).toHaveLength(2);
+
+          await expect(
+            controller.withKeyringV2(
+              { type: KeyringType.PrivateKey },
+              async ({ keyring }) => {
+                const [account] = await keyring.getAccounts();
+                await keyring.deleteAccount(account.id);
+                throw new Error('Oops');
+              },
+            ),
+          ).rejects.toThrow('Oops');
+
+          // Rollback restores the original keyrings (still 2).
+          expect(controller.state.keyrings).toHaveLength(2);
+          expect(controller.state.keyrings[1].accounts).toStrictEqual([
+            importedAccount,
+          ]);
+        });
+      });
     });
   });
 

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -4066,6 +4066,157 @@ describe('KeyringController', () => {
         expect(fn).not.toHaveBeenCalled();
       });
     });
+
+    describe('when the operation drains a keyring of all its accounts', () => {
+      it('removes the now-empty non-primary keyring from state', async () => {
+        await withController(async ({ controller }) => {
+          const importedAccount = await controller.importAccountWithStrategy(
+            AccountImportStrategy.privateKey,
+            [privateKey],
+          );
+          expect(controller.state.keyrings).toHaveLength(2);
+          expect(controller.state.keyrings[1].type).toBe(KeyringTypes.simple);
+
+          await controller.withKeyring(
+            { type: KeyringTypes.simple },
+            async ({ keyring }) => {
+              await keyring.removeAccount?.(importedAccount as Hex);
+            },
+          );
+
+          expect(controller.state.keyrings).toHaveLength(1);
+          expect(controller.state.keyrings[0].type).toBe(KeyringTypes.hd);
+        });
+      });
+
+      it('destroys the drained keyring', async () => {
+        const address = '0x5AC6D462f054690a373FABF8CC28e161003aEB19';
+        stubKeyringClassWithAccount(MockKeyring, address);
+
+        const destroySpy = jest.spyOn(MockKeyring.prototype, 'destroy');
+
+        await withController(
+          { keyringBuilders: [keyringBuilderFactory(MockKeyring)] },
+          async ({ controller }) => {
+            await controller.addNewKeyring(MockKeyring.type);
+            expect(controller.state.keyrings).toHaveLength(2);
+
+            // Drain the mock keyring's accounts via withKeyring.
+            await controller.withKeyring(
+              { type: MockKeyring.type },
+              async ({ keyring }) => {
+                jest
+                  .spyOn(keyring, 'getAccounts')
+                  .mockResolvedValue([] as Hex[]);
+              },
+            );
+
+            expect(controller.state.keyrings).toHaveLength(1);
+            expect(destroySpy).toHaveBeenCalled();
+          },
+        );
+      });
+
+      it('persists the cleanup so the empty keyring does not return on unlock', async () => {
+        await withController(
+          { cacheEncryptionKey: true },
+          async ({ controller }) => {
+            const importedAccount = await controller.importAccountWithStrategy(
+              AccountImportStrategy.privateKey,
+              [privateKey],
+            );
+            expect(controller.state.keyrings).toHaveLength(2);
+
+            await controller.withKeyring(
+              { type: KeyringTypes.simple },
+              async ({ keyring }) => {
+                await keyring.removeAccount?.(importedAccount as Hex);
+              },
+            );
+
+            await controller.setLocked();
+            await controller.submitPassword(password);
+
+            expect(controller.state.keyrings).toHaveLength(1);
+            expect(controller.state.keyrings[0].type).toBe(KeyringTypes.hd);
+          },
+        );
+      });
+
+      it('preserves pre-existing empty keyrings that were not drained by the operation', async () => {
+        await withController(async ({ controller }) => {
+          const importedAccount = await controller.importAccountWithStrategy(
+            AccountImportStrategy.privateKey,
+            [privateKey],
+          );
+          await controller.addNewKeyring(KeyringTypes.simple);
+
+          // HD keyring + Simple-with-account + intentionally empty Simple
+          expect(controller.state.keyrings).toHaveLength(3);
+          expect(controller.state.keyrings[2].accounts).toStrictEqual([]);
+
+          await controller.withKeyring(
+            { address: importedAccount as Hex },
+            async ({ keyring }) => {
+              await keyring.removeAccount?.(importedAccount as Hex);
+            },
+          );
+
+          // The drained keyring is removed; the intentionally empty
+          // keyring (created via addNewKeyring) is preserved.
+          expect(controller.state.keyrings).toHaveLength(2);
+          expect(controller.state.keyrings[0].type).toBe(KeyringTypes.hd);
+          expect(controller.state.keyrings[1].type).toBe(KeyringTypes.simple);
+          expect(controller.state.keyrings[1].accounts).toStrictEqual([]);
+        });
+      });
+
+      it('does not remove the primary keyring even if its last account is removed', async () => {
+        await withController(async ({ controller }) => {
+          const [primaryKeyring] = controller.getKeyringsByType(
+            KeyringTypes.hd,
+          ) as EthKeyring[];
+          const [primaryAccount] = await primaryKeyring.getAccounts();
+
+          await controller.withKeyring(
+            { type: KeyringTypes.hd },
+            async ({ keyring }) => {
+              await keyring.removeAccount?.(primaryAccount as Hex);
+            },
+          );
+
+          expect(controller.state.keyrings).toHaveLength(1);
+          expect(controller.state.keyrings[0].type).toBe(KeyringTypes.hd);
+          expect(controller.state.keyrings[0].accounts).toStrictEqual([]);
+        });
+      });
+
+      it('does not remove keyrings if the operation rolls back', async () => {
+        await withController(async ({ controller }) => {
+          const importedAccount = await controller.importAccountWithStrategy(
+            AccountImportStrategy.privateKey,
+            [privateKey],
+          );
+          expect(controller.state.keyrings).toHaveLength(2);
+
+          await expect(
+            controller.withKeyring(
+              { type: KeyringTypes.simple },
+              async ({ keyring }) => {
+                await keyring.removeAccount?.(importedAccount as Hex);
+                throw new Error('Oops');
+              },
+            ),
+          ).rejects.toThrow('Oops');
+
+          // Rollback restores the original keyrings (still 2).
+          expect(controller.state.keyrings).toHaveLength(2);
+          expect(controller.state.keyrings[1].accounts).toStrictEqual([
+            importedAccount,
+          ]);
+        });
+      });
+    });
   });
 
   describe('withController', () => {
@@ -4722,6 +4873,29 @@ describe('KeyringController', () => {
           );
 
           expect(fn).toHaveBeenCalled();
+        });
+      });
+    });
+
+    describe('when the operation drains a keyring of all its accounts', () => {
+      it('removes the now-empty non-primary keyring from state', async () => {
+        await withController(async ({ controller }) => {
+          await controller.importAccountWithStrategy(
+            AccountImportStrategy.privateKey,
+            [privateKey],
+          );
+          expect(controller.state.keyrings).toHaveLength(2);
+
+          await controller.withKeyringV2(
+            { type: KeyringType.PrivateKey },
+            async ({ keyring }) => {
+              const [account] = await keyring.getAccounts();
+              await keyring.deleteAccount(account.id);
+            },
+          );
+
+          expect(controller.state.keyrings).toHaveLength(1);
+          expect(controller.state.keyrings[0].type).toBe(KeyringTypes.hd);
         });
       });
     });

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -4080,7 +4080,7 @@ describe('KeyringController', () => {
           await controller.withKeyring(
             { type: KeyringTypes.simple },
             async ({ keyring }) => {
-              await keyring.removeAccount?.(importedAccount as Hex);
+              keyring.removeAccount?.(importedAccount as Hex);
             },
           );
 
@@ -4118,29 +4118,26 @@ describe('KeyringController', () => {
       });
 
       it('persists the cleanup so the empty keyring does not return on unlock', async () => {
-        await withController(
-          { cacheEncryptionKey: true },
-          async ({ controller }) => {
-            const importedAccount = await controller.importAccountWithStrategy(
-              AccountImportStrategy.privateKey,
-              [privateKey],
-            );
-            expect(controller.state.keyrings).toHaveLength(2);
+        await withController(async ({ controller }) => {
+          const importedAccount = await controller.importAccountWithStrategy(
+            AccountImportStrategy.privateKey,
+            [privateKey],
+          );
+          expect(controller.state.keyrings).toHaveLength(2);
 
-            await controller.withKeyring(
-              { type: KeyringTypes.simple },
-              async ({ keyring }) => {
-                await keyring.removeAccount?.(importedAccount as Hex);
-              },
-            );
+          await controller.withKeyring(
+            { type: KeyringTypes.simple },
+            async ({ keyring }) => {
+              keyring.removeAccount?.(importedAccount as Hex);
+            },
+          );
 
-            await controller.setLocked();
-            await controller.submitPassword(password);
+          await controller.setLocked();
+          await controller.submitPassword(password);
 
-            expect(controller.state.keyrings).toHaveLength(1);
-            expect(controller.state.keyrings[0].type).toBe(KeyringTypes.hd);
-          },
-        );
+          expect(controller.state.keyrings).toHaveLength(1);
+          expect(controller.state.keyrings[0].type).toBe(KeyringTypes.hd);
+        });
       });
 
       it('preserves pre-existing empty keyrings that were not drained by the operation', async () => {
@@ -4158,7 +4155,7 @@ describe('KeyringController', () => {
           await controller.withKeyring(
             { address: importedAccount as Hex },
             async ({ keyring }) => {
-              await keyring.removeAccount?.(importedAccount as Hex);
+              keyring.removeAccount?.(importedAccount as Hex);
             },
           );
 
@@ -4181,7 +4178,7 @@ describe('KeyringController', () => {
           await controller.withKeyring(
             { type: KeyringTypes.hd },
             async ({ keyring }) => {
-              await keyring.removeAccount?.(primaryAccount as Hex);
+              keyring.removeAccount?.(primaryAccount);
             },
           );
 
@@ -4203,7 +4200,7 @@ describe('KeyringController', () => {
             controller.withKeyring(
               { type: KeyringTypes.simple },
               async ({ keyring }) => {
-                await keyring.removeAccount?.(importedAccount as Hex);
+                keyring.removeAccount?.(importedAccount as Hex);
                 throw new Error('Oops');
               },
             ),

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -2967,8 +2967,8 @@ export class KeyringController<
    * {@link KeyringController.addNewKeyring} without subsequent account
    * creation) are left alone, as are keyrings created within the operation
    * itself (they are not part of the pre-operation snapshot). The primary
-   * keyring (index 0) is also preserved unconditionally to keep
-   * `removeAccount`'s primary-keyring invariant intact.
+   * keyring (see {@link KeyringController.#isPrimaryKeyring}) is also preserved
+   * unconditionally to keep `removeAccount`'s primary-keyring invariant intact.
    *
    * @param operation - The operation to execute.
    * @returns The result of the operation.
@@ -3002,7 +3002,9 @@ export class KeyringController<
 
     const emptied = this.#keyrings.filter(
       (entry, index) =>
-        index !== 0 && wasNonEmpty.has(entry.keyring) && isNowEmpty[index],
+        !this.#isPrimaryKeyring(entry, this.#keyrings) &&
+        wasNonEmpty.has(entry.keyring) &&
+        isNowEmpty[index],
     );
 
     if (emptied.length > 0) {
@@ -3218,6 +3220,25 @@ export class KeyringController<
   }
 
   /**
+   * Check whether the given keyring entry is the primary keyring.
+   *
+   * The primary keyring is the first HD keyring in the given list. Both the
+   * position (index 0) and the keyring type are checked so that the definition
+   * of "primary" lives in one place and does not rely on positional index
+   * alone, which could misidentify the primary keyring in the event of a bug.
+   *
+   * @param entry - The keyring entry to check.
+   * @param keyrings - The list of keyring entries `entry` belongs to.
+   * @returns Whether the entry is the primary keyring.
+   */
+  #isPrimaryKeyring(entry: KeyringEntry, keyrings: KeyringEntry[]): boolean {
+    return (
+      keyrings[0] === entry &&
+      entry.keyring.type === (KeyringTypes.hd as string)
+    );
+  }
+
+  /**
    * Assert that the given keyring entry is not the primary HD keyring.
    *
    * @param entry - The keyring entry to check.
@@ -3228,10 +3249,7 @@ export class KeyringController<
     entry: KeyringEntry,
     keyrings: KeyringEntry[],
   ): void {
-    if (
-      keyrings[0] === entry &&
-      entry.keyring.type === (KeyringTypes.hd as string)
-    ) {
+    if (this.#isPrimaryKeyring(entry, keyrings)) {
       throw new KeyringControllerError(
         KeyringControllerErrorMessage.CannotRemovePrimaryKeyring,
       );

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -1904,7 +1904,9 @@ export class KeyringController<
       const keyring = entry.keyring as SelectedKeyring;
 
       return this.#assertNoUnsafeDirectKeyringAccess(
-        await operation({ keyring, metadata }),
+        await this.#cleanUpEmptiedKeyringsAfter(async () =>
+          operation({ keyring, metadata }),
+        ),
         keyring,
       );
     });
@@ -2036,10 +2038,12 @@ export class KeyringController<
       const keyring = entry.keyringV2 as SelectedKeyring;
 
       return this.#assertNoUnsafeDirectKeyringAccess(
-        await operation({
-          keyring,
-          metadata,
-        }),
+        await this.#cleanUpEmptiedKeyringsAfter(async () =>
+          operation({
+            keyring,
+            metadata,
+          }),
+        ),
         keyring,
       );
     });
@@ -2946,6 +2950,76 @@ export class KeyringController<
     }
 
     return { keyring, keyringV2, metadata: keyringMetadata };
+  }
+
+  /**
+   * Run the given operation and afterwards clean up any keyring whose
+   * account list transitioned from non-empty to empty during the operation.
+   *
+   * This mirrors the cleanup behavior of {@link KeyringController.removeAccount}
+   * for code paths where the consumer mutates a keyring directly via
+   * {@link KeyringController.withKeyring} or
+   * {@link KeyringController.withKeyringV2}: if the consumer drains the last
+   * account from a keyring, the now-empty keyring is removed from
+   * {@link KeyringController.#keyrings} and destroyed before persistence runs.
+   *
+   * Pre-existing empty keyrings (e.g. those created intentionally via
+   * {@link KeyringController.addNewKeyring} without subsequent account
+   * creation) are left alone. The primary keyring (index 0) is also
+   * preserved unconditionally to keep `removeAccount`'s primary-keyring
+   * invariant intact.
+   *
+   * @param operation - The operation to execute.
+   * @returns The result of the operation.
+   * @template Result - The type of the value resolved by the operation.
+   */
+  async #cleanUpEmptiedKeyringsAfter<Result>(
+    operation: () => Promise<Result>,
+  ): Promise<Result> {
+    const wasNonEmpty = new WeakSet<EthKeyring>();
+    await Promise.all(
+      this.#keyrings.map(async ({ keyring }) => {
+        if ((await keyring.getAccounts()).length > 0) {
+          wasNonEmpty.add(keyring);
+        }
+      }),
+    );
+
+    const result = await operation();
+
+    const accountCounts = await Promise.all(
+      this.#keyrings.map(
+        async ({ keyring }) => (await keyring.getAccounts()).length,
+      ),
+    );
+
+    const emptied: KeyringEntry[] = [];
+    const remaining: KeyringEntry[] = [];
+    for (let index = 0; index < this.#keyrings.length; index++) {
+      const entry = this.#keyrings[index];
+      const isPrimary = index === 0;
+      const becameEmpty =
+        !isPrimary &&
+        wasNonEmpty.has(entry.keyring) &&
+        accountCounts[index] === 0;
+
+      if (becameEmpty) {
+        emptied.push(entry);
+      } else {
+        remaining.push(entry);
+      }
+    }
+
+    if (emptied.length > 0) {
+      this.#keyrings = remaining;
+      await Promise.all(
+        emptied.map(({ keyring, keyringV2 }) =>
+          this.#destroyKeyring(keyring, keyringV2),
+        ),
+      );
+    }
+
+    return result;
   }
 
   /**

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -2965,9 +2965,10 @@ export class KeyringController<
    *
    * Pre-existing empty keyrings (e.g. those created intentionally via
    * {@link KeyringController.addNewKeyring} without subsequent account
-   * creation) are left alone. The primary keyring (index 0) is also
-   * preserved unconditionally to keep `removeAccount`'s primary-keyring
-   * invariant intact.
+   * creation) are left alone, as are keyrings created within the operation
+   * itself (they are not part of the pre-operation snapshot). The primary
+   * keyring (index 0) is also preserved unconditionally to keep
+   * `removeAccount`'s primary-keyring invariant intact.
    *
    * @param operation - The operation to execute.
    * @returns The result of the operation.
@@ -2976,6 +2977,12 @@ export class KeyringController<
   async #cleanUpEmptiedKeyringsAfter<Result>(
     operation: () => Promise<Result>,
   ): Promise<Result> {
+    // Only the primary keyring exists, which is never auto-removed, so there
+    // is nothing to clean up regardless of what the operation does.
+    if (this.#keyrings.length <= 1) {
+      return operation();
+    }
+
     const wasNonEmpty = new WeakSet<EthKeyring>();
     await Promise.all(
       this.#keyrings.map(async ({ keyring }) => {
@@ -2987,31 +2994,20 @@ export class KeyringController<
 
     const result = await operation();
 
-    const accountCounts = await Promise.all(
+    const isNowEmpty = await Promise.all(
       this.#keyrings.map(
-        async ({ keyring }) => (await keyring.getAccounts()).length,
+        async ({ keyring }) => (await keyring.getAccounts()).length === 0,
       ),
     );
 
-    const emptied: KeyringEntry[] = [];
-    const remaining: KeyringEntry[] = [];
-    for (let index = 0; index < this.#keyrings.length; index++) {
-      const entry = this.#keyrings[index];
-      const isPrimary = index === 0;
-      const becameEmpty =
-        !isPrimary &&
-        wasNonEmpty.has(entry.keyring) &&
-        accountCounts[index] === 0;
-
-      if (becameEmpty) {
-        emptied.push(entry);
-      } else {
-        remaining.push(entry);
-      }
-    }
+    const emptied = this.#keyrings.filter(
+      (entry, index) =>
+        index !== 0 && wasNonEmpty.has(entry.keyring) && isNowEmpty[index],
+    );
 
     if (emptied.length > 0) {
-      this.#keyrings = remaining;
+      const removed = new Set(emptied);
+      this.#keyrings = this.#keyrings.filter((entry) => !removed.has(entry));
       await Promise.all(
         emptied.map(({ keyring, keyringV2 }) =>
           this.#destroyKeyring(keyring, keyringV2),


### PR DESCRIPTION
## Explanation

When a consumer drains the last account from a non-primary keyring inside a `withKeyring` or `withKeyringV2` callback, the now-empty keyring was left behind in `state.keyrings` and persisted to the vault. This diverges from `removeAccount`, which already removes and destroys a keyring once its final account is removed.

This PR adds a `#cleanUpEmptiedKeyringsAfter` helper that wraps the operation run by `withKeyring`/`withKeyringV2`. It snapshots which keyrings were non-empty before the callback and, afterwards, removes and destroys any non-primary keyring that transitioned from non-empty to empty during the callback, before persistence runs.

To match existing behavior and avoid surprises:

- **Pre-existing empty keyrings are preserved.** Keyrings that were already empty before the callback (e.g. created intentionally via `addNewKeyring` without subsequently adding accounts) are left untouched, mirroring `removeAccount`.
- **The primary keyring (index 0) is never auto-removed**, even if drained, preserving `removeAccount`'s primary-keyring invariant.


## References

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes vault/keyring lifecycle during `withKeyring` paths; behavior is scoped and well-tested but affects persisted wallet state.
> 
> **Overview**
> **`withKeyring` and `withKeyringV2` now align with `removeAccount` when a callback drains a keyring.** A new `#cleanUpEmptiedKeyringsAfter` wrapper snapshots which keyrings had accounts before the callback; after it runs, any **non-primary** keyring that went from non-empty to empty is removed from `#keyrings`, destroyed (including V2), and persisted—so empty keyrings no longer stick in `state.keyrings` or the vault.
> 
> **Intentional empty keyrings and the primary HD keyring are unchanged:** pre-existing empty keyrings (e.g. from `addNewKeyring` only) are not removed; the primary keyring is never auto-removed even if emptied. Failed callbacks still roll back, so cleanup does not run on error. Primary-keyring detection is centralized in `#isPrimaryKeyring` and reused by `#assertNotRemovingPrimaryKeyring`.
> 
> Changelog and broad tests cover persistence after lock/unlock, destroy behavior, and both v1 and v2 APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ba48ce772d6bce1cf0f8b04c6ab49269e43b9c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->