### PR TITLE
feat(bridge-controller): add stxEnabled flag to batch sell trades

### DIFF
--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -7,10 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **BREAKING**: Add required `stxEnabled` parameter to `updateBatchSellTrades`, `fetchBatchSellTrades`, and `formatBatchSellTradesRequest`. The flag is sent to the obtainGaslessBatch API so the backend can estimate gas costs more precisely when Smart Transactions are enabled.
+
 ### Changed
 
 - Bump `@metamask/transaction-controller` from `^66.0.1` to `^67.0.0` ([#9021](https://github.com/MetaMask/core/pull/9021))
-- **BREAKING**: Add required `stxEnabled` parameter to `updateBatchSellTrades`, `fetchBatchSellTrades`, and `formatBatchSellTradesRequest`. The flag is sent to the obtainGaslessBatch API so the backend can estimate gas costs more precisely when Smart Transactions are enabled.
 
 ## [73.2.1]
 

--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `@metamask/transaction-controller` from `^66.0.1` to `^67.0.0` ([#9021](https://github.com/MetaMask/core/pull/9021))
+- **BREAKING**: Add required `stxEnabled` parameter to `updateBatchSellTrades`, `fetchBatchSellTrades`, and `formatBatchSellTradesRequest`. The flag is sent to the obtainGaslessBatch API so the backend can estimate gas costs more precisely when Smart Transactions are enabled.
 
 ## [73.2.1]
 

--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **BREAKING**: Add required `stxEnabled` parameter to `updateBatchSellTrades`, `fetchBatchSellTrades`, and `formatBatchSellTradesRequest`. The flag is sent to the obtainGaslessBatch API so the backend can estimate gas costs more precisely when Smart Transactions are enabled.
+- **BREAKING**: Add required `stxEnabled` parameter to `updateBatchSellTrades`, `fetchBatchSellTrades`, and `formatBatchSellTradesRequest`. The flag is sent to the obtainGaslessBatch API so the backend can estimate gas costs more precisely when Smart Transactions are enabled. ([#9036](https://github.com/MetaMask/core/pull/9036))
 
 ### Changed
 

--- a/packages/bridge-controller/src/bridge-controller.sse.batch.test.ts
+++ b/packages/bridge-controller/src/bridge-controller.sse.batch.test.ts
@@ -526,6 +526,7 @@ describe('BridgeController BatchSell (multiple quote requests) SSE', function ()
           await rootMessenger.call(
             'BridgeController:updateBatchSellTrades',
             [],
+            false,
           );
 
           await jest.advanceTimersByTimeAsync(1000);
@@ -637,10 +638,12 @@ describe('BridgeController BatchSell (multiple quote requests) SSE', function ()
           await rootMessenger.call(
             'BridgeController:updateBatchSellTrades',
             [],
+            false,
           );
           await rootMessenger.call(
             'BridgeController:updateBatchSellTrades',
             mockBridgeQuotesErc20Erc20 as unknown as QuoteResponse[],
+            false,
           );
 
           await jest.advanceTimersByTimeAsync(1000);
@@ -670,6 +673,7 @@ describe('BridgeController BatchSell (multiple quote requests) SSE', function ()
           expect(fetchBatchSellTradesSpy).toHaveBeenCalledTimes(2);
           expect(fetchBatchSellTradesSpy.mock.calls[0]).toStrictEqual([
             [],
+            false,
             expect.any(AbortSignal),
             'extension',
             'AUTH_TOKEN',
@@ -679,6 +683,7 @@ describe('BridgeController BatchSell (multiple quote requests) SSE', function ()
           ]);
           expect(fetchBatchSellTradesSpy.mock.calls[1]).toStrictEqual([
             mockBridgeQuotesErc20Erc20,
+            false,
             expect.any(AbortSignal),
             'extension',
             'AUTH_TOKEN',
@@ -748,6 +753,7 @@ describe('BridgeController BatchSell (multiple quote requests) SSE', function ()
           await rootMessenger.call(
             'BridgeController:updateBatchSellTrades',
             [],
+            false,
           );
           rootMessenger.call('BridgeController:resetState');
 
@@ -774,6 +780,7 @@ describe('BridgeController BatchSell (multiple quote requests) SSE', function ()
           expect(fetchBatchSellTradesSpy).toHaveBeenCalledTimes(1);
           expect(fetchBatchSellTradesSpy.mock.calls[0]).toStrictEqual([
             [],
+            false,
             expect.any(AbortSignal),
             'extension',
             'AUTH_TOKEN',
@@ -845,6 +852,7 @@ describe('BridgeController BatchSell (multiple quote requests) SSE', function ()
           await rootMessenger.call(
             'BridgeController:updateBatchSellTrades',
             [],
+            false,
           );
 
           await jest.advanceTimersByTimeAsync(1000);
@@ -872,6 +880,7 @@ describe('BridgeController BatchSell (multiple quote requests) SSE', function ()
           await rootMessenger.call(
             'BridgeController:updateBatchSellTrades',
             mockBridgeQuotesErc20Erc20 as unknown as QuoteResponse[],
+            false,
           );
 
           await jest.advanceTimersByTimeAsync(2000);

--- a/packages/bridge-controller/src/bridge-controller.test.ts
+++ b/packages/bridge-controller/src/bridge-controller.test.ts
@@ -3764,6 +3764,8 @@ describe('BridgeController', function () {
               bridgeIds: ['bridge1', 'bridge2'],
               fee: 0,
             },
+            [FeatureId.QUICK_BUY]: undefined,
+            [FeatureId.DAPP_SWAP]: undefined,
           },
         });
       messengerCallMock.mockResolvedValueOnce('AUTH_TOKEN');
@@ -4042,6 +4044,179 @@ describe('BridgeController', function () {
         expect(quotes).toHaveLength(2);
         expect(quotes[0].quote.gasSponsored).toBe(true);
         expect(quotes[1].quote.gasSponsored).toBeUndefined();
+      });
+    });
+  });
+
+  describe('updateBatchSellTrades', () => {
+    const mockBatchSellTradesResponse = {
+      transactions: [
+        {
+          chainId: 1,
+          to: '0xabc' as `0x${string}`,
+          from: '0x123' as `0x${string}`,
+          value: '0x0' as `0x${string}`,
+          data: '0x' as `0x${string}`,
+          gasLimit: null,
+          maxFeePerGas: '0x1' as `0x${string}`,
+          maxPriorityFeePerGas: '0x1' as `0x${string}`,
+          type: 'trade' as const,
+        },
+      ],
+    };
+
+    const mockQuote = mockBridgeQuotesNativeErc20Eth[0] as QuoteResponse;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      messengerCallMock.mockImplementation((actionType: string) => {
+        if (actionType === 'AuthenticationController:getBearerToken') {
+          return Promise.resolve('AUTH_TOKEN');
+        }
+        return undefined;
+      });
+    });
+
+    it('sets loading status, fetches trades, and updates state on success', async () => {
+      await withController(async ({ rootMessenger, controller }) => {
+        const fetchBatchSellTradesSpy = jest
+          .spyOn(fetchUtils, 'fetchBatchSellTrades')
+          .mockResolvedValueOnce(mockBatchSellTradesResponse as never);
+
+        await rootMessenger.call(
+          'BridgeController:updateBatchSellTrades',
+          [mockQuote],
+          true,
+        );
+
+        expect(fetchBatchSellTradesSpy).toHaveBeenCalledTimes(1);
+        expect(fetchBatchSellTradesSpy).toHaveBeenCalledWith(
+          [mockQuote],
+          true,
+          expect.any(AbortSignal),
+          BridgeClientId.EXTENSION,
+          'AUTH_TOKEN',
+          mockFetchFn,
+          BRIDGE_PROD_API_BASE_URL,
+          '13.7.0',
+        );
+        expect(controller.state.batchSellTrades).toStrictEqual(
+          mockBatchSellTradesResponse,
+        );
+        expect(controller.state.batchSellTradesLoadingStatus).toBe(
+          RequestStatus.FETCHED,
+        );
+      });
+    });
+
+    it('filters out null quotes before sending the request', async () => {
+      await withController(async ({ rootMessenger }) => {
+        const fetchBatchSellTradesSpy = jest
+          .spyOn(fetchUtils, 'fetchBatchSellTrades')
+          .mockResolvedValueOnce(mockBatchSellTradesResponse as never);
+
+        await rootMessenger.call(
+          'BridgeController:updateBatchSellTrades',
+          [null, mockQuote, null],
+          false,
+        );
+
+        expect(fetchBatchSellTradesSpy).toHaveBeenCalledWith(
+          [null, mockQuote, null],
+          false,
+          expect.any(AbortSignal),
+          BridgeClientId.EXTENSION,
+          'AUTH_TOKEN',
+          mockFetchFn,
+          BRIDGE_PROD_API_BASE_URL,
+          '13.7.0',
+        );
+      });
+    });
+
+    it('sets ERROR status and resets batchSellTrades on non-abort error', async () => {
+      await withController(async ({ rootMessenger, controller }) => {
+        const fetchError = new Error('Network failure');
+        jest
+          .spyOn(fetchUtils, 'fetchBatchSellTrades')
+          .mockRejectedValueOnce(fetchError);
+
+        await rootMessenger.call(
+          'BridgeController:updateBatchSellTrades',
+          [mockQuote],
+          false,
+        );
+
+        expect(controller.state.batchSellTrades).toBeNull();
+        expect(controller.state.batchSellTradesLoadingStatus).toBe(
+          RequestStatus.ERROR,
+        );
+      });
+    });
+
+    it('ignores AbortError and leaves state unchanged', async () => {
+      await withController(async ({ rootMessenger, controller }) => {
+        const abortError = new Error('AbortError: The operation was aborted');
+        abortError.name = 'AbortError';
+        jest
+          .spyOn(fetchUtils, 'fetchBatchSellTrades')
+          .mockRejectedValueOnce(abortError);
+
+        await rootMessenger.call(
+          'BridgeController:updateBatchSellTrades',
+          [mockQuote],
+          false,
+        );
+
+        // State should remain in its initial form — no ERROR status written
+        expect(controller.state.batchSellTrades).toBeNull();
+        expect(controller.state.batchSellTradesLoadingStatus).toBe(
+          RequestStatus.LOADING,
+        );
+      });
+    });
+
+    it('aborts the previous call when called again before it resolves', async () => {
+      await withController(async ({ rootMessenger, controller }) => {
+        let resolveFirst!: (value: unknown) => void;
+        const firstCallPromise = new Promise((resolve) => {
+          resolveFirst = resolve;
+        });
+
+        const fetchBatchSellTradesSpy = jest
+          .spyOn(fetchUtils, 'fetchBatchSellTrades')
+          // First call hangs until we resolve manually
+          .mockImplementationOnce(() => firstCallPromise as never)
+          // Second call resolves immediately
+          .mockResolvedValueOnce(mockBatchSellTradesResponse as never);
+
+        // Start first call (do not await yet)
+        const firstCall = rootMessenger.call(
+          'BridgeController:updateBatchSellTrades',
+          [mockQuote],
+          false,
+        );
+
+        // Start second call while first is still pending — this should abort the first
+        const secondCall = rootMessenger.call(
+          'BridgeController:updateBatchSellTrades',
+          [mockQuote],
+          true,
+        );
+
+        // Let the first call resolve (the abort has already been fired)
+        resolveFirst(mockBatchSellTradesResponse);
+
+        await Promise.all([firstCall, secondCall]);
+
+        expect(fetchBatchSellTradesSpy).toHaveBeenCalledTimes(2);
+        // Final state reflects the second (successful) call
+        expect(controller.state.batchSellTrades).toStrictEqual(
+          mockBatchSellTradesResponse,
+        );
+        expect(controller.state.batchSellTradesLoadingStatus).toBe(
+          RequestStatus.FETCHED,
+        );
       });
     });
   });

--- a/packages/bridge-controller/src/bridge-controller.ts
+++ b/packages/bridge-controller/src/bridge-controller.ts
@@ -450,9 +450,11 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
    * this handler whenever they change.
    *
    * @param quotes - The quotes to fetch the gasless transaction data and fees for
+   * @param stxEnabled - Flag to estimate gas cost more precisely for the batch sell feature.
    */
   updateBatchSellTrades = async (
     quotes: (QuoteResponse | null)[],
+    stxEnabled: boolean,
   ): Promise<void> => {
     this.#batchSellTradesAbortController?.abort(
       AbortReason.GaslessTxBatchFetched,
@@ -467,6 +469,7 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
     try {
       const batchSellTradesResponse = await fetchBatchSellTrades(
         quotes,
+        stxEnabled,
         this.#batchSellTradesAbortController.signal,
         this.#clientId,
         await this.#getJwt(),

--- a/packages/bridge-controller/src/types.ts
+++ b/packages/bridge-controller/src/types.ts
@@ -316,6 +316,7 @@ export type QuoteResponse<
 
 export type BatchSellTradesRequest = {
   quotes: QuoteResponse[];
+  stxEnabled: boolean;
 };
 
 /**

--- a/packages/bridge-controller/src/utils/fetch.test.ts
+++ b/packages/bridge-controller/src/utils/fetch.test.ts
@@ -700,9 +700,8 @@ describe('fetch', () => {
   });
 
   describe('fetchBatchSellTrades', () => {
-    const mockConsoleWarn = jest
-      .spyOn(console, 'warn')
-      .mockImplementation(jest.fn());
+    let mockConsoleWarn: jest.SpyInstance;
+
     const mockBatchSellTrades = {
       transactions: mockBridgeQuotesErc20Erc20.flatMap(
         ({ trade, approval }) => [
@@ -733,151 +732,75 @@ describe('fetch', () => {
       },
     };
 
-    it('should fetch batch sell trades', async () => {
-      mockFetchFn.mockResolvedValue({
-        ok: true,
-        json: jest.fn().mockResolvedValue(mockBatchSellTrades),
-      });
-      const { signal } = new AbortController();
-
-      const result = await fetchBatchSellTrades(
-        mockBridgeQuotesErc20Erc20 as unknown as QuoteResponse[],
-        signal,
-        BridgeClientId.EXTENSION,
-        'AUTH_TOKEN',
-        mockFetchFn,
-        BRIDGE_PROD_API_BASE_URL,
-        '1.0.0',
-      );
-
-      expect(mockFetchFn).toHaveBeenCalledWith(
-        'https://bridge.api.cx.metamask.io/obtainGaslessBatch',
-        {
-          headers: {
-            'X-Client-Id': 'extension',
-            'Client-Version': '1.0.0',
-            Authorization: 'Bearer AUTH_TOKEN',
-            'Content-Type': 'application/json',
-          },
-          signal,
-          method: 'POST',
-          body: JSON.stringify(
-            formatBatchSellTradesRequest(
-              mockBridgeQuotesErc20Erc20 as unknown as QuoteResponse[],
-            ),
-          ),
-        },
-      );
-
-      expect(result).toStrictEqual(mockBatchSellTrades);
-      expect(mockConsoleWarn).not.toHaveBeenCalled();
-      mockConsoleWarn.mockRestore();
-    });
-
-    it('should rethrow fetch error', async () => {
-      mockFetchFn.mockResolvedValue({
-        ok: false,
-        statusText: 'Fetch error',
-      });
-      const { signal } = new AbortController();
-
-      await expect(
-        fetchBatchSellTrades(
+    const expectedRequestOptions = (
+      signal: AbortSignal,
+      stxEnabled: boolean,
+    ): Record<string, unknown> => ({
+      headers: {
+        'X-Client-Id': 'extension',
+        'Client-Version': '1.0.0',
+        Authorization: 'Bearer AUTH_TOKEN',
+        'Content-Type': 'application/json',
+      },
+      signal,
+      method: 'POST',
+      body: JSON.stringify(
+        formatBatchSellTradesRequest(
           mockBridgeQuotesErc20Erc20 as unknown as QuoteResponse[],
-          signal,
-          BridgeClientId.EXTENSION,
-          'AUTH_TOKEN',
-          mockFetchFn,
-          BRIDGE_PROD_API_BASE_URL,
-          '1.0.0',
+          stxEnabled,
         ),
-      ).rejects.toThrow('Fetch error');
+      ),
+    });
 
-      expect(mockFetchFn).toHaveBeenCalledWith(
-        'https://bridge.api.cx.metamask.io/obtainGaslessBatch',
-        {
-          headers: {
-            'X-Client-Id': 'extension',
-            'Client-Version': '1.0.0',
-            Authorization: 'Bearer AUTH_TOKEN',
-            'Content-Type': 'application/json',
-          },
-          signal,
-          method: 'POST',
-          body: JSON.stringify(
-            formatBatchSellTradesRequest(
-              mockBridgeQuotesErc20Erc20 as unknown as QuoteResponse[],
-            ),
-          ),
-        },
-      );
+    beforeEach(() => {
+      jest.clearAllMocks();
+      mockConsoleWarn = jest
+        .spyOn(console, 'warn')
+        .mockImplementation(jest.fn());
+    });
 
-      expect(mockConsoleWarn).not.toHaveBeenCalled();
+    afterEach(() => {
       mockConsoleWarn.mockRestore();
     });
 
-    it('should fetch batch sell trades (malformed response)', async () => {
-      mockFetchFn.mockResolvedValueOnce({
-        ok: true,
-        json: jest.fn().mockResolvedValue({
-          ...mockBatchSellTrades,
-          transactions: mockBatchSellTrades.transactions.map(
-            ({ maxFeePerGas, maxPriorityFeePerGas, ...rest }) => rest,
-          ),
-        }),
-      });
-      mockFetchFn.mockResolvedValueOnce({
-        ok: true,
-        json: jest.fn().mockResolvedValue({
-          ...mockBatchSellTrades,
-          transactions: mockBatchSellTrades.transactions.map((trade) => ({
-            ...trade,
-            maxFeePerGas: 1000,
-            maxPriorityFeePerGas: 1000,
-          })),
-        }),
-      });
-      mockFetchFn.mockResolvedValueOnce({
-        ok: true,
-        json: jest.fn().mockResolvedValue({
-          ...mockBatchSellTrades,
-          transactions: mockBatchSellTrades.transactions.map((trade) => ({
-            ...trade,
-            maxFeePerGas: '1000',
-            maxPriorityFeePerGas: '1000',
-          })),
-        }),
-      });
-      mockFetchFn.mockResolvedValueOnce({
-        ok: true,
-        json: jest.fn().mockResolvedValue({
-          ...mockBatchSellTrades,
-          transactions: mockBatchSellTrades.transactions.map((trade) => ({
-            ...trade,
-            maxFeePerGas: 0x123,
-            maxPriorityFeePerGas: 0x456,
-          })),
-        }),
-      });
+    describe('when stxEnabled is false', () => {
+      it('sends stxEnabled: false in the request body and returns the response', async () => {
+        mockFetchFn.mockResolvedValue({
+          ok: true,
+          json: jest.fn().mockResolvedValue(mockBatchSellTrades),
+        });
+        const { signal } = new AbortController();
 
-      const { signal } = new AbortController();
-
-      await expect(
-        fetchBatchSellTrades(
-          [...(mockBridgeQuotesErc20Erc20 as unknown as QuoteResponse[]), null],
+        const result = await fetchBatchSellTrades(
+          mockBridgeQuotesErc20Erc20 as unknown as QuoteResponse[],
+          false,
           signal,
           BridgeClientId.EXTENSION,
           'AUTH_TOKEN',
           mockFetchFn,
           BRIDGE_PROD_API_BASE_URL,
           '1.0.0',
-        ),
-      ).rejects.toThrow('Invalid batch simulation response');
+        );
 
-      const result = await Promise.allSettled(
-        Array.from({ length: 3 }, () =>
+        expect(mockFetchFn).toHaveBeenCalledWith(
+          'https://bridge.api.cx.metamask.io/obtainGaslessBatch',
+          expectedRequestOptions(signal, false),
+        );
+        expect(result).toStrictEqual(mockBatchSellTrades);
+        expect(mockConsoleWarn).not.toHaveBeenCalled();
+      });
+
+      it('throws when the server responds with a non-ok status', async () => {
+        mockFetchFn.mockResolvedValue({
+          ok: false,
+          statusText: 'Fetch error',
+        });
+        const { signal } = new AbortController();
+
+        await expect(
           fetchBatchSellTrades(
             mockBridgeQuotesErc20Erc20 as unknown as QuoteResponse[],
+            false,
             signal,
             BridgeClientId.EXTENSION,
             'AUTH_TOKEN',
@@ -885,50 +808,149 @@ describe('fetch', () => {
             BRIDGE_PROD_API_BASE_URL,
             '1.0.0',
           ),
-        ),
-      );
+        ).rejects.toThrow('Fetch error');
 
-      expect(mockFetchFn).toHaveBeenCalledTimes(4);
-      expect(mockFetchFn).toHaveBeenCalledWith(
-        'https://bridge.api.cx.metamask.io/obtainGaslessBatch',
-        {
-          headers: {
-            'X-Client-Id': 'extension',
-            'Client-Version': '1.0.0',
-            Authorization: 'Bearer AUTH_TOKEN',
-            'Content-Type': 'application/json',
-          },
-          signal,
-          method: 'POST',
-          body: JSON.stringify(
-            formatBatchSellTradesRequest(
+        expect(mockFetchFn).toHaveBeenCalledWith(
+          'https://bridge.api.cx.metamask.io/obtainGaslessBatch',
+          expectedRequestOptions(signal, false),
+        );
+        expect(mockConsoleWarn).not.toHaveBeenCalled();
+      });
+
+      it('throws on a malformed response', async () => {
+        mockFetchFn.mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValue({
+            ...mockBatchSellTrades,
+            transactions: mockBatchSellTrades.transactions.map(
+              ({ maxFeePerGas, maxPriorityFeePerGas, ...rest }) => rest,
+            ),
+          }),
+        });
+        mockFetchFn.mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValue({
+            ...mockBatchSellTrades,
+            transactions: mockBatchSellTrades.transactions.map((trade) => ({
+              ...trade,
+              maxFeePerGas: 1000,
+              maxPriorityFeePerGas: 1000,
+            })),
+          }),
+        });
+        mockFetchFn.mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValue({
+            ...mockBatchSellTrades,
+            transactions: mockBatchSellTrades.transactions.map((trade) => ({
+              ...trade,
+              maxFeePerGas: '1000',
+              maxPriorityFeePerGas: '1000',
+            })),
+          }),
+        });
+        mockFetchFn.mockResolvedValueOnce({
+          ok: true,
+          json: jest.fn().mockResolvedValue({
+            ...mockBatchSellTrades,
+            transactions: mockBatchSellTrades.transactions.map((trade) => ({
+              ...trade,
+              maxFeePerGas: 0x123,
+              maxPriorityFeePerGas: 0x456,
+            })),
+          }),
+        });
+
+        const { signal } = new AbortController();
+
+        await expect(
+          fetchBatchSellTrades(
+            [
+              ...(mockBridgeQuotesErc20Erc20 as unknown as QuoteResponse[]),
+              null,
+            ],
+            false,
+            signal,
+            BridgeClientId.EXTENSION,
+            'AUTH_TOKEN',
+            mockFetchFn,
+            BRIDGE_PROD_API_BASE_URL,
+            '1.0.0',
+          ),
+        ).rejects.toThrow('Invalid batch simulation response');
+
+        const result = await Promise.allSettled(
+          Array.from({ length: 3 }, () =>
+            fetchBatchSellTrades(
               mockBridgeQuotesErc20Erc20 as unknown as QuoteResponse[],
+              false,
+              signal,
+              BridgeClientId.EXTENSION,
+              'AUTH_TOKEN',
+              mockFetchFn,
+              BRIDGE_PROD_API_BASE_URL,
+              '1.0.0',
             ),
           ),
-        },
-      );
+        );
 
-      expect(
-        // @ts-expect-error - reason is not in type
-        result.map((error) => ({ ...error, reason: error.reason?.message })),
-      ).toMatchInlineSnapshot(`
-        [
-          {
-            "reason": "Invalid batch simulation response. StructError: At path: transactions.0.maxFeePerGas -- Expected a value of type \`HexString\`, but received: \`1000\`",
-            "status": "rejected",
-          },
-          {
-            "reason": "Invalid batch simulation response. StructError: At path: transactions.0.maxFeePerGas -- Expected a value of type \`HexString\`, but received: \`"1000"\`",
-            "status": "rejected",
-          },
-          {
-            "reason": "Invalid batch simulation response. StructError: At path: transactions.0.maxFeePerGas -- Expected a value of type \`HexString\`, but received: \`291\`",
-            "status": "rejected",
-          },
-        ]
-      `);
-      expect(mockConsoleWarn).not.toHaveBeenCalled();
-      mockConsoleWarn.mockRestore();
+        expect(mockFetchFn).toHaveBeenCalledTimes(4);
+        expect(mockFetchFn).toHaveBeenCalledWith(
+          'https://bridge.api.cx.metamask.io/obtainGaslessBatch',
+          expectedRequestOptions(signal, false),
+        );
+
+        expect(
+          // @ts-expect-error - reason is not in type
+          result.map((error) => ({ ...error, reason: error.reason?.message })),
+        ).toMatchInlineSnapshot(`
+          [
+            {
+              "reason": "Invalid batch simulation response. StructError: At path: transactions.0.maxFeePerGas -- Expected a value of type \`HexString\`, but received: \`1000\`",
+              "status": "rejected",
+            },
+            {
+              "reason": "Invalid batch simulation response. StructError: At path: transactions.0.maxFeePerGas -- Expected a value of type \`HexString\`, but received: \`"1000"\`",
+              "status": "rejected",
+            },
+            {
+              "reason": "Invalid batch simulation response. StructError: At path: transactions.0.maxFeePerGas -- Expected a value of type \`HexString\`, but received: \`291\`",
+              "status": "rejected",
+            },
+          ]
+        `);
+        expect(mockConsoleWarn).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when stxEnabled is true', () => {
+      it('sends stxEnabled: true in the request body', async () => {
+        mockFetchFn.mockResolvedValue({
+          ok: true,
+          json: jest.fn().mockResolvedValue(mockBatchSellTrades),
+        });
+        const { signal } = new AbortController();
+
+        await fetchBatchSellTrades(
+          mockBridgeQuotesErc20Erc20 as unknown as QuoteResponse[],
+          true,
+          signal,
+          BridgeClientId.EXTENSION,
+          'AUTH_TOKEN',
+          mockFetchFn,
+          BRIDGE_PROD_API_BASE_URL,
+          '1.0.0',
+        );
+
+        expect(mockFetchFn).toHaveBeenCalledWith(
+          'https://bridge.api.cx.metamask.io/obtainGaslessBatch',
+          expectedRequestOptions(signal, true),
+        );
+        const sentBody = JSON.parse(
+          (mockFetchFn.mock.calls[0][1] as { body: string }).body,
+        );
+        expect(sentBody.stxEnabled).toBe(true);
+      });
     });
   });
 });

--- a/packages/bridge-controller/src/utils/fetch.ts
+++ b/packages/bridge-controller/src/utils/fetch.ts
@@ -495,6 +495,7 @@ export async function fetchBridgeQuoteStream(
 
 export const formatBatchSellTradesRequest = (
   quotes: (QuoteResponse | null)[],
+  stxEnabled: boolean,
 ): BatchSellTradesRequest => ({
   quotes: quotes
     .filter((quote): quote is QuoteResponse => quote !== null)
@@ -513,12 +514,14 @@ export const formatBatchSellTradesRequest = (
         quoteId,
       }),
     ),
+  stxEnabled,
 });
 
 /**
  * Fetches quotes from the bridge-api's getQuote endpoint
  *
  * @param quotes - The quotes to fetch the gasless transaction data and fees for. May contain null values if a quote is not available for a swap
+ * @param stxEnabled - Flag to estimate gas cost more precisely for the batch sell feature.
  * @param signal - The abort signal
  * @param clientId - The client ID for metrics
  * @param jwt - The JWT token for authentication
@@ -529,6 +532,7 @@ export const formatBatchSellTradesRequest = (
  */
 export async function fetchBatchSellTrades(
   quotes: (QuoteResponse | null)[],
+  stxEnabled: boolean,
   signal: AbortSignal | null,
   clientId: string,
   jwt: string | undefined,
@@ -537,7 +541,10 @@ export async function fetchBatchSellTrades(
   clientVersion?: string,
 ): Promise<BatchSellTradesResponse> {
   const url = `${bridgeApiBaseUrl}/obtainGaslessBatch`;
-  const request: BatchSellTradesRequest = formatBatchSellTradesRequest(quotes);
+  const request: BatchSellTradesRequest = formatBatchSellTradesRequest(
+    quotes,
+    stxEnabled,
+  );
   const batchSellTradesResponse = await fetchFn(url, {
     headers: {
       ...getClientHeaders({


### PR DESCRIPTION
## Explanation

### What is the current state of things and why does it need to change?

Batch Sell fetches gasless transaction batches and network fees via `BridgeController:updateBatchSellTrades`, which calls the bridge API's `/obtainGaslessBatch` endpoint. That request did not include whether Smart Transactions (STX) are enabled for the user's chain. The backend uses this flag to estimate gas costs more accurately for batch sell flows, so omitting it could produce incorrect fee estimates when STX is active.

### What is the solution your changes offer and how does it work?

This PR threads a new `stxEnabled: boolean` parameter through the batch-sell trades pipeline:

1. **`BridgeController.updateBatchSellTrades(quotes, stxEnabled)`** — accepts the flag from the client and forwards it to the fetch layer.
2. **`fetchBatchSellTrades(...)` / `formatBatchSellTradesRequest(...)`** — include `stxEnabled` in the POST body sent to `/obtainGaslessBatch`.
3. **`BatchSellTradesRequest`** — type updated to include `stxEnabled: boolean`.

Clients (e.g. MetaMask Extension) should derive `stxEnabled` from their existing Smart Transaction eligibility logic and pass it whenever they call `updateBatchSellTrades`.

### Are there any changes whose purpose might not be obvious to those unfamiliar with the domain?

- **`stxEnabled` is a request hint, not a controller state field.** It is not persisted in `BridgeController` state; it is only sent to the API at fetch time so the backend can adjust gas estimation.
- **Null quotes are still forwarded as-is** from the controller to `fetchBatchSellTrades`; filtering to non-null quotes happens inside `formatBatchSellTradesRequest` before building the request body (unchanged behavior).
- **SSE batch test updates** pass `false` for `stxEnabled` in messenger calls and spy assertions. The earlier `Map.prototype.entries` test failures were a side effect of argument position shifting after the signature change, not a runtime bug.

### If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?

All changes are scoped to `@metamask/bridge-controller`. No other packages were modified.

### If you had to upgrade a dependency, why did you do so?

No dependency upgrades in this PR.

---

**Breaking changes**

The following public APIs now require a `stxEnabled` argument:

| API | Before | After |
|-----|--------|-------|
| `BridgeController.updateBatchSellTrades` | `(quotes)` | `(quotes, stxEnabled)` |
| `fetchBatchSellTrades` | `(quotes, signal, ...)` | `(quotes, stxEnabled, signal, ...)` |
| `formatBatchSellTradesRequest` | `(quotes)` | `(quotes, stxEnabled)` |

Consumers must update their messenger/background calls to pass the second argument.

---

**Test coverage**

- Added `updateBatchSellTrades` unit tests covering success, null-quote passthrough, error handling, abort handling, and concurrent-call abort behavior.
- Updated `bridge-controller.sse.batch.test.ts` to pass `stxEnabled` in all messenger calls and spy assertions.
- Refactored `fetch.test.ts` with dedicated `stxEnabled: true/false` cases for `fetchBatchSellTrades`.
- Fixed a TypeScript error in `quoteRequestOverrides` test fixture by supplying all required `FeatureId` keys.

---

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?
-->

- Related consumer PR: MetaMask Extension batch-sell work (passes `isSmartTransaction` as `stxEnabled` via `ui/ducks/batch-sell/actions.ts`)
- Builds on existing Batch Sell infrastructure: `updateBatchSellTrades` handler and `/obtainGaslessBatch` endpoint ([#8805](https://github.com/MetaMask/core/pull/8805))

---

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public API changes require consumer updates; incorrect `stxEnabled` values could skew fee estimates but do not alter on-chain execution logic in this package.
> 
> **Overview**
> Adds a **breaking** required `stxEnabled` argument to Batch Sell gasless batch fetching so clients can tell the bridge API whether Smart Transactions are on for more accurate gas estimates on `/obtainGaslessBatch`.
> 
> `BridgeController.updateBatchSellTrades`, `fetchBatchSellTrades`, and `formatBatchSellTradesRequest` now take `stxEnabled` and include it on `BatchSellTradesRequest` in the POST body. The flag is **not** stored in controller state—callers pass it on each fetch (e.g. from existing STX eligibility).
> 
> Tests and changelog are updated; new unit coverage exercises success, errors, aborts, and concurrent calls with the new parameter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbc75433c643af78a2dfdf3c1643000c883e1d3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->