### PR TITLE
feat: enhance fiat quote submission to support canonical provider cod…

### DIFF
--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fiat quote submission now treats the provider code (e.g. `transak-native`) as the canonical form when resolving the provider from a ramps quote, while continuing to accept the legacy path form (e.g. `/providers/transak-native`) for backwards compatibility ([#9004](https://github.com/MetaMask/core/pull/9004))
 - Live token balance queries now respect the `confirmations_pay_extended.excludeChainIdsFromInfura` feature flag, skipping the Infura endpoint preference for excluded chains ([#8992](https://github.com/MetaMask/core/pull/8992))
 - Bump `@metamask/assets-controllers` from `^108.3.0` to `^108.5.0` ([#8981](https://github.com/MetaMask/core/pull/8981), [#8999](https://github.com/MetaMask/core/pull/8999))
 - Bump `@metamask/assets-controller` from `^8.0.2` to `^8.3.2` ([#8981](https://github.com/MetaMask/core/pull/8981), [#8985](https://github.com/MetaMask/core/pull/8985), [#8999](https://github.com/MetaMask/core/pull/8999))

--- a/packages/transaction-pay-controller/src/strategy/fiat/fiat-submit.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/fiat-submit.test.ts
@@ -402,11 +402,36 @@ describe('submitFiatQuotes', () => {
 
   it('throws if provider string format is invalid', async () => {
     const { request } = getRequest({
-      rampsQuote: { ...RAMPS_QUOTE_MOCK, provider: 'invalid' },
+      rampsQuote: { ...RAMPS_QUOTE_MOCK, provider: '/unexpected/path' },
     });
 
     await expect(submitFiatQuotes(request)).rejects.toThrow(
       'Missing provider code for fiat submission',
+    );
+  });
+
+  it('throws if the legacy providers path prefix has no provider code', async () => {
+    const { request } = getRequest({
+      rampsQuote: { ...RAMPS_QUOTE_MOCK, provider: '/providers' },
+    });
+
+    await expect(submitFiatQuotes(request)).rejects.toThrow(
+      'Missing provider code for fiat submission',
+    );
+  });
+
+  it('accepts the canonical provider code without the legacy providers path prefix', async () => {
+    const { callMock, request } = getRequest({
+      rampsQuote: { ...RAMPS_QUOTE_MOCK, provider: 'transak-native-staging' },
+    });
+
+    await submitFiatQuotes(request);
+
+    expect(callMock).toHaveBeenCalledWith(
+      'RampsController:getOrder',
+      'transak-native-staging',
+      ORDER_ID_MOCK,
+      WALLET_ADDRESS_MOCK,
     );
   });
 

--- a/packages/transaction-pay-controller/src/strategy/fiat/fiat-submit.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/fiat-submit.ts
@@ -109,7 +109,10 @@ export async function submitFiatQuotes(
 /**
  * Extracts the provider code from a ramps provider string.
  *
- * @param provider - Provider string (e.g. `/providers/transak-native`).
+ * Accepts the canonical provider code (e.g. `transak-native`) and, for
+ * backwards compatibility, the legacy path form (e.g. `/providers/transak-native`).
+ *
+ * @param provider - Canonical provider code, or legacy provider path.
  * @returns The provider code, or `null` if the format is invalid.
  */
 function extractProviderCode(provider: string | undefined): string | null {
@@ -118,7 +121,12 @@ function extractProviderCode(provider: string | undefined): string | null {
   }
 
   const parts = provider.split('/').filter(Boolean);
-  return parts.length >= 2 && parts[0] === 'providers' ? parts[1] : null;
+
+  if (parts[0] === 'providers') {
+    return parts[1] ?? null;
+  }
+
+  return parts.length === 1 ? parts[0] : null;
 }
 
 /**


### PR DESCRIPTION
## Explanation

`submitFiatQuotes` resolves the provider for a fiat order by parsing the `provider` string on a ramps quote. Previously, `extractProviderCode` only accepted the path form (e.g. `/providers/transak-native`) and returned `null` for anything else, which caused submission to throw `Missing provider code for fiat submission`.

Ramps quotes can now surface the provider as a bare code (e.g. `transak-native`) rather than a path. This PR makes the **provider code the canonical form** while keeping the legacy `/providers/...` path form working for backwards compatibility: a single-segment string (`transak-native`) is treated as the provider code directly, a `/providers/<code>` string still resolves to `<code>`, and a `/providers` prefix with no code — or any other unexpected multi-segment path (e.g. `/unexpected/path`) — still resolves to `null` and throws the existing error.

JSDoc on `extractProviderCode` was updated to describe the canonical vs. legacy framing, and tests were added covering the new canonical-code path and the `/providers`-with-no-code edge case, bringing the function back to 100% branch coverage.

## References

<!-- Add the related issue / ticket here, e.g. Fixes #12345 -->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small parsing change in fiat submit with backward-compatible legacy path support; no auth or payment logic changes beyond provider string resolution.
> 
> **Overview**
> Fiat quote submission in **transaction-pay-controller** now resolves the ramps **provider** from either a bare provider code (e.g. `transak-native`) or the legacy `/providers/<code>` path, so `submitFiatQuotes` no longer fails with *Missing provider code* when quotes use the new shape.
> 
> `extractProviderCode` was updated accordingly; invalid multi-segment paths and `/providers` with no code still fail. Tests and the package changelog document the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc4aaf821a138b342c34d7d34dfeb8cbda27c252. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->