### PR TITLE
feat!: set `assets.native.coingeckoCoinId` as optional

### DIFF
--- a/packages/config-registry-controller/CHANGELOG.md
+++ b/packages/config-registry-controller/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `RegistryNetworkConfigSchema.assets.native.coingeckoCoinId` is now optional ([#0000](https://github.com/MetaMask/core/pull/0000))
+  - The controller now accepts chains with no `assets.native.coingeckoCoinId` property in their configuration.
+
 ## [0.3.2]
 
 ### Changed

--- a/packages/config-registry-controller/CHANGELOG.md
+++ b/packages/config-registry-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `RegistryNetworkConfigSchema.assets.native.coingeckoCoinId` is now optional ([#8970](https://github.com/MetaMask/core/pull/8970))
+- **BREAKING:** `RegistryNetworkConfigSchema.assets.native.coingeckoCoinId` is now optional ([#8970](https://github.com/MetaMask/core/pull/8970))
   - The controller now accepts chains with no `assets.native.coingeckoCoinId` property in their configuration.
 
 ## [0.3.2]

--- a/packages/config-registry-controller/CHANGELOG.md
+++ b/packages/config-registry-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `RegistryNetworkConfigSchema.assets.native.coingeckoCoinId` is now optional ([#0000](https://github.com/MetaMask/core/pull/0000))
+- `RegistryNetworkConfigSchema.assets.native.coingeckoCoinId` is now optional ([#8970](https://github.com/MetaMask/core/pull/8970))
   - The controller now accepts chains with no `assets.native.coingeckoCoinId` property in their configuration.
 
 ## [0.3.2]

--- a/packages/config-registry-controller/src/config-registry-api-service/types.ts
+++ b/packages/config-registry-controller/src/config-registry-api-service/types.ts
@@ -15,7 +15,7 @@ const AssetSchema = type({
   name: string(),
   symbol: string(),
   decimals: number(),
-  coingeckoCoinId: string(),
+  coingeckoCoinId: optional(string()),
 });
 
 const AssetsSchema = type({


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->
Some network configurations coming from [the registry](https://client-config.api.cx.metamask.io/v1/config/networks) don't specify any `coingeckoCoinId`. This PR sets the property as optional, so that the controller can accept it.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->
- Related to https://github.com/MetaMask/metamask-extension/pull/40343/
- Related to https://github.com/MetaMask/metamask-mobile/pull/27201

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking inferred types for consumers that assumed `coingeckoCoinId` was always defined; runtime behavior is a narrow schema relaxation for registry payloads.
> 
> **Overview**
> Makes **`assets.native.coingeckoCoinId`** optional in the config registry network schema so chains from the remote registry that omit that field still validate.
> 
> In `AssetSchema`, validation switches from a required string to `optional(string())`, and the unreleased changelog records this as a **breaking** type change for consumers that assumed the field was always present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac4f37efa597db9fe20cc27b0d60ea3c528f64c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->