### PR TITLE
feat: add isDeprecated option to TokenRatesController

### DIFF
--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `isDeprecated` option to `TokenRatesController` constructor ([#9022](https://github.com/MetaMask/core/pull/9022))
+  - When `isDeprecated()` returns `true`, all entry points (`updateExchangeRates`, `_executePoll`, `TokensController:stateChange`, and `NetworkController:stateChange`) become no-ops: no network requests are sent and no state is updated.
+
 ### Changed
 
 - Bump `@metamask/network-enablement-controller` from `^5.2.0` to `^5.3.0` ([#9003](https://github.com/MetaMask/core/pull/9003))

--- a/packages/assets-controllers/src/TokenRatesController.test.ts
+++ b/packages/assets-controllers/src/TokenRatesController.test.ts
@@ -156,6 +156,33 @@ describe('TokenRatesController', () => {
       );
     });
 
+    it('does not fetch or update state when isDeprecated returns true', async () => {
+      const tokenPricesService = buildMockTokenPricesService();
+      jest.spyOn(tokenPricesService, 'fetchTokenPrices');
+
+      await withController(
+        {
+          options: {
+            tokenPricesService,
+            isDeprecated: () => true,
+          },
+        },
+        async ({ controller }) => {
+          const stateBefore = controller.state.marketData;
+
+          await controller.updateExchangeRates([
+            {
+              chainId: '0x1',
+              nativeCurrency: 'ETH',
+            },
+          ]);
+
+          expect(tokenPricesService.fetchTokenPrices).not.toHaveBeenCalled();
+          expect(controller.state.marketData).toBe(stateBefore);
+        },
+      );
+    });
+
     it('fetches rates for tokens in one batch', async () => {
       const chainId = '0x1';
       const nativeCurrency = 'ETH';
@@ -712,6 +739,23 @@ describe('TokenRatesController', () => {
         },
       );
     });
+
+    it('does nothing when isDeprecated returns true', async () => {
+      await withController(
+        {
+          options: {
+            isDeprecated: () => true,
+          },
+        },
+        async ({ controller }) => {
+          jest.spyOn(controller, 'updateExchangeRates');
+
+          await controller._executePoll({ chainIds: ['0x1'] });
+
+          expect(controller.updateExchangeRates).not.toHaveBeenCalled();
+        },
+      );
+    });
   });
 
   describe('TokensController:stateChange', () => {
@@ -816,6 +860,43 @@ describe('TokenRatesController', () => {
         {
           options: {
             disabled: true,
+          },
+        },
+        async ({ controller, triggerTokensStateChange }) => {
+          jest.spyOn(controller, 'updateExchangeRates');
+
+          triggerTokensStateChange({
+            allTokens: {
+              [chainId]: {
+                [defaultSelectedAddress]: [
+                  {
+                    address: '0x0000000000000000000000000000000000000001',
+                    decimals: 0,
+                    symbol: 'TOK1',
+                  },
+                ],
+              },
+            },
+            allDetectedTokens: {},
+            allIgnoredTokens: {},
+          });
+
+          jest.advanceTimersToNextTimer();
+          await flushPromises();
+
+          expect(controller.updateExchangeRates).not.toHaveBeenCalled();
+        },
+      );
+    });
+
+    it('does not fetch when isDeprecated returns true', async () => {
+      jest.useFakeTimers();
+      const chainId = '0x1';
+
+      await withController(
+        {
+          options: {
+            isDeprecated: () => true,
           },
         },
         async ({ controller, triggerTokensStateChange }) => {
@@ -991,6 +1072,46 @@ describe('TokenRatesController', () => {
               } as unknown as MarketDataDetails,
             },
           });
+        },
+      );
+    });
+
+    it('does not update state when isDeprecated returns true', async () => {
+      const chainId = '0x1';
+      const nativeCurrency = 'ETH';
+      const initialMarketData = {
+        [chainId]: {
+          '0x0000000000000000000000000000000000000000': {
+            currency: nativeCurrency,
+            price: 0.001,
+          } as unknown as MarketDataDetails,
+        },
+      };
+
+      await withController(
+        {
+          options: {
+            isDeprecated: () => true,
+            state: { marketData: initialMarketData },
+          },
+        },
+        async ({ controller, triggerNetworkStateChange }) => {
+          triggerNetworkStateChange(
+            {
+              ...getDefaultNetworkControllerState(),
+              networkConfigurationsByChainId: {},
+            },
+            [
+              {
+                op: 'remove',
+                path: ['networkConfigurationsByChainId', chainId],
+              },
+            ],
+          );
+
+          await flushPromises();
+
+          expect(controller.state.marketData).toStrictEqual(initialMarketData);
         },
       );
     });

--- a/packages/assets-controllers/src/TokenRatesController.ts
+++ b/packages/assets-controllers/src/TokenRatesController.ts
@@ -194,6 +194,8 @@ export class TokenRatesController extends StaticIntervalPollingController<TokenR
 
   #disabled: boolean;
 
+  readonly #isDeprecated: () => boolean;
+
   #allTokens: TokensControllerState['allTokens'];
 
   #allDetectedTokens: TokensControllerState['allDetectedTokens'];
@@ -204,6 +206,9 @@ export class TokenRatesController extends StaticIntervalPollingController<TokenR
    * @param options - The controller options.
    * @param options.interval - The polling interval in ms
    * @param options.disabled - Boolean to track if network requests are blocked
+   * @param options.isDeprecated - Optional function that returns true to completely
+   * disable this controller (no requests, no state updates). Intended for use
+   * when a higher-level controller (e.g. AssetsController) supersedes this one.
    * @param options.tokenPricesService - An object in charge of retrieving token price
    * @param options.messenger - The messenger instance for communication
    * @param options.state - Initial state to set on this controller
@@ -211,12 +216,14 @@ export class TokenRatesController extends StaticIntervalPollingController<TokenR
   constructor({
     interval = DEFAULT_INTERVAL,
     disabled = false,
+    isDeprecated = (): boolean => false,
     tokenPricesService,
     messenger,
     state,
   }: {
     interval?: number;
     disabled?: boolean;
+    isDeprecated?: () => boolean;
     tokenPricesService: AbstractTokenPricesService;
     messenger: TokenRatesControllerMessenger;
     state?: Partial<TokenRatesControllerState>;
@@ -231,6 +238,7 @@ export class TokenRatesController extends StaticIntervalPollingController<TokenR
     this.setIntervalLength(interval);
     this.#tokenPricesService = tokenPricesService;
     this.#disabled = disabled;
+    this.#isDeprecated = isDeprecated;
 
     const { allTokens, allDetectedTokens } = this.#getTokensControllerState();
     this.#allTokens = allTokens;
@@ -250,7 +258,7 @@ export class TokenRatesController extends StaticIntervalPollingController<TokenR
       // TODO: Either fix this lint violation or explain why it's necessary to ignore.
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
       async ({ allTokens, allDetectedTokens }) => {
-        if (this.#disabled) {
+        if (this.#disabled || this.#isDeprecated()) {
           return;
         }
 
@@ -306,6 +314,9 @@ export class TokenRatesController extends StaticIntervalPollingController<TokenR
     this.messenger.subscribe(
       'NetworkController:stateChange',
       (_state, patches) => {
+        if (this.#isDeprecated()) {
+          return;
+        }
         // Remove state for deleted networks
         for (const patch of patches) {
           if (
@@ -397,7 +408,7 @@ export class TokenRatesController extends StaticIntervalPollingController<TokenR
   async updateExchangeRates(
     chainIdAndNativeCurrency: ChainIdAndNativeCurrency[],
   ): Promise<void> {
-    if (this.#disabled) {
+    if (this.#disabled || this.#isDeprecated()) {
       return;
     }
 
@@ -585,6 +596,10 @@ export class TokenRatesController extends StaticIntervalPollingController<TokenR
    * @param input.chainIds - The chain ids to poll token rates on.
    */
   async _executePoll({ chainIds }: TokenRatesPollingInput): Promise<void> {
+    if (this.#isDeprecated()) {
+      return;
+    }
+
     const { networkConfigurationsByChainId } = this.messenger.call(
       'NetworkController:getState',
     );


### PR DESCRIPTION
When isDeprecated() returns true the controller becomes a complete no-op: no network requests are sent, no state is updated, and subscription callbacks exit immediately. Intended for use when AssetsController supersedes TokenRatesController.

## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional flag with early returns only; no change when isDeprecated is omitted or false.
> 
> **Overview**
> Adds an optional **`isDeprecated`** constructor callback to **`TokenRatesController`**, mirroring the pattern already used on **`TokenListController`**, so callers can fully retire this controller when **`AssetsController`** takes over pricing.
> 
> When **`isDeprecated()`** is true, **`updateExchangeRates`**, **`_executePoll`**, and the **`TokensController:stateChange`** / **`NetworkController:stateChange`** handlers return immediately: no price fetches and no **`marketData`** updates (existing **`#disabled`** behavior is extended on the fetch paths). Tests assert no-op behavior on each entry point; the changelog documents the new option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92f3bde43714fcd00f2f31767f5af6f127f9e8f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->