### PR TITLE
poc: non-evm native confirmations

### DIFF
--- a/packages/multichain-transactions-controller/CHANGELOG.md
+++ b/packages/multichain-transactions-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Pending universal transaction state on `MultichainTransactionsController` ([#TBD](https://github.com/MetaMask/core/pull/TBD))
+- Pending universal transaction state on `MultichainTransactionsController` ([#9115](https://github.com/MetaMask/core/pull/9115))
   - New non-persisted `pendingTransactions` state keyed by approval ID.
   - New `addPendingTransaction`, `updatePendingTransaction`, and `removePendingTransaction` messenger actions.
   - New `PendingMultichainTransaction` type for protocol-agnostic pending confirmation display data.

--- a/packages/multichain-transactions-controller/CHANGELOG.md
+++ b/packages/multichain-transactions-controller/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Pending universal transaction state on `MultichainTransactionsController` ([#TBD](https://github.com/MetaMask/core/pull/TBD))
+  - New non-persisted `pendingTransactions` state keyed by approval ID.
+  - New `addPendingTransaction`, `updatePendingTransaction`, and `removePendingTransaction` messenger actions.
+  - New `PendingMultichainTransaction` type for protocol-agnostic pending confirmation display data.
+
 ### Changed
 
 - Bump `@metamask/accounts-controller` from `^38.0.0` to `^38.1.1` ([#8755](https://github.com/MetaMask/core/pull/8755), [#8774](https://github.com/MetaMask/core/pull/8774))

--- a/packages/multichain-transactions-controller/src/MultichainTransactionsController-method-action-types.ts
+++ b/packages/multichain-transactions-controller/src/MultichainTransactionsController-method-action-types.ts
@@ -6,6 +6,48 @@
 import type { MultichainTransactionsController } from './MultichainTransactionsController';
 
 /**
+ * Adds or replaces a pending multichain transaction by approval ID.
+ *
+ * @param entry - Pending transaction entry to add.
+ */
+export type MultichainTransactionsControllerAddPendingTransactionAction = {
+  type: `MultichainTransactionsController:addPendingTransaction`;
+  handler: MultichainTransactionsController['addPendingTransaction'];
+};
+
+/**
+ * Updates a pending multichain transaction by approval ID.
+ *
+ * @param approvalId - Approval ID for the pending transaction.
+ * @param patch - Shallow patch to apply to the pending transaction.
+ */
+export type MultichainTransactionsControllerUpdatePendingTransactionAction = {
+  type: `MultichainTransactionsController:updatePendingTransaction`;
+  handler: MultichainTransactionsController['updatePendingTransaction'];
+};
+
+/**
+ * Removes a pending multichain transaction by approval ID.
+ *
+ * @param approvalId - Approval ID for the pending transaction.
+ */
+export type MultichainTransactionsControllerRemovePendingTransactionAction = {
+  type: `MultichainTransactionsController:removePendingTransaction`;
+  handler: MultichainTransactionsController['removePendingTransaction'];
+};
+
+/**
+ * Gets a pending multichain transaction by approval ID.
+ *
+ * @param approvalId - Approval ID for the pending transaction.
+ * @returns Pending transaction entry, if found.
+ */
+export type MultichainTransactionsControllerGetPendingTransactionAction = {
+  type: `MultichainTransactionsController:getPendingTransaction`;
+  handler: MultichainTransactionsController['getPendingTransaction'];
+};
+
+/**
  * Updates transactions for a specific account. This is used for the initial fetch
  * when an account is first added.
  *
@@ -21,4 +63,8 @@ export type MultichainTransactionsControllerUpdateTransactionsForAccountAction =
  * Union of all MultichainTransactionsController action types.
  */
 export type MultichainTransactionsControllerMethodActions =
-  MultichainTransactionsControllerUpdateTransactionsForAccountAction;
+  | MultichainTransactionsControllerAddPendingTransactionAction
+  | MultichainTransactionsControllerUpdatePendingTransactionAction
+  | MultichainTransactionsControllerRemovePendingTransactionAction
+  | MultichainTransactionsControllerGetPendingTransactionAction
+  | MultichainTransactionsControllerUpdateTransactionsForAccountAction;

--- a/packages/multichain-transactions-controller/src/MultichainTransactionsController-method-action-types.ts
+++ b/packages/multichain-transactions-controller/src/MultichainTransactionsController-method-action-types.ts
@@ -37,17 +37,6 @@ export type MultichainTransactionsControllerRemovePendingTransactionAction = {
 };
 
 /**
- * Gets a pending multichain transaction by approval ID.
- *
- * @param approvalId - Approval ID for the pending transaction.
- * @returns Pending transaction entry, if found.
- */
-export type MultichainTransactionsControllerGetPendingTransactionAction = {
-  type: `MultichainTransactionsController:getPendingTransaction`;
-  handler: MultichainTransactionsController['getPendingTransaction'];
-};
-
-/**
  * Updates transactions for a specific account. This is used for the initial fetch
  * when an account is first added.
  *
@@ -66,5 +55,4 @@ export type MultichainTransactionsControllerMethodActions =
   | MultichainTransactionsControllerAddPendingTransactionAction
   | MultichainTransactionsControllerUpdatePendingTransactionAction
   | MultichainTransactionsControllerRemovePendingTransactionAction
-  | MultichainTransactionsControllerGetPendingTransactionAction
   | MultichainTransactionsControllerUpdateTransactionsForAccountAction;

--- a/packages/multichain-transactions-controller/src/MultichainTransactionsController.test.ts
+++ b/packages/multichain-transactions-controller/src/MultichainTransactionsController.test.ts
@@ -258,17 +258,13 @@ const NEW_ACCOUNT_ID = 'new-account-id';
 const TEST_ACCOUNT_ID = 'test-account-id';
 const MOCK_PENDING_TRANSACTION: PendingMultichainTransaction = {
   approvalId: 'approval-id',
-  chainNamespace: 'solana',
-  chain: MultichainNetwork.Solana,
+  chainId: MultichainNetwork.Solana,
   accountId: TEST_ACCOUNT_ID,
-  from: 'from-address',
   to: 'to-address',
-  value: '1000000',
-  assetType: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
-  assetSymbol: 'SOL',
-  assetDecimals: 9,
-  feeRaw: '5000',
-  feeAssetType: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
+  amount: '1000000',
+  fee: {
+    amount: '5000',
+  },
   origin: 'mock-snap',
   createdAt: 123,
 };
@@ -356,14 +352,14 @@ describe('MultichainTransactionsController', () => {
     ).toStrictEqual(MOCK_PENDING_TRANSACTION);
 
     controller.updatePendingTransaction(MOCK_PENDING_TRANSACTION.approvalId, {
-      value: '2000000',
+      amount: '2000000',
     });
 
     expect(
       controller.getPendingTransaction(MOCK_PENDING_TRANSACTION.approvalId),
     ).toStrictEqual({
       ...MOCK_PENDING_TRANSACTION,
-      value: '2000000',
+      amount: '2000000',
     });
 
     controller.removePendingTransaction(MOCK_PENDING_TRANSACTION.approvalId);
@@ -377,7 +373,7 @@ describe('MultichainTransactionsController', () => {
     const { controller } = setupController();
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
 
-    controller.updatePendingTransaction('missing-approval-id', { value: '1' });
+    controller.updatePendingTransaction('missing-approval-id', { amount: '1' });
     controller.removePendingTransaction('missing-approval-id');
 
     expect(warnSpy).toHaveBeenCalledTimes(2);

--- a/packages/multichain-transactions-controller/src/MultichainTransactionsController.test.ts
+++ b/packages/multichain-transactions-controller/src/MultichainTransactionsController.test.ts
@@ -342,13 +342,13 @@ describe('MultichainTransactionsController', () => {
     });
   });
 
-  it('adds, updates, gets, and removes pending multichain transactions', () => {
+  it('adds, updates, and removes pending multichain transactions', () => {
     const { controller } = setupController();
 
     controller.addPendingTransaction(MOCK_PENDING_TRANSACTION);
 
     expect(
-      controller.getPendingTransaction(MOCK_PENDING_TRANSACTION.approvalId),
+      controller.state.pendingTransactions[MOCK_PENDING_TRANSACTION.approvalId],
     ).toStrictEqual(MOCK_PENDING_TRANSACTION);
 
     controller.updatePendingTransaction(MOCK_PENDING_TRANSACTION.approvalId, {
@@ -356,7 +356,7 @@ describe('MultichainTransactionsController', () => {
     });
 
     expect(
-      controller.getPendingTransaction(MOCK_PENDING_TRANSACTION.approvalId),
+      controller.state.pendingTransactions[MOCK_PENDING_TRANSACTION.approvalId],
     ).toStrictEqual({
       ...MOCK_PENDING_TRANSACTION,
       amount: '2000000',
@@ -365,7 +365,7 @@ describe('MultichainTransactionsController', () => {
     controller.removePendingTransaction(MOCK_PENDING_TRANSACTION.approvalId);
 
     expect(
-      controller.getPendingTransaction(MOCK_PENDING_TRANSACTION.approvalId),
+      controller.state.pendingTransactions[MOCK_PENDING_TRANSACTION.approvalId],
     ).toBeUndefined();
   });
 

--- a/packages/multichain-transactions-controller/src/MultichainTransactionsController.test.ts
+++ b/packages/multichain-transactions-controller/src/MultichainTransactionsController.test.ts
@@ -32,6 +32,7 @@ import {
 import type {
   MultichainTransactionsControllerState,
   MultichainTransactionsControllerMessenger,
+  PendingMultichainTransaction,
 } from './MultichainTransactionsController';
 
 const mockBtcAccount = {
@@ -255,11 +256,30 @@ async function waitForAllPromises(): Promise<void> {
 
 const NEW_ACCOUNT_ID = 'new-account-id';
 const TEST_ACCOUNT_ID = 'test-account-id';
+const MOCK_PENDING_TRANSACTION: PendingMultichainTransaction = {
+  approvalId: 'approval-id',
+  chainNamespace: 'solana',
+  chain: MultichainNetwork.Solana,
+  accountId: TEST_ACCOUNT_ID,
+  from: 'from-address',
+  to: 'to-address',
+  value: '1000000',
+  assetType: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
+  assetSymbol: 'SOL',
+  assetDecimals: 9,
+  feeRaw: '5000',
+  feeAssetType: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
+  origin: 'mock-snap',
+  createdAt: 123,
+};
 
 describe('MultichainTransactionsController', () => {
   it('initialize with default state', () => {
     const { controller } = setupController({});
-    expect(controller.state).toStrictEqual({ nonEvmTransactions: {} });
+    expect(controller.state).toStrictEqual({
+      nonEvmTransactions: {},
+      pendingTransactions: {},
+    });
   });
 
   it('updates transactions when "AccountsController:accountAdded" is fired', async () => {
@@ -322,7 +342,51 @@ describe('MultichainTransactionsController', () => {
 
     expect(controller.state).toStrictEqual({
       nonEvmTransactions: {},
+      pendingTransactions: {},
     });
+  });
+
+  it('adds, updates, gets, and removes pending multichain transactions', () => {
+    const { controller } = setupController();
+
+    controller.addPendingTransaction(MOCK_PENDING_TRANSACTION);
+
+    expect(
+      controller.getPendingTransaction(MOCK_PENDING_TRANSACTION.approvalId),
+    ).toStrictEqual(MOCK_PENDING_TRANSACTION);
+
+    controller.updatePendingTransaction(MOCK_PENDING_TRANSACTION.approvalId, {
+      value: '2000000',
+    });
+
+    expect(
+      controller.getPendingTransaction(MOCK_PENDING_TRANSACTION.approvalId),
+    ).toStrictEqual({
+      ...MOCK_PENDING_TRANSACTION,
+      value: '2000000',
+    });
+
+    controller.removePendingTransaction(MOCK_PENDING_TRANSACTION.approvalId);
+
+    expect(
+      controller.getPendingTransaction(MOCK_PENDING_TRANSACTION.approvalId),
+    ).toBeUndefined();
+  });
+
+  it('warns when updating or removing a missing pending multichain transaction', () => {
+    const { controller } = setupController();
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    controller.updatePendingTransaction('missing-approval-id', { value: '1' });
+    controller.removePendingTransaction('missing-approval-id');
+
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Pending multichain transaction not found for approvalId',
+      'missing-approval-id',
+    );
+
+    warnSpy.mockRestore();
   });
 
   it('updates transactions for a specific account', async () => {
@@ -564,6 +628,7 @@ describe('MultichainTransactionsController', () => {
             },
           },
         },
+        pendingTransactions: {},
       },
     });
 
@@ -597,6 +662,7 @@ describe('MultichainTransactionsController', () => {
             },
           },
         },
+        pendingTransactions: {},
       },
     });
 
@@ -621,6 +687,7 @@ describe('MultichainTransactionsController', () => {
     const { controller, rootMessenger } = setupController({
       state: {
         nonEvmTransactions: {},
+        pendingTransactions: {},
       },
     });
 
@@ -653,6 +720,7 @@ describe('MultichainTransactionsController', () => {
             },
           },
         },
+        pendingTransactions: {},
       },
       mocks: {
         listMultichainAccounts: [],
@@ -707,6 +775,7 @@ describe('MultichainTransactionsController', () => {
             },
           },
         },
+        pendingTransactions: {},
       },
     });
 
@@ -755,6 +824,7 @@ describe('MultichainTransactionsController', () => {
             },
           },
         },
+        pendingTransactions: {},
       },
     });
 
@@ -844,6 +914,7 @@ describe('MultichainTransactionsController', () => {
             },
           },
         },
+        pendingTransactions: {},
       },
     });
 
@@ -1027,6 +1098,7 @@ describe('MultichainTransactionsController', () => {
       ).toMatchInlineSnapshot(`
         {
           "nonEvmTransactions": {},
+          "pendingTransactions": {},
         }
       `);
     });
@@ -1059,6 +1131,7 @@ describe('MultichainTransactionsController', () => {
       ).toMatchInlineSnapshot(`
         {
           "nonEvmTransactions": {},
+          "pendingTransactions": {},
         }
       `);
     });

--- a/packages/multichain-transactions-controller/src/MultichainTransactionsController.ts
+++ b/packages/multichain-transactions-controller/src/MultichainTransactionsController.ts
@@ -55,7 +55,9 @@ export type PaginationOptions = {
   next?: string | null;
 };
 
-export type PendingMultichainTransaction = {
+export type PendingMultichainTransaction<
+  CustomData extends Record<string, Json> = Record<string, Json>,
+> = {
   approvalId: string;
   chainId: CaipChainId;
   accountId: string;
@@ -66,6 +68,7 @@ export type PendingMultichainTransaction = {
     amount: string;
     assetId?: CaipAssetType;
   };
+  custom?: CustomData;
   origin?: string;
   createdAt: number;
 };

--- a/packages/multichain-transactions-controller/src/MultichainTransactionsController.ts
+++ b/packages/multichain-transactions-controller/src/MultichainTransactionsController.ts
@@ -21,7 +21,12 @@ import type { Messenger } from '@metamask/messenger';
 import type { SnapControllerHandleRequestAction } from '@metamask/snaps-controllers';
 import type { SnapId } from '@metamask/snaps-sdk';
 import { HandlerType } from '@metamask/snaps-utils';
-import type { CaipChainId, Json, JsonRpcRequest } from '@metamask/utils';
+import type {
+  CaipAssetType,
+  CaipChainId,
+  Json,
+  JsonRpcRequest,
+} from '@metamask/utils';
 import type { Draft } from 'immer';
 
 import type { MultichainTransactionsControllerMethodActions } from './MultichainTransactionsController-method-action-types';
@@ -52,17 +57,15 @@ export type PaginationOptions = {
 
 export type PendingMultichainTransaction = {
   approvalId: string;
-  chainNamespace: 'solana' | 'bip122' | 'tron';
-  chain: string;
+  chainId: CaipChainId;
   accountId: string;
-  from: string;
   to: string;
-  value: string;
-  assetType: string;
-  assetSymbol: string;
-  assetDecimals: number;
-  feeRaw?: string;
-  feeAssetType?: string;
+  amount: string;
+  assetId?: CaipAssetType;
+  fee?: {
+    amount: string;
+    assetId?: CaipAssetType;
+  };
   origin?: string;
   createdAt: number;
 };

--- a/packages/multichain-transactions-controller/src/MultichainTransactionsController.ts
+++ b/packages/multichain-transactions-controller/src/MultichainTransactionsController.ts
@@ -28,7 +28,15 @@ import type { MultichainTransactionsControllerMethodActions } from './Multichain
 
 const controllerName = 'MultichainTransactionsController';
 
-const MESSENGER_EXPOSED_METHODS = ['updateTransactionsForAccount'] as const;
+const MESSENGER_EXPOSED_METHODS = [
+  'addPendingTransaction',
+  'getPendingTransaction',
+  'removePendingTransaction',
+  'updatePendingTransaction',
+  'updateTransactionsForAccount',
+] as const;
+const MISSING_PENDING_TRANSACTION_MESSAGE =
+  'Pending multichain transaction not found for approvalId';
 
 /**
  * PaginationOptions
@@ -42,6 +50,23 @@ export type PaginationOptions = {
   next?: string | null;
 };
 
+export type PendingMultichainTransaction = {
+  approvalId: string;
+  chainNamespace: 'solana' | 'bip122' | 'tron';
+  chain: string;
+  accountId: string;
+  from: string;
+  to: string;
+  value: string;
+  assetType: string;
+  assetSymbol: string;
+  assetDecimals: number;
+  feeRaw?: string;
+  feeAssetType?: string;
+  origin?: string;
+  createdAt: number;
+};
+
 /**
  * State used by the {@link MultichainTransactionsController} to cache account transactions.
  */
@@ -51,6 +76,7 @@ export type MultichainTransactionsControllerState = {
       [chain: CaipChainId]: TransactionStateEntry;
     };
   };
+  pendingTransactions: Record<string, PendingMultichainTransaction>;
 };
 
 /**
@@ -61,6 +87,7 @@ export type MultichainTransactionsControllerState = {
 export function getDefaultMultichainTransactionsControllerState(): MultichainTransactionsControllerState {
   return {
     nonEvmTransactions: {},
+    pendingTransactions: {},
   };
 }
 
@@ -152,6 +179,13 @@ const multichainTransactionsControllerMetadata = {
     includeInDebugSnapshot: false,
     usedInUi: true,
   },
+  pendingTransactions: {
+    includeInStateLogs: true,
+    persist: false,
+    includeInDebugSnapshot: false,
+    usedInUi: true,
+    anonymous: false,
+  },
 };
 
 /**
@@ -217,6 +251,67 @@ export class MultichainTransactionsController extends BaseController<
       (transactionsUpdate: AccountTransactionsUpdatedEventPayload) =>
         this.#handleOnAccountTransactionsUpdated(transactionsUpdate),
     );
+  }
+
+  /**
+   * Adds or replaces a pending multichain transaction by approval ID.
+   *
+   * @param entry - Pending transaction entry to add.
+   */
+  addPendingTransaction(entry: PendingMultichainTransaction): void {
+    this.update((state: Draft<MultichainTransactionsControllerState>) => {
+      state.pendingTransactions[entry.approvalId] = entry;
+    });
+  }
+
+  /**
+   * Updates a pending multichain transaction by approval ID.
+   *
+   * @param approvalId - Approval ID for the pending transaction.
+   * @param patch - Shallow patch to apply to the pending transaction.
+   */
+  updatePendingTransaction(
+    approvalId: string,
+    patch: Partial<PendingMultichainTransaction>,
+  ): void {
+    this.update((state: Draft<MultichainTransactionsControllerState>) => {
+      const pendingTransaction = state.pendingTransactions[approvalId];
+
+      if (!pendingTransaction) {
+        console.warn(MISSING_PENDING_TRANSACTION_MESSAGE, approvalId);
+        return;
+      }
+
+      Object.assign(pendingTransaction, patch);
+    });
+  }
+
+  /**
+   * Removes a pending multichain transaction by approval ID.
+   *
+   * @param approvalId - Approval ID for the pending transaction.
+   */
+  removePendingTransaction(approvalId: string): void {
+    this.update((state: Draft<MultichainTransactionsControllerState>) => {
+      if (!state.pendingTransactions[approvalId]) {
+        console.warn(MISSING_PENDING_TRANSACTION_MESSAGE, approvalId);
+        return;
+      }
+
+      delete state.pendingTransactions[approvalId];
+    });
+  }
+
+  /**
+   * Gets a pending multichain transaction by approval ID.
+   *
+   * @param approvalId - Approval ID for the pending transaction.
+   * @returns Pending transaction entry, if found.
+   */
+  getPendingTransaction(
+    approvalId: string,
+  ): PendingMultichainTransaction | undefined {
+    return this.state.pendingTransactions[approvalId];
   }
 
   /**

--- a/packages/multichain-transactions-controller/src/MultichainTransactionsController.ts
+++ b/packages/multichain-transactions-controller/src/MultichainTransactionsController.ts
@@ -35,7 +35,6 @@ const controllerName = 'MultichainTransactionsController';
 
 const MESSENGER_EXPOSED_METHODS = [
   'addPendingTransaction',
-  'getPendingTransaction',
   'removePendingTransaction',
   'updatePendingTransaction',
   'updateTransactionsForAccount',
@@ -306,18 +305,6 @@ export class MultichainTransactionsController extends BaseController<
 
       delete state.pendingTransactions[approvalId];
     });
-  }
-
-  /**
-   * Gets a pending multichain transaction by approval ID.
-   *
-   * @param approvalId - Approval ID for the pending transaction.
-   * @returns Pending transaction entry, if found.
-   */
-  getPendingTransaction(
-    approvalId: string,
-  ): PendingMultichainTransaction | undefined {
-    return this.state.pendingTransactions[approvalId];
   }
 
   /**

--- a/packages/multichain-transactions-controller/src/index.ts
+++ b/packages/multichain-transactions-controller/src/index.ts
@@ -2,6 +2,7 @@ export { MultichainTransactionsController } from './MultichainTransactionsContro
 export type {
   MultichainTransactionsControllerState,
   PaginationOptions,
+  PendingMultichainTransaction,
   TransactionStateEntry,
   MultichainTransactionsControllerStateChange,
   MultichainTransactionsControllerGetStateAction,


### PR DESCRIPTION
## Explanation

Companion branch for the non-EVM native confirmations POC.

See the extension PR description for the full architecture and cross-repo context:
https://github.com/MetaMask/metamask-extension/pull/43531

## References

- Extension PR: https://github.com/MetaMask/metamask-extension/pull/43531

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them
