### PR TITLE
fix(keyring-controller): remove use of `instanceof` for `isKeyringNotFoundError`

### DIFF
--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `isKeyringControllerError` predicate ([#9095](https://github.com/MetaMask/core/pull/9095))
+
 ### Changed
 
 - Bump `@metamask/utils` from `^11.9.0` to `^11.11.0` ([#9074](https://github.com/MetaMask/core/pull/9074))

--- a/packages/keyring-controller/CHANGELOG.md
+++ b/packages/keyring-controller/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/utils` from `^11.9.0` to `^11.11.0` ([#9074](https://github.com/MetaMask/core/pull/9074))
 
+### Fixed
+
+- Remove use of `instanceof` for `isKeyringNotFoundError` ([#9095](https://github.com/MetaMask/core/pull/9095))
+  - Using `instanceof` causes a lot of issue if we have 2 major `@metamask/keyring-controller` major versions in the dependency tree, `class KeyringControllerError` could be different classes and this, making the check to fail.
+
 ## [27.0.0]
 
 ### Changed

--- a/packages/keyring-controller/src/errors.test.ts
+++ b/packages/keyring-controller/src/errors.test.ts
@@ -1,11 +1,48 @@
 import { KeyringControllerErrorMessage } from './constants';
-import { isKeyringNotFoundError, KeyringControllerError } from './errors';
+import {
+  isKeyringControllerError,
+  isKeyringNotFoundError,
+  KeyringControllerError,
+} from './errors';
+
+describe('isKeyringControllerError', () => {
+  it('returns true for a KeyringControllerError', () => {
+    const error = new KeyringControllerError(
+      KeyringControllerErrorMessage.KeyringNotFound,
+    );
+    expect(isKeyringControllerError(error)).toBe(true);
+  });
+
+  it('returns true for an error from another version of the package (duck-typing)', () => {
+    const error = Object.assign(new Error('some message'), {
+      name: 'KeyringControllerError',
+    });
+    expect(isKeyringControllerError(error)).toBe(true);
+  });
+
+  it('returns false for a plain Error', () => {
+    expect(isKeyringControllerError(new Error('oops'))).toBe(false);
+  });
+
+  it('returns false for a non-error value', () => {
+    expect(isKeyringControllerError('not an error')).toBe(false);
+    expect(isKeyringControllerError(null)).toBe(false);
+    expect(isKeyringControllerError(undefined)).toBe(false);
+  });
+});
 
 describe('isKeyringNotFoundError', () => {
   it('returns true for a KeyringControllerError with the KeyringNotFound message', () => {
     const error = new KeyringControllerError(
       KeyringControllerErrorMessage.KeyringNotFound,
     );
+    expect(isKeyringNotFoundError(error)).toBe(true);
+  });
+
+  it('returns true for an error from another version of the package (duck-typing)', () => {
+    const error = Object.assign(new Error(KeyringControllerErrorMessage.KeyringNotFound), {
+      name: 'KeyringControllerError',
+    });
     expect(isKeyringNotFoundError(error)).toBe(true);
   });
 

--- a/packages/keyring-controller/src/errors.test.ts
+++ b/packages/keyring-controller/src/errors.test.ts
@@ -40,9 +40,12 @@ describe('isKeyringNotFoundError', () => {
   });
 
   it('returns true for an error from another version of the package (duck-typing)', () => {
-    const error = Object.assign(new Error(KeyringControllerErrorMessage.KeyringNotFound), {
-      name: 'KeyringControllerError',
-    });
+    const error = Object.assign(
+      new Error(KeyringControllerErrorMessage.KeyringNotFound),
+      {
+        name: 'KeyringControllerError',
+      },
+    );
     expect(isKeyringNotFoundError(error)).toBe(true);
   });
 

--- a/packages/keyring-controller/src/errors.ts
+++ b/packages/keyring-controller/src/errors.ts
@@ -134,6 +134,27 @@ export class KeyringControllerError extends Error {
 }
 
 /**
+ * Returns `true` if the error is a `KeyringControllerError`.
+ *
+ * Uses duck-typing on `error.name` rather than `instanceof` so that the check
+ * remains correct when multiple major versions of `@metamask/keyring-controller`
+ * coexist in the dependency tree (different versions produce different classes,
+ * so `instanceof` would return `false` for errors from another version).
+ *
+ * @param error - The value to check.
+ * @returns Whether the error is a `KeyringControllerError`.
+ */
+export function isKeyringControllerError(
+  error: unknown,
+): error is KeyringControllerError {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    (error as { name?: unknown }).name === 'KeyringControllerError'
+  );
+}
+
+/**
  * Returns `true` if the error is a `KeyringNotFound` error thrown by
  * `KeyringController:withKeyring`. Use this to distinguish a missing keyring
  * from other failures and apply fallback logic.
@@ -145,7 +166,7 @@ export function isKeyringNotFoundError(
   error: unknown,
 ): error is KeyringControllerError {
   return (
-    error instanceof KeyringControllerError &&
+    isKeyringControllerError(error) &&
     error.message === KeyringControllerErrorMessage.KeyringNotFound
   );
 }


### PR DESCRIPTION
## Explanation

Using `instanceof` is problematic whenever we have multiple major versions of this controller in the dependency tree. So instead, we use duck-typing and fallback on the `.name` to check the error itself + the `.message`.

Functionally speaking there should not have any difference.

## References

N/A

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to error predicates only; intended behavior is unchanged for same-version errors, with improved reliability in duplicate-package installs.
> 
> **Overview**
> Adds **`isKeyringControllerError`**, a public type guard that recognizes `KeyringControllerError` by duck-typing `error.name === 'KeyringControllerError'` instead of `instanceof`.
> 
> **`isKeyringNotFoundError`** now builds on that helper (name + `KeyringNotFound` message) so missing-keyring detection still works when two major versions of `@metamask/keyring-controller` are installed and each bundle has its own `KeyringControllerError` class.
> 
> Tests cover cross-version–style errors and the changelog documents the new export and the `instanceof` fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55950b3377ffbe95c189bf70131d94a619690991. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->