### PR TITLE
ci: address zizmor security findings in GitHub Actions workflows

### DIFF
--- a/.github/actions/check-merge-queue-changelogs/action.yml
+++ b/.github/actions/check-merge-queue-changelogs/action.yml
@@ -15,6 +15,7 @@ runs:
       uses: actions/checkout@v6
       with:
         fetch-depth: 0
+        persist-credentials: false
 
     - name: Get pull request number
       id: pr-number

--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -14,6 +14,7 @@ runs:
       with:
         is-high-risk-environment: false
         skip-install: true
+        persist-credentials: false
 
     - name: Get merge base
       id: merge-base

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    cooldown:
+      default-days: 3
     allow:
       - dependency-name: '@metamask/*'
     versioning-strategy: 'increase'
@@ -16,6 +18,8 @@ updates:
     schedule:
       interval: 'daily'
       time: '06:00'
+    cooldown:
+      default-days: 3
     allow:
       - dependency-name: 'MetaMask/*'
       - dependency-name: 'actions/*'

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -8,6 +8,9 @@ jobs:
   check-changelog:
     name: Check changelog
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: Check changelog
         uses: MetaMask/github-tools/.github/actions/check-changelog@v1

--- a/.github/workflows/create-update-issues.yml
+++ b/.github/workflows/create-update-issues.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout head
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Fetch tags
         run: git fetch --prune --unshallow --tags
       - name: Get extension token

--- a/.github/workflows/deploy-platform-api-docs.yml
+++ b/.github/workflows/deploy-platform-api-docs.yml
@@ -14,6 +14,7 @@ jobs:
         uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: true
+          persist-credentials: false
 
       - name: Generate and build Platform API docs
         # The site is published under the `/platform-api/` subdirectory of
@@ -67,9 +68,9 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
-          fetch-depth: 1
+          persist-credentials: false
 
       - name: Download build artifact
         uses: actions/download-artifact@v8

--- a/.github/workflows/ensure-blocking-pr-labels-absent.yml
+++ b/.github/workflows/ensure-blocking-pr-labels-absent.yml
@@ -16,9 +16,10 @@ jobs:
       pull-requests: read
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v2
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
+          persist-credentials: false
       - name: Run command
         uses: actions/github-script@v8
         with:

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -63,9 +63,6 @@ jobs:
   lint-workflows:
     name: Lint workflows
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [24.x]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -14,9 +14,10 @@ jobs:
       child-workspace-package-names: ${{ steps.workspace-package-names.outputs.child-workspace-package-names }}
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v2
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
+          persist-credentials: false
           cache-node-modules: true
           node-version: ${{ matrix.node-version }}
       - name: Fetch workspace package names
@@ -42,9 +43,10 @@ jobs:
           - readme-content:check
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v2
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
+          persist-credentials: false
           node-version: ${{ matrix.node-version }}
       - name: Run yarn ${{ matrix.script }}
         run: yarn "$SCRIPT"
@@ -68,11 +70,14 @@ jobs:
         package-name: ${{ fromJson(needs.prepare.outputs.child-workspace-package-names) }}
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v2
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
+          persist-credentials: false
           node-version: ${{ matrix.node-version }}
-      - run: yarn workspace ${{ matrix.package-name }} changelog:validate
+      - run: yarn workspace "$PACKAGE_NAME" changelog:validate
+        env:
+          PACKAGE_NAME: ${{ matrix.package-name }}
       - name: Require clean working directory
         shell: bash
         run: |
@@ -88,6 +93,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Validate changelog diffs
         uses: ./.github/actions/check-merge-queue-changelogs
 
@@ -100,9 +107,10 @@ jobs:
         node-version: [24.x]
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v2
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
+          persist-credentials: false
           node-version: ${{ matrix.node-version }}
       - run: yarn build
       - name: Require clean working directory
@@ -122,9 +130,10 @@ jobs:
         node-version: [24.x]
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v2
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
+          persist-credentials: false
           node-version: ${{ matrix.node-version }}
       - run: yarn test:scripts
       - name: Require clean working directory
@@ -147,9 +156,10 @@ jobs:
         package-name: ${{ fromJson(needs.prepare.outputs.child-workspace-package-names) }}
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v2
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
+          persist-credentials: false
           node-version: 18.x
       - run: yarn workspace ${{ matrix.package-name }} run test
       - name: Require clean working directory
@@ -172,6 +182,7 @@ jobs:
         uses: MetaMask/action-checkout-and-setup@v2
         with:
           is-high-risk-environment: false
+          persist-credentials: false
           node-version: 20.x
       - run: yarn workspace ${{ matrix.package-name }} run test
       - name: Require clean working directory
@@ -191,9 +202,10 @@ jobs:
         package-name: ${{ fromJson(needs.prepare.outputs.child-workspace-package-names) }}
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v2
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: false
+          persist-credentials: false
           node-version: 22.x
       - run: yarn workspace ${{ matrix.package-name }} run test
       - name: Require clean working directory

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -20,6 +20,7 @@ jobs:
           persist-credentials: false
           cache-node-modules: true
           node-version: ${{ matrix.node-version }}
+          force-setup: true
       - name: Fetch workspace package names
         id: workspace-package-names
         run: |

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -60,6 +60,24 @@ jobs:
             exit 1
           fi
 
+  lint-workflows:
+    name: Lint workflows
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [24.x]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Lint workflows
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d
+        with:
+          advanced-security: false
+          annotations: true
+          version: v1.25.2
+
   validate-changelog:
     name: Validate changelog
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -162,7 +162,9 @@ jobs:
           is-high-risk-environment: false
           persist-credentials: false
           node-version: 18.x
-      - run: yarn workspace ${{ matrix.package-name }} run test
+      - run: yarn workspace "$PACKAGE_NAME" run test
+        env:
+          PACKAGE_NAME: ${{ matrix.package-name }}
       - name: Require clean working directory
         shell: bash
         run: |
@@ -185,7 +187,9 @@ jobs:
           is-high-risk-environment: false
           persist-credentials: false
           node-version: 20.x
-      - run: yarn workspace ${{ matrix.package-name }} run test
+      - run: yarn workspace "$PACKAGE_NAME" run test
+        env:
+          PACKAGE_NAME: ${{ matrix.package-name }}
       - name: Require clean working directory
         shell: bash
         run: |
@@ -208,7 +212,9 @@ jobs:
           is-high-risk-environment: false
           persist-credentials: false
           node-version: 22.x
-      - run: yarn workspace ${{ matrix.package-name }} run test
+      - run: yarn workspace "$PACKAGE_NAME" run test
+        env:
+          PACKAGE_NAME: ${{ matrix.package-name }}
       - name: Require clean working directory
         shell: bash
         run: |

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -61,21 +61,6 @@ jobs:
             exit 1
           fi
 
-  lint-workflows:
-    name: Lint workflows
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Lint workflows
-        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d
-        with:
-          advanced-security: false
-          annotations: true
-          version: v1.25.2
-
   validate-changelog:
     name: Validate changelog
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,10 +10,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
   cancel-in-progress: ${{ !contains(github.ref, 'refs/heads/main') }}
 
+permissions:
+  contents: read
+
 jobs:
   check-skip-merge-queue:
     name: Check if pull request can skip merge queue
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       skip-merge-queue: ${{ steps.check-skip-merge-queue.outputs.up-to-date }}
     steps:
@@ -28,15 +34,22 @@ jobs:
       - check-skip-merge-queue
     if: github.event_name != 'merge_group' || needs.check-skip-merge-queue.outputs.skip-merge-queue != 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Download actionlint
         id: download-actionlint
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/914e7df21a07ef503a81201c76d2b11c789d3fca/scripts/download-actionlint.bash) 1.7.12
         shell: bash
       - name: Check workflow files
-        run: ${{ steps.download-actionlint.outputs.executable }} -color
+        run: |
+          "$ACTIONLINT" -color
         shell: bash
+        env:
+          ACTIONLINT: ${{ steps.download-actionlint.outputs.executable }}
 
   analyse-code:
     name: Analyse code
@@ -94,9 +107,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Check release
         if: github.event_name != 'push'
         uses: ./.github/actions/check-release

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -24,6 +24,7 @@ jobs:
         uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: true
+          persist-credentials: false
           ref: ${{ github.sha }}
       - name: Build
         run: yarn build
@@ -46,6 +47,7 @@ jobs:
         uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: true
+          persist-credentials: false
           ref: ${{ github.sha }}
           skip-install: true
       - name: Restore build artifacts
@@ -72,6 +74,7 @@ jobs:
         uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: true
+          persist-credentials: false
           ref: ${{ github.sha }}
           skip-install: true
       - name: Restore build artifacts
@@ -95,6 +98,7 @@ jobs:
         uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: true
+          persist-credentials: false
           ref: ${{ github.sha }}
           skip-install: true
       - uses: MetaMask/action-publish-release@v3

--- a/.github/workflows/update-changelogs.yml
+++ b/.github/workflows/update-changelogs.yml
@@ -12,14 +12,15 @@ on:
       - ready_for_review
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   is-fork:
     name: Determine whether this PR is from a fork
     if: (github.event_name == 'pull_request_target' && !github.event.pull_request.draft) || (github.event.issue.pull_request && startsWith(github.event.comment.body, '@metamaskbot update-changelogs'))
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     outputs:
       is-fork: ${{ steps.is-fork.outputs.is-fork }}
     steps:
@@ -38,6 +39,9 @@ jobs:
     if: needs.is-fork.outputs.is-fork == 'false'
     runs-on: ubuntu-latest
     environment: default-branch
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       is-release: ${{ steps.is-release.outputs.IS_RELEASE }}
       head-sha: ${{ steps.pr-info.outputs.pr-head-sha }}
@@ -62,6 +66,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
+          persist-credentials: false
           ref: ${{ steps.pr-info.outputs.pr-head-sha }}
 
       - name: Get merge base
@@ -104,6 +109,8 @@ jobs:
             pull_requests: write
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: React to the comment
         run: |
           gh api \
@@ -140,6 +147,7 @@ jobs:
         with:
           ref: ${{ needs.is-release.outputs.merge-base }}
           token: ${{ steps.get-token.outputs.token }}
+          persist-credentials: false
 
       - name: Detach HEAD (to prevent accidental pushes)
         run: git checkout --detach HEAD
@@ -207,11 +215,12 @@ jobs:
           NEW_COMMIT_ID: ${{ steps.commit-updated-changelogs.outputs.new-commit-id }}
           PR_HEAD_SHA: ${{ needs.is-release.outputs.head-sha }}
           PR_HEAD_REF: ${{ needs.is-release.outputs.head-ref }}
+          TOKEN: ${{ steps.get-token.outputs.token }}
         run: |
           if [[ -n "$NEW_COMMIT_ID" ]]; then
             git checkout "$PR_HEAD_SHA"
             git cherry-pick "$NEW_COMMIT_ID"
-            git push origin "HEAD:$PR_HEAD_REF"
+            git push "https://x-access-token:${TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:$PR_HEAD_REF"
             echo "changes-pushed=true" >> "$GITHUB_OUTPUT"
           else
             echo "changes-pushed=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/update-changelogs.yml
+++ b/.github/workflows/update-changelogs.yml
@@ -107,10 +107,6 @@ jobs:
           permissions: |
             contents: write
             pull_requests: write
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          persist-credentials: false
       - name: React to the comment
         run: |
           gh api \

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,11 @@
+# Please see the documentation for all configuration options:
+# https://docs.zizmor.sh/configuration/
+
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # Allow `actions/*` and `MetaMask/*` to be pinned to a version instead
+        # of only to a commit hash.
+        actions/*: ref-pin
+        MetaMask/*: ref-pin

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -9,6 +9,11 @@ rules:
       # the `default-branch` environment.
       - update-changelogs.yml:3:1
 
+  dependabot-cooldown:
+    config:
+      # Change the minimum allowed cooldown period for Dependabot to 3 days.
+      days: 3
+
   unpinned-uses:
     config:
       policies:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -2,6 +2,13 @@
 # https://docs.zizmor.sh/configuration/
 
 rules:
+  dangerous-triggers:
+    ignore:
+      # `pull_request_target` is used safely here: The workflow checks whether
+      # the PR is from a fork before running, and write access is gated behind
+      # the `default-branch` environment.
+      - update-changelogs.yml:3:1
+
   unpinned-uses:
     config:
       policies:


### PR DESCRIPTION
## Explanation

Adds a zizmor config and addresses all reported security findings across GitHub Actions workflows, actions, and Dependabot config:

- **`artipacked`**: Add `persist-credentials: false` to all `actions/checkout` and `MetaMask/action-checkout-and-setup` calls that don't need to push. For `update-changelogs.yml`, which does need to push, credentials are no longer persisted from the checkout — instead the token is passed directly to the `git push` URL, scoping it to that single command.
- **`template-injection`**: Replace inline `${{ matrix.package-name }}` and `${{ steps.*.outputs.executable }}` expressions in `run` steps with env vars to prevent code injection.
- **`excessive-permissions`**: Add explicit `permissions` blocks at the workflow and job level to restrict each job to only what it needs.
- **`dangerous-triggers`**: Suppress the `pull_request_target` finding in `update-changelogs.yml` — it is used safely (fork check + `default-branch` environment gate).
- **`dependabot-cooldown`**: Add a 3-day cooldown to both Dependabot update configs to reduce the supply-chain attack window.

## References

<!--
Are there any issues that this pull request is tied to?
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI, Dependabot, and zizmor config; runtime product code is untouched, with the main operational risk being a mis-scoped permission or push step in changelog automation.
> 
> **Overview**
> Adds **`.github/zizmor.yml`** and updates workflows, composite actions, and Dependabot so zizmor-reported issues are fixed or explicitly allowed.
> 
> **Credential handling:** `persist-credentials: false` is set on checkout/setup steps that do not need to push. In **`update-changelogs.yml`**, push uses a token in the `git push` URL instead of persisted checkout credentials, and a redundant checkout after token exchange is removed.
> 
> **Injection hardening:** Matrix values and step outputs used in shell steps (e.g. `PACKAGE_NAME`, `ACTIONLINT`) are passed via **`env`** instead of inline `${{ }}` in `run` scripts.
> 
> **Least privilege:** Workflow- and job-level **`permissions`** are tightened (e.g. **`main.yml`** defaults to `contents: read`; changelog/update jobs get scoped read grants). **`update-changelogs.yml`** no longer grants broad `contents: write` / `pull-requests: write` at workflow scope.
> 
> **Other:** Dependabot npm and GitHub Actions configs get a **3-day cooldown**; several jobs bump to **`MetaMask/action-checkout-and-setup@v3`** (and related checkout bumps); **`lint-build-test`** prepare adds **`force-setup: true`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68f6e7ad46863c56f018064a8fcea787fed76fdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->