### PR TITLE
feat: add ARC mainnet to asset controller

### DIFF
--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add ARC mainnet (`5042`/`0x13b2`) in `MulticallClient` ([#8973](https://github.com/MetaMask/core/pull/8973))
+
 ## [8.2.0]
 
 ### Changed

--- a/packages/assets-controller/src/data-sources/evm-rpc-services/clients/MulticallClient.ts
+++ b/packages/assets-controller/src/data-sources/evm-rpc-services/clients/MulticallClient.ts
@@ -369,6 +369,8 @@ const MULTICALL3_ADDRESS_BY_CHAIN: Record<Hex, Hex> = {
   '0x1079': '0xcA11bde05977b3631167028862bE2a173976CA11',
   // Tempo Testnet Moderato
   '0xa5bf': '0xcA11bde05977b3631167028862bE2a173976CA11',
+  // Arc (5042)
+  '0x13b2': '0xcA11bde05977b3631167028862bE2a173976CA11',
 };
 
 // =============================================================================

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add ARC mainnet (`5042`/`0x13b2`) entries in `multicall.ts` and `codefi-v2.ts` ([#8973](https://github.com/MetaMask/core/pull/8973))
+
 ## [108.3.0]
 
 ### Added

--- a/packages/assets-controllers/src/multicall.ts
+++ b/packages/assets-controllers/src/multicall.ts
@@ -315,6 +315,8 @@ const MULTICALL_CONTRACT_BY_CHAINID = {
   '0xa5bf': '0xcA11bde05977b3631167028862bE2a173976CA11',
   // Tempo Mainnet (4217)
   '0x1079': '0xcA11bde05977b3631167028862bE2a173976CA11',
+  // Arc (5042)
+  '0x13b2': '0xcA11bde05977b3631167028862bE2a173976CA11',
 } as Record<Hex, Hex>;
 
 const multicallAbi = [

--- a/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
+++ b/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
@@ -293,6 +293,7 @@ export const SPOT_PRICES_SUPPORT_INFO = {
   '0x1079': 'eip155:4217/slip44:60', // Tempo Mainnet - No native asset
   '0x10e6': 'eip155:4326/erc20:0x0000000000000000000000000000000000000000', // MegaETH Mainnet - Native symbol: ETH
   '0x1388': 'eip155:5000/erc20:0xdeaddeaddeaddeaddeaddeaddeaddeaddead0000', // Mantle - Native symbol: MNT
+  '0x13b2': 'eip155:5042/erc20:0x0000000000000000000000000000000000000000', // Arc - Native symbol: USDC
   '0x1b58': 'eip155:7000/slip44:7000', // ZetaChain - Native symbol: ZETA
   '0x2105': 'eip155:8453/slip44:60', // Base - Native symbol: ETH
   '0x2611': 'eip155:9745/erc20:0x0000000000000000000000000000000000000000', // Plasma mainnet - native symbol: XPL


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## Assets-controller:
### Added
- Add ARC mainnet (`5042`/`0x13b2`) in `MulticallClient` ([#8973](https://github.com/MetaMask/core/pull/8973))

## Asset-controller:
### Added

- Add ARC mainnet (`5042`/`0x13b2`) entries in `multicall.ts` and `codefi-v2.ts` ([#8973](https://github.com/MetaMask/core/pull/8973))

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only chain ID additions to static maps; no logic, auth, or API behavior changes beyond enabling Arc when the network is already selected.
> 
> **Overview**
> Adds **ARC mainnet** (chain `5042` / `0x13b2`) to the assets stack so balances and pricing can work on that network.
> 
> In **`@metamask/assets-controller`**, `MulticallClient`’s per-chain Multicall3 map now includes Arc with the standard `0xcA11…` deployment, enabling batched ERC-20/native balance RPC for the new RPC data source path.
> 
> In **`@metamask/assets-controllers`**, the legacy **`multicall.ts`** registry gets the same Multicall3 entry, and **`codefi-v2.ts`** maps Arc’s native asset to `eip155:5042/erc20:0x000…000` with **USDC** as the native symbol (same pattern as other USDC-native-style chains). Unreleased changelog notes document both packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f5b1c7c671f34e9d2d1cb92f4147726fb01e764. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->