### PR TITLE
fix: held tokens price data

### DIFF
--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/assets-controllers` from `^108.2.0` to `^108.3.0` ([#8941](https://github.com/MetaMask/core/pull/8941))
 - Bump `@metamask/assets-controller` from `^8.1.0` to `^8.2.0` ([#8943](https://github.com/MetaMask/core/pull/8943))
 
+### Fixed
+
+- `selectExchangeRateByAssetId` now resolves fungible asset fiat rates from the unified `AssetsController` `assetsPrice` source, so held tokens (e.g. USDC) produce a fiat value when `useAssetsControllerForRates` is enabled instead of resolving no rate
+
 ## [73.2.0]
 
 ### Added

--- a/packages/bridge-controller/src/selectors.test.ts
+++ b/packages/bridge-controller/src/selectors.test.ts
@@ -3,6 +3,7 @@ import { AddressZero } from '@ethersproject/constants';
 import type { MarketDataDetails } from '@metamask/assets-controllers';
 import { toHex } from '@metamask/controller-utils';
 import { SolScope } from '@metamask/keyring-api';
+import type { CaipAssetType } from '@metamask/utils';
 import { BigNumber } from 'bignumber.js';
 
 import mockQuotesErc20Erc20 from '../tests/mock-quotes-erc20-erc20.json';
@@ -187,6 +188,113 @@ describe('Bridge Selectors', () => {
           'eip155:1/erc20:0x123',
         ),
       ).toStrictEqual({});
+    });
+
+    describe('assetsPrice resolution (unified assets)', () => {
+      // DAI, not present in any other rate source in mockExchangeRateSources.
+      const DAI_ADDRESS = '0x6B175474E89094C44Da98b954EedeAC495271d0F';
+      const daiAssetIdChecksummed = formatAddressToAssetId(
+        DAI_ADDRESS,
+        '1',
+      ) as CaipAssetType;
+
+      it('resolves a fungible rate from assetsPrice when legacy slices lack it', () => {
+        const result = selectExchangeRateByAssetId(
+          {
+            ...mockExchangeRateSources,
+            assetsPrice: {
+              [daiAssetIdChecksummed]: {
+                assetPriceType: 'fungible',
+                price: 1.23,
+                usdPrice: 1.5,
+              },
+            },
+          } as unknown as BridgeAppState,
+          daiAssetIdChecksummed,
+        );
+        expect(result).toStrictEqual({
+          exchangeRate: '1.23',
+          usdExchangeRate: '1.5',
+        });
+      });
+
+      it('matches a checksummed assetsPrice key when the asset ID is lowercased', () => {
+        const result = selectExchangeRateByAssetId(
+          {
+            ...mockExchangeRateSources,
+            assetsPrice: {
+              [daiAssetIdChecksummed]: {
+                assetPriceType: 'fungible',
+                price: 1.23,
+                usdPrice: 1.5,
+              },
+            },
+          } as unknown as BridgeAppState,
+          `eip155:1/erc20:${DAI_ADDRESS.toLowerCase()}`,
+        );
+        expect(result).toStrictEqual({
+          exchangeRate: '1.23',
+          usdExchangeRate: '1.5',
+        });
+      });
+
+      it('ignores non-fungible (NFT) assetsPrice entries', () => {
+        const result = selectExchangeRateByAssetId(
+          {
+            ...mockExchangeRateSources,
+            assetsPrice: {
+              [daiAssetIdChecksummed]: {
+                assetPriceType: 'nft',
+                floorPrice: 1.23,
+              },
+            },
+          } as unknown as BridgeAppState,
+          daiAssetIdChecksummed,
+        );
+        expect(result).toStrictEqual({});
+      });
+
+      it('ignores assetsPrice entries with non-finite price or usdPrice', () => {
+        const result = selectExchangeRateByAssetId(
+          {
+            ...mockExchangeRateSources,
+            assetsPrice: {
+              [daiAssetIdChecksummed]: {
+                assetPriceType: 'fungible',
+                price: Number.NaN,
+                usdPrice: undefined,
+              },
+            },
+          } as unknown as BridgeAppState,
+          daiAssetIdChecksummed,
+        );
+        expect(result).toStrictEqual({});
+      });
+
+      it('prefers bridge controller assetExchangeRates over assetsPrice', () => {
+        const usdcAssetId = formatAddressToAssetId(
+          MOCK_USDC_ADDRESS,
+          '1',
+        ) as CaipAssetType;
+        const result = selectExchangeRateByAssetId(
+          {
+            ...mockExchangeRateSources,
+            assetsPrice: {
+              [usdcAssetId]: {
+                assetPriceType: 'fungible',
+                price: 9.99,
+                usdPrice: 9.99,
+              },
+            },
+          } as unknown as BridgeAppState,
+          usdcAssetId,
+        );
+        // assetExchangeRates entry for USDC (2.5 / 1.5) wins.
+        expect(result).toStrictEqual({
+          exchangeRate: '2.5',
+          usdExchangeRate: '1.5',
+        });
+      });
     });
   });
 

--- a/packages/bridge-controller/src/selectors.ts
+++ b/packages/bridge-controller/src/selectors.ts
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 import { getAddress } from '@ethersproject/address';
+import { normalizeAssetId } from '@metamask/assets-controller';
+import type { AssetsControllerState } from '@metamask/assets-controller';
 import type {
   CurrencyRateState,
   MultichainAssetsRatesControllerState,
@@ -62,7 +64,8 @@ import { getDefaultSlippagePercentage } from './utils/slippage';
 type ExchangeRateControllerState = MultichainAssetsRatesControllerState &
   TokenRatesControllerState &
   CurrencyRateState &
-  Pick<BridgeControllerState, 'assetExchangeRates'>;
+  Pick<BridgeControllerState, 'assetExchangeRates'> &
+  Partial<Pick<AssetsControllerState, 'assetsPrice'>>;
 /**
  * The state of the bridge controller and all its dependency controllers
  */
@@ -81,7 +84,8 @@ export type ExchangeRateSourcesForLookup = Pick<
   'assetExchangeRates'
 > &
   Partial<Pick<CurrencyRateState, 'currencyRates'>> &
-  Partial<Pick<MultichainAssetsRatesControllerState, 'historicalPrices'>> & {
+  Partial<Pick<MultichainAssetsRatesControllerState, 'historicalPrices'>> &
+  Partial<Pick<AssetsControllerState, 'assetsPrice'>> & {
     marketData?:
       | TokenRatesControllerState['marketData']
       | Record<string, Record<string, { price?: number; currency?: string }>>;
@@ -173,8 +177,13 @@ export const selectExchangeRateByAssetId = (
     return {};
   }
 
-  const { assetExchangeRates, currencyRates, marketData, conversionRates } =
-    exchangeRateSources;
+  const {
+    assetExchangeRates,
+    currencyRates,
+    marketData,
+    conversionRates,
+    assetsPrice,
+  } = exchangeRateSources;
 
   // If the asset exchange rate is available in the bridge controller, use it
   // This is defined if the token's rate is not available from the assets controllers
@@ -186,6 +195,24 @@ export const selectExchangeRateByAssetId = (
     bridgeControllerRate?.usdExchangeRate
   ) {
     return bridgeControllerRate;
+  }
+
+  // When the unified assets system is active, held-token fiat rates live in
+  // `assetsPrice` (keyed by checksummed CAIP-19 asset ID) rather than the
+  // legacy market/currency-rate slices. Resolve fungible prices directly so
+  // held tokens (e.g. USDC) produce a fiat value. `normalizeAssetId` checksums
+  // EVM ERC-20 references so a lower-cased input matches the stored key.
+  const assetPrice =
+    assetsPrice?.[normalizeAssetId(assetId)] ?? assetsPrice?.[assetId];
+  if (
+    assetPrice?.assetPriceType === 'fungible' &&
+    Number.isFinite(assetPrice.price) &&
+    Number.isFinite(assetPrice.usdPrice)
+  ) {
+    return {
+      exchangeRate: String(assetPrice.price),
+      usdExchangeRate: String(assetPrice.usdPrice),
+    };
   }
 
   const { chainId } = parseCaipAssetType(assetId);


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped selector change for display and quote metadata pricing; bridge controller rates still take precedence and legacy paths are unchanged when `assetsPrice` is absent.
> 
> **Overview**
> Fixes missing fiat values for held tokens (e.g. USDC) when clients use unified **`AssetsController`** pricing via **`useAssetsControllerForRates`**.
> 
> **`selectExchangeRateByAssetId`** now looks up fungible **`assetsPrice`** entries (after bridge **`assetExchangeRates`**, before legacy **`marketData`** / currency slices), mapping **`price`** / **`usdPrice`** to **`exchangeRate`** / **`usdExchangeRate`**. **`normalizeAssetId`** aligns lowercased CAIP-19 IDs with checksummed keys; NFT and invalid price rows are skipped. Exchange-rate source types include optional **`assetsPrice`**. Tests and changelog document the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffab58fab0a03690ea5c6370cd6e9137a18c1480. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->