### PR TITLE
fix: Update network nicknames and block explorer URLs

### DIFF
--- a/packages/controller-utils/CHANGELOG.md
+++ b/packages/controller-utils/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `NetworkNickname` to match latest client overrides ([#9005](https://github.com/MetaMask/core/pull/9005))
+
 ## [12.1.0]
 
 ### Added

--- a/packages/controller-utils/src/types.ts
+++ b/packages/controller-utils/src/types.ts
@@ -227,7 +227,7 @@ export type BlockExplorerUrl =
   (typeof BlockExplorerUrl)[keyof typeof BlockExplorerUrl];
 
 export const NetworkNickname = {
-  [BuiltInNetworkName.Mainnet]: 'Ethereum Mainnet',
+  [BuiltInNetworkName.Mainnet]: 'Ethereum',
   [BuiltInNetworkName.Goerli]: 'Goerli',
   [BuiltInNetworkName.Sepolia]: 'Sepolia',
   [BuiltInNetworkName.LineaGoerli]: 'Linea Goerli',
@@ -239,14 +239,14 @@ export const NetworkNickname = {
   [BuiltInNetworkName.MegaETHTestnet]: 'Mega Testnet',
   [BuiltInNetworkName.MegaETHTestnetV2]: 'MegaETH Testnet',
   [BuiltInNetworkName.MonadTestnet]: 'Monad Testnet',
-  [BuiltInNetworkName.BaseMainnet]: 'Base Mainnet',
-  [BuiltInNetworkName.ArbitrumOne]: 'Arbitrum One',
-  [BuiltInNetworkName.BscMainnet]: 'BSC Mainnet',
-  [BuiltInNetworkName.OptimismMainnet]: 'Optimism Mainnet',
-  [BuiltInNetworkName.PolygonMainnet]: 'Polygon Mainnet',
+  [BuiltInNetworkName.BaseMainnet]: 'Base',
+  [BuiltInNetworkName.ArbitrumOne]: 'Arbitrum',
+  [BuiltInNetworkName.BscMainnet]: 'BNB Chain',
+  [BuiltInNetworkName.OptimismMainnet]: 'OP',
+  [BuiltInNetworkName.PolygonMainnet]: 'Polygon',
   [BuiltInNetworkName.SeiMainnet]: 'Sei Mainnet',
   [BuiltInNetworkName.MegaETHMainnet]: 'MegaETH Mainnet',
-  [BuiltInNetworkName.MonadMainnet]: 'Monad Mainnet',
+  [BuiltInNetworkName.MonadMainnet]: 'Monad',
   [BuiltInNetworkName.AvalancheMainnet]: 'Avalanche Mainnet',
   [BuiltInNetworkName.ZksyncMainnet]: 'ZKsync Era',
 } as const satisfies Record<BuiltInNetworkType, string>;

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Add defaults for `fetch`, `btoa` and `isOffline` in `RpcServiceOptions` ([#9000](https://github.com/MetaMask/core/pull/9000))
+- Ensure block explorer URLs are populated for default networks ([#9005](https://github.com/MetaMask/core/pull/9005))
 
 ## [32.0.0]
 

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -820,8 +820,11 @@ function getDefaultInfuraNetworkConfigurationsByChainId(): Record<
       const rpcEndpointUrl =
         `https://${infuraNetworkType}.infura.io/v3/{infuraProjectId}` as const;
 
+      const { rpcPrefs } = BUILT_IN_NETWORKS[infuraNetworkType];
+
       const networkConfiguration: NetworkConfiguration = {
-        blockExplorerUrls: [],
+        blockExplorerUrls: [rpcPrefs.blockExplorerUrl],
+        defaultBlockExplorerUrlIndex: 0,
         chainId,
         defaultRpcEndpointIndex: 0,
         name: NetworkNickname[infuraNetworkType],

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -504,10 +504,13 @@ describe('NetworkController', () => {
           {
             "networkConfigurationsByChainId": {
               "0x1": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://etherscan.io",
+                ],
                 "chainId": "0x1",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
-                "name": "Ethereum Mainnet",
+                "name": "Ethereum",
                 "nativeCurrency": "ETH",
                 "rpcEndpoints": [
                   {
@@ -519,10 +522,13 @@ describe('NetworkController', () => {
                 ],
               },
               "0x2105": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://basescan.org",
+                ],
                 "chainId": "0x2105",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
-                "name": "Base Mainnet",
+                "name": "Base",
                 "nativeCurrency": "ETH",
                 "rpcEndpoints": [
                   {
@@ -534,10 +540,13 @@ describe('NetworkController', () => {
                 ],
               },
               "0x38": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://bscscan.com",
+                ],
                 "chainId": "0x38",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
-                "name": "BSC Mainnet",
+                "name": "BNB Chain",
                 "nativeCurrency": "BNB",
                 "rpcEndpoints": [
                   {
@@ -549,10 +558,13 @@ describe('NetworkController', () => {
                 ],
               },
               "0x89": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://polygonscan.com",
+                ],
                 "chainId": "0x89",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
-                "name": "Polygon Mainnet",
+                "name": "Polygon",
                 "nativeCurrency": "POL",
                 "rpcEndpoints": [
                   {
@@ -564,10 +576,13 @@ describe('NetworkController', () => {
                 ],
               },
               "0x8f": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://monadscan.com",
+                ],
                 "chainId": "0x8f",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
-                "name": "Monad Mainnet",
+                "name": "Monad",
                 "nativeCurrency": "MON",
                 "rpcEndpoints": [
                   {
@@ -579,10 +594,13 @@ describe('NetworkController', () => {
                 ],
               },
               "0xa": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://optimistic.etherscan.io",
+                ],
                 "chainId": "0xa",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
-                "name": "Optimism Mainnet",
+                "name": "OP",
                 "nativeCurrency": "ETH",
                 "rpcEndpoints": [
                   {
@@ -594,10 +612,13 @@ describe('NetworkController', () => {
                 ],
               },
               "0xa4b1": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://arbiscan.io",
+                ],
                 "chainId": "0xa4b1",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
-                "name": "Arbitrum One",
+                "name": "Arbitrum",
                 "nativeCurrency": "ETH",
                 "rpcEndpoints": [
                   {
@@ -609,8 +630,11 @@ describe('NetworkController', () => {
                 ],
               },
               "0xaa36a7": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://sepolia.etherscan.io",
+                ],
                 "chainId": "0xaa36a7",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
                 "name": "Sepolia",
                 "nativeCurrency": "SepoliaETH",
@@ -624,8 +648,11 @@ describe('NetworkController', () => {
                 ],
               },
               "0xe705": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://sepolia.lineascan.build",
+                ],
                 "chainId": "0xe705",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
                 "name": "Linea Sepolia",
                 "nativeCurrency": "LineaETH",
@@ -639,8 +666,11 @@ describe('NetworkController', () => {
                 ],
               },
               "0xe708": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://lineascan.build",
+                ],
                 "chainId": "0xe708",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
                 "name": "Linea",
                 "nativeCurrency": "ETH",
@@ -673,10 +703,13 @@ describe('NetworkController', () => {
             {
               "networkConfigurationsByChainId": {
                 "0x1": {
-                  "blockExplorerUrls": [],
+                  "blockExplorerUrls": [
+                    "https://etherscan.io",
+                  ],
                   "chainId": "0x1",
+                  "defaultBlockExplorerUrlIndex": 0,
                   "defaultRpcEndpointIndex": 0,
-                  "name": "Ethereum Mainnet",
+                  "name": "Ethereum",
                   "nativeCurrency": "ETH",
                   "rpcEndpoints": [
                     {
@@ -706,10 +739,13 @@ describe('NetworkController', () => {
                   ],
                 },
                 "0x2105": {
-                  "blockExplorerUrls": [],
+                  "blockExplorerUrls": [
+                    "https://basescan.org",
+                  ],
                   "chainId": "0x2105",
+                  "defaultBlockExplorerUrlIndex": 0,
                   "defaultRpcEndpointIndex": 0,
-                  "name": "Base Mainnet",
+                  "name": "Base",
                   "nativeCurrency": "ETH",
                   "rpcEndpoints": [
                     {
@@ -721,10 +757,13 @@ describe('NetworkController', () => {
                   ],
                 },
                 "0x38": {
-                  "blockExplorerUrls": [],
+                  "blockExplorerUrls": [
+                    "https://bscscan.com",
+                  ],
                   "chainId": "0x38",
+                  "defaultBlockExplorerUrlIndex": 0,
                   "defaultRpcEndpointIndex": 0,
-                  "name": "BSC Mainnet",
+                  "name": "BNB Chain",
                   "nativeCurrency": "BNB",
                   "rpcEndpoints": [
                     {
@@ -736,10 +775,13 @@ describe('NetworkController', () => {
                   ],
                 },
                 "0x89": {
-                  "blockExplorerUrls": [],
+                  "blockExplorerUrls": [
+                    "https://polygonscan.com",
+                  ],
                   "chainId": "0x89",
+                  "defaultBlockExplorerUrlIndex": 0,
                   "defaultRpcEndpointIndex": 0,
-                  "name": "Polygon Mainnet",
+                  "name": "Polygon",
                   "nativeCurrency": "POL",
                   "rpcEndpoints": [
                     {
@@ -751,10 +793,13 @@ describe('NetworkController', () => {
                   ],
                 },
                 "0x8f": {
-                  "blockExplorerUrls": [],
+                  "blockExplorerUrls": [
+                    "https://monadscan.com",
+                  ],
                   "chainId": "0x8f",
+                  "defaultBlockExplorerUrlIndex": 0,
                   "defaultRpcEndpointIndex": 0,
-                  "name": "Monad Mainnet",
+                  "name": "Monad",
                   "nativeCurrency": "MON",
                   "rpcEndpoints": [
                     {
@@ -766,10 +811,13 @@ describe('NetworkController', () => {
                   ],
                 },
                 "0xa": {
-                  "blockExplorerUrls": [],
+                  "blockExplorerUrls": [
+                    "https://optimistic.etherscan.io",
+                  ],
                   "chainId": "0xa",
+                  "defaultBlockExplorerUrlIndex": 0,
                   "defaultRpcEndpointIndex": 0,
-                  "name": "Optimism Mainnet",
+                  "name": "OP",
                   "nativeCurrency": "ETH",
                   "rpcEndpoints": [
                     {
@@ -781,10 +829,13 @@ describe('NetworkController', () => {
                   ],
                 },
                 "0xa4b1": {
-                  "blockExplorerUrls": [],
+                  "blockExplorerUrls": [
+                    "https://arbiscan.io",
+                  ],
                   "chainId": "0xa4b1",
+                  "defaultBlockExplorerUrlIndex": 0,
                   "defaultRpcEndpointIndex": 0,
-                  "name": "Arbitrum One",
+                  "name": "Arbitrum",
                   "nativeCurrency": "ETH",
                   "rpcEndpoints": [
                     {
@@ -796,8 +847,11 @@ describe('NetworkController', () => {
                   ],
                 },
                 "0xaa36a7": {
-                  "blockExplorerUrls": [],
+                  "blockExplorerUrls": [
+                    "https://sepolia.etherscan.io",
+                  ],
                   "chainId": "0xaa36a7",
+                  "defaultBlockExplorerUrlIndex": 0,
                   "defaultRpcEndpointIndex": 0,
                   "name": "Sepolia",
                   "nativeCurrency": "SepoliaETH",
@@ -811,8 +865,11 @@ describe('NetworkController', () => {
                   ],
                 },
                 "0xe705": {
-                  "blockExplorerUrls": [],
+                  "blockExplorerUrls": [
+                    "https://sepolia.lineascan.build",
+                  ],
                   "chainId": "0xe705",
+                  "defaultBlockExplorerUrlIndex": 0,
                   "defaultRpcEndpointIndex": 0,
                   "name": "Linea Sepolia",
                   "nativeCurrency": "LineaETH",
@@ -826,8 +883,11 @@ describe('NetworkController', () => {
                   ],
                 },
                 "0xe708": {
-                  "blockExplorerUrls": [],
+                  "blockExplorerUrls": [
+                    "https://lineascan.build",
+                  ],
                   "chainId": "0xe708",
+                  "defaultBlockExplorerUrlIndex": 0,
                   "defaultRpcEndpointIndex": 0,
                   "name": "Linea",
                   "nativeCurrency": "ETH",
@@ -5045,7 +5105,7 @@ describe('NetworkController', () => {
               }),
             ).toThrow(
               new Error(
-                "Could not add network with chain ID 0x1337 and Infura RPC endpoint for 'Ethereum Mainnet' which represents 0x1, as the two conflict",
+                "Could not add network with chain ID 0x1337 and Infura RPC endpoint for 'Ethereum' which represents 0x1, as the two conflict",
               ),
             );
           },
@@ -8145,7 +8205,7 @@ describe('NetworkController', () => {
                 ],
               }),
             ).rejects.toThrow(
-              "Could not update network to point to same RPC endpoint as existing network for chain 0x1 ('Ethereum Mainnet')",
+              "Could not update network to point to same RPC endpoint as existing network for chain 0x1 ('Ethereum')",
             );
           },
         );
@@ -14896,10 +14956,13 @@ describe('NetworkController', () => {
           {
             "networkConfigurationsByChainId": {
               "0x1": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://etherscan.io",
+                ],
                 "chainId": "0x1",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
-                "name": "Ethereum Mainnet",
+                "name": "Ethereum",
                 "nativeCurrency": "ETH",
                 "rpcEndpoints": [
                   {
@@ -14911,10 +14974,13 @@ describe('NetworkController', () => {
                 ],
               },
               "0x2105": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://basescan.org",
+                ],
                 "chainId": "0x2105",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
-                "name": "Base Mainnet",
+                "name": "Base",
                 "nativeCurrency": "ETH",
                 "rpcEndpoints": [
                   {
@@ -14926,10 +14992,13 @@ describe('NetworkController', () => {
                 ],
               },
               "0x38": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://bscscan.com",
+                ],
                 "chainId": "0x38",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
-                "name": "BSC Mainnet",
+                "name": "BNB Chain",
                 "nativeCurrency": "BNB",
                 "rpcEndpoints": [
                   {
@@ -14941,10 +15010,13 @@ describe('NetworkController', () => {
                 ],
               },
               "0x89": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://polygonscan.com",
+                ],
                 "chainId": "0x89",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
-                "name": "Polygon Mainnet",
+                "name": "Polygon",
                 "nativeCurrency": "POL",
                 "rpcEndpoints": [
                   {
@@ -14956,10 +15028,13 @@ describe('NetworkController', () => {
                 ],
               },
               "0x8f": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://monadscan.com",
+                ],
                 "chainId": "0x8f",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
-                "name": "Monad Mainnet",
+                "name": "Monad",
                 "nativeCurrency": "MON",
                 "rpcEndpoints": [
                   {
@@ -14971,10 +15046,13 @@ describe('NetworkController', () => {
                 ],
               },
               "0xa": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://optimistic.etherscan.io",
+                ],
                 "chainId": "0xa",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
-                "name": "Optimism Mainnet",
+                "name": "OP",
                 "nativeCurrency": "ETH",
                 "rpcEndpoints": [
                   {
@@ -14986,10 +15064,13 @@ describe('NetworkController', () => {
                 ],
               },
               "0xa4b1": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://arbiscan.io",
+                ],
                 "chainId": "0xa4b1",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
-                "name": "Arbitrum One",
+                "name": "Arbitrum",
                 "nativeCurrency": "ETH",
                 "rpcEndpoints": [
                   {
@@ -15001,8 +15082,11 @@ describe('NetworkController', () => {
                 ],
               },
               "0xaa36a7": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://sepolia.etherscan.io",
+                ],
                 "chainId": "0xaa36a7",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
                 "name": "Sepolia",
                 "nativeCurrency": "SepoliaETH",
@@ -15016,8 +15100,11 @@ describe('NetworkController', () => {
                 ],
               },
               "0xe705": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://sepolia.lineascan.build",
+                ],
                 "chainId": "0xe705",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
                 "name": "Linea Sepolia",
                 "nativeCurrency": "LineaETH",
@@ -15031,8 +15118,11 @@ describe('NetworkController', () => {
                 ],
               },
               "0xe708": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://lineascan.build",
+                ],
                 "chainId": "0xe708",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
                 "name": "Linea",
                 "nativeCurrency": "ETH",
@@ -15065,10 +15155,13 @@ describe('NetworkController', () => {
           {
             "networkConfigurationsByChainId": {
               "0x1": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://etherscan.io",
+                ],
                 "chainId": "0x1",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
-                "name": "Ethereum Mainnet",
+                "name": "Ethereum",
                 "nativeCurrency": "ETH",
                 "rpcEndpoints": [
                   {
@@ -15080,10 +15173,13 @@ describe('NetworkController', () => {
                 ],
               },
               "0x2105": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://basescan.org",
+                ],
                 "chainId": "0x2105",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
-                "name": "Base Mainnet",
+                "name": "Base",
                 "nativeCurrency": "ETH",
                 "rpcEndpoints": [
                   {
@@ -15095,10 +15191,13 @@ describe('NetworkController', () => {
                 ],
               },
               "0x38": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://bscscan.com",
+                ],
                 "chainId": "0x38",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
-                "name": "BSC Mainnet",
+                "name": "BNB Chain",
                 "nativeCurrency": "BNB",
                 "rpcEndpoints": [
                   {
@@ -15110,10 +15209,13 @@ describe('NetworkController', () => {
                 ],
               },
               "0x89": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://polygonscan.com",
+                ],
                 "chainId": "0x89",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
-                "name": "Polygon Mainnet",
+                "name": "Polygon",
                 "nativeCurrency": "POL",
                 "rpcEndpoints": [
                   {
@@ -15125,10 +15227,13 @@ describe('NetworkController', () => {
                 ],
               },
               "0x8f": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://monadscan.com",
+                ],
                 "chainId": "0x8f",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
-                "name": "Monad Mainnet",
+                "name": "Monad",
                 "nativeCurrency": "MON",
                 "rpcEndpoints": [
                   {
@@ -15140,10 +15245,13 @@ describe('NetworkController', () => {
                 ],
               },
               "0xa": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://optimistic.etherscan.io",
+                ],
                 "chainId": "0xa",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
-                "name": "Optimism Mainnet",
+                "name": "OP",
                 "nativeCurrency": "ETH",
                 "rpcEndpoints": [
                   {
@@ -15155,10 +15263,13 @@ describe('NetworkController', () => {
                 ],
               },
               "0xa4b1": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://arbiscan.io",
+                ],
                 "chainId": "0xa4b1",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
-                "name": "Arbitrum One",
+                "name": "Arbitrum",
                 "nativeCurrency": "ETH",
                 "rpcEndpoints": [
                   {
@@ -15170,8 +15281,11 @@ describe('NetworkController', () => {
                 ],
               },
               "0xaa36a7": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://sepolia.etherscan.io",
+                ],
                 "chainId": "0xaa36a7",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
                 "name": "Sepolia",
                 "nativeCurrency": "SepoliaETH",
@@ -15185,8 +15299,11 @@ describe('NetworkController', () => {
                 ],
               },
               "0xe705": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://sepolia.lineascan.build",
+                ],
                 "chainId": "0xe705",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
                 "name": "Linea Sepolia",
                 "nativeCurrency": "LineaETH",
@@ -15200,8 +15317,11 @@ describe('NetworkController', () => {
                 ],
               },
               "0xe708": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://lineascan.build",
+                ],
                 "chainId": "0xe708",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
                 "name": "Linea",
                 "nativeCurrency": "ETH",
@@ -15234,10 +15354,13 @@ describe('NetworkController', () => {
           {
             "networkConfigurationsByChainId": {
               "0x1": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://etherscan.io",
+                ],
                 "chainId": "0x1",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
-                "name": "Ethereum Mainnet",
+                "name": "Ethereum",
                 "nativeCurrency": "ETH",
                 "rpcEndpoints": [
                   {
@@ -15249,10 +15372,13 @@ describe('NetworkController', () => {
                 ],
               },
               "0x2105": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://basescan.org",
+                ],
                 "chainId": "0x2105",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
-                "name": "Base Mainnet",
+                "name": "Base",
                 "nativeCurrency": "ETH",
                 "rpcEndpoints": [
                   {
@@ -15264,10 +15390,13 @@ describe('NetworkController', () => {
                 ],
               },
               "0x38": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://bscscan.com",
+                ],
                 "chainId": "0x38",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
-                "name": "BSC Mainnet",
+                "name": "BNB Chain",
                 "nativeCurrency": "BNB",
                 "rpcEndpoints": [
                   {
@@ -15279,10 +15408,13 @@ describe('NetworkController', () => {
                 ],
               },
               "0x89": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://polygonscan.com",
+                ],
                 "chainId": "0x89",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
-                "name": "Polygon Mainnet",
+                "name": "Polygon",
                 "nativeCurrency": "POL",
                 "rpcEndpoints": [
                   {
@@ -15294,10 +15426,13 @@ describe('NetworkController', () => {
                 ],
               },
               "0x8f": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://monadscan.com",
+                ],
                 "chainId": "0x8f",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
-                "name": "Monad Mainnet",
+                "name": "Monad",
                 "nativeCurrency": "MON",
                 "rpcEndpoints": [
                   {
@@ -15309,10 +15444,13 @@ describe('NetworkController', () => {
                 ],
               },
               "0xa": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://optimistic.etherscan.io",
+                ],
                 "chainId": "0xa",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
-                "name": "Optimism Mainnet",
+                "name": "OP",
                 "nativeCurrency": "ETH",
                 "rpcEndpoints": [
                   {
@@ -15324,10 +15462,13 @@ describe('NetworkController', () => {
                 ],
               },
               "0xa4b1": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://arbiscan.io",
+                ],
                 "chainId": "0xa4b1",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
-                "name": "Arbitrum One",
+                "name": "Arbitrum",
                 "nativeCurrency": "ETH",
                 "rpcEndpoints": [
                   {
@@ -15339,8 +15480,11 @@ describe('NetworkController', () => {
                 ],
               },
               "0xaa36a7": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://sepolia.etherscan.io",
+                ],
                 "chainId": "0xaa36a7",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
                 "name": "Sepolia",
                 "nativeCurrency": "SepoliaETH",
@@ -15354,8 +15498,11 @@ describe('NetworkController', () => {
                 ],
               },
               "0xe705": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://sepolia.lineascan.build",
+                ],
                 "chainId": "0xe705",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
                 "name": "Linea Sepolia",
                 "nativeCurrency": "LineaETH",
@@ -15369,8 +15516,11 @@ describe('NetworkController', () => {
                 ],
               },
               "0xe708": {
-                "blockExplorerUrls": [],
+                "blockExplorerUrls": [
+                  "https://lineascan.build",
+                ],
                 "chainId": "0xe708",
+                "defaultBlockExplorerUrlIndex": 0,
                 "defaultRpcEndpointIndex": 0,
                 "name": "Linea",
                 "nativeCurrency": "ETH",


### PR DESCRIPTION
## Explanation

Updates all network nicknames to match overrides used by the clients. Additionally, ensure block explorer URLs are populated by default so the client doesn't have to do it.

## References

https://consensyssoftware.atlassian.net/browse/WPC-1051

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-facing display strings and default network metadata only; no auth, RPC, or transaction logic changes.
> 
> **Overview**
> Aligns **default built-in network display names** with client overrides by updating `NetworkNickname` in `@metamask/controller-utils` (e.g. `Ethereum Mainnet` → `Ethereum`, `BSC Mainnet` → `BNB Chain`, `Optimism Mainnet` → `OP`).
> 
> **`NetworkController`** now seeds default Infura network configurations with **block explorer URLs** from `BUILT_IN_NETWORKS` (`blockExplorerUrls` plus `defaultBlockExplorerUrlIndex: 0`) instead of leaving them empty, so clients do not need to patch explorers separately.
> 
> Changelogs and `NetworkController` test snapshots/error strings were updated to match the new names and explorer fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f166437a3554ea1dd7b6ba9af94cc4a41e93e0b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->