### PR TITLE
ci: set up Yarn via Corepack in check-release action

### DIFF
--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -9,10 +9,12 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Checkout repository
-      uses: actions/checkout@v5
+    - name: Checkout and setup environment
+      uses: MetaMask/action-checkout-and-setup@v3
       with:
+        is-high-risk-environment: false
         fetch-depth: 0
+        skip-install: true
 
     - name: Get merge base
       id: merge-base

--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -13,7 +13,6 @@ runs:
       uses: MetaMask/action-checkout-and-setup@v3
       with:
         is-high-risk-environment: false
-        fetch-depth: 0
         skip-install: true
 
     - name: Get merge base

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,6 +87,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
       - name: Check release
         if: github.event_name != 'push'
         uses: ./.github/actions/check-release


### PR DESCRIPTION
## Explanation

The `check-release` composite action invokes `yarn workspaces list` to enumerate published packages, but the job calling it never sets up the project's pinned Yarn version. As a result, the runner's global Yarn 1.22.22 is used, which fails against the `packageManager` field in `package.json` (`yarn@4.16.0`) with:

> This project's package.json defines "packageManager": "yarn@4.16.0". However the current global version of Yarn is 1.22.22.

This PR replaces the standalone `actions/checkout@v5` step with `MetaMask/action-checkout-and-setup@v3`, which sets up Node and Yarn via Corepack. The new [`skip-install: true`](https://github.com/MetaMask/action-checkout-and-setup/pull/74) input (added in v3.4.0) skips `yarn install`, which this action does not need — it only needs `yarn workspaces list`, which reads workspace globs from `package.json` directly.

## References

- Added in [MetaMask/action-checkout-and-setup#74](https://github.com/MetaMask/action-checkout-and-setup/pull/74) (released in v3.4.0)

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow changes; no application runtime or release publish logic is modified.
> 
> **Overview**
> Fixes the **check-release** composite action failing when it runs `yarn workspaces list` because the runner used global Yarn 1.x instead of the repo’s pinned **Yarn 4** from `packageManager`.
> 
> The action’s checkout step is replaced with **`MetaMask/action-checkout-and-setup@v3`**, enabling Corepack/Yarn without running **`yarn install`** (`skip-install: true`). In **`main.yml`**, the **check-release** job’s checkout now uses **`fetch-depth: 0`** so merge-base/git history checks still work after checkout moved out of the composite action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f178d7620f211525fd337a1c2e5a7026b0e3ea76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->