### PR TITLE
feat: add yarn typecheck script

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "test:packages": "yarn test:verbose --silent --collectCoverage=false --reporters=jest-silent-reporter",
     "test:scripts": "NODE_OPTIONS=--experimental-vm-modules yarn jest --config ./jest.config.scripts.js --silent",
     "test:verbose": "yarn workspaces foreach --all --parallel --verbose run test:verbose",
+    "typecheck": "yarn workspaces foreach --all --no-private --parallel --interlaced --verbose run typecheck",
     "workspaces:list-versions": "./scripts/list-workspace-versions.sh",
     "skills": "metamask-skills sync",
     "skills:postinstall": "metamask-skills postinstall",

--- a/packages/account-tree-controller/package.json
+++ b/packages/account-tree-controller/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/accounts-controller": "^39.0.1",

--- a/packages/account-tree-controller/src/AccountTreeController.test.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.test.ts
@@ -29,7 +29,7 @@ import {
 import type { KeyringObject } from '@metamask/keyring-controller';
 import { KeyringTypes } from '@metamask/keyring-controller';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
-import type { GetSnap as SnapControllerGetSnap } from '@metamask/snaps-controllers';
+import type { SnapControllerGetSnapAction as SnapControllerGetSnap } from '@metamask/snaps-controllers';
 
 import {
   getAccountTreeControllerMessenger,

--- a/packages/account-tree-controller/tsconfig.json
+++ b/packages/account-tree-controller/tsconfig.json
@@ -3,25 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    {
-      "path": "../base-controller"
-    },
-    {
-      "path": "../keyring-controller"
-    },
-    {
-      "path": "../accounts-controller"
-    },
-    {
-      "path": "../messenger"
-    },
-    {
-      "path": "../multichain-account-service"
-    },
-    {
-      "path": "../profile-sync-controller"
-    }
-  ],
+  "references": [],
   "include": ["../../types", "./src", "./tests"]
 }

--- a/packages/accounts-controller/package.json
+++ b/packages/accounts-controller/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@ethereumjs/util": "^9.1.0",

--- a/packages/accounts-controller/tsconfig.json
+++ b/packages/accounts-controller/tsconfig.json
@@ -3,15 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    {
-      "path": "../base-controller"
-    },
-    {
-      "path": "../keyring-controller"
-    },
-    { "path": "../network-controller" },
-    { "path": "../messenger" }
-  ],
+  "references": [],
   "include": ["../../types", "./src", "./tests"]
 }

--- a/packages/address-book-controller/package.json
+++ b/packages/address-book-controller/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/base-controller": "^9.1.0",

--- a/packages/address-book-controller/tsconfig.json
+++ b/packages/address-book-controller/tsconfig.json
@@ -3,10 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    { "path": "../base-controller" },
-    { "path": "../controller-utils" },
-    { "path": "../messenger" }
-  ],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/ai-controllers/package.json
+++ b/packages/ai-controllers/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/base-controller": "^9.1.0",

--- a/packages/ai-controllers/src/AiDigestController.test.ts
+++ b/packages/ai-controllers/src/AiDigestController.test.ts
@@ -15,6 +15,7 @@ import type {
 } from '.';
 
 const mockReport: MarketInsightsReport = {
+  digestId: 'digest-btc-1',
   version: '1.0',
   asset: 'btc',
   generatedAt: '2026-02-11T10:32:52.403Z',

--- a/packages/ai-controllers/tsconfig.json
+++ b/packages/ai-controllers/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [{ "path": "../base-controller" }, { "path": "../messenger" }],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/analytics-controller/package.json
+++ b/packages/analytics-controller/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/base-controller": "^9.1.0",

--- a/packages/analytics-controller/tsconfig.json
+++ b/packages/analytics-controller/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [{ "path": "../base-controller" }, { "path": "../messenger" }],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/analytics-data-regulation-controller/package.json
+++ b/packages/analytics-data-regulation-controller/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/base-controller": "^9.1.0",

--- a/packages/analytics-data-regulation-controller/tsconfig.json
+++ b/packages/analytics-data-regulation-controller/tsconfig.json
@@ -3,10 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    { "path": "../base-controller" },
-    { "path": "../controller-utils" },
-    { "path": "../messenger" }
-  ],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/announcement-controller/package.json
+++ b/packages/announcement-controller/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/base-controller": "^9.1.0",

--- a/packages/announcement-controller/tsconfig.json
+++ b/packages/announcement-controller/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [{ "path": "../base-controller" }, { "path": "../messenger" }],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/app-metadata-controller/package.json
+++ b/packages/app-metadata-controller/package.json
@@ -48,7 +48,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/base-controller": "^9.1.0",

--- a/packages/app-metadata-controller/tsconfig.json
+++ b/packages/app-metadata-controller/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [{ "path": "../base-controller" }, { "path": "../messenger" }],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/approval-controller/package.json
+++ b/packages/approval-controller/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/base-controller": "^9.1.0",

--- a/packages/approval-controller/tsconfig.json
+++ b/packages/approval-controller/tsconfig.json
@@ -3,13 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    {
-      "path": "../base-controller"
-    },
-    {
-      "path": "../messenger"
-    }
-  ],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/assets-controller/package.json
+++ b/packages/assets-controller/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@ethereumjs/util": "^9.1.0",

--- a/packages/assets-controller/tsconfig.json
+++ b/packages/assets-controller/tsconfig.json
@@ -3,17 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    { "path": "../account-tree-controller" },
-    { "path": "../assets-controllers" },
-    { "path": "../base-controller" },
-    { "path": "../client-controller" },
-    { "path": "../core-backend" },
-    { "path": "../keyring-controller" },
-    { "path": "../messenger" },
-    { "path": "../network-enablement-controller" },
-    { "path": "../phishing-controller" },
-    { "path": "../preferences-controller" }
-  ],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@ethereumjs/util": "^9.1.0",

--- a/packages/assets-controllers/tsconfig.json
+++ b/packages/assets-controllers/tsconfig.json
@@ -4,23 +4,6 @@
     "baseUrl": "./",
     "rootDir": "../.."
   },
-  "references": [
-    { "path": "../account-tree-controller" },
-    { "path": "../accounts-controller" },
-    { "path": "../approval-controller" },
-    { "path": "../core-backend" },
-    { "path": "../base-controller" },
-    { "path": "../controller-utils" },
-    { "path": "../keyring-controller" },
-    { "path": "../network-controller" },
-    { "path": "../network-enablement-controller" },
-    { "path": "../messenger" },
-    { "path": "../preferences-controller" },
-    { "path": "../phishing-controller" },
-    { "path": "../polling-controller" },
-    { "path": "../permission-controller" },
-    { "path": "../storage-service" },
-    { "path": "../transaction-controller" }
-  ],
+  "references": [],
   "include": ["../../types", "./src", "../../tests"]
 }

--- a/packages/authenticated-user-storage/package.json
+++ b/packages/authenticated-user-storage/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/base-data-service": "^0.1.3",

--- a/packages/authenticated-user-storage/tsconfig.json
+++ b/packages/authenticated-user-storage/tsconfig.json
@@ -3,10 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    { "path": "../base-data-service" },
-    { "path": "../controller-utils" },
-    { "path": "../messenger" }
-  ],
+  "references": [],
   "include": ["../../types", "./src", "./tests"]
 }

--- a/packages/base-controller/package.json
+++ b/packages/base-controller/package.json
@@ -47,7 +47,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/messenger": "^1.2.0",

--- a/packages/base-controller/tsconfig.json
+++ b/packages/base-controller/tsconfig.json
@@ -3,16 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    {
-      "path": "../controller-utils"
-    },
-    {
-      "path": "../json-rpc-engine"
-    },
-    {
-      "path": "../messenger"
-    }
-  ],
+  "references": [],
   "include": ["../../types", "./src", "./tests"]
 }

--- a/packages/base-data-service/package.json
+++ b/packages/base-data-service/package.json
@@ -51,7 +51,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/controller-utils": "^12.2.0",

--- a/packages/base-data-service/tsconfig.json
+++ b/packages/base-data-service/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [{ "path": "../messenger" }, { "path": "../controller-utils" }],
+  "references": [],
   "include": ["../../types", "./src", "./tests"]
 }

--- a/packages/bridge-controller/package.json
+++ b/packages/bridge-controller/package.json
@@ -49,7 +49,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@ethersproject/address": "^5.7.0",

--- a/packages/bridge-controller/tsconfig.json
+++ b/packages/bridge-controller/tsconfig.json
@@ -4,19 +4,6 @@
     "baseUrl": "./",
     "resolveJsonModule": true
   },
-  "references": [
-    { "path": "../accounts-controller" },
-    { "path": "../base-controller" },
-    { "path": "../controller-utils" },
-    { "path": "../network-controller" },
-    { "path": "../polling-controller" },
-    { "path": "../transaction-controller" },
-    { "path": "../gas-fee-controller" },
-    { "path": "../assets-controllers" },
-    { "path": "../multichain-network-controller" },
-    { "path": "../profile-sync-controller" },
-    { "path": "../remote-feature-flag-controller" },
-    { "path": "../assets-controller" }
-  ],
+  "references": [],
   "include": ["../../types", "./src", "./tests"]
 }

--- a/packages/bridge-status-controller/package.json
+++ b/packages/bridge-status-controller/package.json
@@ -49,7 +49,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/accounts-controller": "^39.0.1",

--- a/packages/bridge-status-controller/tsconfig.json
+++ b/packages/bridge-status-controller/tsconfig.json
@@ -4,17 +4,6 @@
     "baseUrl": "./",
     "resolveJsonModule": true
   },
-  "references": [
-    { "path": "../accounts-controller" },
-    { "path": "../base-controller" },
-    { "path": "../bridge-controller" },
-    { "path": "../controller-utils" },
-    { "path": "../messenger" },
-    { "path": "../network-controller" },
-    { "path": "../polling-controller" },
-    { "path": "../transaction-controller" },
-    { "path": "../profile-sync-controller" },
-    { "path": "../gas-fee-controller" }
-  ],
+  "references": [],
   "include": ["../../types", "./src", "./test"]
 }

--- a/packages/build-utils/package.json
+++ b/packages/build-utils/package.json
@@ -48,7 +48,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/utils": "^11.11.0",

--- a/packages/chain-agnostic-permission/package.json
+++ b/packages/chain-agnostic-permission/package.json
@@ -48,7 +48,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/api-specs": "^0.15.0",

--- a/packages/chain-agnostic-permission/tsconfig.json
+++ b/packages/chain-agnostic-permission/tsconfig.json
@@ -5,10 +5,6 @@
     "resolveJsonModule": true,
     "rootDir": "../.."
   },
-  "references": [
-    { "path": "../controller-utils" },
-    { "path": "../network-controller" },
-    { "path": "../permission-controller" }
-  ],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/chomp-api-service/package.json
+++ b/packages/chomp-api-service/package.json
@@ -48,7 +48,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/base-data-service": "^0.1.3",

--- a/packages/chomp-api-service/tsconfig.json
+++ b/packages/chomp-api-service/tsconfig.json
@@ -3,10 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    { "path": "../messenger" },
-    { "path": "../controller-utils" },
-    { "path": "../base-data-service" }
-  ],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/claims-controller/package.json
+++ b/packages/claims-controller/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/base-controller": "^9.1.0",

--- a/packages/claims-controller/tsconfig.json
+++ b/packages/claims-controller/tsconfig.json
@@ -3,19 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    {
-      "path": "../base-controller/tsconfig.json"
-    },
-    {
-      "path": "../messenger/tsconfig.json"
-    },
-    {
-      "path": "../profile-sync-controller/tsconfig.json"
-    },
-    {
-      "path": "../keyring-controller/tsconfig.json"
-    }
-  ],
+  "references": [],
   "include": ["../../types", "./src", "./tests"]
 }

--- a/packages/client-controller/package.json
+++ b/packages/client-controller/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/base-controller": "^9.1.0",

--- a/packages/compliance-controller/package.json
+++ b/packages/compliance-controller/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/base-controller": "^9.1.0",

--- a/packages/compliance-controller/tsconfig.json
+++ b/packages/compliance-controller/tsconfig.json
@@ -4,9 +4,5 @@
     "baseUrl": "./"
   },
   "include": ["../../types", "./src"],
-  "references": [
-    { "path": "../base-controller" },
-    { "path": "../controller-utils" },
-    { "path": "../messenger" }
-  ]
+  "references": []
 }

--- a/packages/composable-controller/package.json
+++ b/packages/composable-controller/package.json
@@ -48,7 +48,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/base-controller": "^9.1.0",

--- a/packages/composable-controller/tsconfig.json
+++ b/packages/composable-controller/tsconfig.json
@@ -3,16 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    {
-      "path": "../base-controller"
-    },
-    {
-      "path": "../messenger"
-    },
-    {
-      "path": "../json-rpc-engine"
-    }
-  ],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/config-registry-controller/package.json
+++ b/packages/config-registry-controller/package.json
@@ -51,7 +51,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/base-controller": "^9.1.0",

--- a/packages/config-registry-controller/tsconfig.json
+++ b/packages/config-registry-controller/tsconfig.json
@@ -3,14 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    { "path": "../base-controller" },
-    { "path": "../controller-utils" },
-    { "path": "../keyring-controller" },
-    { "path": "../messenger" },
-    { "path": "../polling-controller" },
-    { "path": "../profile-sync-controller" },
-    { "path": "../remote-feature-flag-controller" }
-  ],
+  "references": [],
   "include": ["../../types", "./src", "./tests"]
 }

--- a/packages/connectivity-controller/package.json
+++ b/packages/connectivity-controller/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/base-controller": "^9.1.0",

--- a/packages/connectivity-controller/tsconfig.json
+++ b/packages/connectivity-controller/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [{ "path": "../base-controller" }, { "path": "../messenger" }],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/controller-utils/package.json
+++ b/packages/controller-utils/package.json
@@ -48,7 +48,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@ethersproject/abi": "^5.7.0",

--- a/packages/core-backend/package.json
+++ b/packages/core-backend/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/accounts-controller": "^39.0.1",

--- a/packages/core-backend/tsconfig.json
+++ b/packages/core-backend/tsconfig.json
@@ -2,25 +2,8 @@
   "extends": "../../tsconfig.packages.json",
   "compilerOptions": {
     "baseUrl": "./",
-    "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "../.."
   },
-  "references": [
-    {
-      "path": "../accounts-controller"
-    },
-    {
-      "path": "../controller-utils"
-    },
-    {
-      "path": "../keyring-controller"
-    },
-    {
-      "path": "../messenger"
-    },
-    {
-      "path": "../profile-sync-controller"
-    }
-  ],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/delegation-controller/package.json
+++ b/packages/delegation-controller/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/base-controller": "^9.1.0",

--- a/packages/delegation-controller/tsconfig.json
+++ b/packages/delegation-controller/tsconfig.json
@@ -3,10 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    { "path": "../base-controller" },
-    { "path": "../keyring-controller" },
-    { "path": "../messenger" }
-  ],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/earn-controller/package.json
+++ b/packages/earn-controller/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@ethersproject/bignumber": "^5.7.0",

--- a/packages/earn-controller/tsconfig.json
+++ b/packages/earn-controller/tsconfig.json
@@ -4,21 +4,5 @@
     "baseUrl": "./"
   },
   "include": ["../../types", "./src"],
-  "references": [
-    {
-      "path": "../base-controller"
-    },
-    {
-      "path": "../network-controller"
-    },
-    {
-      "path": "../transaction-controller"
-    },
-    {
-      "path": "../account-tree-controller"
-    },
-    {
-      "path": "../messenger"
-    }
-  ]
+  "references": []
 }

--- a/packages/eip-5792-middleware/package.json
+++ b/packages/eip-5792-middleware/package.json
@@ -48,7 +48,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/messenger": "^1.2.0",

--- a/packages/eip-5792-middleware/tsconfig.json
+++ b/packages/eip-5792-middleware/tsconfig.json
@@ -4,13 +4,6 @@
     "baseUrl": "./",
     "rootDir": "../.."
   },
-  "references": [
-    { "path": "../network-controller" },
-    { "path": "../transaction-controller" },
-    { "path": "../messenger" },
-    { "path": "../accounts-controller" },
-    { "path": "../preferences-controller" },
-    { "path": "../keyring-controller" }
-  ],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/eip-7702-internal-rpc-middleware/package.json
+++ b/packages/eip-7702-internal-rpc-middleware/package.json
@@ -48,7 +48,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/controller-utils": "^12.2.0",

--- a/packages/eip1193-permission-middleware/package.json
+++ b/packages/eip1193-permission-middleware/package.json
@@ -48,7 +48,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/chain-agnostic-permission": "^1.6.2",

--- a/packages/eip1193-permission-middleware/tsconfig.json
+++ b/packages/eip1193-permission-middleware/tsconfig.json
@@ -4,11 +4,6 @@
     "baseUrl": "./",
     "rootDir": "../.."
   },
-  "references": [
-    { "path": "../chain-agnostic-permission" },
-    { "path": "../controller-utils" },
-    { "path": "../json-rpc-engine" },
-    { "path": "../permission-controller" }
-  ],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/ens-controller/package.json
+++ b/packages/ens-controller/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@ethersproject/providers": "^5.7.0",

--- a/packages/ens-controller/tsconfig.json
+++ b/packages/ens-controller/tsconfig.json
@@ -3,11 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    { "path": "../base-controller" },
-    { "path": "../controller-utils" },
-    { "path": "../network-controller" },
-    { "path": "../messenger" }
-  ],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/eth-block-tracker/package.json
+++ b/packages/eth-block-tracker/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/eth-json-rpc-provider": "^6.0.1",

--- a/packages/eth-block-tracker/tsconfig.json
+++ b/packages/eth-block-tracker/tsconfig.json
@@ -3,13 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    {
-      "path": "../eth-json-rpc-provider"
-    },
-    {
-      "path": "../json-rpc-engine"
-    }
-  ],
+  "references": [],
   "include": ["../../types", "./src", "./tests"]
 }

--- a/packages/eth-json-rpc-middleware/package.json
+++ b/packages/eth-json-rpc-middleware/package.json
@@ -49,7 +49,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/eth-block-tracker": "^15.0.1",

--- a/packages/eth-json-rpc-middleware/tsconfig.json
+++ b/packages/eth-json-rpc-middleware/tsconfig.json
@@ -3,22 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    {
-      "path": "../eth-block-tracker"
-    },
-    {
-      "path": "../eth-json-rpc-provider"
-    },
-    {
-      "path": "../json-rpc-engine"
-    },
-    {
-      "path": "../network-controller"
-    },
-    {
-      "path": "../message-manager"
-    }
-  ],
+  "references": [],
   "include": ["../../types", "./src", "./test"]
 }

--- a/packages/eth-json-rpc-provider/package.json
+++ b/packages/eth-json-rpc-provider/package.json
@@ -48,7 +48,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/json-rpc-engine": "^10.5.0",

--- a/packages/eth-json-rpc-provider/tsconfig.json
+++ b/packages/eth-json-rpc-provider/tsconfig.json
@@ -9,10 +9,6 @@
     "noUncheckedIndexedAccess": true,
     "target": "es2017"
   },
-  "references": [
-    {
-      "path": "../json-rpc-engine"
-    }
-  ],
+  "references": [],
   "include": ["../../types", "../../tests", "./src", "./tests"]
 }

--- a/packages/foundryup/package.json
+++ b/packages/foundryup/package.json
@@ -42,7 +42,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "minipass": "^7.1.2",

--- a/packages/gas-fee-controller/package.json
+++ b/packages/gas-fee-controller/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/base-controller": "^9.1.0",

--- a/packages/gas-fee-controller/tsconfig.json
+++ b/packages/gas-fee-controller/tsconfig.json
@@ -3,12 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    { "path": "../base-controller" },
-    { "path": "../controller-utils" },
-    { "path": "../messenger" },
-    { "path": "../network-controller" },
-    { "path": "../polling-controller" }
-  ],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/gator-permissions-controller/package.json
+++ b/packages/gator-permissions-controller/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/7715-permission-types": "^0.7.1",

--- a/packages/gator-permissions-controller/tsconfig.json
+++ b/packages/gator-permissions-controller/tsconfig.json
@@ -3,10 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    { "path": "../base-controller" },
-    { "path": "../messenger" },
-    { "path": "../transaction-controller" }
-  ],
+  "references": [],
   "include": ["../../types", "./src", "./tests"]
 }

--- a/packages/geolocation-controller/package.json
+++ b/packages/geolocation-controller/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/base-controller": "^9.1.0",

--- a/packages/geolocation-controller/tsconfig.json
+++ b/packages/geolocation-controller/tsconfig.json
@@ -3,10 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    { "path": "../base-controller" },
-    { "path": "../controller-utils" },
-    { "path": "../messenger" }
-  ],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/json-rpc-engine/package.json
+++ b/packages/json-rpc-engine/package.json
@@ -62,7 +62,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/messenger": "^1.2.0",

--- a/packages/json-rpc-engine/tsconfig.json
+++ b/packages/json-rpc-engine/tsconfig.json
@@ -9,10 +9,6 @@
     "noUncheckedIndexedAccess": true,
     "target": "es2020"
   },
-  "references": [
-    {
-      "path": "../messenger/tsconfig.json"
-    }
-  ],
+  "references": [],
   "include": ["../../types", "../../tests", "./src", "./tests"]
 }

--- a/packages/json-rpc-middleware-stream/package.json
+++ b/packages/json-rpc-middleware-stream/package.json
@@ -48,7 +48,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/json-rpc-engine": "^10.5.0",

--- a/packages/json-rpc-middleware-stream/tsconfig.json
+++ b/packages/json-rpc-middleware-stream/tsconfig.json
@@ -5,6 +5,6 @@
     "forceConsistentCasingInFileNames": true,
     "target": "es2017"
   },
-  "references": [{ "path": "../json-rpc-engine" }],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/keyring-controller/package.json
+++ b/packages/keyring-controller/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@ethereumjs/util": "^9.1.0",

--- a/packages/keyring-controller/tsconfig.json
+++ b/packages/keyring-controller/tsconfig.json
@@ -3,16 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    {
-      "path": "../base-controller"
-    },
-    {
-      "path": "../message-manager"
-    },
-    {
-      "path": "../messenger"
-    }
-  ],
+  "references": [],
   "include": ["../../types", "./src", "./tests"]
 }

--- a/packages/logging-controller/package.json
+++ b/packages/logging-controller/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/base-controller": "^9.1.0",

--- a/packages/logging-controller/tsconfig.json
+++ b/packages/logging-controller/tsconfig.json
@@ -3,10 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    { "path": "../base-controller" },
-    { "path": "../messenger" },
-    { "path": "../controller-utils" }
-  ],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/message-manager/package.json
+++ b/packages/message-manager/package.json
@@ -48,7 +48,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/base-controller": "^9.1.0",

--- a/packages/message-manager/tsconfig.json
+++ b/packages/message-manager/tsconfig.json
@@ -3,10 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    { "path": "../base-controller" },
-    { "path": "../controller-utils" },
-    { "path": "../messenger" }
-  ],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/messenger-cli/package.json
+++ b/packages/messenger-cli/package.json
@@ -35,7 +35,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/utils": "^11.11.0",

--- a/packages/messenger/package.json
+++ b/packages/messenger/package.json
@@ -51,7 +51,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/utils": "^11.11.0",

--- a/packages/money-account-balance-service/package.json
+++ b/packages/money-account-balance-service/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@ethersproject/contracts": "^5.7.0",

--- a/packages/money-account-balance-service/tsconfig.json
+++ b/packages/money-account-balance-service/tsconfig.json
@@ -3,12 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    { "path": "../base-data-service" },
-    { "path": "../controller-utils" },
-    { "path": "../messenger" },
-    { "path": "../network-controller" },
-    { "path": "../remote-feature-flag-controller" }
-  ],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/money-account-controller/package.json
+++ b/packages/money-account-controller/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/accounts-controller": "^39.0.1",

--- a/packages/money-account-controller/tsconfig.json
+++ b/packages/money-account-controller/tsconfig.json
@@ -3,11 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    { "path": "../base-controller" },
-    { "path": "../accounts-controller" },
-    { "path": "../keyring-controller" },
-    { "path": "../messenger" }
-  ],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/money-account-upgrade-controller/package.json
+++ b/packages/money-account-upgrade-controller/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/authenticated-user-storage": "^2.0.0",

--- a/packages/money-account-upgrade-controller/tsconfig.json
+++ b/packages/money-account-upgrade-controller/tsconfig.json
@@ -3,15 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    { "path": "../authenticated-user-storage" },
-    { "path": "../base-controller" },
-    { "path": "../chomp-api-service" },
-    { "path": "../delegation-controller" },
-    { "path": "../keyring-controller" },
-    { "path": "../messenger" },
-    { "path": "../network-controller" },
-    { "path": "../transaction-controller" }
-  ],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/multichain-account-service/package.json
+++ b/packages/multichain-account-service/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@ethereumjs/util": "^9.1.0",

--- a/packages/multichain-account-service/src/providers/SnapAccountProvider.test.ts
+++ b/packages/multichain-account-service/src/providers/SnapAccountProvider.test.ts
@@ -13,9 +13,9 @@ import type {
   CreateAccountOptions,
   DeleteAccountRequest,
   GetAccountRequest,
-  KeyringCapabilities,
 } from '@metamask/keyring-api';
 import type { EntropySourceId, KeyringAccount } from '@metamask/keyring-api';
+import type { KeyringCapabilities } from '@metamask/keyring-api/v2';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 import type { JsonRpcRequest, SnapId } from '@metamask/snaps-sdk';
 import deepmerge from 'deepmerge';

--- a/packages/multichain-account-service/tsconfig.json
+++ b/packages/multichain-account-service/tsconfig.json
@@ -3,12 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    { "path": "../base-controller" },
-    { "path": "../accounts-controller" },
-    { "path": "../keyring-controller" },
-    { "path": "../snap-account-service" },
-    { "path": "../messenger" }
-  ],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/multichain-api-middleware/package.json
+++ b/packages/multichain-api-middleware/package.json
@@ -48,7 +48,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/accounts-controller": "^39.0.1",

--- a/packages/multichain-api-middleware/tsconfig.json
+++ b/packages/multichain-api-middleware/tsconfig.json
@@ -5,13 +5,6 @@
     "resolveJsonModule": true,
     "rootDir": "../.."
   },
-  "references": [
-    { "path": "../accounts-controller" },
-    { "path": "../chain-agnostic-permission" },
-    { "path": "../json-rpc-engine" },
-    { "path": "../network-controller" },
-    { "path": "../permission-controller" },
-    { "path": "../multichain-transactions-controller" }
-  ],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/multichain-network-controller/package.json
+++ b/packages/multichain-network-controller/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/accounts-controller": "^39.0.1",

--- a/packages/multichain-network-controller/src/MultichainNetworkController/MultichainNetworkController.test.ts
+++ b/packages/multichain-network-controller/src/MultichainNetworkController/MultichainNetworkController.test.ts
@@ -8,6 +8,7 @@ import {
   SolAccountType,
   EthScope,
   TrxAccountType,
+  XlmAccountType,
 } from '@metamask/keyring-api';
 import type {
   AnyAccountType,
@@ -274,6 +275,8 @@ function setupController({
       [BtcAccountType.P2tr]:
         'bc1pxfxst7zrkw39vzh0pchq5ey0q7z6u739cudhz5vmg89wa4kyyp9qzrf5sp',
       [TrxAccountType.Eoa]: 'TYvuLYQvTZp56urTbkeM3vDqU2YipJ7eDk',
+      [XlmAccountType.Account]:
+        'GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ',
     };
     const mockAccountAddress = mockAccountAddressByAccountType[accountType];
 

--- a/packages/multichain-network-controller/tsconfig.json
+++ b/packages/multichain-network-controller/tsconfig.json
@@ -3,12 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    { "path": "../accounts-controller" },
-    { "path": "../base-controller" },
-    { "path": "../controller-utils" },
-    { "path": "../network-controller" },
-    { "path": "../keyring-controller" }
-  ],
+  "references": [],
   "include": ["../../types", "./src", "./tests"]
 }

--- a/packages/multichain-transactions-controller/package.json
+++ b/packages/multichain-transactions-controller/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/accounts-controller": "^39.0.1",

--- a/packages/multichain-transactions-controller/tsconfig.json
+++ b/packages/multichain-transactions-controller/tsconfig.json
@@ -3,12 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    { "path": "../accounts-controller" },
-    { "path": "../base-controller" },
-    { "path": "../keyring-controller" },
-    { "path": "../polling-controller" },
-    { "path": "../messenger" }
-  ],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/name-controller/package.json
+++ b/packages/name-controller/package.json
@@ -51,7 +51,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/base-controller": "^9.1.0",

--- a/packages/name-controller/tsconfig.json
+++ b/packages/name-controller/tsconfig.json
@@ -3,13 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    {
-      "path": "../base-controller"
-    },
-    {
-      "path": "../messenger"
-    }
-  ],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/network-controller/package.json
+++ b/packages/network-controller/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/base-controller": "^9.1.0",

--- a/packages/network-controller/tsconfig.json
+++ b/packages/network-controller/tsconfig.json
@@ -4,16 +4,6 @@
     "baseUrl": "./",
     "rootDir": "../.."
   },
-  "references": [
-    { "path": "../base-controller" },
-    { "path": "../controller-utils" },
-    { "path": "../connectivity-controller" },
-    { "path": "../eth-block-tracker" },
-    { "path": "../eth-json-rpc-middleware" },
-    { "path": "../eth-json-rpc-provider" },
-    { "path": "../json-rpc-engine" },
-    { "path": "../messenger" },
-    { "path": "../remote-feature-flag-controller" }
-  ],
+  "references": [],
   "include": ["../../types", "../../tests", "./src", "./tests"]
 }

--- a/packages/network-enablement-controller/package.json
+++ b/packages/network-enablement-controller/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/base-controller": "^9.1.0",

--- a/packages/network-enablement-controller/tsconfig.json
+++ b/packages/network-enablement-controller/tsconfig.json
@@ -4,13 +4,6 @@
     "baseUrl": "./",
     "rootDir": "../.."
   },
-  "references": [
-    { "path": "../base-controller" },
-    { "path": "../network-controller" },
-    { "path": "../multichain-network-controller" },
-    { "path": "../controller-utils" },
-    { "path": "../transaction-controller" },
-    { "path": "../messenger" }
-  ],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/notification-services-controller/package.json
+++ b/packages/notification-services-controller/package.json
@@ -102,7 +102,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@contentful/rich-text-html-renderer": "^16.5.2",

--- a/packages/notification-services-controller/tsconfig.json
+++ b/packages/notification-services-controller/tsconfig.json
@@ -3,22 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    {
-      "path": "../authenticated-user-storage"
-    },
-    {
-      "path": "../base-controller"
-    },
-    {
-      "path": "../profile-sync-controller"
-    },
-    {
-      "path": "../keyring-controller"
-    },
-    {
-      "path": "../messenger"
-    }
-  ],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/passkey-controller/package.json
+++ b/packages/passkey-controller/package.json
@@ -49,7 +49,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@levischuck/tiny-cbor": "^0.3.3",

--- a/packages/passkey-controller/tsconfig.json
+++ b/packages/passkey-controller/tsconfig.json
@@ -3,13 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    {
-      "path": "../base-controller"
-    },
-    {
-      "path": "../messenger"
-    }
-  ],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/permission-controller/package.json
+++ b/packages/permission-controller/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/approval-controller": "^9.0.2",

--- a/packages/permission-controller/tsconfig.json
+++ b/packages/permission-controller/tsconfig.json
@@ -3,12 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    { "path": "../approval-controller" },
-    { "path": "../base-controller" },
-    { "path": "../controller-utils" },
-    { "path": "../json-rpc-engine" },
-    { "path": "../messenger" }
-  ],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/permission-log-controller/package.json
+++ b/packages/permission-log-controller/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/base-controller": "^9.1.0",

--- a/packages/permission-log-controller/tsconfig.json
+++ b/packages/permission-log-controller/tsconfig.json
@@ -3,10 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    { "path": "../base-controller" },
-    { "path": "../json-rpc-engine" },
-    { "path": "../messenger" }
-  ],
+  "references": [],
   "include": ["../../types", "./src", "./tests"]
 }

--- a/packages/perps-controller/package.json
+++ b/packages/perps-controller/package.json
@@ -93,7 +93,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/abi-utils": "^2.0.3",

--- a/packages/perps-controller/tsconfig.json
+++ b/packages/perps-controller/tsconfig.json
@@ -3,40 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    {
-      "path": "../account-tree-controller"
-    },
-    {
-      "path": "../base-controller"
-    },
-    {
-      "path": "../bridge-controller"
-    },
-    {
-      "path": "../controller-utils"
-    },
-    {
-      "path": "../geolocation-controller"
-    },
-    {
-      "path": "../keyring-controller"
-    },
-    {
-      "path": "../messenger"
-    },
-    {
-      "path": "../network-controller"
-    },
-    {
-      "path": "../profile-sync-controller"
-    },
-    {
-      "path": "../remote-feature-flag-controller"
-    },
-    {
-      "path": "../transaction-controller"
-    }
-  ],
+  "references": [],
   "include": ["../../types", "./src", "./tests"]
 }

--- a/packages/phishing-controller/package.json
+++ b/packages/phishing-controller/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/address-book-controller": "^7.1.2",

--- a/packages/phishing-controller/src/PhishingController.test.ts
+++ b/packages/phishing-controller/src/PhishingController.test.ts
@@ -4647,19 +4647,23 @@ describe('Address poisoning detection', () => {
       [],
     );
 
-    rootMessenger.publish('AddressBookController:stateChange', {
-      addressBook: {
-        '0x1': {
-          [ADDRESS_BOOK_RECIPIENT]: {
-            address: ADDRESS_BOOK_RECIPIENT,
-            name: 'Known recipient',
-            chainId: '0x1',
-            memo: '',
-            isEns: false,
+    rootMessenger.publish(
+      'AddressBookController:stateChange',
+      {
+        addressBook: {
+          '0x1': {
+            [ADDRESS_BOOK_RECIPIENT]: {
+              address: ADDRESS_BOOK_RECIPIENT,
+              name: 'Known recipient',
+              chainId: '0x1',
+              memo: '',
+              isEns: false,
+            },
           },
         },
       },
-    });
+      [],
+    );
 
     await new Promise((resolve) => process.nextTick(resolve));
 

--- a/packages/phishing-controller/tsconfig.json
+++ b/packages/phishing-controller/tsconfig.json
@@ -3,11 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    { "path": "../base-controller" },
-    { "path": "../controller-utils" },
-    { "path": "../transaction-controller" },
-    { "path": "../messenger" }
-  ],
+  "references": [],
   "include": ["../../types", "./src", "./tests"]
 }

--- a/packages/polling-controller/package.json
+++ b/packages/polling-controller/package.json
@@ -48,7 +48,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/base-controller": "^9.1.0",

--- a/packages/polling-controller/tsconfig.json
+++ b/packages/polling-controller/tsconfig.json
@@ -4,11 +4,6 @@
     "baseUrl": "./",
     "rootDir": "../.."
   },
-  "references": [
-    { "path": "../base-controller" },
-    { "path": "../controller-utils" },
-    { "path": "../network-controller" },
-    { "path": "../messenger" }
-  ],
+  "references": [],
   "include": ["../../types", "./src", "../../tests"]
 }

--- a/packages/preferences-controller/package.json
+++ b/packages/preferences-controller/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/base-controller": "^9.1.0",

--- a/packages/preferences-controller/tsconfig.json
+++ b/packages/preferences-controller/tsconfig.json
@@ -3,11 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    { "path": "../base-controller" },
-    { "path": "../controller-utils" },
-    { "path": "../keyring-controller" },
-    { "path": "../messenger" }
-  ],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/profile-metrics-controller/package.json
+++ b/packages/profile-metrics-controller/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/accounts-controller": "^39.0.1",

--- a/packages/profile-metrics-controller/tsconfig.json
+++ b/packages/profile-metrics-controller/tsconfig.json
@@ -3,16 +3,7 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    { "path": "../../packages/accounts-controller" },
-    { "path": "../../packages/base-controller" },
-    { "path": "../../packages/controller-utils" },
-    { "path": "../../packages/keyring-controller" },
-    { "path": "../../packages/messenger" },
-    { "path": "../../packages/polling-controller" },
-    { "path": "../../packages/profile-sync-controller" },
-    { "path": "../../packages/transaction-controller" }
-  ],
+  "references": [],
   "include": ["../../types", "./src"],
   /**
    * Here we ensure that TypeScript resolves `@metamask/*` imports to the

--- a/packages/profile-sync-controller/package.json
+++ b/packages/profile-sync-controller/package.json
@@ -103,7 +103,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/address-book-controller": "^7.1.2",

--- a/packages/profile-sync-controller/tsconfig.json
+++ b/packages/profile-sync-controller/tsconfig.json
@@ -3,11 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    { "path": "../base-controller" },
-    { "path": "../keyring-controller" },
-    { "path": "../address-book-controller" },
-    { "path": "../messenger" }
-  ],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/ramps-controller/package.json
+++ b/packages/ramps-controller/package.json
@@ -51,7 +51,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/base-controller": "^9.1.0",

--- a/packages/ramps-controller/tsconfig.json
+++ b/packages/ramps-controller/tsconfig.json
@@ -4,10 +4,6 @@
     "baseUrl": "./",
     "resolveJsonModule": true
   },
-  "references": [
-    { "path": "../base-controller" },
-    { "path": "../messenger" },
-    { "path": "../profile-sync-controller" }
-  ],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/rate-limit-controller/package.json
+++ b/packages/rate-limit-controller/package.json
@@ -48,7 +48,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/base-controller": "^9.1.0",

--- a/packages/rate-limit-controller/tsconfig.json
+++ b/packages/rate-limit-controller/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [{ "path": "../base-controller" }, { "path": "../messenger" }],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/react-data-query/package.json
+++ b/packages/react-data-query/package.json
@@ -48,7 +48,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/base-data-service": "^0.1.3",

--- a/packages/react-data-query/tsconfig.json
+++ b/packages/react-data-query/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [{ "path": "../base-data-service" }],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/remote-feature-flag-controller/package.json
+++ b/packages/remote-feature-flag-controller/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/base-controller": "^9.1.0",

--- a/packages/remote-feature-flag-controller/tsconfig.json
+++ b/packages/remote-feature-flag-controller/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [{ "path": "../base-controller" }, { "path": "../messenger" }],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/sample-controllers/package.json
+++ b/packages/sample-controllers/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/base-controller": "^9.1.0",

--- a/packages/sample-controllers/tsconfig.json
+++ b/packages/sample-controllers/tsconfig.json
@@ -3,13 +3,7 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    { "path": "../../packages/base-controller" },
-    { "path": "../../packages/base-data-service" },
-    { "path": "../../packages/controller-utils" },
-    { "path": "../../packages/messenger" },
-    { "path": "../../packages/network-controller" }
-  ],
+  "references": [],
   "include": ["../../types", "./src"],
   /**
    * Here we ensure that TypeScript resolves `@metamask/*` imports to the

--- a/packages/seedless-onboarding-controller/package.json
+++ b/packages/seedless-onboarding-controller/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/auth-network-utils": "^0.3.0",

--- a/packages/seedless-onboarding-controller/tsconfig.json
+++ b/packages/seedless-onboarding-controller/tsconfig.json
@@ -3,16 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    {
-      "path": "../base-controller"
-    },
-    {
-      "path": "../message-manager"
-    },
-    {
-      "path": "../keyring-controller"
-    }
-  ],
+  "references": [],
   "include": ["../../types", "./src", "./tests"]
 }

--- a/packages/selected-network-controller/package.json
+++ b/packages/selected-network-controller/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/base-controller": "^9.1.0",

--- a/packages/selected-network-controller/tsconfig.json
+++ b/packages/selected-network-controller/tsconfig.json
@@ -4,22 +4,6 @@
     "baseUrl": "./",
     "rootDir": "../.."
   },
-  "references": [
-    {
-      "path": "../base-controller"
-    },
-    {
-      "path": "../network-controller"
-    },
-    {
-      "path": "../json-rpc-engine"
-    },
-    {
-      "path": "../permission-controller"
-    },
-    {
-      "path": "../messenger"
-    }
-  ],
+  "references": [],
   "include": ["../../types", "../../tests", "./src", "./tests"]
 }

--- a/packages/shield-controller/package.json
+++ b/packages/shield-controller/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/base-controller": "^9.1.0",

--- a/packages/shield-controller/tsconfig.json
+++ b/packages/shield-controller/tsconfig.json
@@ -3,11 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    { "path": "../base-controller" },
-    { "path": "../signature-controller" },
-    { "path": "../transaction-controller" },
-    { "path": "../messenger" }
-  ],
+  "references": [],
   "include": ["../../types", "./src", "./tests"]
 }

--- a/packages/signature-controller/package.json
+++ b/packages/signature-controller/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/accounts-controller": "^39.0.1",

--- a/packages/signature-controller/tsconfig.json
+++ b/packages/signature-controller/tsconfig.json
@@ -3,37 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    {
-      "path": "../accounts-controller"
-    },
-    {
-      "path": "../approval-controller"
-    },
-    {
-      "path": "../base-controller"
-    },
-    {
-      "path": "../controller-utils"
-    },
-    {
-      "path": "../gator-permissions-controller"
-    },
-    {
-      "path": "../message-manager"
-    },
-    {
-      "path": "../keyring-controller"
-    },
-    {
-      "path": "../logging-controller"
-    },
-    {
-      "path": "../network-controller"
-    },
-    {
-      "path": "../messenger"
-    }
-  ],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/snap-account-service/package.json
+++ b/packages/snap-account-service/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/account-api": "^1.0.4",

--- a/packages/snap-account-service/tsconfig.json
+++ b/packages/snap-account-service/tsconfig.json
@@ -3,18 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    // READ THIS CAREFULLY:
-    // `account-tree-controller` is intentionally NOT referenced here to break
-    // a project-reference cycle:
-    //   account-tree-controller -> multichain-account-service
-    //                           -> snap-account-service
-    //                           -> account-tree-controller
-    // The types we'd otherwise pull from `@metamask/account-tree-controller`
-    // are mirrored locally in `./src/types.ts` — keep them in sync.
-    // { "path": "../account-tree-controller" },
-    { "path": "../keyring-controller" },
-    { "path": "../messenger" }
-  ],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/social-controllers/package.json
+++ b/packages/social-controllers/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/base-controller": "^9.1.0",

--- a/packages/social-controllers/tsconfig.json
+++ b/packages/social-controllers/tsconfig.json
@@ -3,12 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    { "path": "../base-controller" },
-    { "path": "../base-data-service" },
-    { "path": "../controller-utils" },
-    { "path": "../messenger" },
-    { "path": "../profile-sync-controller" }
-  ],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/storage-service/package.json
+++ b/packages/storage-service/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/messenger": "^1.2.0",

--- a/packages/storage-service/tsconfig.json
+++ b/packages/storage-service/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [{ "path": "../messenger" }],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/subscription-controller/package.json
+++ b/packages/subscription-controller/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/base-controller": "^9.1.0",

--- a/packages/subscription-controller/tsconfig.json
+++ b/packages/subscription-controller/tsconfig.json
@@ -3,22 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    {
-      "path": "../base-controller"
-    },
-    {
-      "path": "../messenger"
-    },
-    {
-      "path": "../profile-sync-controller"
-    },
-    {
-      "path": "../polling-controller"
-    },
-    {
-      "path": "../transaction-controller"
-    }
-  ],
+  "references": [],
   "include": ["../../types", "./src", "./tests"]
 }

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@ethereumjs/common": "^4.4.0",

--- a/packages/transaction-controller/tsconfig.json
+++ b/packages/transaction-controller/tsconfig.json
@@ -4,16 +4,6 @@
     "baseUrl": "./",
     "target": "ES2022"
   },
-  "references": [
-    { "path": "../accounts-controller" },
-    { "path": "../approval-controller" },
-    { "path": "../base-controller" },
-    { "path": "../controller-utils" },
-    { "path": "../core-backend" },
-    { "path": "../gas-fee-controller" },
-    { "path": "../network-controller" },
-    { "path": "../messenger" },
-    { "path": "../remote-feature-flag-controller" }
-  ],
+  "references": [],
   "include": ["../../types", "./src", "./tests"]
 }

--- a/packages/transaction-pay-controller/package.json
+++ b/packages/transaction-pay-controller/package.json
@@ -51,7 +51,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@ethersproject/abi": "^5.7.0",

--- a/packages/transaction-pay-controller/tsconfig.json
+++ b/packages/transaction-pay-controller/tsconfig.json
@@ -3,40 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    {
-      "path": "../assets-controller"
-    },
-    {
-      "path": "../assets-controllers"
-    },
-    {
-      "path": "../base-controller"
-    },
-    {
-      "path": "../bridge-controller"
-    },
-    {
-      "path": "../bridge-status-controller"
-    },
-    {
-      "path": "../controller-utils"
-    },
-    {
-      "path": "../gas-fee-controller"
-    },
-    {
-      "path": "../network-controller"
-    },
-    {
-      "path": "../ramps-controller"
-    },
-    {
-      "path": "../remote-feature-flag-controller"
-    },
-    {
-      "path": "../transaction-controller"
-    }
-  ],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/user-operation-controller/package.json
+++ b/packages/user-operation-controller/package.json
@@ -51,7 +51,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/approval-controller": "^9.0.2",

--- a/packages/user-operation-controller/tsconfig.json
+++ b/packages/user-operation-controller/tsconfig.json
@@ -3,31 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    {
-      "path": "../base-controller"
-    },
-    {
-      "path": "../controller-utils"
-    },
-    {
-      "path": "../gas-fee-controller"
-    },
-    {
-      "path": "../keyring-controller"
-    },
-    {
-      "path": "../network-controller"
-    },
-    {
-      "path": "../polling-controller"
-    },
-    {
-      "path": "../transaction-controller"
-    },
-    {
-      "path": "../messenger"
-    }
-  ],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/packages/wallet-cli/package.json
+++ b/packages/wallet-cli/package.json
@@ -39,7 +39,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@oclif/core": "^4.10.5"

--- a/packages/wallet-framework-docs/package.json
+++ b/packages/wallet-framework-docs/package.json
@@ -32,7 +32,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "devDependencies": {
     "@docusaurus/core": "^3.10.1",

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -50,7 +50,8 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
-    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "typecheck": "tsc --noEmit --pretty false"
   },
   "dependencies": {
     "@metamask/accounts-controller": "^39.0.1",

--- a/packages/wallet/tsconfig.json
+++ b/packages/wallet/tsconfig.json
@@ -3,16 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    { "path": "../accounts-controller/tsconfig.json" },
-    { "path": "../approval-controller/tsconfig.json" },
-    { "path": "../base-controller/tsconfig.json" },
-    { "path": "../connectivity-controller/tsconfig.json" },
-    { "path": "../controller-utils/tsconfig.json" },
-    { "path": "../keyring-controller/tsconfig.json" },
-    { "path": "../messenger/tsconfig.json" },
-    { "path": "../remote-feature-flag-controller/tsconfig.json" },
-    { "path": "../storage-service/tsconfig.json" }
-  ],
+  "references": [],
   "include": ["../../types", "./src"]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,12 +3,12 @@
    * This configuration is extended by all other TypeScript configurations.
    */
   "compilerOptions": {
-    "composite": true,
     "esModuleInterop": true,
     "isolatedModules": true,
     "lib": ["ES2020", "DOM"],
     "module": "Node16",
     "moduleResolution": "Node16",
+    "skipLibCheck": true,
     "strict": true,
     "target": "ES2020"
   }

--- a/tsconfig.packages.build.json
+++ b/tsconfig.packages.build.json
@@ -4,6 +4,7 @@
    */
   "extends": "./tsconfig.packages.json",
   "compilerOptions": {
+    "composite": true,
     "declaration": true,
     "declarationMap": true,
     "emitDeclarationOnly": true,

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -202,6 +202,13 @@ module.exports = defineConfig({
           'scripts.test:watch',
           'NODE_OPTIONS=--experimental-vm-modules jest --watch',
         );
+
+        // All non-root packages must have the same "typecheck" script.
+        expectWorkspaceField(
+          workspace,
+          'scripts.typecheck',
+          'tsc --noEmit --pretty false',
+        );
       }
 
       if (isChildWorkspace) {


### PR DESCRIPTION
## Explanation

`yarn build:types` excludes `**/*.test.ts` and ESLint doesn't surface TypeScript module-resolution errors, so test-file dangling `import type` declarations slip through CI — the gap that produced #8012.

This PR adds `yarn typecheck` (per-package + root fan-out) that runs `tsc --noEmit` over each package's dev tsconfig with test files included, so renames/removals of exported types are caught before merge.

To keep this to a single dev tsconfig per package (no parallel `tsconfig.typecheck.json`):

- `composite: true` moves from `tsconfig.base.json` → `tsconfig.packages.build.json` (the only consumer was `tsc --build tsconfig.build.json`).
- `skipLibCheck: true` added to `tsconfig.base.json` to match the build config.
- Dev tsconfigs get `references: []` (they were only meaningful under composite mode; build configs keep theirs intact).
- `core-backend` dev tsconfig drops leftover `outDir`/`rootDir`.
- `typecheck` script enforced across all non-private packages via `yarn.config.cjs` constraint.

Five test-file dangling-import bugs that the new script surfaced are fixed here too: `account-tree-controller`, `multichain-account-service`, `ai-controllers`, `phishing-controller`, `multichain-network-controller`.

The script is not wired into `yarn lint` yet — running `yarn typecheck` on `main` currently surfaces ~860 pre-existing errors across other packages, which need to be triaged by package owners before it can be CI-gating.

## References

-

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling and test-only type/import fixes; no production runtime behavior changes. Large tsconfig churn is mechanical and build configs keep composite references.
> 
> **Overview**
> Adds **`yarn typecheck`** at the repo root to fan out **`tsc --noEmit`** across non-private workspaces, with each package getting a matching **`typecheck`** script (enforced in **`yarn.config.cjs`**). Dev **`tsconfig.json`** files no longer use project **`references`**; **`composite`** and **`skipLibCheck`** are shifted so dev typechecking can include tests without a separate **`tsconfig.typecheck.json`**.
> 
> Several test-only fixes align with stricter checking: renamed snap messenger type import, **`KeyringCapabilities`** from **`@metamask/keyring-api/v2`**, **`digestId`** on AI digest mocks, XLM account type in multichain network tests, and an extra argument on **`AddressBookController:stateChange`** publish in phishing tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab1374ec60e56dc3dbf426d4bc93e1848fbb681f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->