### PR TITLE
feat(transaction-controller): support saved gas fee levels

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING:** Expand saved gas fee support to allow transaction-scoped lookup, saved gas fee estimate levels, and legacy gas price values. Consumers that provide `getSavedGasFees` must now accept `TransactionMeta` instead of a chain ID. ([#8993](https://github.com/MetaMask/core/pull/8993))
 - Bump `@metamask/messenger` from `^1.2.0` to `^2.0.0` ([#9392](https://github.com/MetaMask/core/pull/9392))
 
 ### Fixed
@@ -97,8 +98,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - **BREAKING:** Remove incoming transaction support from `TransactionController` ([#9012](https://github.com/MetaMask/core/pull/9012))
-  - Removed constructor option `incomingTransactions`.
-  - Removed public methods `startIncomingTransactionPolling`, `stopIncomingTransactionPolling`, `updateIncomingTransactions`.
+  - The constructor option `incomingTransactions` is ignored for backwards compatibility.
+  - Removed public method `updateIncomingTransactions`; `startIncomingTransactionPolling` and `stopIncomingTransactionPolling` are retained as no-ops for backwards compatibility.
   - Removed event `TransactionController:incomingTransactionsReceived`.
   - Removed exported constant `INCOMING_TRANSACTIONS_SUPPORTED_CHAIN_IDS`.
   - Removed exported types `TransactionControllerIncomingTransactionsReceivedEvent`, `TransactionControllerStartIncomingTransactionPollingAction`, `TransactionControllerStopIncomingTransactionPollingAction`, `TransactionControllerUpdateIncomingTransactionsAction`, `TransactionResponse`, `GetAccountTransactionsRequest`, `GetAccountTransactionsResponse`.

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -98,8 +98,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - **BREAKING:** Remove incoming transaction support from `TransactionController` ([#9012](https://github.com/MetaMask/core/pull/9012))
-  - The constructor option `incomingTransactions` is ignored for backwards compatibility.
-  - Removed public method `updateIncomingTransactions`; `startIncomingTransactionPolling` and `stopIncomingTransactionPolling` are retained as no-ops for backwards compatibility.
+  - Removed constructor option `incomingTransactions`.
+  - Removed public methods `startIncomingTransactionPolling`, `stopIncomingTransactionPolling`, `updateIncomingTransactions`.
   - Removed event `TransactionController:incomingTransactionsReceived`.
   - Removed exported constant `INCOMING_TRANSACTIONS_SUPPORTED_CHAIN_IDS`.
   - Removed exported types `TransactionControllerIncomingTransactionsReceivedEvent`, `TransactionControllerStartIncomingTransactionPollingAction`, `TransactionControllerStopIncomingTransactionPollingAction`, `TransactionControllerUpdateIncomingTransactionsAction`, `TransactionResponse`, `GetAccountTransactionsRequest`, `GetAccountTransactionsResponse`.

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING:** Expand saved gas fee support to allow transaction-scoped lookup, saved gas fee estimate levels, and legacy gas price values. Consumers that provide `getSavedGasFees` must now accept `TransactionMeta` instead of a chain ID. ([#8993](https://github.com/MetaMask/core/pull/8993))
+
 ## [68.4.0]
 
 ### Added
@@ -23,7 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Expand saved gas fee support to allow transaction-scoped lookup, saved gas fee estimate levels, and legacy gas price values. Consumers that provide `getSavedGasFees` must now accept `TransactionMeta` instead of a chain ID. ([#8993](https://github.com/MetaMask/core/pull/8993))
 - Bump `@metamask/messenger` from `^1.2.0` to `^2.0.0` ([#9392](https://github.com/MetaMask/core/pull/9392))
 
 ### Fixed

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -8189,6 +8189,28 @@ describe('TransactionController', () => {
         }
       `);
     });
+
+    it('accepts ignored incoming transaction compatibility options', () => {
+      expect(() =>
+        setupController({
+          options: {
+            incomingTransactions: {
+              client: 'extension-test',
+              includeTokenTransfers: false,
+              isEnabled: () => false,
+              updateTransactions: true,
+            },
+          },
+        }),
+      ).not.toThrow();
+    });
+
+    it('keeps incoming transaction polling compatibility methods as no-ops', () => {
+      const { controller } = setupController();
+
+      expect(() => controller.startIncomingTransactionPolling()).not.toThrow();
+      expect(() => controller.stopIncomingTransactionPolling()).not.toThrow();
+    });
   });
 
   describe('messenger actions', () => {

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -3,6 +3,7 @@ import type { TypedTxData } from '@ethereumjs/tx';
 import type {
   AccountsControllerGetSelectedAccountAction,
   AccountsControllerGetStateAction,
+  AccountsControllerSelectedAccountChangeEvent,
 } from '@metamask/accounts-controller';
 import type {
   AcceptResultCallbacks,
@@ -21,7 +22,11 @@ import {
   convertHexToDecimal,
 } from '@metamask/controller-utils';
 import type { TraceCallback, TraceContext } from '@metamask/controller-utils';
-import type { AccountActivityServiceTransactionUpdatedEvent } from '@metamask/core-backend';
+import type {
+  AccountActivityServiceStatusChangedEvent,
+  AccountActivityServiceTransactionUpdatedEvent,
+  BackendWebSocketServiceConnectionStateChangedEvent,
+} from '@metamask/core-backend';
 import type {
   FetchGasFeeEstimateOptions,
   GasFeeControllerFetchGasFeeEstimatesAction,
@@ -313,6 +318,18 @@ export type TransactionControllerActions =
   | TransactionControllerGetStateAction
   | TransactionControllerMethodActions;
 
+/**
+ * @deprecated Incoming transaction support has been removed. These options are ignored.
+ */
+export type IncomingTransactionCompatibilityOptions = {
+  client?: string;
+  includeTokenTransfers?: boolean;
+  isEnabled?: () => boolean;
+  updateTransactions?: boolean;
+  /** @deprecated Ignored as incoming transaction support has been removed. */
+  etherscanApiKeysByChainId?: Record<Hex, string>;
+};
+
 /** TransactionController constructor options. */
 export type TransactionControllerOptions = {
   /** Whether to disable additional processing on swaps transactions. */
@@ -322,12 +339,19 @@ export type TransactionControllerOptions = {
   getPermittedAccounts?: (origin?: string) => Promise<string[]>;
 
   /** Gets the saved gas fee config. */
-  getSavedGasFees?: (chainId: Hex) => SavedGasFees | undefined;
+  getSavedGasFees?: (
+    transactionMeta: TransactionMeta,
+  ) => SavedGasFees | undefined;
 
   /**
    * Gets the transaction simulation configuration.
    */
   getSimulationConfig?: GetSimulationConfig;
+
+  /**
+   * @deprecated Incoming transaction support has been removed. This option is ignored.
+   */
+  incomingTransactions?: IncomingTransactionCompatibilityOptions;
 
   /**
    * Callback to determine whether gas fee updates should be enabled for a given transaction.
@@ -422,7 +446,10 @@ export type AllowedActions =
  * The external events available to the {@link TransactionController}.
  */
 export type AllowedEvents =
+  | AccountActivityServiceStatusChangedEvent
   | AccountActivityServiceTransactionUpdatedEvent
+  | AccountsControllerSelectedAccountChangeEvent
+  | BackendWebSocketServiceConnectionStateChangedEvent
   | NetworkControllerStateChangeEvent;
 
 /**
@@ -700,7 +727,9 @@ export class TransactionController extends BaseController<
 
   readonly #getPermittedAccounts?: (origin?: string) => Promise<string[]>;
 
-  readonly #getSavedGasFees: (chainId: Hex) => SavedGasFees | undefined;
+  readonly #getSavedGasFees: (
+    transactionMeta: TransactionMeta,
+  ) => SavedGasFees | undefined;
 
   readonly #getSimulationConfig: GetSimulationConfig;
 
@@ -794,7 +823,8 @@ export class TransactionController extends BaseController<
       ((): ReturnType<BeforeSignHook> => Promise.resolve({}));
     this.#getPermittedAccounts = getPermittedAccounts;
     this.#getSavedGasFees =
-      getSavedGasFees ?? ((_chainId): SavedGasFees | undefined => undefined);
+      getSavedGasFees ??
+      ((_transactionMeta): SavedGasFees | undefined => undefined);
     this.#getSimulationConfig =
       getSimulationConfig ??
       ((): ReturnType<GetSimulationConfig> => Promise.resolve({}));
@@ -926,6 +956,20 @@ export class TransactionController extends BaseController<
    */
   destroy(): void {
     this.#stopAllTracking();
+  }
+
+  /**
+   * @deprecated Incoming transaction support has been removed. This method is retained as a no-op for backwards compatibility.
+   */
+  startIncomingTransactionPolling(): void {
+    noop();
+  }
+
+  /**
+   * @deprecated Incoming transaction support has been removed. This method is retained as a no-op for backwards compatibility.
+   */
+  stopIncomingTransactionPolling(): void {
+    noop();
   }
 
   /**

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -1257,13 +1257,15 @@ export type DappSuggestedGasFees = {
 };
 
 /**
- * Gas values saved by the user for a specific chain.
+ * Gas values saved by the user for a specific chain and account.
  */
 // Convert to a `type` in a future major version.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export interface SavedGasFees {
-  maxBaseFee: string;
-  priorityFee: string;
+  level?: UserFeeLevel | GasFeeEstimateLevel;
+  maxBaseFee?: string;
+  priorityFee?: string;
+  gasPrice?: string;
 }
 
 /**

--- a/packages/transaction-controller/src/utils/gas-fees.test.ts
+++ b/packages/transaction-controller/src/utils/gas-fees.test.ts
@@ -299,6 +299,24 @@ describe('gas-fees', () => {
       );
     });
 
+    it('sets userFeeLevel to custom if saved gas fees include both a level and a custom override', async () => {
+      updateGasFeeRequest.txMeta.type = TransactionType.simpleSend;
+      updateGasFeeRequest.getSavedGasFees.mockReturnValueOnce({
+        level: GasFeeEstimateLevel.High,
+        maxBaseFee: '123',
+      });
+      mockGasFeeFlowMockResponse(FLOW_RESPONSE_FEE_MARKET_MOCK);
+
+      await updateGasFees(updateGasFeeRequest);
+
+      expect(updateGasFeeRequest.txMeta.txParams.maxFeePerGas).toBe(
+        '0x1ca35f0e00', // 123 gwei
+      );
+      expect(updateGasFeeRequest.txMeta.userFeeLevel).toBe(
+        UserFeeLevel.CUSTOM,
+      );
+    });
+
     it('uses saved gasPrice if saved gas fees include a legacy custom value', async () => {
       updateGasFeeRequest.eip1559 = false;
       updateGasFeeRequest.txMeta.type = TransactionType.simpleSend;

--- a/packages/transaction-controller/src/utils/gas-fees.test.ts
+++ b/packages/transaction-controller/src/utils/gas-fees.test.ts
@@ -315,6 +315,34 @@ describe('gas-fees', () => {
       expect(updateGasFeeRequest.txMeta.userFeeLevel).toBe(UserFeeLevel.CUSTOM);
     });
 
+    it('sets userFeeLevel to custom if saved gas fees include a level but flow returns a flat gas price estimate', async () => {
+      updateGasFeeRequest.txMeta.type = TransactionType.simpleSend;
+      updateGasFeeRequest.getSavedGasFees.mockReturnValueOnce({
+        level: GasFeeEstimateLevel.High,
+      });
+      mockGasFeeFlowMockResponse(FLOW_RESPONSE_GAS_PRICE_MOCK);
+
+      await updateGasFees(updateGasFeeRequest);
+
+      expect(updateGasFeeRequest.txMeta.userFeeLevel).toBe(UserFeeLevel.CUSTOM);
+    });
+
+    it('sets userFeeLevel to custom if saved gas fees include a level but getGasFeeEstimates throws', async () => {
+      updateGasFeeRequest.txMeta.type = TransactionType.simpleSend;
+      updateGasFeeRequest.getSavedGasFees.mockReturnValueOnce({
+        level: GasFeeEstimateLevel.High,
+      });
+      updateGasFeeRequest.getGasFeeEstimates.mockReset();
+      updateGasFeeRequest.getGasFeeEstimates.mockRejectedValueOnce(
+        new Error('TestError'),
+      );
+      rpcRequestMock.mockResolvedValueOnce(GAS_HEX_MOCK);
+
+      await updateGasFees(updateGasFeeRequest);
+
+      expect(updateGasFeeRequest.txMeta.userFeeLevel).toBe(UserFeeLevel.CUSTOM);
+    });
+
     it('uses saved gasPrice if saved gas fees include a legacy custom value', async () => {
       updateGasFeeRequest.eip1559 = false;
       updateGasFeeRequest.txMeta.type = TransactionType.simpleSend;

--- a/packages/transaction-controller/src/utils/gas-fees.test.ts
+++ b/packages/transaction-controller/src/utils/gas-fees.test.ts
@@ -312,9 +312,7 @@ describe('gas-fees', () => {
       expect(updateGasFeeRequest.txMeta.txParams.maxFeePerGas).toBe(
         '0x1ca35f0e00', // 123 gwei
       );
-      expect(updateGasFeeRequest.txMeta.userFeeLevel).toBe(
-        UserFeeLevel.CUSTOM,
-      );
+      expect(updateGasFeeRequest.txMeta.userFeeLevel).toBe(UserFeeLevel.CUSTOM);
     });
 
     it('uses saved gasPrice if saved gas fees include a legacy custom value', async () => {

--- a/packages/transaction-controller/src/utils/gas-fees.test.ts
+++ b/packages/transaction-controller/src/utils/gas-fees.test.ts
@@ -2,7 +2,12 @@ import type { NetworkClientId } from '@metamask/network-controller';
 
 import type { TransactionControllerMessenger } from '../TransactionController';
 import type { GasFeeFlow, GasFeeFlowResponse } from '../types';
-import { GasFeeEstimateType, TransactionType, UserFeeLevel } from '../types';
+import {
+  GasFeeEstimateLevel,
+  GasFeeEstimateType,
+  TransactionType,
+  UserFeeLevel,
+} from '../types';
 import type { UpdateGasFeesRequest } from './gas-fees';
 import { gweiDecimalToWeiDecimal, updateGasFees } from './gas-fees';
 import { rpcRequest } from './provider';
@@ -15,8 +20,12 @@ jest.mock('./provider', () => ({
 console.error = jest.fn();
 
 const GAS_MOCK = 123;
+const GAS_LOW_MOCK = 111;
+const GAS_HIGH_MOCK = 789;
 const GAS_HEX_MOCK = toHex(GAS_MOCK);
 const GAS_HEX_WEI_MOCK = toHex(GAS_MOCK * 1e9);
+const GAS_LOW_HEX_WEI_MOCK = toHex(GAS_LOW_MOCK * 1e9);
+const GAS_HIGH_HEX_WEI_MOCK = toHex(GAS_HIGH_MOCK * 1e9);
 const ORIGIN_MOCK = 'test.com';
 const MESSENGER_MOCK = {} as unknown as TransactionControllerMessenger;
 const NETWORK_CLIENT_ID_MOCK = 'testNetworkClientId' as NetworkClientId;
@@ -35,9 +44,17 @@ const UPDATE_GAS_FEES_REQUEST_MOCK = {
 const FLOW_RESPONSE_FEE_MARKET_MOCK = {
   estimates: {
     type: GasFeeEstimateType.FeeMarket,
+    low: {
+      maxFeePerGas: GAS_LOW_HEX_WEI_MOCK,
+      maxPriorityFeePerGas: GAS_LOW_HEX_WEI_MOCK,
+    },
     medium: {
       maxFeePerGas: GAS_HEX_WEI_MOCK,
       maxPriorityFeePerGas: GAS_HEX_WEI_MOCK,
+    },
+    high: {
+      maxFeePerGas: GAS_HIGH_HEX_WEI_MOCK,
+      maxPriorityFeePerGas: GAS_HIGH_HEX_WEI_MOCK,
     },
   },
 } as GasFeeFlowResponse;
@@ -45,7 +62,9 @@ const FLOW_RESPONSE_FEE_MARKET_MOCK = {
 const FLOW_RESPONSE_LEGACY_MOCK = {
   estimates: {
     type: GasFeeEstimateType.Legacy,
+    low: GAS_LOW_HEX_WEI_MOCK,
     medium: GAS_HEX_WEI_MOCK,
+    high: GAS_HIGH_HEX_WEI_MOCK,
   },
 } as GasFeeFlowResponse;
 
@@ -220,6 +239,78 @@ describe('gas-fees', () => {
       await updateGasFees(updateGasFeeRequest);
 
       expect(updateGasFeeRequest.getGasFeeEstimates).not.toHaveBeenCalled();
+    });
+
+    it('calls getSavedGasFees with the transaction metadata', async () => {
+      updateGasFeeRequest.txMeta.type = TransactionType.simpleSend;
+
+      await updateGasFees(updateGasFeeRequest);
+
+      expect(updateGasFeeRequest.getSavedGasFees).toHaveBeenCalledWith(
+        updateGasFeeRequest.txMeta,
+      );
+    });
+
+    it('does not call getSavedGasFees if initial gas fee params are provided', async () => {
+      updateGasFeeRequest.txMeta.type = TransactionType.simpleSend;
+      updateGasFeeRequest.txMeta.txParams.maxFeePerGas = GAS_HEX_MOCK;
+      updateGasFeeRequest.txMeta.txParams.maxPriorityFeePerGas = GAS_HEX_MOCK;
+
+      await updateGasFees(updateGasFeeRequest);
+
+      expect(updateGasFeeRequest.getSavedGasFees).not.toHaveBeenCalled();
+    });
+
+    it('uses saved fee market estimate level if saved gas fees include a level', async () => {
+      updateGasFeeRequest.txMeta.type = TransactionType.simpleSend;
+      updateGasFeeRequest.getSavedGasFees.mockReturnValueOnce({
+        level: GasFeeEstimateLevel.High,
+      });
+      mockGasFeeFlowMockResponse(FLOW_RESPONSE_FEE_MARKET_MOCK);
+
+      await updateGasFees(updateGasFeeRequest);
+
+      expect(updateGasFeeRequest.txMeta.txParams.maxFeePerGas).toBe(
+        GAS_HIGH_HEX_WEI_MOCK,
+      );
+      expect(updateGasFeeRequest.txMeta.txParams.maxPriorityFeePerGas).toBe(
+        GAS_HIGH_HEX_WEI_MOCK,
+      );
+      expect(updateGasFeeRequest.txMeta.userFeeLevel).toBe(
+        GasFeeEstimateLevel.High,
+      );
+    });
+
+    it('uses saved legacy estimate level if saved gas fees include a level', async () => {
+      updateGasFeeRequest.eip1559 = false;
+      updateGasFeeRequest.txMeta.type = TransactionType.simpleSend;
+      updateGasFeeRequest.getSavedGasFees.mockReturnValueOnce({
+        level: GasFeeEstimateLevel.Low,
+      });
+      mockGasFeeFlowMockResponse(FLOW_RESPONSE_LEGACY_MOCK);
+
+      await updateGasFees(updateGasFeeRequest);
+
+      expect(updateGasFeeRequest.txMeta.txParams.gasPrice).toBe(
+        GAS_LOW_HEX_WEI_MOCK,
+      );
+      expect(updateGasFeeRequest.txMeta.userFeeLevel).toBe(
+        GasFeeEstimateLevel.Low,
+      );
+    });
+
+    it('uses saved gasPrice if saved gas fees include a legacy custom value', async () => {
+      updateGasFeeRequest.eip1559 = false;
+      updateGasFeeRequest.txMeta.type = TransactionType.simpleSend;
+      updateGasFeeRequest.getSavedGasFees.mockReturnValueOnce({
+        level: UserFeeLevel.CUSTOM,
+        gasPrice: '10',
+      });
+
+      await updateGasFees(updateGasFeeRequest);
+
+      expect(updateGasFeeRequest.txMeta.txParams.gasPrice).toBe('0x2540be400');
+      expect(updateGasFeeRequest.txMeta.userFeeLevel).toBe(UserFeeLevel.CUSTOM);
     });
 
     describe('sets maxFeePerGas', () => {

--- a/packages/transaction-controller/src/utils/gas-fees.ts
+++ b/packages/transaction-controller/src/utils/gas-fees.ts
@@ -14,7 +14,11 @@ import type {
   TransactionMeta,
   GasFeeFlow,
 } from '../types';
-import { GasFeeEstimateType, UserFeeLevel } from '../types';
+import {
+  GasFeeEstimateLevel,
+  GasFeeEstimateType,
+  UserFeeLevel,
+} from '../types';
 import { getGasFeeFlow } from './gas-flow';
 import { rpcRequest } from './provider';
 
@@ -24,7 +28,9 @@ export type UpdateGasFeesRequest = {
   getGasFeeEstimates: (
     options: FetchGasFeeEstimateOptions,
   ) => Promise<GasFeeState>;
-  getSavedGasFees: (chainId: Hex) => SavedGasFees | undefined;
+  getSavedGasFees: (
+    transactionMeta: TransactionMeta,
+  ) => SavedGasFees | undefined;
   messenger: TransactionControllerMessenger;
   txMeta: TransactionMeta;
 };
@@ -58,11 +64,15 @@ export async function updateGasFees(
   // transactions (e.g. swaps and bridges) have their fees dictated by the
   // aggregator or relay, so applying saved gas fees could underprice them and
   // cause them to fail or get stuck.
-  const savedGasFees = txMeta.isInternal
-    ? undefined
-    : request.getSavedGasFees(txMeta.chainId);
+  const savedGasFees =
+    txMeta.isInternal || hasInitialGasFeeParams(initialParams)
+      ? undefined
+      : request.getSavedGasFees(txMeta);
 
-  const suggestedGasFees = await getSuggestedGasFees(request);
+  const suggestedGasFees = await getSuggestedGasFees({
+    ...request,
+    savedGasFees,
+  });
 
   log('Suggested gas fees', suggestedGasFees);
 
@@ -139,7 +149,7 @@ function getMaxFeePerGas(request: GetGasFeeRequest): string | undefined {
     return undefined;
   }
 
-  if (savedGasFees) {
+  if (savedGasFees?.maxBaseFee) {
     const maxFeePerGas = gweiDecimalToWeiHex(savedGasFees.maxBaseFee);
     log('Using maxFeePerGas from savedGasFees', maxFeePerGas);
     return maxFeePerGas;
@@ -191,7 +201,7 @@ function getMaxPriorityFeePerGas(
     return undefined;
   }
 
-  if (savedGasFees) {
+  if (savedGasFees?.priorityFee) {
     const maxPriorityFeePerGas = gweiDecimalToWeiHex(savedGasFees.priorityFee);
     log(
       'Using maxPriorityFeePerGas from savedGasFees.priorityFee',
@@ -243,10 +253,16 @@ function getMaxPriorityFeePerGas(
  * @returns The gasPrice value.
  */
 function getGasPrice(request: GetGasFeeRequest): string | undefined {
-  const { eip1559, initialParams, suggestedGasFees } = request;
+  const { eip1559, initialParams, savedGasFees, suggestedGasFees } = request;
 
   if (eip1559) {
     return undefined;
+  }
+
+  if (savedGasFees?.gasPrice) {
+    const gasPrice = gweiDecimalToWeiHex(savedGasFees.gasPrice);
+    log('Using gasPrice from savedGasFees.gasPrice', gasPrice);
+    return gasPrice;
   }
 
   if (initialParams.gasPrice) {
@@ -274,11 +290,11 @@ function getGasPrice(request: GetGasFeeRequest): string | undefined {
  * @param request - The request object.
  * @returns The user fee level.
  */
-function getUserFeeLevel(request: GetGasFeeRequest): UserFeeLevel | undefined {
+function getUserFeeLevel(request: GetGasFeeRequest): string | undefined {
   const { initialParams, savedGasFees, suggestedGasFees, txMeta } = request;
 
   if (savedGasFees) {
-    return UserFeeLevel.CUSTOM;
+    return savedGasFees.level ?? UserFeeLevel.CUSTOM;
   }
 
   if (
@@ -338,10 +354,16 @@ function updateDefaultGasEstimates(txMeta: TransactionMeta): void {
  * @returns The suggested gas fees.
  */
 async function getSuggestedGasFees(
-  request: UpdateGasFeesRequest,
+  request: UpdateGasFeesRequest & { savedGasFees?: SavedGasFees },
 ): Promise<SuggestedGasFees> {
-  const { eip1559, gasFeeFlows, getGasFeeEstimates, messenger, txMeta } =
-    request;
+  const {
+    eip1559,
+    gasFeeFlows,
+    getGasFeeEstimates,
+    messenger,
+    savedGasFees,
+    txMeta,
+  } = request;
   const { networkClientId } = txMeta;
 
   if (
@@ -369,13 +391,19 @@ async function getSuggestedGasFees(
     });
 
     const gasFeeEstimateType = response.estimates?.type;
+    const savedGasFeeEstimateLevel = getSavedGasFeeEstimateLevel(savedGasFees);
 
     switch (gasFeeEstimateType) {
       case GasFeeEstimateType.FeeMarket:
-        return response.estimates.medium;
+        return (
+          response.estimates[savedGasFeeEstimateLevel] ??
+          response.estimates.medium
+        );
       case GasFeeEstimateType.Legacy:
         return {
-          gasPrice: response.estimates.medium,
+          gasPrice:
+            response.estimates[savedGasFeeEstimateLevel] ??
+            response.estimates.medium,
         };
       case GasFeeEstimateType.GasPrice:
         return { gasPrice: response.estimates.gasPrice };
@@ -399,4 +427,26 @@ async function getSuggestedGasFees(
   const gasPrice = gasPriceHex ? add0x(gasPriceHex) : undefined;
 
   return { gasPrice };
+}
+
+function hasInitialGasFeeParams(initialParams: TransactionParams): boolean {
+  return [
+    initialParams.maxFeePerGas,
+    initialParams.maxPriorityFeePerGas,
+    initialParams.gasPrice,
+  ].some(Boolean);
+}
+
+function getSavedGasFeeEstimateLevel(
+  savedGasFees: SavedGasFees | undefined,
+): GasFeeEstimateLevel {
+  return isGasFeeEstimateLevel(savedGasFees?.level)
+    ? savedGasFees.level
+    : GasFeeEstimateLevel.Medium;
+}
+
+function isGasFeeEstimateLevel(level: unknown): level is GasFeeEstimateLevel {
+  return Object.values(GasFeeEstimateLevel).includes(
+    level as GasFeeEstimateLevel,
+  );
 }

--- a/packages/transaction-controller/src/utils/gas-fees.ts
+++ b/packages/transaction-controller/src/utils/gas-fees.ts
@@ -294,7 +294,17 @@ function getUserFeeLevel(request: GetGasFeeRequest): string | undefined {
   const { initialParams, savedGasFees, suggestedGasFees, txMeta } = request;
 
   if (savedGasFees) {
-    return savedGasFees.level ?? UserFeeLevel.CUSTOM;
+    const hasCustomOverride =
+      savedGasFees.maxBaseFee !== undefined ||
+      savedGasFees.priorityFee !== undefined ||
+      savedGasFees.gasPrice !== undefined;
+
+    // A custom override on any field means the fee is no longer purely
+    // level-derived, so it must not be tracked as a live estimate level by
+    // the gas fee poller, which would otherwise overwrite the override.
+    return hasCustomOverride
+      ? UserFeeLevel.CUSTOM
+      : (savedGasFees.level ?? UserFeeLevel.CUSTOM);
   }
 
   if (

--- a/packages/transaction-controller/src/utils/gas-fees.ts
+++ b/packages/transaction-controller/src/utils/gas-fees.ts
@@ -45,6 +45,14 @@ type SuggestedGasFees = {
   maxFeePerGas?: string;
   maxPriorityFeePerGas?: string;
   gasPrice?: string;
+
+  /**
+   * Whether the suggested fee was derived from a specific estimate level,
+   * such as `low`/`medium`/`high`. This is `false` for estimate types that
+   * do not support per-level pricing, such as a flat `eth_gasPrice` value,
+   * or when the gas fee flow failed and a raw RPC fallback was used.
+   */
+  isEstimateLevelApplied?: boolean;
 };
 
 const log = createModuleLogger(projectLogger, 'gas-fees');
@@ -299,12 +307,17 @@ function getUserFeeLevel(request: GetGasFeeRequest): string | undefined {
       savedGasFees.priorityFee !== undefined ||
       savedGasFees.gasPrice !== undefined;
 
-    // A custom override on any field means the fee is no longer purely
-    // level-derived, so it must not be tracked as a live estimate level by
-    // the gas fee poller, which would otherwise overwrite the override.
-    return hasCustomOverride
-      ? UserFeeLevel.CUSTOM
-      : (savedGasFees.level ?? UserFeeLevel.CUSTOM);
+    const canUseSavedLevel =
+      !hasCustomOverride &&
+      savedGasFees.level !== undefined &&
+      suggestedGasFees.isEstimateLevelApplied;
+
+    // A custom override on any field, or an estimate type that does not
+    // support per-level pricing (e.g. a flat eth_gasPrice value), means the
+    // fee is no longer purely level-derived, so it must not be tracked as a
+    // live estimate level by the gas fee poller, which would otherwise
+    // overwrite the override or misrepresent the fee as matching the level.
+    return canUseSavedLevel ? savedGasFees.level : UserFeeLevel.CUSTOM;
   }
 
   if (
@@ -405,18 +418,23 @@ async function getSuggestedGasFees(
 
     switch (gasFeeEstimateType) {
       case GasFeeEstimateType.FeeMarket:
-        return (
-          response.estimates[savedGasFeeEstimateLevel] ??
-          response.estimates.medium
-        );
+        return {
+          ...(response.estimates[savedGasFeeEstimateLevel] ??
+            response.estimates.medium),
+          isEstimateLevelApplied: true,
+        };
       case GasFeeEstimateType.Legacy:
         return {
           gasPrice:
             response.estimates[savedGasFeeEstimateLevel] ??
             response.estimates.medium,
+          isEstimateLevelApplied: true,
         };
       case GasFeeEstimateType.GasPrice:
-        return { gasPrice: response.estimates.gasPrice };
+        return {
+          gasPrice: response.estimates.gasPrice,
+          isEstimateLevelApplied: false,
+        };
       default:
         throw new Error(
           // TODO: Either fix this lint violation or explain why it's necessary to ignore.


### PR DESCRIPTION
## Explanation

This expands transaction-controller saved gas fee handling so clients can resolve saved preferences with full transaction metadata instead of only a chain ID. That lets consumers key saved gas settings by both chain and account while keeping the controller API responsible for applying saved fees.

The saved gas payload now supports gas fee estimate levels (`low`, `medium`, `high`) and legacy custom `gasPrice` values in addition to EIP-1559 custom fee values. Saved estimate levels reuse the current gas fee flow estimate for the saved level; custom values override only the specific saved fields.

Transactions that already include gas fee params continue to use those initial params, so dapp-proposed fees keep precedence over saved preferences. Swap transaction types continue to skip saved gas fees.

## References

Related PRs:
- https://github.com/MetaMask/metamask-extension/pull/43317
- https://github.com/MetaMask/metamask-mobile/pull/31649

## Checklist

- [x] I’ve updated the test suite for new or updated code as appropriate
- [x] I’ve updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I’ve communicated my changes to consumers by updating changelogs for packages I’ve changed
- [x] I’ve introduced breaking changes in this PR and have prepared client adoption work to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking callback signature and changed gas-fee precedence logic can misprice dApp txs or break extension/mobile until consumers update; changes are confined to gas fee application paths with substantial test coverage.
> 
> **Overview**
> **Breaking change:** `getSavedGasFees` now receives full `TransactionMeta` instead of chain ID so clients can key saved preferences by chain and account. The `SavedGasFees` shape adds optional estimate `level`, legacy `gasPrice`, and makes EIP-1559 fields optional.
> 
> Gas fee application in `updateGasFees` now skips saved lookup when the tx already has initial gas params (dapp fees win), still skips internal txs, and can pick **low/medium/high** from the current gas fee flow when only a level is saved. Custom `maxBaseFee` / `priorityFee` / `gasPrice` override specific fields; `userFeeLevel` stays on the saved level only when pricing is truly level-derived (otherwise `custom`).
> 
> Deprecated **incoming transaction** constructor options and restored **no-op** `startIncomingTransactionPolling` / `stopIncomingTransactionPolling` for backward compatibility, with tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a173b00763d8d82780e2b057a6d0c3f99bd66f7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

