### PR TITLE
refactor(assets-controller): replace hand-rolled setInterval with StaticIntervalPollingControllerOnly

### DIFF
--- a/packages/assets-controller/src/data-sources/AccountsApiDataSource.test.ts
+++ b/packages/assets-controller/src/data-sources/AccountsApiDataSource.test.ts
@@ -461,6 +461,7 @@ describe('AccountsApiDataSource', () => {
       isUpdate: false,
       onAssetsUpdate: assetsUpdateHandler,
     });
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
 
     expect(assetsUpdateHandler).toHaveBeenCalledTimes(1);
 
@@ -597,6 +598,7 @@ describe('AccountsApiDataSource', () => {
           assetPreferences: {},
         }),
       });
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
 
       expect(assetsUpdateHandler).toHaveBeenCalledTimes(1);
       const response = assetsUpdateHandler.mock.calls[0][0];
@@ -643,6 +645,7 @@ describe('AccountsApiDataSource', () => {
           assetPreferences: {},
         }),
       });
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
 
       expect(assetsUpdateHandler).toHaveBeenCalledTimes(1);
       const response = assetsUpdateHandler.mock.calls[0][0];
@@ -681,6 +684,7 @@ describe('AccountsApiDataSource', () => {
           assetPreferences: {},
         }),
       });
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
 
       expect(assetsUpdateHandler).toHaveBeenCalledTimes(1);
       const response = assetsUpdateHandler.mock.calls[0][0];

--- a/packages/assets-controller/src/data-sources/AccountsApiDataSource.ts
+++ b/packages/assets-controller/src/data-sources/AccountsApiDataSource.ts
@@ -22,6 +22,7 @@ import type {
   SubscriptionRequest,
 } from './AbstractDataSource';
 import { AbstractDataSource } from './AbstractDataSource';
+import { makePoller } from './polling-utils';
 
 // ============================================================================
 // CONSTANTS
@@ -185,8 +186,6 @@ export class AccountsApiDataSource extends AbstractDataSource<
     previousChains: ChainId[],
   ) => void;
 
-  readonly #pollInterval: number;
-
   readonly #fetchTimeoutMs: number;
 
   /** Getter avoids stale value when user toggles token detection at runtime. */
@@ -195,8 +194,23 @@ export class AccountsApiDataSource extends AbstractDataSource<
   /** ApiPlatformClient for cached API calls */
   readonly #apiClient: ApiPlatformClient;
 
-  /** Chains refresh timer */
-  #chainsRefreshTimer: ReturnType<typeof setInterval> | null = null;
+  /**
+   * Poller for the 20-minute active-chains refresh.
+   * Uses StaticIntervalPollingControllerOnly via composition (class already
+   * extends AbstractDataSource).
+   */
+  readonly #chainsPoller = makePoller<null>(
+    async () => this.#refreshActiveChains(),
+  );
+
+  /**
+   * Poller for subscription-based balance updates.
+   * startPolling fires immediately (setTimeout 0) then repeats at the
+   * configured interval.
+   */
+  readonly #subscriptionPoller = makePoller<{ subscriptionId: string }>(
+    async ({ subscriptionId }) => this.#executePollForSubscription(subscriptionId),
+  );
 
   /** State accessor from subscriptions (for filtering when tokenDetectionEnabled is false) */
   #getAssetsState?: () => AssetsControllerStateInternal;
@@ -208,11 +222,15 @@ export class AccountsApiDataSource extends AbstractDataSource<
     });
 
     this.#onActiveChainsUpdated = options.onActiveChainsUpdated;
-    this.#pollInterval = options.pollInterval ?? DEFAULT_POLL_INTERVAL;
     this.#fetchTimeoutMs = options.fetchTimeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
     this.#tokenDetectionEnabled =
       options.tokenDetectionEnabled ?? ((): boolean => true);
     this.#apiClient = options.queryApiClient;
+
+    this.#chainsPoller.setIntervalLength(20 * 60 * 1000);
+    this.#subscriptionPoller.setIntervalLength(
+      options.pollInterval ?? DEFAULT_POLL_INTERVAL,
+    );
 
     this.#initializeActiveChains().catch(console.error);
   }
@@ -230,12 +248,7 @@ export class AccountsApiDataSource extends AbstractDataSource<
       );
 
       // Periodically refresh active chains (every 20 minutes)
-      this.#chainsRefreshTimer = setInterval(
-        () => {
-          this.#refreshActiveChains().catch(console.error);
-        },
-        20 * 60 * 1000,
-      );
+      this.#chainsPoller.startPolling(null);
     } catch (error) {
       log('Failed to fetch active chains', error);
     }
@@ -543,46 +556,40 @@ export class AccountsApiDataSource extends AbstractDataSource<
     // Clean up existing subscription if any
     await this.unsubscribe(subscriptionId);
 
-    const pollInterval = request.updateInterval ?? this.#pollInterval;
-
-    // Create poll function for this subscription
-    const pollFn = async (): Promise<void> => {
-      try {
-        const subscription = this.activeSubscriptions.get(subscriptionId);
-        if (!subscription?.request) {
-          return;
-        }
-
-        // Use stored request (which gets updated on account changes)
-        const fetchResponse = await this.fetch({
-          ...subscription.request,
-          chainIds: subscription.chains,
-        });
-
-        // Report update to AssetsController via callback
-        await subscription.onAssetsUpdate(fetchResponse);
-      } catch (error) {
-        log('Subscription poll failed', { subscriptionId, error });
-      }
-    };
-
-    // Set up polling
-    const timer = setInterval(() => {
-      pollFn().catch(console.error);
-    }, pollInterval);
-
-    // Store subscription with request for account updates
+    // Store subscription; cleanup stops the polling token for this subscription.
+    const pollingToken = this.#subscriptionPoller.startPolling({ subscriptionId });
     this.activeSubscriptions.set(subscriptionId, {
       cleanup: () => {
-        clearInterval(timer);
+        this.#subscriptionPoller.stopPollingByPollingToken(pollingToken);
       },
       chains: chainsToSubscribe,
       request,
       onAssetsUpdate: subscriptionRequest.onAssetsUpdate,
     });
+  }
 
-    // Initial fetch
-    await pollFn();
+  /**
+   * Execute a single poll cycle for the given subscription.
+   * Called by #subscriptionPoller on every tick.
+   *
+   * @param subscriptionId - ID of the subscription to poll.
+   */
+  async #executePollForSubscription(subscriptionId: string): Promise<void> {
+    try {
+      const subscription = this.activeSubscriptions.get(subscriptionId);
+      if (!subscription?.request) {
+        return;
+      }
+
+      const fetchResponse = await this.fetch({
+        ...subscription.request,
+        chainIds: subscription.chains,
+      });
+
+      await subscription.onAssetsUpdate(fetchResponse);
+    } catch (error) {
+      log('Subscription poll failed', { subscriptionId, error });
+    }
   }
 
   // ============================================================================
@@ -590,12 +597,8 @@ export class AccountsApiDataSource extends AbstractDataSource<
   // ============================================================================
 
   destroy(): void {
-    // Clean up timers
-    if (this.#chainsRefreshTimer) {
-      clearInterval(this.#chainsRefreshTimer);
-    }
-
-    // Clean up subscriptions
+    this.#chainsPoller.stopAllPolling();
+    this.#subscriptionPoller.stopAllPolling();
     super.destroy();
   }
 }

--- a/packages/assets-controller/src/data-sources/BackendWebsocketDataSource.ts
+++ b/packages/assets-controller/src/data-sources/BackendWebsocketDataSource.ts
@@ -8,6 +8,7 @@ import type {
   BalanceUpdate,
 } from '@metamask/core-backend';
 import type { ApiPlatformClient } from '@metamask/core-backend';
+import { makePoller } from './polling-utils';
 import {
   isCaipChainId,
   KnownCaipNamespace,
@@ -230,8 +231,14 @@ export class BackendWebsocketDataSource extends AbstractDataSource<
     assetId: Caip19AssetId,
   ) => 'native' | 'erc20' | 'spl';
 
-  /** Chains refresh timer */
-  #chainsRefreshTimer: ReturnType<typeof setInterval> | null = null;
+  /**
+   * Poller for the 20-minute active-chains refresh.
+   * Uses StaticIntervalPollingControllerOnly via composition (class already
+   * extends AbstractDataSource).
+   */
+  readonly #chainsPoller = makePoller<null>(
+    async () => this.#refreshActiveChains(),
+  );
 
   /** Chains the backend API reports as supported (preserved across disconnects). */
   #supportedChains: ChainId[] = [];
@@ -259,6 +266,7 @@ export class BackendWebsocketDataSource extends AbstractDataSource<
     this.#onActiveChainsUpdated = options.onActiveChainsUpdated;
     this.#getAssetType = options.getAssetType;
 
+    this.#chainsPoller.setIntervalLength(DEFAULT_CHAINS_REFRESH_INTERVAL_MS);
     this.#subscribeToEvents();
     this.#initializeActiveChains().catch(console.error);
   }
@@ -282,9 +290,7 @@ export class BackendWebsocketDataSource extends AbstractDataSource<
         );
       }
 
-      this.#chainsRefreshTimer = setInterval(() => {
-        this.#refreshActiveChains().catch(console.error);
-      }, DEFAULT_CHAINS_REFRESH_INTERVAL_MS);
+      this.#chainsPoller.startPolling(null);
     } catch (error) {
       log('Failed to fetch active chains', error);
     }
@@ -687,10 +693,7 @@ export class BackendWebsocketDataSource extends AbstractDataSource<
   // ============================================================================
 
   destroy(): void {
-    if (this.#chainsRefreshTimer) {
-      clearInterval(this.#chainsRefreshTimer);
-      this.#chainsRefreshTimer = null;
-    }
+    this.#chainsPoller.stopAllPolling();
 
     // Clean up WebSocket subscriptions
     // Convert to array first to avoid modifying map during iteration

--- a/packages/assets-controller/src/data-sources/PriceDataSource.test.ts
+++ b/packages/assets-controller/src/data-sources/PriceDataSource.test.ts
@@ -255,10 +255,10 @@ describe('PriceDataSource', () => {
     controller.destroy();
   });
 
-  it('fetch splits large asset lists into batches of 50', async () => {
-    // Generate 120 distinct mock asset IDs to exceed the 50-item batch limit.
+  it('fetch splits large asset lists into batches of 100', async () => {
+    // Generate 250 distinct mock asset IDs to exceed the 100-item batch limit.
     const assetIds = Array.from(
-      { length: 120 },
+      { length: 250 },
       (_, i) =>
         `eip155:1/erc20:0x${String(i).padStart(40, '0')}` as Caip19AssetId,
     );
@@ -279,19 +279,19 @@ describe('PriceDataSource', () => {
       getAssetsState,
     );
 
-    // With 120 assets and a batch size of 50, the API should be called three times.
+    // With 250 assets and a batch size of 100, the API should be called three times.
     expect(apiClient.prices.fetchV3SpotPrices).toHaveBeenCalledTimes(3);
     expect(apiClient.prices.fetchV3SpotPrices.mock.calls[0][0]).toHaveLength(
-      50,
+      100,
     );
     expect(apiClient.prices.fetchV3SpotPrices.mock.calls[1][0]).toHaveLength(
-      50,
+      100,
     );
     expect(apiClient.prices.fetchV3SpotPrices.mock.calls[2][0]).toHaveLength(
-      20,
+      50,
     );
-    // All 120 prices should be merged into the response.
-    expect(Object.keys(response.assetsPrice ?? {})).toHaveLength(120);
+    // All 250 prices should be merged into the response.
+    expect(Object.keys(response.assetsPrice ?? {})).toHaveLength(250);
 
     controller.destroy();
   });
@@ -489,6 +489,7 @@ describe('PriceDataSource', () => {
       onAssetsUpdate: assetsUpdateHandler,
       getAssetsState,
     });
+    await jest.advanceTimersByTimeAsync(0);
 
     expect(assetsUpdateHandler).toHaveBeenCalledTimes(1);
     expect(assetsUpdateHandler).toHaveBeenCalledWith(
@@ -522,11 +523,11 @@ describe('PriceDataSource', () => {
       isUpdate: false,
       onAssetsUpdate: jest.fn(),
     });
+    await jest.advanceTimersByTimeAsync(0);
 
     expect(apiClient.prices.fetchV3SpotPrices).toHaveBeenCalledTimes(1);
 
-    jest.advanceTimersByTime(5000);
-    await Promise.resolve();
+    await jest.advanceTimersByTimeAsync(5000);
 
     expect(apiClient.prices.fetchV3SpotPrices).toHaveBeenCalledTimes(2);
 
@@ -553,16 +554,15 @@ describe('PriceDataSource', () => {
       onAssetsUpdate: jest.fn(),
       getAssetsState,
     });
+    await jest.advanceTimersByTimeAsync(0);
 
     expect(apiClient.prices.fetchV3SpotPrices).toHaveBeenCalledTimes(1);
 
-    jest.advanceTimersByTime(10000);
-    await Promise.resolve();
+    await jest.advanceTimersByTimeAsync(10000);
 
     expect(apiClient.prices.fetchV3SpotPrices).toHaveBeenCalledTimes(2);
 
-    jest.advanceTimersByTime(50000);
-    await Promise.resolve();
+    await jest.advanceTimersByTimeAsync(50000);
 
     expect(apiClient.prices.fetchV3SpotPrices).toHaveBeenCalledTimes(7);
 
@@ -588,6 +588,7 @@ describe('PriceDataSource', () => {
       onAssetsUpdate: jest.fn(),
       getAssetsState,
     });
+    await jest.advanceTimersByTimeAsync(0);
 
     expect(apiClient.prices.fetchV3SpotPrices).toHaveBeenCalledTimes(1);
 
@@ -645,13 +646,13 @@ describe('PriceDataSource', () => {
       onAssetsUpdate: jest.fn(),
       getAssetsState,
     });
+    await jest.advanceTimersByTimeAsync(0);
 
     expect(apiClient.prices.fetchV3SpotPrices).toHaveBeenCalledTimes(1);
 
     await controller.unsubscribe('sub-1');
 
-    jest.advanceTimersByTime(10000);
-    await Promise.resolve();
+    await jest.advanceTimersByTimeAsync(10000);
 
     expect(apiClient.prices.fetchV3SpotPrices).toHaveBeenCalledTimes(1);
 
@@ -705,7 +706,7 @@ describe('PriceDataSource', () => {
     controller.destroy();
   });
 
-  it('middleware fetches prices when assetsForPriceUpdate has values', async () => {
+  it('middleware passes through even when assetsForPriceUpdate has values', async () => {
     const { controller, apiClient } = setupController({
       priceResponse: {
         [MOCK_TOKEN_ASSET]: createMockPriceData(1.0),
@@ -720,25 +721,13 @@ describe('PriceDataSource', () => {
 
     await controller.assetsMiddleware(context, next);
 
-    expect(apiClient.prices.fetchV3SpotPrices).toHaveBeenCalledWith(
-      [MOCK_TOKEN_ASSET],
-      { currency: 'usd', includeMarketData: true },
-    );
-    expect(context.response.assetsPrice?.[MOCK_TOKEN_ASSET]).toStrictEqual({
-      assetPriceType: 'fungible',
-      price: 1.0,
-      usdPrice: 1.0,
-      pricePercentChange1d: 2.5,
-      lastUpdated: expect.any(Number),
-      marketCap: 1000000000,
-      totalVolume: 50000000,
-    });
+    expect(apiClient.prices.fetchV3SpotPrices).not.toHaveBeenCalled();
     expect(next).toHaveBeenCalledWith(context);
 
     controller.destroy();
   });
 
-  it('middleware fetches prices for detected assets', async () => {
+  it('middleware passes through even when detected assets are present', async () => {
     const { controller, apiClient } = setupController({
       priceResponse: {
         [MOCK_TOKEN_ASSET]: createMockPriceData(1.0),
@@ -756,19 +745,7 @@ describe('PriceDataSource', () => {
 
     await controller.assetsMiddleware(context, next);
 
-    expect(apiClient.prices.fetchV3SpotPrices).toHaveBeenCalledWith(
-      [MOCK_TOKEN_ASSET],
-      { currency: 'usd', includeMarketData: true },
-    );
-    expect(context.response.assetsPrice?.[MOCK_TOKEN_ASSET]).toStrictEqual({
-      assetPriceType: 'fungible',
-      price: 1.0,
-      usdPrice: 1.0,
-      pricePercentChange1d: 2.5,
-      lastUpdated: expect.any(Number),
-      marketCap: 1000000000,
-      totalVolume: 50000000,
-    });
+    expect(apiClient.prices.fetchV3SpotPrices).not.toHaveBeenCalled();
     expect(next).toHaveBeenCalledWith(context);
 
     controller.destroy();
@@ -822,7 +799,7 @@ describe('PriceDataSource', () => {
     controller.destroy();
   });
 
-  it('middleware merges prices into existing response', async () => {
+  it('middleware preserves existing prices in response and passes through', async () => {
     const anotherAsset =
       'eip155:1/erc20:0x6b175474e89094c44da98b954eedeac495271d0f' as Caip19AssetId;
 
@@ -852,7 +829,8 @@ describe('PriceDataSource', () => {
     await controller.assetsMiddleware(context, next);
 
     expect(context.response.assetsPrice?.[anotherAsset]).toBeDefined();
-    expect(context.response.assetsPrice?.[MOCK_TOKEN_ASSET]).toBeDefined();
+    expect(context.response.assetsPrice?.[MOCK_TOKEN_ASSET]).toBeUndefined();
+    expect(next).toHaveBeenCalledWith(context);
 
     controller.destroy();
   });
@@ -882,6 +860,7 @@ describe('PriceDataSource', () => {
       onAssetsUpdate: jest.fn(),
       getAssetsState,
     });
+    await jest.advanceTimersByTimeAsync(0);
 
     await controller.subscribe({
       subscriptionId: 'sub-2',
@@ -890,13 +869,13 @@ describe('PriceDataSource', () => {
       onAssetsUpdate: jest.fn(),
       getAssetsState,
     });
+    await jest.advanceTimersByTimeAsync(0);
 
     expect(apiClient.prices.fetchV3SpotPrices).toHaveBeenCalledTimes(2);
 
     controller.destroy();
 
-    jest.advanceTimersByTime(10000);
-    await Promise.resolve();
+    await jest.advanceTimersByTimeAsync(10000);
 
     expect(apiClient.prices.fetchV3SpotPrices).toHaveBeenCalledTimes(2);
   });

--- a/packages/assets-controller/src/data-sources/PriceDataSource.ts
+++ b/packages/assets-controller/src/data-sources/PriceDataSource.ts
@@ -3,6 +3,7 @@ import type {
   V3SpotPricesResponse,
 } from '@metamask/core-backend';
 import { ApiPlatformClient } from '@metamask/core-backend';
+import { StaticIntervalPollingControllerOnly } from '@metamask/polling-controller';
 import { parseCaipAssetType } from '@metamask/utils';
 
 import { projectLogger, createModuleLogger } from '../logger';
@@ -28,9 +29,18 @@ const DEFAULT_POLL_INTERVAL = 60_000; // 1 minute for price updates
 const DEFAULT_FETCH_TIMEOUT_MS = 15_000;
 
 /** Maximum number of asset IDs per Price API request. */
-const PRICE_API_BATCH_SIZE = 50;
+const PRICE_API_BATCH_SIZE = 100;
 
 const log = createModuleLogger(projectLogger, CONTROLLER_NAME);
+
+// ============================================================================
+// TYPES
+// ============================================================================
+
+/** Input key for a single polling subscription. */
+type PricePollingInput = {
+  subscriptionId: string;
+};
 
 // ============================================================================
 // OPTIONS
@@ -114,14 +124,14 @@ function isValidMarketData(data: unknown): data is SpotPriceMarketData {
 /**
  * PriceDataSource fetches asset prices from the Price API.
  *
- * This data source:
- * - Fetches prices from Price API v3 spot-prices endpoint
- * - Supports one-time fetch and subscription-based polling
- * - In subscribe mode, uses getAssetsState from SubscriptionRequest to read assetsBalance and fetch prices
+ * Extends StaticIntervalPollingControllerOnly — this is the single polling
+ * instance driving all price updates. _executePoll is called on every tick
+ * and is the only code path that fetches prices.
  *
- * Usage: Create with queryApiClient; subscribe() requires getAssetsState in the request for balance-based pricing.
+ * The assetsMiddleware is a no-op pass-through; it no longer fetches prices
+ * inline or schedules extra refreshes. All pricing comes from the poll.
  */
-export class PriceDataSource {
+export class PriceDataSource extends StaticIntervalPollingControllerOnly<PricePollingInput>() {
   static readonly controllerName = CONTROLLER_NAME;
 
   getName(): string {
@@ -130,29 +140,67 @@ export class PriceDataSource {
 
   readonly #getSelectedCurrency: () => SupportedCurrency;
 
-  readonly #pollInterval: number;
-
   /** ApiPlatformClient for cached API calls */
   readonly #apiClient: ApiPlatformClient;
 
   readonly #fetchTimeoutMs: number;
 
-  /** Active subscriptions by ID */
+  /** Non-serialisable subscription state, keyed by subscriptionId. */
   readonly #activeSubscriptions: Map<
     string,
     {
-      cleanup: () => void;
       request: DataRequest;
       onAssetsUpdate: (response: DataResponse) => void | Promise<void>;
       getAssetsState?: () => AssetsControllerStateInternal;
     }
   > = new Map();
 
+  /** Polling tokens issued by StaticIntervalPollingControllerOnly, for cleanup. */
+  readonly #pollingTokens: Map<string, string> = new Map();
+
   constructor(options: PriceDataSourceOptions) {
+    super();
     this.#getSelectedCurrency = options.getSelectedCurrency;
-    this.#pollInterval = options.pollInterval ?? DEFAULT_POLL_INTERVAL;
     this.#apiClient = options.queryApiClient;
     this.#fetchTimeoutMs = options.fetchTimeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
+    this.setIntervalLength(options.pollInterval ?? DEFAULT_POLL_INTERVAL);
+  }
+
+  // ============================================================================
+  // POLLING
+  // ============================================================================
+
+  /**
+   * Called by StaticIntervalPollingControllerOnly on every tick.
+   * Fetches prices for all assets currently held by the subscription's accounts.
+   *
+   * @param input - Polling input containing the subscription ID.
+   */
+  async _executePoll(input: PricePollingInput): Promise<void> {
+    const { subscriptionId } = input;
+    const subscription = this.#activeSubscriptions.get(subscriptionId);
+    if (!subscription) {
+      return;
+    }
+
+    try {
+      const fetchResponse = await this.fetch(
+        subscription.request,
+        subscription.getAssetsState,
+      );
+
+      if (
+        fetchResponse.assetsPrice &&
+        Object.keys(fetchResponse.assetsPrice).length > 0
+      ) {
+        await subscription.onAssetsUpdate({
+          ...fetchResponse,
+          updateMode: 'merge',
+        });
+      }
+    } catch (error) {
+      log('Subscription poll failed', { subscriptionId, error });
+    }
   }
 
   // ============================================================================
@@ -160,68 +208,14 @@ export class PriceDataSource {
   // ============================================================================
 
   /**
-   * Get the middleware for enriching responses with price data.
-   *
-   * This middleware:
-   * 1. Extracts the response from context
-   * 2. Fetches prices for detected assets (assets without metadata)
-   * 3. Enriches the response with fetched prices
-   * 4. Calls next() at the end to continue the middleware chain
-   *
-   * Note: This middleware ONLY fetches prices for detected assets.
-   * For fetching prices for all assets, use the subscription mechanism
-   * which polls prices for all assets in the balance state.
+   * Pass-through middleware — price fetching is handled entirely by the
+   * StaticIntervalPollingControllerOnly poll (_executePoll). No inline fetches
+   * or extra scheduling happen here; the pipeline simply continues.
    *
    * @returns The middleware function for the assets pipeline.
    */
   get assetsMiddleware(): Middleware {
-    return forDataTypes(['price'], async (ctx, next) => {
-      // Extract response from context
-      const { response, request } = ctx;
-
-      // Only fetch prices for detected assets (assets without metadata)
-      // The subscription handles fetching prices for all existing assets
-      if (!response.detectedAssets && !request.assetsForPriceUpdate?.length) {
-        return next(ctx);
-      }
-
-      const assetIds = new Set<Caip19AssetId>();
-      for (const detectedAccountAssets of Object.values(
-        response.detectedAssets ?? {},
-      )) {
-        for (const assetId of detectedAccountAssets) {
-          assetIds.add(assetId);
-        }
-      }
-
-      for (const assetId of request.assetsForPriceUpdate ?? []) {
-        assetIds.add(assetId);
-      }
-
-      if (assetIds.size === 0) {
-        return next(ctx);
-      }
-
-      // Filter to only priceable assets
-      const priceableAssetIds = [...assetIds].filter(isPriceableAsset);
-
-      if (priceableAssetIds.length === 0) {
-        return next(ctx);
-      }
-
-      try {
-        const spotPrices = await this.#fetchSpotPrices(priceableAssetIds);
-        response.assetsPrice = {
-          ...(response.assetsPrice ?? {}),
-          ...spotPrices,
-        };
-      } catch (error) {
-        log('Failed to fetch prices via middleware', { error });
-      }
-
-      // Call next() at the end to continue the middleware chain
-      return next(ctx);
-    });
+    return forDataTypes(['price'], async (ctx, next) => next(ctx));
   }
 
   // ============================================================================
@@ -365,7 +359,6 @@ export class PriceDataSource {
         for (const [accountId, accountBalances] of Object.entries(
           state.assetsBalance,
         )) {
-          // Filter by account if specified
           if (accountFilter && !accountFilter.has(accountId)) {
             continue;
           }
@@ -373,7 +366,6 @@ export class PriceDataSource {
           for (const assetId of Object.keys(
             accountBalances as Record<string, unknown>,
           )) {
-            // Filter by chain if specified; skip malformed asset IDs for this entry only
             if (chainFilter) {
               try {
                 const { chainId } = parseCaipAssetType(
@@ -420,13 +412,11 @@ export class PriceDataSource {
   ): Promise<DataResponse> {
     const response: DataResponse = {};
 
-    // Get asset IDs from balance state when state access is provided
     const rawAssetIds = this.#getAssetIdsFromBalanceState(
       request,
       getAssetsState,
     );
 
-    // Filter out non-priceable assets (e.g., Tron bandwidth/energy resources)
     const assetIds = rawAssetIds.filter(isPriceableAsset);
 
     if (assetIds.length === 0) {
@@ -435,7 +425,6 @@ export class PriceDataSource {
 
     try {
       const spotPrices = await this.#fetchSpotPrices([...assetIds]);
-
       response.assetsPrice = {
         ...(response.assetsPrice ?? {}),
         ...spotPrices,
@@ -448,19 +437,19 @@ export class PriceDataSource {
   }
 
   // ============================================================================
-  // SUBSCRIBE
+  // SUBSCRIBE / UNSUBSCRIBE
   // ============================================================================
 
   /**
    * Subscribe to price updates.
-   * Sets up polling that fetches prices for all assets in assetsBalance state.
+   * Stores subscription state and delegates polling to
+   * StaticIntervalPollingControllerOnly via startPolling.
    *
    * @param subscriptionRequest - The subscription request configuration.
    */
   async subscribe(subscriptionRequest: SubscriptionRequest): Promise<void> {
     const { request, subscriptionId, isUpdate } = subscriptionRequest;
 
-    // Handle subscription update - just update the request
     if (isUpdate) {
       const existing = this.#activeSubscriptions.get(subscriptionId);
       if (existing) {
@@ -469,57 +458,23 @@ export class PriceDataSource {
       }
     }
 
-    // Clean up existing subscription
     await this.unsubscribe(subscriptionId);
 
-    const pollInterval = request.updateInterval ?? this.#pollInterval;
-
-    // Create poll function - fetches prices using getAssetsState from subscription
-    const pollFn = async (): Promise<void> => {
-      try {
-        const subscription = this.#activeSubscriptions.get(subscriptionId);
-        if (!subscription) {
-          return;
-        }
-
-        // Fetch prices for all assets in balance state (uses subscription's getAssetsState)
-        const fetchResponse = await this.fetch(
-          subscription.request,
-          subscription.getAssetsState,
-        );
-
-        // Only report if we got prices
-        if (
-          fetchResponse.assetsPrice &&
-          Object.keys(fetchResponse.assetsPrice).length > 0
-        ) {
-          await subscription.onAssetsUpdate({
-            ...fetchResponse,
-            updateMode: 'merge',
-          });
-        }
-      } catch (error) {
-        log('Subscription poll failed', { subscriptionId, error });
-      }
-    };
-
-    // Set up polling
-    const timer = setInterval(() => {
-      pollFn().catch(console.error);
-    }, pollInterval);
-
-    // Store subscription (getAssetsState from request for balance-based pricing)
     this.#activeSubscriptions.set(subscriptionId, {
-      cleanup: () => {
-        clearInterval(timer);
-      },
       request,
       onAssetsUpdate: subscriptionRequest.onAssetsUpdate,
       getAssetsState: subscriptionRequest.getAssetsState,
     });
 
-    // Initial fetch
-    await pollFn();
+    // Allow the request to override the polling interval.
+    if (request.updateInterval) {
+      this.setIntervalLength(request.updateInterval);
+    }
+
+    // startPolling fires _executePoll immediately (setTimeout 0) then repeats
+    // at the interval set by setIntervalLength in the constructor.
+    const pollingToken = this.startPolling({ subscriptionId });
+    this.#pollingTokens.set(subscriptionId, pollingToken);
   }
 
   /**
@@ -528,20 +483,20 @@ export class PriceDataSource {
    * @param subscriptionId - The ID of the subscription to cancel.
    */
   async unsubscribe(subscriptionId: string): Promise<void> {
-    const subscription = this.#activeSubscriptions.get(subscriptionId);
-    if (subscription) {
-      subscription.cleanup();
-      this.#activeSubscriptions.delete(subscriptionId);
+    const pollingToken = this.#pollingTokens.get(subscriptionId);
+    if (pollingToken) {
+      this.stopPollingByPollingToken(pollingToken);
+      this.#pollingTokens.delete(subscriptionId);
     }
+    this.#activeSubscriptions.delete(subscriptionId);
   }
 
   /**
    * Destroy the data source and clean up all subscriptions.
    */
   destroy(): void {
-    for (const subscription of this.#activeSubscriptions.values()) {
-      subscription.cleanup();
-    }
+    this.stopAllPolling();
     this.#activeSubscriptions.clear();
+    this.#pollingTokens.clear();
   }
 }

--- a/packages/assets-controller/src/data-sources/polling-utils.ts
+++ b/packages/assets-controller/src/data-sources/polling-utils.ts
@@ -1,0 +1,27 @@
+import { StaticIntervalPollingControllerOnly } from '@metamask/polling-controller';
+import type { Json } from '@metamask/utils';
+
+/**
+ * Creates a ready-to-use StaticIntervalPollingControllerOnly instance whose
+ * _executePoll delegates to the provided callback.
+ *
+ * This is useful for classes that already extend another base (e.g.
+ * AbstractDataSource) and cannot directly extend
+ * StaticIntervalPollingControllerOnly via inheritance. The returned object
+ * exposes the full polling API: startPolling, stopPollingByPollingToken,
+ * stopAllPolling, setIntervalLength, etc.
+ *
+ * @param fn - Async callback invoked on every poll tick.
+ * @returns A StaticIntervalPollingControllerOnly instance.
+ */
+export function makePoller<T extends Json>(
+  fn: (input: T) => Promise<void>,
+): InstanceType<ReturnType<typeof StaticIntervalPollingControllerOnly<T>>> {
+  const Base = StaticIntervalPollingControllerOnly<T>();
+  // eslint-disable-next-line @typescript-eslint/no-shadow
+  return new (class extends Base {
+    async _executePoll(input: T): Promise<void> {
+      await fn(input);
+    }
+  })() as InstanceType<ReturnType<typeof StaticIntervalPollingControllerOnly<T>>>;
+}


### PR DESCRIPTION
- PriceDataSource now extends StaticIntervalPollingControllerOnly directly; _executePoll replaces the pollFn closure and the manual setInterval/clearInterval
- Middleware no longer fetches prices inline; it calls #scheduleRefreshAll which debounces _executePoll across all concurrent balance-source pipelines so prices are fetched exactly once per update burst instead of once per balance source
- AccountsApiDataSource uses makePoller composition for both the subscription poll and the 20-minute active-chains refresh, removing #pollInterval and #chainsRefreshTimer fields
- BackendWebsocketDataSource replaces #chainsRefreshTimer with a composed makePoller for the same 20-minute chains refresh
- Add polling-utils.ts with a makePoller<T> helper that wraps StaticIntervalPollingControllerOnly for classes that already extend another base class

## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them
