### PR TITLE
chore: Bump Yarn to `4.16.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
   "engines": {
     "node": "^18.18 || >=20"
   },
-  "packageManager": "yarn@4.14.1",
+  "packageManager": "yarn@4.16.0",
   "lavamoat": {
     "allowScripts": {
       "@lavamoat/preinstall-always-fail": false,

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -257,7 +257,7 @@ module.exports = defineConfig({
       if (isChildWorkspace) {
         workspace.unset('packageManager');
       } else {
-        expectWorkspaceField(workspace, 'packageManager', 'yarn@4.14.1');
+        expectWorkspaceField(workspace, 'packageManager', 'yarn@4.16.0');
       }
 
       // All packages must specify a minimum Node.js version of 18.18.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 9
+  version: 10
   cacheKey: 10
 
 "@adraffy/ens-normalize@npm:1.10.1":


### PR DESCRIPTION
## Explanation

Forgot to do this in #8998.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling-only change with no runtime or library code touched; main impact is developers using Corepack/Yarn 4.16.0 for installs.
> 
> **Overview**
> Bumps the monorepo’s required **Yarn** version from **4.14.1** to **4.16.0** (follow-up to a prior upgrade).
> 
> Root `packageManager` is updated, and `yarn constraints` in `yarn.config.cjs` now enforces `yarn@4.16.0` on the root workspace. `yarn.lock`’s `__metadata.version` moves from **9** to **10**, consistent with regenerating the lockfile under the newer Yarn release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 125eef332ad01baf3c433ed5270803c4931d5e22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->