### PR TITLE
feat: expose 'runMigrations' to the messenger actions

### DIFF
--- a/packages/seedless-onboarding-controller/CHANGELOG.md
+++ b/packages/seedless-onboarding-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Expose `runMigrations` as a messenger action (`SeedlessOnboardingController:runMigrations`)
+
 ## [10.0.0]
 
 ### Added

--- a/packages/seedless-onboarding-controller/CHANGELOG.md
+++ b/packages/seedless-onboarding-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Expose `runMigrations` as a messenger action (`SeedlessOnboardingController:runMigrations`)
+- Expose `runMigrations` as a messenger action (`SeedlessOnboardingController:runMigrations`) ([#9031](https://github.com/MetaMask/core/pull/9031))
 
 ## [10.0.0]
 

--- a/packages/seedless-onboarding-controller/src/SeedlessOnboardingController-method-action-types.ts
+++ b/packages/seedless-onboarding-controller/src/SeedlessOnboardingController-method-action-types.ts
@@ -71,6 +71,24 @@ export type SeedlessOnboardingControllerAddNewSecretDataAction = {
 };
 
 /**
+ * Run any pending seedless onboarding migrations.
+ *
+ * This method should be called by clients after the controller is unlocked
+ * to ensure legacy data is migrated to the latest format.
+ *
+ * Migrations are idempotent - running this multiple times is safe.
+ * The migration version is tracked in state to prevent re-running migrations.
+ *
+ * @returns A promise that resolves to `true` if data was actually migrated
+ * (items were updated on the server), `false` otherwise.
+ * @throws If the password is outdated (changed on another device).
+ */
+export type SeedlessOnboardingControllerRunMigrationsAction = {
+  type: `SeedlessOnboardingController:runMigrations`;
+  handler: SeedlessOnboardingController['runMigrations'];
+};
+
+/**
  * Fetches all secret data items from the metadata store.
  *
  * Decrypts the secret data and returns the decrypted secret data using the recovered encryption key from the password.
@@ -350,6 +368,7 @@ export type SeedlessOnboardingControllerMethodActions =
   | SeedlessOnboardingControllerAuthenticateAction
   | SeedlessOnboardingControllerCreateToprfKeyAndBackupSeedPhraseAction
   | SeedlessOnboardingControllerAddNewSecretDataAction
+  | SeedlessOnboardingControllerRunMigrationsAction
   | SeedlessOnboardingControllerFetchAllSecretDataAction
   | SeedlessOnboardingControllerChangePasswordAction
   | SeedlessOnboardingControllerUpdateBackupMetadataStateAction

--- a/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.ts
+++ b/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.ts
@@ -109,6 +109,7 @@ const MESSENGER_EXPOSED_METHODS = [
   'checkNodeAuthTokenExpired',
   'checkMetadataAccessTokenExpired',
   'checkAccessTokenExpired',
+  'runMigrations',
 ] as const;
 
 // Actions

--- a/packages/seedless-onboarding-controller/src/index.ts
+++ b/packages/seedless-onboarding-controller/src/index.ts
@@ -37,6 +37,7 @@ export type {
   SeedlessOnboardingControllerCheckNodeAuthTokenExpiredAction,
   SeedlessOnboardingControllerCheckMetadataAccessTokenExpiredAction,
   SeedlessOnboardingControllerCheckAccessTokenExpiredAction,
+  SeedlessOnboardingControllerRunMigrationsAction,
 } from './SeedlessOnboardingController-method-action-types';
 export type {
   AuthenticatedUserDetails,


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

This PR adds and exposes `runMigrations` method to the messenger action. 

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Callers can trigger legacy secret metadata migrations that update server-side backup items; behavior is unchanged from the existing public method but now reachable through the messenger boundary.
> 
> **Overview**
> Clients can invoke **`SeedlessOnboardingController:runMigrations`** through the controller messenger instead of calling the controller instance directly, matching how other public methods were exposed in 9.1.0.
> 
> The PR adds **`runMigrations`** to **`MESSENGER_EXPOSED_METHODS`**, defines **`SeedlessOnboardingControllerRunMigrationsAction`** (with the same unlock / idempotency / return-value semantics as the existing method), includes it in the **`SeedlessOnboardingControllerMethodActions`** union, and re-exports the action type from the package entry. The **[Unreleased]** changelog documents the new action. **No change to migration logic**—only messenger wiring and types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 091dc245bb312b4feef1374f7175655edf0ce4cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->