### PR TITLE
chore: register `stopAllPolling` to `SubscriptionController` messenger

### DIFF
--- a/packages/subscription-controller/CHANGELOG.md
+++ b/packages/subscription-controller/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Expose missing `SubscriptionController:stopAllPolling` action through its messenger ([#9061](https://github.com/MetaMask/core/pull/9061))
+  - Corresponding action type is available as well.
+
 ### Changed
 
 - Bump `@metamask/controller-utils` from `^12.0.0` to `^12.1.0` ([#8774](https://github.com/MetaMask/core/pull/8774))

--- a/packages/subscription-controller/src/SubscriptionController-method-action-types.ts
+++ b/packages/subscription-controller/src/SubscriptionController-method-action-types.ts
@@ -227,6 +227,11 @@ export type SubscriptionControllerTriggerAccessTokenRefreshAction = {
   handler: SubscriptionController['triggerAccessTokenRefresh'];
 };
 
+export type SubscriptionControllerStopAllPollingAction = {
+  type: `SubscriptionController:stopAllPolling`;
+  handler: SubscriptionController['stopAllPolling'];
+};
+
 /**
  * Union of all SubscriptionController action types.
  */
@@ -252,4 +257,5 @@ export type SubscriptionControllerMethodActions =
   | SubscriptionControllerGetTokenApproveAmountAction
   | SubscriptionControllerGetTokenMinimumBalanceAmountAction
   | SubscriptionControllerClearStateAction
-  | SubscriptionControllerTriggerAccessTokenRefreshAction;
+  | SubscriptionControllerTriggerAccessTokenRefreshAction
+  | SubscriptionControllerStopAllPollingAction;

--- a/packages/subscription-controller/src/SubscriptionController.ts
+++ b/packages/subscription-controller/src/SubscriptionController.ts
@@ -197,6 +197,7 @@ const MESSENGER_EXPOSED_METHODS = [
   'unCancelSubscription',
   'startShieldSubscriptionWithCard',
   'startSubscriptionWithCrypto',
+  'stopAllPolling',
   'submitShieldSubscriptionCryptoApproval',
   'getCryptoApproveTransactionParams',
   'updatePaymentMethod',

--- a/packages/subscription-controller/src/index.ts
+++ b/packages/subscription-controller/src/index.ts
@@ -32,6 +32,7 @@ export type {
   SubscriptionControllerGetTokenMinimumBalanceAmountAction,
   SubscriptionControllerClearStateAction,
   SubscriptionControllerTriggerAccessTokenRefreshAction,
+  SubscriptionControllerStopAllPollingAction,
 } from './SubscriptionController-method-action-types';
 export {
   SubscriptionController,


### PR DESCRIPTION
## Explanation

This registers the `stopAllPolling` method available in `SubscriptionController` to its messenger.

## References

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Messenger registration and type exports only; no change to polling behavior itself.
> 
> **Overview**
> Registers the existing **`stopAllPolling`** polling API on **`SubscriptionController`** so other packages can invoke it via the messenger as **`SubscriptionController:stopAllPolling`**.
> 
> Adds **`SubscriptionControllerStopAllPollingAction`** to the method-action types union, includes **`stopAllPolling`** in **`MESSENGER_EXPOSED_METHODS`**, exports the action type from the package entrypoint, and documents the change in the changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abee7d5897e26f8563ad4d6a69bcb6f365be2d74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->