### PR TITLE
fix: map non-prefixed payment method IDs in Transak translation

### DIFF
--- a/packages/ramps-controller/CHANGELOG.md
+++ b/packages/ramps-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix Transak Native deposits failing on staging/UAT with a 400 `paymentMethod is required parameter` error by mapping canonical payment method IDs supplied without the `/payments/` prefix (e.g. `apple-pay`) to their deposit-format equivalents, in addition to the prefixed forms (e.g. `/payments/apple-pay`) ([#8916](https://github.com/MetaMask/core/pull/8916))
+
 ## [14.1.0]
 
 ### Added

--- a/packages/ramps-controller/CHANGELOG.md
+++ b/packages/ramps-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix Transak Native deposits failing on staging/UAT with a 400 `paymentMethod is required parameter` error by mapping canonical payment method IDs supplied without the `/payments/` prefix (e.g. `apple-pay`) to their deposit-format equivalents, in addition to the prefixed forms (e.g. `/payments/apple-pay`) ([#8916](https://github.com/MetaMask/core/pull/8916))
+- Fix Transak Native deposits failing on staging/UAT with a 400 `paymentMethod is required parameter` error by mapping canonical payment method IDs supplied without the `/payments/` prefix (e.g. `apple-pay`) to their deposit-format equivalents, in addition to the prefixed forms (e.g. `/payments/apple-pay`) ([#8980](https://github.com/MetaMask/core/pull/8980))
 
 ## [14.1.0]
 

--- a/packages/ramps-controller/src/TransakService.test.ts
+++ b/packages/ramps-controller/src/TransakService.test.ts
@@ -1172,6 +1172,28 @@ describe('TransakService', () => {
       expect(await promise).toStrictEqual(MOCK_TRANSLATION);
     });
 
+    it('normalizes canonical payment method IDs without the /payments/ prefix', async () => {
+      nock(STAGING_ORDERS_BASE)
+        .get(`${STAGING_PROVIDER_PATH}/native/translate`)
+        .query(
+          (query) =>
+            query.paymentMethod === 'apple_pay' &&
+            query.fiatCurrencyId === 'USD',
+        )
+        .reply(200, MOCK_TRANSLATION);
+
+      const { service } = getService();
+
+      const promise = service.getTranslation({
+        fiatCurrencyId: 'USD',
+        paymentMethod: 'apple-pay',
+      });
+      await jest.runAllTimersAsync();
+      await flushPromises();
+
+      expect(await promise).toStrictEqual(MOCK_TRANSLATION);
+    });
+
     it('passes through payment methods already in deposit format', async () => {
       nock(STAGING_ORDERS_BASE)
         .get(`${STAGING_PROVIDER_PATH}/native/translate`)

--- a/packages/ramps-controller/src/TransakService.ts
+++ b/packages/ramps-controller/src/TransakService.ts
@@ -354,8 +354,10 @@ export type TransakServiceMessenger = Messenger<
  * (e.g., "credit_debit_card").
  *
  * The translation endpoint only understands the deposit-format IDs.
- * If no mapping exists, the input is returned as-is (it may already be
- * in the deposit format).
+ * Canonical IDs may arrive either with the "/payments/" prefix
+ * (e.g., "/payments/apple-pay") or without it (e.g., "apple-pay"), so both
+ * forms are accepted. If no mapping exists, the input is returned as-is (it
+ * may already be in the deposit format).
  */
 const RAMPS_TO_DEPOSIT_PAYMENT_METHOD: Record<string, string> = {
   '/payments/debit-credit-card': 'credit_debit_card',
@@ -366,13 +368,22 @@ const RAMPS_TO_DEPOSIT_PAYMENT_METHOD: Record<string, string> = {
   '/payments/gbp-bank-transfer': 'gbp_bank_transfer',
 };
 
+const PAYMENTS_PREFIX = '/payments/';
+
 function normalizePaymentMethodForTranslation(
   paymentMethod: string | undefined,
 ): string | undefined {
   if (!paymentMethod) {
     return undefined;
   }
-  return RAMPS_TO_DEPOSIT_PAYMENT_METHOD[paymentMethod] ?? paymentMethod;
+  const prefixed = paymentMethod.startsWith(PAYMENTS_PREFIX)
+    ? paymentMethod
+    : `${PAYMENTS_PREFIX}${paymentMethod}`;
+  return (
+    RAMPS_TO_DEPOSIT_PAYMENT_METHOD[paymentMethod] ??
+    RAMPS_TO_DEPOSIT_PAYMENT_METHOD[prefixed] ??
+    paymentMethod
+  );
 }
 
 function getTransakApiBaseUrl(environment: TransakEnvironment): string {


### PR DESCRIPTION
## Explanation

Transak Native deposits were failing on staging/UAT with a `400` response and the error message `paymentMethod is required parameter`.

The root cause is in `TransakService.normalizePaymentMethodForTranslation` (in `@metamask/ramps-controller`). The translation endpoint only understands deposit-format payment method IDs (e.g. `apple_pay`), so the service maps canonical ramps IDs to that format via the `RAMPS_TO_DEPOSIT_PAYMENT_METHOD` lookup. However, that lookup was keyed **only** on the `/payments/`-prefixed form (e.g. `/payments/apple-pay`). When a canonical ID arrived **without** the prefix (e.g. `apple-pay`), it missed the map and was forwarded to the translation endpoint unchanged. The endpoint doesn't recognize that value, returns no usable `paymentMethod`, and the downstream deposit call fails with `paymentMethod is required parameter`.

The fix updates `normalizePaymentMethodForTranslation` to accept both forms: before falling back to passing the input through untouched, it now also tries the `/payments/`-prefixed variant of the input against the lookup. So both `apple-pay` and `/payments/apple-pay` resolve to `apple_pay`, while values already in deposit format (e.g. `credit_debit_card`) still pass through unchanged.

This helper feeds every Transak translation call (`getBuyQuote`, `createOrder`, `getUserLimits`, `confirmPayment`, `getTranslation`), so the fix applies uniformly across the deposit flow. The change is purely additive — it only broadens the set of accepted inputs and does not alter behavior for inputs that already worked, so it is **not** a breaking change.

**Before**:

https://github.com/user-attachments/assets/25e2591e-eb44-40c4-a269-9e3db00892df


**After**:


https://github.com/user-attachments/assets/f859e315-8e8d-422d-b857-2399c2a44321



## References

* Fixes [TRAM-3610](https://consensyssoftware.atlassian.net/browse/TRAM-3610)
* Follow-up (separate, in the mobile app repo): bump `@metamask/ramps-controller` to adopt this fix.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


[TRAM-3610]: https://consensyssoftware.atlassian.net/browse/TRAM-3610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive lookup change in payment method normalization with tests; no auth or breaking API changes.
> 
> **Overview**
> Fixes **Transak Native** deposits on staging/UAT that failed with `paymentMethod is required parameter` when callers passed canonical payment method IDs **without** the `/payments/` prefix (e.g. `apple-pay`).
> 
> `normalizePaymentMethodForTranslation` in `TransakService` now resolves both unprefixed and `/payments/…` canonical IDs to deposit-format values (e.g. `apple_pay`) before the native translate call; prefixed inputs and values already in deposit format behave as before. A unit test covers the unprefixed case; the changelog documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4a1c57ef8473c5d6b2e27ef7e4e506b4f6662a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->