### PR TITLE
ci: Check that root package is bumped for release pull requests

### DIFF
--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -40,11 +40,16 @@ runs:
       run: |
         set -euo pipefail
 
-        mapfile -t PACKAGES < <(yarn workspaces list --json --no-private | jq --raw-output '.location' | xargs -I{} cat '{}/package.json')
+        mapfile -t PACKAGES < <(yarn workspaces list --json --no-private | jq --raw-output '.location + "/package.json"')
         ANY_PACKAGE_BUMPED=false
 
         for package in "${PACKAGES[@]}"; do
-          CURRENT_VERSION=$(git show "$MERGE_BASE:$package" 2>/dev/null | jq -r .version || echo "")
+          if ! PACKAGE_JSON_AT_BASE=$(git show "$MERGE_BASE:$package" 2>/dev/null); then
+            # Package didn't exist at the merge base; it's newly added, not a
+            # version bump.
+            continue
+          fi
+          CURRENT_VERSION=$(echo "$PACKAGE_JSON_AT_BASE" | jq -r .version)
           NEW_VERSION=$(jq -r .version "$package")
 
           if [ "$NEW_VERSION" != "$CURRENT_VERSION" ]; then

--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -40,7 +40,7 @@ runs:
       run: |
         set -euo pipefail
 
-        mapfile -t PACKAGES < <(find packages -maxdepth 2 -name "package.json" -not -path "*/node_modules/*")
+        mapfile -t PACKAGES < <(yarn workspaces list --json --no-private | jq --raw-output '.location' | xargs -I{} cat '{}/package.json')
         HAS_VERSION_BUMP=false
 
         for package in "${PACKAGES[@]}"; do

--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -33,6 +33,41 @@ runs:
         MERGE_BASE=$(git merge-base HEAD "refs/remotes/origin/$BASE_REF")
         echo "MERGE_BASE=$MERGE_BASE" >> "$GITHUB_OUTPUT"
 
+    - name: Check that root package.json is bumped for release PRs
+      shell: bash
+      env:
+        MERGE_BASE: ${{ steps.merge-base.outputs.MERGE_BASE }}
+      run: |
+        set -euo pipefail
+
+        mapfile -t PACKAGES < <(find packages -maxdepth 2 -name "package.json" -not -path "*/node_modules/*")
+        HAS_VERSION_BUMP=false
+
+        for package in "${PACKAGES[@]}"; do
+          MAIN_VERSION=$(git show "$MERGE_BASE:$package" 2>/dev/null | jq -r .version || echo "")
+          HEAD_VERSION=$(jq -r .version "$package")
+
+          if [ "$HEAD_VERSION" != "$MAIN_VERSION" ]; then
+            HAS_VERSION_BUMP=true
+            package_name=$(jq -r ".name" "$package")
+            echo "📦 Package \`$package_name\` has a version bump (\`$MAIN_VERSION\` -> \`$HEAD_VERSION\`)"
+          fi
+        done
+
+        if [ "$HAS_VERSION_BUMP" = "true" ]; then
+          ROOT_MAIN_VERSION=$(git show "$MERGE_BASE:package.json" | jq -r .version)
+          ROOT_HEAD_VERSION=$(jq -r .version package.json)
+
+          if [ "$ROOT_MAIN_VERSION" = "$ROOT_HEAD_VERSION" ]; then
+            echo "::error::This pull request is a release (one or more packages have a version bump), but the root package.json version was not bumped. Please bump the root package.json version."
+            exit 1
+          else
+            echo "✅ Root package.json is bumped (\`$ROOT_MAIN_VERSION\` -> \`$ROOT_HEAD_VERSION\`)"
+          fi
+        else
+          echo "✅ No package version bumps detected; skipping root package.json check."
+        fi
+
     - name: Check if the commit or pull request is a release
       id: is-release
       uses: MetaMask/action-is-release@v2

--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -41,28 +41,28 @@ runs:
         set -euo pipefail
 
         mapfile -t PACKAGES < <(yarn workspaces list --json --no-private | jq --raw-output '.location' | xargs -I{} cat '{}/package.json')
-        HAS_VERSION_BUMP=false
+        ANY_PACKAGE_BUMPED=false
 
         for package in "${PACKAGES[@]}"; do
-          MAIN_VERSION=$(git show "$MERGE_BASE:$package" 2>/dev/null | jq -r .version || echo "")
-          HEAD_VERSION=$(jq -r .version "$package")
+          CURRENT_VERSION=$(git show "$MERGE_BASE:$package" 2>/dev/null | jq -r .version || echo "")
+          NEW_VERSION=$(jq -r .version "$package")
 
-          if [ "$HEAD_VERSION" != "$MAIN_VERSION" ]; then
-            HAS_VERSION_BUMP=true
+          if [ "$NEW_VERSION" != "$CURRENT_VERSION" ]; then
+            ANY_PACKAGE_BUMPED=true
             package_name=$(jq -r ".name" "$package")
-            echo "📦 Package \`$package_name\` has a version bump (\`$MAIN_VERSION\` -> \`$HEAD_VERSION\`)"
+            echo "📦 Package \`$package_name\` has a version bump (\`$CURRENT_VERSION\` -> \`$NEW_VERSION\`)"
           fi
         done
 
-        if [ "$HAS_VERSION_BUMP" = "true" ]; then
-          ROOT_MAIN_VERSION=$(git show "$MERGE_BASE:package.json" | jq -r .version)
-          ROOT_HEAD_VERSION=$(jq -r .version package.json)
+        if [ "$ANY_PACKAGE_BUMPED" = "true" ]; then
+          CURRENT_ROOT_VERSION=$(git show "$MERGE_BASE:package.json" | jq -r .version)
+          NEW_ROOT_VERSION=$(jq -r .version package.json)
 
-          if [ "$ROOT_MAIN_VERSION" = "$ROOT_HEAD_VERSION" ]; then
+          if [ "$NEW_ROOT_VERSION" = "$CURRENT_ROOT_VERSION" ]; then
             echo "::error::This pull request is a release (one or more packages have a version bump), but the root package.json version was not bumped. Please bump the root package.json version."
             exit 1
           else
-            echo "✅ Root package.json is bumped (\`$ROOT_MAIN_VERSION\` -> \`$ROOT_HEAD_VERSION\`)"
+            echo "✅ Root package.json is bumped (\`$CURRENT_ROOT_VERSION\` -> \`$NEW_ROOT_VERSION\`)"
           fi
         else
           echo "✅ No package version bumps detected; skipping root package.json check."


### PR DESCRIPTION
## Explanation

This adds a check to the `check-release` action that validates that if any package.json version is changed, the root package.json version must be changed as well.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a non-runtime GitHub Actions guard on version fields only; no application code or deployment behavior changes.
> 
> **Overview**
> Adds a **new CI step** to the `check-release` composite action that enforces monorepo release hygiene: if **any** non-private workspace `package.json` version changes vs the PR merge base, the **root** `package.json` version must change too.
> 
> The step walks `yarn workspaces list` (excluding private workspaces), compares each package’s version at `MERGE_BASE` to HEAD (skipping packages that did not exist at the base), and **fails the job** with a GitHub Actions error when a workspace bump is detected but the root version is unchanged. If no workspace versions changed, it logs success and skips the root check.
> 
> This runs **before** the existing `action-is-release` / release-conflict logic, so the root bump rule applies whenever workspace versions move, not only when the PR is classified as a release by title/commit rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94ae2d32a50a3adba1cc0af619d24056eada0232. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->