### PR TITLE
chore(transaction-pay-controller): declare @metamask/keyring-controller as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,6 +550,7 @@ linkStyle default opacity:0.5
   transaction_pay_controller --> bridge_status_controller;
   transaction_pay_controller --> controller_utils;
   transaction_pay_controller --> gas_fee_controller;
+  transaction_pay_controller --> keyring_controller;
   transaction_pay_controller --> messenger;
   transaction_pay_controller --> network_controller;
   transaction_pay_controller --> ramps_controller;

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `@metamask/keyring-controller` `^26.0.0` as a dependency
+
 ## [23.1.0]
 
 ### Changed

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `@metamask/keyring-controller` `^26.0.0` as a dependency
+- Add `@metamask/keyring-controller` `^26.0.0` as a dependency ([#8972](https://github.com/MetaMask/core/pull/8972))
+  - The package was already imported at runtime by `src/strategy/relay/hyperliquid-withdraw.ts` but wasn't declared in `package.json`; this PR fixes the omission.
 
 ## [23.1.0]
 

--- a/packages/transaction-pay-controller/package.json
+++ b/packages/transaction-pay-controller/package.json
@@ -64,6 +64,7 @@
     "@metamask/bridge-status-controller": "^72.0.0",
     "@metamask/controller-utils": "^12.1.0",
     "@metamask/gas-fee-controller": "^26.2.2",
+    "@metamask/keyring-controller": "^26.0.0",
     "@metamask/messenger": "^1.2.0",
     "@metamask/metamask-eth-abis": "^3.1.1",
     "@metamask/network-controller": "^32.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5783,6 +5783,7 @@ __metadata:
     "@metamask/bridge-status-controller": "npm:^72.0.0"
     "@metamask/controller-utils": "npm:^12.1.0"
     "@metamask/gas-fee-controller": "npm:^26.2.2"
+    "@metamask/keyring-controller": "npm:^26.0.0"
     "@metamask/messenger": "npm:^1.2.0"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
     "@metamask/network-controller": "npm:^32.0.0"


### PR DESCRIPTION
## Explanation

`src/strategy/relay/hyperliquid-withdraw{,.test}.ts` imports `@metamask/keyring-controller` at runtime, but the package wasn't listed in `dependencies`. Consumers were relying on transitive hoisting to install it — once a stricter `import-x/no-extraneous-dependencies` runs (or yarn's hoisting layout changes), the missing dep would surface. This PR adds it explicitly so the dep relationship is correct and consumers get the package installed transitively.

Also regenerates `README.md` so the workspace dependency graph reflects the new edge.

## References

- Surfaced while investigating the scoped lint-plugin resolutions on #8012.
- Extracted from the parked #8940 so the dep cleanup can land independently of the lint-plugin major bumps that PR also carried.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them — N/A