### PR TITLE
Fix threshold flag fallback without MetaMetrics ID

### DIFF
--- a/packages/remote-feature-flag-controller/CHANGELOG.md
+++ b/packages/remote-feature-flag-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Process threshold feature flags without a MetaMetrics ID by selecting the first valid threshold entry instead of preserving the raw threshold array ([#9059](https://github.com/MetaMask/core/pull/9059))
+
 ## [4.2.2]
 
 ### Changed

--- a/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.test.ts
+++ b/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.test.ts
@@ -1474,7 +1474,7 @@ describe('RemoteFeatureFlagController', () => {
       jest.useRealTimers();
     });
 
-    it('preserves threshold arrays when metaMetricsId is empty', async () => {
+    it('selects the first threshold group when metaMetricsId is empty', async () => {
       // Arrange
       const mockFlags = {
         thresholdFlag: [
@@ -1503,10 +1503,53 @@ describe('RemoteFeatureFlagController', () => {
         'RemoteFeatureFlagController:updateRemoteFeatureFlags',
       );
 
-      // Assert - Array preserved as-is without processing
+      // Assert - First threshold group selected without calculating a bucket
       expect(controller.state.remoteFeatureFlags.thresholdFlag).toStrictEqual(
-        mockFlags.thresholdFlag,
+        {
+          name: 'groupA',
+          value: 'A',
+        },
       );
+      expect(controller.state.thresholdCache).toStrictEqual({});
+    });
+
+    it('selects the first direct threshold value when metaMetricsId is empty', async () => {
+      // Arrange
+      const thresholdFlagValue = {
+        payStrategies: {
+          relay: {
+            gaslessEnabled: true,
+          },
+        },
+      };
+      const mockFlags = {
+        thresholdFlag: [
+          {
+            thresholdName: 'enabled',
+            thresholdVersion: ThresholdVersion.DirectValue,
+            scope: { type: 'threshold', value: 1.0 },
+            value: thresholdFlagValue,
+          },
+        ],
+      };
+      const clientConfigApiService = buildClientConfigApiService({
+        remoteFeatureFlags: mockFlags,
+      });
+      const { controller, messenger } = createController({
+        clientConfigApiService,
+        getMetaMetricsId: () => '',
+      });
+
+      // Act
+      await messenger.call(
+        'RemoteFeatureFlagController:updateRemoteFeatureFlags',
+      );
+
+      // Assert
+      expect(controller.state.remoteFeatureFlags.thresholdFlag).toStrictEqual(
+        thresholdFlagValue,
+      );
+      expect(controller.state.thresholdCache).toStrictEqual({});
     });
 
     it('handles flag names containing colons correctly', async () => {

--- a/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.ts
+++ b/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.ts
@@ -343,21 +343,20 @@ export class RemoteFeatureFlagController extends BaseController<
       }
 
       if (Array.isArray(processedValue)) {
-        // Validate array has valid threshold items before doing expensive crypto operation
-        const hasValidThresholds = processedValue.some(
+        const thresholdValues = processedValue.filter(
           isFeatureFlagWithScopeValue,
         );
 
-        if (!hasValidThresholds) {
+        if (thresholdValues.length === 0) {
           // Not a threshold array - preserve as-is
           processedFlags[remoteFeatureFlagName] = processedValue;
           continue;
         }
 
-        // Skip threshold processing if metaMetricsId is not available
         if (!metaMetricsId) {
-          // Preserve array as-is when user hasn't opted into MetaMetrics
-          processedFlags[remoteFeatureFlagName] = processedValue;
+          processedFlags[remoteFeatureFlagName] = normalizeThresholdValue(
+            thresholdValues[0],
+          );
           continue;
         }
 
@@ -376,15 +375,9 @@ export class RemoteFeatureFlagController extends BaseController<
         }
 
         const threshold = thresholdValue;
-        const selectedGroup = processedValue.find(
-          (featureFlag): featureFlag is FeatureFlagScopeValue => {
-            if (!isFeatureFlagWithScopeValue(featureFlag)) {
-              return false;
-            }
-
-            return threshold <= featureFlag.scope.value;
-          },
-        );
+        const selectedGroup = thresholdValues.find((featureFlag) => {
+          return threshold <= featureFlag.scope.value;
+        });
 
         if (selectedGroup) {
           processedValue = normalizeThresholdValue(selectedGroup);


### PR DESCRIPTION
## What changed

Remote feature flag threshold arrays now fall back to the first valid threshold entry when there is no MetaMetrics ID available. This keeps threshold flags in their processed shape instead of exposing the raw array to consumers.

The change preserves the existing behavior for non-threshold arrays, and it supports both legacy threshold wrappers and `ThresholdVersion.DirectValue` entries.

## Why

Users who have not opted into MetaMetrics do not have a MetaMetrics ID, so the controller could not calculate a threshold bucket. The previous behavior passed the raw threshold array through, which caused consumers such as `confirmations_pay_extended` to miss nested values like `payStrategies.relay.gaslessEnabled`.
