### PR TITLE
feat: adding transaction config parameter 'isQuoteRequired' to enforce using relay quotes for transactions

### DIFF
--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `isQuoteRequired` transaction config parameter to enforce fetching relay quotes even when source and target tokens are identical ([#9117](https://github.com/MetaMask/core/pull/9117))
+
 ### Changed
 
 - Bump `@metamask/assets-controllers` from `^109.0.0` to `^109.1.0` ([#9110](https://github.com/MetaMask/core/pull/9110))

--- a/packages/transaction-pay-controller/src/TransactionPayController.ts
+++ b/packages/transaction-pay-controller/src/TransactionPayController.ts
@@ -147,6 +147,7 @@ export class TransactionPayController extends BaseController<
         isPostQuote: transactionData.isPostQuote,
         isHyperliquidSource: transactionData.isHyperliquidSource,
         isPolymarketDepositWallet: transactionData.isPolymarketDepositWallet,
+        isQuoteRequired: transactionData.isQuoteRequired,
         refundTo: transactionData.refundTo,
         accountOverride: transactionData.accountOverride,
         paymentOverride: transactionData.paymentOverride,
@@ -162,6 +163,7 @@ export class TransactionPayController extends BaseController<
       transactionData.isHyperliquidSource = config.isHyperliquidSource;
       transactionData.isPolymarketDepositWallet =
         config.isPolymarketDepositWallet;
+      transactionData.isQuoteRequired = config.isQuoteRequired;
       transactionData.refundTo = config.refundTo;
       transactionData.paymentOverride = config.paymentOverride;
 

--- a/packages/transaction-pay-controller/src/types.ts
+++ b/packages/transaction-pay-controller/src/types.ts
@@ -138,6 +138,9 @@ export type TransactionConfig = {
   /** Overrides the payment source for the transaction. */
   paymentOverride?: PaymentOverride;
 
+  /** When true, a quote is always fetched even when the source and target tokens are identical. */
+  isQuoteRequired?: boolean;
+
   /**
    * Optional address to receive refunds if the quote provider transaction fails.
    * When set, overrides the default refund recipient (EOA) in the quote
@@ -311,6 +314,9 @@ export type TransactionData = {
 
   /** Overrides the payment source for the transaction. */
   paymentOverride?: PaymentOverride;
+
+  /** When true, a quote is always fetched even when the source and target tokens are identical. */
+  isQuoteRequired?: boolean;
 
   /**
    * Optional address to receive refunds if the quote provider transaction fails.

--- a/packages/transaction-pay-controller/src/utils/source-amounts.test.ts
+++ b/packages/transaction-pay-controller/src/utils/source-amounts.test.ts
@@ -177,6 +177,25 @@ describe('Source Amounts Utils', () => {
       expect(transactionData.sourceAmounts).toHaveLength(1);
     });
 
+    it('does not return empty array if payment token matches but isQuoteRequired is true', () => {
+      const transactionData: TransactionData = {
+        isLoading: false,
+        isQuoteRequired: true,
+        paymentToken: PAYMENT_TOKEN_MOCK,
+        tokens: [
+          {
+            ...TRANSACTION_TOKEN_MOCK,
+            address: PAYMENT_TOKEN_MOCK.address,
+            chainId: PAYMENT_TOKEN_MOCK.chainId,
+          },
+        ],
+      };
+
+      updateSourceAmounts(TRANSACTION_ID_MOCK, transactionData, messenger);
+
+      expect(transactionData.sourceAmounts).toHaveLength(1);
+    });
+
     it('returns empty array if skipIfBalance and has balance', () => {
       const transactionData: TransactionData = {
         isLoading: false,

--- a/packages/transaction-pay-controller/src/utils/source-amounts.ts
+++ b/packages/transaction-pay-controller/src/utils/source-amounts.ts
@@ -147,6 +147,7 @@ function calculatePostQuoteSourceAmounts(
  * @param messenger - Controller messenger.
  * @param transactionId - ID of the transaction.
  * @param isMaxAmount - Whether the transaction is a maximum amount transaction.
+ * @param isQuoteRequired - When true, a quote is always fetched even when source and target tokens are identical.
  * @returns The source amount or undefined if calculation failed.
  */
 function calculateSourceAmount(
@@ -228,6 +229,7 @@ function calculateSourceAmount(
  * @param token - Target token.
  * @param strategy - Payment strategy.
  * @param parentTransactionType - Parent transaction type, if available.
+ * @param isQuoteRequired - When true, a quote is always fetched even when source and target tokens are identical.
  * @returns True if a quote is always required, false otherwise.
  */
 function isQuoteAlwaysRequired(

--- a/packages/transaction-pay-controller/src/utils/source-amounts.ts
+++ b/packages/transaction-pay-controller/src/utils/source-amounts.ts
@@ -64,6 +64,8 @@ export function updateSourceAmounts(
     return;
   }
 
+  const { isQuoteRequired } = transactionData;
+
   const sourceAmounts = tokens
     .map((singleToken) =>
       calculateSourceAmount(
@@ -72,6 +74,7 @@ export function updateSourceAmounts(
         messenger,
         transactionId,
         isMaxAmount ?? false,
+        isQuoteRequired,
       ),
     )
     .filter(Boolean) as TransactionPaySourceAmount[];
@@ -152,6 +155,7 @@ function calculateSourceAmount(
   messenger: TransactionPayControllerMessenger,
   transactionId: string,
   isMaxAmount: boolean,
+  isQuoteRequired?: boolean,
 ): TransactionPaySourceAmount | undefined {
   const paymentTokenFiatRate = getTokenFiatRate(
     messenger,
@@ -180,6 +184,7 @@ function calculateSourceAmount(
     token,
     strategy,
     parentTransactionType,
+    isQuoteRequired,
   );
 
   if (isSameToken(token, paymentToken) && !isAlwaysRequired) {
@@ -229,7 +234,12 @@ function isQuoteAlwaysRequired(
   token: TransactionPayRequiredToken,
   strategy: TransactionPayStrategy,
   parentTransactionType?: TransactionType,
+  isQuoteRequired?: boolean,
 ): boolean {
+  if (isQuoteRequired) {
+    return true;
+  }
+
   const isHyperliquidDeposit =
     token.chainId === CHAIN_ID_ARBITRUM &&
     token.address.toLowerCase() === ARBITRUM_USDC_ADDRESS.toLowerCase();


### PR DESCRIPTION
## Explanation

Adding transaction config parameter 'isQuoteRequired' to enforce using relay quotes for transactions.

## References

Related to https://consensyssoftware.atlassian.net/browse/CONF-1549

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them
