### PR TITLE
feat(wallet): export `importSecretRecoveryPhrase` from package root

### DIFF
--- a/packages/wallet/CHANGELOG.md
+++ b/packages/wallet/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Export `importSecretRecoveryPhrase` from the package root ([#8951](https://github.com/MetaMask/core/pull/8951))
+- Export `importSecretRecoveryPhrase` from the package root ([#8952](https://github.com/MetaMask/core/pull/8952))
 
 ## [1.0.1]
 

--- a/packages/wallet/CHANGELOG.md
+++ b/packages/wallet/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Export `importSecretRecoveryPhrase` from the package root ([#8951](https://github.com/MetaMask/core/pull/8951))
+
 ## [1.0.1]
 
 ### Changed

--- a/packages/wallet/src/index.ts
+++ b/packages/wallet/src/index.ts
@@ -1,4 +1,5 @@
 export { Wallet } from './Wallet';
+export { importSecretRecoveryPhrase } from './utilities';
 export type { WalletOptions } from './types';
 export type {
   DefaultActions,


### PR DESCRIPTION
## Explanation

Re-exports the existing `importSecretRecoveryPhrase` utility from `@metamask/wallet`'s `index.ts` so consumers can import it from the package root.

The function already exists in `packages/wallet/src/utilities.ts` (fully covered by tests) but was not part of the package's public surface. This unblocks `@metamask/wallet-cli`'s import of `importSecretRecoveryPhrase` independently of the in-flight controller work.

## References

- Part of the wallet-CLI-on-`main` effort (Phase 0.1: export `importSecretRecoveryPhrase` from package root).

## Changelog

### `@metamask/wallet`

### Added

- Export `importSecretRecoveryPhrase` from the package root

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for cross-repo changes as appropriate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Surface-area-only change with no logic or behavior changes to the existing utility.
> 
> **Overview**
> Exposes **`importSecretRecoveryPhrase`** on `@metamask/wallet`'s public API by re-exporting it from `packages/wallet/src/index.ts`. The helper already lived in `./utilities` and is unchanged; consumers (e.g. `@metamask/wallet-cli`) can import it from the package root instead of deep paths.
> 
> The **Unreleased** changelog entry documents the new export.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c363cccacfe8ba10f9dbcd14e01c913cace6bcf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->