### PR TITLE
feat(wallet)!: Add `NetworkController` initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,6 +615,7 @@ linkStyle default opacity:0.5
   wallet --> controller_utils;
   wallet --> keyring_controller;
   wallet --> messenger;
+  wallet --> network_controller;
   wallet --> remote_feature_flag_controller;
   wallet --> storage_service;
   wallet_cli --> base_controller;

--- a/packages/wallet/CHANGELOG.md
+++ b/packages/wallet/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **BREAKING:** Add `NetworkController` initialization ([#9001](https://github.com/MetaMask/core/pull/9001))
   - Passing `instanceOptions.networkController.infuraProjectId` is now required.
+- Add the `Wallet.init` function which calls `init` on required instances ([#9001](https://github.com/MetaMask/core/pull/9001))
 
 ### Changed
 

--- a/packages/wallet/CHANGELOG.md
+++ b/packages/wallet/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **BREAKING:** Add `NetworkController` initialization ([#9001](https://github.com/MetaMask/core/pull/9001))
+  - Passing `instanceOptions.networkController.infuraProjectId` is now required.
+
 ### Changed
 
 - Bump `@metamask/accounts-controller` from `^39.0.2` to `^39.0.3` ([#9231](https://github.com/MetaMask/core/pull/9231))

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -61,6 +61,7 @@
     "@metamask/controller-utils": "^12.3.0",
     "@metamask/keyring-controller": "^27.1.0",
     "@metamask/messenger": "^1.2.0",
+    "@metamask/network-controller": "^32.0.0",
     "@metamask/remote-feature-flag-controller": "^4.2.2",
     "@metamask/scure-bip39": "^2.1.1",
     "@metamask/storage-service": "^1.0.2",

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -61,7 +61,7 @@
     "@metamask/controller-utils": "^12.3.0",
     "@metamask/keyring-controller": "^27.1.0",
     "@metamask/messenger": "^1.2.0",
-    "@metamask/network-controller": "^32.0.0",
+    "@metamask/network-controller": "^33.0.0",
     "@metamask/remote-feature-flag-controller": "^4.2.2",
     "@metamask/scure-bip39": "^2.1.1",
     "@metamask/storage-service": "^1.0.2",

--- a/packages/wallet/src/Wallet.test.ts
+++ b/packages/wallet/src/Wallet.test.ts
@@ -28,6 +28,9 @@ async function setupWallet(): Promise<Wallet> {
       connectivityController: {
         connectivityAdapter: new AlwaysOnlineAdapter(),
       },
+      networkController: {
+        infuraProjectId: 'fake-infura-project-id',
+      },
       storageService: {
         storage: new InMemoryStorageAdapter(),
       },
@@ -88,6 +91,9 @@ describe('Wallet', () => {
         keyringController: {
           encryptor: new MockEncryptor(),
         },
+        networkController: {
+          infuraProjectId: 'fake-infura-project-id',
+        },
         storageService: {
           storage: new InMemoryStorageAdapter(),
         },
@@ -134,6 +140,9 @@ describe('Wallet', () => {
         connectivityController: {
           connectivityAdapter: new AlwaysOnlineAdapter(),
         },
+        networkController: {
+          infuraProjectId: 'fake-infura-project-id',
+        },
         storageService: {
           storage: new InMemoryStorageAdapter(),
         },
@@ -173,6 +182,9 @@ describe('Wallet', () => {
       instanceOptions: {
         connectivityController: {
           connectivityAdapter: new AlwaysOnlineAdapter(),
+        },
+        networkController: {
+          infuraProjectId: 'fake-infura-project-id',
         },
         storageService: {
           storage: new InMemoryStorageAdapter(),
@@ -249,6 +261,9 @@ describe('Wallet', () => {
           connectivityController: {
             connectivityAdapter: new AlwaysOnlineAdapter(),
           },
+          networkController: {
+            infuraProjectId: 'fake-infura-project-id',
+          },
           storageService: {
             storage: new InMemoryStorageAdapter(),
           },
@@ -285,6 +300,9 @@ describe('Wallet', () => {
         instanceOptions: {
           connectivityController: {
             connectivityAdapter: new AlwaysOnlineAdapter(),
+          },
+          networkController: {
+            infuraProjectId: 'fake-infura-project-id',
           },
           storageService: {
             storage: new InMemoryStorageAdapter(),
@@ -360,6 +378,9 @@ describe('Wallet', () => {
         instanceOptions: {
           connectivityController: {
             connectivityAdapter: new AlwaysOnlineAdapter(),
+          },
+          networkController: {
+            infuraProjectId: 'fake-infura-project-id',
           },
           keyringController: { encryptor: new MockEncryptor() },
           storageService: { storage: new InMemoryStorageAdapter() },

--- a/packages/wallet/src/Wallet.test.ts
+++ b/packages/wallet/src/Wallet.test.ts
@@ -199,6 +199,19 @@ describe('Wallet', () => {
     expect(Object.keys(wallet.state)).toStrictEqual(['WithMeta', 'NoMeta']);
   });
 
+  it('calls init on all instances and returns the results', async () => {
+    const wallet = await setupWallet();
+
+    const results = await wallet.init();
+
+    expect(results).toStrictEqual([
+      {
+        status: 'fulfilled',
+        value: undefined,
+      },
+    ]);
+  });
+
   it('disallows modifying the messenger', async () => {
     const wallet = await setupWallet();
 

--- a/packages/wallet/src/Wallet.test.ts
+++ b/packages/wallet/src/Wallet.test.ts
@@ -204,12 +204,7 @@ describe('Wallet', () => {
 
     const results = await wallet.init();
 
-    expect(results).toStrictEqual([
-      {
-        status: 'fulfilled',
-        value: undefined,
-      },
-    ]);
+    expect(results).toHaveLength(2);
   });
 
   it('disallows modifying the messenger', async () => {

--- a/packages/wallet/src/Wallet.ts
+++ b/packages/wallet/src/Wallet.ts
@@ -135,7 +135,7 @@ export class Wallet {
           (instance): instance is Extract<typeof instance, { init: unknown }> =>
             // We do actually want to check the prototype here.
             // eslint-disable-next-line no-restricted-syntax
-            'init' in instance,
+            'init' in instance && typeof instance.init === 'function',
         )
         .map(async (instance) => instance.init()),
     );

--- a/packages/wallet/src/Wallet.ts
+++ b/packages/wallet/src/Wallet.ts
@@ -124,6 +124,19 @@ export class Wallet {
   }
 
   /**
+   * Complete additional initialization of instantiated controllers or services after instantiating `Wallet`.
+   *
+   * @returns The results of all initialization calls.
+   */
+  init() {
+    return Promise.allSettled(
+      Object.values(this.#instances)
+        .map((instance) => ('init' in instance ? instance.init() : null))
+        .filter(Boolean),
+    );
+  }
+
+  /**
    * Destroy the wallet instance.
    */
   async destroy(): Promise<void> {

--- a/packages/wallet/src/Wallet.ts
+++ b/packages/wallet/src/Wallet.ts
@@ -128,11 +128,16 @@ export class Wallet {
    *
    * @returns The results of all initialization calls.
    */
-  init() {
+  init(): Promise<PromiseSettledResult<unknown>[]> {
     return Promise.allSettled(
       Object.values(this.#instances)
-        .map((instance) => ('init' in instance ? instance.init() : null))
-        .filter(Boolean),
+        .filter(
+          (instance): instance is Extract<typeof instance, { init: unknown }> =>
+            // We do actually want to check the prototype here.
+            // eslint-disable-next-line no-restricted-syntax
+            'init' in instance,
+        )
+        .map(async (instance) => instance.init()),
     );
   }
 

--- a/packages/wallet/src/initialization/instances/index.ts
+++ b/packages/wallet/src/initialization/instances/index.ts
@@ -2,5 +2,6 @@ export { accountsController } from './accounts-controller/accounts-controller';
 export { approvalController } from './approval-controller/approval-controller';
 export { connectivityController } from './connectivity-controller/connectivity-controller';
 export { keyringController } from './keyring-controller/keyring-controller';
+export { networkController } from './network-controller/network-controller';
 export { remoteFeatureFlagController } from './remote-feature-flag-controller/remote-feature-flag-controller';
 export { storageService } from './storage-service/storage-service';

--- a/packages/wallet/src/initialization/instances/network-controller/network-controller.ts
+++ b/packages/wallet/src/initialization/instances/network-controller/network-controller.ts
@@ -16,6 +16,7 @@ export const networkController: InitializationConfiguration<
       state,
       messenger,
       infuraProjectId: options.infuraProjectId,
+      failoverUrls: options.failoverUrls,
     }),
   getMessenger: (parent) => {
     const networkControllerMessenger: NetworkControllerMessenger =

--- a/packages/wallet/src/initialization/instances/network-controller/network-controller.ts
+++ b/packages/wallet/src/initialization/instances/network-controller/network-controller.ts
@@ -27,8 +27,11 @@ export const networkController: InitializationConfiguration<
 
     parent.delegate({
       messenger: networkControllerMessenger,
-      actions: ['ConnectivityController:getState'],
-      events: [],
+      actions: [
+        'ConnectivityController:getState',
+        'RemoteFeatureFlagController:getState',
+      ],
+      events: ['RemoteFeatureFlagController:stateChange'],
     });
 
     return networkControllerMessenger;

--- a/packages/wallet/src/initialization/instances/network-controller/network-controller.ts
+++ b/packages/wallet/src/initialization/instances/network-controller/network-controller.ts
@@ -31,7 +31,11 @@ export const networkController: InitializationConfiguration<
         'ConnectivityController:getState',
         'RemoteFeatureFlagController:getState',
       ],
-      events: ['RemoteFeatureFlagController:stateChange'],
+
+      events: [
+        // eslint-disable-next-line no-restricted-syntax
+        'RemoteFeatureFlagController:stateChange',
+      ],
     });
 
     return networkControllerMessenger;

--- a/packages/wallet/src/initialization/instances/network-controller/network-controller.ts
+++ b/packages/wallet/src/initialization/instances/network-controller/network-controller.ts
@@ -1,0 +1,35 @@
+import { Messenger } from '@metamask/messenger';
+import {
+  NetworkController,
+  NetworkControllerMessenger,
+} from '@metamask/network-controller';
+
+import { InitializationConfiguration } from '../../types';
+
+export const networkController: InitializationConfiguration<
+  NetworkController,
+  NetworkControllerMessenger
+> = {
+  name: 'NetworkController',
+  init: ({ state, messenger, options }) =>
+    new NetworkController({
+      state,
+      messenger,
+      infuraProjectId: options.infuraProjectId,
+    }),
+  getMessenger: (parent) => {
+    const networkControllerMessenger: NetworkControllerMessenger =
+      new Messenger({
+        namespace: 'NetworkController',
+        parent,
+      });
+
+    parent.delegate({
+      messenger: networkControllerMessenger,
+      actions: ['ConnectivityController:getState'],
+      events: [],
+    });
+
+    return networkControllerMessenger;
+  },
+};

--- a/packages/wallet/src/initialization/instances/network-controller/types.ts
+++ b/packages/wallet/src/initialization/instances/network-controller/types.ts
@@ -1,6 +1,15 @@
+import { Hex } from '@metamask/utils';
+
 /**
  * Per-instance options for the wallet's `NetworkController`.
  */
 export type NetworkControllerInstanceOptions = {
+  /**
+   * The API key for Infura, used to make requests to Infura.
+   */
   infuraProjectId: string;
+  /**
+   * An optional map of available failover URLs for each chain ID.
+   */
+  failoverUrls?: Record<Hex, string[]>;
 };

--- a/packages/wallet/src/initialization/instances/network-controller/types.ts
+++ b/packages/wallet/src/initialization/instances/network-controller/types.ts
@@ -1,0 +1,6 @@
+/**
+ * Per-instance options for the wallet's `NetworkController`.
+ */
+export type NetworkControllerInstanceOptions = {
+  infuraProjectId: string;
+};

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -10,7 +10,8 @@ import type { ConnectivityControllerInstanceOptions } from './initialization/ins
 import type { KeyringControllerInstanceOptions } from './initialization/instances/keyring-controller/types';
 import type { RemoteFeatureFlagControllerInstanceOptions } from './initialization/instances/remote-feature-flag-controller/types';
 import type { StorageServiceInstanceOptions } from './initialization/instances/storage-service/types';
-import { InitializationConfiguration } from './initialization/types';
+import type { NetworkControllerInstanceOptions } from './initialization/instances/network-controller/types';
+import type { InitializationConfiguration } from './initialization/types';
 
 export type WalletOptions = {
   messenger?: RootMessenger<DefaultActions, DefaultEvents>;
@@ -26,6 +27,7 @@ export type InstanceSpecificOptions = {
   approvalController?: ApprovalControllerInstanceOptions;
   connectivityController: ConnectivityControllerInstanceOptions;
   keyringController?: KeyringControllerInstanceOptions;
+  networkController: NetworkControllerInstanceOptions;
   remoteFeatureFlagController: RemoteFeatureFlagControllerInstanceOptions;
   storageService: StorageServiceInstanceOptions;
 };

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -8,9 +8,9 @@ import type {
 import type { ApprovalControllerInstanceOptions } from './initialization/instances/approval-controller/types';
 import type { ConnectivityControllerInstanceOptions } from './initialization/instances/connectivity-controller/types';
 import type { KeyringControllerInstanceOptions } from './initialization/instances/keyring-controller/types';
+import type { NetworkControllerInstanceOptions } from './initialization/instances/network-controller/types';
 import type { RemoteFeatureFlagControllerInstanceOptions } from './initialization/instances/remote-feature-flag-controller/types';
 import type { StorageServiceInstanceOptions } from './initialization/instances/storage-service/types';
-import type { NetworkControllerInstanceOptions } from './initialization/instances/network-controller/types';
 import type { InitializationConfiguration } from './initialization/types';
 
 export type WalletOptions = {

--- a/packages/wallet/tsconfig.build.json
+++ b/packages/wallet/tsconfig.build.json
@@ -13,6 +13,7 @@
     { "path": "../controller-utils/tsconfig.build.json" },
     { "path": "../keyring-controller/tsconfig.build.json" },
     { "path": "../messenger/tsconfig.build.json" },
+    { "path": "../network-controller/tsconfig.build.json" },
     { "path": "../remote-feature-flag-controller/tsconfig.build.json" },
     { "path": "../storage-service/tsconfig.build.json" }
   ],

--- a/packages/wallet/tsconfig.json
+++ b/packages/wallet/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "../controller-utils/tsconfig.json" },
     { "path": "../keyring-controller/tsconfig.json" },
     { "path": "../messenger/tsconfig.json" },
+    { "path": "../network-controller/tsconfig.json" },
     { "path": "../remote-feature-flag-controller/tsconfig.json" },
     { "path": "../storage-service/tsconfig.json" }
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -8941,6 +8941,7 @@ __metadata:
     "@metamask/controller-utils": "npm:^12.3.0"
     "@metamask/keyring-controller": "npm:^27.1.0"
     "@metamask/messenger": "npm:^1.2.0"
+    "@metamask/network-controller": "npm:^32.0.0"
     "@metamask/remote-feature-flag-controller": "npm:^4.2.2"
     "@metamask/scure-bip39": "npm:^2.1.1"
     "@metamask/storage-service": "npm:^1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8941,7 +8941,7 @@ __metadata:
     "@metamask/controller-utils": "npm:^12.3.0"
     "@metamask/keyring-controller": "npm:^27.1.0"
     "@metamask/messenger": "npm:^1.2.0"
-    "@metamask/network-controller": "npm:^32.0.0"
+    "@metamask/network-controller": "npm:^33.0.0"
     "@metamask/remote-feature-flag-controller": "npm:^4.2.2"
     "@metamask/scure-bip39": "npm:^2.1.1"
     "@metamask/storage-service": "npm:^1.0.2"


### PR DESCRIPTION
## Explanation

This PR adds `NetworkController` initialization to `@metamask/wallet` alongside an `init` function on `Wallet` than can be used to initialize controller and services after instantiation (e.g. if the controller/service needs to use the messenger to seed its initial state).

`instanceOptions.networkController.infuraProjectId` is now required.

## References

https://consensyssoftware.atlassian.net/browse/WPC-1023

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking API change for all wallet consumers plus core network/RPC configuration (Infura project ID), which affects how chains and providers are initialized.
> 
> **Overview**
> **Breaking:** `@metamask/wallet` now boots a default **`NetworkController`** and requires `instanceOptions.networkController.infuraProjectId` (optional `failoverUrls`). The new initialization module wires the controller messenger to **`ConnectivityController`** and **`RemoteFeatureFlagController`** state/actions.
> 
> Adds **`Wallet.init()`**, which runs `init()` on every registered instance that exposes it (via `Promise.allSettled`) so controllers can finish setup after construction—for example seeding state through the messenger.
> 
> Tests and docs/changelog/README dependency graph are updated for the new required options and dependency on `@metamask/network-controller`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f882afddc9199ebbc567109c0f3efbdb9b1d56bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->