### PR TITLE
chore(smart-transactions-controller): replace configs to extend monorepo roots

### DIFF
--- a/merged-packages/smart-transactions-controller/jest.config.js
+++ b/merged-packages/smart-transactions-controller/jest.config.js
@@ -1,9 +1,20 @@
-module.exports = {
-  collectCoverage: true,
-  // Ensures that we collect coverage from all source files, not just tested
-  // ones.
-  collectCoverageFrom: ['./src/**.ts', '!./src/index.ts'],
-  coverageReporters: ['text', 'html'],
+/*
+ * For a detailed explanation regarding each configuration property and type check, visit:
+ * https://jestjs.io/docs/configuration
+ */
+
+const merge = require('deepmerge');
+const path = require('path');
+
+const baseConfig = require('../../jest.config.packages');
+
+const displayName = path.basename(__dirname);
+
+module.exports = merge(baseConfig, {
+  // The display name when running multiple projects
+  displayName,
+
+  // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
       branches: 74.65,
@@ -12,17 +23,8 @@ module.exports = {
       statements: 91.89,
     },
   },
-  moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],
-  preset: 'ts-jest',
-  // "resetMocks" resets all mocks, including mocked modules, to jest.fn(),
-  // between each test case.
-  resetMocks: true,
-  // "restoreMocks" restores all mocks created using jest.spyOn to their
-  // original implementations, between each test. It does not affect mocked
-  // modules.
-  restoreMocks: true,
+
   setupFiles: ['./setupJest.js'],
-  testEnvironment: 'node',
-  testRegex: ['\\.test\\.(ts|js)$'],
+
   testTimeout: 2500,
-};
+});

--- a/merged-packages/smart-transactions-controller/package.json
+++ b/merged-packages/smart-transactions-controller/package.json
@@ -77,6 +77,7 @@
     "@metamask/json-rpc-engine": "^10.5.0",
     "@metamask/messenger-cli": "^0.2.0",
     "@ts-bridge/cli": "^0.6.4",
+    "deepmerge": "^4.2.2",
     "eslint": "^9.39.1",
     "eslint-config-prettier": "^9.1.0",
     "eslint-import-resolver-typescript": "^3.6.3",

--- a/merged-packages/smart-transactions-controller/tsconfig.build.json
+++ b/merged-packages/smart-transactions-controller/tsconfig.build.json
@@ -1,24 +1,25 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../tsconfig.packages.build.json",
   "compilerOptions": {
-    "declaration": true,
-    "declarationMap": true,
-    "emitDeclarationOnly": true,
-    "inlineSources": true,
-    "noEmit": false,
-    "outDir": "dist",
-    "rootDir": "src",
-    "sourceMap": true
+    "baseUrl": "./",
+    "outDir": "./dist",
+    "rootDir": "./src"
   },
-  "include": ["./src/**/*.ts"],
-  "exclude": [
-    "./src/**/__fixtures__/**/*",
-    "./src/**/__mocks__/**/*",
-    "./src/**/__test__/**/*",
-    "./src/**/__tests__/**/*",
-    "./src/**/__snapshots__/**/*",
-    "./src/**/*.test.ts",
-    "./src/**/*.test-d.ts",
-    "./src/**/*.test.*.ts"
-  ]
+  "references": [
+    { "path": "../accounts-controller/tsconfig.build.json" },
+    { "path": "../approval-controller/tsconfig.build.json" },
+    { "path": "../base-controller/tsconfig.build.json" },
+    { "path": "../controller-utils/tsconfig.build.json" },
+    { "path": "../eth-block-tracker/tsconfig.build.json" },
+    { "path": "../eth-json-rpc-provider/tsconfig.build.json" },
+    { "path": "../gas-fee-controller/tsconfig.build.json" },
+    { "path": "../json-rpc-engine/tsconfig.build.json" },
+    { "path": "../messenger/tsconfig.build.json" },
+    { "path": "../network-controller/tsconfig.build.json" },
+    { "path": "../polling-controller/tsconfig.build.json" },
+    { "path": "../profile-sync-controller/tsconfig.build.json" },
+    { "path": "../remote-feature-flag-controller/tsconfig.build.json" },
+    { "path": "../transaction-controller/tsconfig.build.json" }
+  ],
+  "include": ["../../types", "./src"]
 }

--- a/merged-packages/smart-transactions-controller/tsconfig.json
+++ b/merged-packages/smart-transactions-controller/tsconfig.json
@@ -1,16 +1,25 @@
 {
+  "extends": "../../tsconfig.packages.json",
   "compilerOptions": {
-    "esModuleInterop": true,
-    "isolatedModules": true,
-    "lib": ["ES2020", "DOM"],
-    "module": "Node16",
-    "moduleResolution": "Node16",
-    "noEmit": true,
+    "baseUrl": "./",
     "noErrorTruncation": true,
-    "resolveJsonModule": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "target": "ES2020"
+    "resolveJsonModule": true
   },
-  "exclude": ["./dist", "**/node_modules"]
+  "references": [
+    { "path": "../accounts-controller" },
+    { "path": "../approval-controller" },
+    { "path": "../base-controller" },
+    { "path": "../controller-utils" },
+    { "path": "../eth-block-tracker" },
+    { "path": "../eth-json-rpc-provider" },
+    { "path": "../gas-fee-controller" },
+    { "path": "../json-rpc-engine" },
+    { "path": "../messenger" },
+    { "path": "../network-controller" },
+    { "path": "../polling-controller" },
+    { "path": "../profile-sync-controller" },
+    { "path": "../remote-feature-flag-controller" },
+    { "path": "../transaction-controller" }
+  ],
+  "include": ["../../types", "./src", "./tests"]
 }


### PR DESCRIPTION
## Explanation

Phase B PR #9 of the [package migration process guide](https://github.com/MetaMask/core/blob/main/docs/processes/package-migration-process-guide.md) for [\`@metamask/smart-transactions-controller\`](https://github.com/MetaMask/core/tree/main/merged-packages/smart-transactions-controller).

### Replaced

- **\`tsconfig.json\`** — now extends \`../../tsconfig.packages.json\`. Lists references for the in-monorepo upstream \`@metamask/*\` deps and optional peers. \`noErrorTruncation\` and \`resolveJsonModule\` preserved from the source repo's tsconfig.
- **\`tsconfig.build.json\`** — extends \`../../tsconfig.packages.build.json\` and mirrors the same references with \`tsconfig.build.json\` paths.
- **\`jest.config.js\`** — merges into the root \`jest.config.packages.js\`. Preserves the package's coverage thresholds (branches 74.65, functions 88.18, lines 92.33, statements 91.89), \`setupJest.js\` setup, and \`testTimeout: 2500\`.

### Unchanged

- **\`typedoc.json\`** — already matches the template (\`scripts/create-package/package-template/typedoc.json\`).
- **\`setupJest.js\`** — kept as-is; may be removable in PR #10 since Node 18+ has native \`fetch\` and \`isomorphic-fetch\` is no longer strictly required.

### DevDependency added

- \`deepmerge@^4.2.2\` (used by the new \`jest.config.js\`)

Package is still in \`merged-packages/\` so \`yarn install\` doesn't include it; configs aren't exercised until Phase C PR #12 moves it into \`packages/\`.

## References

- Prior steps: history merge (#9130), CHANGELOG reset (#9131), strip source-repo-only files (#9132)
- Migration process: [\`docs/processes/package-migration-process-guide.md\`](https://github.com/MetaMask/core/blob/main/docs/processes/package-migration-process-guide.md)

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them