### PR TITLE
fix: MM Pay transaction with paymentOverride and isPostQuote defined when source and target tokens have different number of decimal places

### DIFF
--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/assets-controllers` from `^109.0.0` to `^109.1.0` ([#9110](https://github.com/MetaMask/core/pull/9110))
 
+### Fixed
+
+- Fix token amount in `buildTokenTransferData` for MM Pay post-quote Money Account transactions when source and target tokens have different decimal places ([#9116](https://github.com/MetaMask/core/pull/9116))
+
 ## [23.6.0]
 
 ### Added

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.ts
@@ -461,14 +461,15 @@ async function processMoneyAccountPostQuote(
   }
 
   const fundingRecipient = recipient ?? request.from;
+  const rawAmount = transactionData?.tokens?.[0]?.amountRaw ?? '0';
 
   requestBody.authorizationList = normalizeAuthorizationList(authorizationList);
   requestBody.tradeType = 'EXACT_OUTPUT';
-  requestBody.amount = transactionData?.tokens?.[0]?.amountRaw ?? '0';
+  requestBody.amount = rawAmount;
   requestBody.txs = [
     {
       to: request.targetTokenAddress,
-      data: buildTokenTransferData(fundingRecipient, request.sourceTokenAmount),
+      data: buildTokenTransferData(fundingRecipient, rawAmount),
       value: '0x0',
     },
     ...overrideCalls.map((call) => ({


### PR DESCRIPTION
## Explanation

The PR fixed perps withdraw into money account. These are transactions which have paymentOverride and isPostQuote defined. In those cases token amount was set wrong.

## References
Related to https://consensyssoftware.atlassian.net/browse/CONF-1540

## Checklist

- [X] I've updated the test suite for new or updated code as appropriate
- [X] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [X] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [X] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them
