### PR TITLE
feat!: Use `RemoteFeatureFlagController` for `isRpcFailoverEnabled`

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ linkStyle default opacity:0.5
   network_controller --> eth_json_rpc_provider;
   network_controller --> json_rpc_engine;
   network_controller --> messenger;
+  network_controller --> remote_feature_flag_controller;
   network_enablement_controller --> base_controller;
   network_enablement_controller --> controller_utils;
   network_enablement_controller --> messenger;

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- **BREAKING:** Automatically populate `isRpcFailoverEnabled` using `RemoteFeatureFlagController` ([#9013](https://github.com/MetaMask/core/pull/9013))
-  - `NetworkController.init` must now be called to fully initialize the controller.
-  - The constructor argument `isRpcFailoverEnabled` is no longer available.
-  - `RemoteFeatureFlagController:stateChange` and `RemoteFeatureFlagController:getState` are now required.
-
 ### Added
 
 - Add defaults for policy and block tracker options ([#9002](https://github.com/MetaMask/core/pull/9002))
@@ -23,6 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The default `policyOptions.circuitBreakDuration` is now `30` seconds.
   - The default `pollingInterval` for the block tracker is now `20` seconds.
   - The default `retryTimeout` for the block tracker is now `20` seconds.
+
+### Changed
+
+- **BREAKING:** Automatically populate `isRpcFailoverEnabled` using `RemoteFeatureFlagController` ([#9013](https://github.com/MetaMask/core/pull/9013))
+  - `NetworkController.init` must now be called to fully initialize the controller.
+  - The constructor argument `isRpcFailoverEnabled` is no longer available.
+  - `RemoteFeatureFlagController:stateChange` and `RemoteFeatureFlagController:getState` are now required.
 
 ### Fixed
 

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING:** Automatically populate `isRpcFailoverEnabled` using `RemoteFeatureFlagController` ([#9013](https://github.com/MetaMask/core/pull/9013))
+  - `NetworkController.init` must now be called to fully initialize the controller.
+  - The constructor argument `isRpcFailoverEnabled` is no longer available.
+  - `RemoteFeatureFlagController:stateChange` and `RemoteFeatureFlagController:getState` are now required.
+
 ### Added
 
 - Add defaults for policy and block tracker options ([#9002](https://github.com/MetaMask/core/pull/9002))

--- a/packages/network-controller/package.json
+++ b/packages/network-controller/package.json
@@ -63,6 +63,7 @@
     "@metamask/eth-query": "^4.0.0",
     "@metamask/json-rpc-engine": "^10.5.0",
     "@metamask/messenger": "^1.2.0",
+    "@metamask/remote-feature-flag-controller": "^4.2.2",
     "@metamask/rpc-errors": "^7.0.2",
     "@metamask/swappable-obj-proxy": "^2.3.0",
     "@metamask/utils": "^11.9.0",

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -1394,6 +1394,7 @@ export class NetworkController extends BaseController<
     );
 
     this.messenger.subscribe(
+      // eslint-disable-next-line no-restricted-syntax
       'RemoteFeatureFlagController:stateChange',
       (isRpcFailoverEnabled) => {
         this.#updateRpcFailoverEnabled(isRpcFailoverEnabled);
@@ -1634,7 +1635,7 @@ export class NetworkController extends BaseController<
   /**
    * Initialize the NetworkController, updating the RPC failover feature flag.
    */
-  init() {
+  init(): void {
     const state = this.messenger.call('RemoteFeatureFlagController:getState');
     this.#updateRpcFailoverEnabled(getIsRpcFailoverEnabled(state));
   }

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -21,6 +21,10 @@ import {
 import type { PollingBlockTrackerOptions } from '@metamask/eth-block-tracker';
 import EthQuery from '@metamask/eth-query';
 import type { Messenger } from '@metamask/messenger';
+import {
+  RemoteFeatureFlagControllerGetStateAction,
+  RemoteFeatureFlagControllerStateChangeEvent,
+} from '@metamask/remote-feature-flag-controller';
 import { errorCodes } from '@metamask/rpc-errors';
 import {
   createEventEmitterProxy,
@@ -55,6 +59,7 @@ import type {
   NetworkControllerMethodActions,
 } from './NetworkController-method-action-types';
 import type { RpcServiceOptionsWithDefaults } from './rpc-service/rpc-service';
+import { getIsRpcFailoverEnabled } from './selectors';
 import { NetworkClientType } from './types';
 import type {
   BlockTracker,
@@ -663,7 +668,7 @@ export type NetworkControllerEvents =
 /**
  * All events that {@link NetworkController} calls internally.
  */
-type AllowedEvents = never;
+type AllowedEvents = RemoteFeatureFlagControllerStateChangeEvent;
 
 const MESSENGER_EXPOSED_METHODS = [
   'addNetwork',
@@ -714,7 +719,9 @@ export type NetworkControllerGetNetworkConfigurationByNetworkClientId =
 /**
  * All actions that {@link NetworkController} calls internally.
  */
-type AllowedActions = ConnectivityControllerGetStateAction;
+type AllowedActions =
+  | ConnectivityControllerGetStateAction
+  | RemoteFeatureFlagControllerGetStateAction;
 
 export type NetworkControllerMessenger = Messenger<
   typeof controllerName,
@@ -767,11 +774,6 @@ export type NetworkControllerOptions = {
    * An array of Hex Chain IDs representing the additional networks to be included as default.
    */
   additionalDefaultNetworks?: AdditionalDefaultNetwork[];
-  /**
-   * Whether or not requests sent to unavailable RPC endpoints should be
-   * automatically diverted to configured failover RPC endpoints.
-   */
-  isRpcFailoverEnabled?: boolean;
 };
 
 /**
@@ -1295,10 +1297,7 @@ export class NetworkController extends BaseController<
     NetworkConfiguration
   >;
 
-  #isRpcFailoverEnabled: Exclude<
-    NetworkControllerOptions['isRpcFailoverEnabled'],
-    undefined
-  >;
+  #isRpcFailoverEnabled = false;
 
   /**
    * Constructs a NetworkController.
@@ -1314,7 +1313,6 @@ export class NetworkController extends BaseController<
       getRpcServiceOptions,
       getBlockTrackerOptions,
       additionalDefaultNetworks,
-      isRpcFailoverEnabled = false,
     } = options;
     const initialState = {
       ...getDefaultNetworkControllerState(additionalDefaultNetworks),
@@ -1357,7 +1355,6 @@ export class NetworkController extends BaseController<
     this.#log = log;
     this.#getRpcServiceOptions = getRpcServiceOptions;
     this.#getBlockTrackerOptions = getBlockTrackerOptions;
-    this.#isRpcFailoverEnabled = isRpcFailoverEnabled;
 
     this.#previouslySelectedNetworkClientId =
       this.state.selectedNetworkClientId;
@@ -1394,6 +1391,14 @@ export class NetworkController extends BaseController<
           networkStatus: NetworkStatus.Available,
         });
       },
+    );
+
+    this.messenger.subscribe(
+      'RemoteFeatureFlagController:stateChange',
+      (isRpcFailoverEnabled) => {
+        this.#updateRpcFailoverEnabled(isRpcFailoverEnabled);
+      },
+      getIsRpcFailoverEnabled,
     );
   }
 
@@ -1624,6 +1629,14 @@ export class NetworkController extends BaseController<
     this.#applyNetworkSelection(networkClientId, options);
     this.messenger.publish('NetworkController:networkDidChange', this.state);
     await this.lookupNetwork();
+  }
+
+  /**
+   * Initialize the NetworkController, updating the RPC failover feature flag.
+   */
+  init() {
+    const state = this.messenger.call('RemoteFeatureFlagController:getState');
+    this.#updateRpcFailoverEnabled(getIsRpcFailoverEnabled(state));
   }
 
   /**

--- a/packages/network-controller/src/selectors.ts
+++ b/packages/network-controller/src/selectors.ts
@@ -2,7 +2,7 @@ import { RemoteFeatureFlagControllerState } from '@metamask/remote-feature-flag-
 
 export function getIsRpcFailoverEnabled(
   state: RemoteFeatureFlagControllerState,
-) {
+): boolean {
   const walletFrameworkRpcFailoverEnabled = state.remoteFeatureFlags
     .walletFrameworkRpcFailoverEnabled as boolean | undefined;
   return walletFrameworkRpcFailoverEnabled ?? false;

--- a/packages/network-controller/src/selectors.ts
+++ b/packages/network-controller/src/selectors.ts
@@ -1,0 +1,9 @@
+import { RemoteFeatureFlagControllerState } from '@metamask/remote-feature-flag-controller';
+
+export function getIsRpcFailoverEnabled(
+  state: RemoteFeatureFlagControllerState,
+) {
+  const walletFrameworkRpcFailoverEnabled = state.remoteFeatureFlags
+    .walletFrameworkRpcFailoverEnabled as boolean | undefined;
+  return walletFrameworkRpcFailoverEnabled ?? false;
+}

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -1131,6 +1131,23 @@ describe('NetworkController', () => {
   describe('disableRpcFailover', () => {
     describe('if the controller was initialized with isRpcFailoverEnabled = true', () => {
       it('calls disableRpcFailover on only the network clients whose RPC endpoints have configured failover URLs', async () => {
+        const originalCreateAutoManagedNetworkClient =
+          createAutoManagedNetworkClientModule.createAutoManagedNetworkClient;
+        const autoManagedNetworkClients: AutoManagedNetworkClient<NetworkClientConfiguration>[] =
+          [];
+        jest
+          .spyOn(
+            createAutoManagedNetworkClientModule,
+            'createAutoManagedNetworkClient',
+          )
+          .mockImplementation((...args) => {
+            const autoManagedNetworkClient =
+              originalCreateAutoManagedNetworkClient(...args);
+            jest.spyOn(autoManagedNetworkClient, 'disableRpcFailover');
+            autoManagedNetworkClients.push(autoManagedNetworkClient);
+            return autoManagedNetworkClient;
+          });
+
         await withController(
           {
             isRpcFailoverEnabled: true,
@@ -1171,23 +1188,6 @@ describe('NetworkController', () => {
             },
           },
           async ({ controller }) => {
-            const originalCreateAutoManagedNetworkClient =
-              createAutoManagedNetworkClientModule.createAutoManagedNetworkClient;
-            const autoManagedNetworkClients: AutoManagedNetworkClient<NetworkClientConfiguration>[] =
-              [];
-            jest
-              .spyOn(
-                createAutoManagedNetworkClientModule,
-                'createAutoManagedNetworkClient',
-              )
-              .mockImplementation((...args) => {
-                const autoManagedNetworkClient =
-                  originalCreateAutoManagedNetworkClient(...args);
-                jest.spyOn(autoManagedNetworkClient, 'disableRpcFailover');
-                autoManagedNetworkClients.push(autoManagedNetworkClient);
-                return autoManagedNetworkClient;
-              });
-
             controller.disableRpcFailover();
 
             expect(autoManagedNetworkClients).toHaveLength(3);

--- a/packages/network-controller/tests/helpers.ts
+++ b/packages/network-controller/tests/helpers.ts
@@ -93,8 +93,10 @@ export const TESTNET = {
  */
 export function buildRootMessenger({
   connectivityStatus = CONNECTIVITY_STATUSES.Online,
+  isRpcFailoverEnabled = false,
 }: {
   connectivityStatus?: ConnectivityStatus;
+  isRpcFailoverEnabled?: boolean;
 } = {}): RootMessenger {
   const rootMessenger = new Messenger<
     MockAnyNamespace,
@@ -106,6 +108,16 @@ export function buildRootMessenger({
     'ConnectivityController:getState',
     () => ({
       connectivityStatus,
+    }),
+  );
+
+  rootMessenger.registerActionHandler(
+    'RemoteFeatureFlagController:getState',
+    () => ({
+      remoteFeatureFlags: {
+        walletFrameworkRpcFailoverEnabled: isRpcFailoverEnabled,
+      },
+      cacheTimestamp: 0,
     }),
   );
 
@@ -133,7 +145,10 @@ export function buildNetworkControllerMessenger(
 
   rootMessenger.delegate({
     messenger: networkControllerMessenger,
-    actions: ['ConnectivityController:getState'],
+    actions: [
+      'ConnectivityController:getState',
+      'RemoteFeatureFlagController:getState',
+    ],
   });
 
   return networkControllerMessenger;
@@ -612,7 +627,9 @@ type WithControllerCallback<ReturnValue> = ({
   networkControllerMessenger: NetworkControllerMessenger;
 }) => Promise<ReturnValue> | ReturnValue;
 
-type WithControllerOptions = Partial<NetworkControllerOptions>;
+type WithControllerOptions = Partial<NetworkControllerOptions> & {
+  isRpcFailoverEnabled?: boolean;
+};
 
 type WithControllerArgs<ReturnValue> =
   | [WithControllerCallback<ReturnValue>]
@@ -632,7 +649,8 @@ export async function withController<ReturnValue>(
   ...args: WithControllerArgs<ReturnValue>
 ): Promise<ReturnValue> {
   const [{ ...rest }, fn] = args.length === 2 ? args : [{}, args[0]];
-  const messenger = buildRootMessenger();
+  const { isRpcFailoverEnabled, ...controllerOptions } = rest;
+  const messenger = buildRootMessenger({ isRpcFailoverEnabled });
   const networkControllerMessenger = buildNetworkControllerMessenger(messenger);
   const controller = new NetworkController({
     messenger: networkControllerMessenger,
@@ -645,8 +663,11 @@ export async function withController<ReturnValue>(
       btoa,
       isOffline: (): boolean => false,
     }),
-    ...rest,
+    ...controllerOptions,
   });
+
+  controller.init();
+
   try {
     return await fn({ controller, messenger, networkControllerMessenger });
   } finally {

--- a/packages/network-controller/tests/helpers.ts
+++ b/packages/network-controller/tests/helpers.ts
@@ -149,6 +149,7 @@ export function buildNetworkControllerMessenger(
       'ConnectivityController:getState',
       'RemoteFeatureFlagController:getState',
     ],
+    events: ['RemoteFeatureFlagController:stateChange'],
   });
 
   return networkControllerMessenger;

--- a/packages/network-controller/tests/helpers.ts
+++ b/packages/network-controller/tests/helpers.ts
@@ -89,6 +89,7 @@ export const TESTNET = {
  * @param options - Optional configuration.
  * @param options.connectivityStatus - The connectivity status to return by default.
  * If not provided, defaults to Online.
+ * @param options.isRpcFailoverEnabled - The RPC failover feature flag to return, defaults to false.
  * @returns The messenger.
  */
 export function buildRootMessenger({
@@ -149,6 +150,7 @@ export function buildNetworkControllerMessenger(
       'ConnectivityController:getState',
       'RemoteFeatureFlagController:getState',
     ],
+    // eslint-disable-next-line no-restricted-syntax
     events: ['RemoteFeatureFlagController:stateChange'],
   });
 

--- a/packages/network-controller/tsconfig.build.json
+++ b/packages/network-controller/tsconfig.build.json
@@ -13,7 +13,8 @@
     { "path": "../eth-json-rpc-middleware/tsconfig.build.json" },
     { "path": "../eth-json-rpc-provider/tsconfig.build.json" },
     { "path": "../json-rpc-engine/tsconfig.build.json" },
-    { "path": "../messenger/tsconfig.build.json" }
+    { "path": "../messenger/tsconfig.build.json" },
+    { "path": "../remote-feature-flag-controller/tsconfig.build.json" },
   ],
   "include": ["../../types", "./src"]
 }

--- a/packages/network-controller/tsconfig.build.json
+++ b/packages/network-controller/tsconfig.build.json
@@ -14,7 +14,7 @@
     { "path": "../eth-json-rpc-provider/tsconfig.build.json" },
     { "path": "../json-rpc-engine/tsconfig.build.json" },
     { "path": "../messenger/tsconfig.build.json" },
-    { "path": "../remote-feature-flag-controller/tsconfig.build.json" },
+    { "path": "../remote-feature-flag-controller/tsconfig.build.json" }
   ],
   "include": ["../../types", "./src"]
 }

--- a/packages/network-controller/tsconfig.json
+++ b/packages/network-controller/tsconfig.json
@@ -12,7 +12,8 @@
     { "path": "../eth-json-rpc-middleware" },
     { "path": "../eth-json-rpc-provider" },
     { "path": "../json-rpc-engine" },
-    { "path": "../messenger" }
+    { "path": "../messenger" },
+    { "path": "../remote-feature-flag-controller" },
   ],
   "include": ["../../types", "../../tests", "./src", "./tests"]
 }

--- a/packages/network-controller/tsconfig.json
+++ b/packages/network-controller/tsconfig.json
@@ -13,7 +13,7 @@
     { "path": "../eth-json-rpc-provider" },
     { "path": "../json-rpc-engine" },
     { "path": "../messenger" },
-    { "path": "../remote-feature-flag-controller" },
+    { "path": "../remote-feature-flag-controller" }
   ],
   "include": ["../../types", "../../tests", "./src", "./tests"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7658,6 +7658,7 @@ __metadata:
     "@metamask/eth-query": "npm:^4.0.0"
     "@metamask/json-rpc-engine": "npm:^10.5.0"
     "@metamask/messenger": "npm:^1.2.0"
+    "@metamask/remote-feature-flag-controller": "npm:^4.2.2"
     "@metamask/rpc-errors": "npm:^7.0.2"
     "@metamask/swappable-obj-proxy": "npm:^2.3.0"
     "@metamask/utils": "npm:^11.9.0"


### PR DESCRIPTION
## Explanation

This PR enables use of the `RemoteFeatureFlagController` to automatically determine the state of `isRpcFailoverEnabled`. Thus, the constructor argument has been removed and a `init` function has been introduced.

## References

https://consensyssoftware.atlassian.net/browse/WPC-1053

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking API and required init/messenger setup; mis-wiring leaves failover off or stale, and failover changes affect live RPC routing for configured endpoints.
> 
> **Overview**
> **Breaking change:** `NetworkController` no longer accepts `isRpcFailoverEnabled` in the constructor. RPC failover is driven by `RemoteFeatureFlagController` via the `walletFrameworkRpcFailoverEnabled` flag.
> 
> Consumers must wire `RemoteFeatureFlagController:getState` and `RemoteFeatureFlagController:stateChange` on the network controller messenger, call **`init()`** after construction to apply the initial flag, and drop any manual `isRpcFailoverEnabled` option. The controller subscribes to remote flag updates and toggles failover through the existing `#updateRpcFailoverEnabled` path (same behavior as `enableRpcFailover` / `disableRpcFailover`).
> 
> Adds `@metamask/remote-feature-flag-controller`, `getIsRpcFailoverEnabled` in `selectors.ts`, dependency graph/README updates, and test helpers that mock the remote flag and call `init()` in `withController`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ffe1c5b18d9f7edcda4e0febc091b51fe705cc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->