### PR TITLE
feat(wallet): add injectable `logger` to `WalletOptions`

### DIFF
--- a/packages/wallet/CHANGELOG.md
+++ b/packages/wallet/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add an optional `logger` option to `WalletOptions` for initialization diagnostics ([#8791](https://github.com/MetaMask/core/pull/8791))
+- Add an optional `logger` option to `WalletOptions` for initialization diagnostics ([#9097](https://github.com/MetaMask/core/pull/9097))
   - When provided (e.g. `{ logger: console }`), a `[wallet] ${name}: initialized` breadcrumb is emitted via `logger.info` immediately after each controller's `init()` completes, in initialization order. Defaults to no output.
 - **BREAKING:** Add `AccountsController` and `ConnectivityController` as default initialized controllers ([#8924](https://github.com/MetaMask/core/pull/8924))
   - Passing `instanceOptions.connectivityController.connectivityAdapter` is now required.

--- a/packages/wallet/CHANGELOG.md
+++ b/packages/wallet/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add an optional `logger` option to `WalletOptions` for initialization diagnostics ([#8791](https://github.com/MetaMask/core/pull/8791))
+  - When provided (e.g. `{ logger: console }`), a `[wallet] ${name}: initialized` breadcrumb is emitted via `logger.info` immediately after each controller's `init()` completes, in initialization order. Defaults to no output.
 - **BREAKING:** Add `AccountsController` and `ConnectivityController` as default initialized controllers ([#8924](https://github.com/MetaMask/core/pull/8924))
   - Passing `instanceOptions.connectivityController.connectivityAdapter` is now required.
   - Export `AlwaysOnlineAdapter` from the package root for environments without a platform-specific network API (e.g. Node/tests).

--- a/packages/wallet/src/Wallet.test.ts
+++ b/packages/wallet/src/Wallet.test.ts
@@ -5,6 +5,7 @@ import { Json } from '@metamask/utils';
 import { webcrypto } from 'crypto';
 
 import MockEncryptor from '../../keyring-controller/tests/mocks/mockEncryptor';
+import { defaultConfigurations } from './initialization/defaults';
 import * as initializationModule from './initialization/initialization';
 import { AlwaysOnlineAdapter } from './initialization/instances/connectivity-controller/always-online-adapter';
 import { importSecretRecoveryPhrase } from './utilities';
@@ -147,6 +148,51 @@ describe('Wallet', () => {
     });
 
     expect((state as Record<string, Json>).TestService).toBeUndefined();
+  });
+
+  it('logs an initialization breadcrumb for each controller in order when a logger is provided', () => {
+    const info = jest.fn();
+
+    const wallet = new Wallet({
+      logger: { info },
+      instanceOptions: {
+        connectivityController: {
+          connectivityAdapter: new AlwaysOnlineAdapter(),
+        },
+        storageService: {
+          storage: new InMemoryStorageAdapter(),
+        },
+        remoteFeatureFlagController: REMOTE_FEATURE_FLAG_OPTIONS,
+      },
+    });
+
+    const loggedMessages = info.mock.calls.map(([message]) => message);
+    const expectedMessages = Object.values(defaultConfigurations).map(
+      (config) => `[wallet] ${config.name}: initialized`,
+    );
+
+    expect(loggedMessages).toStrictEqual(expectedMessages);
+    // The constructed wallet exposes the controllers it logged.
+    expect(
+      wallet.getInstance(defaultConfigurations.keyringController.name),
+    ).toBeDefined();
+  });
+
+  it('does not throw when no logger is provided', () => {
+    expect(
+      () =>
+        new Wallet({
+          instanceOptions: {
+            connectivityController: {
+              connectivityAdapter: new AlwaysOnlineAdapter(),
+            },
+            storageService: {
+              storage: new InMemoryStorageAdapter(),
+            },
+            remoteFeatureFlagController: REMOTE_FEATURE_FLAG_OPTIONS,
+          },
+        }),
+    ).not.toThrow();
   });
 
   it('exposes controllerMetadata for each initialized controller', async () => {

--- a/packages/wallet/src/Wallet.ts
+++ b/packages/wallet/src/Wallet.ts
@@ -34,6 +34,8 @@ export class Wallet {
    * required beyond the ones included by default.
    * @param options.instanceOptions - An optional object containing options that should be passed
    * to specific instances for additional customization.
+   * @param options.logger - An optional logger used to emit a breadcrumb after each controller's
+   * initialization completes. Defaults to no output.
    */
   constructor(options: WalletOptions) {
     this.#messenger =

--- a/packages/wallet/src/initialization/initialization.ts
+++ b/packages/wallet/src/initialization/initialization.ts
@@ -23,6 +23,7 @@ export function initialize(options: InitializeOptions): DefaultInstances {
     state = {},
     initializationConfigurations = [],
     instanceOptions,
+    logger,
   } = options;
 
   const overriddenConfiguration = initializationConfigurations.map(
@@ -55,6 +56,8 @@ export function initialize(options: InitializeOptions): DefaultInstances {
     });
 
     instances[name] = instance;
+
+    logger?.info(`[wallet] ${name}: initialized`);
   }
 
   return instances as DefaultInstances;

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -20,6 +20,12 @@ export type WalletOptions = {
     unknown
   >[];
   instanceOptions: InstanceSpecificOptions;
+  /**
+   * An optional logger used to emit initialization diagnostics. When provided,
+   * a breadcrumb is logged immediately after each controller's `init()`
+   * completes, in initialization order. Defaults to no output.
+   */
+  logger?: Pick<Console, 'info'>;
 };
 
 export type InstanceSpecificOptions = {


### PR DESCRIPTION
## Explanation

`@metamask/wallet` is the shared controller-integration layer for the extension, mobile, and other clients (e.g. wallet-cli), so any value that differs between clients is an injectable `WalletOptions` field rather than something hardcoded.

This PR adds an optional `logger?: Pick<Console, 'info'>` field to `WalletOptions`. When provided, the initialization loop emits a `[wallet] ${name}: initialized` breadcrumb via `logger.info` immediately after each controller's `init()` returns, in initialization order. The field is no-op by default, so library consumers are unaffected unless they opt in.

Passing `{ logger: console }` during a development run then produces one timestamped log line per wired controller, in order. This gives visibility into controller initialization sequence and timing — the empirical data needed to observe which messenger actions a controller calls during `init()` versus at runtime. Any messenger action observed before a controller's init-complete breadcrumb is a candidate for an init messenger; calls after are runtime uses.

Closes #8791.

### Options

| Option   | Extension      | Mobile         | Default (e.g. wallet-cli) |
| -------- | -------------- | -------------- | ------------------------- |
| `logger` | omit, or pass the client's logger (e.g. `console`) for dev diagnostics | omit, or pass the client's logger | omit (no output), or `console` during development |

The default is no output, so the field has no effect on any client that does not pass it.

## References

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
  - No breaking changes — the field is optional and defaults to no output.
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional diagnostic logging only; no change to init logic or required options when `logger` is omitted.
> 
> **Overview**
> Adds an optional **`logger`** on **`WalletOptions`** (`Pick<Console, 'info'>`) so clients can opt into initialization diagnostics without changing default behavior.
> 
> During **`initialize()`**, after each controller's **`init()`** finishes, the wallet calls **`logger?.info`** with **`[wallet] ${name}: initialized`** in wiring order. **`Wallet`** forwards the option unchanged; JSDoc and the changelog document the hook. Tests assert ordered breadcrumbs match **`defaultConfigurations`** and that construction still works when **`logger`** is omitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f01e8f5aac622122abb401251b7ac6d556840ffa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->