### PR TITLE
fix: Add proper defaults for `RpcServiceOptions`

### DIFF
--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add defaults for `fetch`, `btoa` and `isOffline` in `RpcServiceOptions` ([#9000](https://github.com/MetaMask/core/pull/9000))
+
 ## [32.0.0]
 
 ### Changed

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -54,7 +54,10 @@ import type {
   NetworkControllerGetNetworkConfigurationByNetworkClientIdAction,
   NetworkControllerMethodActions,
 } from './NetworkController-method-action-types';
-import type { RpcServiceOptions } from './rpc-service/rpc-service';
+import type {
+  RpcServiceOptions,
+  RpcServiceOptionsWithDefaults,
+} from './rpc-service/rpc-service';
 import { NetworkClientType } from './types';
 import type {
   BlockTracker,
@@ -753,7 +756,7 @@ export type NetworkControllerOptions = {
    */
   getRpcServiceOptions: (
     rpcEndpointUrl: string,
-  ) => Omit<RpcServiceOptions, 'failoverService' | 'endpointUrl'>;
+  ) => RpcServiceOptionsWithDefaults;
   /**
    * A function that can be used to customize a block tracker constructed for an
    * RPC endpoint. The function takes the URL of the endpoint and should return

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -54,10 +54,7 @@ import type {
   NetworkControllerGetNetworkConfigurationByNetworkClientIdAction,
   NetworkControllerMethodActions,
 } from './NetworkController-method-action-types';
-import type {
-  RpcServiceOptions,
-  RpcServiceOptionsWithDefaults,
-} from './rpc-service/rpc-service';
+import type { RpcServiceOptionsWithDefaults } from './rpc-service/rpc-service';
 import { NetworkClientType } from './types';
 import type {
   BlockTracker,
@@ -751,7 +748,7 @@ export type NetworkControllerOptions = {
   /**
    * A function that can be used to customize a RPC service constructed for an
    * RPC endpoint. The function takes the URL of the endpoint and should return
-   * an object with type {@link RpcServiceOptions}, minus `failoverService`
+   * an object with type {@link RpcServiceOptionsWithDefaults}, minus `failoverService`
    * and `endpointUrl` (as they are filled in automatically).
    */
   getRpcServiceOptions: (

--- a/packages/network-controller/src/create-auto-managed-network-client.ts
+++ b/packages/network-controller/src/create-auto-managed-network-client.ts
@@ -8,7 +8,7 @@ import type {
   NetworkClientId,
   NetworkControllerMessenger,
 } from './NetworkController';
-import type { RpcServiceOptions } from './rpc-service/rpc-service';
+import type { RpcServiceOptionsWithDefaults } from './rpc-service/rpc-service';
 import type {
   BlockTracker,
   NetworkClientConfiguration,
@@ -102,7 +102,7 @@ export function createAutoManagedNetworkClient<
   networkClientConfiguration: Configuration;
   getRpcServiceOptions: (
     rpcEndpointUrl: string,
-  ) => Omit<RpcServiceOptions, 'failoverService' | 'endpointUrl'>;
+  ) => RpcServiceOptionsWithDefaults;
   getBlockTrackerOptions?: (
     rpcEndpointUrl: string,
   ) => Omit<PollingBlockTrackerOptions, 'provider'>;

--- a/packages/network-controller/src/create-network-client-tests/rpc-endpoint-events.test.ts
+++ b/packages/network-controller/src/create-network-client-tests/rpc-endpoint-events.test.ts
@@ -313,12 +313,9 @@ describe('createNetworkClient - RPC endpoint events', () => {
                       failoverRpcUrls: [failoverEndpointUrl],
                       messenger: rootMessenger,
                       getRpcServiceOptions: () => ({
-                        fetch,
-                        btoa,
                         policyOptions: {
                           backoff: new ConstantBackoff(backoffDuration),
                         },
-                        isOffline: (): boolean => false,
                       }),
                     },
                     async ({ makeRpcCall }) => {
@@ -399,12 +396,9 @@ describe('createNetworkClient - RPC endpoint events', () => {
                       failoverRpcUrls: [failoverEndpointUrl],
                       messenger: rootMessenger,
                       getRpcServiceOptions: () => ({
-                        fetch,
-                        btoa,
                         policyOptions: {
                           backoff: new ConstantBackoff(backoffDuration),
                         },
-                        isOffline: (): boolean => false,
                       }),
                     },
                     async ({ makeRpcCall }) => {
@@ -1422,12 +1416,9 @@ describe('createNetworkClient - RPC endpoint events', () => {
                   networkClientId: 'AAAA-AAAA-AAAA-AAAA',
                   messenger: rootMessenger,
                   getRpcServiceOptions: () => ({
-                    fetch,
-                    btoa,
                     policyOptions: {
                       backoff: new ConstantBackoff(backoffDuration),
                     },
-                    isOffline: (): boolean => false,
                   }),
                 },
                 async ({ makeRpcCall }) => {
@@ -1485,12 +1476,9 @@ describe('createNetworkClient - RPC endpoint events', () => {
                   networkClientId: 'AAAA-AAAA-AAAA-AAAA',
                   messenger: rootMessenger,
                   getRpcServiceOptions: () => ({
-                    fetch,
-                    btoa,
                     policyOptions: {
                       backoff: new ConstantBackoff(backoffDuration),
                     },
-                    isOffline: (): boolean => false,
                   }),
                 },
                 async ({ makeRpcCall }) => {

--- a/packages/network-controller/src/create-network-client.ts
+++ b/packages/network-controller/src/create-network-client.ts
@@ -28,13 +28,14 @@ import type {
   MiddlewareContext,
 } from '@metamask/json-rpc-engine/v2';
 import type { Hex, Json, JsonRpcRequest } from '@metamask/utils';
+import { inMilliseconds, Duration } from '@metamask/utils';
 import type { Logger } from 'loglevel';
 
 import type {
   NetworkClientId,
   NetworkControllerMessenger,
 } from './NetworkController';
-import type { RpcServiceOptions } from './rpc-service/rpc-service';
+import type { RpcServiceOptionsWithDefaults } from './rpc-service/rpc-service';
 import {
   isConnectionError,
   isConnectionResetError,
@@ -146,7 +147,7 @@ export function createNetworkClient({
   configuration: NetworkClientConfiguration;
   getRpcServiceOptions: (
     rpcEndpointUrl: string,
-  ) => Omit<RpcServiceOptions, 'failoverService' | 'endpointUrl'>;
+  ) => RpcServiceOptionsWithDefaults;
   getBlockTrackerOptions: (
     rpcEndpointUrl: string,
   ) => Omit<PollingBlockTrackerOptions, 'provider'>;
@@ -254,7 +255,7 @@ function createRpcServiceChain({
   configuration: NetworkClientConfiguration;
   getRpcServiceOptions: (
     rpcEndpointUrl: string,
-  ) => Omit<RpcServiceOptions, 'failoverService' | 'endpointUrl'>;
+  ) => RpcServiceOptionsWithDefaults;
   messenger: NetworkControllerMessenger;
   isRpcFailoverEnabled: boolean;
   logger?: Logger;
@@ -271,10 +272,12 @@ function createRpcServiceChain({
   };
 
   const rpcServiceConfigurations = availableEndpointUrls.map((endpointUrl) => ({
+    fetch: globalThis.fetch.bind(globalThis),
+    btoa: globalThis.btoa.bind(globalThis),
+    isOffline,
     ...getRpcServiceOptions(endpointUrl),
     endpointUrl,
     logger,
-    isOffline,
   }));
 
   /**

--- a/packages/network-controller/src/create-network-client.ts
+++ b/packages/network-controller/src/create-network-client.ts
@@ -28,7 +28,6 @@ import type {
   MiddlewareContext,
 } from '@metamask/json-rpc-engine/v2';
 import type { Hex, Json, JsonRpcRequest } from '@metamask/utils';
-import { inMilliseconds, Duration } from '@metamask/utils';
 import type { Logger } from 'loglevel';
 
 import type {

--- a/packages/network-controller/src/rpc-service/rpc-service.ts
+++ b/packages/network-controller/src/rpc-service/rpc-service.ts
@@ -30,6 +30,15 @@ import type {
 } from './shared';
 
 /**
+ * Options for the RpcService constructor with some properties omitted and made optional as they have defaults.
+ */
+export type RpcServiceOptionsWithDefaults = Omit<
+  RpcServiceOptions,
+  'failoverService' | 'endpointUrl' | 'isOffline' | 'btoa' | 'fetch'
+> &
+  Partial<Pick<RpcServiceOptions, 'isOffline' | 'btoa' | 'fetch'>>;
+
+/**
  * Options for the RpcService constructor.
  */
 export type RpcServiceOptions = {


### PR DESCRIPTION
## Explanation

Add proper defaults for `fetch`, `btoa`, and `isOffline` in `RpcServiceOptions`.

## References

https://consensyssoftware.atlassian.net/browse/WPC-1055

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 57eb7e65674a329fa153f059828b551f8ead7faf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->