### PR TITLE
feat: add `getFeatureFlags` action to `RemoteFeatureFlagController`

### DIFF
--- a/packages/remote-feature-flag-controller/CHANGELOG.md
+++ b/packages/remote-feature-flag-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `RemoteFeatureFlagController:getFeatureFlags` messenger action that returns feature flags with local overrides merged on top of remote flags ([#9053](https://github.com/MetaMask/core/pull/9053))
+
 ## [4.2.2]
 
 ### Changed

--- a/packages/remote-feature-flag-controller/src/index.ts
+++ b/packages/remote-feature-flag-controller/src/index.ts
@@ -11,6 +11,7 @@ export type {
   RemoteFeatureFlagControllerClearAllFlagOverridesAction,
   RemoteFeatureFlagControllerDisableAction,
   RemoteFeatureFlagControllerEnableAction,
+  RemoteFeatureFlagControllerGetFeatureFlagsAction,
   RemoteFeatureFlagControllerMethodActions,
   RemoteFeatureFlagControllerRemoveFlagOverrideAction,
   RemoteFeatureFlagControllerSetFlagOverrideAction,

--- a/packages/remote-feature-flag-controller/src/remote-feature-flag-controller-method-action-types.ts
+++ b/packages/remote-feature-flag-controller/src/remote-feature-flag-controller-method-action-types.ts
@@ -62,6 +62,17 @@ export type RemoteFeatureFlagControllerClearAllFlagOverridesAction = {
 };
 
 /**
+ * Returns the effective feature flags by merging remote feature flags
+ * with local overrides. Local overrides take precedence over remote flags.
+ *
+ * @returns The merged feature flags.
+ */
+export type RemoteFeatureFlagControllerGetFeatureFlagsAction = {
+  type: `RemoteFeatureFlagController:getFeatureFlags`;
+  handler: RemoteFeatureFlagController['getFeatureFlags'];
+};
+
+/**
  * Union of all RemoteFeatureFlagController action types.
  */
 export type RemoteFeatureFlagControllerMethodActions =
@@ -70,4 +81,5 @@ export type RemoteFeatureFlagControllerMethodActions =
   | RemoteFeatureFlagControllerDisableAction
   | RemoteFeatureFlagControllerSetFlagOverrideAction
   | RemoteFeatureFlagControllerRemoveFlagOverrideAction
-  | RemoteFeatureFlagControllerClearAllFlagOverridesAction;
+  | RemoteFeatureFlagControllerClearAllFlagOverridesAction
+  | RemoteFeatureFlagControllerGetFeatureFlagsAction;

--- a/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.test.ts
+++ b/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.test.ts
@@ -1235,6 +1235,86 @@ describe('RemoteFeatureFlagController', () => {
         });
       });
     });
+
+    describe('getFeatureFlags', () => {
+      it('returns remote flags when no overrides exist', async () => {
+        const clientConfigApiService = buildClientConfigApiService({
+          remoteFeatureFlags: MOCK_FLAGS,
+        });
+        const { messenger } = createController({
+          clientConfigApiService,
+        });
+
+        await messenger.call(
+          'RemoteFeatureFlagController:updateRemoteFeatureFlags',
+        );
+
+        const result = messenger.call(
+          'RemoteFeatureFlagController:getFeatureFlags',
+        );
+
+        expect(result).toStrictEqual(MOCK_FLAGS);
+      });
+
+      it('returns overrides merged on top of remote flags', async () => {
+        const clientConfigApiService = buildClientConfigApiService({
+          remoteFeatureFlags: {
+            feature1: true,
+            feature2: { chrome: '<109' },
+          },
+        });
+        const { messenger } = createController({
+          clientConfigApiService,
+        });
+
+        await messenger.call(
+          'RemoteFeatureFlagController:updateRemoteFeatureFlags',
+        );
+
+        messenger.call(
+          'RemoteFeatureFlagController:setFlagOverride',
+          'feature1',
+          false,
+        );
+
+        const result = messenger.call(
+          'RemoteFeatureFlagController:getFeatureFlags',
+        );
+
+        expect(result).toStrictEqual({
+          feature1: false,
+          feature2: { chrome: '<109' },
+        });
+      });
+
+      it('includes override-only flags not present in remote flags', () => {
+        const { messenger } = createController();
+
+        messenger.call(
+          'RemoteFeatureFlagController:setFlagOverride',
+          'localOnly',
+          'localValue',
+        );
+
+        const result = messenger.call(
+          'RemoteFeatureFlagController:getFeatureFlags',
+        );
+
+        expect(result).toStrictEqual({
+          localOnly: 'localValue',
+        });
+      });
+
+      it('returns empty object when no flags or overrides exist', () => {
+        const { messenger } = createController();
+
+        const result = messenger.call(
+          'RemoteFeatureFlagController:getFeatureFlags',
+        );
+
+        expect(result).toStrictEqual({});
+      });
+    });
   });
 
   describe('threshold cache cleanup', () => {

--- a/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.ts
+++ b/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.ts
@@ -75,6 +75,7 @@ const MESSENGER_EXPOSED_METHODS = [
   'clearAllFlagOverrides',
   'disable',
   'enable',
+  'getFeatureFlags',
   'removeFlagOverride',
   'setFlagOverride',
   'updateRemoteFeatureFlags',
@@ -455,5 +456,18 @@ export class RemoteFeatureFlagController extends BaseController<
         localOverrides: {},
       };
     });
+  }
+
+  /**
+   * Returns the effective feature flags by merging remote feature flags
+   * with local overrides. Local overrides take precedence over remote flags.
+   *
+   * @returns The merged feature flags.
+   */
+  getFeatureFlags(): FeatureFlags {
+    return {
+      ...this.state.remoteFeatureFlags,
+      ...this.state.localOverrides,
+    };
   }
 }


### PR DESCRIPTION
## Explanation

Adds a new `RemoteFeatureFlagController:getFeatureFlags` messenger action that returns the effective feature flags by explicitly merging `remoteFeatureFlags` with `localOverrides` from the controller state. Local overrides take precedence over remote flags.

## References

N/A

## Changelog

### `@metamask/remote-feature-flag-controller`

#### Added

- Added `RemoteFeatureFlagController:getFeatureFlags` messenger action that returns feature flags with local overrides merged on top of remote flags

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only merge of in-memory state with no fetch or persistence changes; behavior is covered by new tests.
> 
> **Overview**
> Adds **`getFeatureFlags`** on `RemoteFeatureFlagController` and exposes it as the messenger action **`RemoteFeatureFlagController:getFeatureFlags`**, so callers can read **effective** flags in one place instead of merging `remoteFeatureFlags` and `localOverrides` themselves.
> 
> The implementation is a shallow merge: remote flags first, then `localOverrides` (overrides win). Override-only keys are included; with no remote flags and no overrides it returns `{}`. The new action type is exported from the package index, and unit tests cover the merge behavior via the messenger.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75a806100c2ea7ced7f262b9073fd5b8a297271a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->