### PR TITLE
perf: Faster ABI encoding for `MulticallClient`

### DIFF
--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Use `encodeFunctionData` from `@metamask/controller-utils` for improved performance ([#9057](https://github.com/MetaMask/core/pull/9057))
 - Bump `@metamask/transaction-controller` from `^67.0.0` to `^67.1.0` ([#9066](https://github.com/MetaMask/core/pull/9066))
 
 ### Removed
@@ -19,7 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Use `encodeFunctionData` from `@metamask/controller-utils` for improved performance ([#9057](https://github.com/MetaMask/core/pull/9057))
 - Bump `@metamask/network-enablement-controller` from `^5.2.0` to `^5.3.0` ([#9003](https://github.com/MetaMask/core/pull/9003))
 - Bump `@metamask/transaction-controller` from `^66.0.1` to `^67.0.0` ([#9021](https://github.com/MetaMask/core/pull/9021))
 - Bump `@metamask/account-tree-controller` from `^7.5.1` to `^7.5.2` ([#9058](https://github.com/MetaMask/core/pull/9058))

--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Use `encodeFunctionData` and `decodeFunctionResult` from `@metamask/controller-utils` for improved performance ([#9057](https://github.com/MetaMask/core/pull/9057))
 - Bump `@metamask/transaction-controller` from `^67.0.0` to `^67.1.0` ([#9066](https://github.com/MetaMask/core/pull/9066))
 
 ### Removed
@@ -20,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Use `encodeFunctionData` from `@metamask/controller-utils` for improved performance ([#9057](https://github.com/MetaMask/core/pull/9057))
 - Bump `@metamask/network-enablement-controller` from `^5.2.0` to `^5.3.0` ([#9003](https://github.com/MetaMask/core/pull/9003))
 - Bump `@metamask/transaction-controller` from `^66.0.1` to `^67.0.0` ([#9021](https://github.com/MetaMask/core/pull/9021))
 - Bump `@metamask/account-tree-controller` from `^7.5.1` to `^7.5.2` ([#9058](https://github.com/MetaMask/core/pull/9058))

--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Use `encodeFunctionData` and `decodeFunctionResult` from `@metamask/controller-utils` for improved performance ([#9057](https://github.com/MetaMask/core/pull/9057))
 - Bump `@metamask/transaction-controller` from `^67.0.0` to `^67.1.0` ([#9066](https://github.com/MetaMask/core/pull/9066))
 
 ### Removed
@@ -19,7 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Use `encodeFunctionData` from `@metamask/controller-utils` for improved performance ([#9057](https://github.com/MetaMask/core/pull/9057))
 - Bump `@metamask/network-enablement-controller` from `^5.2.0` to `^5.3.0` ([#9003](https://github.com/MetaMask/core/pull/9003))
 - Bump `@metamask/transaction-controller` from `^66.0.1` to `^67.0.0` ([#9021](https://github.com/MetaMask/core/pull/9021))
 - Bump `@metamask/account-tree-controller` from `^7.5.1` to `^7.5.2` ([#9058](https://github.com/MetaMask/core/pull/9058))

--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Use `encodeFunctionData` from `@metamask/controller-utils` for improved performance ([#9057](https://github.com/MetaMask/core/pull/9057))
 - Bump `@metamask/network-enablement-controller` from `^5.2.0` to `^5.3.0` ([#9003](https://github.com/MetaMask/core/pull/9003))
 - Bump `@metamask/transaction-controller` from `^66.0.1` to `^67.0.0` ([#9021](https://github.com/MetaMask/core/pull/9021))
 - Bump `@metamask/account-tree-controller` from `^7.5.1` to `^7.5.2` ([#9058](https://github.com/MetaMask/core/pull/9058))

--- a/packages/assets-controller/src/data-sources/evm-rpc-services/clients/MulticallClient.test.ts
+++ b/packages/assets-controller/src/data-sources/evm-rpc-services/clients/MulticallClient.test.ts
@@ -875,6 +875,47 @@ describe('encodeAggregate3', () => {
     expect(decodedCalls[1].allowFailure).toBe(false);
     expect(decodedCalls[1].callData.toLowerCase()).toBe(calls[1].callData);
   });
+
+  it('should produce identical calldata to regular Ethers implementation', () => {
+    const multicall3Interface = new Interface([
+      'function aggregate3((address target, bool allowFailure, bytes callData)[] calls) payable returns ((bool success, bytes returnData)[])',
+      'function getEthBalance(address addr) view returns (uint256)',
+    ]);
+
+    const erc20Interface = new Interface([
+      'function balanceOf(address account) view returns (uint256)',
+    ]);
+
+    const calls = [
+      {
+        target: TEST_TOKEN_1,
+        allowFailure: true,
+        callData: erc20Interface.encodeFunctionData('balanceOf', [
+          TEST_TOKEN_1,
+        ]) as Hex,
+      },
+      {
+        target: TEST_TOKEN_2,
+        allowFailure: false,
+        callData: erc20Interface.encodeFunctionData('balanceOf', [
+          TEST_TOKEN_1,
+        ]) as Hex,
+      },
+      {
+        target: '0xcA11bde05977b3631167028862bE2a173976CA11' as Address,
+        allowFailure: true,
+        callData: multicall3Interface.encodeFunctionData('getEthBalance', [
+          TEST_TOKEN_1,
+        ]) as Hex,
+      },
+    ];
+
+    const expected = multicall3Interface.encodeFunctionData('aggregate3', [
+      calls,
+    ]);
+
+    expect(encodeAggregate3(calls)).toBe(expected);
+  });
 });
 
 describe('decodeAggregate3Response', () => {

--- a/packages/assets-controller/src/data-sources/evm-rpc-services/clients/MulticallClient.ts
+++ b/packages/assets-controller/src/data-sources/evm-rpc-services/clients/MulticallClient.ts
@@ -1,7 +1,6 @@
 import { Interface } from '@ethersproject/abi';
 import {
   createServicePolicy,
-  decodeFunctionResult,
   encodeFunctionData,
 } from '@metamask/controller-utils';
 import type { Hex } from '@metamask/utils';
@@ -433,7 +432,7 @@ export function decodeAggregate3Response(
   data: Hex,
   callCount: number,
 ): { success: boolean; returnData: Hex }[] {
-  const decoded = decodeFunctionResult(multicall3Interface, 'aggregate3', data);
+  const decoded = multicall3Interface.decodeFunctionResult('aggregate3', data);
 
   // decoded[0] is the array of (success, returnData) tuples
   const results = decoded[0] as readonly {
@@ -462,7 +461,7 @@ function decodeUint256(data: Hex): string {
     // Empty or invalid data; treat as 0
     return '0';
   }
-  const decoded = decodeFunctionResult(erc20Interface, 'balanceOf', data);
+  const decoded = erc20Interface.decodeFunctionResult('balanceOf', data);
   return decoded[0].toString();
 }
 

--- a/packages/assets-controller/src/data-sources/evm-rpc-services/clients/MulticallClient.ts
+++ b/packages/assets-controller/src/data-sources/evm-rpc-services/clients/MulticallClient.ts
@@ -1,6 +1,7 @@
 import { Interface } from '@ethersproject/abi';
 import {
   createServicePolicy,
+  decodeFunctionResult,
   encodeFunctionData,
 } from '@metamask/controller-utils';
 import type { Hex } from '@metamask/utils';
@@ -432,7 +433,7 @@ export function decodeAggregate3Response(
   data: Hex,
   callCount: number,
 ): { success: boolean; returnData: Hex }[] {
-  const decoded = multicall3Interface.decodeFunctionResult('aggregate3', data);
+  const decoded = decodeFunctionResult(multicall3Interface, 'aggregate3', data);
 
   // decoded[0] is the array of (success, returnData) tuples
   const results = decoded[0] as readonly {
@@ -461,7 +462,7 @@ function decodeUint256(data: Hex): string {
     // Empty or invalid data; treat as 0
     return '0';
   }
-  const decoded = erc20Interface.decodeFunctionResult('balanceOf', data);
+  const decoded = decodeFunctionResult(erc20Interface, 'balanceOf', data);
   return decoded[0].toString();
 }
 

--- a/packages/assets-controller/src/data-sources/evm-rpc-services/clients/MulticallClient.ts
+++ b/packages/assets-controller/src/data-sources/evm-rpc-services/clients/MulticallClient.ts
@@ -1,12 +1,5 @@
-import { AbiCoder, Interface, ParamType } from '@ethersproject/abi';
-import { createServicePolicy } from '@metamask/controller-utils';
-import {
-  concatBytes,
-  hexToBytes,
-  bytesToHex,
-  getChecksumAddress,
-  add0x,
-} from '@metamask/utils';
+import { Interface } from '@ethersproject/abi';
+import { createServicePolicy, encodeFunctionData } from '@metamask/controller-utils';
 import type { Hex } from '@metamask/utils';
 
 import { ZERO_ADDRESS } from '../../../utils/constants';
@@ -383,63 +376,6 @@ const MULTICALL3_ADDRESS_BY_CHAIN: Record<Hex, Hex> = {
 // =============================================================================
 // ENCODING/DECODING UTILITIES (using @ethersproject/abi)
 // =============================================================================
-
-// Ethers does not export these unfortunately.
-type Coder = ReturnType<AbiCoder['_getCoder']>;
-type Writer = Parameters<Coder['encode']>[0];
-type Reader = Parameters<Coder['decode']>[0];
-
-// FastAddressCoder that skips checksumming addresses when encoding and uses the memoized `getChecksumAddress` for decoding.
-class FastAddressCoder {
-  name = 'address';
-
-  type = 'address';
-
-  dynamic = false;
-
-  localName: string;
-
-  constructor(localName: string) {
-    this.localName = localName;
-  }
-
-  encode(writer: Writer, value: string): number {
-    return writer.writeValue(value);
-  }
-
-  decode(reader: Reader): unknown {
-    const value = reader.readValue();
-    const paddedHex = value.toHexString().slice(2).padStart(40);
-    return getChecksumAddress(add0x(paddedHex));
-  }
-
-  defaultValue(): string {
-    return ZERO_ADDRESS;
-  }
-}
-
-class FastAbiCoder extends AbiCoder {
-  _getCoder(param: ParamType): Coder {
-    if (param.type === 'address') {
-      // Casting since we are missing internal unused methods, such _throwError.
-      return new FastAddressCoder(param.name) as unknown as Coder;
-    }
-    return super._getCoder(param);
-  }
-}
-
-const fastAbiCoder = new FastAbiCoder();
-
-function encodeFunctionData(
-  abi: Interface,
-  functionName: string,
-  values: unknown[],
-): Hex {
-  const func = abi.getFunction(functionName);
-  const sigHash = hexToBytes(abi.getSighash(func));
-  const encodedParams = fastAbiCoder.encode(func.inputs, values);
-  return bytesToHex(concatBytes([sigHash, encodedParams]));
-}
 
 /**
  * Encode a balanceOf call for an ERC-20 token.

--- a/packages/assets-controller/src/data-sources/evm-rpc-services/clients/MulticallClient.ts
+++ b/packages/assets-controller/src/data-sources/evm-rpc-services/clients/MulticallClient.ts
@@ -4,10 +4,10 @@ import {
   concatBytes,
   hexToBytes,
   bytesToHex,
-  type Hex,
   getChecksumAddress,
   add0x,
 } from '@metamask/utils';
+import type { Hex } from '@metamask/utils';
 
 import { ZERO_ADDRESS } from '../../../utils/constants';
 import type {
@@ -392,8 +392,11 @@ type Reader = Parameters<Coder['decode']>[0];
 // FastAddressCoder that skips checksumming addresses when encoding and uses the memoized `getChecksumAddress` for decoding.
 class FastAddressCoder {
   name = 'address';
+
   type = 'address';
+
   dynamic = false;
+
   localName: string;
 
   constructor(localName: string) {
@@ -406,8 +409,8 @@ class FastAddressCoder {
 
   decode(reader: Reader): unknown {
     const value = reader.readValue();
-    const hex = value.toHexString().slice(2).padStart(40);
-    return getChecksumAddress(add0x(hex));
+    const paddedHex = value.toHexString().slice(2).padStart(40);
+    return getChecksumAddress(add0x(paddedHex));
   }
 
   defaultValue(): string {
@@ -444,9 +447,7 @@ function encodeFunctionData(
  * @returns The encoded call data.
  */
 function encodeBalanceOf(accountAddress: Address): Hex {
-  return encodeFunctionData(erc20Interface, 'balanceOf', [
-    accountAddress,
-  ]) as Hex;
+  return encodeFunctionData(erc20Interface, 'balanceOf', [accountAddress]);
 }
 
 /**
@@ -458,7 +459,7 @@ function encodeBalanceOf(accountAddress: Address): Hex {
 function encodeGetEthBalance(accountAddress: Address): Hex {
   return encodeFunctionData(multicall3Interface, 'getEthBalance', [
     accountAddress,
-  ]) as Hex;
+  ]);
 }
 
 /**
@@ -476,7 +477,7 @@ export function encodeAggregate3(
       allowFailure: call.allowFailure,
       callData: call.callData,
     })),
-  ]) as Hex;
+  ]);
 }
 
 /**

--- a/packages/assets-controller/src/data-sources/evm-rpc-services/clients/MulticallClient.ts
+++ b/packages/assets-controller/src/data-sources/evm-rpc-services/clients/MulticallClient.ts
@@ -421,7 +421,8 @@ class FastAddressCoder {
 class FastAbiCoder extends AbiCoder {
   _getCoder(param: ParamType): Coder {
     if (param.type === 'address') {
-      return new FastAddressCoder(param.name);
+      // Casting since we are missing internal unused methods, such _throwError.
+      return new FastAddressCoder(param.name) as unknown as Coder;
     }
     return super._getCoder(param);
   }

--- a/packages/assets-controller/src/data-sources/evm-rpc-services/clients/MulticallClient.ts
+++ b/packages/assets-controller/src/data-sources/evm-rpc-services/clients/MulticallClient.ts
@@ -1,6 +1,13 @@
-import { Interface } from '@ethersproject/abi';
+import { AbiCoder, Interface, ParamType } from '@ethersproject/abi';
 import { createServicePolicy } from '@metamask/controller-utils';
-import type { Hex } from '@metamask/utils';
+import {
+  concatBytes,
+  hexToBytes,
+  bytesToHex,
+  type Hex,
+  getChecksumAddress,
+  add0x,
+} from '@metamask/utils';
 
 import { ZERO_ADDRESS } from '../../../utils/constants';
 import type {
@@ -377,6 +384,59 @@ const MULTICALL3_ADDRESS_BY_CHAIN: Record<Hex, Hex> = {
 // ENCODING/DECODING UTILITIES (using @ethersproject/abi)
 // =============================================================================
 
+// Ethers does not export these unfortunately.
+type Coder = ReturnType<AbiCoder['_getCoder']>;
+type Writer = Parameters<Coder['encode']>[0];
+type Reader = Parameters<Coder['decode']>[0];
+
+// FastAddressCoder that skips checksumming addresses when encoding and uses the memoized `getChecksumAddress` for decoding.
+class FastAddressCoder {
+  name = 'address';
+  type = 'address';
+  dynamic = false;
+  localName: string;
+
+  constructor(localName: string) {
+    this.localName = localName;
+  }
+
+  encode(writer: Writer, value: string): number {
+    return writer.writeValue(value);
+  }
+
+  decode(reader: Reader): unknown {
+    const value = reader.readValue();
+    const hex = value.toHexString().slice(2).padStart(40);
+    return getChecksumAddress(add0x(hex));
+  }
+
+  defaultValue(): string {
+    return ZERO_ADDRESS;
+  }
+}
+
+class FastAbiCoder extends AbiCoder {
+  _getCoder(param: ParamType): Coder {
+    if (param.type === 'address') {
+      return new FastAddressCoder(param.name);
+    }
+    return super._getCoder(param);
+  }
+}
+
+const fastAbiCoder = new FastAbiCoder();
+
+function encodeFunctionData(
+  abi: Interface,
+  functionName: string,
+  values: unknown[],
+): Hex {
+  const func = abi.getFunction(functionName);
+  const sigHash = hexToBytes(abi.getSighash(func));
+  const encodedParams = fastAbiCoder.encode(func.inputs, values);
+  return bytesToHex(concatBytes([sigHash, encodedParams]));
+}
+
 /**
  * Encode a balanceOf call for an ERC-20 token.
  *
@@ -384,7 +444,7 @@ const MULTICALL3_ADDRESS_BY_CHAIN: Record<Hex, Hex> = {
  * @returns The encoded call data.
  */
 function encodeBalanceOf(accountAddress: Address): Hex {
-  return erc20Interface.encodeFunctionData('balanceOf', [
+  return encodeFunctionData(erc20Interface, 'balanceOf', [
     accountAddress,
   ]) as Hex;
 }
@@ -396,7 +456,7 @@ function encodeBalanceOf(accountAddress: Address): Hex {
  * @returns The encoded call data.
  */
 function encodeGetEthBalance(accountAddress: Address): Hex {
-  return multicall3Interface.encodeFunctionData('getEthBalance', [
+  return encodeFunctionData(multicall3Interface, 'getEthBalance', [
     accountAddress,
   ]) as Hex;
 }
@@ -410,7 +470,7 @@ function encodeGetEthBalance(accountAddress: Address): Hex {
 export function encodeAggregate3(
   calls: readonly { target: Address; allowFailure: boolean; callData: Hex }[],
 ): Hex {
-  return multicall3Interface.encodeFunctionData('aggregate3', [
+  return encodeFunctionData(multicall3Interface, 'aggregate3', [
     calls.map((call) => ({
       target: call.target,
       allowFailure: call.allowFailure,

--- a/packages/assets-controller/src/data-sources/evm-rpc-services/clients/MulticallClient.ts
+++ b/packages/assets-controller/src/data-sources/evm-rpc-services/clients/MulticallClient.ts
@@ -1,5 +1,8 @@
 import { Interface } from '@ethersproject/abi';
-import { createServicePolicy, encodeFunctionData } from '@metamask/controller-utils';
+import {
+  createServicePolicy,
+  encodeFunctionData,
+} from '@metamask/controller-utils';
 import type { Hex } from '@metamask/utils';
 
 import { ZERO_ADDRESS } from '../../../utils/constants';

--- a/packages/controller-utils/CHANGELOG.md
+++ b/packages/controller-utils/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `encodeFunctionData` to improve ABI encoding speed for addresses ([#9057](https://github.com/MetaMask/core/pull/9057))
+- Add `encodeFunctionData` and `decodeFunctionResult` to improve ABI encoding speed for addresses ([#9057](https://github.com/MetaMask/core/pull/9057))
 
 ## [12.1.1]
 

--- a/packages/controller-utils/CHANGELOG.md
+++ b/packages/controller-utils/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `encodeFunctionData` to improve ABI encoding speed for addresses ([#9057](https://github.com/MetaMask/core/pull/9057))
+
 ## [12.1.1]
 
 ### Changed

--- a/packages/controller-utils/CHANGELOG.md
+++ b/packages/controller-utils/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `encodeFunctionData` and `decodeFunctionResult` to improve ABI encoding speed for addresses ([#9057](https://github.com/MetaMask/core/pull/9057))
+- Add `encodeFunctionData` to improve ABI encoding speed for addresses ([#9057](https://github.com/MetaMask/core/pull/9057))
 
 ## [12.1.1]
 

--- a/packages/controller-utils/package.json
+++ b/packages/controller-utils/package.json
@@ -51,6 +51,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
+    "@ethersproject/abi": "^5.7.0",
     "@metamask/eth-query": "^4.0.0",
     "@metamask/ethjs-unit": "^0.3.0",
     "@metamask/utils": "^11.9.0",

--- a/packages/controller-utils/src/abi.test.ts
+++ b/packages/controller-utils/src/abi.test.ts
@@ -1,7 +1,6 @@
 import { Interface } from '@ethersproject/abi';
-import { Hex } from '@metamask/utils';
 
-import { encodeFunctionData, decodeFunctionResult } from './abi';
+import { encodeFunctionData } from './abi';
 
 const ERC20_ABI = [
   {
@@ -21,14 +20,6 @@ const ERC20_ABI = [
     name: 'transfer',
     outputs: [{ name: '', type: 'bool' }],
     stateMutability: 'nonpayable',
-    type: 'function',
-  },
-  {
-    constant: true,
-    inputs: [],
-    name: 'owner',
-    outputs: [{ name: '', type: 'address' }],
-    stateMutability: 'view',
     type: 'function',
   },
 ] as const;
@@ -79,60 +70,7 @@ describe('encodeFunctionData', () => {
       expect(() =>
         encodeFunctionData(erc20Interface, 'nonExistentFunction', []),
       ).toThrow(
-        'no matching function (argument="name", value="nonExistentFunction", code=INVALID_ARGUMENT, version=abi/5.7.0)',
-      );
-    });
-  });
-});
-
-describe('decodeFunctionResult', () => {
-  describe('with the ERC-20 ABI', () => {
-    const erc20Interface = new Interface(ERC20_ABI);
-
-    it('decodes a single uint256 output', () => {
-      const data = erc20Interface.encodeFunctionResult('balanceOf', [
-        '1000000000000000000',
-      ]) as Hex;
-
-      const result = decodeFunctionResult(erc20Interface, 'balanceOf', data);
-
-      expect(result[0].toString()).toBe('1000000000000000000');
-      expect(result).toStrictEqual(
-        erc20Interface.decodeFunctionResult('balanceOf', data),
-      );
-    });
-
-    it('decodes an address output and returns it checksummed', () => {
-      const data = erc20Interface.encodeFunctionResult('owner', [
-        ACCOUNT_ADDRESS.toLowerCase(),
-      ]) as Hex;
-
-      const result = decodeFunctionResult(erc20Interface, 'owner', data);
-
-      expect(result[0]).toBe(ACCOUNT_ADDRESS);
-      expect(result).toStrictEqual(
-        erc20Interface.decodeFunctionResult('owner', data),
-      );
-    });
-
-    it('decodes a boolean output', () => {
-      const data = erc20Interface.encodeFunctionResult('transfer', [
-        true,
-      ]) as Hex;
-
-      const result = decodeFunctionResult(erc20Interface, 'transfer', data);
-
-      expect(result[0]).toBe(true);
-      expect(result).toStrictEqual(
-        erc20Interface.decodeFunctionResult('transfer', data),
-      );
-    });
-
-    it('throws when the function does not exist', () => {
-      expect(() =>
-        decodeFunctionResult(erc20Interface, 'nonExistentFunction', '0x'),
-      ).toThrow(
-        'no matching function (argument="name", value="nonExistentFunction", code=INVALID_ARGUMENT, version=abi/5.7.0)',
+        'no matching function (argument=\"name\", value=\"nonExistentFunction\", code=INVALID_ARGUMENT, version=abi/5.7.0)',
       );
     });
   });

--- a/packages/controller-utils/src/abi.test.ts
+++ b/packages/controller-utils/src/abi.test.ts
@@ -1,6 +1,7 @@
 import { Interface } from '@ethersproject/abi';
+import { Hex } from '@metamask/utils';
 
-import { encodeFunctionData } from './abi';
+import { encodeFunctionData, decodeFunctionResult } from './abi';
 
 const ERC20_ABI = [
   {
@@ -20,6 +21,14 @@ const ERC20_ABI = [
     name: 'transfer',
     outputs: [{ name: '', type: 'bool' }],
     stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    constant: true,
+    inputs: [],
+    name: 'owner',
+    outputs: [{ name: '', type: 'address' }],
+    stateMutability: 'view',
     type: 'function',
   },
 ] as const;
@@ -70,7 +79,60 @@ describe('encodeFunctionData', () => {
       expect(() =>
         encodeFunctionData(erc20Interface, 'nonExistentFunction', []),
       ).toThrow(
-        'no matching function (argument=\"name\", value=\"nonExistentFunction\", code=INVALID_ARGUMENT, version=abi/5.7.0)',
+        'no matching function (argument="name", value="nonExistentFunction", code=INVALID_ARGUMENT, version=abi/5.7.0)',
+      );
+    });
+  });
+});
+
+describe('decodeFunctionResult', () => {
+  describe('with the ERC-20 ABI', () => {
+    const erc20Interface = new Interface(ERC20_ABI);
+
+    it('decodes a single uint256 output', () => {
+      const data = erc20Interface.encodeFunctionResult('balanceOf', [
+        '1000000000000000000',
+      ]) as Hex;
+
+      const result = decodeFunctionResult(erc20Interface, 'balanceOf', data);
+
+      expect(result[0].toString()).toBe('1000000000000000000');
+      expect(result).toStrictEqual(
+        erc20Interface.decodeFunctionResult('balanceOf', data),
+      );
+    });
+
+    it('decodes an address output and returns it checksummed', () => {
+      const data = erc20Interface.encodeFunctionResult('owner', [
+        ACCOUNT_ADDRESS.toLowerCase(),
+      ]) as Hex;
+
+      const result = decodeFunctionResult(erc20Interface, 'owner', data);
+
+      expect(result[0]).toBe(ACCOUNT_ADDRESS);
+      expect(result).toStrictEqual(
+        erc20Interface.decodeFunctionResult('owner', data),
+      );
+    });
+
+    it('decodes a boolean output', () => {
+      const data = erc20Interface.encodeFunctionResult('transfer', [
+        true,
+      ]) as Hex;
+
+      const result = decodeFunctionResult(erc20Interface, 'transfer', data);
+
+      expect(result[0]).toBe(true);
+      expect(result).toStrictEqual(
+        erc20Interface.decodeFunctionResult('transfer', data),
+      );
+    });
+
+    it('throws when the function does not exist', () => {
+      expect(() =>
+        decodeFunctionResult(erc20Interface, 'nonExistentFunction', '0x'),
+      ).toThrow(
+        'no matching function (argument="name", value="nonExistentFunction", code=INVALID_ARGUMENT, version=abi/5.7.0)',
       );
     });
   });

--- a/packages/controller-utils/src/abi.test.ts
+++ b/packages/controller-utils/src/abi.test.ts
@@ -70,7 +70,7 @@ describe('encodeFunctionData', () => {
       expect(() =>
         encodeFunctionData(erc20Interface, 'nonExistentFunction', []),
       ).toThrow(
-        'no matching function (argument=\"name\", value=\"nonExistentFunction\", code=INVALID_ARGUMENT, version=abi/5.7.0)',
+        'no matching function (argument="name", value="nonExistentFunction", code=INVALID_ARGUMENT, version=abi/5.7.0)',
       );
     });
   });

--- a/packages/controller-utils/src/abi.test.ts
+++ b/packages/controller-utils/src/abi.test.ts
@@ -1,0 +1,77 @@
+import { Interface } from '@ethersproject/abi';
+
+import { encodeFunctionData } from './abi';
+
+const ERC20_ABI = [
+  {
+    constant: true,
+    inputs: [{ name: '_owner', type: 'address' }],
+    name: 'balanceOf',
+    outputs: [{ name: 'balance', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    constant: false,
+    inputs: [
+      { name: '_to', type: 'address' },
+      { name: '_value', type: 'uint256' },
+    ],
+    name: 'transfer',
+    outputs: [{ name: '', type: 'bool' }],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+] as const;
+
+const ACCOUNT_ADDRESS = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+
+describe('encodeFunctionData', () => {
+  describe('with the ERC-20 ABI', () => {
+    const erc20Interface = new Interface(ERC20_ABI);
+
+    it('encodes a function with a single address parameter', () => {
+      const result = encodeFunctionData(erc20Interface, 'balanceOf', [
+        ACCOUNT_ADDRESS,
+      ]);
+
+      expect(result).toBe(
+        erc20Interface.encodeFunctionData('balanceOf', [ACCOUNT_ADDRESS]),
+      );
+    });
+
+    it('encodes a function with multiple parameters', () => {
+      const result = encodeFunctionData(erc20Interface, 'transfer', [
+        ACCOUNT_ADDRESS,
+        '1000000000000000000',
+      ]);
+
+      expect(result).toBe(
+        erc20Interface.encodeFunctionData('transfer', [
+          ACCOUNT_ADDRESS,
+          '1000000000000000000',
+        ]),
+      );
+    });
+
+    it('encodes addresses that are not checksummed', () => {
+      const lowercaseAddress = ACCOUNT_ADDRESS.toLowerCase();
+
+      const result = encodeFunctionData(erc20Interface, 'balanceOf', [
+        lowercaseAddress,
+      ]);
+
+      expect(result).toBe(
+        erc20Interface.encodeFunctionData('balanceOf', [ACCOUNT_ADDRESS]),
+      );
+    });
+
+    it('throws when the function does not exist', () => {
+      expect(() =>
+        encodeFunctionData(erc20Interface, 'nonExistentFunction', []),
+      ).toThrow(
+        'no matching function (argument=\"name\", value=\"nonExistentFunction\", code=INVALID_ARGUMENT, version=abi/5.7.0)',
+      );
+    });
+  });
+});

--- a/packages/controller-utils/src/abi.ts
+++ b/packages/controller-utils/src/abi.ts
@@ -41,6 +41,7 @@ class FastAddressCoder implements Coder {
     return '0x0000000000000000000000000000000000000000';
   }
 
+  /* istanbul ignore next */
   _throwError(_message: string, _value: unknown): void {
     throw new Error('Method not implemented.');
   }

--- a/packages/controller-utils/src/abi.ts
+++ b/packages/controller-utils/src/abi.ts
@@ -1,10 +1,11 @@
-import { AbiCoder, Interface, ParamType } from '@ethersproject/abi';
+import { AbiCoder, Interface, ParamType, Result } from '@ethersproject/abi';
 import {
   concatBytes,
   hexToBytes,
   bytesToHex,
   getChecksumAddress,
   add0x,
+  assert,
 } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
 
@@ -73,4 +74,32 @@ export function encodeFunctionData(
   const sigHash = hexToBytes(abi.getSighash(func));
   const encodedParams = fastAbiCoder.encode(func.inputs, values);
   return bytesToHex(concatBytes([sigHash, encodedParams]));
+}
+
+/**
+ * Decode the data returned from a function call.
+ *
+ * Note: This uses `@ethersproject/abi` under the hood, but with some performance optimizations.
+ *
+ * @param abi - The ABI instance.
+ * @param functionName - The function name.
+ * @param data - The data to decode.
+ * @returns The decoded data for the function call.
+ */
+export function decodeFunctionResult(
+  abi: Interface,
+  functionName: string,
+  data: Hex,
+): Result {
+  const func = abi.getFunction(functionName);
+  assert(
+    func.outputs,
+    'ABI outputs are required when using decodeFunctionResult.',
+  );
+  try {
+    return fastAbiCoder.decode(func.outputs, data);
+  } catch {
+    // In case of failure, fallback to slower Ethers implementation.
+    return abi.decodeFunctionData(func, data);
+  }
 }

--- a/packages/controller-utils/src/abi.ts
+++ b/packages/controller-utils/src/abi.ts
@@ -38,7 +38,7 @@ class FastAddressCoder {
   }
 
   defaultValue(): string {
-    return "0x0000000000000000000000000000000000000000";
+    return '0x0000000000000000000000000000000000000000';
   }
 }
 
@@ -56,9 +56,9 @@ const fastAbiCoder = new FastAbiCoder();
 
 /**
  * Encode the data required for a function call.
- * 
+ *
  * Note: This uses `@ethersproject/abi` under the hood, but with some performance optimizations.
- * 
+ *
  * @param abi - The ABI instance.
  * @param functionName - The function name.
  * @param values - The parameters to encode.

--- a/packages/controller-utils/src/abi.ts
+++ b/packages/controller-utils/src/abi.ts
@@ -1,0 +1,76 @@
+import { AbiCoder, Interface, ParamType } from '@ethersproject/abi';
+import {
+  concatBytes,
+  hexToBytes,
+  bytesToHex,
+  getChecksumAddress,
+  add0x,
+} from '@metamask/utils';
+import type { Hex } from '@metamask/utils';
+
+// Ethers does not export these unfortunately.
+type Coder = ReturnType<AbiCoder['_getCoder']>;
+type Writer = Parameters<Coder['encode']>[0];
+type Reader = Parameters<Coder['decode']>[0];
+
+// FastAddressCoder that skips checksumming addresses when encoding and uses the memoized `getChecksumAddress` for decoding.
+class FastAddressCoder {
+  name = 'address';
+
+  type = 'address';
+
+  dynamic = false;
+
+  localName: string;
+
+  constructor(localName: string) {
+    this.localName = localName;
+  }
+
+  encode(writer: Writer, value: string): number {
+    return writer.writeValue(value);
+  }
+
+  decode(reader: Reader): unknown {
+    const value = reader.readValue();
+    const paddedHex = value.toHexString().slice(2).padStart(40);
+    return getChecksumAddress(add0x(paddedHex));
+  }
+
+  defaultValue(): string {
+    return "0x0000000000000000000000000000000000000000";
+  }
+}
+
+class FastAbiCoder extends AbiCoder {
+  _getCoder(param: ParamType): Coder {
+    if (param.type === 'address') {
+      // Casting since we are missing internal unused methods, such _throwError.
+      return new FastAddressCoder(param.name) as unknown as Coder;
+    }
+    return super._getCoder(param);
+  }
+}
+
+const fastAbiCoder = new FastAbiCoder();
+
+/**
+ * Encode the data required for a function call.
+ * 
+ * Note: This uses `@ethersproject/abi` under the hood, but with some performance optimizations.
+ * 
+ * @param abi - The ABI instance.
+ * @param functionName - The function name.
+ * @param values - The parameters to encode.
+ * @returns The encoded data for the function call in hexadecimal.
+ */
+export function encodeFunctionData(
+  abi: Interface,
+  functionName: string,
+  values: unknown[],
+): Hex {
+  const func = abi.getFunction(functionName);
+  const sigHash = hexToBytes(abi.getSighash(func));
+  const encodedParams = fastAbiCoder.encode(func.inputs, values);
+  return bytesToHex(concatBytes([sigHash, encodedParams]));
+}

--- a/packages/controller-utils/src/abi.ts
+++ b/packages/controller-utils/src/abi.ts
@@ -57,7 +57,9 @@ const fastAbiCoder = new FastAbiCoder();
 /**
  * Encode the data required for a function call.
  *
- * Note: This uses `@ethersproject/abi` under the hood, but with some performance optimizations.
+ * Note: This uses `@ethersproject/abi` under the hood, but for improved
+ * performance, does not verify checksums of addresses. Make sure addresses
+ * passed to this function are valid and checksummed if necessary.
  *
  * @param abi - The ABI instance.
  * @param functionName - The function name.

--- a/packages/controller-utils/src/abi.ts
+++ b/packages/controller-utils/src/abi.ts
@@ -14,7 +14,7 @@ type Writer = Parameters<Coder['encode']>[0];
 type Reader = Parameters<Coder['decode']>[0];
 
 // FastAddressCoder that skips checksumming addresses when encoding and uses the memoized `getChecksumAddress` for decoding.
-class FastAddressCoder {
+class FastAddressCoder implements Coder {
   name = 'address';
 
   type = 'address';
@@ -40,13 +40,16 @@ class FastAddressCoder {
   defaultValue(): string {
     return '0x0000000000000000000000000000000000000000';
   }
+
+  _throwError(_message: string, _value: unknown): void {
+    throw new Error('Method not implemented.');
+  }
 }
 
 class FastAbiCoder extends AbiCoder {
   _getCoder(param: ParamType): Coder {
     if (param.type === 'address') {
-      // Casting since we are missing internal unused methods, such _throwError.
-      return new FastAddressCoder(param.name) as unknown as Coder;
+      return new FastAddressCoder(param.name);
     }
     return super._getCoder(param);
   }

--- a/packages/controller-utils/src/abi.ts
+++ b/packages/controller-utils/src/abi.ts
@@ -1,11 +1,10 @@
-import { AbiCoder, Interface, ParamType, Result } from '@ethersproject/abi';
+import { AbiCoder, Interface, ParamType } from '@ethersproject/abi';
 import {
   concatBytes,
   hexToBytes,
   bytesToHex,
   getChecksumAddress,
   add0x,
-  assert,
 } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
 
@@ -74,32 +73,4 @@ export function encodeFunctionData(
   const sigHash = hexToBytes(abi.getSighash(func));
   const encodedParams = fastAbiCoder.encode(func.inputs, values);
   return bytesToHex(concatBytes([sigHash, encodedParams]));
-}
-
-/**
- * Decode the data returned from a function call.
- *
- * Note: This uses `@ethersproject/abi` under the hood, but with some performance optimizations.
- *
- * @param abi - The ABI instance.
- * @param functionName - The function name.
- * @param data - The data to decode.
- * @returns The decoded data for the function call.
- */
-export function decodeFunctionResult(
-  abi: Interface,
-  functionName: string,
-  data: Hex,
-): Result {
-  const func = abi.getFunction(functionName);
-  assert(
-    func.outputs,
-    'ABI outputs are required when using decodeFunctionResult.',
-  );
-  try {
-    return fastAbiCoder.decode(func.outputs, data);
-  } catch {
-    // In case of failure, fallback to slower Ethers implementation.
-    return abi.decodeFunctionData(func, data);
-  }
 }

--- a/packages/controller-utils/src/index.test.ts
+++ b/packages/controller-utils/src/index.test.ts
@@ -5,6 +5,7 @@ describe('@metamask/controller-utils', () => {
     expect(Object.keys(allExports)).toMatchInlineSnapshot(`
       [
         "encodeFunctionData",
+        "decodeFunctionResult",
         "BrokenCircuitError",
         "CircuitState",
         "CockatielEventEmitter",

--- a/packages/controller-utils/src/index.test.ts
+++ b/packages/controller-utils/src/index.test.ts
@@ -4,6 +4,7 @@ describe('@metamask/controller-utils', () => {
   it('has expected JavaScript exports', () => {
     expect(Object.keys(allExports)).toMatchInlineSnapshot(`
       [
+        "encodeFunctionData",
         "BrokenCircuitError",
         "CircuitState",
         "CockatielEventEmitter",

--- a/packages/controller-utils/src/index.test.ts
+++ b/packages/controller-utils/src/index.test.ts
@@ -5,7 +5,6 @@ describe('@metamask/controller-utils', () => {
     expect(Object.keys(allExports)).toMatchInlineSnapshot(`
       [
         "encodeFunctionData",
-        "decodeFunctionResult",
         "BrokenCircuitError",
         "CircuitState",
         "CockatielEventEmitter",

--- a/packages/controller-utils/src/index.ts
+++ b/packages/controller-utils/src/index.ts
@@ -1,3 +1,4 @@
+export { encodeFunctionData } from './abi';
 export {
   BrokenCircuitError,
   CircuitState,

--- a/packages/controller-utils/src/index.ts
+++ b/packages/controller-utils/src/index.ts
@@ -1,4 +1,4 @@
-export { encodeFunctionData } from './abi';
+export { encodeFunctionData, decodeFunctionResult } from './abi';
 export {
   BrokenCircuitError,
   CircuitState,

--- a/packages/controller-utils/src/index.ts
+++ b/packages/controller-utils/src/index.ts
@@ -1,4 +1,4 @@
-export { encodeFunctionData, decodeFunctionResult } from './abi';
+export { encodeFunctionData } from './abi';
 export {
   BrokenCircuitError,
   CircuitState,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6212,6 +6212,7 @@ __metadata:
   resolution: "@metamask/controller-utils@workspace:packages/controller-utils"
   dependencies:
     "@babel/runtime": "npm:^7.23.9"
+    "@ethersproject/abi": "npm:^5.7.0"
     "@metamask/auto-changelog": "npm:^6.1.0"
     "@metamask/eth-query": "npm:^4.0.0"
     "@metamask/ethjs-unit": "npm:^0.3.0"


### PR DESCRIPTION
## Explanation

Improve `MulticallClient` performance by speeding up ABI encoding by introducing `encodeFunctionData` which skips calculating checksums.

```
encodeFunctionData — balanceOf(address) (100,000 iterations)
  controller-utils                 607.31 ms         164,661 ops/s
  ethers                          1160.67 ms          86,157 ops/s
  → controller-utils is 1.91x faster

encodeFunctionData — aggregate3(tuple[]) (100,000 iterations)
  controller-utils               54318.63 ms           1,841 ops/s
  ethers                         98961.99 ms           1,010 ops/s
  → controller-utils is 1.82x faster
```

## References

https://consensyssoftware.atlassian.net/browse/WPC-1063

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Encoding output is validated against ethers in tests; risk is mainly assuming inputs are valid addresses without checksum enforcement at encode time.
> 
> **Overview**
> Adds **`encodeFunctionData`** to `@metamask/controller-utils`: ABI call encoding via a custom `FastAbiCoder` that avoids ethers’ address checksumming on encode (documented tradeoff: callers must supply valid addresses). The package now depends on `@ethersproject/abi` and includes unit tests plus export snapshot updates.
> 
> **`MulticallClient`** in assets-controller routes `balanceOf`, `getEthBalance`, and **`aggregate3`** encoding through the new helper instead of `Interface.encodeFunctionData`, with a test asserting **byte-identical** calldata vs the standard ethers path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c24588709b53d17134fe27c59016f496c6eae1c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->