### PR TITLE
ci: Add top-level permissions to `publish-release` workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,6 +8,9 @@ on:
       SLACK_WEBHOOK_URL:
         required: true
 
+permissions:
+  contents: read
+
 concurrency:
   group: publish-release
   queue: max


### PR DESCRIPTION
## Explanation

By default, all jobs in a workflow inherit the permissions provided to it in the caller (`main.yml` in this case). This meant that `publish-release.yml` had `contents: write` and `id-token: write` in all jobs, including the dry run job. This made the dry run job think it was an actual run, and try to publish (which failed). By explicitly specifying permissions, jobs will inherit those permissions instead. We do this in the module template too.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only permission scoping for GitHub Actions; no application or runtime behavior changes.
> 
> **Overview**
> Adds **workflow-level `permissions: contents: read`** to the reusable `publish-release` workflow so jobs no longer inherit **`contents: write`** and **`id-token: write`** from the caller in `main.yml`.
> 
> Without this default, the **`publish-npm-dry-run`** job received publish-level permissions and the npm publish action treated the run as a real release instead of a dry run. Jobs that still need elevated access keep explicit overrides: **`publish-release`** sets `contents: write`, and **`publish-npm`** sets `contents: read` plus `id-token: write`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cbf2ba650f87f0d556ef915b515a0fd29761132. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->