### PR TITLE
chore: add optional environment_type to unified swap bridge button clicked event properties

### DIFF
--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add optional `environment_type` property to the `ButtonClicked` unified swap/bridge event context ([#43540](https://github.com/MetaMask/metamask-extension/pull/43540))
+- Add optional `environment_type` property to the `ButtonClicked` unified swap/bridge event context ([#9121](https://github.com/MetaMask/core/pull/9121))
 
 ### Changed
 

--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add optional `environment_type` property to the `ButtonClicked` unified swap/bridge event context ([#43540](https://github.com/MetaMask/metamask-extension/pull/43540))
+
 ### Changed
 
 - Bump `@metamask/assets-controllers` from `^109.0.0` to `^109.1.0` ([#9110](https://github.com/MetaMask/core/pull/9110))

--- a/packages/bridge-controller/src/utils/metrics/types.ts
+++ b/packages/bridge-controller/src/utils/metrics/types.ts
@@ -111,7 +111,7 @@ type RequiredEventContextFromClientBase = {
   [UnifiedSwapBridgeEventName.ButtonClicked]: Pick<
     RequestParams,
     'token_symbol_source' | 'token_symbol_destination'
-  >;
+  > & { environment_type?: string };
   // When type is object, the payload can be anything
   [UnifiedSwapBridgeEventName.PageViewed]: object;
   [UnifiedSwapBridgeEventName.InputChanged]: {


### PR DESCRIPTION
## Explanation

For this [core extension UX ticket](https://consensyssoftware.atlassian.net/browse/CEUX-1092), we want to embellish the Unified SwapBridge Button Clicked event with the `environment_type` of the UI context. These metrics do already include environment type, but they always have the value `background` as that is the context used when they are emitted. We want to however have the UI context for this metric so we can track `sidepanel` vs `popup` etc. 

So this PR modifies the `Unified SwapBridge Button Clicked` event properties (exported via `RequiredEventContextFromClient` in `@metamask/bridge-controller`) to add optional `environment_type` to be able to pass this data in directly at the call site where the values are either `sidepanel`, `popup` or `fullscreen`. Client side PR [here](https://github.com/MetaMask/metamask-extension/pull/43540). 

## References

* Part fixes: https://consensyssoftware.atlassian.net/browse/CEUX-1092

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them
