### PR TITLE
ci: Enable Corepack in `check-release` workflow

### DIFF
--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -33,6 +33,10 @@ runs:
         MERGE_BASE=$(git merge-base HEAD "refs/remotes/origin/$BASE_REF")
         echo "MERGE_BASE=$MERGE_BASE" >> "$GITHUB_OUTPUT"
 
+    - name: Enable Corepack
+      shell: bash
+      run: corepack enable
+
     - name: Check that root package.json is bumped for release PRs
       shell: bash
       env:


### PR DESCRIPTION
## Explanation

Because Corepack wasn't enabled, the check that ensures the root `package.json` is bumped failed with "error This project's package.json defines "packageManager": "yarn@4.16.0". However the current global version of Yarn is 1.22.22.". Yarn is used in a subshell, so the script didn't fail despite this error.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them
