### PR TITLE
ci: use explicit dry-run input for npm publish

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -55,6 +55,7 @@ jobs:
       - name: Dry run publish to NPM
         uses: MetaMask/action-npm-publish@v6
         with:
+          dry-run: true
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           subteam: S042S7RE4AE # @metamask-npm-publishers
 
@@ -80,6 +81,7 @@ jobs:
       - name: Publish to NPM
         uses: MetaMask/action-npm-publish@v6
         with:
+          dry-run: false
           npm-token: ${{ secrets.NPM_TOKEN }}
 
   publish-release:


### PR DESCRIPTION
## Explanation

We now pass in an explicit `dry-run` parameter when calling `action-npm-publish`, rather than relying on it to infer whether it's a dry run or not from context.

This ensures that if authentication is not setup correctly, CI will fail rather than silently succeeding with a dry run.

## References

Feature added here: https://github.com/MetaMask/action-npm-publish/pull/122

Released in 6.2

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only GitHub Actions workflow inputs change; it tightens release CI behavior without altering application code.
> 
> **Overview**
> The **publish release** workflow now passes an explicit **`dry-run`** flag to `MetaMask/action-npm-publish@v6` instead of letting the action infer mode from context.
> 
> The dry-run job sets **`dry-run: true`**; the real NPM publish job sets **`dry-run: false`** alongside the existing `npm-token`. That way a misconfigured publish step is less likely to **pass CI while only simulating** a publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2cadbb1e848de151797596c9c873149d82ee85c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->