### PR TITLE
ci: create GitHub release after NPM publishing

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -16,19 +16,17 @@ concurrency:
   queue: max
 
 jobs:
-  publish-release:
-    permissions:
-      contents: write
+  build:
+    name: Build release artifacts
     runs-on: ubuntu-latest
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v2
         with:
           is-high-risk-environment: true
-      - uses: MetaMask/action-publish-release@v3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: yarn build
+          ref: ${{ github.sha }}
+      - name: Build
+        run: yarn build
       - name: Upload build artifacts
         uses: actions/upload-artifact@v6
         with:
@@ -42,7 +40,7 @@ jobs:
   publish-npm-dry-run:
     name: Dry run publish to NPM
     runs-on: ubuntu-latest
-    needs: publish-release
+    needs: build
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v2
@@ -81,3 +79,18 @@ jobs:
         uses: MetaMask/action-npm-publish@v6
         with:
           npm-token: ${{ secrets.NPM_TOKEN }}
+
+  publish-release:
+    name: Publish release to GitHub
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    needs: publish-npm
+    steps:
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v2
+        with:
+          is-high-risk-environment: true
+      - uses: MetaMask/action-publish-release@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -91,6 +91,7 @@ jobs:
         uses: MetaMask/action-checkout-and-setup@v2
         with:
           is-high-risk-environment: true
+          ref: ${{ github.sha }}
       - uses: MetaMask/action-publish-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Moves the `action-publish-release` step (GitHub release creation) to after NPM publishing succeeds, matching the pattern used in [metamask-module-template](https://github.com/MetaMask/metamask-module-template/blob/main/.github/workflows/publish-release.yml).
- The build step is extracted into a dedicated `build` job, and `publish-release` now runs last with `needs: publish-npm`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to job order and dependencies; no runtime or package code affected.
> 
> **Overview**
> Reorders the **publish-release** workflow so a **GitHub release is created only after NPM publish succeeds**, aligned with the metamask-module-template pattern.
> 
> **Build** is now its own job (`build`): checkout at `github.sha`, `yarn build`, and artifact upload. `publish-npm-dry-run` and `publish-npm` depend on `build` instead of the old combined job. **Publish release to GitHub** is a final job with `needs: publish-npm`, `contents: write`, and `MetaMask/action-publish-release@v3`—moved out of the front of the pipeline where it previously ran before the build step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0fb8d5dd484895382aaea4dc5164d554a93bb63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->