### PR TITLE
refactor(wallet): migrate keyring + storage instances to directory convention

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -130,7 +130,8 @@
 
 ## Initialization
 /packages/wallet/src/initialization/instances/approval-controller/ @MetaMask/confirmations
-/packages/wallet/src/initialization/instances/keyring-controller.ts @MetaMask/accounts-engineers @MetaMask/core-platform
+/packages/wallet/src/initialization/instances/keyring-controller/ @MetaMask/accounts-engineers @MetaMask/core-platform
+/packages/wallet/src/initialization/instances/storage-service/ @MetaMask/extension-platform @MetaMask/mobile-platform @MetaMask/core-platform
 
 ## Package Release related
 /packages/account-tree-controller/package.json  @MetaMask/accounts-engineers @MetaMask/core-platform

--- a/packages/wallet/src/initialization/instances/index.ts
+++ b/packages/wallet/src/initialization/instances/index.ts
@@ -1,3 +1,3 @@
 export { approvalController } from './approval-controller/approval-controller';
-export { keyringController } from './keyring-controller';
-export { storageService } from './storage-service';
+export { keyringController } from './keyring-controller/keyring-controller';
+export { storageService } from './storage-service/storage-service';

--- a/packages/wallet/src/initialization/instances/keyring-controller/encryptor.test.ts
+++ b/packages/wallet/src/initialization/instances/keyring-controller/encryptor.test.ts
@@ -1,38 +1,6 @@
-import { KeyringController } from '@metamask/keyring-controller';
-import type {
-  KeyringControllerMessenger,
-  KeyringControllerOptions,
-} from '@metamask/keyring-controller';
 import { webcrypto } from 'crypto';
 
-import { encryptorFactory, keyringController } from './keyring-controller';
-
-jest.mock('@metamask/keyring-controller', () => ({
-  ...jest.requireActual('@metamask/keyring-controller'),
-  KeyringController: jest.fn(),
-}));
-
-describe('keyringController', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  it('forwards keyringV2Builders to the KeyringController', () => {
-    const keyringV2Builders = [
-      Object.assign(jest.fn(), { type: 'Test Keyring V2' }),
-    ] as KeyringControllerOptions['keyringV2Builders'];
-
-    keyringController.init({
-      state: undefined,
-      messenger: {} as KeyringControllerMessenger,
-      options: { keyringV2Builders },
-    });
-
-    expect(KeyringController).toHaveBeenCalledWith(
-      expect.objectContaining({ keyringV2Builders }),
-    );
-  });
-});
+import { encryptorFactory } from './encryptor';
 
 describe('encryptorFactory', () => {
   beforeAll(() => {

--- a/packages/wallet/src/initialization/instances/keyring-controller/encryptor.ts
+++ b/packages/wallet/src/initialization/instances/keyring-controller/encryptor.ts
@@ -17,13 +17,6 @@ import {
   generateSalt,
 } from '@metamask/browser-passworder';
 import type { Encryptor } from '@metamask/keyring-controller';
-import {
-  KeyringController,
-  KeyringControllerMessenger,
-} from '@metamask/keyring-controller';
-import { Messenger } from '@metamask/messenger';
-
-import { InitializationConfiguration } from '../types';
 
 /**
  * A factory function for the encrypt method of the browser-passworder library,
@@ -160,25 +153,3 @@ export type GenericEncryptor =
       KeyDerivationOptions,
       MobileEncryptionResult
     >;
-
-export const keyringController: InitializationConfiguration<
-  KeyringController,
-  KeyringControllerMessenger
-> = {
-  name: 'KeyringController',
-  init: ({ state, messenger, options }) =>
-    new KeyringController({
-      state,
-      messenger,
-      keyringBuilders: options.keyringBuilders,
-      keyringV2Builders: options.keyringV2Builders,
-      encryptor: (options.encryptor ?? encryptorFactory(600_000)) as Encryptor<
-        EncryptionKey | CryptoKey
-      >,
-    }),
-  getMessenger: (parent) =>
-    new Messenger({
-      namespace: 'KeyringController',
-      parent,
-    }),
-};

--- a/packages/wallet/src/initialization/instances/keyring-controller/keyring-controller.test.ts
+++ b/packages/wallet/src/initialization/instances/keyring-controller/keyring-controller.test.ts
@@ -1,0 +1,34 @@
+import { KeyringController } from '@metamask/keyring-controller';
+import type {
+  KeyringControllerMessenger,
+  KeyringControllerOptions,
+} from '@metamask/keyring-controller';
+
+import { keyringController } from './keyring-controller';
+
+jest.mock('@metamask/keyring-controller', () => ({
+  ...jest.requireActual('@metamask/keyring-controller'),
+  KeyringController: jest.fn(),
+}));
+
+describe('keyringController', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('forwards keyringV2Builders to the KeyringController', () => {
+    const keyringV2Builders = [
+      Object.assign(jest.fn(), { type: 'Test Keyring V2' }),
+    ] as KeyringControllerOptions['keyringV2Builders'];
+
+    keyringController.init({
+      state: undefined,
+      messenger: {} as KeyringControllerMessenger,
+      options: { keyringV2Builders },
+    });
+
+    expect(KeyringController).toHaveBeenCalledWith(
+      expect.objectContaining({ keyringV2Builders }),
+    );
+  });
+});

--- a/packages/wallet/src/initialization/instances/keyring-controller/keyring-controller.ts
+++ b/packages/wallet/src/initialization/instances/keyring-controller/keyring-controller.ts
@@ -1,0 +1,32 @@
+import type { EncryptionKey } from '@metamask/browser-passworder';
+import type { Encryptor } from '@metamask/keyring-controller';
+import {
+  KeyringController,
+  KeyringControllerMessenger,
+} from '@metamask/keyring-controller';
+import { Messenger } from '@metamask/messenger';
+
+import { InitializationConfiguration } from '../../types';
+import { encryptorFactory } from './encryptor';
+
+export const keyringController: InitializationConfiguration<
+  KeyringController,
+  KeyringControllerMessenger
+> = {
+  name: 'KeyringController',
+  init: ({ state, messenger, options }) =>
+    new KeyringController({
+      state,
+      messenger,
+      keyringBuilders: options.keyringBuilders,
+      keyringV2Builders: options.keyringV2Builders,
+      encryptor: (options.encryptor ?? encryptorFactory(600_000)) as Encryptor<
+        EncryptionKey | CryptoKey
+      >,
+    }),
+  getMessenger: (parent) =>
+    new Messenger({
+      namespace: 'KeyringController',
+      parent,
+    }),
+};

--- a/packages/wallet/src/initialization/instances/keyring-controller/types.ts
+++ b/packages/wallet/src/initialization/instances/keyring-controller/types.ts
@@ -1,0 +1,23 @@
+import type { KeyringControllerOptions } from '@metamask/keyring-controller';
+
+import type { GenericEncryptor } from './encryptor';
+
+/**
+ * Per-instance options for the wallet's `KeyringController`. All fields are
+ * optional; see the controller's `init` for the defaults applied when omitted.
+ */
+export type KeyringControllerInstanceOptions = {
+  /**
+   * Encryptor used to protect the keyring vault. Defaults to a PBKDF2 encryptor
+   * configured with 600,000 iterations.
+   */
+  encryptor?: GenericEncryptor;
+  /**
+   * Builders for the keyrings the controller supports.
+   */
+  keyringBuilders?: KeyringControllerOptions['keyringBuilders'];
+  /**
+   * Builders for the v2 keyrings the controller supports.
+   */
+  keyringV2Builders?: KeyringControllerOptions['keyringV2Builders'];
+};

--- a/packages/wallet/src/initialization/instances/storage-service/storage-service.ts
+++ b/packages/wallet/src/initialization/instances/storage-service/storage-service.ts
@@ -2,7 +2,7 @@ import { Messenger } from '@metamask/messenger';
 import { StorageService } from '@metamask/storage-service';
 import { StorageServiceMessenger } from '@metamask/storage-service';
 
-import { InitializationConfiguration } from '../types';
+import { InitializationConfiguration } from '../../types';
 
 export const storageService: InitializationConfiguration<
   StorageService,

--- a/packages/wallet/src/initialization/instances/storage-service/types.ts
+++ b/packages/wallet/src/initialization/instances/storage-service/types.ts
@@ -1,0 +1,12 @@
+import type { StorageAdapter } from '@metamask/storage-service';
+
+/**
+ * Per-instance options for the wallet's `StorageService`.
+ */
+export type StorageServiceInstanceOptions = {
+  /**
+   * Storage adapter the service persists data through. Supplied by the
+   * consumer, as the backing store differs per environment.
+   */
+  storage: StorageAdapter;
+};

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -1,5 +1,3 @@
-import { KeyringControllerOptions } from '@metamask/keyring-controller';
-import { StorageAdapter } from '@metamask/storage-service';
 import type { Json } from '@metamask/utils';
 
 import type {
@@ -8,7 +6,8 @@ import type {
   RootMessenger,
 } from './initialization/defaults';
 import type { ApprovalControllerInstanceOptions } from './initialization/instances/approval-controller/types';
-import { GenericEncryptor } from './initialization/instances/keyring-controller';
+import type { KeyringControllerInstanceOptions } from './initialization/instances/keyring-controller/types';
+import type { StorageServiceInstanceOptions } from './initialization/instances/storage-service/types';
 import { InitializationConfiguration } from './initialization/types';
 
 export type WalletOptions = {
@@ -23,12 +22,6 @@ export type WalletOptions = {
 
 export type InstanceSpecificOptions = {
   approvalController?: ApprovalControllerInstanceOptions;
-  keyringController?: {
-    encryptor?: GenericEncryptor;
-    keyringBuilders?: KeyringControllerOptions['keyringBuilders'];
-    keyringV2Builders?: KeyringControllerOptions['keyringV2Builders'];
-  };
-  storageService: {
-    storage: StorageAdapter;
-  };
+  keyringController?: KeyringControllerInstanceOptions;
+  storageService: StorageServiceInstanceOptions;
 };


### PR DESCRIPTION
## Explanation

Follow-up to #8953, which introduced a per-controller layout for wallet initialization instances — each controller gets its own directory under `src/initialization/instances/<controller>/` holding the config, a controller-specific `*InstanceOptions` type in `types.ts`, colocated tests, and any controller-specific utils. That PR left the package in two styles: `approval-controller` used the new directory layout while the pre-existing `keyring-controller` and `storage-service` were still flat single files. This migrates the latter two to match, as agreed in [this thread](https://github.com/MetaMask/core/pull/8953#discussion_r3342296263).

Changes (all internal to `@metamask/wallet`; no public exports or option shapes change):

- Move `keyring-controller.ts` and `storage-service.ts` into `keyring-controller/` and `storage-service/` directories.
- Pull the keyring encryptor out of the controller file into its own `keyring-controller/encryptor.ts` sibling (per [@FrederikBolding's suggestion](https://github.com/MetaMask/core/pull/8953#discussion_r3342376600)), and split the test file so the encryptor tests live in `encryptor.test.ts` next to it and the controller tests stay in `keyring-controller.test.ts`.
- Add per-controller `KeyringControllerInstanceOptions` / `StorageServiceInstanceOptions` types in each directory's `types.ts`, wired into `InstanceSpecificOptions`. The resulting option shape is byte-for-byte identical to before.
- Update `instances/index.ts` import paths and the `## Initialization` CODEOWNERS entries to the directory form (keyring mirrors its package owners; added a `storage-service/` entry mirroring its package owners).

No dependencies change, and none of these symbols are part of the package's public API (`src/index.ts`), so there's no consumer-facing change — hence no changelog entry.

## References

- Introduces the convention: #8953
- Motivating thread: https://github.com/MetaMask/core/pull/8953#discussion_r3342296263 (and the encryptor extraction: https://github.com/MetaMask/core/pull/8953#discussion_r3342376600)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md) — n/a, internal refactor with no consumer-facing change
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal file moves and type re-exports only; keyring encryptor defaults and instance option shapes are unchanged with no public API surface.
> 
> **Overview**
> Aligns **keyring** and **storage** wallet initialization with the per-controller directory layout already used for **approval-controller** (post-#8953).
> 
> **Keyring** moves from a single flat file into `keyring-controller/`: controller wiring stays in `keyring-controller.ts`, vault **encryptor** logic and tests split into `encryptor.ts` / `encryptor.test.ts`, and **`KeyringControllerInstanceOptions`** lives in `types.ts`. **Storage** moves into `storage-service/` with **`StorageServiceInstanceOptions`** in its own `types.ts`. `InstanceSpecificOptions` in `types.ts` now references those types instead of inline shapes—the option contract is unchanged.
> 
> `instances/index.ts` export paths and **CODEOWNERS** under `## Initialization` are updated to the directory paths (including a new `storage-service/` entry).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ef5b687d6adf6c155eb7d7e9e57bee609f8528d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->