### PR TITLE
feat(perps-controller): centralize market category classification

### DIFF
--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `getMarketTypeFilter`, `isEquityAsset`, and `STOCK_LIKE_MARKET_TYPES` to centralise market category classification, mapping the `MarketCategory` data model onto the UI `MarketTypeFilter` pills so consumers share one mapping instead of re-deriving it per client ([#9009](https://github.com/MetaMask/core/pull/9009))
+- Export `matchesCategory`, `getMarketTypeFilter`, and `applyMarketFilters` so consumers share one market-category classification (the `MarketTypeFilter` model) instead of re-deriving it per client; `getMarketTypeFilter` is the inverse of `matchesCategory` ([#9009](https://github.com/MetaMask/core/pull/9009))
 
 ## [7.0.0]
 

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Centralise market category classification so consumers share one model instead of re-deriving it per client ([#9009](https://github.com/MetaMask/core/pull/9009))
-  - Export `getMarketTypeFilter` (resolves a market to its UI category filter, collapsing stock-like categories into `stocks`), `isEquityAsset`, and `STOCK_LIKE_MARKET_TYPES`.
+  - Export `getMarketTypeFilter` (resolves a market to its UI category filter, collapsing stock-like categories into `stocks`), `isEquityAsset`, `isHip3Market`, and `STOCK_LIKE_MARKET_TYPES`. `getMarketTypeFilter` and `matchesCategory` treat a `marketSource` DEX id as a HIP-3 signal consistently, so partial (route-param) markets classify the same way in both.
   - Export the pure `matchesCategory` and `applyMarketFilters` helpers (moved from `MarketDataService`).
   - Add `MARKET_TYPE_FILTER` named constants for the `MarketTypeFilter` values.
 

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Export `getMarketTypeFilter` (resolves a market to its UI category filter with singular values aligned to `MarketCategory`) and `isHip3Market`. `getMarketTypeFilter` and `matchesCategory` treat a `marketSource` DEX id as a HIP-3 signal consistently, so partial (route-param) markets classify the same way in both.
   - Export the pure `matchesCategory` and `applyMarketFilters` helpers (moved from `MarketDataService`).
 
+### Changed
+
+- **BREAKING:** Align `MarketTypeFilter` and `MARKET_CATEGORIES` values with `MarketCategory` singular values ([#9009](https://github.com/MetaMask/core/pull/9009))
+  - Replace `stocks` with `stock`, `indices` with `index`, `etfs` with `etf`, and `commodities` with `commodity`.
+
 ## [7.0.0]
 
 ### Added

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -10,9 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Centralise market category classification so consumers share one model instead of re-deriving it per client ([#9009](https://github.com/MetaMask/core/pull/9009))
-  - Export `getMarketTypeFilter` (resolves a market to its UI category filter, collapsing stock-like categories into `stocks`), `isEquityAsset`, `isHip3Market`, and `STOCK_LIKE_MARKET_TYPES`. `getMarketTypeFilter` and `matchesCategory` treat a `marketSource` DEX id as a HIP-3 signal consistently, so partial (route-param) markets classify the same way in both.
+  - Export `getMarketTypeFilter` (resolves a market to its UI category filter with singular values aligned to `MarketCategory`) and `isHip3Market`. `getMarketTypeFilter` and `matchesCategory` treat a `marketSource` DEX id as a HIP-3 signal consistently, so partial (route-param) markets classify the same way in both.
   - Export the pure `matchesCategory` and `applyMarketFilters` helpers (moved from `MarketDataService`).
-  - Add `MARKET_TYPE_FILTER` named constants for the `MarketTypeFilter` values.
 
 ## [7.0.0]
 

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -9,7 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Export `matchesCategory`, `getMarketTypeFilter`, and `applyMarketFilters` so consumers share one market-category classification (the `MarketTypeFilter` model) instead of re-deriving it per client; `getMarketTypeFilter` is the inverse of `matchesCategory` ([#9009](https://github.com/MetaMask/core/pull/9009))
+- Centralise market category classification so consumers share one model instead of re-deriving it per client ([#9009](https://github.com/MetaMask/core/pull/9009))
+  - Export `getMarketTypeFilter` (resolves a market to its UI category filter, collapsing stock-like categories into `stocks`), `isEquityAsset`, and `STOCK_LIKE_MARKET_TYPES`.
+  - Export the pure `matchesCategory` and `applyMarketFilters` helpers (moved from `MarketDataService`).
+  - Add `MARKET_TYPE_FILTER` named constants for the `MarketTypeFilter` values.
 
 ## [7.0.0]
 

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `getMarketTypeFilter`, `isEquityAsset`, and `STOCK_LIKE_MARKET_TYPES` to centralise market category classification, mapping the `MarketCategory` data model onto the UI `MarketTypeFilter` pills so consumers share one mapping instead of re-deriving it per client ([#9009](https://github.com/MetaMask/core/pull/9009))
+
 ## [7.0.0]
 
 ### Added

--- a/packages/perps-controller/src/index.ts
+++ b/packages/perps-controller/src/index.ts
@@ -137,7 +137,6 @@ export {
   WebSocketConnectionState,
   PerpsAnalyticsEvent,
   MARKET_CATEGORIES,
-  MARKET_TYPE_FILTER,
   MarketCategory,
 } from './types';
 export type {
@@ -495,9 +494,7 @@ export {
   matchesCategory,
   getMarketTypeFilter,
   applyMarketFilters,
-  isEquityAsset,
   isHip3Market,
-  STOCK_LIKE_MARKET_TYPES,
 } from './utils';
 export type { MarketPatternMatcher, CompiledMarketPattern } from './utils';
 export type {

--- a/packages/perps-controller/src/index.ts
+++ b/packages/perps-controller/src/index.ts
@@ -491,9 +491,9 @@ export {
   calculateFundingCountdown,
   calculate24hHighLow,
   filterMarketsByQuery,
-  isEquityAsset,
+  matchesCategory,
   getMarketTypeFilter,
-  STOCK_LIKE_MARKET_TYPES,
+  applyMarketFilters,
 } from './utils';
 export type { MarketPatternMatcher, CompiledMarketPattern } from './utils';
 export type {

--- a/packages/perps-controller/src/index.ts
+++ b/packages/perps-controller/src/index.ts
@@ -137,6 +137,7 @@ export {
   WebSocketConnectionState,
   PerpsAnalyticsEvent,
   MARKET_CATEGORIES,
+  MARKET_TYPE_FILTER,
   MarketCategory,
 } from './types';
 export type {
@@ -494,6 +495,8 @@ export {
   matchesCategory,
   getMarketTypeFilter,
   applyMarketFilters,
+  isEquityAsset,
+  STOCK_LIKE_MARKET_TYPES,
 } from './utils';
 export type { MarketPatternMatcher, CompiledMarketPattern } from './utils';
 export type {

--- a/packages/perps-controller/src/index.ts
+++ b/packages/perps-controller/src/index.ts
@@ -496,6 +496,7 @@ export {
   getMarketTypeFilter,
   applyMarketFilters,
   isEquityAsset,
+  isHip3Market,
   STOCK_LIKE_MARKET_TYPES,
 } from './utils';
 export type { MarketPatternMatcher, CompiledMarketPattern } from './utils';

--- a/packages/perps-controller/src/index.ts
+++ b/packages/perps-controller/src/index.ts
@@ -491,6 +491,9 @@ export {
   calculateFundingCountdown,
   calculate24hHighLow,
   filterMarketsByQuery,
+  isEquityAsset,
+  getMarketTypeFilter,
+  STOCK_LIKE_MARKET_TYPES,
 } from './utils';
 export type { MarketPatternMatcher, CompiledMarketPattern } from './utils';
 export type {

--- a/packages/perps-controller/src/services/MarketDataService.ts
+++ b/packages/perps-controller/src/services/MarketDataService.ts
@@ -4,11 +4,7 @@ import type { CandlePeriod } from '../constants/chartConfig';
 import { PerpsMeasurementName } from '../constants/performanceMetrics';
 import { PERPS_CONSTANTS } from '../constants/perpsConfig';
 import { PERPS_ERROR_CODES } from '../perpsErrorCodes';
-import {
-  MarketCategory,
-  PerpsTraceNames,
-  PerpsTraceOperations,
-} from '../types';
+import { PerpsTraceNames, PerpsTraceOperations } from '../types';
 import type {
   PerpsProvider,
   Position,
@@ -36,12 +32,11 @@ import type {
   AssetRoute,
   PerpsPlatformDependencies,
   PerpsMarketData,
-  MarketTypeFilter,
 } from '../types';
 import type { CandleData } from '../types/perps-types';
 import { coalescePerpsRestRequest } from '../utils/coalescePerpsRestRequest';
 import { ensureError, isAbortError } from '../utils/errorUtils';
-import { sortMarkets } from '../utils/sortMarkets';
+import { applyMarketFilters } from '../utils/marketUtils';
 import type { ServiceContext } from './ServiceContext';
 
 /**
@@ -1257,89 +1252,4 @@ export class MarketDataService {
     const { provider, address } = options;
     return provider.getBlockExplorerUrl(address);
   }
-}
-
-// ============================================================================
-// Market filtering helpers (module-level pure functions)
-// These live outside the class because they have no service dependencies —
-// they are pure data transformations that can be tested and reused independently.
-// ============================================================================
-
-/**
- * Returns true when a market matches the given UI filter category.
- *
- * @param market - The market data to test.
- * @param category - The filter category to test against.
- * @returns Whether the market matches the category.
- */
-export function matchesCategory(
-  market: PerpsMarketData,
-  category: MarketTypeFilter,
-): boolean {
-  switch (category) {
-    case 'all':
-      return true;
-    case 'new':
-      return market.isNewMarket === true;
-    case 'crypto':
-      // Includes non-HIP3 markets AND HIP-3 assets explicitly typed as CryptoCurrency.
-      return (
-        !market.isHip3 || market.marketType === MarketCategory.CryptoCurrency
-      );
-    case 'stocks':
-      return market.marketType === MarketCategory.Stock;
-    case 'pre-ipo':
-      return market.marketType === MarketCategory.PreIpo;
-    case 'indices':
-      return market.marketType === MarketCategory.Index;
-    case 'etfs':
-      return market.marketType === MarketCategory.Etf;
-    case 'commodities':
-      return market.marketType === MarketCategory.Commodity;
-    case 'forex':
-      return market.marketType === MarketCategory.Forex;
-    default:
-      return true;
-  }
-}
-
-/**
- * Applies optional category filtering, sorting, and limit to a list of markets.
- *
- * @param markets - Source market array.
- * @param params - Optional filter/sort/limit params.
- * @returns Filtered, sorted, and/or sliced market array.
- */
-export function applyMarketFilters(
-  markets: PerpsMarketData[],
-  params?: GetMarketDataWithPricesParams,
-): PerpsMarketData[] {
-  let result = markets;
-
-  if (params?.categories?.length) {
-    const { categories } = params;
-    result = result.filter((market) =>
-      // A market is included if it matches ANY of the requested categories.
-      categories.some((category) => matchesCategory(market, category)),
-    );
-  }
-
-  if (params?.excludeSymbols?.length) {
-    const excluded = new Set(params.excludeSymbols);
-    result = result.filter((market) => !excluded.has(market.symbol));
-  }
-
-  if (params?.sortBy) {
-    result = sortMarkets({
-      markets: result,
-      sortBy: params.sortBy,
-      direction: params.direction,
-    });
-  }
-
-  if (params?.limit !== undefined) {
-    result = result.slice(0, params.limit);
-  }
-
-  return result;
 }

--- a/packages/perps-controller/src/types/index.ts
+++ b/packages/perps-controller/src/types/index.ts
@@ -87,33 +87,16 @@ export enum MarketCategory {
 export type MarketType = `${MarketCategory}`;
 
 // Market type filter for UI category badges
-// Note: 'stocks' maps to 'stock', 'commodities' maps to 'commodity' in the data model
 export type MarketTypeFilter =
   | 'all'
   | 'crypto'
-  | 'stocks'
+  | 'stock'
   | 'pre-ipo'
-  | 'indices'
-  | 'etfs'
-  | 'commodities'
+  | 'index'
+  | 'etf'
+  | 'commodity'
   | 'forex'
   | 'new';
-
-/**
- * Named constants for the {@link MarketTypeFilter} values, so consumers
- * reference `MARKET_TYPE_FILTER.Stocks` instead of bare string literals.
- */
-export const MARKET_TYPE_FILTER = {
-  All: 'all',
-  Crypto: 'crypto',
-  Stocks: 'stocks',
-  PreIpo: 'pre-ipo',
-  Indices: 'indices',
-  Etfs: 'etfs',
-  Commodities: 'commodities',
-  Forex: 'forex',
-  New: 'new',
-} as const satisfies Record<string, MarketTypeFilter>;
 
 /**
  * Ordered list of the 7 data-model market categories for UI pills.
@@ -123,11 +106,11 @@ export const MARKET_TYPE_FILTER = {
  */
 export const MARKET_CATEGORIES = [
   'crypto',
-  'stocks',
+  'stock',
   'pre-ipo',
-  'indices',
-  'etfs',
-  'commodities',
+  'index',
+  'etf',
+  'commodity',
   'forex',
 ] as const satisfies MarketTypeFilter[];
 

--- a/packages/perps-controller/src/types/index.ts
+++ b/packages/perps-controller/src/types/index.ts
@@ -100,6 +100,22 @@ export type MarketTypeFilter =
   | 'new';
 
 /**
+ * Named constants for the {@link MarketTypeFilter} values, so consumers
+ * reference `MARKET_TYPE_FILTER.Stocks` instead of bare string literals.
+ */
+export const MARKET_TYPE_FILTER = {
+  All: 'all',
+  Crypto: 'crypto',
+  Stocks: 'stocks',
+  PreIpo: 'pre-ipo',
+  Indices: 'indices',
+  Etfs: 'etfs',
+  Commodities: 'commodities',
+  Forex: 'forex',
+  New: 'new',
+} as const satisfies Record<string, MarketTypeFilter>;
+
+/**
  * Ordered list of the 7 data-model market categories for UI pills.
  * Does not include the 'all' or 'new' sentinel values — those are applied
  * via dedicated UI controls, not the category pills.

--- a/packages/perps-controller/src/utils/marketUtils.ts
+++ b/packages/perps-controller/src/utils/marketUtils.ts
@@ -1,7 +1,6 @@
-import { MARKET_TYPE_FILTER, MarketCategory } from '../types';
+import { MarketCategory } from '../types';
 import type {
   GetMarketDataWithPricesParams,
-  MarketType,
   MarketTypeFilter,
   PerpsMarketData,
 } from '../types';
@@ -11,23 +10,23 @@ import { sortMarkets } from './sortMarkets';
 // ============================================================================
 // Market category classification (pure functions)
 // No service dependencies — pure data transformations that can be tested and
-// reused independently. `matchesCategory` is the single source of truth for the
-// UI category model; `getMarketTypeFilter` is its inverse.
+// reused independently. `matchesCategory` and `getMarketTypeFilter` share the
+// same category model.
 // ============================================================================
 
 /**
  * Maps each data-model {@link MarketCategory} to its UI {@link MarketTypeFilter}
- * (e.g. `stock` → `stocks`). Exhaustive: adding a `MarketCategory` is a compile
- * error here until it is mapped, so the model can't silently drift.
+ * with matching singular values. Exhaustive: adding a `MarketCategory` is a
+ * compile error here until it is mapped, so the model can't silently drift.
  */
 const MARKET_CATEGORY_TO_FILTER: Record<MarketCategory, MarketTypeFilter> = {
-  [MarketCategory.CryptoCurrency]: MARKET_TYPE_FILTER.Crypto,
-  [MarketCategory.Stock]: MARKET_TYPE_FILTER.Stocks,
-  [MarketCategory.PreIpo]: MARKET_TYPE_FILTER.PreIpo,
-  [MarketCategory.Index]: MARKET_TYPE_FILTER.Indices,
-  [MarketCategory.Etf]: MARKET_TYPE_FILTER.Etfs,
-  [MarketCategory.Commodity]: MARKET_TYPE_FILTER.Commodities,
-  [MarketCategory.Forex]: MARKET_TYPE_FILTER.Forex,
+  [MarketCategory.CryptoCurrency]: 'crypto',
+  [MarketCategory.Stock]: 'stock',
+  [MarketCategory.PreIpo]: 'pre-ipo',
+  [MarketCategory.Index]: 'index',
+  [MarketCategory.Etf]: 'etf',
+  [MarketCategory.Commodity]: 'commodity',
+  [MarketCategory.Forex]: 'forex',
 };
 
 /**
@@ -55,16 +54,16 @@ export function matchesCategory(
   category: MarketTypeFilter,
 ): boolean {
   switch (category) {
-    case MARKET_TYPE_FILTER.All:
+    case 'all':
       return true;
-    case MARKET_TYPE_FILTER.New:
+    case 'new':
       // Explicitly flagged, or an uncategorized HIP-3 market (kept in sync with
       // getMarketTypeFilter's 'new' bucket).
       return (
         market.isNewMarket === true ||
         (isHip3Market(market) && market.marketType === undefined)
       );
-    case MARKET_TYPE_FILTER.Crypto:
+    case 'crypto':
       // Main-DEX markets, plus HIP-3 assets explicitly typed as CryptoCurrency.
       return (
         !isHip3Market(market) ||
@@ -80,35 +79,12 @@ export function matchesCategory(
 }
 
 /**
- * Stock-like market categories (stock, pre-ipo, index, etf). Clients collapse
- * these into the single 'stocks' filter, and they share traditional market
- * hours. Single source of truth for the equity bucket.
- */
-export const STOCK_LIKE_MARKET_TYPES: ReadonlySet<MarketType> = new Set([
-  MarketCategory.Stock,
-  MarketCategory.PreIpo,
-  MarketCategory.Index,
-  MarketCategory.Etf,
-]);
-
-/**
- * Check whether a market type is stock-like (stock, pre-ipo, index, etf).
- *
- * @param marketType - The market type from {@link PerpsMarketData}.
- * @returns True if the asset is stock-like.
- */
-export const isEquityAsset = (marketType?: string): boolean =>
-  marketType !== undefined &&
-  STOCK_LIKE_MARKET_TYPES.has(marketType as MarketType);
-
-/**
  * Resolve the user-facing category bucket for a market — one of `crypto`,
- * `stocks`, `commodities`, `forex`, or `new`. Stock-like categories (stock,
- * pre-ipo, index, etf) collapse into the single `stocks` bucket (see
- * {@link isEquityAsset}); the remaining categories map 1:1. A market with no
- * data-model category is `crypto` when it is main-DEX, or `new` when it is an
- * uncategorized HIP-3 market (`isHip3`, or a `marketSource` DEX id when `isHip3`
- * is unset, e.g. minimal route params). Never returns the `all` sentinel.
+ * `stock`, `pre-ipo`, `index`, `etf`, `commodity`, `forex`, or `new`. Data-model
+ * categories map 1:1. A market with no data-model category is `crypto` when it
+ * is main-DEX, or `new` when it is an uncategorized HIP-3 market (`isHip3`, or a
+ * `marketSource` DEX id when `isHip3` is unset, e.g. minimal route params).
+ * Never returns the `all` sentinel.
  *
  * Centralised as the single source of truth so consumers (e.g. category
  * shortcuts, related markets) share one classification instead of re-deriving
@@ -119,19 +95,12 @@ export const isEquityAsset = (marketType?: string): boolean =>
  */
 export function getMarketTypeFilter(market: PerpsMarketData): MarketTypeFilter {
   const { marketType } = market;
-  // Stock-like categories (stock, pre-ipo, index, etf) collapse into one pill.
-  if (isEquityAsset(marketType)) {
-    return MARKET_TYPE_FILTER.Stocks;
-  }
-  // Every other data-model category maps 1:1 (commodity, forex, crypto).
   if (marketType) {
     return MARKET_CATEGORY_TO_FILTER[marketType];
   }
   // No data-model category: an uncategorized HIP-3 market is the 'new' bucket;
   // otherwise it's a main-DEX crypto market.
-  return isHip3Market(market)
-    ? MARKET_TYPE_FILTER.New
-    : MARKET_TYPE_FILTER.Crypto;
+  return isHip3Market(market) ? 'new' : 'crypto';
 }
 
 /**

--- a/packages/perps-controller/src/utils/marketUtils.ts
+++ b/packages/perps-controller/src/utils/marketUtils.ts
@@ -1,4 +1,3 @@
-import { MarketCategory } from '../types';
 import type {
   GetMarketDataWithPricesParams,
   MarketTypeFilter,
@@ -13,21 +12,6 @@ import { sortMarkets } from './sortMarkets';
 // reused independently. `matchesCategory` and `getMarketTypeFilter` share the
 // same category model.
 // ============================================================================
-
-/**
- * Maps each data-model {@link MarketCategory} to its UI {@link MarketTypeFilter}
- * with matching singular values. Exhaustive: adding a `MarketCategory` is a
- * compile error here until it is mapped, so the model can't silently drift.
- */
-const MARKET_CATEGORY_TO_FILTER: Record<MarketCategory, MarketTypeFilter> = {
-  [MarketCategory.CryptoCurrency]: 'crypto',
-  [MarketCategory.Stock]: 'stock',
-  [MarketCategory.PreIpo]: 'pre-ipo',
-  [MarketCategory.Index]: 'index',
-  [MarketCategory.Etf]: 'etf',
-  [MarketCategory.Commodity]: 'commodity',
-  [MarketCategory.Forex]: 'forex',
-};
 
 /**
  * Whether a market is a HIP-3 (non-main-DEX) market. A `marketSource` DEX id
@@ -65,16 +49,10 @@ export function matchesCategory(
       );
     case 'crypto':
       // Main-DEX markets, plus HIP-3 assets explicitly typed as CryptoCurrency.
-      return (
-        !isHip3Market(market) ||
-        market.marketType === MarketCategory.CryptoCurrency
-      );
+      return !isHip3Market(market) || market.marketType === 'crypto';
     default:
       // Every other filter is a 1:1 data-model category match.
-      return (
-        market.marketType !== undefined &&
-        MARKET_CATEGORY_TO_FILTER[market.marketType] === category
-      );
+      return market.marketType !== undefined && market.marketType === category;
   }
 }
 
@@ -96,7 +74,7 @@ export function matchesCategory(
 export function getMarketTypeFilter(market: PerpsMarketData): MarketTypeFilter {
   const { marketType } = market;
   if (marketType) {
-    return MARKET_CATEGORY_TO_FILTER[marketType];
+    return marketType;
   }
   // No data-model category: an uncategorized HIP-3 market is the 'new' bucket;
   // otherwise it's a main-DEX crypto market.

--- a/packages/perps-controller/src/utils/marketUtils.ts
+++ b/packages/perps-controller/src/utils/marketUtils.ts
@@ -1,68 +1,118 @@
-import { MarketCategory } from '../types';
-import type { MarketType, MarketTypeFilter, PerpsMarketData } from '../types';
+import { MARKET_CATEGORIES, MarketCategory } from '../types';
+import type {
+  GetMarketDataWithPricesParams,
+  MarketTypeFilter,
+  PerpsMarketData,
+} from '../types';
 import type { CandleData, CandleStick } from '../types/perps-types';
+import { sortMarkets } from './sortMarkets';
+
+// ============================================================================
+// Market category classification (pure functions)
+// No service dependencies — pure data transformations that can be tested and
+// reused independently. `matchesCategory` is the single source of truth for the
+// UI category model; `getMarketTypeFilter` is its inverse.
+// ============================================================================
 
 /**
- * Stock-like market categories that share the 'stocks' UI filter and follow
- * traditional market hours. These replaced the former 'equity' `MarketType`.
+ * Returns true when a market matches the given UI filter category.
+ *
+ * @param market - The market data to test.
+ * @param category - The filter category to test against.
+ * @returns Whether the market matches the category.
  */
-export const STOCK_LIKE_MARKET_TYPES: ReadonlySet<MarketType> = new Set([
-  MarketCategory.Stock,
-  MarketCategory.PreIpo,
-  MarketCategory.Index,
-  MarketCategory.Etf,
-]);
+export function matchesCategory(
+  market: PerpsMarketData,
+  category: MarketTypeFilter,
+): boolean {
+  switch (category) {
+    case 'all':
+      return true;
+    case 'new':
+      return market.isNewMarket === true;
+    case 'crypto':
+      // Includes non-HIP3 markets AND HIP-3 assets explicitly typed as CryptoCurrency.
+      return (
+        !market.isHip3 || market.marketType === MarketCategory.CryptoCurrency
+      );
+    case 'stocks':
+      return market.marketType === MarketCategory.Stock;
+    case 'pre-ipo':
+      return market.marketType === MarketCategory.PreIpo;
+    case 'indices':
+      return market.marketType === MarketCategory.Index;
+    case 'etfs':
+      return market.marketType === MarketCategory.Etf;
+    case 'commodities':
+      return market.marketType === MarketCategory.Commodity;
+    case 'forex':
+      return market.marketType === MarketCategory.Forex;
+    default:
+      return true;
+  }
+}
 
 /**
- * Check whether a market type is a stock-like asset (stock, pre-ipo, index,
- * etf). Stock-like assets share the 'stocks' category filter and follow
- * traditional market hours.
+ * Resolve the category filter pill for a given market — the inverse of
+ * {@link matchesCategory}. Returns the granular data-model filter (e.g. 'etfs',
+ * 'indices', 'pre-ipo', 'stocks', 'commodities', 'forex', 'crypto'); markets
+ * with no matching category (uncategorized HIP-3 / new markets) fall back to
+ * 'all' so the opened tab always contains the market.
  *
- * @param marketType - The market type from {@link PerpsMarketData}.
- * @returns True if the asset is a stock, pre-ipo, index, or etf.
- */
-export const isEquityAsset = (marketType?: string): boolean =>
-  marketType !== undefined &&
-  STOCK_LIKE_MARKET_TYPES.has(marketType as MarketType);
-
-/**
- * Resolve the category filter pill to pre-select for a given market.
+ * Centralised as the single source of truth so consumers (e.g. category
+ * shortcuts, related markets) share one classification instead of re-deriving
+ * it per client and drifting as new categories are added.
  *
- * Maps the {@link MarketCategory} data model onto the UI {@link MarketTypeFilter}
- * pills. Stock-like categories (stock, pre-ipo, index, etf) collapse to the
- * single 'stocks' pill via {@link isEquityAsset}. Any HIP-3 signal — `isHip3`,
- * `isNewMarket`, or a `marketSource` DEX id — on an otherwise-uncategorized
- * market resolves to 'all' rather than 'crypto', because the crypto pill only
- * contains main-DEX (non-HIP-3) markets. Only true main-DEX markets resolve to
- * 'crypto'.
- *
- * Centralised here so consumers (e.g. category shortcuts, related markets) share
- * one classification instead of re-deriving it per client and drifting as new
- * categories are added.
- *
- * @param market - Market data (marketType, isNewMarket, isHip3, marketSource).
+ * @param market - The market data to classify.
  * @returns The market type filter to apply.
  */
-export const getMarketTypeFilter = (
-  market: Pick<
-    PerpsMarketData,
-    'marketType' | 'isNewMarket' | 'isHip3' | 'marketSource'
-  >,
-): MarketTypeFilter => {
-  if (isEquityAsset(market.marketType)) {
-    return 'stocks';
+export function getMarketTypeFilter(market: PerpsMarketData): MarketTypeFilter {
+  return (
+    MARKET_CATEGORIES.find((category) => matchesCategory(market, category)) ??
+    'all'
+  );
+}
+
+/**
+ * Applies optional category filtering, sorting, and limit to a list of markets.
+ *
+ * @param markets - Source market array.
+ * @param params - Optional filter/sort/limit params.
+ * @returns Filtered, sorted, and/or sliced market array.
+ */
+export function applyMarketFilters(
+  markets: PerpsMarketData[],
+  params?: GetMarketDataWithPricesParams,
+): PerpsMarketData[] {
+  let result = markets;
+
+  if (params?.categories?.length) {
+    const { categories } = params;
+    result = result.filter((market) =>
+      // A market is included if it matches ANY of the requested categories.
+      categories.some((category) => matchesCategory(market, category)),
+    );
   }
-  if (market.marketType === MarketCategory.Commodity) {
-    return 'commodities';
+
+  if (params?.excludeSymbols?.length) {
+    const excluded = new Set(params.excludeSymbols);
+    result = result.filter((market) => !excluded.has(market.symbol));
   }
-  if (market.marketType === MarketCategory.Forex) {
-    return 'forex';
+
+  if (params?.sortBy) {
+    result = sortMarkets({
+      markets: result,
+      sortBy: params.sortBy,
+      direction: params.direction,
+    });
   }
-  if (market.isNewMarket || market.isHip3 || market.marketSource) {
-    return 'all';
+
+  if (params?.limit !== undefined) {
+    result = result.slice(0, params.limit);
   }
-  return 'crypto';
-};
+
+  return result;
+}
 
 /**
  * Maximum length for market filter patterns (prevents DoS attacks)

--- a/packages/perps-controller/src/utils/marketUtils.ts
+++ b/packages/perps-controller/src/utils/marketUtils.ts
@@ -31,6 +31,19 @@ const MARKET_CATEGORY_TO_FILTER: Record<MarketCategory, MarketTypeFilter> = {
 };
 
 /**
+ * Whether a market is a HIP-3 (non-main-DEX) market. A `marketSource` DEX id
+ * marks a HIP-3 market even when the `isHip3` flag is unset (e.g. partial route
+ * params), so both signals are checked. Used as the single HIP-3 signal so the
+ * classifiers stay consistent.
+ *
+ * @param market - The market data to test.
+ * @returns True if the market is HIP-3.
+ */
+export const isHip3Market = (
+  market: Pick<PerpsMarketData, 'isHip3' | 'marketSource'>,
+): boolean => Boolean(market.isHip3) || Boolean(market.marketSource);
+
+/**
  * Returns true when a market matches the given UI filter category.
  *
  * @param market - The market data to test.
@@ -45,11 +58,17 @@ export function matchesCategory(
     case MARKET_TYPE_FILTER.All:
       return true;
     case MARKET_TYPE_FILTER.New:
-      return market.isNewMarket === true;
-    case MARKET_TYPE_FILTER.Crypto:
-      // Non-HIP3 markets, plus HIP-3 assets explicitly typed as CryptoCurrency.
+      // Explicitly flagged, or an uncategorized HIP-3 market (kept in sync with
+      // getMarketTypeFilter's 'new' bucket).
       return (
-        !market.isHip3 || market.marketType === MarketCategory.CryptoCurrency
+        market.isNewMarket === true ||
+        (isHip3Market(market) && market.marketType === undefined)
+      );
+    case MARKET_TYPE_FILTER.Crypto:
+      // Main-DEX markets, plus HIP-3 assets explicitly typed as CryptoCurrency.
+      return (
+        !isHip3Market(market) ||
+        market.marketType === MarketCategory.CryptoCurrency
       );
     default:
       // Every other filter is a 1:1 data-model category match.
@@ -108,9 +127,9 @@ export function getMarketTypeFilter(market: PerpsMarketData): MarketTypeFilter {
   if (marketType) {
     return MARKET_CATEGORY_TO_FILTER[marketType];
   }
-  // No data-model category: a HIP-3 market (isHip3, or a marketSource DEX id) is
-  // uncategorized → the 'new' bucket; otherwise it's a main-DEX crypto market.
-  return market.isHip3 || market.marketSource
+  // No data-model category: an uncategorized HIP-3 market is the 'new' bucket;
+  // otherwise it's a main-DEX crypto market.
+  return isHip3Market(market)
     ? MARKET_TYPE_FILTER.New
     : MARKET_TYPE_FILTER.Crypto;
 }

--- a/packages/perps-controller/src/utils/marketUtils.ts
+++ b/packages/perps-controller/src/utils/marketUtils.ts
@@ -1,6 +1,7 @@
-import { MARKET_CATEGORIES, MarketCategory } from '../types';
+import { MARKET_TYPE_FILTER, MarketCategory } from '../types';
 import type {
   GetMarketDataWithPricesParams,
+  MarketType,
   MarketTypeFilter,
   PerpsMarketData,
 } from '../types';
@@ -15,6 +16,21 @@ import { sortMarkets } from './sortMarkets';
 // ============================================================================
 
 /**
+ * Maps each data-model {@link MarketCategory} to its UI {@link MarketTypeFilter}
+ * (e.g. `stock` → `stocks`). Exhaustive: adding a `MarketCategory` is a compile
+ * error here until it is mapped, so the model can't silently drift.
+ */
+const MARKET_CATEGORY_TO_FILTER: Record<MarketCategory, MarketTypeFilter> = {
+  [MarketCategory.CryptoCurrency]: MARKET_TYPE_FILTER.Crypto,
+  [MarketCategory.Stock]: MARKET_TYPE_FILTER.Stocks,
+  [MarketCategory.PreIpo]: MARKET_TYPE_FILTER.PreIpo,
+  [MarketCategory.Index]: MARKET_TYPE_FILTER.Indices,
+  [MarketCategory.Etf]: MARKET_TYPE_FILTER.Etfs,
+  [MarketCategory.Commodity]: MARKET_TYPE_FILTER.Commodities,
+  [MarketCategory.Forex]: MARKET_TYPE_FILTER.Forex,
+};
+
+/**
  * Returns true when a market matches the given UI filter category.
  *
  * @param market - The market data to test.
@@ -26,51 +42,77 @@ export function matchesCategory(
   category: MarketTypeFilter,
 ): boolean {
   switch (category) {
-    case 'all':
+    case MARKET_TYPE_FILTER.All:
       return true;
-    case 'new':
+    case MARKET_TYPE_FILTER.New:
       return market.isNewMarket === true;
-    case 'crypto':
-      // Includes non-HIP3 markets AND HIP-3 assets explicitly typed as CryptoCurrency.
+    case MARKET_TYPE_FILTER.Crypto:
+      // Non-HIP3 markets, plus HIP-3 assets explicitly typed as CryptoCurrency.
       return (
         !market.isHip3 || market.marketType === MarketCategory.CryptoCurrency
       );
-    case 'stocks':
-      return market.marketType === MarketCategory.Stock;
-    case 'pre-ipo':
-      return market.marketType === MarketCategory.PreIpo;
-    case 'indices':
-      return market.marketType === MarketCategory.Index;
-    case 'etfs':
-      return market.marketType === MarketCategory.Etf;
-    case 'commodities':
-      return market.marketType === MarketCategory.Commodity;
-    case 'forex':
-      return market.marketType === MarketCategory.Forex;
     default:
-      return true;
+      // Every other filter is a 1:1 data-model category match.
+      return (
+        market.marketType !== undefined &&
+        MARKET_CATEGORY_TO_FILTER[market.marketType] === category
+      );
   }
 }
 
 /**
- * Resolve the category filter pill for a given market — the inverse of
- * {@link matchesCategory}. Returns the granular data-model filter (e.g. 'etfs',
- * 'indices', 'pre-ipo', 'stocks', 'commodities', 'forex', 'crypto'); markets
- * with no matching category (uncategorized HIP-3 / new markets) fall back to
- * 'all' so the opened tab always contains the market.
+ * Stock-like market categories (stock, pre-ipo, index, etf). Clients collapse
+ * these into the single 'stocks' filter, and they share traditional market
+ * hours. Single source of truth for the equity bucket.
+ */
+export const STOCK_LIKE_MARKET_TYPES: ReadonlySet<MarketType> = new Set([
+  MarketCategory.Stock,
+  MarketCategory.PreIpo,
+  MarketCategory.Index,
+  MarketCategory.Etf,
+]);
+
+/**
+ * Check whether a market type is stock-like (stock, pre-ipo, index, etf).
+ *
+ * @param marketType - The market type from {@link PerpsMarketData}.
+ * @returns True if the asset is stock-like.
+ */
+export const isEquityAsset = (marketType?: string): boolean =>
+  marketType !== undefined &&
+  STOCK_LIKE_MARKET_TYPES.has(marketType as MarketType);
+
+/**
+ * Resolve the user-facing category bucket for a market — one of `crypto`,
+ * `stocks`, `commodities`, `forex`, or `new`. Stock-like categories (stock,
+ * pre-ipo, index, etf) collapse into the single `stocks` bucket (see
+ * {@link isEquityAsset}); the remaining categories map 1:1. A market with no
+ * data-model category is `crypto` when it is main-DEX, or `new` when it is an
+ * uncategorized HIP-3 market (`isHip3`, or a `marketSource` DEX id when `isHip3`
+ * is unset, e.g. minimal route params). Never returns the `all` sentinel.
  *
  * Centralised as the single source of truth so consumers (e.g. category
  * shortcuts, related markets) share one classification instead of re-deriving
  * it per client and drifting as new categories are added.
  *
  * @param market - The market data to classify.
- * @returns The market type filter to apply.
+ * @returns The market type filter bucket.
  */
 export function getMarketTypeFilter(market: PerpsMarketData): MarketTypeFilter {
-  return (
-    MARKET_CATEGORIES.find((category) => matchesCategory(market, category)) ??
-    'all'
-  );
+  const { marketType } = market;
+  // Stock-like categories (stock, pre-ipo, index, etf) collapse into one pill.
+  if (isEquityAsset(marketType)) {
+    return MARKET_TYPE_FILTER.Stocks;
+  }
+  // Every other data-model category maps 1:1 (commodity, forex, crypto).
+  if (marketType) {
+    return MARKET_CATEGORY_TO_FILTER[marketType];
+  }
+  // No data-model category: a HIP-3 market (isHip3, or a marketSource DEX id) is
+  // uncategorized → the 'new' bucket; otherwise it's a main-DEX crypto market.
+  return market.isHip3 || market.marketSource
+    ? MARKET_TYPE_FILTER.New
+    : MARKET_TYPE_FILTER.Crypto;
 }
 
 /**

--- a/packages/perps-controller/src/utils/marketUtils.ts
+++ b/packages/perps-controller/src/utils/marketUtils.ts
@@ -1,5 +1,68 @@
-import type { PerpsMarketData } from '../types';
+import { MarketCategory } from '../types';
+import type { MarketType, MarketTypeFilter, PerpsMarketData } from '../types';
 import type { CandleData, CandleStick } from '../types/perps-types';
+
+/**
+ * Stock-like market categories that share the 'stocks' UI filter and follow
+ * traditional market hours. These replaced the former 'equity' `MarketType`.
+ */
+export const STOCK_LIKE_MARKET_TYPES: ReadonlySet<MarketType> = new Set([
+  MarketCategory.Stock,
+  MarketCategory.PreIpo,
+  MarketCategory.Index,
+  MarketCategory.Etf,
+]);
+
+/**
+ * Check whether a market type is a stock-like asset (stock, pre-ipo, index,
+ * etf). Stock-like assets share the 'stocks' category filter and follow
+ * traditional market hours.
+ *
+ * @param marketType - The market type from {@link PerpsMarketData}.
+ * @returns True if the asset is a stock, pre-ipo, index, or etf.
+ */
+export const isEquityAsset = (marketType?: string): boolean =>
+  marketType !== undefined &&
+  STOCK_LIKE_MARKET_TYPES.has(marketType as MarketType);
+
+/**
+ * Resolve the category filter pill to pre-select for a given market.
+ *
+ * Maps the {@link MarketCategory} data model onto the UI {@link MarketTypeFilter}
+ * pills. Stock-like categories (stock, pre-ipo, index, etf) collapse to the
+ * single 'stocks' pill via {@link isEquityAsset}. Any HIP-3 signal — `isHip3`,
+ * `isNewMarket`, or a `marketSource` DEX id — on an otherwise-uncategorized
+ * market resolves to 'all' rather than 'crypto', because the crypto pill only
+ * contains main-DEX (non-HIP-3) markets. Only true main-DEX markets resolve to
+ * 'crypto'.
+ *
+ * Centralised here so consumers (e.g. category shortcuts, related markets) share
+ * one classification instead of re-deriving it per client and drifting as new
+ * categories are added.
+ *
+ * @param market - Market data (marketType, isNewMarket, isHip3, marketSource).
+ * @returns The market type filter to apply.
+ */
+export const getMarketTypeFilter = (
+  market: Pick<
+    PerpsMarketData,
+    'marketType' | 'isNewMarket' | 'isHip3' | 'marketSource'
+  >,
+): MarketTypeFilter => {
+  if (isEquityAsset(market.marketType)) {
+    return 'stocks';
+  }
+  if (market.marketType === MarketCategory.Commodity) {
+    return 'commodities';
+  }
+  if (market.marketType === MarketCategory.Forex) {
+    return 'forex';
+  }
+  if (market.isNewMarket || market.isHip3 || market.marketSource) {
+    return 'all';
+  }
+  return 'crypto';
+};
 
 /**
  * Maximum length for market filter patterns (prevents DoS attacks)

--- a/packages/perps-controller/tests/src/PerpsController.market-filtering.test.ts
+++ b/packages/perps-controller/tests/src/PerpsController.market-filtering.test.ts
@@ -153,11 +153,11 @@ describe('PerpsController — market categories & filtering', () => {
     it('includes all 7 data categories', () => {
       const categories = controller.getMarketCategories();
       expect(categories).toContain('crypto');
-      expect(categories).toContain('stocks');
+      expect(categories).toContain('stock');
       expect(categories).toContain('pre-ipo');
-      expect(categories).toContain('indices');
-      expect(categories).toContain('etfs');
-      expect(categories).toContain('commodities');
+      expect(categories).toContain('index');
+      expect(categories).toContain('etf');
+      expect(categories).toContain('commodity');
       expect(categories).toContain('forex');
     });
   });
@@ -213,7 +213,7 @@ describe('PerpsController — market categories & filtering', () => {
       expect(symbols).not.toContain('xyz:TSLA');
     });
 
-    it('filters to only stock markets when categories is ["stocks"]', async () => {
+    it('filters to only stock markets when categories is ["stock"]', async () => {
       const markets = [
         buildMarket({ symbol: 'BTC', isHip3: false }),
         buildMarket({
@@ -235,7 +235,7 @@ describe('PerpsController — market categories & filtering', () => {
       mockProvider.getMarketDataWithPrices.mockResolvedValue(markets);
 
       const result = await controller.getMarketDataWithPrices({
-        categories: ['stocks'],
+        categories: ['stock'],
       });
 
       expect(result).toHaveLength(2);
@@ -266,7 +266,7 @@ describe('PerpsController — market categories & filtering', () => {
       mockProvider.getMarketDataWithPrices.mockResolvedValue(markets);
 
       const result = await controller.getMarketDataWithPrices({
-        categories: ['stocks', 'etfs'],
+        categories: ['stock', 'etf'],
       });
 
       expect(result).toHaveLength(2);
@@ -483,7 +483,7 @@ describe('PerpsController — market categories & filtering', () => {
       mockProvider.getMarketDataWithPrices.mockResolvedValue(markets);
 
       const result = await controller.getMarketDataWithPrices({
-        categories: ['stocks'],
+        categories: ['stock'],
         sortBy: 'openInterest',
         direction: 'desc',
         limit: 2,

--- a/packages/perps-controller/tests/src/constants/hyperLiquidConfig.test.ts
+++ b/packages/perps-controller/tests/src/constants/hyperLiquidConfig.test.ts
@@ -121,11 +121,11 @@ describe('MARKET_CATEGORIES', () => {
   it('includes all 7 MarketTypeFilter data categories', () => {
     const dataCategories: MarketTypeFilter[] = [
       'crypto',
-      'stocks',
+      'stock',
       'pre-ipo',
-      'indices',
-      'etfs',
-      'commodities',
+      'index',
+      'etf',
+      'commodity',
       'forex',
     ];
     for (const category of dataCategories) {
@@ -138,11 +138,11 @@ describe('MARKET_CATEGORIES', () => {
     // The runtime check here mirrors that constraint.
     const validValues: readonly string[] = [
       'crypto',
-      'stocks',
+      'stock',
       'pre-ipo',
-      'indices',
-      'etfs',
-      'commodities',
+      'index',
+      'etf',
+      'commodity',
       'forex',
     ];
     for (const entry of MARKET_CATEGORIES) {

--- a/packages/perps-controller/tests/src/utils/marketUtils.test.ts
+++ b/packages/perps-controller/tests/src/utils/marketUtils.test.ts
@@ -1,8 +1,6 @@
 import type { PerpsMarketData } from '../../../src/types';
 import {
-  STOCK_LIKE_MARKET_TYPES,
   getMarketTypeFilter,
-  isEquityAsset,
   isHip3Market,
   matchesCategory,
 } from '../../../src/utils/marketUtils';
@@ -20,33 +18,6 @@ const market = (overrides: Partial<PerpsMarketData>): PerpsMarketData =>
   }) as PerpsMarketData;
 
 describe('marketUtils category classification', () => {
-  describe('STOCK_LIKE_MARKET_TYPES', () => {
-    it('contains the four stock-like categories', () => {
-      expect([...STOCK_LIKE_MARKET_TYPES].sort()).toStrictEqual([
-        'etf',
-        'index',
-        'pre-ipo',
-        'stock',
-      ]);
-    });
-  });
-
-  describe('isEquityAsset', () => {
-    it.each(['stock', 'pre-ipo', 'index', 'etf'])(
-      'returns true for stock-like %s',
-      (marketType) => {
-        expect(isEquityAsset(marketType)).toBe(true);
-      },
-    );
-
-    it.each(['crypto', 'commodity', 'forex', 'bond', undefined])(
-      'returns false for non-equity %s',
-      (marketType) => {
-        expect(isEquityAsset(marketType)).toBe(false);
-      },
-    );
-  });
-
   describe('isHip3Market', () => {
     it('is true when isHip3 is set', () => {
       expect(isHip3Market(market({ isHip3: true }))).toBe(true);
@@ -108,38 +79,31 @@ describe('marketUtils category classification', () => {
     });
 
     it.each([
-      ['stock', 'stocks'],
+      ['stock', 'stock'],
       ['pre-ipo', 'pre-ipo'],
-      ['index', 'indices'],
-      ['etf', 'etfs'],
-      ['commodity', 'commodities'],
+      ['index', 'index'],
+      ['etf', 'etf'],
+      ['commodity', 'commodity'],
       ['forex', 'forex'],
     ] as const)(
-      'matches marketType %s for the granular filter %s',
+      'matches marketType %s for the aligned filter %s',
       (marketType, filter) => {
         expect(matchesCategory(market({ marketType }), filter)).toBe(true);
       },
     );
-
-    it('keeps stock-like categories distinct in the granular model', () => {
-      expect(matchesCategory(market({ marketType: 'etf' }), 'stocks')).toBe(
-        false,
-      );
-    });
   });
 
   describe('getMarketTypeFilter', () => {
-    // HIP-3 markets carry a marketType; main-DEX crypto does not. Stock-like
-    // categories collapse into the single 'stocks' filter.
+    // HIP-3 markets carry a marketType; main-DEX crypto does not.
     it.each([
-      ['stock', 'stocks'],
-      ['pre-ipo', 'stocks'],
-      ['index', 'stocks'],
-      ['etf', 'stocks'],
-      ['commodity', 'commodities'],
+      ['stock', 'stock'],
+      ['pre-ipo', 'pre-ipo'],
+      ['index', 'index'],
+      ['etf', 'etf'],
+      ['commodity', 'commodity'],
       ['forex', 'forex'],
     ] as const)(
-      'collapses HIP-3 marketType %s to the %s filter',
+      'resolves HIP-3 marketType %s to the %s filter',
       (marketType, expected) => {
         expect(getMarketTypeFilter(market({ marketType, isHip3: true }))).toBe(
           expected,
@@ -189,10 +153,12 @@ describe('marketUtils category classification', () => {
       );
     });
 
-    // The resolved bucket must agree with matchesCategory (stock-like is the one
-    // intentional exception: it collapses to 'stocks' while matchesCategory keeps
-    // stock/pre-ipo/index/etf granular).
+    // The resolved bucket must agree with matchesCategory.
     it.each([
+      market({ marketType: 'stock', isHip3: true }),
+      market({ marketType: 'pre-ipo', isHip3: true }),
+      market({ marketType: 'index', isHip3: true }),
+      market({ marketType: 'etf', isHip3: true }),
       market({ marketType: 'commodity', isHip3: true }),
       market({ marketType: 'forex', isHip3: true }),
       market({ marketType: undefined, isHip3: false }),

--- a/packages/perps-controller/tests/src/utils/marketUtils.test.ts
+++ b/packages/perps-controller/tests/src/utils/marketUtils.test.ts
@@ -1,8 +1,7 @@
-import type { MarketType, PerpsMarketData } from '../../../src/types';
+import type { PerpsMarketData } from '../../../src/types';
 import {
-  STOCK_LIKE_MARKET_TYPES,
   getMarketTypeFilter,
-  isEquityAsset,
+  matchesCategory,
 } from '../../../src/utils/marketUtils';
 
 const market = (overrides: Partial<PerpsMarketData>): PerpsMarketData =>
@@ -17,91 +16,90 @@ const market = (overrides: Partial<PerpsMarketData>): PerpsMarketData =>
     ...overrides,
   }) as PerpsMarketData;
 
-describe('marketUtils category helpers', () => {
-  describe('STOCK_LIKE_MARKET_TYPES', () => {
-    it('contains the four stock-like categories', () => {
-      expect([...STOCK_LIKE_MARKET_TYPES].sort()).toStrictEqual([
-        'etf',
-        'index',
-        'pre-ipo',
-        'stock',
-      ]);
-    });
-  });
-
-  describe('isEquityAsset', () => {
-    it.each(['stock', 'pre-ipo', 'index', 'etf'] as const)(
-      'returns true for stock-like %s',
-      (marketType) => {
-        expect(isEquityAsset(marketType)).toBe(true);
-      },
-    );
-
-    it.each(['crypto', 'commodity', 'forex'] as const)(
-      'returns false for non-equity %s',
-      (marketType) => {
-        expect(isEquityAsset(marketType)).toBe(false);
-      },
-    );
-
-    it('returns false for undefined marketType', () => {
-      expect(isEquityAsset(undefined)).toBe(false);
+describe('marketUtils category classification', () => {
+  describe('matchesCategory', () => {
+    it("matches every market for 'all'", () => {
+      expect(matchesCategory(market({ marketType: 'etf' }), 'all')).toBe(true);
     });
 
-    it('returns false for an unknown marketType', () => {
-      expect(isEquityAsset('bond')).toBe(false);
+    it("matches only new markets for 'new'", () => {
+      expect(matchesCategory(market({ isNewMarket: true }), 'new')).toBe(true);
+      expect(matchesCategory(market({ isNewMarket: false }), 'new')).toBe(
+        false,
+      );
+    });
+
+    it("matches non-HIP3 markets for 'crypto'", () => {
+      expect(matchesCategory(market({ isHip3: false }), 'crypto')).toBe(true);
+    });
+
+    it("matches HIP-3 markets explicitly typed crypto for 'crypto'", () => {
+      expect(
+        matchesCategory(
+          market({ isHip3: true, marketType: 'crypto' }),
+          'crypto',
+        ),
+      ).toBe(true);
+    });
+
+    it("excludes other HIP-3 markets from 'crypto'", () => {
+      expect(
+        matchesCategory(market({ isHip3: true, marketType: 'etf' }), 'crypto'),
+      ).toBe(false);
+    });
+
+    it.each([
+      ['stock', 'stocks'],
+      ['pre-ipo', 'pre-ipo'],
+      ['index', 'indices'],
+      ['etf', 'etfs'],
+      ['commodity', 'commodities'],
+      ['forex', 'forex'],
+    ] as const)('matches marketType %s for filter %s', (marketType, filter) => {
+      expect(matchesCategory(market({ marketType }), filter)).toBe(true);
+    });
+
+    it('keeps stock-like categories distinct (stock !== etf filter)', () => {
+      expect(matchesCategory(market({ marketType: 'stock' }), 'etfs')).toBe(
+        false,
+      );
+      expect(matchesCategory(market({ marketType: 'etf' }), 'stocks')).toBe(
+        false,
+      );
     });
   });
 
   describe('getMarketTypeFilter', () => {
-    it('returns stocks for stock marketType', () => {
-      expect(getMarketTypeFilter(market({ marketType: 'stock' }))).toBe(
-        'stocks',
-      );
-    });
-
-    it.each(['pre-ipo', 'index', 'etf'] as const)(
-      'returns stocks for stock-like %s marketType',
-      (marketType) => {
-        expect(getMarketTypeFilter(market({ marketType }))).toBe('stocks');
+    // HIP-3 markets carry a marketType; main-DEX crypto does not.
+    it.each([
+      ['stock', 'stocks'],
+      ['pre-ipo', 'pre-ipo'],
+      ['index', 'indices'],
+      ['etf', 'etfs'],
+      ['commodity', 'commodities'],
+      ['forex', 'forex'],
+    ] as const)(
+      'resolves HIP-3 marketType %s to the %s filter',
+      (marketType, expected) => {
+        expect(getMarketTypeFilter(market({ marketType, isHip3: true }))).toBe(
+          expected,
+        );
       },
     );
 
-    it('returns commodities for commodity marketType', () => {
-      expect(getMarketTypeFilter(market({ marketType: 'commodity' }))).toBe(
-        'commodities',
-      );
-    });
-
-    it('returns forex for forex marketType', () => {
-      expect(getMarketTypeFilter(market({ marketType: 'forex' }))).toBe(
-        'forex',
-      );
-    });
-
-    it('returns crypto for main-DEX markets without a marketType', () => {
-      expect(
-        getMarketTypeFilter(
-          market({ marketType: undefined, isHip3: false, isNewMarket: false }),
-        ),
-      ).toBe('crypto');
-    });
-
-    it('returns crypto for explicit crypto marketType', () => {
+    it('resolves an explicit crypto marketType to crypto', () => {
       expect(getMarketTypeFilter(market({ marketType: 'crypto' }))).toBe(
         'crypto',
       );
     });
 
-    it('returns all for new markets without a marketType', () => {
+    it('resolves a main-DEX market without a marketType to crypto', () => {
       expect(
-        getMarketTypeFilter(
-          market({ marketType: undefined, isNewMarket: true }),
-        ),
-      ).toBe('all');
+        getMarketTypeFilter(market({ marketType: undefined, isHip3: false })),
+      ).toBe('crypto');
     });
 
-    it('returns all for uncategorized HIP-3 markets (not in the crypto pill)', () => {
+    it('falls back to all for uncategorized HIP-3 markets', () => {
       expect(
         getMarketTypeFilter(
           market({ marketType: undefined, isHip3: true, isNewMarket: false }),
@@ -109,33 +107,19 @@ describe('marketUtils category helpers', () => {
       ).toBe('all');
     });
 
-    it('returns all when only marketSource marks a HIP-3 market', () => {
+    it('falls back to all for new markets without a marketType', () => {
       expect(
         getMarketTypeFilter(
-          market({
-            marketType: undefined,
-            isHip3: undefined,
-            isNewMarket: false,
-            marketSource: 'xyz',
-          }),
+          market({ marketType: undefined, isHip3: true, isNewMarket: true }),
         ),
       ).toBe('all');
     });
 
-    it('prioritizes marketType over the HIP-3 / new fallbacks', () => {
-      expect(
-        getMarketTypeFilter(
-          market({ marketType: 'stock', isHip3: true, isNewMarket: true }),
-        ),
-      ).toBe('stocks');
-    });
-
-    it('treats an unknown HIP-3 category as all, never crypto', () => {
-      expect(
-        getMarketTypeFilter(
-          market({ marketType: 'bond' as MarketType, isHip3: true }),
-        ),
-      ).toBe('all');
+    it('is the inverse of matchesCategory for the resolved filter', () => {
+      const etfMarket = market({ marketType: 'etf', isHip3: true });
+      const filter = getMarketTypeFilter(etfMarket);
+      expect(filter).toBe('etfs');
+      expect(matchesCategory(etfMarket, filter)).toBe(true);
     });
   });
 });

--- a/packages/perps-controller/tests/src/utils/marketUtils.test.ts
+++ b/packages/perps-controller/tests/src/utils/marketUtils.test.ts
@@ -74,7 +74,9 @@ describe('marketUtils category helpers', () => {
     });
 
     it('returns forex for forex marketType', () => {
-      expect(getMarketTypeFilter(market({ marketType: 'forex' }))).toBe('forex');
+      expect(getMarketTypeFilter(market({ marketType: 'forex' }))).toBe(
+        'forex',
+      );
     });
 
     it('returns crypto for main-DEX markets without a marketType', () => {
@@ -93,7 +95,9 @@ describe('marketUtils category helpers', () => {
 
     it('returns all for new markets without a marketType', () => {
       expect(
-        getMarketTypeFilter(market({ marketType: undefined, isNewMarket: true })),
+        getMarketTypeFilter(
+          market({ marketType: undefined, isNewMarket: true }),
+        ),
       ).toBe('all');
     });
 

--- a/packages/perps-controller/tests/src/utils/marketUtils.test.ts
+++ b/packages/perps-controller/tests/src/utils/marketUtils.test.ts
@@ -1,6 +1,8 @@
 import type { PerpsMarketData } from '../../../src/types';
 import {
+  STOCK_LIKE_MARKET_TYPES,
   getMarketTypeFilter,
+  isEquityAsset,
   matchesCategory,
 } from '../../../src/utils/marketUtils';
 
@@ -17,6 +19,33 @@ const market = (overrides: Partial<PerpsMarketData>): PerpsMarketData =>
   }) as PerpsMarketData;
 
 describe('marketUtils category classification', () => {
+  describe('STOCK_LIKE_MARKET_TYPES', () => {
+    it('contains the four stock-like categories', () => {
+      expect([...STOCK_LIKE_MARKET_TYPES].sort()).toStrictEqual([
+        'etf',
+        'index',
+        'pre-ipo',
+        'stock',
+      ]);
+    });
+  });
+
+  describe('isEquityAsset', () => {
+    it.each(['stock', 'pre-ipo', 'index', 'etf'])(
+      'returns true for stock-like %s',
+      (marketType) => {
+        expect(isEquityAsset(marketType)).toBe(true);
+      },
+    );
+
+    it.each(['crypto', 'commodity', 'forex', 'bond', undefined])(
+      'returns false for non-equity %s',
+      (marketType) => {
+        expect(isEquityAsset(marketType)).toBe(false);
+      },
+    );
+  });
+
   describe('matchesCategory', () => {
     it("matches every market for 'all'", () => {
       expect(matchesCategory(market({ marketType: 'etf' }), 'all')).toBe(true);
@@ -55,14 +84,14 @@ describe('marketUtils category classification', () => {
       ['etf', 'etfs'],
       ['commodity', 'commodities'],
       ['forex', 'forex'],
-    ] as const)('matches marketType %s for filter %s', (marketType, filter) => {
-      expect(matchesCategory(market({ marketType }), filter)).toBe(true);
-    });
+    ] as const)(
+      'matches marketType %s for the granular filter %s',
+      (marketType, filter) => {
+        expect(matchesCategory(market({ marketType }), filter)).toBe(true);
+      },
+    );
 
-    it('keeps stock-like categories distinct (stock !== etf filter)', () => {
-      expect(matchesCategory(market({ marketType: 'stock' }), 'etfs')).toBe(
-        false,
-      );
+    it('keeps stock-like categories distinct in the granular model', () => {
       expect(matchesCategory(market({ marketType: 'etf' }), 'stocks')).toBe(
         false,
       );
@@ -70,16 +99,17 @@ describe('marketUtils category classification', () => {
   });
 
   describe('getMarketTypeFilter', () => {
-    // HIP-3 markets carry a marketType; main-DEX crypto does not.
+    // HIP-3 markets carry a marketType; main-DEX crypto does not. Stock-like
+    // categories collapse into the single 'stocks' filter.
     it.each([
       ['stock', 'stocks'],
-      ['pre-ipo', 'pre-ipo'],
-      ['index', 'indices'],
-      ['etf', 'etfs'],
+      ['pre-ipo', 'stocks'],
+      ['index', 'stocks'],
+      ['etf', 'stocks'],
       ['commodity', 'commodities'],
       ['forex', 'forex'],
     ] as const)(
-      'resolves HIP-3 marketType %s to the %s filter',
+      'collapses HIP-3 marketType %s to the %s filter',
       (marketType, expected) => {
         expect(getMarketTypeFilter(market({ marketType, isHip3: true }))).toBe(
           expected,
@@ -99,27 +129,34 @@ describe('marketUtils category classification', () => {
       ).toBe('crypto');
     });
 
-    it('falls back to all for uncategorized HIP-3 markets', () => {
+    it('resolves uncategorized HIP-3 markets to the new bucket', () => {
       expect(
-        getMarketTypeFilter(
-          market({ marketType: undefined, isHip3: true, isNewMarket: false }),
-        ),
-      ).toBe('all');
+        getMarketTypeFilter(market({ marketType: undefined, isHip3: true })),
+      ).toBe('new');
     });
 
-    it('falls back to all for new markets without a marketType', () => {
+    it('treats a marketSource DEX id as HIP-3 (new, not crypto) when isHip3 is unset', () => {
       expect(
         getMarketTypeFilter(
-          market({ marketType: undefined, isHip3: true, isNewMarket: true }),
+          market({
+            marketType: undefined,
+            isHip3: undefined,
+            marketSource: 'xyz',
+          }),
         ),
-      ).toBe('all');
+      ).toBe('new');
     });
 
-    it('is the inverse of matchesCategory for the resolved filter', () => {
-      const etfMarket = market({ marketType: 'etf', isHip3: true });
-      const filter = getMarketTypeFilter(etfMarket);
-      expect(filter).toBe('etfs');
-      expect(matchesCategory(etfMarket, filter)).toBe(true);
+    it('never returns the all sentinel', () => {
+      const samples = [
+        market({ marketType: 'stock', isHip3: true }),
+        market({ marketType: 'commodity', isHip3: true }),
+        market({ marketType: undefined, isHip3: false }),
+        market({ marketType: undefined, isHip3: true }),
+      ];
+      samples.forEach((sample) =>
+        expect(getMarketTypeFilter(sample)).not.toBe('all'),
+      );
     });
   });
 });

--- a/packages/perps-controller/tests/src/utils/marketUtils.test.ts
+++ b/packages/perps-controller/tests/src/utils/marketUtils.test.ts
@@ -1,0 +1,137 @@
+import type { MarketType, PerpsMarketData } from '../../../src/types';
+import {
+  STOCK_LIKE_MARKET_TYPES,
+  getMarketTypeFilter,
+  isEquityAsset,
+} from '../../../src/utils/marketUtils';
+
+const market = (overrides: Partial<PerpsMarketData>): PerpsMarketData =>
+  ({
+    name: 'BTC',
+    symbol: 'BTC',
+    price: '50000',
+    volume: '$1M',
+    openInterest: '$1M',
+    change24hPercent: '+1.00%',
+    fundingRate: 0,
+    ...overrides,
+  }) as PerpsMarketData;
+
+describe('marketUtils category helpers', () => {
+  describe('STOCK_LIKE_MARKET_TYPES', () => {
+    it('contains the four stock-like categories', () => {
+      expect([...STOCK_LIKE_MARKET_TYPES].sort()).toStrictEqual([
+        'etf',
+        'index',
+        'pre-ipo',
+        'stock',
+      ]);
+    });
+  });
+
+  describe('isEquityAsset', () => {
+    it.each(['stock', 'pre-ipo', 'index', 'etf'] as const)(
+      'returns true for stock-like %s',
+      (marketType) => {
+        expect(isEquityAsset(marketType)).toBe(true);
+      },
+    );
+
+    it.each(['crypto', 'commodity', 'forex'] as const)(
+      'returns false for non-equity %s',
+      (marketType) => {
+        expect(isEquityAsset(marketType)).toBe(false);
+      },
+    );
+
+    it('returns false for undefined marketType', () => {
+      expect(isEquityAsset(undefined)).toBe(false);
+    });
+
+    it('returns false for an unknown marketType', () => {
+      expect(isEquityAsset('bond')).toBe(false);
+    });
+  });
+
+  describe('getMarketTypeFilter', () => {
+    it('returns stocks for stock marketType', () => {
+      expect(getMarketTypeFilter(market({ marketType: 'stock' }))).toBe(
+        'stocks',
+      );
+    });
+
+    it.each(['pre-ipo', 'index', 'etf'] as const)(
+      'returns stocks for stock-like %s marketType',
+      (marketType) => {
+        expect(getMarketTypeFilter(market({ marketType }))).toBe('stocks');
+      },
+    );
+
+    it('returns commodities for commodity marketType', () => {
+      expect(getMarketTypeFilter(market({ marketType: 'commodity' }))).toBe(
+        'commodities',
+      );
+    });
+
+    it('returns forex for forex marketType', () => {
+      expect(getMarketTypeFilter(market({ marketType: 'forex' }))).toBe('forex');
+    });
+
+    it('returns crypto for main-DEX markets without a marketType', () => {
+      expect(
+        getMarketTypeFilter(
+          market({ marketType: undefined, isHip3: false, isNewMarket: false }),
+        ),
+      ).toBe('crypto');
+    });
+
+    it('returns crypto for explicit crypto marketType', () => {
+      expect(getMarketTypeFilter(market({ marketType: 'crypto' }))).toBe(
+        'crypto',
+      );
+    });
+
+    it('returns all for new markets without a marketType', () => {
+      expect(
+        getMarketTypeFilter(market({ marketType: undefined, isNewMarket: true })),
+      ).toBe('all');
+    });
+
+    it('returns all for uncategorized HIP-3 markets (not in the crypto pill)', () => {
+      expect(
+        getMarketTypeFilter(
+          market({ marketType: undefined, isHip3: true, isNewMarket: false }),
+        ),
+      ).toBe('all');
+    });
+
+    it('returns all when only marketSource marks a HIP-3 market', () => {
+      expect(
+        getMarketTypeFilter(
+          market({
+            marketType: undefined,
+            isHip3: undefined,
+            isNewMarket: false,
+            marketSource: 'xyz',
+          }),
+        ),
+      ).toBe('all');
+    });
+
+    it('prioritizes marketType over the HIP-3 / new fallbacks', () => {
+      expect(
+        getMarketTypeFilter(
+          market({ marketType: 'stock', isHip3: true, isNewMarket: true }),
+        ),
+      ).toBe('stocks');
+    });
+
+    it('treats an unknown HIP-3 category as all, never crypto', () => {
+      expect(
+        getMarketTypeFilter(
+          market({ marketType: 'bond' as MarketType, isHip3: true }),
+        ),
+      ).toBe('all');
+    });
+  });
+});

--- a/packages/perps-controller/tests/src/utils/marketUtils.test.ts
+++ b/packages/perps-controller/tests/src/utils/marketUtils.test.ts
@@ -3,6 +3,7 @@ import {
   STOCK_LIKE_MARKET_TYPES,
   getMarketTypeFilter,
   isEquityAsset,
+  isHip3Market,
   matchesCategory,
 } from '../../../src/utils/marketUtils';
 
@@ -46,6 +47,24 @@ describe('marketUtils category classification', () => {
     );
   });
 
+  describe('isHip3Market', () => {
+    it('is true when isHip3 is set', () => {
+      expect(isHip3Market(market({ isHip3: true }))).toBe(true);
+    });
+
+    it('is true when only marketSource is set', () => {
+      expect(
+        isHip3Market(market({ isHip3: undefined, marketSource: 'xyz' })),
+      ).toBe(true);
+    });
+
+    it('is false for a main-DEX market', () => {
+      expect(
+        isHip3Market(market({ isHip3: false, marketSource: undefined })),
+      ).toBe(false);
+    });
+  });
+
   describe('matchesCategory', () => {
     it("matches every market for 'all'", () => {
       expect(matchesCategory(market({ marketType: 'etf' }), 'all')).toBe(true);
@@ -75,6 +94,17 @@ describe('marketUtils category classification', () => {
       expect(
         matchesCategory(market({ isHip3: true, marketType: 'etf' }), 'crypto'),
       ).toBe(false);
+    });
+
+    it("treats a marketSource-only partial market as 'new', not 'crypto'", () => {
+      const partial = market({
+        marketType: undefined,
+        isHip3: undefined,
+        isNewMarket: undefined,
+        marketSource: 'xyz',
+      });
+      expect(matchesCategory(partial, 'crypto')).toBe(false);
+      expect(matchesCategory(partial, 'new')).toBe(true);
     });
 
     it.each([
@@ -157,6 +187,19 @@ describe('marketUtils category classification', () => {
       samples.forEach((sample) =>
         expect(getMarketTypeFilter(sample)).not.toBe('all'),
       );
+    });
+
+    // The resolved bucket must agree with matchesCategory (stock-like is the one
+    // intentional exception: it collapses to 'stocks' while matchesCategory keeps
+    // stock/pre-ipo/index/etf granular).
+    it.each([
+      market({ marketType: 'commodity', isHip3: true }),
+      market({ marketType: 'forex', isHip3: true }),
+      market({ marketType: undefined, isHip3: false }),
+      market({ marketType: undefined, isHip3: true }),
+      market({ marketType: undefined, marketSource: 'xyz' }),
+    ])('is consistent with matchesCategory for %o', (sample) => {
+      expect(matchesCategory(sample, getMarketTypeFilter(sample))).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Explanation

MetaMask Mobile currently re-derives "which market category does this market belong to" in the client. Two in-flight features need the same mapping and each implemented it independently:

- [metamask-mobile#30738](https://github.com/MetaMask/metamask-mobile/pull/30738) (category shortcut) — `getMarketTypeFilter`
- [metamask-mobile#30728](https://github.com/MetaMask/metamask-mobile/pull/30728) (related markets) — `resolveMarketCategory`

Both lean on a mobile-local `isEquityAsset` plus a hand-maintained stock/commodity/forex/crypto switch. Keeping this in the clients means every new `MarketCategory` (the controller already grew `stock`/`pre-ipo`/`index`/`etf` in 7.0.0) forces a parallel edit in each client, and the mappings drift.

This PR centralises the classification in `@metamask/perps-controller` so consumers share one source of truth:

- `STOCK_LIKE_MARKET_TYPES` — the set of stock-like categories (`stock`, `pre-ipo`, `index`, `etf`) that share the `stocks` filter and traditional market hours.
- `isEquityAsset(marketType)` — predicate over that set (moved out of the mobile client).
- `getMarketTypeFilter(market)` — maps a `PerpsMarketData` onto a UI `MarketTypeFilter` pill. Stock-like → `stocks`; `commodity` → `commodities`; `forex` → `forex`; any HIP-3 signal (`isHip3` / `isNewMarket` / `marketSource`) on an otherwise-uncategorized market → `all` (the crypto pill only contains main-DEX markets); otherwise → `crypto`.

Clients will replace their local copies with imports in follow-up PRs.

## References

- Related to [metamask-mobile#30738](https://github.com/MetaMask/metamask-mobile/pull/30738)
- Related to [metamask-mobile#30728](https://github.com/MetaMask/metamask-mobile/pull/30728)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking renames on `MarketTypeFilter`/`MARKET_CATEGORIES` require consumer updates; classification behavior changes slightly for partial HIP-3 markets and the `new` filter.
> 
> **Overview**
> Centralises perps **market category** logic in `@metamask/perps-controller` so mobile and other clients can import one model instead of duplicating classifiers.
> 
> **`matchesCategory`** and **`applyMarketFilters`** move from `MarketDataService` into `marketUtils` and are re-exported from the package root alongside new **`getMarketTypeFilter`**, **`isHip3Market`**, and shared HIP-3 detection (`isHip3` or `marketSource`). Uncategorized HIP-3 markets align on the **`new`** bucket in both `getMarketTypeFilter` and `matchesCategory`; typed categories map 1:1 to filter values.
> 
> **BREAKING:** `MarketTypeFilter` and `MARKET_CATEGORIES` drop plural UI strings (`stocks`, `indices`, `etfs`, `commodities`) in favor of singular values aligned with `MarketCategory` (`stock`, `index`, `etf`, `commodity`). Tests and changelog are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61587758075db591de39b11a0d6b7fb26daf3664. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

