### PR TITLE
fix: transaction parameters for batch swap transactions

### DIFF
--- a/packages/bridge-status-controller/CHANGELOG.md
+++ b/packages/bridge-status-controller/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix gas-related transaction options for batch and batch-sell swaps ((8979)[https://github.com/MetaMask/core/pull/8979])
+  - When the fee is paid in an ERC20 token, set it as the `gasFeeToken`
+  - Set `excludeNativeTokenForFee=true` when `gasFeeToken` is set, which tells the TransactionController to use the gasFeeToken for payment regardless of whether the user has enough native assets
+  - Set `skipInitialGasEstimate=false` if submitting gasIncluded7702 quotes and account has not been upgraded to a smart account
+
 ## [72.0.0]
 
 ### Added

--- a/packages/bridge-status-controller/CHANGELOG.md
+++ b/packages/bridge-status-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix gas-related transaction options for batch and batch-sell swaps ([8979](https://github.com/MetaMask/core/pull/8979))
+- Fix gas-related transaction options for batch and batch-sell swaps ([#8979](https://github.com/MetaMask/core/pull/8979))
   - When the fee is paid in an ERC20 token, set it as the `gasFeeToken`
   - Set `excludeNativeTokenForFee=true` when `gasFeeToken` is set, which tells the TransactionController to use the gasFeeToken for payment regardless of whether the user has enough native assets
   - Set `skipInitialGasEstimate=false` if submitting gasIncluded7702 quotes and account has not been upgraded to a smart account

--- a/packages/bridge-status-controller/CHANGELOG.md
+++ b/packages/bridge-status-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix gas-related transaction options for batch and batch-sell swaps ((8979)[https://github.com/MetaMask/core/pull/8979])
+- Fix gas-related transaction options for batch and batch-sell swaps ([8979](https://github.com/MetaMask/core/pull/8979))
   - When the fee is paid in an ERC20 token, set it as the `gasFeeToken`
   - Set `excludeNativeTokenForFee=true` when `gasFeeToken` is set, which tells the TransactionController to use the gasFeeToken for payment regardless of whether the user has enough native assets
   - Set `skipInitialGasEstimate=false` if submitting gasIncluded7702 quotes and account has not been upgraded to a smart account

--- a/packages/bridge-status-controller/src/__snapshots__/bridge-status-controller.test.ts.snap
+++ b/packages/bridge-status-controller/src/__snapshots__/bridge-status-controller.test.ts.snap
@@ -1231,13 +1231,16 @@ exports[`BridgeStatusController submitTx: EVM bridge should handle smart transac
     {
       "atomic": true,
       "disable7702": true,
+      "excludeNativeTokenForFee": true,
       "from": "0xaccount1",
+      "gasFeeToken": undefined,
       "isGasFeeIncluded": false,
       "isGasFeeSponsored": false,
       "isInternal": true,
       "networkClientId": "arbitrum",
       "origin": "metamask",
       "requireApproval": false,
+      "skipInitialGasEstimate": false,
       "transactions": [
         {
           "assetsFiatValues": {
@@ -3633,6 +3636,15 @@ exports[`BridgeStatusController submitTx: EVM swap should handle a gasless swap 
     "destTokenAmount": "990654755978612",
     "feeData": {
       "txFee": {
+        "asset": {
+          "address": "0x0000000000000000000000000000000000000000",
+          "assetId": "eip155:42161/slip44:60",
+          "chainId": 42161,
+          "decimals": 18,
+          "iconUrl": "",
+          "name": "Ether",
+          "symbol": "ETH",
+        },
         "maxFeePerGas": "123",
         "maxPriorityFeePerGas": "123",
       },
@@ -3692,6 +3704,40 @@ exports[`BridgeStatusController submitTx: EVM swap should handle a gasless swap 
         "srcChainId": 42161,
       },
     ],
+  },
+  "slippagePercentage": 0,
+  "startTime": 1234567890,
+  "status": {
+    "srcChain": {
+      "chainId": 42161,
+      "txHash": undefined,
+    },
+    "status": "PENDING",
+  },
+  "targetContractAddress": undefined,
+  "txMetaId": "test-tx-id",
+}
+`;
+
+exports[`BridgeStatusController submitTx: EVM swap should handle a gasless swap transaction with fees paid in ERC20 1`] = `
+{
+  "account": "0xaccount1",
+  "actionId": undefined,
+  "approvalTxId": undefined,
+  "batchId": "batchId1",
+  "estimatedProcessingTimeInSeconds": 0,
+  "featureId": undefined,
+  "hasApprovalTx": true,
+  "initialDestAssetBalance": undefined,
+  "isStxEnabled": true,
+  "location": "Main View",
+  "originalTransactionId": "test-tx-id",
+  "pricingData": {
+    "amountSent": "1.234",
+    "amountSentInUsd": "1.01",
+    "quotedGasAmount": ".00055",
+    "quotedGasInUsd": "2.5778",
+    "quotedReturnInUsd": "0.134214",
   },
   "slippagePercentage": 0,
   "startTime": 1234567890,
@@ -3858,13 +3904,16 @@ exports[`BridgeStatusController submitTx: EVM swap should handle smart transacti
     {
       "atomic": true,
       "disable7702": true,
+      "excludeNativeTokenForFee": true,
       "from": "0xaccount1",
+      "gasFeeToken": undefined,
       "isGasFeeIncluded": false,
       "isGasFeeSponsored": false,
       "isInternal": true,
       "networkClientId": "arbitrum",
       "origin": "metamask",
       "requireApproval": false,
+      "skipInitialGasEstimate": false,
       "transactions": [
         {
           "assetsFiatValues": undefined,

--- a/packages/bridge-status-controller/src/bridge-status-controller.batch-sell.test.ts
+++ b/packages/bridge-status-controller/src/bridge-status-controller.batch-sell.test.ts
@@ -358,7 +358,9 @@ describe('BridgeStatusController', () => {
                       networkClientId: 'networkClientId',
                       origin: 'metamask',
                       requireApproval: false,
-                      skipInitialGasEstimate: Boolean(transferTx),
+                      skipInitialGasEstimate: gasIncluded7702
+                        ? isDelegatedAccount
+                        : Boolean(transferTx),
                     });
 
                     expect(transactions).toStrictEqual(

--- a/packages/bridge-status-controller/src/bridge-status-controller.batch-sell.test.ts
+++ b/packages/bridge-status-controller/src/bridge-status-controller.batch-sell.test.ts
@@ -348,9 +348,8 @@ describe('BridgeStatusController', () => {
 
                     // addTransactionBatch options
                     expect(batchParams).toStrictEqual({
-                      disable7702: !is7702 || stxEnabled,
-                      excludeNativeTokenForFee:
-                        Boolean(transferTx) || gasIncluded,
+                      disable7702: !is7702,
+                      excludeNativeTokenForFee: !transferTx,
                       atomic: false,
                       from: '0xaccount1',
                       isGasFeeIncluded: gasIncluded7702,
@@ -359,7 +358,7 @@ describe('BridgeStatusController', () => {
                       networkClientId: 'networkClientId',
                       origin: 'metamask',
                       requireApproval: false,
-                      skipInitialGasEstimate: !transferTx,
+                      skipInitialGasEstimate: Boolean(transferTx),
                     });
 
                     expect(transactions).toStrictEqual(

--- a/packages/bridge-status-controller/src/bridge-status-controller.batch-sell.test.ts
+++ b/packages/bridge-status-controller/src/bridge-status-controller.batch-sell.test.ts
@@ -348,8 +348,9 @@ describe('BridgeStatusController', () => {
 
                     // addTransactionBatch options
                     expect(batchParams).toStrictEqual({
-                      disable7702: !is7702,
-                      excludeNativeTokenForFee: Boolean(transferTx),
+                      disable7702: !is7702 || stxEnabled,
+                      excludeNativeTokenForFee:
+                        Boolean(transferTx) || gasIncluded,
                       atomic: false,
                       from: '0xaccount1',
                       isGasFeeIncluded: gasIncluded7702,
@@ -358,7 +359,7 @@ describe('BridgeStatusController', () => {
                       networkClientId: 'networkClientId',
                       origin: 'metamask',
                       requireApproval: false,
-                      skipInitialGasEstimate: false,
+                      skipInitialGasEstimate: !transferTx,
                     });
 
                     expect(transactions).toStrictEqual(

--- a/packages/bridge-status-controller/src/bridge-status-controller.test.ts
+++ b/packages/bridge-status-controller/src/bridge-status-controller.test.ts
@@ -3968,6 +3968,7 @@ describe('BridgeStatusController', () => {
                 gasIncluded: true,
                 feeData: {
                   txFee: {
+                    asset: getNativeAssetForChainId(42161),
                     maxFeePerGas: '123',
                     maxPriorityFeePerGas: '123',
                   },
@@ -4008,10 +4009,94 @@ describe('BridgeStatusController', () => {
         {
           "atomic": true,
           "disable7702": true,
+          "excludeNativeTokenForFee": true,
+          "gasFeeToken": undefined,
           "isDelegatedAccount": false,
           "isGasFeeIncluded": false,
           "isGasFeeSponsored": false,
           "requireApproval": false,
+          "skipInitialGasEstimate": false,
+        }
+      `);
+    });
+
+    it('should handle a gasless swap transaction with fees paid in ERC20', async () => {
+      setupEventTrackingMocks(mockMessengerCall);
+      mockMessengerCall.mockReturnValueOnce(mockSelectedAccount);
+      mockMessengerCall.mockReturnValueOnce('arbitrum');
+      addTransactionBatchFn.mockResolvedValueOnce({
+        batchId: 'batchId1',
+      });
+      mockMessengerCall.mockReturnValueOnce({
+        transactions: [{ ...mockEvmTxMeta, batchId: 'batchId1' }],
+      });
+
+      const getAddTransactionBatchParamsSpy = jest.spyOn(
+        transactionUtils,
+        'getAddTransactionBatchParams',
+      );
+
+      await withController(
+        { mockMessengerCall },
+        async ({
+          controller,
+          rootMessenger,
+          startPollingForBridgeTxStatusSpy,
+        }) => {
+          const result = await rootMessenger.call(
+            'BridgeStatusController:submitTx',
+            (mockEvmQuoteResponse.trade as TxData).from,
+            {
+              ...mockEvmQuoteResponse,
+              quote: {
+                ...mockEvmQuoteResponse.quote,
+                gasIncluded: true,
+                feeData: {
+                  txFee: {
+                    asset: {
+                      address: '0x0000000000000000000000000000000000000032',
+                      symbol: 'WETH',
+                      chainId: 10,
+                      assetId: 'eip155:10/slip44:60',
+                      name: 'WETH',
+                      decimals: 18,
+                    },
+                    maxFeePerGas: '123',
+                    maxPriorityFeePerGas: '123',
+                  },
+                },
+              },
+            },
+            true,
+          );
+          controller.stopAllPolling();
+
+          expect(startPollingForBridgeTxStatusSpy).toHaveBeenCalledTimes(0);
+          expect(addTransactionBatchFn).toHaveBeenCalledTimes(1);
+          expect(
+            mockMessengerCall.mock.calls.filter(
+              ([action]) => action === 'TransactionController:addTransaction',
+            ),
+          ).toHaveLength(0);
+          expect(mockMessengerCall).toHaveBeenCalledTimes(8);
+          const { quote, ...history } = controller.state.txHistory[result.id];
+          expect(history).toMatchSnapshot();
+        },
+      );
+
+      const { messenger, tradeData, ...params } =
+        getAddTransactionBatchParamsSpy.mock.calls[0][0];
+      expect(params).toMatchInlineSnapshot(`
+        {
+          "atomic": true,
+          "disable7702": true,
+          "excludeNativeTokenForFee": false,
+          "gasFeeToken": "0x0000000000000000000000000000000000000032",
+          "isDelegatedAccount": false,
+          "isGasFeeIncluded": false,
+          "isGasFeeSponsored": false,
+          "requireApproval": false,
+          "skipInitialGasEstimate": true,
         }
       `);
     });
@@ -4332,10 +4417,13 @@ describe('BridgeStatusController', () => {
         {
           "atomic": true,
           "disable7702": false,
+          "excludeNativeTokenForFee": true,
+          "gasFeeToken": undefined,
           "isDelegatedAccount": true,
           "isGasFeeIncluded": false,
           "isGasFeeSponsored": false,
           "requireApproval": false,
+          "skipInitialGasEstimate": false,
         }
       `);
     });
@@ -4449,10 +4537,13 @@ describe('BridgeStatusController', () => {
         {
           "atomic": true,
           "disable7702": false,
+          "excludeNativeTokenForFee": true,
+          "gasFeeToken": undefined,
           "isDelegatedAccount": false,
           "isGasFeeIncluded": true,
           "isGasFeeSponsored": false,
           "requireApproval": false,
+          "skipInitialGasEstimate": false,
         }
       `);
     });
@@ -4504,10 +4595,13 @@ describe('BridgeStatusController', () => {
         {
           "atomic": true,
           "disable7702": true,
+          "excludeNativeTokenForFee": true,
+          "gasFeeToken": undefined,
           "isDelegatedAccount": false,
           "isGasFeeIncluded": false,
           "isGasFeeSponsored": false,
           "requireApproval": false,
+          "skipInitialGasEstimate": false,
         }
       `);
     });

--- a/packages/bridge-status-controller/src/strategy/batch-sell-strategy.ts
+++ b/packages/bridge-status-controller/src/strategy/batch-sell-strategy.ts
@@ -64,7 +64,9 @@ export async function* submitBatchSellHandler(
     ),
     isGasFeeSponsored: gasSponsored,
     isGasFeeIncluded: Boolean(gasIncluded7702),
-    skipInitialGasEstimate: Boolean(gasFeeToken),
+    skipInitialGasEstimate: gasIncluded7702
+      ? isDelegatedAccount
+      : Boolean(gasFeeToken),
     excludeNativeTokenForFee: !gasFeeToken,
   });
 

--- a/packages/bridge-status-controller/src/strategy/batch-sell-strategy.ts
+++ b/packages/bridge-status-controller/src/strategy/batch-sell-strategy.ts
@@ -37,6 +37,7 @@ export async function* submitBatchSellHandler(
     addTransactionBatchFn,
     isDelegatedAccount,
     batchSellTrades,
+    isStxEnabled,
   } = args;
 
   const tradeData = toQuoteAndTxMetadataBatch({
@@ -57,15 +58,13 @@ export async function* submitBatchSellHandler(
     isDelegatedAccount,
     // Tx success/failure is independent of other txs in the batch
     atomic: false,
-    disable7702: shouldDisable7702(
-      gasIncluded7702,
-      gasIncluded,
-      isDelegatedAccount,
-    ),
+    disable7702:
+      isStxEnabled ||
+      shouldDisable7702(gasIncluded7702, gasIncluded, isDelegatedAccount),
     isGasFeeSponsored: gasSponsored,
     isGasFeeIncluded: Boolean(gasIncluded7702),
-    skipInitialGasEstimate: false,
-    excludeNativeTokenForFee: Boolean(gasFeeToken),
+    skipInitialGasEstimate: !gasFeeToken,
+    excludeNativeTokenForFee: Boolean(gasFeeToken) || gasIncluded,
   });
 
   // Submit the batch to the TransactionController

--- a/packages/bridge-status-controller/src/strategy/batch-sell-strategy.ts
+++ b/packages/bridge-status-controller/src/strategy/batch-sell-strategy.ts
@@ -37,7 +37,6 @@ export async function* submitBatchSellHandler(
     addTransactionBatchFn,
     isDelegatedAccount,
     batchSellTrades,
-    isStxEnabled,
   } = args;
 
   const tradeData = toQuoteAndTxMetadataBatch({
@@ -58,13 +57,15 @@ export async function* submitBatchSellHandler(
     isDelegatedAccount,
     // Tx success/failure is independent of other txs in the batch
     atomic: false,
-    disable7702:
-      isStxEnabled ||
-      shouldDisable7702(gasIncluded7702, gasIncluded, isDelegatedAccount),
+    disable7702: shouldDisable7702(
+      gasIncluded7702,
+      gasIncluded,
+      isDelegatedAccount,
+    ),
     isGasFeeSponsored: gasSponsored,
     isGasFeeIncluded: Boolean(gasIncluded7702),
-    skipInitialGasEstimate: !gasFeeToken,
-    excludeNativeTokenForFee: Boolean(gasFeeToken) || gasIncluded,
+    skipInitialGasEstimate: Boolean(gasFeeToken),
+    excludeNativeTokenForFee: !gasFeeToken,
   });
 
   // Submit the batch to the TransactionController

--- a/packages/bridge-status-controller/src/strategy/batch-strategy.ts
+++ b/packages/bridge-status-controller/src/strategy/batch-strategy.ts
@@ -1,3 +1,4 @@
+import { FeeType, isNativeAddress } from '@metamask/bridge-controller';
 import type { TxData } from '@metamask/bridge-controller';
 
 import {
@@ -10,6 +11,7 @@ import {
 } from '../utils/transaction';
 import { SubmitStep } from './types';
 import type { SubmitStrategyParams, SubmitStepResult } from './types';
+import type { Hex } from '@metamask/utils';
 
 /**
  * Submits batched EVM transactions to the TransactionController
@@ -34,6 +36,12 @@ export async function* submitBatchHandler(
     isBridgeTx,
   });
 
+  const gasFeeToken =
+    quoteResponse.quote.feeData[FeeType.TX_FEE]?.asset?.address &&
+    isNativeAddress(quoteResponse.quote.feeData[FeeType.TX_FEE].asset.address)
+      ? undefined
+      : (quoteResponse.quote.feeData[FeeType.TX_FEE]?.asset?.address as Hex);
+
   const transactionParams = await getAddTransactionBatchParams({
     tradeData,
     requireApproval,
@@ -47,6 +55,9 @@ export async function* submitBatchHandler(
     ),
     isGasFeeSponsored: Boolean(quoteResponse.quote.gasSponsored),
     isGasFeeIncluded: Boolean(quoteResponse.quote.gasIncluded7702),
+    gasFeeToken,
+    excludeNativeTokenForFee: !gasFeeToken,
+    skipInitialGasEstimate: Boolean(gasFeeToken),
   });
 
   const { batchId } = await addTransactionBatchFn(transactionParams);

--- a/packages/bridge-status-controller/src/strategy/batch-strategy.ts
+++ b/packages/bridge-status-controller/src/strategy/batch-strategy.ts
@@ -1,5 +1,6 @@
 import { FeeType, isNativeAddress } from '@metamask/bridge-controller';
 import type { TxData } from '@metamask/bridge-controller';
+import type { Hex } from '@metamask/utils';
 
 import {
   findAllTransactionsInBatch,
@@ -11,7 +12,6 @@ import {
 } from '../utils/transaction';
 import { SubmitStep } from './types';
 import type { SubmitStrategyParams, SubmitStepResult } from './types';
-import type { Hex } from '@metamask/utils';
 
 /**
  * Submits batched EVM transactions to the TransactionController
@@ -56,8 +56,8 @@ export async function* submitBatchHandler(
     isGasFeeSponsored: Boolean(quoteResponse.quote.gasSponsored),
     isGasFeeIncluded: Boolean(quoteResponse.quote.gasIncluded7702),
     gasFeeToken,
-    excludeNativeTokenForFee: !gasFeeToken,
     skipInitialGasEstimate: Boolean(gasFeeToken),
+    excludeNativeTokenForFee: !gasFeeToken,
   });
 
   const { batchId } = await addTransactionBatchFn(transactionParams);

--- a/packages/bridge-status-controller/src/strategy/batch-strategy.ts
+++ b/packages/bridge-status-controller/src/strategy/batch-strategy.ts
@@ -56,7 +56,9 @@ export async function* submitBatchHandler(
     isGasFeeSponsored: Boolean(quoteResponse.quote.gasSponsored),
     isGasFeeIncluded: Boolean(quoteResponse.quote.gasIncluded7702),
     gasFeeToken,
-    skipInitialGasEstimate: Boolean(gasFeeToken),
+    skipInitialGasEstimate: quoteResponse.quote.gasIncluded7702
+      ? isDelegatedAccount
+      : Boolean(gasFeeToken),
     excludeNativeTokenForFee: !gasFeeToken,
   });
 

--- a/packages/bridge-status-controller/src/utils/transaction.test.ts
+++ b/packages/bridge-status-controller/src/utils/transaction.test.ts
@@ -1759,7 +1759,7 @@ describe('Bridge Status Controller Transaction Utils', () => {
           valueInCurrency: '200',
           usd: '200',
         },
-      }) as never;
+      } as never);
 
     const createMockMessagingSystem = (
       estimateGasFeeOverrides: Record<string, unknown> = { estimates: {} },
@@ -1780,7 +1780,7 @@ describe('Bridge Status Controller Transaction Utils', () => {
           }
           return undefined;
         }),
-      }) as unknown as BridgeStatusControllerMessenger;
+      } as unknown as BridgeStatusControllerMessenger);
 
     beforeEach(() => {
       jest.clearAllMocks();

--- a/packages/bridge-status-controller/src/utils/transaction.test.ts
+++ b/packages/bridge-status-controller/src/utils/transaction.test.ts
@@ -1759,7 +1759,7 @@ describe('Bridge Status Controller Transaction Utils', () => {
           valueInCurrency: '200',
           usd: '200',
         },
-      } as never);
+      }) as never;
 
     const createMockMessagingSystem = (
       estimateGasFeeOverrides: Record<string, unknown> = { estimates: {} },
@@ -1780,7 +1780,7 @@ describe('Bridge Status Controller Transaction Utils', () => {
           }
           return undefined;
         }),
-      } as unknown as BridgeStatusControllerMessenger);
+      }) as unknown as BridgeStatusControllerMessenger;
 
     beforeEach(() => {
       jest.clearAllMocks();

--- a/packages/bridge-status-controller/src/utils/transaction.ts
+++ b/packages/bridge-status-controller/src/utils/transaction.ts
@@ -29,7 +29,7 @@ import type {
   TransactionBatchSingleRequest,
   BatchTransactionParams,
 } from '@metamask/transaction-controller';
-import { createProjectLogger } from '@metamask/utils';
+import { createProjectLogger, isStrictHexString } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
 
 import { APPROVAL_DELAY_MS } from '../constants';
@@ -71,12 +71,9 @@ export const shouldDisable7702 = (
     return false;
   }
   // Enable batching when the account is already delegated (to avoid the in-flight transaction limit for delegated accounts)
-  if (isDelegatedAccount) {
-    return false;
-  }
   // For gasless transactions with STX/sendBundle we keep disabling 7702
-  if (gasIncluded) {
-    return true;
+  if (isDelegatedAccount && !gasIncluded) {
+    return false;
   }
   /**
    * Explicitly return default instead of falsy value (see TransactionBatchRequest.disable7702)
@@ -433,16 +430,12 @@ export const toTransactionParams = async (
   chainId: Hex,
   simulatedGasFeeLimits?: SimulatedGasFeeLimits | TxFeeGasLimits,
 ): Promise<BatchTransactionParams> => {
-  const normalizedTrade = {
-    ...trade,
+  const transactionParams = {
     data: trade.data,
     to: trade.to,
     from: trade.from,
     value: trade.value,
-  };
-  const transactionParams = {
-    ...normalizedTrade,
-    // Only add gasLimit and gas if they're truthy
+    // Only add gas if it's truthy
     gas: gasLimit ? toHex(gasLimit) : undefined,
   };
 
@@ -450,8 +443,15 @@ export const toTransactionParams = async (
   if (simulatedGasFeeLimits) {
     return {
       ...transactionParams,
-      maxFeePerGas: toHex(simulatedGasFeeLimits.maxFeePerGas),
-      maxPriorityFeePerGas: toHex(simulatedGasFeeLimits.maxPriorityFeePerGas),
+      // Sometimes estimates are hex, somethings numeric strings
+      maxFeePerGas: isStrictHexString(simulatedGasFeeLimits.maxFeePerGas)
+        ? simulatedGasFeeLimits.maxFeePerGas
+        : toHex(simulatedGasFeeLimits.maxFeePerGas),
+      maxPriorityFeePerGas: isStrictHexString(
+        simulatedGasFeeLimits.maxPriorityFeePerGas,
+      )
+        ? simulatedGasFeeLimits.maxPriorityFeePerGas
+        : toHex(simulatedGasFeeLimits.maxPriorityFeePerGas),
     };
   }
 


### PR DESCRIPTION
## Explanation

Fixes batch-sell submission edge case which causes tx failure if `gasIncluded7702=true` and STX is enabled. See changelog for exact parameters changed

In addition to these changes, clients need to update the TransactionController `publishHook` to prioritize publishing via 7702 if `isGasFeeIncluded=true`. The current logic submits using STX although the quote requires 7702 processing

#### Example transaction-controller-init change
```
+  const isSwapGasIncluded7702 = transactionMeta.isGasFeeIncluded;
   let attemptedHook = false;
 
   if (
     keyringSupports7702 &&
     !isRevokeDelegation &&
-    (!isSmartTransaction || !sendBundleSupport || isExternalSign)
+    (isSwapGasIncluded7702 || !isSmartTransaction || !sendBundleSupport || isExternalSign)
    ) {
     const hook = new Delegation7702PublishHook({
      messenger: initMessenger,
    }).getHook();
```



<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how batched swaps choose 7702 vs STX paths and how fees are paid; misconfiguration can cause submission failures, and full behavior depends on a coordinated TransactionController publishHook update in clients.
> 
> **Overview**
> Fixes **gas and EIP-7702 batch options** passed from `BridgeStatusController` into `TransactionController` for batched swaps and batch-sell flows, addressing failures when quotes use **gas-included 7702** with STX enabled or **ERC-20–denominated** fees.
> 
> **Batch swap strategy** now derives `gasFeeToken` from the quote’s `TX_FEE` asset (omitted when the fee asset is native), and sets `skipInitialGasEstimate` / `excludeNativeTokenForFee` from that token and from `gasIncluded7702` plus whether the account is already delegated. **`shouldDisable7702`** is tightened so delegated accounts only keep 7702 enabled when the quote is not plain `gasIncluded` STX gasless.
> 
> **Batch-sell** uses the same `skipInitialGasEstimate` and `excludeNativeTokenForFee` rules. **`toTransactionParams`** accepts bridge-api fee fields whether they are already hex or numeric strings.
> 
> Tests and snapshots cover native vs ERC-20 gasless swaps and the updated batch params. **Clients** still need a separate `publishHook` change so `isGasFeeIncluded` quotes publish via 7702 instead of STX when required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 402df45bbf31948127e8c74b8da6996ed5d97d37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->