### PR TITLE
feat(passkey): reveal SRP and private keys with passkey verification

### DIFF
--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** `exportSeedPhrase` and `exportAccount` now take `VerificationCredentials` (`{ password }` | `{ encryptionKey }`) instead of a bare password string ([#8996](https://github.com/MetaMask/core/pull/8996))
+- **BREAKING:** `exportSeedPhrase` and `exportAccount` now take `Credentials` (`{ password }` | `{ encryptionKey, encryptionSalt? }`) instead of a bare password string ([#8996](https://github.com/MetaMask/core/pull/8996))
 
 ### Fixed
 

--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Allow `exportSeedPhrase` to accept `{ encryptionKey }` credentials ([#8996](https://github.com/MetaMask/core/pull/8996))
+
 ### Fixed
 
 - Automatically remove and destroy non-primary keyrings whose last account is removed during a `withKeyring` or `withKeyringV2` callback ([#8951](https://github.com/MetaMask/core/pull/8951))

--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
+### Changed
 
-- Allow `exportSeedPhrase` to accept `{ encryptionKey }` credentials ([#8996](https://github.com/MetaMask/core/pull/8996))
+- **BREAKING:** `exportSeedPhrase` and `exportAccount` now take `VerificationCredentials` (`{ password }` | `{ encryptionKey }`) instead of a bare password string ([#8996](https://github.com/MetaMask/core/pull/8996))
 
 ### Fixed
 

--- a/packages/keyring-controller/src/KeyringController-method-action-types.ts
+++ b/packages/keyring-controller/src/KeyringController-method-action-types.ts
@@ -82,9 +82,6 @@ export type KeyringControllerIsUnlockedAction = {
 /**
  * Gets the seed phrase of the HD keyring.
  *
- * The keyring can be re-authenticated with the wallet `{ password }` or with
- * the vault `{ encryptionKey }`.
- *
  * @param credentials - Object holding either the `password` or the vault
  * `encryptionKey`.
  * @param keyringId - The id of the keyring.

--- a/packages/keyring-controller/src/KeyringController-method-action-types.ts
+++ b/packages/keyring-controller/src/KeyringController-method-action-types.ts
@@ -82,6 +82,10 @@ export type KeyringControllerIsUnlockedAction = {
 /**
  * Gets the seed phrase of the HD keyring.
  *
+ * The keyring can be re-authenticated with the wallet password (passed either
+ * as a bare string or as `{ password }`) or with the vault `{ encryptionKey }`.
+ * The bare-string form is kept for backwards compatibility.
+ *
  * @param credentials - The wallet password, or an object holding either the
  * `password` or the vault `encryptionKey`.
  * @param keyringId - The id of the keyring.

--- a/packages/keyring-controller/src/KeyringController-method-action-types.ts
+++ b/packages/keyring-controller/src/KeyringController-method-action-types.ts
@@ -82,7 +82,8 @@ export type KeyringControllerIsUnlockedAction = {
 /**
  * Gets the seed phrase of the HD keyring.
  *
- * @param password - Password of the keyring.
+ * @param credentials - The wallet password, or an object holding either the
+ * `password` or the vault `encryptionKey`.
  * @param keyringId - The id of the keyring.
  * @returns Promise resolving to the seed phrase.
  */

--- a/packages/keyring-controller/src/KeyringController-method-action-types.ts
+++ b/packages/keyring-controller/src/KeyringController-method-action-types.ts
@@ -82,12 +82,11 @@ export type KeyringControllerIsUnlockedAction = {
 /**
  * Gets the seed phrase of the HD keyring.
  *
- * The keyring can be re-authenticated with the wallet password (passed either
- * as a bare string or as `{ password }`) or with the vault `{ encryptionKey }`.
- * The bare-string form is kept for backwards compatibility.
+ * The keyring can be re-authenticated with the wallet `{ password }` or with
+ * the vault `{ encryptionKey }`.
  *
- * @param credentials - The wallet password, or an object holding either the
- * `password` or the vault `encryptionKey`.
+ * @param credentials - Object holding either the `password` or the vault
+ * `encryptionKey`.
  * @param keyringId - The id of the keyring.
  * @returns Promise resolving to the seed phrase.
  */
@@ -99,7 +98,8 @@ export type KeyringControllerExportSeedPhraseAction = {
 /**
  * Gets the private key from the keyring controlling an address.
  *
- * @param password - Password of the keyring.
+ * @param credentials - Object holding either the `password` or the vault
+ * `encryptionKey`.
  * @param address - Address to export.
  * @returns Promise resolving to the private key for an address.
  */

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -605,7 +605,7 @@ describe('KeyringController', () => {
           { type: 'HD Key Tree' },
           async ({ keyring }) => keyring.serialize(),
         );
-        const currentSeedWord = await controller.exportSeedPhrase(password);
+        const currentSeedWord = await controller.exportSeedPhrase({ password });
 
         await controller.createNewVaultAndRestore(password, currentSeedWord);
 
@@ -680,7 +680,7 @@ describe('KeyringController', () => {
             await controller.createNewVaultAndKeychain(password);
 
             const currentSeedPhrase =
-              await controller.exportSeedPhrase(password);
+              await controller.exportSeedPhrase({ password });
 
             expect(currentSeedPhrase.length).toBeGreaterThan(0);
             expect(
@@ -794,13 +794,13 @@ describe('KeyringController', () => {
     describe('when there is an existing vault', () => {
       it('should not create a new vault or keychain', async () => {
         await withController(async ({ controller, initialState }) => {
-          const initialSeedWord = await controller.exportSeedPhrase(password);
+          const initialSeedWord = await controller.exportSeedPhrase({ password });
           expect(initialSeedWord).toBeDefined();
           const initialVault = controller.state.vault;
 
           await controller.createNewVaultAndKeychain(password);
 
-          const currentSeedWord = await controller.exportSeedPhrase(password);
+          const currentSeedWord = await controller.exportSeedPhrase({ password });
           expect(initialState).toStrictEqual(controller.state);
           expect(initialSeedWord).toBe(currentSeedWord);
           expect(initialVault).toStrictEqual(controller.state.vault);
@@ -867,7 +867,7 @@ describe('KeyringController', () => {
 
           primaryKeyring.mnemonic = '';
 
-          await expect(controller.exportSeedPhrase(password)).rejects.toThrow(
+          await expect(controller.exportSeedPhrase({ password })).rejects.toThrow(
             "Can't get mnemonic bytes from keyring",
           );
         });
@@ -878,7 +878,7 @@ describe('KeyringController', () => {
       describe('when correct password is provided', () => {
         it('should export seed phrase without keyringId', async () => {
           await withController(async ({ controller }) => {
-            const seed = await controller.exportSeedPhrase(password);
+            const seed = await controller.exportSeedPhrase({ password });
             expect(seed).not.toBe('');
           });
         });
@@ -886,7 +886,7 @@ describe('KeyringController', () => {
         it('should export seed phrase with valid keyringId', async () => {
           await withController(async ({ controller, initialState }) => {
             const keyringId = initialState.keyrings[0].metadata.id;
-            const seed = await controller.exportSeedPhrase(password, keyringId);
+            const seed = await controller.exportSeedPhrase({ password }, keyringId);
             expect(seed).not.toBe('');
           });
         });
@@ -901,7 +901,7 @@ describe('KeyringController', () => {
         it('should throw error if keyringId is invalid', async () => {
           await withController(async ({ controller }) => {
             await expect(
-              controller.exportSeedPhrase(password, 'invalid-id'),
+              controller.exportSeedPhrase({ password }, 'invalid-id'),
             ).rejects.toThrow('Keyring not found');
           });
         });
@@ -913,7 +913,7 @@ describe('KeyringController', () => {
             jest
               .spyOn(encryptor, 'decrypt')
               .mockRejectedValueOnce(new Error('Invalid password'));
-            await expect(controller.exportSeedPhrase('')).rejects.toThrow(
+            await expect(controller.exportSeedPhrase({ password: '' })).rejects.toThrow(
               'Invalid password',
             );
           });
@@ -927,7 +927,7 @@ describe('KeyringController', () => {
                 .spyOn(encryptor, 'decrypt')
                 .mockRejectedValueOnce(new Error('Invalid password'));
               await expect(
-                controller.exportSeedPhrase('', keyringId),
+                controller.exportSeedPhrase({ password: '' }, keyringId),
               ).rejects.toThrow('Invalid password');
             },
           );
@@ -975,7 +975,7 @@ describe('KeyringController', () => {
       await withController(async ({ controller }) => {
         await controller.setLocked();
 
-        await expect(controller.exportSeedPhrase(password)).rejects.toThrow(
+        await expect(controller.exportSeedPhrase({ password })).rejects.toThrow(
           KeyringControllerErrorMessage.ControllerLocked,
         );
       });
@@ -990,7 +990,7 @@ describe('KeyringController', () => {
             await withController(async ({ controller, initialState }) => {
               const account = initialState.keyrings[0].accounts[0];
               const newPrivateKey = await controller.exportAccount(
-                password,
+                { password },
                 account,
               );
               expect(newPrivateKey).not.toBe('');
@@ -1002,7 +1002,7 @@ describe('KeyringController', () => {
           it('should throw error', async () => {
             await withController(async ({ controller }) => {
               await expect(
-                controller.exportAccount(password, ''),
+                controller.exportAccount({ password }, ''),
               ).rejects.toThrow(KeyringControllerErrorMessage.KeyringNotFound);
             });
           });
@@ -1011,17 +1011,59 @@ describe('KeyringController', () => {
 
       describe('when wrong password is provided', () => {
         it('should throw error', async () => {
-          await withController(async ({ controller, encryptor }) => {
+          await withController(async ({ controller, initialState, encryptor }) => {
+            const account = initialState.keyrings[0].accounts[0];
             jest
               .spyOn(encryptor, 'decrypt')
               .mockRejectedValueOnce(new Error('Invalid password'));
-            await expect(controller.exportSeedPhrase('')).rejects.toThrow(
-              'Invalid password',
+            await expect(
+              controller.exportAccount({ password: '' }, account),
+            ).rejects.toThrow('Invalid password');
+          });
+        });
+      });
+
+      describe('when correct encryption key is provided', () => {
+        it('should export account with an encryption key credential', async () => {
+          await withController(async ({ controller, initialState }) => {
+            const account = initialState.keyrings[0].accounts[0];
+            const encryptionKey = await controller.exportEncryptionKey();
+            const newPrivateKey = await controller.exportAccount(
+              { encryptionKey },
+              account,
             );
+            expect(newPrivateKey).not.toBe('');
+          });
+        });
+      });
+
+      describe('when wrong encryption key is provided', () => {
+        it('should throw the decryption error', async () => {
+          await withController(async ({ controller, initialState, encryptor }) => {
+            const account = initialState.keyrings[0].accounts[0];
+            const encryptionKey = await controller.exportEncryptionKey();
+            jest
+              .spyOn(encryptor, 'decryptWithKey')
+              .mockRejectedValueOnce(new Error('Invalid key'));
+            await expect(
+              controller.exportAccount({ encryptionKey }, account),
+            ).rejects.toThrow('Invalid key');
           });
         });
       });
     });
+
+    it('should throw error when the controller is locked', async () => {
+      await withController(async ({ controller, initialState }) => {
+        const account = initialState.keyrings[0].accounts[0];
+        await controller.setLocked();
+
+        await expect(
+          controller.exportAccount({ password }, account),
+        ).rejects.toThrow(KeyringControllerErrorMessage.ControllerLocked);
+      });
+    });
+
     describe('when the keyring for the given address does not support exportAccount', () => {
       it('should throw error', async () => {
         const address = '0x5AC6D462f054690a373FABF8CC28e161003aEB19';
@@ -1032,7 +1074,7 @@ describe('KeyringController', () => {
             await controller.addNewKeyring(MockKeyring.type);
 
             await expect(
-              controller.exportAccount(password, address),
+              controller.exportAccount({ password }, address),
             ).rejects.toThrow(
               KeyringControllerErrorMessage.UnsupportedExportAccount,
             );
@@ -5767,7 +5809,7 @@ describe('KeyringController', () => {
 
             expect(controller.state).toStrictEqual(initialState);
             await expect(
-              controller.exportAccount(password, mockAddress),
+              controller.exportAccount({ password }, mockAddress),
             ).rejects.toThrow(KeyringControllerErrorMessage.KeyringNotFound);
           },
         );

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -3706,44 +3706,6 @@ describe('KeyringController', () => {
     });
   });
 
-  describe('verifyEncryptionKey', () => {
-    describe('when correct encryption key is provided', () => {
-      it('should not throw any error', async () => {
-        await withController(async ({ controller }) => {
-          const encryptionKey = await controller.exportEncryptionKey();
-          expect(
-            await controller.verifyEncryptionKey(encryptionKey),
-          ).toBeUndefined();
-        });
-      });
-
-      it('should throw error if vault is missing', async () => {
-        await withController(
-          { skipVaultCreation: true },
-          async ({ controller }) => {
-            await expect(
-              controller.verifyEncryptionKey('encryption-key'),
-            ).rejects.toThrow(KeyringControllerErrorMessage.VaultError);
-          },
-        );
-      });
-    });
-
-    describe('when wrong encryption key is provided', () => {
-      it('should throw the decryption error', async () => {
-        await withController(async ({ controller, encryptor }) => {
-          const encryptionKey = await controller.exportEncryptionKey();
-          jest
-            .spyOn(encryptor, 'decryptWithKey')
-            .mockRejectedValueOnce(new Error('Decryption failed'));
-          await expect(
-            controller.verifyEncryptionKey(encryptionKey),
-          ).rejects.toThrow('Decryption failed');
-        });
-      });
-    });
-  });
-
   describe('withKeyring', () => {
     it('should rollback if an error is thrown', async () => {
       await withController(async ({ controller, initialState }) => {

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -679,8 +679,9 @@ describe('KeyringController', () => {
           async ({ controller }) => {
             await controller.createNewVaultAndKeychain(password);
 
-            const currentSeedPhrase =
-              await controller.exportSeedPhrase({ password });
+            const currentSeedPhrase = await controller.exportSeedPhrase({
+              password,
+            });
 
             expect(currentSeedPhrase.length).toBeGreaterThan(0);
             expect(
@@ -794,13 +795,17 @@ describe('KeyringController', () => {
     describe('when there is an existing vault', () => {
       it('should not create a new vault or keychain', async () => {
         await withController(async ({ controller, initialState }) => {
-          const initialSeedWord = await controller.exportSeedPhrase({ password });
+          const initialSeedWord = await controller.exportSeedPhrase({
+            password,
+          });
           expect(initialSeedWord).toBeDefined();
           const initialVault = controller.state.vault;
 
           await controller.createNewVaultAndKeychain(password);
 
-          const currentSeedWord = await controller.exportSeedPhrase({ password });
+          const currentSeedWord = await controller.exportSeedPhrase({
+            password,
+          });
           expect(initialState).toStrictEqual(controller.state);
           expect(initialSeedWord).toBe(currentSeedWord);
           expect(initialVault).toStrictEqual(controller.state.vault);
@@ -867,9 +872,9 @@ describe('KeyringController', () => {
 
           primaryKeyring.mnemonic = '';
 
-          await expect(controller.exportSeedPhrase({ password })).rejects.toThrow(
-            "Can't get mnemonic bytes from keyring",
-          );
+          await expect(
+            controller.exportSeedPhrase({ password }),
+          ).rejects.toThrow("Can't get mnemonic bytes from keyring");
         });
       });
     });
@@ -886,7 +891,10 @@ describe('KeyringController', () => {
         it('should export seed phrase with valid keyringId', async () => {
           await withController(async ({ controller, initialState }) => {
             const keyringId = initialState.keyrings[0].metadata.id;
-            const seed = await controller.exportSeedPhrase({ password }, keyringId);
+            const seed = await controller.exportSeedPhrase(
+              { password },
+              keyringId,
+            );
             expect(seed).not.toBe('');
           });
         });
@@ -906,9 +914,9 @@ describe('KeyringController', () => {
             jest
               .spyOn(encryptor, 'decrypt')
               .mockRejectedValueOnce(new Error('Invalid password'));
-            await expect(controller.exportSeedPhrase({ password: '' })).rejects.toThrow(
-              'Invalid password',
-            );
+            await expect(
+              controller.exportSeedPhrase({ password: '' }),
+            ).rejects.toThrow('Invalid password');
           });
         });
 
@@ -1004,15 +1012,17 @@ describe('KeyringController', () => {
 
       describe('when wrong password is provided', () => {
         it('should throw error', async () => {
-          await withController(async ({ controller, initialState, encryptor }) => {
-            const account = initialState.keyrings[0].accounts[0];
-            jest
-              .spyOn(encryptor, 'decrypt')
-              .mockRejectedValueOnce(new Error('Invalid password'));
-            await expect(
-              controller.exportAccount({ password: '' }, account),
-            ).rejects.toThrow('Invalid password');
-          });
+          await withController(
+            async ({ controller, initialState, encryptor }) => {
+              const account = initialState.keyrings[0].accounts[0];
+              jest
+                .spyOn(encryptor, 'decrypt')
+                .mockRejectedValueOnce(new Error('Invalid password'));
+              await expect(
+                controller.exportAccount({ password: '' }, account),
+              ).rejects.toThrow('Invalid password');
+            },
+          );
         });
       });
 
@@ -1032,16 +1042,18 @@ describe('KeyringController', () => {
 
       describe('when wrong encryption key is provided', () => {
         it('should throw the decryption error', async () => {
-          await withController(async ({ controller, initialState, encryptor }) => {
-            const account = initialState.keyrings[0].accounts[0];
-            const encryptionKey = await controller.exportEncryptionKey();
-            jest
-              .spyOn(encryptor, 'decryptWithKey')
-              .mockRejectedValueOnce(new Error('Invalid key'));
-            await expect(
-              controller.exportAccount({ encryptionKey }, account),
-            ).rejects.toThrow('Invalid key');
-          });
+          await withController(
+            async ({ controller, initialState, encryptor }) => {
+              const account = initialState.keyrings[0].accounts[0];
+              const encryptionKey = await controller.exportEncryptionKey();
+              jest
+                .spyOn(encryptor, 'decryptWithKey')
+                .mockRejectedValueOnce(new Error('Invalid key'));
+              await expect(
+                controller.exportAccount({ encryptionKey }, account),
+              ).rejects.toThrow('Invalid key');
+            },
+          );
         });
       });
     });

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -891,6 +891,13 @@ describe('KeyringController', () => {
           });
         });
 
+        it('should export seed phrase with a password credential object', async () => {
+          await withController(async ({ controller }) => {
+            const seed = await controller.exportSeedPhrase({ password });
+            expect(seed).not.toBe('');
+          });
+        });
+
         it('should throw error if keyringId is invalid', async () => {
           await withController(async ({ controller }) => {
             await expect(
@@ -924,6 +931,42 @@ describe('KeyringController', () => {
               ).rejects.toThrow('Invalid password');
             },
           );
+        });
+      });
+
+      describe('when correct encryption key is provided', () => {
+        it('should export seed phrase with an encryption key credential', async () => {
+          await withController(async ({ controller }) => {
+            const encryptionKey = await controller.exportEncryptionKey();
+            const seed = await controller.exportSeedPhrase({ encryptionKey });
+            expect(seed).not.toBe('');
+          });
+        });
+
+        it('should export seed phrase with an encryption key and a valid keyringId', async () => {
+          await withController(async ({ controller, initialState }) => {
+            const keyringId = initialState.keyrings[0].metadata.id;
+            const encryptionKey = await controller.exportEncryptionKey();
+            const seed = await controller.exportSeedPhrase(
+              { encryptionKey },
+              keyringId,
+            );
+            expect(seed).not.toBe('');
+          });
+        });
+      });
+
+      describe('when wrong encryption key is provided', () => {
+        it('should throw the decryption error', async () => {
+          await withController(async ({ controller, encryptor }) => {
+            const encryptionKey = await controller.exportEncryptionKey();
+            jest
+              .spyOn(encryptor, 'decryptWithKey')
+              .mockRejectedValueOnce(new Error('Invalid key'));
+            await expect(
+              controller.exportSeedPhrase({ encryptionKey }),
+            ).rejects.toThrow('Invalid key');
+          });
         });
       });
     });
@@ -3612,6 +3655,44 @@ describe('KeyringController', () => {
             );
           },
         );
+      });
+    });
+  });
+
+  describe('verifyEncryptionKey', () => {
+    describe('when correct encryption key is provided', () => {
+      it('should not throw any error', async () => {
+        await withController(async ({ controller }) => {
+          const encryptionKey = await controller.exportEncryptionKey();
+          expect(
+            await controller.verifyEncryptionKey(encryptionKey),
+          ).toBeUndefined();
+        });
+      });
+
+      it('should throw error if vault is missing', async () => {
+        await withController(
+          { skipVaultCreation: true },
+          async ({ controller }) => {
+            await expect(
+              controller.verifyEncryptionKey('encryption-key'),
+            ).rejects.toThrow(KeyringControllerErrorMessage.VaultError);
+          },
+        );
+      });
+    });
+
+    describe('when wrong encryption key is provided', () => {
+      it('should throw the decryption error', async () => {
+        await withController(async ({ controller, encryptor }) => {
+          const encryptionKey = await controller.exportEncryptionKey();
+          jest
+            .spyOn(encryptor, 'decryptWithKey')
+            .mockRejectedValueOnce(new Error('Decryption failed'));
+          await expect(
+            controller.verifyEncryptionKey(encryptionKey),
+          ).rejects.toThrow('Decryption failed');
+        });
       });
     });
   });

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -955,6 +955,31 @@ describe('KeyringController', () => {
             expect(seed).not.toBe('');
           });
         });
+
+        it('should export seed phrase with an encryption key and matching encryptionSalt', async () => {
+          await withController(async ({ controller, initialState }) => {
+            const encryptionKey = await controller.exportEncryptionKey();
+            const seed = await controller.exportSeedPhrase({
+              encryptionKey,
+              encryptionSalt: initialState.encryptionSalt,
+            });
+            expect(seed).not.toBe('');
+          });
+        });
+      });
+
+      describe('when encryptionSalt does not match the vault', () => {
+        it('should throw error', async () => {
+          await withController(async ({ controller }) => {
+            const encryptionKey = await controller.exportEncryptionKey();
+            await expect(
+              controller.exportSeedPhrase({
+                encryptionKey,
+                encryptionSalt: '0x1234',
+              }),
+            ).rejects.toThrow(KeyringControllerErrorMessage.ExpiredCredentials);
+          });
+        });
       });
 
       describe('when wrong encryption key is provided', () => {

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -891,13 +891,6 @@ describe('KeyringController', () => {
           });
         });
 
-        it('should export seed phrase with a password credential object', async () => {
-          await withController(async ({ controller }) => {
-            const seed = await controller.exportSeedPhrase({ password });
-            expect(seed).not.toBe('');
-          });
-        });
-
         it('should throw error if keyringId is invalid', async () => {
           await withController(async ({ controller }) => {
             await expect(

--- a/packages/keyring-controller/src/KeyringController.test.ts
+++ b/packages/keyring-controller/src/KeyringController.test.ts
@@ -970,6 +970,26 @@ describe('KeyringController', () => {
           });
         });
       });
+
+      describe('when vault is missing', () => {
+        it('should throw error', async () => {
+          await withController(
+            {
+              skipVaultCreation: true,
+              state: {
+                isUnlocked: true,
+              } as KeyringControllerState,
+            },
+            async ({ controller }) => {
+              await expect(
+                controller.exportSeedPhrase({
+                  encryptionKey: 'encryption-key',
+                }),
+              ).rejects.toThrow(KeyringControllerErrorMessage.VaultError);
+            },
+          );
+        });
+      });
     });
 
     it('should throw error when the controller is locked', async () => {

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -1051,16 +1051,30 @@ export class KeyringController<
    * encryption key is invalid, i.e. it cannot decrypt the vault.
    *
    * @param encryptionKey - Serialized vault encryption key.
+   * @param encryptionSalt - Optional salt to verify against the vault. When
+   * omitted, the salt serialized alongside the vault is used.
    */
-  async #verifyEncryptionKey(encryptionKey: string): Promise<void> {
+  async #verifyEncryptionKey(
+    encryptionKey: string,
+    encryptionSalt?: string,
+  ): Promise<void> {
     if (!this.state.vault) {
       throw new KeyringControllerError(
         KeyringControllerErrorMessage.VaultError,
       );
     }
 
+    const parsedEncryptedVault = JSON.parse(this.state.vault);
+    const salt = encryptionSalt ?? parsedEncryptedVault.salt;
+
+    if (parsedEncryptedVault.salt !== salt) {
+      throw new KeyringControllerError(
+        KeyringControllerErrorMessage.ExpiredCredentials,
+      );
+    }
+
     const key = await this.#encryptor.importKey(encryptionKey);
-    await this.#encryptor.decryptWithKey(key, JSON.parse(this.state.vault));
+    await this.#encryptor.decryptWithKey(key, parsedEncryptedVault);
   }
 
   /**
@@ -1075,7 +1089,10 @@ export class KeyringController<
     if ('password' in credentials) {
       await this.verifyPassword(credentials.password);
     } else {
-      await this.#verifyEncryptionKey(credentials.encryptionKey);
+      await this.#verifyEncryptionKey(
+        credentials.encryptionKey,
+        credentials.encryptionSalt,
+      );
     }
   }
 
@@ -2712,16 +2729,7 @@ export class KeyringController<
    * @param credentials - The credentials to unlock the keyrings.
    * @returns A promise resolving to the deserialized keyrings array.
    */
-  async #unlockKeyrings(
-    credentials:
-      | {
-          password: string;
-        }
-      | {
-          encryptionKey: string;
-          encryptionSalt?: string;
-        },
-  ): Promise<{
+  async #unlockKeyrings(credentials: Credentials): Promise<{
     keyrings: { keyring: EthKeyring; metadata: KeyringMetadata }[];
     hasChanged: boolean;
   }> {

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -1046,6 +1046,23 @@ export class KeyringController<
   }
 
   /**
+   * Method to verify a given encryption key validity. Throws an error if the
+   * encryption key is invalid, i.e. it cannot decrypt the vault.
+   *
+   * @param encryptionKey - Serialized vault encryption key.
+   */
+  async verifyEncryptionKey(encryptionKey: string): Promise<void> {
+    if (!this.state.vault) {
+      throw new KeyringControllerError(
+        KeyringControllerErrorMessage.VaultError,
+      );
+    }
+
+    const key = await this.#encryptor.importKey(encryptionKey);
+    await this.#encryptor.decryptWithKey(key, JSON.parse(this.state.vault));
+  }
+
+  /**
    * Returns the status of the vault.
    *
    * @returns Boolean returning true if the vault is unlocked.
@@ -1057,16 +1074,34 @@ export class KeyringController<
   /**
    * Gets the seed phrase of the HD keyring.
    *
-   * @param password - Password of the keyring.
+   * The keyring can be re-authenticated with the wallet password (passed either
+   * as a bare string or as `{ password }`) or with the vault `{ encryptionKey }`.
+   * The bare-string form is kept for backwards compatibility.
+   *
+   * @param credentials - The wallet password, or an object holding either the
+   * `password` or the vault `encryptionKey`.
    * @param keyringId - The id of the keyring.
    * @returns Promise resolving to the seed phrase.
    */
   async exportSeedPhrase(
-    password: string,
+    credentials: string | { password: string } | { encryptionKey: string },
     keyringId?: string,
   ): Promise<Uint8Array> {
     this.#assertIsUnlocked();
-    await this.verifyPassword(password);
+
+    if (typeof credentials === 'string') {
+      await this.verifyPassword(credentials);
+    } else {
+      const { encryptionKey } = credentials as { encryptionKey?: string };
+      if (typeof encryptionKey === 'string') {
+        await this.verifyEncryptionKey(encryptionKey);
+      } else {
+        await this.verifyPassword(
+          (credentials as { password: string }).password,
+        );
+      }
+    }
+
     const selectedKeyring = this.#getKeyringByIdOrDefault(keyringId);
     if (!selectedKeyring) {
       throw new KeyringControllerError('Keyring not found');

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -48,6 +48,7 @@ import { KeyringControllerError } from './errors';
 import type { KeyringControllerMethodActions } from './KeyringController-method-action-types';
 import type {
   Eip7702AuthorizationParams,
+  VerificationCredentials,
   PersonalMessageParams,
   TypedMessageParams,
 } from './types';
@@ -1063,6 +1064,21 @@ export class KeyringController<
   }
 
   /**
+   * Verifies export credentials by checking either the wallet password or the
+   * vault encryption key.
+   *
+   * @param credentials - Object holding either the `password` or the vault
+   * `encryptionKey`.
+   */
+  async #verifyCredentials(credentials: VerificationCredentials): Promise<void> {
+    if ('password' in credentials) {
+      await this.verifyPassword(credentials.password);
+    } else {
+      await this.verifyEncryptionKey(credentials.encryptionKey);
+    }
+  }
+
+  /**
    * Returns the status of the vault.
    *
    * @returns Boolean returning true if the vault is unlocked.
@@ -1074,28 +1090,21 @@ export class KeyringController<
   /**
    * Gets the seed phrase of the HD keyring.
    *
-   * The keyring can be re-authenticated with the wallet password (passed either
-   * as a bare string or as `{ password }`) or with the vault `{ encryptionKey }`.
-   * The bare-string form is kept for backwards compatibility.
+   * The keyring can be re-authenticated with the wallet `{ password }` or with
+   * the vault `{ encryptionKey }`.
    *
-   * @param credentials - The wallet password, or an object holding either the
-   * `password` or the vault `encryptionKey`.
+   * @param credentials - Object holding either the `password` or the vault
+   * `encryptionKey`.
    * @param keyringId - The id of the keyring.
    * @returns Promise resolving to the seed phrase.
    */
   async exportSeedPhrase(
-    credentials: string | { password: string } | { encryptionKey: string },
+    credentials: VerificationCredentials,
     keyringId?: string,
   ): Promise<Uint8Array> {
     this.#assertIsUnlocked();
 
-    if (typeof credentials === 'string') {
-      await this.verifyPassword(credentials);
-    } else if (hasProperty(credentials, 'password')) {
-      await this.verifyPassword(credentials.password as string);
-    } else {
-      await this.verifyEncryptionKey(credentials.encryptionKey);
-    }
+    await this.#verifyCredentials(credentials);
 
     const selectedKeyring = this.#getKeyringByIdOrDefault(keyringId);
     if (!selectedKeyring) {
@@ -1109,12 +1118,21 @@ export class KeyringController<
   /**
    * Gets the private key from the keyring controlling an address.
    *
-   * @param password - Password of the keyring.
+   * The keyring can be re-authenticated with the wallet `{ password }` or with
+   * the vault `{ encryptionKey }`.
+   *
+   * @param credentials - Object holding either the `password` or the vault
+   * `encryptionKey`.
    * @param address - Address to export.
    * @returns Promise resolving to the private key for an address.
    */
-  async exportAccount(password: string, address: string): Promise<string> {
-    await this.verifyPassword(password);
+  async exportAccount(
+    credentials: VerificationCredentials,
+    address: string,
+  ): Promise<string> {
+    this.#assertIsUnlocked();
+
+    await this.#verifyCredentials(credentials);
 
     const keyring = (await this.getKeyringForAccount(address)) as EthKeyring;
     if (!keyring.exportAccount) {

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -1073,6 +1073,7 @@ export class KeyringController<
   async #verifyCredentials(
     credentials: VerificationCredentials,
   ): Promise<void> {
+    // eslint-disable-next-line no-restricted-syntax
     if ('password' in credentials) {
       await this.verifyPassword(credentials.password);
     } else {

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -48,7 +48,7 @@ import { KeyringControllerError } from './errors';
 import type { KeyringControllerMethodActions } from './KeyringController-method-action-types';
 import type {
   Eip7702AuthorizationParams,
-  VerificationCredentials,
+  Credentials,
   PersonalMessageParams,
   TypedMessageParams,
 } from './types';
@@ -1052,7 +1052,7 @@ export class KeyringController<
    *
    * @param encryptionKey - Serialized vault encryption key.
    */
-  async verifyEncryptionKey(encryptionKey: string): Promise<void> {
+  async #verifyEncryptionKey(encryptionKey: string): Promise<void> {
     if (!this.state.vault) {
       throw new KeyringControllerError(
         KeyringControllerErrorMessage.VaultError,
@@ -1070,14 +1070,12 @@ export class KeyringController<
    * @param credentials - Object holding either the `password` or the vault
    * `encryptionKey`.
    */
-  async #verifyCredentials(
-    credentials: VerificationCredentials,
-  ): Promise<void> {
+  async #verifyCredentials(credentials: Credentials): Promise<void> {
     // eslint-disable-next-line no-restricted-syntax
     if ('password' in credentials) {
       await this.verifyPassword(credentials.password);
     } else {
-      await this.verifyEncryptionKey(credentials.encryptionKey);
+      await this.#verifyEncryptionKey(credentials.encryptionKey);
     }
   }
 
@@ -1099,7 +1097,7 @@ export class KeyringController<
    * @returns Promise resolving to the seed phrase.
    */
   async exportSeedPhrase(
-    credentials: VerificationCredentials,
+    credentials: Credentials,
     keyringId?: string,
   ): Promise<Uint8Array> {
     this.#assertIsUnlocked();
@@ -1124,7 +1122,7 @@ export class KeyringController<
    * @returns Promise resolving to the private key for an address.
    */
   async exportAccount(
-    credentials: VerificationCredentials,
+    credentials: Credentials,
     address: string,
   ): Promise<string> {
     this.#assertIsUnlocked();

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -1070,7 +1070,9 @@ export class KeyringController<
    * @param credentials - Object holding either the `password` or the vault
    * `encryptionKey`.
    */
-  async #verifyCredentials(credentials: VerificationCredentials): Promise<void> {
+  async #verifyCredentials(
+    credentials: VerificationCredentials,
+  ): Promise<void> {
     if ('password' in credentials) {
       await this.verifyPassword(credentials.password);
     } else {

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -1090,9 +1090,6 @@ export class KeyringController<
   /**
    * Gets the seed phrase of the HD keyring.
    *
-   * The keyring can be re-authenticated with the wallet `{ password }` or with
-   * the vault `{ encryptionKey }`.
-   *
    * @param credentials - Object holding either the `password` or the vault
    * `encryptionKey`.
    * @param keyringId - The id of the keyring.
@@ -1117,9 +1114,6 @@ export class KeyringController<
 
   /**
    * Gets the private key from the keyring controlling an address.
-   *
-   * The keyring can be re-authenticated with the wallet `{ password }` or with
-   * the vault `{ encryptionKey }`.
    *
    * @param credentials - Object holding either the `password` or the vault
    * `encryptionKey`.

--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -1091,15 +1091,10 @@ export class KeyringController<
 
     if (typeof credentials === 'string') {
       await this.verifyPassword(credentials);
+    } else if (hasProperty(credentials, 'password')) {
+      await this.verifyPassword(credentials.password as string);
     } else {
-      const { encryptionKey } = credentials as { encryptionKey?: string };
-      if (typeof encryptionKey === 'string') {
-        await this.verifyEncryptionKey(encryptionKey);
-      } else {
-        await this.verifyPassword(
-          (credentials as { password: string }).password,
-        );
-      }
+      await this.verifyEncryptionKey(credentials.encryptionKey);
     }
 
     const selectedKeyring = this.#getKeyringByIdOrDefault(keyringId);

--- a/packages/keyring-controller/src/types.ts
+++ b/packages/keyring-controller/src/types.ts
@@ -77,6 +77,4 @@ export type TypedMessageParams = {
  * Credentials for re-authenticating the keyring during sensitive operations
  * such as `exportSeedPhrase` and `exportAccount`.
  */
-export type VerificationCredentials =
-  | { password: string }
-  | { encryptionKey: string };
+export type Credentials = { password: string } | { encryptionKey: string };

--- a/packages/keyring-controller/src/types.ts
+++ b/packages/keyring-controller/src/types.ts
@@ -72,3 +72,11 @@ export type SignTypedDataMessageV3V4 = {
 export type TypedMessageParams = {
   data: Record<string, unknown>[] | string | SignTypedDataMessageV3V4;
 } & AbstractMessageParams;
+
+/**
+ * Credentials for re-authenticating the keyring during sensitive operations
+ * such as `exportSeedPhrase` and `exportAccount`.
+ */
+export type VerificationCredentials =
+  | { password: string }
+  | { encryptionKey: string };

--- a/packages/keyring-controller/src/types.ts
+++ b/packages/keyring-controller/src/types.ts
@@ -77,4 +77,6 @@ export type TypedMessageParams = {
  * Credentials for re-authenticating the keyring during sensitive operations
  * such as `exportSeedPhrase` and `exportAccount`.
  */
-export type Credentials = { password: string } | { encryptionKey: string };
+export type Credentials =
+  | { password: string }
+  | { encryptionKey: string; encryptionSalt?: string };


### PR DESCRIPTION
## **Description**

Passkey-enrolled wallets currently require the wallet password to reveal sensitive key material (Secret Recovery Phrase and account private keys), even when the user has already unlocked MetaMask with a passkey. That creates friction and inconsistency with other passkey-gated flows (e.g. change password).

This PR adds password-less reveal paths for non–social-login wallets with an enrolled passkey:

- **SRP reveal:** `revealSeedWordsWithPasskey` verifies the WebAuthn assertion, retrieves the passkey-wrapped vault key via `retrieveVaultKeyWithPasskey`, and calls `keyringController.exportSeedPhrase({ encryptionKey: vaultKey })`.
- **Private key reveal:** `exportAccountsWithPasskey` uses the same vault-key retrieval, then calls `keyringController.exportAccount({ encryptionKey: vaultKey }, address)` for each address in a multichain account group. The multichain private key list UI uses passkey verification as the initial credential step, with password fallback.
- **Shared component:** Extracts reusable `PasskeyVerification` (and `runPasskeyVerificationCeremony`) from change-password, reducing duplicated WebAuthn ceremony logic across settings and reveal flows.
- **Metrics:** Adds `SrpRevealWithPasskey` MetaMetrics events (started / completed / failed).

In both flows, the passkey assertion is not only a step-up UI gate — the passkey-derived vault key must successfully decrypt the vault via the keyring controller export APIs, cryptographically binding the passkey to this vault.

**Not supported:**
- Social-login (seedless) wallets — still password-only.
- Side panel when the enrolled passkey is incompatible with WebAuthn in the side panel — falls back to password (no full-tab handoff).

**Dependency:** Requires the breaking `@metamask/keyring-controller` change that accepts `VerificationCredentials` (`{ password }` | `{ encryptionKey }`) on `exportSeedPhrase` and `exportAccount` (mm-core PR for TO-737).

## **Changelog**

CHANGELOG entry: Added the ability to reveal your Secret Recovery Phrase and account private keys using passkey verification instead of your wallet password.

## **Related issues**

Fixes: TO-737

## **Manual testing steps**

### SRP reveal
1. Set up a wallet with passkey enrolled (non–social-login).
2. Go to **Settings → Security & Privacy → Reveal Secret Recovery Phrase**.
3. Complete the SRP quiz (if shown).
4. Confirm the passkey verification step appears instead of the password prompt.
5. Complete the passkey ceremony and verify the SRP is revealed.
6. Click **Use password** and confirm the password flow still works.
7. Cancel or fail the passkey ceremony and confirm fallback to the password prompt.

### Private key reveal (multichain account group)
8. Open the multichain account group private key reveal flow.
9. Confirm passkey verification is offered when passkey is active.
10. Complete the passkey ceremony and verify private keys are shown for exportable addresses.
11. Confirm password fallback works on failure or when choosing **Use password**.

### General
12. Repeat in the side panel with a passkey incompatible with side-panel WebAuthn — confirm password fallback.
13. Confirm social-login wallets still use password-only reveal.
14. Run unit tests: `yarn test:unit ui/pages/keychains/reveal-seed.test.tsx ui/components/app/passkey-verification/passkey-verification.test.tsx ui/store/actions.test.js app/scripts/metamask-controller.actions.test.js`

## **Screenshots/Recordings**

### **Before**

<!-- Password prompt is always shown for SRP and private key reveal on passkey-enrolled wallets. -->

### **After**

<!-- Passkey verification step shown; SRP / private keys revealed after successful passkey ceremony. -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking API on methods that expose seed phrases and private keys, with new encryption-key verification touching vault decryption—high impact for security-sensitive consumers.
> 
> **Overview**
> **Breaking:** `exportSeedPhrase` and `exportAccount` no longer accept a plain password string. Callers must pass a `Credentials` object: `{ password }` or `{ encryptionKey, encryptionSalt? }`.
> 
> Sensitive exports now go through shared `#verifyCredentials`, which either runs existing password decryption or a new `#verifyEncryptionKey` path (vault salt check, `importKey` + `decryptWithKey`). A mismatched optional `encryptionSalt` throws `ExpiredCredentials`. `exportAccount` also enforces the unlocked controller guard before verification.
> 
> The public `Credentials` type is exported from `types.ts`, messenger action JSDoc is updated, and tests cover password and encryption-key success/failure cases. The changelog records the breaking API change for passkey-style vault-key verification (e.g. SRP / private key reveal without re-entering the wallet password).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccbd63131a52e6ae4026eabbda6f08f44a940650. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->