### PR TITLE
fix: clear TokenRatesController marketData when deprecated

### DIFF
--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `isDeprecated` option to `TokenRatesController` constructor ([#9022](https://github.com/MetaMask/core/pull/9022))
-  - When `isDeprecated()` returns `true`, all entry points (`updateExchangeRates`, `_executePoll`, `TokensController:stateChange`, and `NetworkController:stateChange`) become no-ops: no network requests are sent and no state is updated.
+  - When `isDeprecated()` returns `true`, no network requests are sent and `marketData` is reset to `{}` at construction and at every entry point (`updateExchangeRates`, `_executePoll`, `TokensController:stateChange`, and `NetworkController:stateChange`), so no stale rates remain in state.
+  - The function is re-evaluated on each entry point so it can be toggled at runtime without reconstructing the controller.
 
 ### Changed
 

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `isDeprecated` option to `TokenRatesController` constructor ([#9033](https://github.com/MetaMask/core/pull/9033))
   - When `isDeprecated()` returns `true`, no network requests are sent and `marketData` is reset to `{}` at construction and at every entry point (`updateExchangeRates`, `_executePoll`, `TokensController:stateChange`, and `NetworkController:stateChange`), so no stale rates remain in state.
   - The function is re-evaluated on each entry point so it can be toggled at runtime without reconstructing the controller.
+- Add `isDeprecated` option to `TokenBalancesController` constructor ([#9033](https://github.com/MetaMask/core/pull/9033))
+  - When `isDeprecated()` returns `true`, no network requests are sent and `tokenBalances` is reset to `{}` at construction and at every entry point (`updateBalances`, `_executePoll`, `TokensController:stateChange`, `NetworkController:stateChange`, `KeyringController:accountRemoved`, `AccountsController:selectedEvmAccountChange`, and the `AccountActivityService` events), so no stale balances remain in state.
+  - The function is re-evaluated on each entry point so it can be toggled at runtime without reconstructing the controller.
 
 ### Changed
 

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `isDeprecated` option to `TokenRatesController` constructor ([#9022](https://github.com/MetaMask/core/pull/9022))
+- Add `isDeprecated` option to `TokenRatesController` constructor ([#9033](https://github.com/MetaMask/core/pull/9033))
   - When `isDeprecated()` returns `true`, no network requests are sent and `marketData` is reset to `{}` at construction and at every entry point (`updateExchangeRates`, `_executePoll`, `TokensController:stateChange`, and `NetworkController:stateChange`), so no stale rates remain in state.
   - The function is re-evaluated on each entry point so it can be toggled at runtime without reconstructing the controller.
 

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `isDeprecated` option to `TokenBalancesController` constructor ([#9033](https://github.com/MetaMask/core/pull/9033))
   - When `isDeprecated()` returns `true`, no network requests are sent and `tokenBalances` is reset to `{}` at construction and at every entry point (`updateBalances`, `_executePoll`, `TokensController:stateChange`, `NetworkController:stateChange`, `KeyringController:accountRemoved`, `AccountsController:selectedEvmAccountChange`, and the `AccountActivityService` events), so no stale balances remain in state.
   - The function is re-evaluated on each entry point so it can be toggled at runtime without reconstructing the controller.
+- Add `isDeprecated` option to `AccountTrackerController` constructor ([#9033](https://github.com/MetaMask/core/pull/9033))
+  - When `isDeprecated()` returns `true`, no network requests are sent and `accountsByChainId` is reset to `{}` at construction and at every entry point (`refresh`, `refreshAddresses`, `_executePoll`, `syncBalanceWithAddresses`, `updateNativeBalances`, and `updateStakedBalances`), so no stale balances remain in state.
+  - The function is re-evaluated on each entry point so it can be toggled at runtime without reconstructing the controller.
 
 ### Changed
 

--- a/packages/assets-controllers/src/AccountTrackerController.test.ts
+++ b/packages/assets-controllers/src/AccountTrackerController.test.ts
@@ -2070,6 +2070,176 @@ describe('AccountTrackerController', () => {
       });
     });
   });
+
+  describe('isDeprecated', () => {
+    const initialState = {
+      accountsByChainId: {
+        '0x1': {
+          [CHECKSUM_ADDRESS_1]: { balance: '0x1' },
+        },
+      },
+    };
+
+    it('clears persisted accountsByChainId at construction when isDeprecated() returns true', async () => {
+      await withController(
+        {
+          options: { state: initialState, isDeprecated: () => true },
+        },
+        ({ controller }) => {
+          expect(controller.state.accountsByChainId).toStrictEqual({});
+        },
+      );
+    });
+
+    it('preserves persisted accountsByChainId at construction when isDeprecated() returns false', async () => {
+      await withController(
+        {
+          options: { state: initialState, isDeprecated: () => false },
+        },
+        ({ controller }) => {
+          expect(controller.state.accountsByChainId).toStrictEqual(
+            initialState.accountsByChainId,
+          );
+        },
+      );
+    });
+
+    it('does not throw at construction when isDeprecated() is true and state is already empty', async () => {
+      await withController(
+        {
+          options: {
+            state: { accountsByChainId: {} },
+            isDeprecated: () => true,
+          },
+        },
+        ({ controller }) => {
+          expect(controller.state.accountsByChainId).toStrictEqual({});
+        },
+      );
+    });
+
+    it('does not fetch and clears stale state on refresh when isDeprecated toggles to true at runtime', async () => {
+      let deprecated = false;
+      await withController(
+        {
+          options: { state: initialState, isDeprecated: () => deprecated },
+          selectedAccount: ACCOUNT_1,
+          listAccounts: [ACCOUNT_1],
+        },
+        async ({ controller, refresh }) => {
+          expect(controller.state.accountsByChainId).toStrictEqual(
+            initialState.accountsByChainId,
+          );
+
+          deprecated = true;
+
+          await refresh(['mainnet']);
+
+          expect(
+            mockedGetTokenBalancesForMultipleAddresses,
+          ).not.toHaveBeenCalled();
+          expect(controller.state.accountsByChainId).toStrictEqual({});
+        },
+      );
+    });
+
+    it('clears stale state on _executePoll when isDeprecated toggles to true at runtime', async () => {
+      let deprecated = false;
+      await withController(
+        {
+          options: { state: initialState, isDeprecated: () => deprecated },
+        },
+        async ({ controller }) => {
+          deprecated = true;
+
+          await controller._executePoll({ networkClientIds: ['mainnet'] });
+
+          expect(controller.state.accountsByChainId).toStrictEqual({});
+        },
+      );
+    });
+
+    it('clears stale state on refreshAddresses when isDeprecated toggles to true at runtime', async () => {
+      let deprecated = false;
+      await withController(
+        {
+          options: { state: initialState, isDeprecated: () => deprecated },
+          listAccounts: [ACCOUNT_1],
+        },
+        async ({ controller }) => {
+          deprecated = true;
+
+          await controller.refreshAddresses({
+            networkClientIds: ['mainnet'],
+            addresses: [ADDRESS_1],
+          });
+
+          expect(controller.state.accountsByChainId).toStrictEqual({});
+        },
+      );
+    });
+
+    it('returns no balances and clears stale state on syncBalanceWithAddresses when isDeprecated returns true', async () => {
+      let deprecated = false;
+      await withController(
+        {
+          options: { state: initialState, isDeprecated: () => deprecated },
+        },
+        async ({ controller }) => {
+          deprecated = true;
+
+          const result = await controller.syncBalanceWithAddresses([ADDRESS_1]);
+
+          expect(result).toStrictEqual({});
+          expect(controller.state.accountsByChainId).toStrictEqual({});
+        },
+      );
+    });
+
+    it('clears stale state on updateNativeBalances when isDeprecated returns true', async () => {
+      let deprecated = false;
+      await withController(
+        {
+          options: { state: initialState, isDeprecated: () => deprecated },
+        },
+        ({ controller }) => {
+          deprecated = true;
+
+          controller.updateNativeBalances([
+            {
+              address: CHECKSUM_ADDRESS_1,
+              chainId: '0x1' as const,
+              balance: '0x5',
+            },
+          ]);
+
+          expect(controller.state.accountsByChainId).toStrictEqual({});
+        },
+      );
+    });
+
+    it('clears stale state on updateStakedBalances when isDeprecated returns true', async () => {
+      let deprecated = false;
+      await withController(
+        {
+          options: { state: initialState, isDeprecated: () => deprecated },
+        },
+        ({ controller }) => {
+          deprecated = true;
+
+          controller.updateStakedBalances([
+            {
+              address: CHECKSUM_ADDRESS_1,
+              chainId: '0x1' as const,
+              stakedBalance: '0x5',
+            },
+          ]);
+
+          expect(controller.state.accountsByChainId).toStrictEqual({});
+        },
+      );
+    });
+  });
 });
 
 type NetworkEnablementMocks = {

--- a/packages/assets-controllers/src/AccountTrackerController.ts
+++ b/packages/assets-controllers/src/AccountTrackerController.ts
@@ -262,6 +262,8 @@ export class AccountTrackerController extends StaticIntervalPollingController<Ac
 
   readonly #isHomepageSectionsV1Enabled: () => boolean;
 
+  readonly #isDeprecated: () => boolean;
+
   /** Track if the keyring is locked */
   #isLocked = true;
 
@@ -279,6 +281,12 @@ export class AccountTrackerController extends StaticIntervalPollingController<Ac
    * @param options.fetchingEnabled - Function that returns whether the controller is fetching enabled.
    * @param options.isOnboarded - Whether the user has completed onboarding. If false, balance updates are skipped.
    * @param options.isHomepageSectionsV1Enabled - Whether the homepage sections v1 is enabled.
+   * @param options.isDeprecated - Optional function that returns true to completely
+   * disable this controller (no requests, no state updates). When it returns
+   * `true`, `accountsByChainId` is reset to `{}` at construction and at every
+   * entry point, so no stale balances remain in state. The function is evaluated
+   * dynamically on each entry point so it can be toggled at runtime. Intended for
+   * use when a higher-level controller (e.g. AssetsController) supersedes this one.
    */
   constructor({
     interval = 10000,
@@ -291,6 +299,7 @@ export class AccountTrackerController extends StaticIntervalPollingController<Ac
     fetchingEnabled = (): boolean => true,
     isOnboarded = (): boolean => true,
     isHomepageSectionsV1Enabled = (): boolean => false,
+    isDeprecated = (): boolean => false,
   }: {
     interval?: number;
     state?: Partial<AccountTrackerControllerState>;
@@ -302,6 +311,7 @@ export class AccountTrackerController extends StaticIntervalPollingController<Ac
     allowExternalServices?: () => boolean;
     fetchingEnabled?: () => boolean;
     isOnboarded?: () => boolean;
+    isDeprecated?: () => boolean;
   }) {
     const { selectedNetworkClientId } = messenger.call(
       'NetworkController:getState',
@@ -343,6 +353,11 @@ export class AccountTrackerController extends StaticIntervalPollingController<Ac
 
     this.#fetchingEnabled = fetchingEnabled;
     this.#isOnboarded = isOnboarded;
+    this.#isDeprecated = isDeprecated;
+
+    if (this.#isDeprecated()) {
+      this.#enforceDisabledState();
+    }
 
     const { isUnlocked } = this.messenger.call('KeyringController:getState');
     this.#isLocked = !isUnlocked;
@@ -429,6 +444,25 @@ export class AccountTrackerController extends StaticIntervalPollingController<Ac
    */
   get isActive(): boolean {
     return !this.#isLocked && this.#isOnboarded();
+  }
+
+  /**
+   * Clears all persisted `accountsByChainId` so that no stale balances remain in
+   * state.
+   *
+   * Called from every entry point when `isDeprecated()` is true so that a runtime
+   * toggle propagates to state immediately, even if the controller was originally
+   * constructed while it was enabled. The update is skipped when
+   * `accountsByChainId` is already empty to avoid emitting redundant state
+   * changes.
+   */
+  #enforceDisabledState(): void {
+    if (Object.keys(this.state.accountsByChainId).length === 0) {
+      return;
+    }
+    this.update((state) => {
+      state.accountsByChainId = {};
+    });
   }
 
   #syncAccounts(newChainIds: string[]): void {
@@ -631,6 +665,10 @@ export class AccountTrackerController extends StaticIntervalPollingController<Ac
     networkClientIds,
     queryAllAccounts = false,
   }: AccountTrackerPollingInput): Promise<void> {
+    if (this.#isDeprecated()) {
+      this.#enforceDisabledState();
+      return;
+    }
     // TODO: Either fix this lint violation or explain why it's necessary to ignore.
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.refresh(networkClientIds, queryAllAccounts);
@@ -648,6 +686,10 @@ export class AccountTrackerController extends StaticIntervalPollingController<Ac
     networkClientIds: NetworkClientId[],
     queryAllAccounts: boolean = false,
   ): Promise<void> {
+    if (this.#isDeprecated()) {
+      this.#enforceDisabledState();
+      return;
+    }
     const selectedAccount = this.messenger.call(
       'AccountsController:getSelectedAccount',
     );
@@ -673,6 +715,10 @@ export class AccountTrackerController extends StaticIntervalPollingController<Ac
     networkClientIds: NetworkClientId[];
     addresses: string[];
   }): Promise<void> {
+    if (this.#isDeprecated()) {
+      this.#enforceDisabledState();
+      return;
+    }
     const checksummedAddresses = addresses.map((address) =>
       toChecksumHexAddress(address),
     );
@@ -881,6 +927,10 @@ export class AccountTrackerController extends StaticIntervalPollingController<Ac
   ): Promise<
     Record<string, { balance: string; stakedBalance?: StakedBalance }>
   > {
+    if (this.#isDeprecated()) {
+      this.#enforceDisabledState();
+      return {};
+    }
     // Skip balance fetching if locked or not onboarded to avoid unnecessary RPC calls
     if (!this.isActive) {
       return {};
@@ -946,6 +996,10 @@ export class AccountTrackerController extends StaticIntervalPollingController<Ac
   updateNativeBalances(
     balances: { address: string; chainId: Hex; balance: Hex }[],
   ): void {
+    if (this.#isDeprecated()) {
+      this.#enforceDisabledState();
+      return;
+    }
     const nextAccountsByChainId = cloneDeep(this.state.accountsByChainId);
     let hasChanges = false;
 
@@ -1002,6 +1056,10 @@ export class AccountTrackerController extends StaticIntervalPollingController<Ac
       stakedBalance: StakedBalance;
     }[],
   ): void {
+    if (this.#isDeprecated()) {
+      this.#enforceDisabledState();
+      return;
+    }
     const nextAccountsByChainId = cloneDeep(this.state.accountsByChainId);
     let hasChanges = false;
 

--- a/packages/assets-controllers/src/TokenBalancesController.test.ts
+++ b/packages/assets-controllers/src/TokenBalancesController.test.ts
@@ -1781,6 +1781,263 @@ describe('TokenBalancesController', () => {
     });
   });
 
+  describe('isDeprecated', () => {
+    const initialState: TokenBalancesControllerState = {
+      tokenBalances: {
+        '0x0000000000000000000000000000000000000001': {
+          '0x1': {
+            '0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0': toHex(new BN(1)),
+          },
+        },
+      },
+    };
+
+    it('clears persisted tokenBalances at construction when isDeprecated() returns true', () => {
+      const { controller } = setupController({
+        config: { state: initialState, isDeprecated: () => true },
+      });
+
+      expect(controller.state.tokenBalances).toStrictEqual({});
+    });
+
+    it('preserves persisted tokenBalances at construction when isDeprecated() returns false', () => {
+      const { controller } = setupController({
+        config: { state: initialState, isDeprecated: () => false },
+      });
+
+      expect(controller.state.tokenBalances).toStrictEqual(
+        initialState.tokenBalances,
+      );
+    });
+
+    it('does not fetch and clears stale tokenBalances when isDeprecated returns true', async () => {
+      let deprecated = false;
+      const { controller } = setupController({
+        config: { state: initialState, isDeprecated: () => deprecated },
+      });
+
+      expect(controller.state.tokenBalances).toStrictEqual(
+        initialState.tokenBalances,
+      );
+
+      const fetchSpy = jest.spyOn(
+        multicall,
+        'getTokenBalancesForMultipleAddresses',
+      );
+
+      deprecated = true;
+
+      await controller.updateBalances({ chainIds: ['0x1'] });
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(controller.state.tokenBalances).toStrictEqual({});
+    });
+
+    it('clears stale tokenBalances on _executePoll when isDeprecated toggles to true at runtime', async () => {
+      let deprecated = false;
+      const { controller } = setupController({
+        config: { state: initialState, isDeprecated: () => deprecated },
+      });
+
+      expect(controller.state.tokenBalances).toStrictEqual(
+        initialState.tokenBalances,
+      );
+
+      const fetchSpy = jest.spyOn(
+        multicall,
+        'getTokenBalancesForMultipleAddresses',
+      );
+
+      deprecated = true;
+
+      await controller._executePoll({ chainIds: ['0x1'] });
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(controller.state.tokenBalances).toStrictEqual({});
+    });
+
+    it('clears stale tokenBalances on NetworkController:stateChange when isDeprecated toggles to true at runtime', () => {
+      let deprecated = false;
+      const { controller, messenger } = setupController({
+        config: { state: initialState, isDeprecated: () => deprecated },
+      });
+
+      expect(controller.state.tokenBalances).toStrictEqual(
+        initialState.tokenBalances,
+      );
+
+      deprecated = true;
+
+      messenger.publish(
+        'NetworkController:stateChange',
+        {
+          networkConfigurationsByChainId: {},
+        } as NetworkState,
+        [
+          {
+            op: 'remove',
+            path: ['networkConfigurationsByChainId', '0x1'],
+          },
+        ],
+      );
+
+      expect(controller.state.tokenBalances).toStrictEqual({});
+    });
+
+    it('does not throw at construction when isDeprecated() is true and state is already empty', () => {
+      const { controller } = setupController({
+        config: { isDeprecated: () => true },
+      });
+
+      expect(controller.state.tokenBalances).toStrictEqual({});
+    });
+
+    it('clears stale tokenBalances when a queued batched update flushes after isDeprecated toggles to true', async () => {
+      jest.useFakeTimers();
+      let deprecated = false;
+      const { controller } = setupController({
+        config: { state: initialState, isDeprecated: () => deprecated },
+      });
+
+      const fetchSpy = jest.spyOn(
+        multicall,
+        'getTokenBalancesForMultipleAddresses',
+      );
+
+      // Schedule a batched update while still enabled.
+      const promise = controller.updateBalances({ chainIds: ['0x1'] });
+
+      // Toggle deprecation before the batch flushes.
+      deprecated = true;
+
+      await jest.advanceTimersByTimeAsync(UPDATE_BALANCES_BATCH_MS);
+      await promise;
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(controller.state.tokenBalances).toStrictEqual({});
+    });
+
+    it('clears stale tokenBalances on TokensController:stateChange when isDeprecated toggles to true at runtime', async () => {
+      let deprecated = false;
+      const { controller, messenger } = setupController({
+        config: { state: initialState, isDeprecated: () => deprecated },
+      });
+
+      deprecated = true;
+
+      messenger.publish(
+        'TokensController:stateChange',
+        {
+          allDetectedTokens: {},
+          allIgnoredTokens: {},
+          allTokens: {
+            '0x1': {
+              '0x0000000000000000000000000000000000000001': [
+                { address: '0xtoken', decimals: 0, symbol: 'S' },
+              ],
+            },
+          },
+        } as unknown as TokensControllerState,
+        [],
+      );
+
+      await flushPromises();
+
+      expect(controller.state.tokenBalances).toStrictEqual({});
+    });
+
+    it('clears stale tokenBalances on KeyringController:accountRemoved when isDeprecated toggles to true at runtime', () => {
+      let deprecated = false;
+      const { controller, messenger } = setupController({
+        config: { state: initialState, isDeprecated: () => deprecated },
+      });
+
+      deprecated = true;
+
+      messenger.publish(
+        'KeyringController:accountRemoved',
+        '0x0000000000000000000000000000000000000001',
+      );
+
+      expect(controller.state.tokenBalances).toStrictEqual({});
+    });
+
+    it('clears stale tokenBalances on AccountsController:selectedEvmAccountChange when isDeprecated toggles to true at runtime', () => {
+      let deprecated = false;
+      const { controller, messenger } = setupController({
+        config: { state: initialState, isDeprecated: () => deprecated },
+        tokens: {
+          allTokens: {
+            '0x1': {
+              '0x0000000000000000000000000000000000000001': [
+                { address: '0xtoken', decimals: 0, symbol: 'S' },
+              ],
+            },
+          },
+          allDetectedTokens: {},
+          allIgnoredTokens: {},
+        },
+      });
+
+      deprecated = true;
+
+      messenger.publish(
+        'AccountsController:selectedEvmAccountChange',
+        createMockInternalAccount({
+          address: '0x0000000000000000000000000000000000000001',
+        }),
+      );
+
+      expect(controller.state.tokenBalances).toStrictEqual({});
+    });
+
+    it('clears stale tokenBalances on AccountActivityService:balanceUpdated when isDeprecated toggles to true at runtime', async () => {
+      let deprecated = false;
+      const { controller, messenger } = setupController({
+        config: { state: initialState, isDeprecated: () => deprecated },
+      });
+
+      deprecated = true;
+
+      messenger.publish('AccountActivityService:balanceUpdated', {
+        address: '0x0000000000000000000000000000000000000001',
+        chain: 'eip155:1',
+        updates: [
+          {
+            asset: {
+              type: 'eip155:1/slip44:60',
+              unit: 'ETH',
+              fungible: true,
+              decimals: 18,
+            },
+            postBalance: { amount: '0x1' },
+            transfers: [],
+          },
+        ],
+      });
+
+      await flushPromises();
+
+      expect(controller.state.tokenBalances).toStrictEqual({});
+    });
+
+    it('clears stale tokenBalances on AccountActivityService:statusChanged when isDeprecated toggles to true at runtime', () => {
+      let deprecated = false;
+      const { controller, messenger } = setupController({
+        config: { state: initialState, isDeprecated: () => deprecated },
+      });
+
+      deprecated = true;
+
+      messenger.publish('AccountActivityService:statusChanged', {
+        chainIds: ['eip155:1'],
+        status: 'up',
+      });
+
+      expect(controller.state.tokenBalances).toStrictEqual({});
+    });
+  });
+
   describe('when accountRemoved is published', () => {
     it('does not update state if account removed is EVM account', async () => {
       const { controller, messenger, updateSpy } = setupController();

--- a/packages/assets-controllers/src/TokenBalancesController.ts
+++ b/packages/assets-controllers/src/TokenBalancesController.ts
@@ -234,6 +234,15 @@ export type TokenBalancesControllerOptions = {
   websocketActivePollingInterval?: number;
   /** Whether the user has completed onboarding. If false, balance updates are skipped. */
   isOnboarded?: () => boolean;
+  /**
+   * Optional function that returns true to completely disable this controller
+   * (no requests, no state updates). When it returns `true`, `tokenBalances` is
+   * reset to `{}` at construction and at every entry point, so no stale balances
+   * remain in state. The function is evaluated dynamically on each entry point so
+   * it can be toggled at runtime. Intended for use when a higher-level controller
+   * (e.g. AssetsController) supersedes this one.
+   */
+  isDeprecated?: () => boolean;
 };
 
 const draft = <State>(base: State, fn: (draftState: State) => void): State =>
@@ -317,6 +326,8 @@ export class TokenBalancesController extends StaticIntervalPollingController<{
 
   readonly #isOnboarded: () => boolean;
 
+  readonly #isDeprecated: () => boolean;
+
   readonly #balanceFetchers: { fetcher: BalanceFetcher; name: string }[];
 
   #allTokens: TokensControllerState['allTokens'] = {};
@@ -370,6 +381,7 @@ export class TokenBalancesController extends StaticIntervalPollingController<{
     allowExternalServices = (): boolean => true,
     platform,
     isOnboarded = (): boolean => true,
+    isDeprecated = (): boolean => false,
   }: TokenBalancesControllerOptions) {
     super({
       name: CONTROLLER,
@@ -385,6 +397,7 @@ export class TokenBalancesController extends StaticIntervalPollingController<{
     this.#accountsApiChainIds = accountsApiChainIds;
     this.#allowExternalServices = allowExternalServices;
     this.#isOnboarded = isOnboarded;
+    this.#isDeprecated = isDeprecated;
     this.#defaultInterval = interval;
     this.#websocketActivePollingInterval = websocketActivePollingInterval;
     this.#chainPollingConfig = { ...chainPollingIntervals };
@@ -434,8 +447,28 @@ export class TokenBalancesController extends StaticIntervalPollingController<{
         this.#executeUpdateBalances(merged),
     );
 
+    if (this.#isDeprecated()) {
+      this.#enforceDisabledState();
+    }
+
     this.#subscribeToControllers();
     messenger.registerMethodActionHandlers(this, MESSENGER_EXPOSED_METHODS);
+  }
+
+  /**
+   * Clears all persisted `tokenBalances` so that no stale balances remain in
+   * state.
+   *
+   * Called from every entry point when `isDeprecated()` is true so that a runtime
+   * toggle propagates to state immediately, even if the controller was originally
+   * constructed while it was enabled. The update is skipped when `tokenBalances`
+   * is already empty to avoid emitting redundant state changes.
+   */
+  #enforceDisabledState(): void {
+    if (Object.keys(this.state.tokenBalances).length === 0) {
+      return;
+    }
+    this.update(() => ({ tokenBalances: {} }));
   }
 
   #subscribeToControllers(): void {
@@ -730,6 +763,10 @@ export class TokenBalancesController extends StaticIntervalPollingController<{
     chainIds: ChainIdHex[];
     queryAllAccounts?: boolean;
   }): Promise<void> {
+    if (this.#isDeprecated()) {
+      this.#enforceDisabledState();
+      return;
+    }
     await this.#executeUpdateBalances({ chainIds, queryAllAccounts });
   }
 
@@ -748,6 +785,10 @@ export class TokenBalancesController extends StaticIntervalPollingController<{
   }
 
   async updateBalances(options: UpdateBalancesOptions = {}): Promise<void> {
+    if (this.#isDeprecated()) {
+      this.#enforceDisabledState();
+      return;
+    }
     if (!this.isActive) {
       return;
     }
@@ -759,6 +800,10 @@ export class TokenBalancesController extends StaticIntervalPollingController<{
     tokenAddresses,
     queryAllAccounts = false,
   }: UpdateBalancesOptions = {}): Promise<void> {
+    if (this.#isDeprecated()) {
+      this.#enforceDisabledState();
+      return;
+    }
     if (!this.isActive) {
       return;
     }
@@ -1261,6 +1306,10 @@ export class TokenBalancesController extends StaticIntervalPollingController<{
   readonly #onTokensChanged = async (
     state: TokensControllerState,
   ): Promise<void> => {
+    if (this.#isDeprecated()) {
+      this.#enforceDisabledState();
+      return;
+    }
     const changed: ChainIdHex[] = [];
     let hasChanges = false;
 
@@ -1342,6 +1391,10 @@ export class TokenBalancesController extends StaticIntervalPollingController<{
   };
 
   readonly #onNetworkChanged = (state: NetworkState): void => {
+    if (this.#isDeprecated()) {
+      this.#enforceDisabledState();
+      return;
+    }
     const currentNetworks = new Set(
       Object.keys(state.networkConfigurationsByChainId),
     );
@@ -1378,6 +1431,10 @@ export class TokenBalancesController extends StaticIntervalPollingController<{
   };
 
   readonly #onAccountRemoved = (addr: string): void => {
+    if (this.#isDeprecated()) {
+      this.#enforceDisabledState();
+      return;
+    }
     if (!isStrictHexString(addr) || !isValidHexAddress(addr)) {
       return;
     }
@@ -1387,6 +1444,10 @@ export class TokenBalancesController extends StaticIntervalPollingController<{
   };
 
   readonly #onAccountChanged = (): void => {
+    if (this.#isDeprecated()) {
+      this.#enforceDisabledState();
+      return;
+    }
     const chainIds = this.#chainIdsWithTokens();
     if (!chainIds.length) {
       return;
@@ -1470,6 +1531,10 @@ export class TokenBalancesController extends StaticIntervalPollingController<{
     chain: string;
     updates: BalanceUpdate[];
   }): Promise<void> => {
+    if (this.#isDeprecated()) {
+      this.#enforceDisabledState();
+      return;
+    }
     const chainId = caipChainIdToHex(chain);
     const checksummedAccount = checksum(address);
 
@@ -1527,6 +1592,10 @@ export class TokenBalancesController extends StaticIntervalPollingController<{
     chainIds: string[];
     status: 'up' | 'down';
   }): void => {
+    if (this.#isDeprecated()) {
+      this.#enforceDisabledState();
+      return;
+    }
     for (const chainId of chainIds) {
       this.#statusChangeDebouncer.pendingChanges.set(chainId, status);
     }

--- a/packages/assets-controllers/src/TokenRatesController.test.ts
+++ b/packages/assets-controllers/src/TokenRatesController.test.ts
@@ -129,6 +129,52 @@ describe('TokenRatesController', () => {
         },
       );
     });
+
+    it('clears persisted marketData at construction when isDeprecated() returns true', async () => {
+      const initialMarketData = {
+        '0x1': {
+          '0x0000000000000000000000000000000000000000': {
+            currency: 'ETH',
+            price: 0.001,
+          } as unknown as MarketDataDetails,
+        },
+      };
+
+      await withController(
+        {
+          options: {
+            isDeprecated: () => true,
+            state: { marketData: initialMarketData },
+          },
+        },
+        async ({ controller }) => {
+          expect(controller.state.marketData).toStrictEqual({});
+        },
+      );
+    });
+
+    it('preserves persisted marketData at construction when isDeprecated() returns false', async () => {
+      const initialMarketData = {
+        '0x1': {
+          '0x0000000000000000000000000000000000000000': {
+            currency: 'ETH',
+            price: 0.001,
+          } as unknown as MarketDataDetails,
+        },
+      };
+
+      await withController(
+        {
+          options: {
+            isDeprecated: () => false,
+            state: { marketData: initialMarketData },
+          },
+        },
+        async ({ controller }) => {
+          expect(controller.state.marketData).toStrictEqual(initialMarketData);
+        },
+      );
+    });
   });
 
   describe('updateExchangeRates', () => {
@@ -179,6 +225,45 @@ describe('TokenRatesController', () => {
 
           expect(tokenPricesService.fetchTokenPrices).not.toHaveBeenCalled();
           expect(controller.state.marketData).toBe(stateBefore);
+        },
+      );
+    });
+
+    it('clears stale marketData when isDeprecated toggles to true at runtime', async () => {
+      const tokenPricesService = buildMockTokenPricesService();
+      jest.spyOn(tokenPricesService, 'fetchTokenPrices');
+      let deprecated = false;
+      const initialMarketData = {
+        '0x1': {
+          '0x0000000000000000000000000000000000000000': {
+            currency: 'ETH',
+            price: 0.001,
+          } as unknown as MarketDataDetails,
+        },
+      };
+
+      await withController(
+        {
+          options: {
+            tokenPricesService,
+            isDeprecated: () => deprecated,
+            state: { marketData: initialMarketData },
+          },
+        },
+        async ({ controller }) => {
+          expect(controller.state.marketData).toStrictEqual(initialMarketData);
+
+          deprecated = true;
+
+          await controller.updateExchangeRates([
+            {
+              chainId: '0x1',
+              nativeCurrency: 'ETH',
+            },
+          ]);
+
+          expect(tokenPricesService.fetchTokenPrices).not.toHaveBeenCalled();
+          expect(controller.state.marketData).toStrictEqual({});
         },
       );
     });
@@ -756,6 +841,38 @@ describe('TokenRatesController', () => {
         },
       );
     });
+
+    it('clears stale marketData when isDeprecated toggles to true at runtime', async () => {
+      let deprecated = false;
+      const initialMarketData = {
+        '0x1': {
+          '0x0000000000000000000000000000000000000000': {
+            currency: 'ETH',
+            price: 0.001,
+          } as unknown as MarketDataDetails,
+        },
+      };
+
+      await withController(
+        {
+          options: {
+            isDeprecated: () => deprecated,
+            state: { marketData: initialMarketData },
+          },
+        },
+        async ({ controller }) => {
+          jest.spyOn(controller, 'updateExchangeRates');
+          expect(controller.state.marketData).toStrictEqual(initialMarketData);
+
+          deprecated = true;
+
+          await controller._executePoll({ chainIds: ['0x1'] });
+
+          expect(controller.updateExchangeRates).not.toHaveBeenCalled();
+          expect(controller.state.marketData).toStrictEqual({});
+        },
+      );
+    });
   });
 
   describe('TokensController:stateChange', () => {
@@ -1076,7 +1193,7 @@ describe('TokenRatesController', () => {
       );
     });
 
-    it('does not update state when isDeprecated returns true', async () => {
+    it('clears marketData when isDeprecated returns true', async () => {
       const chainId = '0x1';
       const nativeCurrency = 'ETH';
       const initialMarketData = {
@@ -1111,7 +1228,7 @@ describe('TokenRatesController', () => {
 
           await flushPromises();
 
-          expect(controller.state.marketData).toStrictEqual(initialMarketData);
+          expect(controller.state.marketData).toStrictEqual({});
         },
       );
     });

--- a/packages/assets-controllers/src/TokenRatesController.ts
+++ b/packages/assets-controllers/src/TokenRatesController.ts
@@ -207,8 +207,11 @@ export class TokenRatesController extends StaticIntervalPollingController<TokenR
    * @param options.interval - The polling interval in ms
    * @param options.disabled - Boolean to track if network requests are blocked
    * @param options.isDeprecated - Optional function that returns true to completely
-   * disable this controller (no requests, no state updates). Intended for use
-   * when a higher-level controller (e.g. AssetsController) supersedes this one.
+   * disable this controller (no requests, no state updates). When it returns
+   * `true`, `marketData` is reset to `{}` at construction and at every polling
+   * entry point, so no stale rates remain in state. The function is evaluated
+   * dynamically on each entry point so it can be toggled at runtime. Intended for
+   * use when a higher-level controller (e.g. AssetsController) supersedes this one.
    * @param options.tokenPricesService - An object in charge of retrieving token price
    * @param options.messenger - The messenger instance for communication
    * @param options.state - Initial state to set on this controller
@@ -240,6 +243,10 @@ export class TokenRatesController extends StaticIntervalPollingController<TokenR
     this.#disabled = disabled;
     this.#isDeprecated = isDeprecated;
 
+    if (this.#isDeprecated()) {
+      this.#enforceDisabledState();
+    }
+
     const { allTokens, allDetectedTokens } = this.#getTokensControllerState();
     this.#allTokens = allTokens;
     this.#allDetectedTokens = allDetectedTokens;
@@ -252,13 +259,34 @@ export class TokenRatesController extends StaticIntervalPollingController<TokenR
     this.#subscribeToNetworkStateChange();
   }
 
+  /**
+   * Clears all persisted `marketData` so that no stale rates remain in state.
+   *
+   * Called from every polling entry point when `isDeprecated()` is true so that
+   * a runtime toggle propagates to state immediately, even if the controller was
+   * originally constructed while it was enabled. The update is skipped when
+   * `marketData` is already empty to avoid emitting redundant state changes.
+   */
+  #enforceDisabledState(): void {
+    if (Object.keys(this.state.marketData).length === 0) {
+      return;
+    }
+    this.update((state) => {
+      state.marketData = {};
+    });
+  }
+
   #subscribeToTokensStateChange() {
     this.messenger.subscribe(
       'TokensController:stateChange',
       // TODO: Either fix this lint violation or explain why it's necessary to ignore.
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
       async ({ allTokens, allDetectedTokens }) => {
-        if (this.#disabled || this.#isDeprecated()) {
+        if (this.#isDeprecated()) {
+          this.#enforceDisabledState();
+          return;
+        }
+        if (this.#disabled) {
           return;
         }
 
@@ -315,6 +343,7 @@ export class TokenRatesController extends StaticIntervalPollingController<TokenR
       'NetworkController:stateChange',
       (_state, patches) => {
         if (this.#isDeprecated()) {
+          this.#enforceDisabledState();
           return;
         }
         // Remove state for deleted networks
@@ -408,7 +437,11 @@ export class TokenRatesController extends StaticIntervalPollingController<TokenR
   async updateExchangeRates(
     chainIdAndNativeCurrency: ChainIdAndNativeCurrency[],
   ): Promise<void> {
-    if (this.#disabled || this.#isDeprecated()) {
+    if (this.#isDeprecated()) {
+      this.#enforceDisabledState();
+      return;
+    }
+    if (this.#disabled) {
       return;
     }
 
@@ -597,6 +630,7 @@ export class TokenRatesController extends StaticIntervalPollingController<TokenR
    */
   async _executePoll({ chainIds }: TokenRatesPollingInput): Promise<void> {
     if (this.#isDeprecated()) {
+      this.#enforceDisabledState();
       return;
     }
 


### PR DESCRIPTION
When `isDeprecated()` returns `true`, `TokenRatesController` previously only blocked updates but left already-persisted `marketData` in state. Reset `marketData` to `{}` at construction and at every entry point so stale rates no longer remain when the controller is deprecated.

UI PR: https://github.com/MetaMask/metamask-extension/pull/43301

## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core wallet balance/rate state and persistence paths across three controllers; wrong clearing could briefly empty UI asset data when feature flags toggle, but behavior is gated on an explicit deprecation hook.
> 
> **Overview**
> When **`isDeprecated()`** is true, asset controllers now **clear persisted state** instead of only skipping fetches, so superseded controllers (e.g. by `AssetsController`) do not leave stale balances or rates in Redux.
> 
> **`TokenRatesController`** resets **`marketData`** to `{}` at construction and on every entry point (`updateExchangeRates`, `_executePoll`, token/network subscriptions) via **`#enforceDisabledState()`**; behavior is re-checked on each call so deprecation can flip at runtime.
> 
> **`TokenBalancesController`** and **`AccountTrackerController`** gain the same optional **`isDeprecated`** callback, clearing **`tokenBalances`** and **`accountsByChainId`** respectively across polls, updates, messenger-driven handlers, and batched balance paths.
> 
> Changelog documents the expanded contract; tests cover construction, runtime toggles, and no-fetch guarantees.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17b57e8eb857a332d9688c00c130b59a04ace256. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->