### PR TITLE
chore: drop unused jest-it-up devDep

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -84,9 +84,6 @@ const config: KnipConfig = {
     'packages/eth-json-rpc-middleware': {
       ignoreDependencies: ['@metamask/network-controller', 'pify', 'tsd'],
     },
-    'packages/eth-json-rpc-provider': {
-      ignoreDependencies: ['jest-it-up'],
-    },
     'packages/foundryup': {
       // `anvil` and `sysctl` are external system binaries, not npm packages.
       ignoreBinaries: ['anvil', 'sysctl'],
@@ -97,12 +94,6 @@ const config: KnipConfig = {
     },
     'packages/geolocation-controller': {
       ignoreDependencies: ['cockatiel'],
-    },
-    'packages/json-rpc-engine': {
-      ignoreDependencies: ['jest-it-up'],
-    },
-    'packages/json-rpc-middleware-stream': {
-      ignoreDependencies: ['jest-it-up'],
     },
     'packages/logging-controller': {
       ignoreDependencies: ['@metamask/controller-utils'],

--- a/packages/eth-json-rpc-provider/package.json
+++ b/packages/eth-json-rpc-provider/package.json
@@ -66,7 +66,6 @@
     "deepmerge": "^4.2.2",
     "ethers": "^6.12.0",
     "jest": "^29.7.0",
-    "jest-it-up": "^2.0.2",
     "ts-jest": "^29.2.5",
     "typedoc": "^0.25.13",
     "typescript": "~5.3.3"

--- a/packages/json-rpc-engine/package.json
+++ b/packages/json-rpc-engine/package.json
@@ -81,7 +81,6 @@
     "@types/jest": "^29.5.14",
     "deepmerge": "^4.2.2",
     "jest": "^29.7.0",
-    "jest-it-up": "^2.0.2",
     "ts-jest": "^29.2.5",
     "typedoc": "^0.25.13",
     "typescript": "~5.3.3"

--- a/packages/json-rpc-middleware-stream/package.json
+++ b/packages/json-rpc-middleware-stream/package.json
@@ -64,7 +64,6 @@
     "deepmerge": "^4.2.2",
     "extension-port-stream": "^3.0.0",
     "jest": "^29.7.0",
-    "jest-it-up": "^2.0.2",
     "ts-jest": "^29.2.5",
     "typedoc": "^0.25.13",
     "typedoc-plugin-missing-exports": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4422,17 +4422,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@inquirer/confirm@npm:^0.0.14-alpha.0":
-  version: 0.0.14-alpha.0
-  resolution: "@inquirer/confirm@npm:0.0.14-alpha.0"
-  dependencies:
-    "@inquirer/core": "npm:^0.0.15-alpha.0"
-    "@inquirer/input": "npm:^0.0.15-alpha.0"
-    chalk: "npm:^4.1.1"
-  checksum: 10/a661d37ab86162d0e9533a6d4726fe0d536c4036b3e416dd272a179685407c9ab52a53b72072b3a41bb89573b078352f4f836e4c8a66317c0fc49fc29a83bff9
-  languageName: node
-  linkType: hard
-
 "@inquirer/confirm@npm:^6.0.5":
   version: 6.0.7
   resolution: "@inquirer/confirm@npm:6.0.7"
@@ -4445,23 +4434,6 @@ __metadata:
     "@types/node":
       optional: true
   checksum: 10/c7da13527dd46f09515f68f1a809791eb8fc349422a39d9fd4c4254082edff3f8c9ffda4c86d10f1b80ebdbed34d2bc2c86c2275096be3d4559a35a88955da41
-  languageName: node
-  linkType: hard
-
-"@inquirer/core@npm:^0.0.15-alpha.0":
-  version: 0.0.15-alpha.0
-  resolution: "@inquirer/core@npm:0.0.15-alpha.0"
-  dependencies:
-    ansi-escapes: "npm:^4.2.1"
-    chalk: "npm:^4.1.1"
-    cli-spinners: "npm:^2.6.0"
-    cli-width: "npm:^3.0.0"
-    lodash: "npm:^4.17.21"
-    mute-stream: "npm:^0.0.8"
-    run-async: "npm:^2.3.0"
-    string-width: "npm:^4.1.0"
-    strip-ansi: "npm:^6.0.0"
-  checksum: 10/04fe0ea3fcbf2f625a0db3ef75e5882a3cf867b77ad3ff84fb8e46d8d94566643c6fdfb2c30848c1d3d946f81cdf07122af1091bb6c443fd31e829bb246bac44
   languageName: node
   linkType: hard
 
@@ -4535,16 +4507,6 @@ __metadata:
   version: 2.0.3
   resolution: "@inquirer/figures@npm:2.0.3"
   checksum: 10/d1496081e28e8fb5f50790fdbf7fb5f437933de557092a3eaac7f290190f9597ff9d75693bbb6d94e3da71b4dae567f2e88d3c54557b280b7b832219ff26e072
-  languageName: node
-  linkType: hard
-
-"@inquirer/input@npm:^0.0.15-alpha.0":
-  version: 0.0.15-alpha.0
-  resolution: "@inquirer/input@npm:0.0.15-alpha.0"
-  dependencies:
-    "@inquirer/core": "npm:^0.0.15-alpha.0"
-    chalk: "npm:^4.1.1"
-  checksum: 10/14345455de7f50aec9c496c3d842ca4d2c49ee8b5684cdfca5c1ddb5e60e5a6b7ff2178ac340666d19a583b01fc880ddc54f947da00a5e6d09ab49dad58f005a
   languageName: node
   linkType: hard
 
@@ -6739,7 +6701,6 @@ __metadata:
     deepmerge: "npm:^4.2.2"
     ethers: "npm:^6.12.0"
     jest: "npm:^29.7.0"
-    jest-it-up: "npm:^2.0.2"
     nanoid: "npm:^3.3.8"
     ts-jest: "npm:^29.2.5"
     typedoc: "npm:^0.25.13"
@@ -7101,7 +7062,6 @@ __metadata:
     deep-freeze-strict: "npm:^1.1.1"
     deepmerge: "npm:^4.2.2"
     jest: "npm:^29.7.0"
-    jest-it-up: "npm:^2.0.2"
     klona: "npm:^2.0.6"
     ts-jest: "npm:^29.2.5"
     typedoc: "npm:^0.25.13"
@@ -7123,7 +7083,6 @@ __metadata:
     deepmerge: "npm:^4.2.2"
     extension-port-stream: "npm:^3.0.0"
     jest: "npm:^29.7.0"
-    jest-it-up: "npm:^2.0.2"
     readable-stream: "npm:^3.6.2"
     ts-jest: "npm:^29.2.5"
     typedoc: "npm:^0.25.13"
@@ -11973,13 +11932,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-colors@npm:^4.1.0":
-  version: 4.1.3
-  resolution: "ansi-colors@npm:4.1.3"
-  checksum: 10/43d6e2fc7b1c6e4dc373de708ee76311ec2e0433e7e8bd3194e7ff123ea6a747428fc61afdcf5969da5be3a5f0fd054602bec56fc0ebe249ce2fcde6e649e3c2
-  languageName: node
-  linkType: hard
-
 "ansi-escapes@npm:^4.2.1":
   version: 4.3.2
   resolution: "ansi-escapes@npm:4.3.2"
@@ -12918,7 +12870,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.1, chalk@npm:^4.1.2":
+"chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -13119,13 +13071,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cli-spinners@npm:^2.6.0":
-  version: 2.9.2
-  resolution: "cli-spinners@npm:2.9.2"
-  checksum: 10/a0a863f442df35ed7294424f5491fa1756bd8d2e4ff0c8736531d886cec0ece4d85e8663b77a5afaf1d296e3cbbebff92e2e99f52bbea89b667cbe789b994794
-  languageName: node
-  linkType: hard
-
 "cli-table3@npm:^0.6.3":
   version: 0.6.5
   resolution: "cli-table3@npm:0.6.5"
@@ -13136,13 +13081,6 @@ __metadata:
     "@colors/colors":
       optional: true
   checksum: 10/8dca71256f6f1367bab84c33add3f957367c7c43750a9828a4212ebd31b8df76bd7419d386e3391ac7419698a8540c25f1a474584028f35b170841cde2e055c5
-  languageName: node
-  linkType: hard
-
-"cli-width@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "cli-width@npm:3.0.0"
-  checksum: 10/8730848b04fb189666ab037a35888d191c8f05b630b1d770b0b0e4c920b47bb5cc14bddf6b8ffe5bfc66cee97c8211d4d18e756c1ffcc75d7dbe7e1186cd7826
   languageName: node
   linkType: hard
 
@@ -13316,13 +13254,6 @@ __metadata:
   version: 8.3.0
   resolution: "commander@npm:8.3.0"
   checksum: 10/6b7b5d334483ce24bd73c5dac2eab901a7dbb25fd983ea24a1eeac6e7166bb1967f641546e8abf1920afbde86a45fbfe5812fbc69d0dc451bb45ca416a12a3a3
-  languageName: node
-  linkType: hard
-
-"commander@npm:^9.0.0":
-  version: 9.5.0
-  resolution: "commander@npm:9.5.0"
-  checksum: 10/41c49b3d0f94a1fbeb0463c85b13f15aa15a9e0b4d5e10a49c0a1d58d4489b549d62262b052ae0aa6cfda53299bee487bfe337825df15e342114dde543f82906
   languageName: node
   linkType: hard
 
@@ -17800,19 +17731,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-it-up@npm:^2.0.2":
-  version: 2.2.0
-  resolution: "jest-it-up@npm:2.2.0"
-  dependencies:
-    "@inquirer/confirm": "npm:^0.0.14-alpha.0"
-    ansi-colors: "npm:^4.1.0"
-    commander: "npm:^9.0.0"
-  bin:
-    jest-it-up: bin/jest-it-up
-  checksum: 10/f329561bff2b96f2ba7b4a0eb2c565782affb4b2f38e1b1c488b7cc3633be59f79932d4c26b25afeedc196c565e6c45094519051b7da7587a87c3f7ad8b780e2
-  languageName: node
-  linkType: hard
-
 "jest-leak-detector@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-leak-detector@npm:29.7.0"
@@ -19991,13 +19909,6 @@ __metadata:
   version: 9.9.0
   resolution: "multiformats@npm:9.9.0"
   checksum: 10/ad55c7d480d22f4258a68fd88aa2aab744fe0cb1e68d732fc886f67d858b37e3aa6c2cec12b2960ead7730d43be690931485238569952d8a3d7f90fdc726c652
-  languageName: node
-  linkType: hard
-
-"mute-stream@npm:^0.0.8":
-  version: 0.0.8
-  resolution: "mute-stream@npm:0.0.8"
-  checksum: 10/a2d2e79dde87e3424ffc8c334472c7f3d17b072137734ca46e6f221131f1b014201cc593b69a38062e974fb2394d3d1cb4349f80f012bbf8b8ac1b28033e515f
   languageName: node
   linkType: hard
 
@@ -23041,13 +22952,6 @@ __metadata:
   version: 7.0.0
   resolution: "run-applescript@npm:7.0.0"
   checksum: 10/b02462454d8b182ad4117e5d4626e9e6782eb2072925c9fac582170b0627ae3c1ea92ee9b2df7daf84b5e9ffe14eb1cf5fb70bc44b15c8a0bfcdb47987e2410c
-  languageName: node
-  linkType: hard
-
-"run-async@npm:^2.3.0":
-  version: 2.4.1
-  resolution: "run-async@npm:2.4.1"
-  checksum: 10/c79551224dafa26ecc281cb1efad3510c82c79116aaf681f8a931ce70fdf4ca880d58f97d3b930a38992c7aad7955a08e065b32ec194e1dd49d7790c874ece50
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation

\`jest-it-up\` is listed as a \`devDependency\` of \`@metamask/json-rpc-engine\`, \`@metamask/eth-json-rpc-provider\`, and \`@metamask/json-rpc-middleware-stream\`, but it isn't referenced from any script, jest config, source file, or CI workflow in this repo — it's a leftover from when these packages lived in standalone repos. \`yarn knip\` (added in #9047 and expanded in #9049) flagged it as unused; this PR removes it and drops the matching \`ignoreDependencies\` entries from \`knip.config.ts\`.

No CHANGELOG entries are needed because devDependencies are not consumer-facing.

## References

First entry in the \`ignoreDependencies\` cleanup follow-ups noted in #9049.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only dependency and tooling config cleanup with no runtime or consumer-facing changes.
> 
> **Overview**
> Removes the unused **`jest-it-up`** devDependency from **`@metamask/json-rpc-engine`**, **`@metamask/eth-json-rpc-provider`**, and **`@metamask/json-rpc-middleware-stream`**, after knip reported it was not referenced anywhere in scripts, tests, or CI.
> 
> Also deletes the three matching **`ignoreDependencies`** workspace entries from **`knip.config.ts`** and refreshes **`yarn.lock`** so transitive packages that only existed for `jest-it-up` are dropped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b116d15bbd57049c33342a3346a9de38acd18ca3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->