### PR TITLE
ci: Add missing OIDC permissions

### DIFF
--- a/.github/workflows/create-update-issues.yml
+++ b/.github/workflows/create-update-issues.yml
@@ -10,6 +10,9 @@ jobs:
   create-update-issues:
     environment: default-branch
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout head
         uses: actions/checkout@v5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -122,6 +122,9 @@ jobs:
     needs: [is-release, publish-release]
     if: needs.is-release.outputs.IS_RELEASE == 'true'
     uses: ./.github/workflows/create-update-issues.yml
+    permissions:
+      contents: read
+      id-token: write
 
   all-jobs-complete:
     name: All jobs complete

--- a/.github/workflows/update-changelogs.yml
+++ b/.github/workflows/update-changelogs.yml
@@ -38,6 +38,8 @@ jobs:
     if: needs.is-fork.outputs.is-fork == 'false'
     runs-on: ubuntu-latest
     environment: default-branch
+    permissions:
+      id-token: write
     outputs:
       token: ${{ steps.get-token.outputs.token }}
     steps:


### PR DESCRIPTION
## Explanation

Forgot to add the `id-token: write` permission in #8932.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only permission fixes with no application or security logic changes.
> 
> **Overview**
> Adds the missing **`id-token: write`** permission so workflows using `MetaMask/github-tools/.github/actions/get-token` can obtain OIDC tokens for token exchange.
> 
> **`create-update-issues.yml`** now sets job-level `contents: read` and `id-token: write`. **`main.yml`** passes the same permissions into the reusable `create-update-issues` workflow on release. **`update-changelogs.yml`** grants `id-token: write` on the `get-token` job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b381e20f2ce1781a86af0a05c2c1999be0498ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->