### PR TITLE
feat: make fiat order polling interval and timeout configurable via feature flags

### DIFF
--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Make fiat order polling interval and timeout remotely configurable via `confirmations_pay_fiat.orderPollIntervalMs` and `confirmations_pay_fiat.orderPollTimeoutMs` feature flags
+- Make fiat order polling interval and timeout remotely configurable via `confirmations_pay_fiat.orderPollIntervalMs` and `confirmations_pay_fiat.orderPollTimeoutMs` feature flags ([#9090](https://github.com/MetaMask/core/pull/9090))
 
 ### Changed
 

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Make fiat order polling interval and timeout remotely configurable via `confirmations_pay_fiat.orderPollIntervalMs` and `confirmations_pay_fiat.orderPollTimeoutMs` feature flags
+
 ### Changed
 
 - Bump `@metamask/utils` from `^11.9.0` to `^11.11.0` ([#9074](https://github.com/MetaMask/core/pull/9074))

--- a/packages/transaction-pay-controller/src/strategy/fiat/fiat-submit.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/fiat-submit.test.ts
@@ -695,6 +695,60 @@ describe('submitFiatQuotes', () => {
     dateNowSpy.mockRestore();
   });
 
+  it('uses configurable poll timeout from feature flag', async () => {
+    const customTimeoutMs = 30000;
+
+    const dateNowSpy = jest
+      .spyOn(Date, 'now')
+      .mockReturnValueOnce(0)
+      .mockReturnValue(customTimeoutMs);
+
+    const pendingOrder = getFiatOrderMock({ status: RampsOrderStatus.Pending });
+    const callMock = jest.fn((action: string) => {
+      if (action === 'TransactionPayController:getState') {
+        return {
+          transactionData: {
+            [TRANSACTION_ID_MOCK]: {
+              fiatPayment: {
+                orderId: ORDER_ID_MOCK,
+                rampsQuote: RAMPS_QUOTE_MOCK,
+              },
+              isLoading: false,
+              tokens: [],
+            },
+          },
+        };
+      }
+      if (action === 'RampsController:getOrder') {
+        return pendingOrder;
+      }
+      if (action === 'RemoteFeatureFlagController:getState') {
+        return {
+          remoteFeatureFlags: {
+            confirmations_pay_fiat: { orderPollTimeoutMs: customTimeoutMs },
+          },
+        };
+      }
+      throw new Error(`Unexpected action: ${action}`);
+    });
+
+    const request: PayStrategyExecuteRequest<FiatQuote> = {
+      accountSupports7702: false,
+      isSmartTransaction: () => false,
+      messenger: {
+        call: callMock,
+      } as unknown as PayStrategyExecuteRequest<FiatQuote>['messenger'],
+      quotes: [getFiatQuoteMock()],
+      transaction: TRANSACTION_MOCK,
+    };
+
+    await expect(submitFiatQuotes(request)).rejects.toThrow(
+      'Fiat order polling timed out (last status: PENDING)',
+    );
+
+    dateNowSpy.mockRestore();
+  });
+
   it('throws if token info is unavailable for the fiat asset', async () => {
     resolveSourceAmountRawMock.mockRejectedValue(
       new Error(

--- a/packages/transaction-pay-controller/src/strategy/fiat/fiat-submit.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/fiat-submit.ts
@@ -12,6 +12,10 @@ import type {
   PayStrategyExecuteRequest,
   TransactionPayControllerMessenger,
 } from '../../types';
+import {
+  getFiatOrderPollIntervalMs,
+  getFiatOrderPollTimeoutMs,
+} from '../../utils/feature-flags';
 import { buildCaipAssetType } from '../../utils/token';
 import { updateTransaction } from '../../utils/transaction';
 import type { TransactionPayFiatAsset } from './constants';
@@ -25,9 +29,6 @@ import {
 } from './utils';
 
 const log = createModuleLogger(projectLogger, 'fiat-submit');
-
-const ORDER_POLL_INTERVAL_MS = 1000;
-const ORDER_POLL_TIMEOUT_MS = 10 * 60 * 1000;
 
 const TERMINAL_FAILURE_STATUSES: RampsOrderStatus[] = [
   RampsOrderStatus.Cancelled,
@@ -172,6 +173,8 @@ async function waitForOrderCompletion({
   transactionId: string;
   walletAddress: string;
 }): Promise<RampsOrder> {
+  const pollIntervalMs = getFiatOrderPollIntervalMs(messenger);
+  const pollTimeoutMs = getFiatOrderPollTimeoutMs(messenger);
   const startTime = Date.now();
   let lastStatus: string | undefined;
 
@@ -207,13 +210,13 @@ async function waitForOrderCompletion({
       }
     }
 
-    if (Date.now() - startTime >= ORDER_POLL_TIMEOUT_MS) {
+    if (Date.now() - startTime >= pollTimeoutMs) {
       throw new Error(
         `Fiat order polling timed out (last status: ${lastStatus})`,
       );
     }
 
-    await new Promise((resolve) => setTimeout(resolve, ORDER_POLL_INTERVAL_MS));
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
   }
 }
 

--- a/packages/transaction-pay-controller/src/utils/feature-flags.test.ts
+++ b/packages/transaction-pay-controller/src/utils/feature-flags.test.ts
@@ -21,6 +21,8 @@ import {
   getFiatEnabledTypes,
   getFiatFeeReserveMultiplier,
   getFiatMaxRateDriftPercent,
+  getFiatOrderPollIntervalMs,
+  getFiatOrderPollTimeoutMs,
   DEFAULT_RELAY_EXECUTE_URL,
   getServerPollingInterval,
   getServerPollingTimeout,
@@ -1655,6 +1657,94 @@ describe('Feature Flags Utils', () => {
       });
 
       expect(getFiatMaxRateDriftPercent(messenger)).toBe(10);
+    });
+  });
+
+  describe('getFiatOrderPollIntervalMs', () => {
+    it('returns 1000 when feature flag is not set', () => {
+      getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+        ...getDefaultRemoteFeatureFlagControllerState(),
+        remoteFeatureFlags: {},
+      });
+
+      expect(getFiatOrderPollIntervalMs(messenger)).toBe(1000);
+    });
+
+    it('returns the configured value from feature flag', () => {
+      getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+        ...getDefaultRemoteFeatureFlagControllerState(),
+        remoteFeatureFlags: {
+          confirmations_pay_fiat: { orderPollIntervalMs: 5000 },
+        },
+      });
+
+      expect(getFiatOrderPollIntervalMs(messenger)).toBe(5000);
+    });
+
+    it('returns 1000 when value is zero', () => {
+      getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+        ...getDefaultRemoteFeatureFlagControllerState(),
+        remoteFeatureFlags: {
+          confirmations_pay_fiat: { orderPollIntervalMs: 0 },
+        },
+      });
+
+      expect(getFiatOrderPollIntervalMs(messenger)).toBe(1000);
+    });
+
+    it('returns 1000 when value is negative', () => {
+      getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+        ...getDefaultRemoteFeatureFlagControllerState(),
+        remoteFeatureFlags: {
+          confirmations_pay_fiat: { orderPollIntervalMs: -500 },
+        },
+      });
+
+      expect(getFiatOrderPollIntervalMs(messenger)).toBe(1000);
+    });
+  });
+
+  describe('getFiatOrderPollTimeoutMs', () => {
+    it('returns 600000 when feature flag is not set', () => {
+      getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+        ...getDefaultRemoteFeatureFlagControllerState(),
+        remoteFeatureFlags: {},
+      });
+
+      expect(getFiatOrderPollTimeoutMs(messenger)).toBe(600000);
+    });
+
+    it('returns the configured value from feature flag', () => {
+      getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+        ...getDefaultRemoteFeatureFlagControllerState(),
+        remoteFeatureFlags: {
+          confirmations_pay_fiat: { orderPollTimeoutMs: 300000 },
+        },
+      });
+
+      expect(getFiatOrderPollTimeoutMs(messenger)).toBe(300000);
+    });
+
+    it('returns 600000 when value is zero', () => {
+      getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+        ...getDefaultRemoteFeatureFlagControllerState(),
+        remoteFeatureFlags: {
+          confirmations_pay_fiat: { orderPollTimeoutMs: 0 },
+        },
+      });
+
+      expect(getFiatOrderPollTimeoutMs(messenger)).toBe(600000);
+    });
+
+    it('returns 600000 when value is negative', () => {
+      getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+        ...getDefaultRemoteFeatureFlagControllerState(),
+        remoteFeatureFlags: {
+          confirmations_pay_fiat: { orderPollTimeoutMs: -1000 },
+        },
+      });
+
+      expect(getFiatOrderPollTimeoutMs(messenger)).toBe(600000);
     });
   });
 });

--- a/packages/transaction-pay-controller/src/utils/feature-flags.ts
+++ b/packages/transaction-pay-controller/src/utils/feature-flags.ts
@@ -28,6 +28,8 @@ type StrategyOrder = TransactionPayStrategy[];
 
 export const DEFAULT_FEE_RESERVE_MULTIPLIER = 1.2;
 export const DEFAULT_MAX_RATE_DRIFT_PERCENT = 10;
+export const DEFAULT_ORDER_POLL_INTERVAL_MS = 1000;
+export const DEFAULT_ORDER_POLL_TIMEOUT_MS = 10 * 60 * 1000;
 
 export const DEFAULT_GAS_BUFFER = 1.0;
 export const DEFAULT_FALLBACK_GAS_ESTIMATE = 900000;
@@ -98,6 +100,8 @@ type FiatFlags = {
   enabledTransactionTypes: TransactionType[];
   feeReserveMultiplier?: number;
   maxRateDriftPercent?: number;
+  orderPollIntervalMs?: number;
+  orderPollTimeoutMs?: number;
 };
 
 type StrategyRoutingConfig = {
@@ -892,6 +896,54 @@ export function getFiatMaxRateDriftPercent(
   return typeof maxDrift === 'number' && maxDrift > 0
     ? maxDrift
     : DEFAULT_MAX_RATE_DRIFT_PERCENT;
+}
+
+/**
+ * Returns the fiat order poll interval in milliseconds.
+ *
+ * Controls how frequently the fiat order status is polled during
+ * the on-ramp completion wait loop. Defaults to 1 000 ms.
+ *
+ * @param messenger - Controller messenger.
+ * @returns The poll interval in milliseconds.
+ */
+export function getFiatOrderPollIntervalMs(
+  messenger: TransactionPayControllerMessenger,
+): number {
+  const state = messenger.call('RemoteFeatureFlagController:getState');
+  const fiatFlags = state.remoteFeatureFlags?.confirmations_pay_fiat as
+    | FiatFlags
+    | undefined;
+
+  const interval = fiatFlags?.orderPollIntervalMs;
+
+  return typeof interval === 'number' && interval > 0
+    ? interval
+    : DEFAULT_ORDER_POLL_INTERVAL_MS;
+}
+
+/**
+ * Returns the fiat order poll timeout in milliseconds.
+ *
+ * Controls how long the fiat order polling loop waits for a terminal
+ * status before timing out. Defaults to 600 000 ms (10 minutes).
+ *
+ * @param messenger - Controller messenger.
+ * @returns The poll timeout in milliseconds.
+ */
+export function getFiatOrderPollTimeoutMs(
+  messenger: TransactionPayControllerMessenger,
+): number {
+  const state = messenger.call('RemoteFeatureFlagController:getState');
+  const fiatFlags = state.remoteFeatureFlags?.confirmations_pay_fiat as
+    | FiatFlags
+    | undefined;
+
+  const timeout = fiatFlags?.orderPollTimeoutMs;
+
+  return typeof timeout === 'number' && timeout > 0
+    ? timeout
+    : DEFAULT_ORDER_POLL_TIMEOUT_MS;
 }
 
 /**


### PR DESCRIPTION
## Explanation

The fiat order polling loop in `fiat-submit.ts` previously used hardcoded values for the poll interval (1 second) and timeout (10 minutes). This change makes both values remotely configurable through the `confirmations_pay_fiat` feature flag, using the existing values as defaults when the flag is not set.

- `confirmations_pay_fiat.orderPollIntervalMs` — controls how frequently the fiat order status is polled (default: 1000ms)
- `confirmations_pay_fiat.orderPollTimeoutMs` — controls how long the polling loop waits before timing out (default: 600000ms / 10 minutes)

This follows the same pattern used by other configurable values in the fiat feature flag (`feeReserveMultiplier`, `maxRateDriftPercent`, etc.).

## References

- Fixes [CONF-1494](https://consensyssoftware.atlassian.net/browse/CONF-1494)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

[CONF-1494]: https://consensyssoftware.atlassian.net/browse/CONF-1494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how long fiat submit waits on ramp order completion; misconfigured remote flags could cause earlier timeouts or heavier polling, though defaults preserve prior behavior.
> 
> **Overview**
> Fiat on-ramp order polling in `fiat-submit` no longer uses fixed 1s interval and 10-minute timeout constants. **`waitForOrderCompletion`** now reads **`getFiatOrderPollIntervalMs`** and **`getFiatOrderPollTimeoutMs`**, which resolve **`confirmations_pay_fiat.orderPollIntervalMs`** and **`orderPollTimeoutMs`** from remote feature flags (defaults unchanged: 1000 ms and 600000 ms). Invalid or non-positive flag values fall back to those defaults, matching other fiat flag helpers.
> 
> Unit coverage was added for the new getters and for submit timing out when a custom **`orderPollTimeoutMs`** is set; the package changelog documents the addition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d689d278b597d667323b7ba48533de29c4ce0fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->