### PR TITLE
refactor(transaction-pay-controller): use `autoSelectProvider` and `restrictToKnownOrNativeProviders` in fiat quotes

### DIFF
--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Fiat quote flow now uses `autoSelectProvider` and `restrictToKnownOrNativeProviders` instead of manually reading the selected provider from `RampsController` state ([#8963](https://github.com/MetaMask/core/pull/8963))
+
 ## [23.0.0]
 
 ### Changed

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fiat quote flow now uses `autoSelectProvider` and `restrictToKnownOrNativeProviders` instead of manually reading the selected provider from `RampsController` state ([#8963](https://github.com/MetaMask/core/pull/8963))
+- Remove `RampsControllerGetStateAction` and `RampsControllerSetSelectedTokenAction` from `AllowedActions` as they are no longer used ([#8963](https://github.com/MetaMask/core/pull/8963))
 
 ## [23.0.0]
 

--- a/packages/transaction-pay-controller/src/strategy/fiat/fiat-quotes.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/fiat-quotes.test.ts
@@ -71,8 +71,6 @@ const FIAT_QUOTE_MOCK: RampsQuote = {
   },
 };
 
-const SELECTED_PROVIDER_ID = '/providers/transak-native-staging';
-
 const FIAT_QUOTES_RESPONSE_MOCK: RampsQuotesResponse = {
   customActions: [],
   error: [],
@@ -129,14 +127,12 @@ function getRequest({
   amountFiat = '10',
   fiatPaymentMethod = '/payments/debit-credit-card',
   rampsQuotes = FIAT_QUOTES_RESPONSE_MOCK,
-  selectedProviderId = SELECTED_PROVIDER_ID as string | null,
   tokens = [REQUIRED_TOKEN_MOCK],
   throwsOnRampsQuotes,
 }: {
   amountFiat?: string;
   fiatPaymentMethod?: string;
   rampsQuotes?: RampsQuotesResponse;
-  selectedProviderId?: string | null;
   tokens?: TransactionPayRequiredToken[];
   throwsOnRampsQuotes?: Error;
 } = {}): {
@@ -155,14 +151,6 @@ function getRequest({
               isLoading: false,
               tokens,
             },
-          },
-        };
-      }
-
-      if (action === 'RampsController:getState') {
-        return {
-          providers: {
-            selected: selectedProviderId ? { id: selectedProviderId } : null,
           },
         };
       }
@@ -252,9 +240,10 @@ describe('getFiatQuotes', () => {
       expect.objectContaining({
         amount: 20,
         assetId: FIAT_ASSET_CAIP_ID_MOCK,
+        autoSelectProvider: true,
         fiat: 'USD',
         paymentMethods: ['/payments/debit-credit-card'],
-        providers: [SELECTED_PROVIDER_ID],
+        restrictToKnownOrNativeProviders: true,
         walletAddress: WALLET_ADDRESS,
       }),
     );
@@ -496,21 +485,6 @@ describe('getFiatQuotes', () => {
     expect(result).toStrictEqual([]);
   });
 
-  it('passes undefined providers when no provider is selected', async () => {
-    const { callMock, request } = getRequest({
-      selectedProviderId: null,
-    });
-
-    await getFiatQuotes(request);
-
-    expect(callMock).toHaveBeenCalledWith(
-      'RampsController:getQuotes',
-      expect.objectContaining({
-        providers: undefined,
-      }),
-    );
-  });
-
   it('stores rampsQuote on fiat payment state via updateFiatPayment', async () => {
     const fiatPaymentState: TransactionFiatPayment = {};
     const callMock = jest.fn(
@@ -524,12 +498,6 @@ describe('getFiatQuotes', () => {
                 tokens: [REQUIRED_TOKEN_MOCK],
               },
             },
-          };
-        }
-
-        if (action === 'RampsController:getState') {
-          return {
-            providers: { selected: { id: SELECTED_PROVIDER_ID } },
           };
         }
 

--- a/packages/transaction-pay-controller/src/strategy/fiat/fiat-quotes.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/fiat-quotes.ts
@@ -166,21 +166,18 @@ async function getRampsQuote({
   messenger: PayStrategyGetQuotesRequest['messenger'];
   walletAddress: string;
 }): Promise<RampsQuote> {
-  const rampsState = messenger.call('RampsController:getState');
-  const selectedProviderId = rampsState.providers.selected?.id;
-
   const quotes = await messenger.call('RampsController:getQuotes', {
     amount: adjustedAmount,
     assetId: buildCaipAssetType(fiatAsset.chainId, fiatAsset.address),
+    autoSelectProvider: true,
     fiat: DEFAULT_FIAT_CURRENCY,
     paymentMethods: [fiatPaymentMethod],
-    providers: selectedProviderId ? [selectedProviderId] : undefined,
+    restrictToKnownOrNativeProviders: true,
     walletAddress,
   });
 
   log('Fetched ramps quotes', {
     quotesCount: quotes.success?.length ?? 0,
-    selectedProviderId,
   });
 
   const quote = quotes.success?.[0];

--- a/packages/transaction-pay-controller/src/types.ts
+++ b/packages/transaction-pay-controller/src/types.ts
@@ -36,8 +36,6 @@ import type { Quote as RampsQuote } from '@metamask/ramps-controller';
 import type {
   RampsControllerGetOrderAction,
   RampsControllerGetQuotesAction,
-  RampsControllerGetStateAction,
-  RampsControllerSetSelectedTokenAction,
 } from '@metamask/ramps-controller';
 import type { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
 import type {
@@ -82,8 +80,6 @@ export type AllowedActions =
   | NetworkControllerGetNetworkConfigurationByChainIdAction
   | RampsControllerGetOrderAction
   | RampsControllerGetQuotesAction
-  | RampsControllerGetStateAction
-  | RampsControllerSetSelectedTokenAction
   | RemoteFeatureFlagControllerGetStateAction
   | TokenBalancesControllerGetStateAction
   | TokenRatesControllerGetStateAction


### PR DESCRIPTION
## Explanation

The fiat quotes flow in `transaction-pay-controller` previously called `RampsController:getState` to read the selected provider ID, then passed it as `providers: [selectedProviderId]` to `RampsController:getQuotes`. This coupled the fiat strategy to manual provider selection state.

With the latest `RampsController.getQuotes` API (`#8949`), provider selection can be delegated to the ramps controller itself. This PR:

- Removes the `RampsController:getState` call from `getRampsQuote`.
- Replaces the `providers` parameter with `autoSelectProvider: true` and `restrictToKnownOrNativeProviders: true`, letting the ramps controller handle provider selection internally.
- Removes the now-unnecessary `selectedProviderId` from log output.
- Updates tests to match the new call signature and removes the obsolete "passes undefined providers when no provider is selected" test case.

## References

- Related to #8949

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how fiat on-ramp providers are chosen (may differ from prior manual selection) and narrows required messenger permissions for hosts that still grant the removed Ramps actions.
> 
> **Overview**
> The fiat strategy no longer reads `RampsController` state to pick a provider. **`getRampsQuote`** now calls **`RampsController:getQuotes`** with **`autoSelectProvider: true`** and **`restrictToKnownOrNativeProviders: true`** instead of passing a **`providers`** array from **`providers.selected`**.
> 
> **`AllowedActions`** drops **`RampsControllerGetStateAction`** and **`RampsControllerSetSelectedTokenAction`**, so integrators should stop granting those messenger permissions if they only existed for this flow. Tests and the changelog are updated accordingly; the obsolete “undefined providers when none selected” case is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 733496f37e83d22e88f1f9f076a37bb0bfcb433e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->