### PR TITLE
feat: Add defaults for policy and block tracker options

### DIFF
--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add defaults for `policyOptions` ([#9002](https://github.com/MetaMask/core/pull/9002))
+- Add defaults for policy and block tracker options ([#9002](https://github.com/MetaMask/core/pull/9002))
   - The `NetworkController` constructor argument `getRpcServiceOptions` is now optional.
   - The default `policyOptions.maxRetries` is now `3`.
   - The default `policyOptions.maxConsecutiveFailures` is now `12` for regular RPC endpoints and `40` for fallback RPC endpoints.

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add defaults for `policyOptions` ([#9002](https://github.com/MetaMask/core/pull/9002))
+  - The `NetworkController` constructor argument `getRpcServiceOptions` is now optional.
+  - The default `policyOptions.maxRetries` is now `3`.
+  - The default `policyOptions.maxConsecutiveFailures` is now `12` for regular RPC endpoints and `40` for fallback RPC endpoints.
+  - The default `policyOptions.circuitBreakDuration` is now `30` seconds.
+  - The default `pollingInterval` for the block tracker is now `20` seconds.
+  - The default `retryTimeout` for the block tracker is now `20` seconds.
+
 ### Fixed
 
 - Add defaults for `fetch`, `btoa` and `isOffline` in `RpcServiceOptions` ([#9000](https://github.com/MetaMask/core/pull/9000))

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -751,7 +751,7 @@ export type NetworkControllerOptions = {
    * an object with type {@link RpcServiceOptionsWithDefaults}, minus `failoverService`
    * and `endpointUrl` (as they are filled in automatically).
    */
-  getRpcServiceOptions: (
+  getRpcServiceOptions?: (
     rpcEndpointUrl: string,
   ) => RpcServiceOptionsWithDefaults;
   /**

--- a/packages/network-controller/src/create-auto-managed-network-client.ts
+++ b/packages/network-controller/src/create-auto-managed-network-client.ts
@@ -100,7 +100,7 @@ export function createAutoManagedNetworkClient<
 }: {
   networkClientId: NetworkClientId;
   networkClientConfiguration: Configuration;
-  getRpcServiceOptions: (
+  getRpcServiceOptions?: (
     rpcEndpointUrl: string,
   ) => RpcServiceOptionsWithDefaults;
   getBlockTrackerOptions?: (

--- a/packages/network-controller/src/create-network-client.ts
+++ b/packages/network-controller/src/create-network-client.ts
@@ -490,9 +490,9 @@ function createBlockTracker({
   provider: InternalProvider;
 }): PollingBlockTracker {
   const defaultOptions = {
-    // Needed for testing.
-    // eslint-disable-next-line no-restricted-globals
     pollingInterval:
+      // Needed for testing.
+      // eslint-disable-next-line no-restricted-globals
       process.env.IN_TEST && networkClientType === NetworkClientType.Custom
         ? inMilliseconds(1, Duration.Second)
         : inMilliseconds(20, Duration.Second),

--- a/packages/network-controller/src/create-network-client.ts
+++ b/packages/network-controller/src/create-network-client.ts
@@ -297,21 +297,25 @@ function createRpcServiceChain({
   // activate the "cooldown" accidentally.
   const maxConsecutiveFailuresFailover = (DEFAULT_MAX_RETRIES + 1) * 10;
 
-  const rpcServiceConfigurations = availableEndpoints.map((endpoint) => ({
-    fetch: globalThis.fetch.bind(globalThis),
-    btoa: globalThis.btoa.bind(globalThis),
-    isOffline,
-    policyOptions: {
-      maxRetries: DEFAULT_MAX_RETRIES,
-      circuitBreakDuration: inMilliseconds(30, Duration.Second),
-      maxConsecutiveFailures: endpoint.isFailover
-        ? maxConsecutiveFailuresFailover
-        : maxConsecutiveFailures,
-    },
-    ...(getRpcServiceOptions?.(endpoint.url) ?? {}),
-    endpointUrl: endpoint.url,
-    logger,
-  }));
+  const rpcServiceConfigurations = availableEndpoints.map((endpoint) => {
+    const overriddenOptions = getRpcServiceOptions?.(endpoint.url) ?? {};
+    return {
+      fetch: globalThis.fetch.bind(globalThis),
+      btoa: globalThis.btoa.bind(globalThis),
+      isOffline,
+      policyOptions: {
+        maxRetries: DEFAULT_MAX_RETRIES,
+        circuitBreakDuration: inMilliseconds(30, Duration.Second),
+        maxConsecutiveFailures: endpoint.isFailover
+          ? maxConsecutiveFailuresFailover
+          : maxConsecutiveFailures,
+        ...(overriddenOptions.policyOptions ?? {}),
+      },
+      ...overriddenOptions,
+      endpointUrl: endpoint.url,
+      logger,
+    };
+  });
 
   /**
    * Extracts the error from Cockatiel's `FailureReason` type received in

--- a/packages/network-controller/src/create-network-client.ts
+++ b/packages/network-controller/src/create-network-client.ts
@@ -3,7 +3,11 @@ import type {
   CockatielFailureReason,
   InfuraNetworkType,
 } from '@metamask/controller-utils';
-import { ChainId, DEFAULT_MAX_CONSECUTIVE_FAILURES, DEFAULT_MAX_RETRIES } from '@metamask/controller-utils';
+import {
+  ChainId,
+  DEFAULT_MAX_CONSECUTIVE_FAILURES,
+  DEFAULT_MAX_RETRIES,
+} from '@metamask/controller-utils';
 import type { PollingBlockTrackerOptions } from '@metamask/eth-block-tracker';
 import { PollingBlockTracker } from '@metamask/eth-block-tracker';
 import { createInfuraMiddleware } from '@metamask/eth-json-rpc-infura';
@@ -298,6 +302,7 @@ function createRpcServiceChain({
     btoa: globalThis.btoa.bind(globalThis),
     isOffline,
     policyOptions: {
+      maxRetries: DEFAULT_MAX_RETRIES,
       circuitBreakDuration: inMilliseconds(30, Duration.Second),
       maxConsecutiveFailures: endpoint.isFailover
         ? maxConsecutiveFailuresFailover

--- a/packages/network-controller/src/create-network-client.ts
+++ b/packages/network-controller/src/create-network-client.ts
@@ -3,7 +3,7 @@ import type {
   CockatielFailureReason,
   InfuraNetworkType,
 } from '@metamask/controller-utils';
-import { ChainId } from '@metamask/controller-utils';
+import { ChainId, DEFAULT_MAX_CONSECUTIVE_FAILURES, DEFAULT_MAX_RETRIES } from '@metamask/controller-utils';
 import type { PollingBlockTrackerOptions } from '@metamask/eth-block-tracker';
 import { PollingBlockTracker } from '@metamask/eth-block-tracker';
 import { createInfuraMiddleware } from '@metamask/eth-json-rpc-infura';
@@ -27,6 +27,7 @@ import type {
   JsonRpcMiddleware,
   MiddlewareContext,
 } from '@metamask/json-rpc-engine/v2';
+import { inMilliseconds, Duration } from '@metamask/utils';
 import type { Hex, Json, JsonRpcRequest } from '@metamask/utils';
 import type { Logger } from 'loglevel';
 
@@ -144,7 +145,7 @@ export function createNetworkClient({
 }: {
   id: NetworkClientId;
   configuration: NetworkClientConfiguration;
-  getRpcServiceOptions: (
+  getRpcServiceOptions?: (
     rpcEndpointUrl: string,
   ) => RpcServiceOptionsWithDefaults;
   getBlockTrackerOptions: (
@@ -252,16 +253,22 @@ function createRpcServiceChain({
   id: NetworkClientId;
   primaryEndpointUrl: string;
   configuration: NetworkClientConfiguration;
-  getRpcServiceOptions: (
+  getRpcServiceOptions?: (
     rpcEndpointUrl: string,
   ) => RpcServiceOptionsWithDefaults;
   messenger: NetworkControllerMessenger;
   isRpcFailoverEnabled: boolean;
   logger?: Logger;
 }): RpcServiceChain {
-  const availableEndpointUrls: [string, ...string[]] = isRpcFailoverEnabled
-    ? [primaryEndpointUrl, ...(configuration.failoverRpcUrls ?? [])]
-    : [primaryEndpointUrl];
+  const availableEndpoints = isRpcFailoverEnabled
+    ? [
+        { url: primaryEndpointUrl, isFailover: false },
+        ...(configuration.failoverRpcUrls ?? []).map((url) => ({
+          url,
+          isFailover: true,
+        })),
+      ]
+    : [{ url: primaryEndpointUrl, isFailover: false }];
 
   const isOffline = (): boolean => {
     const connectivityState = messenger.call('ConnectivityController:getState');
@@ -270,12 +277,34 @@ function createRpcServiceChain({
     );
   };
 
-  const rpcServiceConfigurations = availableEndpointUrls.map((endpointUrl) => ({
+  // Ensure that if the endpoint continually responds with errors, we
+  // break the circuit relatively fast (but not prematurely).
+  //
+  // Note that the circuit will break much faster if the errors are
+  // retriable (e.g. 503) than if not (e.g. 500), so we attempt to strike
+  // a balance here.
+  const maxConsecutiveFailures = DEFAULT_MAX_CONSECUTIVE_FAILURES;
+
+  // The number of rounds of retries that will break the circuit,
+  // triggering a "cooldown".
+  //
+  // When we fail over to QuickNode, we expect it to be down at first
+  // while it is being automatically activated, and we don't want to
+  // activate the "cooldown" accidentally.
+  const maxConsecutiveFailuresFailover = (DEFAULT_MAX_RETRIES + 1) * 10;
+
+  const rpcServiceConfigurations = availableEndpoints.map((endpoint) => ({
     fetch: globalThis.fetch.bind(globalThis),
     btoa: globalThis.btoa.bind(globalThis),
     isOffline,
-    ...getRpcServiceOptions(endpointUrl),
-    endpointUrl,
+    policyOptions: {
+      circuitBreakDuration: inMilliseconds(30, Duration.Second),
+      maxConsecutiveFailures: endpoint.isFailover
+        ? maxConsecutiveFailuresFailover
+        : maxConsecutiveFailures,
+    },
+    ...(getRpcServiceOptions?.(endpoint.url) ?? {}),
+    endpointUrl: endpoint.url,
     logger,
   }));
 
@@ -457,9 +486,14 @@ function createBlockTracker({
     process.env.IN_TEST && networkClientType === NetworkClientType.Custom
       ? { pollingInterval: SECOND }
       : {};
+  const defaultOptions = {
+    pollingInterval: inMilliseconds(20, Duration.Second),
+    retryTimeout: inMilliseconds(20, Duration.Second),
+  };
 
   return new PollingBlockTracker({
     ...testOptions,
+    ...defaultOptions,
     ...getOptions(endpointUrl),
     provider,
   });

--- a/packages/network-controller/src/create-network-client.ts
+++ b/packages/network-controller/src/create-network-client.ts
@@ -485,19 +485,17 @@ function createBlockTracker({
   ) => Omit<PollingBlockTrackerOptions, 'provider'>;
   provider: InternalProvider;
 }): PollingBlockTracker {
-  const testOptions =
+  const defaultOptions = {
     // Needed for testing.
     // eslint-disable-next-line no-restricted-globals
-    process.env.IN_TEST && networkClientType === NetworkClientType.Custom
-      ? { pollingInterval: SECOND }
-      : {};
-  const defaultOptions = {
-    pollingInterval: inMilliseconds(20, Duration.Second),
+    pollingInterval:
+      process.env.IN_TEST && networkClientType === NetworkClientType.Custom
+        ? inMilliseconds(1, Duration.Second)
+        : inMilliseconds(20, Duration.Second),
     retryTimeout: inMilliseconds(20, Duration.Second),
   };
 
   return new PollingBlockTracker({
-    ...testOptions,
     ...defaultOptions,
     ...getOptions(endpointUrl),
     provider,

--- a/packages/network-controller/src/rpc-service/rpc-service.ts
+++ b/packages/network-controller/src/rpc-service/rpc-service.ts
@@ -84,6 +84,8 @@ const log = createModuleLogger(projectLogger, 'RpcService');
 /**
  * The maximum number of times that a failing service should be re-run before
  * giving up.
+ *
+ * Note: This is not used in production and should be removed.
  */
 export const DEFAULT_MAX_RETRIES = 4;
 

--- a/packages/network-controller/tests/NetworkController.provider.test.ts
+++ b/packages/network-controller/tests/NetworkController.provider.test.ts
@@ -1,7 +1,5 @@
-import {
-  DEFAULT_CIRCUIT_BREAK_DURATION,
-  DEFAULT_DEGRADED_THRESHOLD,
-} from '@metamask/controller-utils';
+import { DEFAULT_DEGRADED_THRESHOLD } from '@metamask/controller-utils';
+import { Duration, inMilliseconds } from '@metamask/utils';
 import nock from 'nock';
 
 import { NetworkStatus } from '../src/constants';
@@ -559,7 +557,7 @@ describe('NetworkController provider tests', () => {
         method: 'eth_blockNumber',
         params: [],
       })
-      .times(15)
+      .times(12)
       .reply(503);
     nock(secondaryEndpointUrl)
       .post('/', {
@@ -568,7 +566,7 @@ describe('NetworkController provider tests', () => {
         method: 'eth_blockNumber',
         params: [],
       })
-      .times(15)
+      .times(40)
       .reply(503);
 
     await withController(
@@ -617,8 +615,14 @@ describe('NetworkController provider tests', () => {
         // Hit the primary, break the circuit, fail over to the secondary,
         // run out of retries.
         await expect(provider.request(request)).rejects.toThrow(expectedError);
-        // Hit the secondary, run out of retries.
-        await expect(provider.request(request)).rejects.toThrow(expectedError);
+
+        for (let i = 0; i < 8; i++) {
+          // Hit the secondary, run out of retries.
+          await expect(provider.request(request)).rejects.toThrow(
+            expectedError,
+          );
+        }
+
         // Hit the secondary, break the circuit.
         await expect(provider.request(request)).rejects.toThrow(expectedError);
 
@@ -641,7 +645,7 @@ describe('NetworkController provider tests', () => {
         method: 'eth_blockNumber',
         params: [],
       })
-      .times(15)
+      .times(12)
       .reply(503)
       .post('/', {
         id: /^\d+$/u,
@@ -717,7 +721,7 @@ describe('NetworkController provider tests', () => {
         await expect(provider.request(request)).rejects.toThrow(expectedError);
         // Wait until the circuit break duration passes and hit the endpoint
         // again.
-        jest.advanceTimersByTime(DEFAULT_CIRCUIT_BREAK_DURATION);
+        jest.advanceTimersByTime(inMilliseconds(30, Duration.Second));
         await provider.request(request);
 
         expect(stateChangeListener).toHaveBeenCalledTimes(3);
@@ -781,7 +785,7 @@ describe('NetworkController provider tests', () => {
         method: 'eth_blockNumber',
         params: [],
       })
-      .times(15)
+      .times(12)
       .reply(503)
       .post('/', {
         id: 1,

--- a/packages/network-controller/tests/network-client/block-hash-in-response.ts
+++ b/packages/network-controller/tests/network-client/block-hash-in-response.ts
@@ -446,7 +446,7 @@ export function testsForRpcMethodsThatCheckForBlockHashInResponse(
         code: errorCodes.rpc.resourceUnavailable,
       });
 
-      it('retries the request up to 5 times until there is a 200 response', async () => {
+      it('retries the request up to 4 times until there is a 200 response', async () => {
         await withMockedCommunications({ providerType }, async (comms) => {
           const request = { method };
 
@@ -462,7 +462,7 @@ export function testsForRpcMethodsThatCheckForBlockHashInResponse(
               error: 'Some error',
               httpStatus,
             },
-            times: 4,
+            times: 3,
           });
           comms.mockRpcCall({
             request,
@@ -546,7 +546,7 @@ export function testsForRpcMethodsThatCheckForBlockHashInResponse(
       // still used by Node.
       error.code = errorCode;
 
-      it('retries the request up to 5 times until it is successful', async () => {
+      it('retries the request up to 4 times until it is successful', async () => {
         await withMockedCommunications({ providerType }, async (comms) => {
           const request = { method };
 
@@ -559,7 +559,7 @@ export function testsForRpcMethodsThatCheckForBlockHashInResponse(
           comms.mockRpcCall({
             request,
             error,
-            times: 4,
+            times: 3,
           });
           comms.mockRpcCall({
             request,
@@ -633,7 +633,7 @@ export function testsForRpcMethodsThatCheckForBlockHashInResponse(
       code: errorCodes.rpc.parse,
     });
 
-    it('retries the request up to 5 times until it responds with valid JSON', async () => {
+    it('retries the request up to 4 times until it responds with valid JSON', async () => {
       await withMockedCommunications({ providerType }, async (comms) => {
         const request = { method };
 
@@ -648,7 +648,7 @@ export function testsForRpcMethodsThatCheckForBlockHashInResponse(
           response: {
             body: 'invalid JSON',
           },
-          times: 4,
+          times: 3,
         });
         comms.mockRpcCall({
           request,
@@ -726,7 +726,7 @@ export function testsForRpcMethodsThatCheckForBlockHashInResponse(
   describe('if making the request throws a connection error', () => {
     const error = new TypeError('Failed to fetch');
 
-    it('retries the request up to 5 times until there is no connection error', async () => {
+    it('retries the request up to 4 times until there is no connection error', async () => {
       await withMockedCommunications({ providerType }, async (comms) => {
         const request = { method };
 
@@ -739,7 +739,7 @@ export function testsForRpcMethodsThatCheckForBlockHashInResponse(
         comms.mockRpcCall({
           request,
           error,
-          times: 4,
+          times: 3,
         });
         comms.mockRpcCall({
           request,

--- a/packages/network-controller/tests/network-client/block-param.ts
+++ b/packages/network-controller/tests/network-client/block-param.ts
@@ -552,7 +552,7 @@ export function testsForRpcMethodSupportingBlockParam(
           code: errorCodes.rpc.resourceUnavailable,
         });
 
-        it('retries the request up to 5 times until there is a 200 response', async () => {
+        it('retries the request up to 4 times until there is a 200 response', async () => {
           await withMockedCommunications({ providerType }, async (comms) => {
             const request = {
               method,
@@ -582,7 +582,7 @@ export function testsForRpcMethodSupportingBlockParam(
                 error: 'some error',
                 httpStatus,
               },
-              times: 4,
+              times: 3,
             });
             comms.mockRpcCall({
               request: buildRequestWithReplacedBlockParam(
@@ -685,7 +685,7 @@ export function testsForRpcMethodSupportingBlockParam(
         // still used by Node.
         error.code = errorCode;
 
-        it('retries the request up to 5 times until it is successful', async () => {
+        it('retries the request up to 4 times until it is successful', async () => {
           await withMockedCommunications({ providerType }, async (comms) => {
             const request = {
               method,
@@ -712,7 +712,7 @@ export function testsForRpcMethodSupportingBlockParam(
                 '0x100',
               ),
               error,
-              times: 4,
+              times: 3,
             });
             comms.mockRpcCall({
               request: buildRequestWithReplacedBlockParam(
@@ -807,7 +807,7 @@ export function testsForRpcMethodSupportingBlockParam(
         code: errorCodes.rpc.parse,
       });
 
-      it('retries the request up to 5 times until it responds with valid JSON', async () => {
+      it('retries the request up to 4 times until it responds with valid JSON', async () => {
         await withMockedCommunications({ providerType }, async (comms) => {
           const request = {
             method,
@@ -836,7 +836,7 @@ export function testsForRpcMethodSupportingBlockParam(
             response: {
               body: 'invalid JSON',
             },
-            times: 4,
+            times: 3,
           });
           comms.mockRpcCall({
             request: buildRequestWithReplacedBlockParam(
@@ -932,7 +932,7 @@ export function testsForRpcMethodSupportingBlockParam(
     describe('if making the request throws a connection error', () => {
       const error = new TypeError('Failed to fetch');
 
-      it('retries the request up to 5 times until there is no connection error', async () => {
+      it('retries the request up to 4 times until there is no connection error', async () => {
         await withMockedCommunications({ providerType }, async (comms) => {
           const request = {
             method,
@@ -959,7 +959,7 @@ export function testsForRpcMethodSupportingBlockParam(
               '0x100',
             ),
             error,
-            times: 4,
+            times: 3,
           });
           comms.mockRpcCall({
             request: buildRequestWithReplacedBlockParam(

--- a/packages/network-controller/tests/network-client/no-block-param.ts
+++ b/packages/network-controller/tests/network-client/no-block-param.ts
@@ -399,7 +399,7 @@ export function testsForRpcMethodAssumingNoBlockParam(
         code: errorCodes.rpc.resourceUnavailable,
       });
 
-      it('retries the request up to 5 times until there is a 200 response', async () => {
+      it('retries the request up to 4 times until there is a 200 response', async () => {
         await withMockedCommunications({ providerType }, async (comms) => {
           const request = { method };
 
@@ -415,7 +415,7 @@ export function testsForRpcMethodAssumingNoBlockParam(
               error: 'Some error',
               httpStatus,
             },
-            times: 4,
+            times: 3,
           });
           comms.mockRpcCall({
             request,
@@ -499,7 +499,7 @@ export function testsForRpcMethodAssumingNoBlockParam(
       // still used by Node.
       error.code = errorCode;
 
-      it('retries the request up to 5 times until it is successful', async () => {
+      it('retries the request up to 4 times until it is successful', async () => {
         await withMockedCommunications({ providerType }, async (comms) => {
           const request = { method };
 
@@ -512,7 +512,7 @@ export function testsForRpcMethodAssumingNoBlockParam(
           comms.mockRpcCall({
             request,
             error,
-            times: 4,
+            times: 3,
           });
           comms.mockRpcCall({
             request,
@@ -586,7 +586,7 @@ export function testsForRpcMethodAssumingNoBlockParam(
       code: errorCodes.rpc.parse,
     });
 
-    it('retries the request up to 5 times until it responds with valid JSON', async () => {
+    it('retries the request up to 4 times until it responds with valid JSON', async () => {
       await withMockedCommunications({ providerType }, async (comms) => {
         const request = { method };
 
@@ -601,7 +601,7 @@ export function testsForRpcMethodAssumingNoBlockParam(
           response: {
             body: 'invalid JSON',
           },
-          times: 4,
+          times: 3,
         });
         comms.mockRpcCall({
           request,
@@ -679,7 +679,7 @@ export function testsForRpcMethodAssumingNoBlockParam(
   describe('if making the request throws a connection error', () => {
     const error = new TypeError('Failed to fetch');
 
-    it('retries the request up to 5 times until there is no connection error', async () => {
+    it('retries the request up to 4 times until there is no connection error', async () => {
       await withMockedCommunications({ providerType }, async (comms) => {
         const request = { method };
 
@@ -692,7 +692,7 @@ export function testsForRpcMethodAssumingNoBlockParam(
         comms.mockRpcCall({
           request,
           error,
-          times: 4,
+          times: 3,
         });
         comms.mockRpcCall({
           request,


### PR DESCRIPTION
## Explanation

Port defaults for `maxRetries`, `maxConsecutiveFailures` and `circuitBreakDuration` from the clients into core. This also enables us to make `getRpcServiceOptions` optional. Also brings in defaults for `pollingInterval` and `retryTimeout`. 

## References

https://consensyssoftware.atlassian.net/browse/WPC-1054

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default RPC retry/circuit-break and block polling behavior for all network clients; consumers who omitted `getRpcServiceOptions` or depended on prior client-only defaults may see different failover and unavailable timing.
> 
> **Overview**
> **Network clients now ship built-in RPC and block-tracker tuning** so callers no longer have to supply `getRpcServiceOptions` for standard retry/circuit behavior.
> 
> `getRpcServiceOptions` is **optional** on `NetworkController` and network client creation paths. When omitted, `create-network-client` merges **`@metamask/controller-utils` defaults** into each RPC endpoint: **`maxRetries` 3**, **`circuitBreakDuration` 30s**, and **`maxConsecutiveFailures` 12** on the primary URL vs **40** on failover URLs (higher threshold so QuickNode-style activation does not trip the circuit too early). Custom overrides from `getRpcServiceOptions` still win via spread after those defaults.
> 
> **Block tracker** defaults are set in the same layer: **20s** `pollingInterval` and **retryTimeout** (still **1s** for custom networks under `IN_TEST`). Tests were updated for the new retry counts and circuit timing (e.g. 12 vs 40 mocked failures, 30s timer advance).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ae0d775c15890eb3dd72f3221da89cf85e2f0f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->