### PR TITLE
chore(react-data-query): declare @metamask/messenger as a devDep

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,7 @@ linkStyle default opacity:0.5
   rate_limit_controller --> base_controller;
   rate_limit_controller --> messenger;
   react_data_query --> base_data_service;
+  react_data_query --> messenger;
   remote_feature_flag_controller --> base_controller;
   remote_feature_flag_controller --> controller_utils;
   remote_feature_flag_controller --> messenger;

--- a/packages/react-data-query/package.json
+++ b/packages/react-data-query/package.json
@@ -58,6 +58,7 @@
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^6.1.0",
+    "@metamask/messenger": "^1.2.0",
     "@ts-bridge/cli": "^0.6.4",
     "@types/jest": "^29.5.14",
     "deepmerge": "^4.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5237,6 +5237,7 @@ __metadata:
   dependencies:
     "@metamask/auto-changelog": "npm:^6.1.0"
     "@metamask/base-data-service": "npm:^0.1.3"
+    "@metamask/messenger": "npm:^1.2.0"
     "@metamask/utils": "npm:^11.9.0"
     "@tanstack/query-core": "npm:^4.43.0"
     "@tanstack/react-query": "npm:^4.43.0"


### PR DESCRIPTION
## Explanation

`packages/react-data-query/src/createUIQueryClient.test.ts` imports `Messenger` from `@metamask/messenger`, but the package wasn't listed in `react-data-query`'s `devDependencies`. That's an `import-x/no-extraneous-dependencies` violation — the currently-pinned plugin version misses it but newer versions flag it. This PR adds the missing devDep so the relationship is declared explicitly and the test file lints cleanly under newer plugin versions.

Also regenerates `README.md` so the workspace dependency graph reflects the new edge.

## References

- Surfaced while investigating the scoped lint-plugin resolutions on #8012.
- Extracted from the parked #8940 so the dep cleanup can land independently of the lint-plugin major bumps that PR also carried.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md) — N/A, devDep only, not consumer-facing
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them — N/A