### PR TITLE
docs: add Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,3 +219,33 @@ When adding or updating data services in packages, follow these guidelines:
 - Make sure to write comprehensive tests for the service class.
 
 Use the `sample-gas-prices-service/` directory in the `sample-controllers` package as examples for implementation and tests.
+
+## Cursor Cloud specific instructions
+
+This is a **library monorepo** (shared npm packages for MetaMask Extension/Mobile), not a deployable application. There are no long-running services, Docker Compose stacks, or in-repo E2E apps to start. Verification is done via build, test, and lint.
+
+### Prerequisites
+
+- **Node.js** `^18.18 || >=20` (see `.nvmrc` for LTS)
+- **Yarn 4.16.0** via Corepack: run `corepack enable` before `yarn install`
+
+If a global Yarn 1.x install is on `PATH`, Corepack must be enabled so the repo's `packageManager` field pins Yarn 4.
+
+### Common commands
+
+See `docs/getting-started/setting-up-your-environment.md` and the root `package.json` scripts. Typical workflow:
+
+| Task | Command |
+|------|---------|
+| Install deps | `yarn install` |
+| Build all packages | `yarn build` |
+| Test one package | `yarn workspace <package-name> run test` |
+| Test all packages | `yarn test` |
+| Lint | `yarn lint` |
+
+### Non-obvious caveats
+
+- **`yarn lint:eslint` deletes `dist/`** before linting (`yarn build:only-clean`). Re-run `yarn build` after lint if you need compiled output for runtime imports.
+- **Tests mock external HTTP/RPC** via nock (see `tests/setupAfterEnv/nock.ts`). No Infura, profile-sync, or other live APIs are required.
+- **Package builds use project references.** Building a single workspace package after a clean may fail until dependencies are built; prefer `yarn build` at the repo root.
+- **`@metamask/ramps-controller`** has an optional `dev` script (`node dev-watch.js`) for local rebuild watching; it is not required for tests or CI.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Cursor Cloud specific instructions** section to `AGENTS.md` documenting how to develop in this MetaMask Core library monorepo within Cloud Agent VMs.

## Context

This repo is a Yarn 4 / TypeScript monorepo of shared npm packages (controllers, services, middleware). It is **not** a deployable application — verification is done via build, test, and lint rather than running a long-lived server.

## Changes

- Document prerequisites (Node.js, Corepack/Yarn 4)
- Add a quick-reference table for common commands
- Capture non-obvious caveats discovered during environment setup:
  - `yarn lint:eslint` runs `build:only-clean` and deletes `dist/`
  - Tests mock external APIs via nock
  - Package builds require project references (prefer root `yarn build`)

## VM update script

```
corepack enable
yarn install
```

## Verification performed

- `corepack enable` + `yarn install` (2132 packages)
- `yarn build` — all packages compiled successfully
- `yarn workspace @metamask/sample-controllers run test:verbose` — 38 tests passed
- `yarn workspace @metamask/ramps-controller run test:verbose` — 519 tests passed
- `yarn test:scripts` — 17 tests passed
- `yarn lint:eslint`, `yarn lint:misc --check`, `yarn constraints` — all passed
- Runtime demo: instantiated `SamplePetnamesController`, assigned a petname, verified state

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5b490e56-4129-43ba-ab5c-3c9aa0076372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b490e56-4129-43ba-ab5c-3c9aa0076372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

