### PR TITLE
chore(smart-transactions-controller): align deps and build scripts with monorepo

### DIFF
--- a/merged-packages/smart-transactions-controller/package.json
+++ b/merged-packages/smart-transactions-controller/package.json
@@ -1,12 +1,20 @@
 {
   "name": "@metamask/smart-transactions-controller",
   "version": "24.2.1",
-  "description": "Improves success rates for swaps by trialing transactions privately and finding minimum fees",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/MetaMask/smart-transactions-controller.git"
+  "description": "Improves success rates for swaps by trialing transactions privately and finding minimum fees.",
+  "keywords": [
+    "Ethereum",
+    "MetaMask"
+  ],
+  "homepage": "https://github.com/MetaMask/core/tree/main/packages/smart-transactions-controller#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/core/issues"
   },
   "license": "SEE LICENSE IN LICENSE",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MetaMask/core.git"
+  },
   "sideEffects": false,
   "exports": {
     ".": {
@@ -22,23 +30,23 @@
     "./package.json": "./package.json"
   },
   "main": "./dist/index.cjs",
-  "module": "./dist/index.mjs",
   "types": "./dist/index.d.cts",
   "files": [
-    "dist"
+    "dist/"
   ],
   "scripts": {
-    "build": "ts-bridge --project tsconfig.build.json --clean",
-    "lint": "yarn lint:eslint && yarn lint:misc --check && yarn lint:changelog && yarn messenger-action-types:check",
-    "lint:changelog": "auto-changelog validate --prettier",
-    "lint:eslint": "eslint . --cache",
-    "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write && yarn lint:changelog && yarn messenger-action-types:generate",
-    "lint:misc": "prettier '**/*.json' '**/*.md' '**/*.yml' '!.yarnrc.yml' --ignore-path .gitignore --no-error-on-unmatched-pattern",
-    "messenger-action-types:check": "messenger-action-types --check",
-    "messenger-action-types:generate": "messenger-action-types --generate",
-    "prepack": "./scripts/prepack.sh",
-    "test": "jest && attw --pack",
-    "test:watch": "jest --watchAll"
+    "build": "ts-bridge --project tsconfig.build.json --verbose --clean --no-references",
+    "build:all": "ts-bridge --project tsconfig.build.json --verbose --clean",
+    "build:docs": "typedoc",
+    "changelog:update": "../../scripts/update-changelog.sh @metamask/smart-transactions-controller",
+    "changelog:validate": "../../scripts/validate-changelog.sh @metamask/smart-transactions-controller",
+    "messenger-action-types:check": "tsx ../../packages/messenger-cli/src/cli.ts --formatter oxfmt --check",
+    "messenger-action-types:generate": "tsx ../../packages/messenger-cli/src/cli.ts --formatter oxfmt --generate",
+    "since-latest-release": "../../scripts/since-latest-release.sh",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
+    "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
+    "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
     "@babel/runtime": "^7.23.9",
@@ -65,70 +73,24 @@
     "reselect": "^5.1.1"
   },
   "devDependencies": {
-    "@arethetypeswrong/cli": "^0.18.2",
-    "@lavamoat/allow-scripts": "^3.0.4",
-    "@lavamoat/preinstall-always-fail": "^2.1.0",
     "@metamask/auto-changelog": "^6.1.0",
-    "@metamask/eslint-config": "^15.0.0",
-    "@metamask/eslint-config-jest": "^15.0.0",
-    "@metamask/eslint-config-nodejs": "^15.0.0",
-    "@metamask/eslint-config-typescript": "^15.0.0",
     "@metamask/gas-fee-controller": "^26.2.2",
     "@metamask/json-rpc-engine": "^10.5.0",
-    "@metamask/messenger-cli": "^0.2.0",
     "@ts-bridge/cli": "^0.6.4",
     "deepmerge": "^4.2.2",
-    "eslint": "^9.39.1",
-    "eslint-config-prettier": "^9.1.0",
-    "eslint-import-resolver-typescript": "^3.6.3",
-    "eslint-plugin-import-x": "^4.3.0",
-    "eslint-plugin-jest": "^28.8.3",
-    "eslint-plugin-jsdoc": "^50.2.4",
-    "eslint-plugin-n": "^17.10.3",
-    "eslint-plugin-prettier": "^5.2.1",
-    "eslint-plugin-promise": "^7.1.0",
-    "isomorphic-fetch": "^3.0.0",
     "jest": "^29.7.0",
     "nock": "^14.0.0-beta.7",
-    "prettier": "^3.3.3",
-    "prettier-plugin-packagejson": "^2.4.3",
     "ts-jest": "^29.2.5",
-    "typescript": "~5.3.3",
-    "typescript-eslint": "^8.48.0"
-  },
-  "peerDependenciesMeta": {
-    "@metamask/accounts-controller": {
-      "optional": true
-    },
-    "@metamask/approval-controller": {
-      "optional": true
-    },
-    "@metamask/eth-block-tracker": {
-      "optional": true
-    },
-    "@metamask/gas-fee-controller": {
-      "optional": true
-    }
-  },
-  "packageManager": "yarn@3.2.1",
-  "engines": {
-    "node": "^18.18 || >=20"
+    "tsx": "^4.20.5",
+    "typedoc": "^0.25.13",
+    "typedoc-plugin-missing-exports": "^2.0.0",
+    "typescript": "~5.3.3"
   },
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"
   },
-  "lavamoat": {
-    "allowScripts": {
-      "@lavamoat/preinstall-always-fail": false,
-      "eslint-plugin-import-x>unrs-resolver": false,
-      "@metamask/controller-utils>ethereumjs-util>ethereum-cryptography>keccak": false,
-      "@metamask/controller-utils>ethereumjs-util>ethereum-cryptography>secp256k1": false,
-      "@metamask/controller-utils>babel-runtime>core-js": false,
-      "@metamask/transaction-controller>@metamask/core-backend>@metamask/keyring-controller>ethereumjs-wallet>ethereum-cryptography>keccak": false,
-      "@metamask/transaction-controller>@metamask/core-backend>@metamask/keyring-controller>ethereumjs-wallet>ethereum-cryptography>secp256k1": false,
-      "@metamask/profile-sync-controller>@metamask/keyring-controller>ethereumjs-wallet>ethereum-cryptography>keccak": false,
-      "@metamask/profile-sync-controller>@metamask/keyring-controller>ethereumjs-wallet>ethereum-cryptography>secp256k1": false
-    }
+  "engines": {
+    "node": "^18.18 || >=20"
   }
 }


### PR DESCRIPTION
## Explanation

Phase B PR #10 of the [package migration process guide](https://github.com/MetaMask/core/blob/main/docs/processes/package-migration-process-guide.md) for [\`@metamask/smart-transactions-controller\`](https://github.com/MetaMask/core/tree/main/merged-packages/smart-transactions-controller).

Slims \`package.json\` down to match other non-root packages (modelled on \`packages/transaction-controller/package.json\`).

### Scripts

- **Build** swapped to the monorepo standard \`ts-bridge ... --verbose --clean --no-references\`; added \`build:all\`, \`build:docs\`.
- Added monorepo-standard \`changelog:update\`, \`changelog:validate\`, \`since-latest-release\`, \`test:clean\`, \`test:verbose\`, \`test:watch\`.
- \`messenger-action-types:check\`/\`:generate\` now invoke the workspace messenger-cli via \`tsx ../../packages/messenger-cli/src/cli.ts\` instead of the package-local binary.
- \`test\` reduced to \`jest --reporters=jest-silent-reporter\` (drops \`attw --pack\`; the dep that backed it is also removed below).
- Removed all \`lint*\` scripts and \`prepack\` — lint runs at the monorepo root, prepack is root-handled.

### DevDeps

| Removed (provided by root) | Kept (per-package toolchain) |
|---|---|
| \`@arethetypeswrong/cli\` (no longer used) | \`@metamask/auto-changelog\` |
| \`@lavamoat/allow-scripts\` | \`@metamask/gas-fee-controller\` (test helper) |
| \`@lavamoat/preinstall-always-fail\` | \`@metamask/json-rpc-engine\` (test helper) |
| \`@metamask/eslint-config*\` | \`@ts-bridge/cli\` |
| \`@metamask/messenger-cli\` (now invoked via \`tsx + path\`) | \`deepmerge\` |
| \`eslint\`, \`eslint-*\` | \`jest\` |
| \`isomorphic-fetch\` | \`nock\` |
| \`prettier\`, \`prettier-plugin-packagejson\` | \`ts-jest\` |
| \`typescript-eslint\` | \`typescript\` (kept per guide exception) |
| | \`tsx\`, \`typedoc\`, \`typedoc-plugin-missing-exports\` (added) |

### Other

- \`repository.url\` updated to point at \`MetaMask/core\`.
- Added required workspace fields: \`keywords\`, \`homepage\`, \`bugs\`. Description now ends with a period.
- Removed the dangling \`peerDependenciesMeta\` block (it had no matching \`peerDependencies\` entries).
- Removed per-package \`lavamoat\` config and \`packageManager\` — both handled at the monorepo root.

### Known holdout

\`nock\` is intentionally kept at \`^14.0.0-beta.7\` rather than aligning to root's \`^13.3.1\` — downgrade breaks 22 tests. Will be resolved in Phase C PR #12 via either an \`ALLOWED_INCONSISTENT_DEPENDENCIES\` entry or a core-side nock bump.

Package is still in \`merged-packages/\` so \`yarn install\` doesn't actually exercise this manifest yet; it's verified in PR #12 when the package moves into \`packages/\`.

## References

- Prior steps: history merge (#9130), CHANGELOG reset (#9131), strip files (#9132), replace configs (#9134)
- Migration process: [\`docs/processes/package-migration-process-guide.md\`](https://github.com/MetaMask/core/blob/main/docs/processes/package-migration-process-guide.md)

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them