### PR TITLE
Release 1037.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "1036.0.0",
+  "version": "1037.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {

--- a/packages/chain-agnostic-permission/CHANGELOG.md
+++ b/packages/chain-agnostic-permission/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.2]
+
 ### Changed
 
 - Bump `@metamask/api-specs` from `^0.14.0` to `^0.15.0` ([#9096](https://github.com/MetaMask/core/pull/9096))
@@ -217,7 +219,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/chain-agnostic-permission@1.6.1...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/chain-agnostic-permission@1.6.2...HEAD
+[1.6.2]: https://github.com/MetaMask/core/compare/@metamask/chain-agnostic-permission@1.6.1...@metamask/chain-agnostic-permission@1.6.2
 [1.6.1]: https://github.com/MetaMask/core/compare/@metamask/chain-agnostic-permission@1.6.0...@metamask/chain-agnostic-permission@1.6.1
 [1.6.0]: https://github.com/MetaMask/core/compare/@metamask/chain-agnostic-permission@1.5.0...@metamask/chain-agnostic-permission@1.6.0
 [1.5.0]: https://github.com/MetaMask/core/compare/@metamask/chain-agnostic-permission@1.4.0...@metamask/chain-agnostic-permission@1.5.0

--- a/packages/chain-agnostic-permission/package.json
+++ b/packages/chain-agnostic-permission/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/chain-agnostic-permission",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Defines a CAIP-25 based endowment permission and helpers for interfacing with it",
   "keywords": [
     "Ethereum",

--- a/packages/eip1193-permission-middleware/CHANGELOG.md
+++ b/packages/eip1193-permission-middleware/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/utils` from `^11.9.0` to `^11.11.0` ([#9074](https://github.com/MetaMask/core/pull/9074))
 - Bump `@metamask/controller-utils` from `^12.0.0` to `^12.2.0` ([#8774](https://github.com/MetaMask/core/pull/8774), [#9058](https://github.com/MetaMask/core/pull/9058), [#9083](https://github.com/MetaMask/core/pull/9083))
-- Bump `@metamask/chain-agnostic-permission` from `^1.6.1` to `^1.6.2` ([#9096](https://github.com/MetaMask/core/pull/9096))
+- Bump `@metamask/chain-agnostic-permission` from `^1.6.1` to `^1.6.2` ([#9103](https://github.com/MetaMask/core/pull/9103))
 
 ## [2.0.1]
 

--- a/packages/eip1193-permission-middleware/CHANGELOG.md
+++ b/packages/eip1193-permission-middleware/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/utils` from `^11.9.0` to `^11.11.0` ([#9074](https://github.com/MetaMask/core/pull/9074))
 - Bump `@metamask/controller-utils` from `^12.0.0` to `^12.2.0` ([#8774](https://github.com/MetaMask/core/pull/8774), [#9058](https://github.com/MetaMask/core/pull/9058), [#9083](https://github.com/MetaMask/core/pull/9083))
+- Bump `@metamask/chain-agnostic-permission` from `^1.6.1` to `^1.6.2` ([#9096](https://github.com/MetaMask/core/pull/9096))
 
 ## [2.0.1]
 

--- a/packages/eip1193-permission-middleware/package.json
+++ b/packages/eip1193-permission-middleware/package.json
@@ -51,7 +51,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/chain-agnostic-permission": "^1.6.1",
+    "@metamask/chain-agnostic-permission": "^1.6.2",
     "@metamask/controller-utils": "^12.2.0",
     "@metamask/json-rpc-engine": "^10.5.0",
     "@metamask/permission-controller": "^13.1.1",

--- a/packages/multichain-api-middleware/CHANGELOG.md
+++ b/packages/multichain-api-middleware/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/controller-utils` from `^12.1.0` to `^12.2.0` ([#9058](https://github.com/MetaMask/core/pull/9058), [#9083](https://github.com/MetaMask/core/pull/9083))
 - Bump `@metamask/accounts-controller` from `^39.0.0` to `^39.0.1` ([#9058](https://github.com/MetaMask/core/pull/9058))
 - Bump `@metamask/api-specs` from `^0.14.0` to `^0.15.0` ([#9096](https://github.com/MetaMask/core/pull/9096))
-- Bump `@metamask/chain-agnostic-permission` from `^1.6.1` to `^1.6.2` ([#9096](https://github.com/MetaMask/core/pull/9096))
+- Bump `@metamask/chain-agnostic-permission` from `^1.6.1` to `^1.6.2` ([#9103](https://github.com/MetaMask/core/pull/9103))
 
 ## [3.1.3]
 

--- a/packages/multichain-api-middleware/CHANGELOG.md
+++ b/packages/multichain-api-middleware/CHANGELOG.md
@@ -7,12 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.4]
+
 ### Changed
 
 - Bump `@metamask/utils` from `^11.9.0` to `^11.11.0` ([#9074](https://github.com/MetaMask/core/pull/9074))
 - Bump `@metamask/controller-utils` from `^12.1.0` to `^12.2.0` ([#9058](https://github.com/MetaMask/core/pull/9058), [#9083](https://github.com/MetaMask/core/pull/9083))
 - Bump `@metamask/accounts-controller` from `^39.0.0` to `^39.0.1` ([#9058](https://github.com/MetaMask/core/pull/9058))
 - Bump `@metamask/api-specs` from `^0.14.0` to `^0.15.0` ([#9096](https://github.com/MetaMask/core/pull/9096))
+- Bump `@metamask/chain-agnostic-permission` from `^1.6.1` to `^1.6.2` ([#9096](https://github.com/MetaMask/core/pull/9096))
 
 ## [3.1.3]
 
@@ -242,7 +245,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/multichain-api-middleware@3.1.3...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/multichain-api-middleware@3.1.4...HEAD
+[3.1.4]: https://github.com/MetaMask/core/compare/@metamask/multichain-api-middleware@3.1.3...@metamask/multichain-api-middleware@3.1.4
 [3.1.3]: https://github.com/MetaMask/core/compare/@metamask/multichain-api-middleware@3.1.2...@metamask/multichain-api-middleware@3.1.3
 [3.1.2]: https://github.com/MetaMask/core/compare/@metamask/multichain-api-middleware@3.1.1...@metamask/multichain-api-middleware@3.1.2
 [3.1.1]: https://github.com/MetaMask/core/compare/@metamask/multichain-api-middleware@3.1.0...@metamask/multichain-api-middleware@3.1.1

--- a/packages/multichain-api-middleware/package.json
+++ b/packages/multichain-api-middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/multichain-api-middleware",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "JSON-RPC methods and middleware to support the MetaMask Multichain API",
   "keywords": [
     "Ethereum",
@@ -53,7 +53,7 @@
   "dependencies": {
     "@metamask/accounts-controller": "^39.0.1",
     "@metamask/api-specs": "^0.15.0",
-    "@metamask/chain-agnostic-permission": "^1.6.1",
+    "@metamask/chain-agnostic-permission": "^1.6.2",
     "@metamask/controller-utils": "^12.2.0",
     "@metamask/json-rpc-engine": "^10.5.0",
     "@metamask/network-controller": "^32.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5997,7 +5997,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/chain-agnostic-permission@npm:^1.6.1, @metamask/chain-agnostic-permission@workspace:packages/chain-agnostic-permission":
+"@metamask/chain-agnostic-permission@npm:^1.6.2, @metamask/chain-agnostic-permission@workspace:packages/chain-agnostic-permission":
   version: 0.0.0-use.local
   resolution: "@metamask/chain-agnostic-permission@workspace:packages/chain-agnostic-permission"
   dependencies:
@@ -6472,7 +6472,7 @@ __metadata:
   resolution: "@metamask/eip1193-permission-middleware@workspace:packages/eip1193-permission-middleware"
   dependencies:
     "@metamask/auto-changelog": "npm:^6.1.0"
-    "@metamask/chain-agnostic-permission": "npm:^1.6.1"
+    "@metamask/chain-agnostic-permission": "npm:^1.6.2"
     "@metamask/controller-utils": "npm:^12.2.0"
     "@metamask/json-rpc-engine": "npm:^10.5.0"
     "@metamask/permission-controller": "npm:^13.1.1"
@@ -7485,7 +7485,7 @@ __metadata:
     "@metamask/accounts-controller": "npm:^39.0.1"
     "@metamask/api-specs": "npm:^0.15.0"
     "@metamask/auto-changelog": "npm:^6.1.0"
-    "@metamask/chain-agnostic-permission": "npm:^1.6.1"
+    "@metamask/chain-agnostic-permission": "npm:^1.6.2"
     "@metamask/controller-utils": "npm:^12.2.0"
     "@metamask/eth-json-rpc-filters": "npm:^9.0.0"
     "@metamask/json-rpc-engine": "npm:^10.5.0"


### PR DESCRIPTION
## Release

### `@metamask/chain-agnostic-permission` 1.6.2

#### Changed

- Bump `@metamask/api-specs` from `^0.14.0` to `^0.15.0` ([#9096](https://github.com/MetaMask/core/pull/9096))
- Bump `@metamask/utils` from `^11.9.0` to `^11.11.0` ([#9074](https://github.com/MetaMask/core/pull/9074))
- Bump `@metamask/controller-utils` from `^12.0.0` to `^12.2.0` ([#8774](https://github.com/MetaMask/core/pull/8774), [#9058](https://github.com/MetaMask/core/pull/9058), [#9083](https://github.com/MetaMask/core/pull/9083))

### `@metamask/multichain-api-middleware` 3.1.4

#### Changed

- Bump `@metamask/utils` from `^11.9.0` to `^11.11.0` ([#9074](https://github.com/MetaMask/core/pull/9074))
- Bump `@metamask/controller-utils` from `^12.1.0` to `^12.2.0` ([#9058](https://github.com/MetaMask/core/pull/9058), [#9083](https://github.com/MetaMask/core/pull/9083))
- Bump `@metamask/accounts-controller` from `^39.0.0` to `^39.0.1` ([#9058](https://github.com/MetaMask/core/pull/9058))
- Bump `@metamask/api-specs` from `^0.14.0` to `^0.15.0` ([#9096](https://github.com/MetaMask/core/pull/9096))
- Bump `@metamask/chain-agnostic-permission` from `^1.6.1` to `^1.6.2` ([#9096](https://github.com/MetaMask/core/pull/9096))

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch releases and dependency version bumps only; no logic or API changes in the diff.
> 
> **Overview**
> **Monorepo release 1037.0.0** — version and changelog updates with no runtime code changes in this diff.
> 
> **`@metamask/chain-agnostic-permission` 1.6.2** documents patch-level dependency bumps: `@metamask/api-specs` ^0.15.0, `@metamask/utils` ^11.11.0, and `@metamask/controller-utils` ^12.2.0.
> 
> **`@metamask/multichain-api-middleware` 3.1.4** picks up the same stack plus `@metamask/accounts-controller` ^39.0.1 and **`@metamask/chain-agnostic-permission` ^1.6.2** in `package.json` and `yarn.lock`.
> 
> **`@metamask/eip1193-permission-middleware`** updates its declared dependency to `@metamask/chain-agnostic-permission` ^1.6.2 and records that under `[Unreleased]` in its changelog (no package version bump in this diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit daf565d360f98320089b0c4211325fc5c8ea1918. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->