### PR TITLE
ci: Skip Yarn install in publish jobs that don't need deps

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v2
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: true
           ref: ${{ github.sha }}
@@ -43,10 +43,11 @@ jobs:
     needs: build
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v2
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: true
           ref: ${{ github.sha }}
+          skip-install: true
       - name: Restore build artifacts
         uses: actions/download-artifact@v7
         with:
@@ -67,10 +68,11 @@ jobs:
       id-token: write
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v2
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: true
           ref: ${{ github.sha }}
+          skip-install: true
       - name: Restore build artifacts
         uses: actions/download-artifact@v7
         with:
@@ -88,10 +90,11 @@ jobs:
     needs: publish-npm
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v2
+        uses: MetaMask/action-checkout-and-setup@v3
         with:
           is-high-risk-environment: true
           ref: ${{ github.sha }}
+          skip-install: true
       - uses: MetaMask/action-publish-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Explanation

The `publish-npm-dry-run`, `publish-npm`, and `publish-release` jobs in the release workflow don't need the project's `node_modules` installed:

- `publish-npm-dry-run` and `publish-npm` use `MetaMask/action-npm-publish`, which runs `yarn pack` / `yarn npm publish` against the already-built `./packages/**/dist` (restored from the build artifact). These commands don't read `node_modules`.
- `publish-release` uses `MetaMask/action-publish-release`, which only reads `package.json` and runs its own bundled JS to create the GitHub release.

Running `yarn --immutable` on each of these jobs is wasted work. This PR bumps `action-checkout-and-setup` from `@v2` to `@v3` (which introduced the `skip-install` input) and sets `skip-install: true` in those three jobs, so they still get a checkout and Node setup but skip the install.

The `build` job is also bumped to `@v3` for consistency but is unchanged otherwise — it still runs `yarn build` and genuinely needs dependencies.

## References

Mirrors https://github.com/MetaMask/metamask-module-template/pull/321.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow tuning with no application, auth, or publish logic changes beyond skipping redundant installs.
> 
> **Overview**
> Updates the **publish release** workflow to use `MetaMask/action-checkout-and-setup@v3` everywhere and sets **`skip-install: true`** on the NPM dry-run, NPM publish, and GitHub release jobs so they no longer run `yarn --immutable` after checkout.
> 
> The **build** job is bumped to `@v3` only; it still installs deps and runs `yarn build` before uploading artifacts. Downstream jobs continue to restore `./packages/**/dist` (and related paths) and rely on publish actions that do not need a full `node_modules` tree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03a8a22fcd8cf89acbcc2962c416c85b97117292. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->