### PR TITLE
fix(transaction-pay-controller): block raw publish without Pay quote

### DIFF
--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Prevent Pay-configured transactions from falling back to raw publish when no Pay quote is available ([#0000](https://github.com/MetaMask/core/pull/0000))
+- Prevent Pay-configured transactions from falling back to raw publish when no Pay quote is available ([#9101](https://github.com/MetaMask/core/pull/9101))
 - Clear stale `fiatPayment.rampsQuote` when a fiat quote fetch fails, preventing the "No quotes" alert from being silently suppressed after a prior successful fetch ([#9073](https://github.com/MetaMask/core/pull/9073))
 
 ## [23.5.1]

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Prevent Pay-configured transactions from falling back to raw publish when no Pay quote is available ([#0000](https://github.com/MetaMask/core/pull/0000))
 - Clear stale `fiatPayment.rampsQuote` when a fiat quote fetch fails, preventing the "No quotes" alert from being silently suppressed after a prior successful fetch ([#9073](https://github.com/MetaMask/core/pull/9073))
 
 ## [23.5.1]

--- a/packages/transaction-pay-controller/src/helpers/TransactionPayPublishHook.test.ts
+++ b/packages/transaction-pay-controller/src/helpers/TransactionPayPublishHook.test.ts
@@ -6,6 +6,7 @@ import type {
 import { TransactionPayStrategy } from '..';
 import { getMessengerMock } from '../tests/messenger-mock';
 import type {
+  TransactionData,
   TransactionPayControllerState,
   TransactionPayQuote,
 } from '../types';
@@ -24,6 +25,22 @@ const TRANSACTION_META_MOCK = {
 const QUOTE_MOCK = {
   strategy: TransactionPayStrategy.Test,
 } as TransactionPayQuote<unknown>;
+
+const PAYMENT_TOKEN_MOCK = {
+  address: '0xdef',
+  balanceFiat: '1',
+  balanceHuman: '1',
+  balanceRaw: '1000000',
+  balanceUsd: '1',
+  chainId: '0x1',
+  decimals: 6,
+  symbol: 'TEST',
+};
+
+const EMPTY_TRANSACTION_DATA_MOCK = {
+  isLoading: false,
+  tokens: [],
+} as TransactionData;
 
 describe('TransactionPayPublishHook', () => {
   const isSmartTransactionMock = jest.fn();
@@ -114,6 +131,47 @@ describe('TransactionPayPublishHook', () => {
 
     expect(executeMock).not.toHaveBeenCalled();
   });
+
+  it('does nothing if no quotes exist for transaction data without explicit pay config', async () => {
+    getControllerStateMock.mockReturnValue({
+      transactionData: {
+        [TRANSACTION_META_MOCK.id]: EMPTY_TRANSACTION_DATA_MOCK,
+      },
+    });
+
+    await runHook();
+
+    expect(executeMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['account override', { accountOverride: '0xdef' }],
+    [
+      'fiat payment method',
+      { fiatPayment: { selectedPaymentMethodId: 'test-payment-method' } },
+    ],
+    ['payment override', { paymentOverride: {} }],
+    ['payment token', { paymentToken: PAYMENT_TOKEN_MOCK }],
+    ['post-quote flag', { isPostQuote: true }],
+  ] as [string, Partial<TransactionData>][])(
+    'throws if no quotes exist for transaction data with %s',
+    async (_description, transactionData) => {
+      getControllerStateMock.mockReturnValue({
+        transactionData: {
+          [TRANSACTION_META_MOCK.id]: {
+            ...EMPTY_TRANSACTION_DATA_MOCK,
+            ...transactionData,
+          },
+        },
+      });
+
+      await expect(runHook()).rejects.toThrow(
+        'MetaMask Pay: No pay quote available',
+      );
+
+      expect(executeMock).not.toHaveBeenCalled();
+    },
+  );
 
   it('sets submittedTime on the transaction before executing strategy', async () => {
     await runHook();

--- a/packages/transaction-pay-controller/src/helpers/TransactionPayPublishHook.ts
+++ b/packages/transaction-pay-controller/src/helpers/TransactionPayPublishHook.ts
@@ -6,6 +6,7 @@ import { createModuleLogger } from '@metamask/utils';
 
 import { projectLogger } from '../logger';
 import type {
+  TransactionData,
   TransactionPayControllerMessenger,
   TransactionPayQuote,
 } from '../types';
@@ -18,6 +19,8 @@ const log = createModuleLogger(projectLogger, 'pay-publish-hook');
 const EMPTY_RESULT = {
   transactionHash: undefined,
 };
+
+const ERROR_NO_PAY_QUOTE = 'No pay quote available';
 
 export class TransactionPayPublishHook {
   readonly #isSmartTransaction: (chainId: Hex) => boolean;
@@ -62,11 +65,16 @@ export class TransactionPayPublishHook {
       'TransactionPayController:getState',
     );
 
+    const transactionData = controllerState.transactionData?.[transactionId];
+
     const quotes =
-      (controllerState.transactionData?.[transactionId]
-        ?.quotes as TransactionPayQuote<unknown>[]) ?? [];
+      (transactionData?.quotes as TransactionPayQuote<unknown>[]) ?? [];
 
     if (!quotes?.length) {
+      if (hasExplicitPayConfig(transactionData)) {
+        throw new Error(ERROR_NO_PAY_QUOTE);
+      }
+
       log('Skipping as no quotes found');
       return EMPTY_RESULT;
     }
@@ -93,4 +101,18 @@ export class TransactionPayPublishHook {
       transaction: transactionMeta,
     });
   }
+}
+
+function hasExplicitPayConfig(transactionData?: TransactionData): boolean {
+  if (!transactionData) {
+    return false;
+  }
+
+  return [
+    transactionData.accountOverride,
+    transactionData.fiatPayment?.selectedPaymentMethodId,
+    transactionData.isPostQuote,
+    transactionData.paymentOverride,
+    transactionData.paymentToken,
+  ].some(Boolean);
 }


### PR DESCRIPTION
## Explanation

`TransactionPayPublishHook` previously returned an empty hook result whenever a transaction had no Pay quotes. That is still useful for transactions the Pay controller is only observing, but unsafe once a transaction has explicit Pay configuration because `TransactionController` can continue through its normal raw-publish fallback.

This PR makes empty quotes fail closed for transactions with explicit Pay configuration, while preserving the existing fallthrough behavior for unmanaged transactions with no quote state.

## References

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate\n- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate\n- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)\n- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them