### PR TITLE
feat(social-controllers): expose perp metadata on Position and Trade types

### DIFF
--- a/packages/social-controllers/CHANGELOG.md
+++ b/packages/social-controllers/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add optional perp fields to the `Trade` type (and `TradeStruct`): `classification` (`'spot' | 'perp' | 'send' | 'receive' | null`), `perpPositionType` (`'long' | 'short' | null`), and `perpLeverage` (`number | null`) — exposing Hyperliquid/perp trade metadata to consumers ([#0000](https://github.com/MetaMask/core/pull/0000))
+- Add optional perp fields to the `Position` type (and `PositionStruct`): `perpPositionType` (`'long' | 'short' | null`), `perpLeverage` (`number | null`), and `positionAmountWithLeverage` (`number | null`) — exposing Hyperliquid/perp position metadata to consumers ([#0000](https://github.com/MetaMask/core/pull/0000))
+
 ### Changed
 
 - Bump `@metamask/controller-utils` from `^12.0.0` to `^12.2.0` ([#8774](https://github.com/MetaMask/core/pull/8774), [#9058](https://github.com/MetaMask/core/pull/9058), [#9083](https://github.com/MetaMask/core/pull/9083))

--- a/packages/social-controllers/CHANGELOG.md
+++ b/packages/social-controllers/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add optional perp fields to the `Trade` type (and `TradeStruct`): `classification` (`'spot' | 'perp' | 'send' | 'receive' | null`), `perpPositionType` (`'long' | 'short' | null`), and `perpLeverage` (`number | null`) — exposing Hyperliquid/perp trade metadata to consumers ([#0000](https://github.com/MetaMask/core/pull/0000))
-- Add optional perp fields to the `Position` type (and `PositionStruct`): `perpPositionType` (`'long' | 'short' | null`), `perpLeverage` (`number | null`), and `positionAmountWithLeverage` (`number | null`) — exposing Hyperliquid/perp position metadata to consumers ([#0000](https://github.com/MetaMask/core/pull/0000))
+- Add optional perp fields to the `Trade` type (and `TradeStruct`): `classification` (`'spot' | 'perp' | 'send' | 'receive' | null`), `perpPositionType` (`'long' | 'short' | null`), and `perpLeverage` (`number | null`) — exposing Hyperliquid/perp trade metadata to consumers ([#9094](https://github.com/MetaMask/core/pull/9094))
+- Add optional perp fields to the `Position` type (and `PositionStruct`): `perpPositionType` (`'long' | 'short' | null`), `perpLeverage` (`number | null`), and `positionAmountWithLeverage` (`number | null`) — exposing Hyperliquid/perp position metadata to consumers ([#9094](https://github.com/MetaMask/core/pull/9094))
 
 ### Changed
 

--- a/packages/social-controllers/src/SocialService.test.ts
+++ b/packages/social-controllers/src/SocialService.test.ts
@@ -53,6 +53,37 @@ const mockPosition = {
   tokenImageUrl: 'https://assets.daylight.xyz/images/token-eth.png',
 };
 
+const mockPerpTrade = {
+  direction: 'buy',
+  intent: 'enter',
+  classification: 'perp',
+  perpPositionType: 'long',
+  perpLeverage: 10,
+  tokenAmount: 1.5,
+  usdCost: 3000,
+  timestamp: 1700000000,
+  transactionHash:
+    '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890',
+};
+
+const mockPerpPosition = {
+  positionId: 'position-perp-1',
+  tokenSymbol: 'BTC',
+  tokenName: 'Bitcoin',
+  tokenAddress: 'BTC',
+  chain: 'hyperliquid',
+  positionAmount: 2.5,
+  boughtUsd: 112500,
+  soldUsd: 0,
+  realizedPnl: 0,
+  costBasis: 112500,
+  trades: [mockPerpTrade],
+  lastTradeAt: 1700000000,
+  perpPositionType: 'long',
+  perpLeverage: 10,
+  positionAmountWithLeverage: 25,
+};
+
 const MOCK_TOKEN = 'mock-bearer-token';
 
 type RootMessenger = Messenger<
@@ -485,6 +516,86 @@ describe('SocialService', () => {
                 trades: [{ ...mockTrade, tokenAmount: 'not-a-number' }],
               },
             ],
+            pagination: { hasMore: false },
+          }),
+      });
+
+      const service = createService();
+
+      await expect(
+        service.fetchOpenPositions({ addressOrId: '0x1234' }),
+      ).rejects.toThrow(
+        SocialServiceErrorMessage.FETCH_OPEN_POSITIONS_INVALID_RESPONSE,
+      );
+    });
+
+    it('passes through perp metadata on positions and trades', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            positions: [mockPerpPosition],
+            pagination: { hasMore: false },
+          }),
+      });
+
+      const service = createService();
+      const result = await service.fetchOpenPositions({
+        addressOrId: '0x1234',
+      });
+
+      expect(result.positions[0]).toStrictEqual(mockPerpPosition);
+      expect(result.positions[0].perpPositionType).toBe('long');
+      expect(result.positions[0].perpLeverage).toBe(10);
+      expect(result.positions[0].positionAmountWithLeverage).toBe(25);
+      expect(result.positions[0].trades[0].classification).toBe('perp');
+      expect(result.positions[0].trades[0].perpPositionType).toBe('long');
+      expect(result.positions[0].trades[0].perpLeverage).toBe(10);
+    });
+
+    it('accepts null perp fields for spot positions', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            positions: [
+              {
+                ...mockPosition,
+                perpPositionType: null,
+                perpLeverage: null,
+                positionAmountWithLeverage: null,
+                trades: [
+                  {
+                    ...mockTrade,
+                    classification: null,
+                    perpPositionType: null,
+                    perpLeverage: null,
+                  },
+                ],
+              },
+            ],
+            pagination: { hasMore: false },
+          }),
+      });
+
+      const service = createService();
+      const result = await service.fetchOpenPositions({
+        addressOrId: '0x1234',
+      });
+
+      expect(result.positions[0].perpPositionType).toBeNull();
+      expect(result.positions[0].trades[0].classification).toBeNull();
+    });
+
+    it('rejects an invalid perpPositionType', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            positions: [{ ...mockPerpPosition, perpPositionType: 'sideways' }],
             pagination: { hasMore: false },
           }),
       });

--- a/packages/social-controllers/src/SocialService.ts
+++ b/packages/social-controllers/src/SocialService.ts
@@ -11,6 +11,7 @@ import type { AuthenticationController } from '@metamask/profile-sync-controller
 import {
   array,
   boolean,
+  enums,
   is,
   nullable,
   number,
@@ -76,6 +77,9 @@ const PositionStruct = structType({
   currentValueUSD: optional(nullable(number())),
   pnlValueUsd: optional(nullable(number())),
   pnlPercent: optional(nullable(number())),
+  perpPositionType: optional(nullable(enums(['long', 'short']))),
+  perpLeverage: optional(nullable(number())),
+  positionAmountWithLeverage: optional(nullable(number())),
 });
 
 const PaginationStruct = structType({

--- a/packages/social-controllers/src/social-types.ts
+++ b/packages/social-controllers/src/social-types.ts
@@ -1,6 +1,7 @@
 import type { Infer } from '@metamask/superstruct';
 import {
   enums,
+  nullable,
   number,
   optional,
   string,
@@ -39,6 +40,14 @@ export const TradeStruct = structType({
   direction: enums(['buy', 'sell']),
   intent: enums(['enter', 'exit']),
   category: optional(string()),
+  /** High-level trade classification. `null` when Clicker does not classify. */
+  classification: optional(
+    nullable(enums(['spot', 'perp', 'send', 'receive'])),
+  ),
+  /** Perp side for this fill. `null` for spot trades. */
+  perpPositionType: optional(nullable(enums(['long', 'short']))),
+  /** Leverage multiplier for perp trades (e.g. `5` for 5x). `null` for spot. */
+  perpLeverage: optional(nullable(number())),
   tokenAmount: number(),
   usdCost: number(),
   timestamp: number(),
@@ -153,6 +162,15 @@ export type Position = {
   pnlValueUsd?: number | null;
   /** PnL as a percentage of cost basis. */
   pnlPercent?: number | null;
+  /** Perp side of the position. `null`/absent for spot positions. */
+  perpPositionType?: 'long' | 'short' | null;
+  /** Leverage multiplier for perp positions. `null`/absent for spot. */
+  perpLeverage?: number | null;
+  /**
+   * Leveraged position size (un-leveraged `positionAmount` × leverage), i.e.
+   * the capital at risk. Hyperliquid/perp positions only; absent for spot.
+   */
+  positionAmountWithLeverage?: number | null;
 };
 
 export type Pagination = {

--- a/packages/social-controllers/src/social-types.ts
+++ b/packages/social-controllers/src/social-types.ts
@@ -167,8 +167,12 @@ export type Position = {
   /** Leverage multiplier for perp positions. `null`/absent for spot. */
   perpLeverage?: number | null;
   /**
-   * Leveraged position size (un-leveraged `positionAmount` × leverage), i.e.
-   * the capital at risk. Hyperliquid/perp positions only; absent for spot.
+   * Leveraged/notional position size as reported by Clicker. NOT necessarily
+   * `positionAmount` × `perpLeverage` — the ratio varies for positions built
+   * across fills at different leverage, so use this field directly rather than
+   * deriving it, and treat `perpLeverage` as the authoritative leverage. This is
+   * notional exposure, not capital at risk (the margin/capital at risk is
+   * `costBasis`). Hyperliquid/perp positions only; absent for spot.
    */
   positionAmountWithLeverage?: number | null;
 };


### PR DESCRIPTION
## Explanation

The mobile Perps leaderboard/position UX needs typed, validated access to the perp metadata that social-api now returns for Hyperliquid (and other perp) positions. Today `@metamask/social-controllers` drops those fields on the floor because they aren't declared on the response types or their superstruct schemas.

This PR extends the `SocialService` response types and validation schemas with the optional perp fields:

- `Trade` (and `TradeStruct`): adds `classification` (`'spot' | 'perp' | 'send' | 'receive' | null`), `perpPositionType` (`'long' | 'short' | null`), and `perpLeverage` (`number | null`).
- `Position` (and `PositionStruct`): adds `perpPositionType`, `perpLeverage`, and `positionAmountWithLeverage` (the leveraged/notional position size — Hyperliquid/perp only).

All fields are optional and nullable, so spot responses validate exactly as before — this is a purely additive, non-breaking change. This is the client-side half of the Hyperliquid perps work; the matching server-side passthrough lives in social-api.

**Audit follow-up (TSA-726):** corrected the `positionAmountWithLeverage` JSDoc — it is the leveraged/notional size as reported by Clicker (**not** necessarily `positionAmount × perpLeverage`; the ratio varies across multi-fill positions) and is notional exposure, **not** capital at risk (the margin/capital at risk is `costBasis`). This keeps consumers from mis-deriving leverage or risk from the field; the perp PnL fix that depends on this contract lives in consensys-vertical-apps/va-mmcx-social-api#86.

## References

- TSA-629
- Part of: TSA-726 (perp PnL correctness — this PR clarifies the `positionAmountWithLeverage` contract used by the fix)
- social-api passthrough PR: https://github.com/consensys-vertical-apps/va-mmcx-social-api/pull/86
- Consumer follow-up: metamask-mobile Perps leaderboard/position UI (next step of this task)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional/nullable fields and stricter validation only when new perp keys are present; spot payloads without those fields behave as before.
> 
> **Overview**
> Adds **optional, nullable perp/Hyperliquid metadata** to social position and trade models so `SocialService` no longer strips fields the API already returns.
> 
> **`Trade` / `TradeStruct`** now include `classification` (`spot` | `perp` | `send` | `receive`), `perpPositionType`, and `perpLeverage`. **`Position` / `PositionStruct`** add `perpPositionType`, `perpLeverage`, and `positionAmountWithLeverage` (leveraged size / capital at risk). Matching superstruct rules on `PositionStruct` validate these on open/closed positions and `fetchPositionById`.
> 
> Tests cover passthrough of perp payloads, explicit `null` for spot, and rejection of invalid enum values (e.g. bad `perpPositionType`). Changelog documents the additive API surface for consumers (e.g. mobile Perps UI).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3e0ef7eb7ce5f6fb401bad29bd75c463290d014. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
