### PR TITLE
fix: export network enablement state change event type

### DIFF
--- a/packages/network-enablement-controller/CHANGELOG.md
+++ b/packages/network-enablement-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Export `NetworkEnablementControllerStateChangeEvent` type from the package root
+- Export `NetworkEnablementControllerStateChangeEvent` type from the package root ([#9084](https://github.com/MetaMask/core/pull/9084))
 
 ### Changed
 

--- a/packages/network-enablement-controller/CHANGELOG.md
+++ b/packages/network-enablement-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Export `NetworkEnablementControllerStateChangeEvent` type from the package root
+
 ### Changed
 
 - Bump `@metamask/controller-utils` from `^12.1.0` to `^12.2.0` ([#9058](https://github.com/MetaMask/core/pull/9058), [#9083](https://github.com/MetaMask/core/pull/9083))

--- a/packages/network-enablement-controller/src/index.ts
+++ b/packages/network-enablement-controller/src/index.ts
@@ -5,6 +5,7 @@ export type {
   NetworkEnablementControllerGetStateAction,
   NetworkEnablementControllerActions,
   NetworkEnablementControllerEvents,
+  NetworkEnablementControllerStateChangeEvent,
   NetworkEnablementControllerMessenger,
   NativeAssetIdentifier,
   NativeAssetIdentifiersMap,


### PR DESCRIPTION
## Explanation

`NetworkEnablementControllerStateChangeEvent` is defined and included in `NetworkEnablementControllerEvents`, but it is not exported from the package root. Consumers therefore cannot import the concrete state change event type directly from `@metamask/network-enablement-controller`.

This change exports `NetworkEnablementControllerStateChangeEvent` from the package entry point and documents the new public type in the package changelog.

## References

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
  - No new tests are required for this type-only package export; the existing package test suite passes with 100% coverage.
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
  - No API documentation changes are required beyond the package changelog.
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them
  - This change is additive and does not introduce a breaking change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive type-only export with no runtime or behavioral changes.
> 
> **Overview**
> Re-exports **`NetworkEnablementControllerStateChangeEvent`** from `@metamask/network-enablement-controller` so consumers can import the concrete state-change event type from the package root (it was already defined on the controller but missing from the public entry point).
> 
> The **Unreleased** changelog records this as an additive public API change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12a298955b8987e2cd869b7aa7480a1ceea7e592. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->