### PR TITLE
assets controllers deprecation

### DIFF
--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/network-enablement-controller` from `^5.2.0` to `^5.3.0` ([#9003](https://github.com/MetaMask/core/pull/9003))
 
+### Deprecated
+
+- Mark legacy assets controllers, their state types, and public methods as deprecated in favor of `AssetsController` from `@metamask/assets-controller`
+  - Affected controllers: `AccountTrackerController`, `CurrencyRateController`, `MultichainAssetsController`, `MultichainAssetsRatesController`, `MultichainBalancesController`, `RatesController`, `TokenBalancesController`, `TokenListController`, `TokenRatesController`, and `TokensController`.
+
 ## [108.5.0]
 
 ### Added

--- a/packages/assets-controllers/src/AccountTrackerController-method-action-types.ts
+++ b/packages/assets-controllers/src/AccountTrackerController-method-action-types.ts
@@ -6,6 +6,7 @@
 import type { AccountTrackerController } from './AccountTrackerController';
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Refreshes the balances of the accounts depending on the multi-account setting.
  * If multi-account is disabled, only updates the selected account balance.
  * If multi-account is enabled, updates balances for all accounts.
@@ -19,6 +20,7 @@ export type AccountTrackerControllerRefreshAction = {
 };
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Sync accounts balances with some additional addresses.
  *
  * @param addresses - the additional addresses, may be hardware wallet addresses.
@@ -31,6 +33,7 @@ export type AccountTrackerControllerSyncBalanceWithAddressesAction = {
 };
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Updates the balances of multiple native tokens in a single batch operation.
  * This is more efficient than calling updateNativeToken multiple times as it
  * triggers only one state update.
@@ -43,6 +46,7 @@ export type AccountTrackerControllerUpdateNativeBalancesAction = {
 };
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Updates the staked balances of multiple accounts in a single batch operation.
  * This is more efficient than updating staked balances individually as it
  * triggers only one state update.

--- a/packages/assets-controllers/src/AccountTrackerController.ts
+++ b/packages/assets-controllers/src/AccountTrackerController.ts
@@ -140,6 +140,7 @@ export type AccountInformation = {
 };
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * AccountTrackerControllerState
  *
  * Account tracker controller state
@@ -160,6 +161,7 @@ const accountTrackerMetadata: StateMetadata<AccountTrackerControllerState> = {
 };
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * The action that can be performed to get the state of the {@link AccountTrackerController}.
  */
 export type AccountTrackerControllerGetStateAction = ControllerGetStateAction<
@@ -168,6 +170,7 @@ export type AccountTrackerControllerGetStateAction = ControllerGetStateAction<
 >;
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * The actions that can be performed using the {@link AccountTrackerController}.
  */
 export type AccountTrackerControllerActions =
@@ -175,6 +178,7 @@ export type AccountTrackerControllerActions =
   | AccountTrackerControllerMethodActions;
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * The messenger of the {@link AccountTrackerController} for communication.
  */
 export type AllowedActions =
@@ -191,6 +195,7 @@ export type AllowedActions =
   | KeyringControllerGetStateAction;
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * The event that {@link AccountTrackerController} can emit.
  */
 export type AccountTrackerControllerStateChangeEvent =
@@ -200,12 +205,14 @@ export type AccountTrackerControllerStateChangeEvent =
   >;
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * The events that {@link AccountTrackerController} can emit.
  */
 export type AccountTrackerControllerEvents =
   AccountTrackerControllerStateChangeEvent;
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * The external events available to the {@link AccountTrackerController}.
  */
 export type AllowedEvents =
@@ -217,6 +224,7 @@ export type AllowedEvents =
   | KeyringControllerUnlockEvent;
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * The messenger of the {@link AccountTrackerController}.
  */
 export type AccountTrackerControllerMessenger = Messenger<
@@ -239,6 +247,7 @@ const MESSENGER_EXPOSED_METHODS = [
 ] as const;
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Controller that tracks the network balances for all user accounts.
  */
 export class AccountTrackerController extends StaticIntervalPollingController<AccountTrackerPollingInput>()<
@@ -422,6 +431,7 @@ export class AccountTrackerController extends StaticIntervalPollingController<Ac
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Whether the controller is active (keyring is unlocked and user is onboarded).
    * When locked or not onboarded, balance updates should be skipped.
    *
@@ -621,6 +631,7 @@ export class AccountTrackerController extends StaticIntervalPollingController<Ac
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Refreshes the balances of the accounts using the networkClientId
    *
    * @param input - The input for the poll.
@@ -637,6 +648,7 @@ export class AccountTrackerController extends StaticIntervalPollingController<Ac
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Refreshes the balances of the accounts depending on the multi-account setting.
    * If multi-account is disabled, only updates the selected account balance.
    * If multi-account is enabled, updates balances for all accounts.
@@ -666,6 +678,9 @@ export class AccountTrackerController extends StaticIntervalPollingController<Ac
     });
   }
 
+  /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+   */
   async refreshAddresses({
     networkClientIds,
     addresses,
@@ -869,6 +884,7 @@ export class AccountTrackerController extends StaticIntervalPollingController<Ac
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Sync accounts balances with some additional addresses.
    *
    * @param addresses - the additional addresses, may be hardware wallet addresses.
@@ -937,6 +953,7 @@ export class AccountTrackerController extends StaticIntervalPollingController<Ac
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Updates the balances of multiple native tokens in a single batch operation.
    * This is more efficient than calling updateNativeToken multiple times as it
    * triggers only one state update.
@@ -989,6 +1006,7 @@ export class AccountTrackerController extends StaticIntervalPollingController<Ac
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Updates the staked balances of multiple accounts in a single batch operation.
    * This is more efficient than updating staked balances individually as it
    * triggers only one state update.

--- a/packages/assets-controllers/src/CurrencyRateController-method-action-types.ts
+++ b/packages/assets-controllers/src/CurrencyRateController-method-action-types.ts
@@ -6,6 +6,7 @@
 import type { CurrencyRateController } from './CurrencyRateController';
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Sets a currency to track.
  *
  * @param currentCurrency - ISO 4217 currency code.
@@ -16,6 +17,7 @@ export type CurrencyRateControllerSetCurrentCurrencyAction = {
 };
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Updates the exchange rate for the current currency and native currency pairs.
  *
  * @param nativeCurrencies - The native currency symbols to fetch exchange rates for.

--- a/packages/assets-controllers/src/CurrencyRateController.ts
+++ b/packages/assets-controllers/src/CurrencyRateController.ts
@@ -22,6 +22,7 @@ import type { AbstractTokenPricesService } from './token-prices-service/abstract
 import { getNativeTokenAddress } from './token-prices-service/codefi-v2';
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * currencyRates - Object keyed by native currency
  *
  * currencyRates.conversionDate - Timestamp of conversion rate expressed in ms since UNIX epoch
@@ -51,18 +52,30 @@ const MESSENGER_EXPOSED_METHODS = [
   'updateExchangeRate',
 ] as const;
 
+/**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+ */
 export type CurrencyRateStateChange = ControllerStateChangeEvent<
   typeof name,
   CurrencyRateState
 >;
 
+/**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+ */
 export type CurrencyRateControllerEvents = CurrencyRateStateChange;
 
+/**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+ */
 export type CurrencyRateControllerGetStateAction = ControllerGetStateAction<
   typeof name,
   CurrencyRateState
 >;
 
+/**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+ */
 export type CurrencyRateControllerActions =
   | CurrencyRateControllerGetStateAction
   | CurrencyRateControllerMethodActions;
@@ -71,6 +84,9 @@ type AllowedActions =
   | NetworkControllerGetNetworkClientByIdAction
   | NetworkControllerGetStateAction;
 
+/**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+ */
 export type CurrencyRateMessenger = Messenger<
   typeof name,
   CurrencyRateControllerActions | AllowedActions,
@@ -124,6 +140,7 @@ type FetchRatesResult = {
 };
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Controller that passively polls on a set interval for an exchange rate from the current network
  * asset to the user's preferred currency.
  */
@@ -184,6 +201,7 @@ export class CurrencyRateController extends StaticIntervalPollingController<Curr
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Sets a currency to track.
    *
    * @param currentCurrency - ISO 4217 currency code.
@@ -425,6 +443,7 @@ export class CurrencyRateController extends StaticIntervalPollingController<Curr
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Updates the exchange rate for the current currency and native currency pairs.
    *
    * @param nativeCurrencies - The native currency symbols to fetch exchange rates for.
@@ -473,6 +492,7 @@ export class CurrencyRateController extends StaticIntervalPollingController<Curr
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Prepare to discard this controller.
    *
    * This stops any active polling.
@@ -483,6 +503,7 @@ export class CurrencyRateController extends StaticIntervalPollingController<Curr
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Updates exchange rate for the current currency.
    *
    * @param input - The input for the poll.

--- a/packages/assets-controllers/src/MultichainAssetsController/MultichainAssetsController-method-action-types.ts
+++ b/packages/assets-controllers/src/MultichainAssetsController/MultichainAssetsController-method-action-types.ts
@@ -6,6 +6,7 @@
 import type { MultichainAssetsController } from './MultichainAssetsController';
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Returns the metadata for the given asset
  *
  * @param asset - The asset to get metadata for
@@ -17,6 +18,7 @@ export type MultichainAssetsControllerGetAssetMetadataAction = {
 };
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Ignores a batch of assets for a specific account.
  *
  * @param assetsToIgnore - Array of asset IDs to ignore.
@@ -28,6 +30,7 @@ export type MultichainAssetsControllerIgnoreAssetsAction = {
 };
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Adds multiple assets to the stored asset list for a specific account.
  * All assets must belong to the same chain.
  *

--- a/packages/assets-controllers/src/MultichainAssetsController/MultichainAssetsController.ts
+++ b/packages/assets-controllers/src/MultichainAssetsController/MultichainAssetsController.ts
@@ -46,6 +46,9 @@ import { getChainIdsCaveat } from './utils';
 
 const controllerName = 'MultichainAssetsController';
 
+/**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+ */
 export type MultichainAssetsControllerState = {
   assetsMetadata: {
     [asset: CaipAssetType]: FungibleAssetMetadata;
@@ -67,6 +70,7 @@ export type MultichainAssetsControllerAccountAssetListUpdatedEvent = {
 };
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Constructs the default {@link MultichainAssetsController} state. This allows
  * consumers to provide a partial state object when initializing the controller
  * and also helps in constructing complete state objects for this controller in
@@ -79,6 +83,7 @@ export function getDefaultMultichainAssetsControllerState(): MultichainAssetsCon
 }
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Returns the state of the {@link MultichainAssetsController}.
  */
 export type MultichainAssetsControllerGetStateAction = ControllerGetStateAction<
@@ -87,6 +92,7 @@ export type MultichainAssetsControllerGetStateAction = ControllerGetStateAction<
 >;
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Event emitted when the state of the {@link MultichainAssetsController} changes.
  */
 export type MultichainAssetsControllerStateChangeEvent =
@@ -96,6 +102,7 @@ export type MultichainAssetsControllerStateChangeEvent =
   >;
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Actions exposed by the {@link MultichainAssetsController}.
  */
 export type MultichainAssetsControllerActions =
@@ -103,6 +110,7 @@ export type MultichainAssetsControllerActions =
   | MultichainAssetsControllerMethodActions;
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Events emitted by {@link MultichainAssetsController}.
  */
 export type MultichainAssetsControllerEvents =
@@ -140,6 +148,7 @@ type AllowedEvents =
   | AccountsControllerAccountAssetListUpdatedEvent;
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Messenger type for the MultichainAssetsController.
  */
 export type MultichainAssetsControllerMessenger = Messenger<
@@ -202,6 +211,9 @@ type BulkTokenScanBatchOutcome =
     }
   | { status: 'rejected'; entries: ChainTokenEntry[] };
 
+/**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+ */
 export class MultichainAssetsController extends StaticIntervalPollingController<null>()<
   typeof controllerName,
   MultichainAssetsControllerState,
@@ -258,6 +270,9 @@ export class MultichainAssetsController extends StaticIntervalPollingController<
     messenger.registerMethodActionHandlers(this, MESSENGER_EXPOSED_METHODS);
   }
 
+  /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+   */
   async _executePoll(_input: null): Promise<void> {
     await this.#withControllerLock(async () => {
       const assetsByAccount: Record<
@@ -318,6 +333,7 @@ export class MultichainAssetsController extends StaticIntervalPollingController<
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Returns the metadata for the given asset
    *
    * @param asset - The asset to get metadata for
@@ -328,6 +344,7 @@ export class MultichainAssetsController extends StaticIntervalPollingController<
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Ignores a batch of assets for a specific account.
    *
    * @param assetsToIgnore - Array of asset IDs to ignore.
@@ -353,6 +370,7 @@ export class MultichainAssetsController extends StaticIntervalPollingController<
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Adds multiple assets to the stored asset list for a specific account.
    * All assets must belong to the same chain.
    *

--- a/packages/assets-controllers/src/MultichainAssetsRatesController/MultichainAssetsRatesController-method-action-types.ts
+++ b/packages/assets-controllers/src/MultichainAssetsRatesController/MultichainAssetsRatesController-method-action-types.ts
@@ -6,6 +6,7 @@
 import type { MultichainAssetsRatesController } from './MultichainAssetsRatesController';
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Updates token conversion rates for each non-EVM account.
  *
  * @returns A promise that resolves when the rates are updated.
@@ -16,6 +17,7 @@ export type MultichainAssetsRatesControllerUpdateAssetsRatesAction = {
 };
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Fetches historical prices for the current account
  *
  * @param asset - The asset to fetch historical prices for.

--- a/packages/assets-controllers/src/MultichainAssetsRatesController/MultichainAssetsRatesController.ts
+++ b/packages/assets-controllers/src/MultichainAssetsRatesController/MultichainAssetsRatesController.ts
@@ -61,6 +61,7 @@ type HistoricalPrice = {
 };
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * State used by the MultichainAssetsRatesController to cache token conversion rates.
  */
 export type MultichainAssetsRatesControllerState = {
@@ -69,6 +70,7 @@ export type MultichainAssetsRatesControllerState = {
 };
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Returns the state of the MultichainAssetsRatesController.
  */
 export type MultichainAssetsRatesControllerGetStateAction =
@@ -82,6 +84,7 @@ type UnifiedAssetConversion = AssetConversion & {
 };
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Constructs the default {@link MultichainAssetsRatesController} state. This allows
  * consumers to provide a partial state object when initializing the controller
  * and also helps in constructing complete state objects for this controller in
@@ -94,6 +97,7 @@ export function getDefaultMultichainAssetsRatesControllerState(): MultichainAsse
 }
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Event emitted when the state of the MultichainAssetsRatesController changes.
  */
 export type MultichainAssetsRatesControllerStateChange =
@@ -103,6 +107,7 @@ export type MultichainAssetsRatesControllerStateChange =
   >;
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Actions exposed by the MultichainAssetsRatesController.
  */
 export type MultichainAssetsRatesControllerActions =
@@ -110,12 +115,14 @@ export type MultichainAssetsRatesControllerActions =
   | MultichainAssetsRatesControllerMethodActions;
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Events emitted by MultichainAssetsRatesController.
  */
 export type MultichainAssetsRatesControllerEvents =
   MultichainAssetsRatesControllerStateChange;
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Actions that this controller is allowed to call.
  */
 export type AllowedActions =
@@ -126,6 +133,7 @@ export type AllowedActions =
   | AccountsControllerGetSelectedMultichainAccountAction;
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Events that this controller is allowed to subscribe to.
  */
 export type AllowedEvents =
@@ -135,6 +143,7 @@ export type AllowedEvents =
   | CurrencyRateStateChange
   | MultichainAssetsControllerAccountAssetListUpdatedEvent;
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Messenger type for the MultichainAssetsRatesController.
  */
 export type MultichainAssetsRatesControllerMessenger = Messenger<
@@ -187,6 +196,7 @@ const MESSENGER_EXPOSED_METHODS = [
 ] as const;
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Controller that manages multichain token conversion rates.
  *
  * This controller polls for token conversion rates and updates its state.
@@ -275,6 +285,7 @@ export class MultichainAssetsRatesController extends StaticIntervalPollingContro
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Executes a poll by updating token conversion rates for the current account.
    *
    * @returns A promise that resolves when the polling completes.
@@ -284,6 +295,7 @@ export class MultichainAssetsRatesController extends StaticIntervalPollingContro
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Determines whether the controller is active.
    *
    * @returns True if the keyring is unlocked; otherwise, false.
@@ -360,6 +372,7 @@ export class MultichainAssetsRatesController extends StaticIntervalPollingContro
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Updates token conversion rates for each non-EVM account.
    *
    * @returns A promise that resolves when the rates are updated.
@@ -549,6 +562,7 @@ export class MultichainAssetsRatesController extends StaticIntervalPollingContro
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Fetches historical prices for the current account
    *
    * @param asset - The asset to fetch historical prices for.

--- a/packages/assets-controllers/src/MultichainBalancesController/MultichainBalancesController.ts
+++ b/packages/assets-controllers/src/MultichainBalancesController/MultichainBalancesController.ts
@@ -34,6 +34,7 @@ import type {
 const controllerName = 'MultichainBalancesController';
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * State used by the {@link MultichainBalancesController} to cache account balances.
  */
 export type MultichainBalancesControllerState = {
@@ -48,6 +49,7 @@ export type MultichainBalancesControllerState = {
 };
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Constructs the default {@link MultichainBalancesController} state. This allows
  * consumers to provide a partial state object when initializing the controller
  * and also helps in constructing complete state objects for this controller in
@@ -60,6 +62,7 @@ export function getDefaultMultichainBalancesControllerState(): MultichainBalance
 }
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Returns the state of the {@link MultichainBalancesController}.
  */
 export type MultichainBalancesControllerGetStateAction =
@@ -69,6 +72,7 @@ export type MultichainBalancesControllerGetStateAction =
   >;
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Event emitted when the state of the {@link MultichainBalancesController} changes.
  */
 export type MultichainBalancesControllerStateChange =
@@ -78,12 +82,14 @@ export type MultichainBalancesControllerStateChange =
   >;
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Actions exposed by the {@link MultichainBalancesController}.
  */
 export type MultichainBalancesControllerActions =
   MultichainBalancesControllerGetStateAction;
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Events emitted by {@link MultichainBalancesController}.
  */
 export type MultichainBalancesControllerEvents =
@@ -107,6 +113,7 @@ type AllowedEvents =
   | AccountsControllerAccountBalancesUpdatesEvent
   | MultichainAssetsControllerAccountAssetListUpdatedEvent;
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Messenger type for the MultichainBalancesController.
  */
 export type MultichainBalancesControllerMessenger = Messenger<
@@ -133,6 +140,7 @@ const balancesControllerMetadata: StateMetadata<MultichainBalancesControllerStat
   };
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * The MultichainBalancesController is responsible for fetching and caching account
  * balances.
  */
@@ -306,6 +314,7 @@ export class MultichainBalancesController extends BaseController<
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Updates the balances of one account. This method doesn't return
    * anything, but it updates the state of the controller.
    *

--- a/packages/assets-controllers/src/RatesController/RatesController.ts
+++ b/packages/assets-controllers/src/RatesController/RatesController.ts
@@ -62,6 +62,9 @@ const defaultState = {
   cryptocurrencies: [Cryptocurrency.Btc, Cryptocurrency.Solana],
 };
 
+/**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+ */
 export class RatesController extends BaseController<
   typeof name,
   RatesControllerState,
@@ -172,6 +175,7 @@ export class RatesController extends BaseController<
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Starts the polling process.
    */
   async start(): Promise<void> {
@@ -189,6 +193,7 @@ export class RatesController extends BaseController<
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Stops the polling process.
    */
   async stop(): Promise<void> {
@@ -202,6 +207,7 @@ export class RatesController extends BaseController<
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Returns the current list of cryptocurrency.
    *
    * @returns The cryptocurrency list.
@@ -212,6 +218,7 @@ export class RatesController extends BaseController<
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Sets the list of supported cryptocurrencies.
    *
    * @param cryptocurrencies - The list of supported cryptocurrencies.
@@ -232,6 +239,7 @@ export class RatesController extends BaseController<
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Sets the internal fiat currency and update rates accordingly.
    *
    * @param fiatCurrency - The fiat currency.

--- a/packages/assets-controllers/src/RatesController/types.ts
+++ b/packages/assets-controllers/src/RatesController/types.ts
@@ -33,6 +33,7 @@ export type Rate = {
 export type ConversionRates = Record<string, Rate>;
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Represents the state structure for the RatesController.
  */
 export type RatesControllerState = {
@@ -53,6 +54,7 @@ export type RatesControllerState = {
 };
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Type definition for RatesController state change events.
  */
 export type RatesControllerStateChangeEvent = ControllerStateChangeEvent<
@@ -77,6 +79,7 @@ export type RatesControllerPollingStoppedEvent = {
 };
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Defines the events that the RatesController can emit.
  */
 export type RatesControllerEvents =
@@ -84,17 +87,22 @@ export type RatesControllerEvents =
   | RatesControllerPollingStartedEvent
   | RatesControllerPollingStoppedEvent;
 
+/**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+ */
 export type RatesControllerGetStateAction = ControllerGetStateAction<
   typeof ratesControllerName,
   RatesControllerState
 >;
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Defines the actions that can be performed to get the state of the RatesController.
  */
 export type RatesControllerActions = RatesControllerGetStateAction;
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Defines the actions that the RatesController can perform.
  */
 export type RatesControllerMessenger = Messenger<

--- a/packages/assets-controllers/src/TokenBalancesController-method-action-types.ts
+++ b/packages/assets-controllers/src/TokenBalancesController-method-action-types.ts
@@ -5,21 +5,33 @@
 
 import type { TokenBalancesController } from './TokenBalancesController';
 
+/**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+ */
 export type TokenBalancesControllerGetChainPollingConfigAction = {
   type: `TokenBalancesController:getChainPollingConfig`;
   handler: TokenBalancesController['getChainPollingConfig'];
 };
 
+/**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+ */
 export type TokenBalancesControllerUpdateChainPollingConfigsAction = {
   type: `TokenBalancesController:updateChainPollingConfigs`;
   handler: TokenBalancesController['updateChainPollingConfigs'];
 };
 
+/**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+ */
 export type TokenBalancesControllerUpdateBalancesAction = {
   type: `TokenBalancesController:updateBalances`;
   handler: TokenBalancesController['updateBalances'];
 };
 
+/**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+ */
 export type TokenBalancesControllerResetStateAction = {
   type: `TokenBalancesController:resetState`;
   handler: TokenBalancesController['resetState'];

--- a/packages/assets-controllers/src/TokenBalancesController.ts
+++ b/packages/assets-controllers/src/TokenBalancesController.ts
@@ -144,19 +144,31 @@ export type TokenBalances = Record<
   Record<ChainIdHex, Record<ChecksumAddress, Hex>>
 >;
 
+/**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+ */
 export type TokenBalancesControllerState = {
   tokenBalances: TokenBalances;
 };
 
+/**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+ */
 export type TokenBalancesControllerGetStateAction = ControllerGetStateAction<
   typeof CONTROLLER,
   TokenBalancesControllerState
 >;
 
+/**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+ */
 export type TokenBalancesControllerActions =
   | TokenBalancesControllerGetStateAction
   | TokenBalancesControllerMethodActions;
 
+/**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+ */
 export type TokenBalancesControllerStateChangeEvent =
   ControllerStateChangeEvent<typeof CONTROLLER, TokenBalancesControllerState>;
 
@@ -165,10 +177,16 @@ export type NativeBalanceEvent = {
   payload: unknown[];
 };
 
+/**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+ */
 export type TokenBalancesControllerEvents =
   | TokenBalancesControllerStateChangeEvent
   | NativeBalanceEvent;
 
+/**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+ */
 export type AllowedActions =
   | NetworkControllerGetNetworkClientByIdAction
   | NetworkControllerGetStateAction
@@ -185,6 +203,9 @@ export type AllowedActions =
   | KeyringControllerGetStateAction
   | AuthenticationController.AuthenticationControllerGetBearerTokenAction;
 
+/**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+ */
 export type AllowedEvents =
   | TokensControllerStateChangeEvent
   | PreferencesControllerStateChangeEvent
@@ -198,6 +219,9 @@ export type AllowedEvents =
   | TransactionControllerTransactionConfirmedEvent
   | TransactionControllerIncomingTransactionsReceivedEvent;
 
+/**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+ */
 export type TokenBalancesControllerMessenger = Messenger<
   typeof CONTROLLER,
   TokenBalancesControllerActions | AllowedActions,
@@ -300,6 +324,9 @@ const MESSENGER_EXPOSED_METHODS = [
   'resetState',
 ] as const;
 
+/**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+ */
 export class TokenBalancesController extends StaticIntervalPollingController<{
   chainIds: ChainIdHex[];
 }>()<
@@ -509,6 +536,7 @@ export class TokenBalancesController extends StaticIntervalPollingController<{
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Whether the controller is active (keyring is unlocked and user is onboarded).
    * When locked or not onboarded, balance updates should be skipped.
    *
@@ -611,6 +639,9 @@ export class TokenBalancesController extends StaticIntervalPollingController<{
     };
   };
 
+  /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+   */
   override _startPolling({ chainIds }: { chainIds: ChainIdHex[] }): void {
     this.#requestedChainIds = [...chainIds];
     this.#isControllerPollingActive = true;
@@ -684,6 +715,9 @@ export class TokenBalancesController extends StaticIntervalPollingController<{
     this.#intervalPollingTimers.set(interval, timer);
   }
 
+  /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+   */
   override _stopPollingByPollingTokenSetId(tokenSetId: string): void {
     let chainsToStop: ChainIdHex[] = [];
 
@@ -715,6 +749,9 @@ export class TokenBalancesController extends StaticIntervalPollingController<{
     this.#intervalPollingTimers.clear();
   }
 
+  /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+   */
   getChainPollingConfig(chainId: ChainIdHex): ChainPollingConfig {
     return (
       this.#chainPollingConfig[chainId] ?? {
@@ -723,6 +760,9 @@ export class TokenBalancesController extends StaticIntervalPollingController<{
     );
   }
 
+  /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+   */
   override async _executePoll({
     chainIds,
     queryAllAccounts = false,
@@ -733,6 +773,9 @@ export class TokenBalancesController extends StaticIntervalPollingController<{
     await this.#executeUpdateBalances({ chainIds, queryAllAccounts });
   }
 
+  /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+   */
   updateChainPollingConfigs(
     configs: Record<ChainIdHex, ChainPollingConfig>,
     options: UpdateChainPollingConfigsOptions = { immediateUpdate: true },
@@ -747,6 +790,9 @@ export class TokenBalancesController extends StaticIntervalPollingController<{
     }
   }
 
+  /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+   */
   async updateBalances(options: UpdateBalancesOptions = {}): Promise<void> {
     if (!this.isActive) {
       return;
@@ -1228,6 +1274,9 @@ export class TokenBalancesController extends StaticIntervalPollingController<{
     }
   }
 
+  /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+   */
   resetState(): void {
     this.update(() => ({ tokenBalances: {} }));
   }
@@ -1583,6 +1632,9 @@ export class TokenBalancesController extends StaticIntervalPollingController<{
     }
   }
 
+  /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+   */
   override destroy(): void {
     this.#isControllerPollingActive = false;
     this.#intervalPollingTimers.forEach((timer) => clearInterval(timer));

--- a/packages/assets-controllers/src/TokenListController.ts
+++ b/packages/assets-controllers/src/TokenListController.ts
@@ -52,22 +52,37 @@ export type TokensChainsCache = {
   [chainId: Hex]: DataCache;
 };
 
+/**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+ */
 export type TokenListState = {
   tokensChainsCache: TokensChainsCache;
 };
 
+/**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+ */
 export type TokenListStateChange = ControllerStateChangeEvent<
   typeof name,
   TokenListState
 >;
 
+/**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+ */
 export type TokenListControllerEvents = TokenListStateChange;
 
+/**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+ */
 export type GetTokenListState = ControllerGetStateAction<
   typeof name,
   TokenListState
 >;
 
+/**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+ */
 export type TokenListControllerActions = GetTokenListState;
 
 type AllowedActions =
@@ -78,6 +93,9 @@ type AllowedActions =
 
 type AllowedEvents = NetworkControllerStateChangeEvent;
 
+/**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+ */
 export type TokenListControllerMessenger = Messenger<
   typeof name,
   TokenListControllerActions | AllowedActions,
@@ -93,6 +111,9 @@ const metadata: StateMetadata<TokenListState> = {
   },
 };
 
+/**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+ */
 export const getDefaultTokenListState = (): TokenListState => {
   return {
     tokensChainsCache: {},
@@ -105,6 +126,7 @@ type TokenListPollingInput = {
 };
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Controller that passively polls on a set interval for the list of tokens from metaswaps api
  */
 export class TokenListController extends StaticIntervalPollingController<TokenListPollingInput>()<
@@ -243,6 +265,7 @@ export class TokenListController extends StaticIntervalPollingController<TokenLi
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Initialize the controller by loading cache from storage and running migration.
    * This method should be called by clients after construction.
    *
@@ -529,8 +552,7 @@ export class TokenListController extends StaticIntervalPollingController<TokenLi
   /**
    * Start polling for the token list.
    *
-   * @deprecated This method is deprecated and will be removed in the future.
-   * Consider using the new polling approach instead
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    */
   async start(): Promise<void> {
     if (this.#isDeprecated()) {
@@ -546,8 +568,7 @@ export class TokenListController extends StaticIntervalPollingController<TokenLi
   /**
    * Restart polling for the token list.
    *
-   * @deprecated This method is deprecated and will be removed in the future.
-   * Consider using the new polling approach instead
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    */
   async restart(): Promise<void> {
     this.#stopPolling();
@@ -561,8 +582,7 @@ export class TokenListController extends StaticIntervalPollingController<TokenLi
   /**
    * Stop polling for the token list.
    *
-   * @deprecated This method is deprecated and will be removed in the future.
-   * Consider using the new polling approach instead
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    */
   stop(): void {
     this.#stopPolling();
@@ -571,8 +591,7 @@ export class TokenListController extends StaticIntervalPollingController<TokenLi
   /**
    * This stops any active polling.
    *
-   * @deprecated This method is deprecated and will be removed in the future.
-   * Consider using the new polling approach instead
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    */
   override destroy(): void {
     super.destroy();
@@ -589,8 +608,7 @@ export class TokenListController extends StaticIntervalPollingController<TokenLi
   /**
    * This stops any active polling intervals.
    *
-   * @deprecated This method is deprecated and will be removed in the future.
-   * Consider using the new polling approach instead
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    */
   #stopPolling(): void {
     if (this.#intervalId) {
@@ -601,8 +619,7 @@ export class TokenListController extends StaticIntervalPollingController<TokenLi
   /**
    * Starts a new polling interval for a given chainId (this should be deprecated in favor of _executePoll)
    *
-   * @deprecated This method is deprecated and will be removed in the future.
-   * Consider using the new polling approach instead
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    */
   async #startDeprecatedPolling(): Promise<void> {
     // renaming this to avoid collision with base class
@@ -615,6 +632,7 @@ export class TokenListController extends StaticIntervalPollingController<TokenLi
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * This starts a new polling loop for any given chain. Under the hood it is deduping polls
    *
    * @param input - The input for the poll.
@@ -703,6 +721,7 @@ export class TokenListController extends StaticIntervalPollingController<TokenLi
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Fetching token list from the Token Service API. This will fetch tokens across chains.
    * State changes are automatically persisted via the stateChange subscription.
    *
@@ -769,6 +788,9 @@ export class TokenListController extends StaticIntervalPollingController<TokenLi
     }
   }
 
+  /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+   */
   isCacheValid(chainId: Hex): boolean {
     const { tokensChainsCache }: TokenListState = this.state;
     const timestamp: number | undefined = tokensChainsCache[chainId]?.timestamp;

--- a/packages/assets-controllers/src/TokenRatesController.ts
+++ b/packages/assets-controllers/src/TokenRatesController.ts
@@ -90,6 +90,7 @@ type ChainIdAndNativeCurrency = {
 };
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * The external actions available to the {@link TokenRatesController}.
  */
 export type AllowedActions =
@@ -98,6 +99,7 @@ export type AllowedActions =
   | NetworkEnablementControllerGetStateAction;
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * The external events available to the {@link TokenRatesController}.
  */
 export type AllowedEvents =
@@ -110,6 +112,7 @@ export type AllowedEvents =
 export const controllerName = 'TokenRatesController';
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * @type TokenRatesState
  *
  * Token rates controller state
@@ -121,6 +124,7 @@ export type TokenRatesControllerState = {
 };
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * The action that can be performed to get the state of the {@link TokenRatesController}.
  */
 export type TokenRatesControllerGetStateAction = ControllerGetStateAction<
@@ -129,11 +133,13 @@ export type TokenRatesControllerGetStateAction = ControllerGetStateAction<
 >;
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * The actions that can be performed using the {@link TokenRatesController}.
  */
 export type TokenRatesControllerActions = TokenRatesControllerGetStateAction;
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * The event that {@link TokenRatesController} can emit.
  */
 export type TokenRatesControllerStateChangeEvent = ControllerStateChangeEvent<
@@ -142,11 +148,13 @@ export type TokenRatesControllerStateChangeEvent = ControllerStateChangeEvent<
 >;
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * The events that {@link TokenRatesController} can emit.
  */
 export type TokenRatesControllerEvents = TokenRatesControllerStateChangeEvent;
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * The messenger of the {@link TokenRatesController} for communication.
  */
 export type TokenRatesControllerMessenger = Messenger<
@@ -165,6 +173,7 @@ const tokenRatesControllerMetadata: StateMetadata<TokenRatesControllerState> = {
 };
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Get the default {@link TokenRatesController} state.
  *
  * @returns The default {@link TokenRatesController} state.
@@ -182,6 +191,7 @@ export type TokenRatesPollingInput = {
 };
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Controller that passively polls on a set interval for token-to-fiat exchange rates
  * for tokens stored in the TokensController
  */
@@ -362,6 +372,7 @@ export class TokenRatesController extends StaticIntervalPollingController<TokenR
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Allows controller to make active and passive polling requests
    */
   enable(): void {
@@ -369,6 +380,7 @@ export class TokenRatesController extends StaticIntervalPollingController<TokenR
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Blocks controller from making network calls
    */
   disable(): void {
@@ -390,6 +402,7 @@ export class TokenRatesController extends StaticIntervalPollingController<TokenR
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Updates exchange rates for all tokens.
    *
    * @param chainIdAndNativeCurrency - The chain ID and native currency.
@@ -579,6 +592,7 @@ export class TokenRatesController extends StaticIntervalPollingController<TokenR
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Updates token rates for the given networkClientId
    *
    * @param input - The input for the poll.
@@ -610,6 +624,7 @@ export class TokenRatesController extends StaticIntervalPollingController<TokenR
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Reset the controller state to the default state.
    */
   resetState() {

--- a/packages/assets-controllers/src/TokensController-method-action-types.ts
+++ b/packages/assets-controllers/src/TokensController-method-action-types.ts
@@ -6,6 +6,7 @@
 import type { TokensController } from './TokensController';
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Adds a token to the stored token list.
  *
  * @param options - The method argument object.
@@ -25,6 +26,7 @@ export type TokensControllerAddTokenAction = {
 };
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Add a batch of tokens.
  *
  * @param tokensToImport - Array of tokens to import.
@@ -36,6 +38,7 @@ export type TokensControllerAddTokensAction = {
 };
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Ignore a batch of tokens.
  *
  * @param tokenAddressesToIgnore - Array of token addresses to ignore.
@@ -47,6 +50,7 @@ export type TokensControllerIgnoreTokensAction = {
 };
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Adds a batch of detected tokens to the stored token list.
  *
  * @param incomingDetectedTokens - Array of detected tokens to be added or updated.
@@ -60,6 +64,7 @@ export type TokensControllerAddDetectedTokensAction = {
 };
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Adds isERC721 field to token object. This is called when a user attempts to add tokens that
  * were previously added which do not yet had isERC721 field.
  *
@@ -73,6 +78,7 @@ export type TokensControllerUpdateTokenTypeAction = {
 };
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Adds a new suggestedAsset to the list of watched assets.
  * Parameters will be validated according to the asset type being watched.
  *
@@ -92,6 +98,7 @@ export type TokensControllerWatchAssetAction = {
 };
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Removes all tokens from the ignored list.
  */
 export type TokensControllerClearIgnoredTokensAction = {
@@ -100,6 +107,7 @@ export type TokensControllerClearIgnoredTokensAction = {
 };
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Reset the controller state to the default state.
  */
 export type TokensControllerResetStateAction = {

--- a/packages/assets-controllers/src/TokensController.ts
+++ b/packages/assets-controllers/src/TokensController.ts
@@ -93,6 +93,7 @@ const getNonEmptyString = (
 };
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * @type TokensControllerState
  *
  * Assets controller state
@@ -130,16 +131,23 @@ const metadata: StateMetadata<TokensControllerState> = {
 
 const controllerName = 'TokensController';
 
+/**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+ */
 export type TokensControllerGetStateAction = ControllerGetStateAction<
   typeof controllerName,
   TokensControllerState
 >;
 
+/**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+ */
 export type TokensControllerActions =
   | TokensControllerGetStateAction
   | TokensControllerMethodActions;
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * The external actions available to the {@link TokensController}.
  */
 export type AllowedActions =
@@ -149,13 +157,22 @@ export type AllowedActions =
   | AccountsControllerGetSelectedAccountAction
   | AccountsControllerListAccountsAction;
 
+/**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+ */
 export type TokensControllerStateChangeEvent = ControllerStateChangeEvent<
   typeof controllerName,
   TokensControllerState
 >;
 
+/**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+ */
 export type TokensControllerEvents = TokensControllerStateChangeEvent;
 
+/**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+ */
 export type AllowedEvents =
   | NetworkControllerStateChangeEvent
   | NetworkControllerNetworkDidChangeEvent
@@ -163,6 +180,7 @@ export type AllowedEvents =
   | KeyringControllerAccountRemovedEvent;
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * The messenger of the {@link TokensController}.
  */
 export type TokensControllerMessenger = Messenger<
@@ -171,6 +189,9 @@ export type TokensControllerMessenger = Messenger<
   TokensControllerEvents | AllowedEvents
 >;
 
+/**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
+ */
 export const getDefaultTokensState = (): TokensControllerState => {
   return {
     allTokens: {},
@@ -191,6 +212,7 @@ const MESSENGER_EXPOSED_METHODS = [
 ] as const;
 
 /**
+ * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
  * Controller that stores assets and exposes convenience methods
  */
 export class TokensController extends BaseController<
@@ -423,6 +445,7 @@ export class TokensController extends BaseController<
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Adds a token to the stored token list.
    *
    * @param options - The method argument object.
@@ -536,6 +559,7 @@ export class TokensController extends BaseController<
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Add a batch of tokens.
    *
    * @param tokensToImport - Array of tokens to import.
@@ -613,6 +637,7 @@ export class TokensController extends BaseController<
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Ignore a batch of tokens.
    *
    * @param tokenAddressesToIgnore - Array of token addresses to ignore.
@@ -668,6 +693,7 @@ export class TokensController extends BaseController<
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Adds a batch of detected tokens to the stored token list.
    *
    * @param incomingDetectedTokens - Array of detected tokens to be added or updated.
@@ -771,6 +797,7 @@ export class TokensController extends BaseController<
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Adds isERC721 field to token object. This is called when a user attempts to add tokens that
    * were previously added which do not yet had isERC721 field.
    *
@@ -864,6 +891,7 @@ export class TokensController extends BaseController<
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Adds a new suggestedAsset to the list of watched assets.
    * Parameters will be validated according to the asset type being watched.
    *
@@ -1118,6 +1146,7 @@ export class TokensController extends BaseController<
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Removes all tokens from the ignored list.
    */
   clearIgnoredTokens() {
@@ -1173,6 +1202,7 @@ export class TokensController extends BaseController<
   }
 
   /**
+   * @deprecated This is deprecated and will be removed in a future version. Use `AssetsController` from `@metamask/assets-controller` instead.
    * Reset the controller state to the default state.
    */
   resetState() {


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Spreads deprecation messages for all legacy assets controller state, public methods, actions and events.

It does not functionally change anything, but it signals that they should not be used moving forward.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation-only change with no runtime logic; low risk aside from IDE deprecation noise for consumers still on the old controllers.
> 
> **Overview**
> Documents the migration from the legacy split assets stack to unified **`AssetsController`** in `@metamask/assets-controller`.
> 
> **`@metamask/assets-controllers`** adds a **Deprecated** changelog entry and applies a shared JSDoc `@deprecated` tag across eleven legacy controllers: `AccountTrackerController`, `CurrencyRateController`, `MultichainAssetsController`, `MultichainAssetsRatesController`, `MultichainBalancesController`, `RatesController`, `TokenBalancesController`, `TokenListController`, `TokenRatesController`, and `TokensController`. Coverage includes exported state/types, messenger action types (including auto-generated `*-method-action-types` files), and public instance methods.
> 
> **`TokenListController`** polling helpers (`start`, `restart`, `stop`, `destroy`, etc.) now use the same deprecation wording as the rest of the package instead of generic “new polling approach” notes.
> 
> There is **no** functional or API behavior change in this PR—only TypeScript/editor deprecation surfacing and changelog documentation. The unreleased section also bumps `@metamask/network-enablement-controller` to `^5.3.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a09963b5a61dfc11d18102ae5b1d1b2578299cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->