### PR TITLE
chore: add unknown to feature ids

### DIFF
--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `UNKNOWN` to `FeatureId` enum
+- Add `UNKNOWN` to `FeatureId` enum ([#9071](https://github.com/MetaMask/core/pull/9071))
 
 ## [75.0.0]
 

--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `UNKNOWN` to `FeatureId` enum
+
 ## [75.0.0]
 
 ### Added

--- a/packages/bridge-controller/src/types.ts
+++ b/packages/bridge-controller/src/types.ts
@@ -259,6 +259,7 @@ export enum StatusTypes {
 }
 
 export enum FeatureId {
+  UNKNOWN = 'unknown',
   PERPS = 'perps',
   QUICK_BUY_FOLLOW_TRADING = 'quick_buy_follow_trading',
   QUICK_BUY_TOKEN_DETAILS = 'quick_buy_token_details',


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

`FeatureId` in `@metamask/bridge-controller` enumerates the client experiences that request quotes and emit Unified Swap/Bridge analytics (e.g. `perps`, `unified_swap_bridge`, `dapp_swap`). There was no explicit value for cases where the originating feature cannot be determined, so callers had to reuse an existing ID (typically `UNIFIED_SWAP_BRIDGE`) or omit `featureId` entirely and rely on controller fallbacks.

This PR adds `FeatureId.UNKNOWN = 'unknown'` to the enum. The string value follows the existing snake_case segment convention used by other `FeatureId` members. Callers can now pass `FeatureId.UNKNOWN` explicitly to `fetchQuotes`, quote requests, and analytics events when the feature context is unavailable.

No controller behavior changes are included. Sorting, quote-request overrides, and metrics fallbacks (which still default to `UNIFIED_SWAP_BRIDGE` when `featureId` is absent) are unchanged. This is an additive, non-breaking export.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

* Related to #8964 (introduced `FeatureId` and required `feature_id` on analytics events)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Enum-only additive export with no runtime or controller logic changes; low risk aside from consumers optionally adopting the new analytics value.
> 
> **Overview**
> Adds **`FeatureId.UNKNOWN`** (`'unknown'`) to `@metamask/bridge-controller` so clients can tag quote fetches and Unified Swap/Bridge analytics when the originating UI/feature cannot be identified, instead of reusing another `FeatureId` or omitting the field.
> 
> This is an **additive, non-breaking** type export only; controller defaults and metrics behavior when `featureId` is missing are unchanged. The **Unreleased** changelog entry documents the new enum member.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3770e52cfb598362460c35082fde646e25914bfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->