### PR TITLE
feat: deduplicate USDC token on ARC mainnet

### DIFF
--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add USDC on ARC mainnet (`eip155:5042/erc20:0x3600000000000000000000000000000000000000`) to default tokens to display on ARC ([#9011](https://github.com/MetaMask/core/pull/9011))
+
 ### Changed
 
 - Bump `@metamask/transaction-controller` from `^67.0.0` to `^67.1.0` ([#9066](https://github.com/MetaMask/core/pull/9066))

--- a/packages/assets-controller/src/AssetsController.test.ts
+++ b/packages/assets-controller/src/AssetsController.test.ts
@@ -28,7 +28,7 @@ import type {
   DataResponse,
   FungibleAssetMetadata,
 } from './types';
-import { formatExchangeRatesForBridge } from './utils';
+import { formatExchangeRatesForBridge, normalizeAssetId } from './utils';
 
 jest.mock('./utils', () => {
   const actual = jest.requireActual<typeof import('./utils')>('./utils');
@@ -269,12 +269,10 @@ describe('AssetsController', () => {
       const defaultState = getDefaultAssetsControllerState();
       const assetIds = Object.keys(defaultState.assetsInfo);
       expect(assetIds.length).toBeGreaterThan(0);
-      // Every erc20 asset ID must contain at least one uppercase hex letter
-      // (EIP-55 checksum property) so that keys match normalizeAssetId output.
       const erc20Ids = assetIds.filter((id) => id.includes('/erc20:'));
       expect(erc20Ids.length).toBeGreaterThan(0);
       for (const id of erc20Ids) {
-        expect(id).toMatch(/\/erc20:0x[0-9a-fA-F]*[A-F][0-9a-fA-F]*/u);
+        expect(id).toBe(normalizeAssetId(id as Caip19AssetId));
       }
     });
   });

--- a/packages/assets-controller/src/defaults.ts
+++ b/packages/assets-controller/src/defaults.ts
@@ -32,6 +32,23 @@ const MUSD_METADATA: FungibleAssetMetadata = {
 };
 
 /**
+ * Harcoded metadata for USDC on Arc (5042/0x13b2).
+ * USDC exists as both native (18 decimals) and ERC20 (6 decimals).
+ * We choose to force-hide the native version to avoid double listing using
+ * `CHAIN_IDS_WITH_NO_NATIVE_TOKEN`.
+ * In the meantime, the code below force-shows USDC the ERC20 token.
+ */
+const USDC_ON_ARC_ASSET_ID =
+  'eip155:5042/erc20:0x3600000000000000000000000000000000000000';
+
+const USDC_ON_ARC_METADATA: FungibleAssetMetadata = {
+  type: 'erc20',
+  symbol: 'USDC',
+  name: 'USDC',
+  decimals: 6,
+};
+
+/**
  * Build the CAIP-19 asset ID for the mUSD ERC-20 token on a given EVM
  * chain.
  *
@@ -59,6 +76,7 @@ export const DEFAULT_TRACKED_ASSETS_BY_CHAIN: ReadonlyMap<
   ['eip155:1' as ChainId, [musdAssetId('eip155:1' as ChainId)]],
   ['eip155:59144' as ChainId, [musdAssetId('eip155:59144' as ChainId)]],
   ['eip155:143' as ChainId, [musdAssetId('eip155:143' as ChainId)]],
+  ['eip155:5042' as ChainId, [USDC_ON_ARC_ASSET_ID]],
 ]);
 
 /**
@@ -79,6 +97,7 @@ export const DEFAULT_ASSET_METADATA: ReadonlyMap<string, AssetMetadata> =
     [musdAssetId('eip155:1' as ChainId), MUSD_METADATA],
     [musdAssetId('eip155:59144' as ChainId), MUSD_METADATA],
     [musdAssetId('eip155:143' as ChainId), MUSD_METADATA],
+    [USDC_ON_ARC_ASSET_ID, USDC_ON_ARC_METADATA],
   ]);
 
 /**
@@ -120,7 +139,10 @@ export function buildDefaultAssetsInfo(): Record<Caip19AssetId, AssetMetadata> {
   const info: Record<Caip19AssetId, AssetMetadata> = {};
   for (const assetIds of DEFAULT_TRACKED_ASSETS_BY_CHAIN.values()) {
     for (const assetId of assetIds) {
-      info[assetId] = MUSD_METADATA;
+      const metadata = DEFAULT_ASSET_METADATA.get(assetId);
+      if (metadata) {
+        info[assetId] = metadata;
+      }
     }
   }
   return info;


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## Context:

We want to display the ERC20 version of USDC on Arc (0x3600000000000000000000000000000000000000), regardless of user balance.

The following PR leverages a similar logic to mUSD to enforce this display on Arc network only, for all accounts.

## assets-controller:
### Added

- Add USDC on ARC mainnet (`eip155:5042/erc20:0x3600000000000000000000000000000000000000`) to default tokens to display on ARC ([#9011](https://github.com/MetaMask/core/pull/9011))


## controller-utils:
### Added

- Add ARC mainnet (`eip155:5042`) to `CHAIN_IDS_WITH_NO_NATIVE_TOKEN` to hide native USDC from assets list ([#9011](https://github.com/MetaMask/core/pull/9011))


## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to ARC default token seeding and a small refactor of buildDefaultAssetsInfo; no auth or balance pipeline logic changes in this diff.
> 
> **Overview**
> **ARC mainnet** now pre-seeds **ERC20 USDC** (`eip155:5042/erc20:0x3600…`) in default `assetsInfo` for every account on that chain, using the same default-tracked-asset pattern as mUSD on other networks so USDC shows even at zero balance.
> 
> `defaults.ts` registers Arc in `DEFAULT_TRACKED_ASSETS_BY_CHAIN` and `DEFAULT_ASSET_METADATA`, and **`buildDefaultAssetsInfo`** now pulls metadata from that map per asset instead of always applying mUSD metadata. The changelog documents the addition; the default-state test asserts ERC20 keys match **`normalizeAssetId`**.
> 
> Native USDC on Arc is intended to stay hidden via **`CHAIN_IDS_WITH_NO_NATIVE_TOKEN`** in controller-utils (companion change in the same PR, not in this diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55c113b0b8e5d8e3b13f2a772b4ec135b973b3eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->