### PR TITLE
feat: add ARC and TEMPO to popular networks in ne ctrl

### DIFF
--- a/packages/network-enablement-controller/CHANGELOG.md
+++ b/packages/network-enablement-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added Arc (`0x13b2`) to `POPULAR_NETWORKS` ([#8997](https://github.com/MetaMask/core/pull/8997))
+
 ### Changed
 
 - Bump `@metamask/transaction-controller` from `^65.4.0` to `^66.0.0` ([#8848](https://github.com/MetaMask/core/pull/8848))

--- a/packages/network-enablement-controller/src/constants.ts
+++ b/packages/network-enablement-controller/src/constants.ts
@@ -15,4 +15,5 @@ export const POPULAR_NETWORKS: readonly Hex[] = [
   '0x3e7', // HyperEVM (999)
   '0x8f', // Monad (143)
   '0x10e6', // MegaETH (4326)
+  '0x13b2', // Arc (5042)
 ];


### PR DESCRIPTION
## Explanation

### Added

- Added Arc (`0x13b2`) and Tempo (`0x1079`) to `POPULAR_NETWORKS`

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single new hex entry in a constants array plus changelog; no logic, auth, or dependency changes in this diff.
> 
> **Overview**
> Adds **Arc** (chain ID **5042**, hex **`0x13b2`**) to the `POPULAR_NETWORKS` list in `network-enablement-controller`, so Arc is treated like other popular EVM chains for enablement and listing APIs that read that constant. The package **Unreleased** changelog documents the addition.
> 
> Note: the PR description also mentions Tempo, but the diff only includes Arc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a302a81d387a8cdacd2efdaa339145ddd631b8c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->