### PR TITLE
ci: Get access token in each job individually in `update-changelogs` workflow

### DIFF
--- a/.github/workflows/update-changelogs.yml
+++ b/.github/workflows/update-changelogs.yml
@@ -32,29 +32,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
 
-  get-token:
-    name: Get access token
-    needs: is-fork
-    if: needs.is-fork.outputs.is-fork == 'false'
-    runs-on: ubuntu-latest
-    environment: default-branch
-    permissions:
-      id-token: write
-    outputs:
-      token: ${{ steps.get-token.outputs.token }}
-    steps:
-      - name: Get access token
-        id: get-token
-        uses: MetaMask/github-tools/.github/actions/get-token@v1
-        with:
-          token-exchange-url: ${{ vars.TOKEN_EXCHANGE_URL }}
-          permissions: |
-            contents: write
-            pull_requests: write
-
   is-release:
     name: Determine whether this PR is a release PR
-    needs: get-token
+    needs: is-fork
+    if: needs.is-fork.outputs.is-fork == 'false'
     runs-on: ubuntu-latest
     environment: default-branch
     outputs:
@@ -67,7 +48,7 @@ jobs:
       - name: Get pull request info
         id: pr-info
         env:
-          GH_TOKEN: ${{ needs.get-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
         run: |
           gh pr view "$PR_NUMBER" \
@@ -105,14 +86,22 @@ jobs:
 
   react-to-comment:
     name: React to the comment
-    needs:
-      - get-token
-      - is-release
+    needs: is-release
     if: needs.is-release.outputs.is-release == 'true' && github.event_name == 'issue_comment'
     runs-on: ubuntu-latest
     environment: default-branch
+    permissions:
+      id-token: write
     continue-on-error: true
     steps:
+      - name: Get access token
+        id: get-token
+        uses: MetaMask/github-tools/.github/actions/get-token@v1
+        with:
+          token-exchange-url: ${{ vars.TOKEN_EXCHANGE_URL }}
+          permissions: |
+            contents: write
+            pull_requests: write
       - name: Checkout repository
         uses: actions/checkout@v6
       - name: React to the comment
@@ -125,23 +114,32 @@ jobs:
             -f content='+1'
         env:
           COMMENT_ID: ${{ github.event.comment.id }}
-          GH_TOKEN: ${{ needs.get-token.outputs.token }}
+          GH_TOKEN: ${{ steps.get-token.outputs.token }}
           REPO: ${{ github.repository }}
 
   update-changelogs:
     name: Update changelogs
-    needs:
-      - get-token
-      - is-release
+    needs: is-release
     if: ${{ needs.is-release.outputs.is-release == 'true' }}
     runs-on: ubuntu-latest
     environment: default-branch
+    permissions:
+      id-token: write
     steps:
+      - name: Get access token
+        id: get-token
+        uses: MetaMask/github-tools/.github/actions/get-token@v1
+        with:
+          token-exchange-url: ${{ vars.TOKEN_EXCHANGE_URL }}
+          permissions: |
+            contents: write
+            pull_requests: write
+
       - name: Check out the base branch
         uses: actions/checkout@v6
         with:
           ref: ${{ needs.is-release.outputs.merge-base }}
-          token: ${{ needs.get-token.outputs.token }}
+          token: ${{ steps.get-token.outputs.token }}
 
       - name: Detach HEAD (to prevent accidental pushes)
         run: git checkout --detach HEAD
@@ -229,7 +227,7 @@ jobs:
           UPDATE_CHANGELOGS_OUTCOME: ${{ steps.update-changelogs.outcome }}
           PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
         with:
-          github-token: ${{ needs.get-token.outputs.token }}
+          github-token: ${{ steps.get-token.outputs.token }}
           script: |
             const {
               CHANGES_PUSHED,


### PR DESCRIPTION
## Explanation

This attempts to fix the `update-changelogs` workflow.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow wiring change; write paths still use the same get-token action and default-branch environment, with read steps on the default token.
> 
> **Overview**
> Refactors the **update-changelogs** workflow so elevated GitHub access is no longer minted once in a shared `get-token` job and passed downstream.
> 
> The **`is-release`** job now depends only on **`is-fork`**, runs when the PR is not from a fork, and uses **`GITHUB_TOKEN`** for read-only steps (`gh pr view`, checkout, merge-base, release detection). The standalone **`get-token`** job is removed.
> 
> **`react-to-comment`** and **`update-changelogs`** each declare **`id-token: write`**, call **`get-token`** in their own steps, and use that token for reactions, checkout with push rights, and PR comments—instead of **`needs.get-token.outputs.token`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28fedae1a65c0c4a02c4a76e05bf3fde49a853ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->