### PR TITLE
feat(transaction-pay-controller): validate relay quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,6 +632,7 @@ linkStyle default opacity:0.5
   transaction_pay_controller --> network_controller;
   transaction_pay_controller --> ramps_controller;
   transaction_pay_controller --> remote_feature_flag_controller;
+  transaction_pay_controller --> sentinel_api_service;
   transaction_pay_controller --> transaction_controller;
   user_operation_controller --> approval_controller;
   user_operation_controller --> base_controller;

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **BREAKING:** Validate Relay quotes by simulating their transactions, surfacing failures as a structured `quoteError` on `TransactionData` ([#9143](https://github.com/MetaMask/core/pull/9143))
+  - The messenger must now allow the `SentinelApiService:simulateTransactions` action.
+  - Add `quoteError` (`QuoteErrorInfo`: `{ message, reason, detail? }`) and export `QuoteErrorInfo` and `QuoteErrorReason`.
+  - Add `payStrategies.relay.validationEnabled` extended feature flag (in `confirmations_pay_extended`) as a kill switch; validation is disabled by default.
+
 ### Changed
 
 - Bump `@metamask/assets-controller` from `^11.1.1` to `^11.2.0` ([#9629](https://github.com/MetaMask/core/pull/9629))

--- a/packages/transaction-pay-controller/package.json
+++ b/packages/transaction-pay-controller/package.json
@@ -70,6 +70,7 @@
     "@metamask/network-controller": "^34.0.0",
     "@metamask/ramps-controller": "^17.0.0",
     "@metamask/remote-feature-flag-controller": "^4.2.2",
+    "@metamask/sentinel-api-service": "^1.0.0",
     "@metamask/transaction-controller": "^69.2.1",
     "@metamask/utils": "^11.11.0",
     "bignumber.js": "^9.1.2",

--- a/packages/transaction-pay-controller/src/index.ts
+++ b/packages/transaction-pay-controller/src/index.ts
@@ -17,6 +17,8 @@ export type {
   TransactionPayControllerOptions,
   TransactionPayControllerState,
   PolymarketCallbacks,
+  QuoteErrorInfo,
+  QuoteErrorReason,
   TransactionPayControllerStateChangeEvent,
   TransactionPaymentToken,
   TransactionPayQuote,

--- a/packages/transaction-pay-controller/src/strategy/relay/RelayStrategy.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/RelayStrategy.test.ts
@@ -1,5 +1,6 @@
 import type { Hex } from '@metamask/utils';
 
+import { TransactionPayStrategy } from '../../constants.js';
 import type {
   PayStrategyExecuteRequest,
   PayStrategyGetQuotesRequest,
@@ -84,7 +85,13 @@ describe('RelayStrategy', () => {
   });
 
   it('delegates getQuotes', async () => {
-    const quote = { strategy: 'relay' } as TransactionPayQuote<RelayQuote>;
+    const quote = {
+      request: {
+        sourceChainId: '0x1' as Hex,
+        sourceTokenAddress: '0xabc' as Hex,
+      },
+      strategy: TransactionPayStrategy.Relay,
+    } as TransactionPayQuote<RelayQuote>;
     getRelayQuotesMock.mockResolvedValue([quote]);
 
     const strategy = new RelayStrategy();

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.test.ts
@@ -61,6 +61,7 @@ jest.mock('../../utils/feature-flags', () => ({
   getGasBuffer: jest.fn(),
   getSlippage: jest.fn(),
 }));
+jest.mock('./relay-validation');
 
 const TRANSACTION_META_MOCK = { txParams: {} } as TransactionMeta;
 const PREDICT_WITHDRAW_TRANSACTION_MOCK = {
@@ -4102,9 +4103,7 @@ describe('Relay Quotes Utils', () => {
           requests: [QUOTE_REQUEST_MOCK],
           transaction: TRANSACTION_META_MOCK,
         }),
-      ).rejects.toThrow(
-        'Failed to fetch Relay quotes: Error: Batch estimation failed',
-      );
+      ).rejects.toThrow('Batch estimation failed');
     });
 
     it('includes gas limits in quote', async () => {
@@ -4167,7 +4166,7 @@ describe('Relay Quotes Utils', () => {
           requests: [QUOTE_REQUEST_MOCK],
           transaction: TRANSACTION_META_MOCK,
         }),
-      ).rejects.toThrow('Failed to fetch Relay quotes');
+      ).rejects.toThrow(Error);
     });
 
     it('throws when relay transaction estimation fields are missing', async () => {
@@ -4191,7 +4190,7 @@ describe('Relay Quotes Utils', () => {
           requests: [QUOTE_REQUEST_MOCK],
           transaction: TRANSACTION_META_MOCK,
         }),
-      ).rejects.toThrow('Failed to fetch Relay quotes');
+      ).rejects.toThrow(Error);
     });
 
     describe('Polymarket deposit-wallet source (isPolymarketDepositWallet)', () => {

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.ts
@@ -64,6 +64,7 @@ import { applyHyperliquidActivationFee } from './hyperliquid-activation.js';
 import { applyPolymarketDepositWalletOverrides } from './polymarket/withdraw.js';
 import { fetchRelayQuote } from './relay-api.js';
 import { getRelayMaxGasStationQuote } from './relay-max-gas-station.js';
+import { validateRelayQuotes } from './relay-validation.js';
 import type {
   RelayQuote,
   RelayQuoteMetamask,
@@ -130,14 +131,23 @@ export async function getRelayQuotes(
 
     log('Normalized requests', normalizedRequests);
 
-    return await Promise.all(
+    const quotes = await Promise.all(
       normalizedRequests.map((singleRequest) =>
         getQuoteWithMaxAmountHandling(singleRequest, request),
       ),
     );
+
+    await validateRelayQuotes({
+      messenger: request.messenger,
+      quotes,
+      signal: request.signal,
+      transaction: request.transaction,
+    });
+
+    return quotes;
   } catch (error) {
     log('Error fetching quotes', { error });
-    throw new Error(`Failed to fetch Relay quotes: ${String(error)}`);
+    throw error;
   }
 }
 

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-submit-execute.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-submit-execute.test.ts
@@ -11,7 +11,10 @@ import {
   getRelayPollingInterval,
   getRelayPollingTimeout,
 } from '../../utils/feature-flags.js';
-import { submitViaRelayExecute } from './relay-submit-execute.js';
+import {
+  getRelayExecuteRequest,
+  submitViaRelayExecute,
+} from './relay-submit-execute.js';
 import type { RelayQuote } from './types.js';
 
 jest.mock('../../utils/feature-flags');
@@ -454,6 +457,276 @@ describe('Relay Submit Execute', () => {
       ).rejects.toThrow(
         'Execute: Missing metamask.signature — cannot submit to /relay/execute without the HMAC token',
       );
+    });
+  });
+
+  describe('getRelayExecuteRequest', () => {
+    beforeEach(() => {
+      getDelegationTransactionMock.mockResolvedValue(DELEGATION_RESULT_MOCK);
+    });
+
+    it('builds execute request with authorizationList when delegation has one', async () => {
+      const result = await getRelayExecuteRequest({
+        allParams,
+        messenger,
+        quote,
+        requestId: REQUEST_ID_MOCK,
+        transaction,
+      });
+
+      expect(result.data.authorizationList).toStrictEqual([
+        {
+          chainId: 1,
+          address: '0xdelegateAddr',
+          nonce: 0,
+          yParity: 0,
+          r: '0xr',
+          s: '0xs',
+        },
+      ]);
+    });
+
+    it('omits authorizationList when delegation has none', async () => {
+      getDelegationTransactionMock.mockResolvedValue({
+        ...DELEGATION_RESULT_MOCK,
+        authorizationList: undefined,
+      });
+
+      const result = await getRelayExecuteRequest({
+        allParams,
+        messenger,
+        quote,
+        requestId: REQUEST_ID_MOCK,
+        transaction,
+      });
+
+      expect(result.data.authorizationList).toBeUndefined();
+    });
+
+    it('returns correct executionKind and requestId', async () => {
+      const result = await getRelayExecuteRequest({
+        allParams,
+        messenger,
+        quote,
+        requestId: REQUEST_ID_MOCK,
+        transaction,
+      });
+
+      expect(result.executionKind).toBe('rawCalls');
+      expect(result.requestId).toBe(REQUEST_ID_MOCK);
+    });
+
+    it('sets nestedTransactions from allParams', async () => {
+      await getRelayExecuteRequest({
+        allParams,
+        messenger,
+        quote,
+        requestId: REQUEST_ID_MOCK,
+        transaction,
+      });
+
+      expect(getDelegationTransactionMock).toHaveBeenCalledWith({
+        transaction: expect.objectContaining({
+          nestedTransactions: [
+            {
+              data: '0x1234',
+              to: '0xfedcb',
+              value: '0x4d2',
+            },
+          ],
+        }),
+        isSubsidized: false,
+      });
+    });
+
+    it('uses 0x fallback when params.data is undefined', async () => {
+      const paramsWithoutData = [
+        {
+          to: '0xfedcb' as Hex,
+          data: undefined,
+          value: '0x4d2' as Hex,
+        },
+      ];
+
+      await getRelayExecuteRequest({
+        allParams: paramsWithoutData,
+        messenger,
+        quote,
+        requestId: REQUEST_ID_MOCK,
+        transaction,
+      });
+
+      expect(getDelegationTransactionMock).toHaveBeenCalledWith({
+        transaction: expect.objectContaining({
+          nestedTransactions: [
+            expect.objectContaining({
+              data: '0x',
+            }),
+          ],
+        }),
+        isSubsidized: false,
+      });
+    });
+
+    it('does not regenerate batch txParams when regenerateBatchParams is false (default)', async () => {
+      transaction.txParams.data = '0xoriginaldata2' as Hex;
+      transaction.txParams.to = '0xoriginalto2' as Hex;
+
+      await getRelayExecuteRequest({
+        allParams,
+        messenger,
+        quote,
+        requestId: REQUEST_ID_MOCK,
+        transaction,
+      });
+
+      const call = getDelegationTransactionMock.mock.calls[0][0] as {
+        transaction: TransactionMeta;
+      };
+
+      // Without regenerateBatchParams, txParams retains the original to/data
+      expect(call.transaction.txParams.to).toBe('0xoriginalto2');
+      expect(call.transaction.txParams.data).toBe('0xoriginaldata2');
+    });
+
+    it('does not regenerate txParams when regenerateBatchParams is false (default)', async () => {
+      transaction.txParams.data = '0xoriginaldata' as Hex;
+      transaction.txParams.to = '0xoriginalto' as Hex;
+
+      await getRelayExecuteRequest({
+        allParams,
+        messenger,
+        quote,
+        requestId: REQUEST_ID_MOCK,
+        transaction,
+      });
+
+      const call = getDelegationTransactionMock.mock.calls[0][0] as {
+        transaction: TransactionMeta;
+      };
+
+      expect(call.transaction.txParams.from).toBe(FROM_MOCK);
+      expect(call.transaction.txParams.data).toBe('0xoriginaldata');
+      expect(call.transaction.txParams.to).toBe('0xoriginalto');
+    });
+
+    it('uses single nested transaction directly without batch wrapping when regenerateBatchParams is true and single param', async () => {
+      // Single param: no EIP-7702 batch wrapping; txParams.to/data/value come from the single nested tx
+      await getRelayExecuteRequest({
+        allParams,
+        messenger,
+        quote,
+        regenerateBatchParams: true,
+        requestId: REQUEST_ID_MOCK,
+        transaction,
+      });
+
+      const call = getDelegationTransactionMock.mock.calls[0][0] as {
+        transaction: TransactionMeta;
+      };
+
+      // txParams should reflect the single nested transaction directly (not a batch wrapper)
+      expect(call.transaction.txParams.to).toBe(allParams[0].to);
+      expect(call.transaction.txParams.data).toBe(allParams[0].data);
+      expect(call.transaction.txParams.value).toBe(allParams[0].value);
+    });
+
+    it('uses single nested transaction directly in txParams when regenerateBatchParams is true', async () => {
+      await getRelayExecuteRequest({
+        allParams,
+        messenger,
+        quote,
+        regenerateBatchParams: true,
+        requestId: REQUEST_ID_MOCK,
+        transaction,
+      });
+
+      expect(getDelegationTransactionMock).toHaveBeenCalledWith({
+        transaction: expect.objectContaining({
+          txParams: expect.objectContaining({
+            from: FROM_MOCK,
+            to: '0xfedcb',
+            data: '0x1234',
+            value: '0x4d2',
+          }),
+        }),
+        isSubsidized: false,
+      });
+    });
+
+    it('calls generateEIP7702BatchTransaction for multiple params when regenerateBatchParams is true', async () => {
+      const batchFrom = '0x1111111111111111111111111111111111111111' as Hex;
+      quote.request.from = batchFrom;
+
+      const multiParams = [
+        {
+          to: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as Hex,
+          data: '0x1111' as Hex,
+          value: '0x1' as Hex,
+        },
+        {
+          to: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' as Hex,
+          data: '0x2222' as Hex,
+          value: '0x2' as Hex,
+        },
+      ];
+
+      const expectedBatch = generateEIP7702BatchTransaction(
+        batchFrom,
+        multiParams,
+      );
+
+      await getRelayExecuteRequest({
+        allParams: multiParams,
+        messenger,
+        quote,
+        regenerateBatchParams: true,
+        requestId: REQUEST_ID_MOCK,
+        transaction,
+      });
+
+      expect(getDelegationTransactionMock).toHaveBeenCalledWith({
+        transaction: expect.objectContaining({
+          txParams: expect.objectContaining({
+            from: batchFrom,
+            to: expectedBatch.to,
+            data: expectedBatch.data,
+            value: '0x0',
+          }),
+        }),
+        isSubsidized: false,
+      });
+    });
+
+    it('calls getDelegationTransaction with isSubsidized: true when specified', async () => {
+      await getRelayExecuteRequest({
+        allParams,
+        isSubsidized: true,
+        messenger,
+        quote,
+        requestId: REQUEST_ID_MOCK,
+        transaction,
+      });
+
+      expect(getDelegationTransactionMock).toHaveBeenCalledWith({
+        transaction: expect.objectContaining({}),
+        isSubsidized: true,
+      });
+    });
+
+    it('calls getDelegationTransaction with isSubsidized: false by default', async () => {
+      await getRelayExecuteRequest({
+        allParams,
+        messenger,
+        quote,
+        requestId: REQUEST_ID_MOCK,
+        transaction,
+      });
+
+      expect(getDelegationTransactionMock).toHaveBeenCalledWith({
+        transaction: expect.objectContaining({}),
+        isSubsidized: false,
+      });
     });
   });
 });

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-submit-execute.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-submit-execute.ts
@@ -50,61 +50,17 @@ async function submitViaRelayExecuteInternal(
   const requestId = getRelayExecuteRequestId(quote.original);
   const metamask = getRelayExecuteMetamask(quote.original, isSubsidized);
 
-  const { from, sourceChainId } = quote.request;
-  const networkClientId = getNetworkClientId(messenger, sourceChainId);
-
-  const nestedTransactions = allParams.map((param) => ({
-    data: (param.data ?? '0x') as Hex,
-    to: param.to as Hex,
-    value: (param.value ?? '0x0') as Hex,
-  }));
-
-  // Regenerate `txParams` so it matches the current quote's nested transactions.
-  // The original `transaction.txParams` may be stale (from a previous quote), and
-  // downstream delegation caveats are built from `txParams.data`, so it must reflect
-  // the transactions being redeemed. A single nested transaction is used directly;
-  // multiple are wrapped into an atomic EIP-7702 (ERC-7821) batch.
-  const batchParams =
-    nestedTransactions.length === 1
-      ? nestedTransactions[0]
-      : generateEIP7702BatchTransaction(from, nestedTransactions);
-
-  const executionTransaction: TransactionMeta = {
-    ...transaction,
-    chainId: sourceChainId,
-    networkClientId,
-    nestedTransactions,
-    txParams: {
-      ...transaction.txParams,
-      from,
-      to: batchParams.to,
-      value: batchParams.value ?? '0x0',
-      data: batchParams.data,
-    },
-  } as TransactionMeta;
-
-  const delegation = await messenger.call(
-    'TransactionPayController:getDelegationTransaction',
-    { transaction: executionTransaction, isSubsidized },
-  );
-
-  log('Delegation result for execute', delegation);
-
-  const executeBody: RelayExecuteRequest = {
-    executionKind: 'rawCalls',
-    data: {
-      chainId: Number(quote.request.sourceChainId),
-      to: delegation.to,
-      data: delegation.data,
-      value: new BigNumber(delegation.value).toFixed(),
-      ...mapAuthorizationList(delegation.authorizationList),
-    },
-    executionOptions: {
-      subsidizeFees: false,
-    },
+  const core = await getRelayExecuteRequest({
+    allParams,
+    isSubsidized,
+    messenger,
+    quote,
+    regenerateBatchParams: true,
     requestId,
-    metamask,
-  };
+    transaction,
+  });
+
+  const executeBody: RelayExecuteRequest = { ...core, metamask };
 
   log('Submitting to Relay execute', { executeBody, from: quote.request.from });
 
@@ -197,4 +153,81 @@ function replaceFirstStepRequestId(quote: RelayQuote, requestId: string): void {
   const remainingSteps = steps.slice(1);
 
   quote.steps = [{ ...existingStep, requestId }, ...remainingSteps];
+}
+
+export async function getRelayExecuteRequest({
+  allParams,
+  isSubsidized = false,
+  messenger,
+  quote,
+  regenerateBatchParams = false,
+  requestId,
+  transaction,
+}: {
+  allParams: TransactionParams[];
+  isSubsidized?: boolean;
+  messenger: TransactionPayControllerMessenger;
+  quote: TransactionPayQuote<RelayQuote>;
+  regenerateBatchParams?: boolean;
+  requestId: string;
+  transaction: TransactionMeta;
+}): Promise<Omit<RelayExecuteRequest, 'metamask'>> {
+  const { from, sourceChainId } = quote.request;
+  const networkClientId = getNetworkClientId(messenger, sourceChainId);
+
+  const nestedTransactions = allParams.map((param) => ({
+    data: (param.data ?? '0x') as Hex,
+    to: param.to as Hex,
+    value: (param.value ?? '0x0') as Hex,
+  }));
+
+  let txParams = { ...transaction.txParams, from };
+
+  if (regenerateBatchParams) {
+    // Regenerate `txParams` so it matches the current quote's nested transactions.
+    // The original `transaction.txParams` may be stale (from a previous quote), and
+    // downstream delegation caveats are built from `txParams.data`, so it must reflect
+    // the transactions being redeemed. A single nested transaction is used directly;
+    // multiple are wrapped into an atomic EIP-7702 (ERC-7821) batch.
+    const batchParams =
+      nestedTransactions.length === 1
+        ? nestedTransactions[0]
+        : generateEIP7702BatchTransaction(from, nestedTransactions);
+    txParams = {
+      ...txParams,
+      to: batchParams.to,
+      value: batchParams.value ?? '0x0',
+      data: batchParams.data,
+    };
+  }
+
+  const executionTransaction: TransactionMeta = {
+    ...transaction,
+    chainId: sourceChainId,
+    networkClientId,
+    nestedTransactions,
+    txParams,
+  } as TransactionMeta;
+
+  const delegation = await messenger.call(
+    'TransactionPayController:getDelegationTransaction',
+    { transaction: executionTransaction, isSubsidized },
+  );
+
+  log('Delegation result for execute request', delegation);
+
+  return {
+    executionKind: 'rawCalls',
+    data: {
+      chainId: Number(sourceChainId),
+      to: delegation.to,
+      data: delegation.data,
+      value: new BigNumber(delegation.value).toFixed(),
+      ...mapAuthorizationList(delegation.authorizationList),
+    },
+    executionOptions: {
+      subsidizeFees: false,
+    },
+    requestId,
+  };
 }

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-submit.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-submit.test.ts
@@ -32,7 +32,7 @@ import {
 } from '../../utils/transaction.js';
 import { RELAY_STATUS_URL } from './constants.js';
 import { submitViaRelayExecute } from './relay-submit-execute.js';
-import { submitRelayQuotes } from './relay-submit.js';
+import { getRelaySubmitCalls, submitRelayQuotes } from './relay-submit.js';
 import type { RelayQuote } from './types.js';
 
 jest.mock('../../utils/token');
@@ -41,7 +41,6 @@ jest.mock('../../utils/feature-flags');
 jest.mock('./hyperliquid-withdraw');
 jest.mock('./polymarket/withdraw');
 jest.mock('./relay-submit-execute');
-
 const NETWORK_CLIENT_ID_MOCK = 'networkClientIdMock';
 const TRANSACTION_HASH_MOCK = '0x1234';
 const SOURCE_HASH_MOCK = '0xsourcehash';
@@ -1703,12 +1702,69 @@ describe('Relay Submit Utils', () => {
       beforeEach(() => {
         request.quotes[0].original.metamask.isExecute = true;
         submitViaRelayExecuteMock.mockResolvedValue(undefined);
+        getDelegationTransactionMock.mockResolvedValue({
+          data: '0xdelegationdata' as Hex,
+          to: '0xdelegationManager' as Hex,
+          value: '0x0' as Hex,
+        });
       });
 
       it('delegates to submitViaRelayExecute when isExecute is true', async () => {
         await submitRelayQuotes(request);
 
         expect(submitViaRelayExecuteMock).toHaveBeenCalledTimes(1);
+      });
+
+      it('uses fallback data and value when step item data/value are undefined', async () => {
+        request.quotes[0].original.steps[0].items[0].data.data =
+          undefined as unknown as Hex;
+        request.quotes[0].original.steps[0].items[0].data.value =
+          undefined as unknown as string;
+
+        await submitRelayQuotes(request);
+
+        expect(submitViaRelayExecuteMock).toHaveBeenCalledTimes(1);
+      });
+
+      it('includes authorizationList in execute request when delegation returns one', async () => {
+        getDelegationTransactionMock.mockResolvedValue({
+          data: '0xdelegationdata' as Hex,
+          to: '0xdelegationManager' as Hex,
+          value: '0x0' as Hex,
+          authorizationList: [
+            {
+              address: '0xabc' as Hex,
+              chainId: '0x1' as Hex,
+              nonce: '0x2' as Hex,
+              r: '0xr' as Hex,
+              s: '0xs' as Hex,
+              yParity: '0x0' as Hex,
+            },
+          ],
+        });
+
+        // submitViaRelayExecute is mocked; we just verify the flow completes
+        // without error, which exercises the authorizationList.map branch in
+        // buildRelayExecuteRequest (line 654 of relay-submit.ts)
+        await submitRelayQuotes(request);
+        expect(submitViaRelayExecuteMock).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe('getRelaySubmitCalls', () => {
+    it('returns calls from buildRelaySubmitParams', async () => {
+      const { calls } = await getRelaySubmitCalls({
+        messenger,
+        quote: request.quotes[0],
+        transaction: request.transaction,
+      });
+
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toMatchObject({
+        data: '0x1234',
+        from: FROM_MOCK,
+        to: '0xfedcb',
       });
     });
   });

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-submit.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-submit.ts
@@ -1,9 +1,11 @@
 import { ORIGIN_METAMASK, toHex } from '@metamask/controller-utils';
 import { TransactionType } from '@metamask/transaction-controller';
-import type { TransactionParams } from '@metamask/transaction-controller';
 import type {
   AuthorizationList,
+  TransactionBatchRequest,
+  TransactionBatchSingleRequest,
   TransactionMeta,
+  TransactionParams,
 } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 import { createModuleLogger } from '@metamask/utils';
@@ -57,6 +59,13 @@ import type {
 const log = createModuleLogger(projectLogger, 'relay-strategy');
 const RELAY_ERROR_PREFIX = 'Relay: ';
 
+type RelaySubmitParams = {
+  allParams: TransactionParams[];
+  normalizedParams: TransactionParams[];
+};
+
+export type RelaySubmitCalls = { calls: TransactionParams[] };
+
 /**
  * Submits Relay quotes.
  *
@@ -71,6 +80,23 @@ export async function submitRelayQuotes(
   } catch (error) {
     throw prefixError(error, RELAY_ERROR_PREFIX);
   }
+}
+
+export async function getRelaySubmitCalls({
+  messenger,
+  quote,
+  transaction,
+}: {
+  messenger: TransactionPayControllerMessenger;
+  quote: TransactionPayQuote<RelayQuote>;
+  transaction: TransactionMeta;
+}): Promise<RelaySubmitCalls> {
+  const { allParams } = await buildRelaySubmitParams({
+    messenger,
+    quote,
+    transaction,
+  });
+  return { calls: allParams };
 }
 
 async function submitRelayQuotesInternal(
@@ -393,20 +419,6 @@ async function submitTransactions(
   transaction: TransactionMeta,
   messenger: TransactionPayControllerMessenger,
 ): Promise<Hex> {
-  const { steps } = quote.original;
-  const txSteps = steps.filter(
-    (step): step is RelayTransactionStep => step.kind === 'transaction',
-  );
-  const params = txSteps.flatMap((step) => step.items).map((item) => item.data);
-  const SUPPORTED_STEP_KINDS = ['transaction', 'signature'];
-  const invalidKind = steps.find(
-    (step) => !SUPPORTED_STEP_KINDS.includes(step.kind),
-  )?.kind;
-
-  if (invalidKind) {
-    throw new Error(`Unsupported step kind: ${invalidKind}`);
-  }
-
   // In post-quote flows (e.g. Predict withdraw), the source tokens are held in
   // the Safe — not the EOA — and only become available after the original tx
   // executes as part of the batch. Skip the EOA balance check here.
@@ -414,6 +426,65 @@ async function submitTransactions(
     await validateSourceBalance(quote, messenger);
   }
 
+  const { allParams, normalizedParams } = await buildRelaySubmitParams({
+    messenger,
+    quote,
+    transaction,
+  });
+
+  if (quote.original.metamask.isExecute) {
+    return await submitViaRelayExecute(
+      quote,
+      transaction,
+      messenger,
+      allParams,
+    );
+  }
+
+  return await submitViaTransactionController(
+    quote,
+    transaction,
+    messenger,
+    normalizedParams,
+    allParams,
+  );
+}
+
+function getRelayTransactionStepData(
+  quote: TransactionPayQuote<RelayQuote>,
+): RelayTransactionStep['items'][0]['data'][] {
+  const { steps } = quote.original;
+  const supportedStepKinds = ['transaction', 'signature'];
+  const invalidKind = steps.find(
+    (step) => !supportedStepKinds.includes(step.kind),
+  )?.kind;
+
+  if (invalidKind) {
+    throw new Error(`Unsupported step kind: ${invalidKind}`);
+  }
+
+  const txSteps = steps.filter(
+    (step): step is RelayTransactionStep => step.kind === 'transaction',
+  );
+
+  return txSteps
+    .flatMap((step) => step.items)
+    .map((item) => item.data)
+    .filter((data): data is RelayTransactionStep['items'][0]['data'] =>
+      isRelayTransactionStepData(data),
+    );
+}
+
+async function buildRelaySubmitParams({
+  messenger,
+  quote,
+  transaction,
+}: {
+  messenger: TransactionPayControllerMessenger;
+  quote: TransactionPayQuote<RelayQuote>;
+  transaction: TransactionMeta;
+}): Promise<RelaySubmitParams> {
+  const params = getRelayTransactionStepData(quote);
   const normalizedParams = params.map((singleParams) =>
     normalizeParams(singleParams, messenger),
   );
@@ -471,22 +542,14 @@ async function submitTransactions(
     allParams = [prependedParams, ...normalizedParams];
   }
 
-  if (quote.original.metamask.isExecute) {
-    return await submitViaRelayExecute(
-      quote,
-      transaction,
-      messenger,
-      allParams,
-    );
-  }
+  return { allParams, normalizedParams };
+}
 
-  return await submitViaTransactionController(
-    quote,
-    transaction,
-    messenger,
-    normalizedParams,
-    allParams,
-  );
+function isRelayTransactionStepData(
+  data: RelayTransactionStep['items'][0]['data'],
+): data is RelayTransactionStep['items'][0]['data'] {
+  const maybeStepData = data as { to?: unknown };
+  return maybeStepData.to !== undefined;
 }
 
 /**
@@ -633,50 +696,17 @@ async function submitViaTransactionController(
       },
     );
   } else {
-    const gasLimit7702 = metamask.is7702
-      ? toHex(metamask.gasLimits[0])
-      : undefined;
-
-    const prependCount = allParams.length - normalizedParams.length;
-
-    const transactions = allParams.map((singleParams, index) => {
-      const gasLimit = gasLimits[index];
-      const gas =
-        gasLimit === undefined || gasLimit7702 ? undefined : toHex(gasLimit);
-
-      return {
-        params: {
-          data: singleParams.data as Hex,
-          gas,
-          maxFeePerGas: singleParams.maxFeePerGas as Hex,
-          maxPriorityFeePerGas: singleParams.maxPriorityFeePerGas as Hex,
-          to: singleParams.to as Hex,
-          value: singleParams.value as Hex,
-        },
-        type: getTransactionType(
-          prependCount,
-          index,
-          getEffectiveTransactionType(transaction),
-          normalizedParams.length,
-        ),
-      };
-    });
-
-    await messenger.call('TransactionController:addTransactionBatch', {
-      from,
-      disable7702: !gasLimit7702,
-      disableHook: Boolean(gasLimit7702),
-      disableSequential: Boolean(gasLimit7702),
-      gasFeeToken,
-      gasLimit7702,
-      networkClientId,
-      origin: ORIGIN_METAMASK,
-      isInternal: true,
-      isGasFeeSponsored: isSourceGasFeeSponsored,
-      overwriteUpgrade: true,
-      requireApproval: false,
-      transactions,
-    });
+    await messenger.call(
+      'TransactionController:addTransactionBatch',
+      buildRelayTransactionBatchRequest({
+        allParams,
+        isGasFeeSponsored: isSourceGasFeeSponsored,
+        messenger,
+        normalizedParams,
+        quote,
+        transaction,
+      }),
+    );
   }
 
   end();
@@ -705,6 +735,100 @@ async function submitViaTransactionController(
   }
 
   return hash as Hex;
+}
+
+function buildRelayTransactionBatchRequest({
+  allParams,
+  isGasFeeSponsored,
+  messenger,
+  normalizedParams,
+  quote,
+  transaction,
+}: {
+  allParams: TransactionParams[];
+  isGasFeeSponsored: boolean | undefined;
+  messenger: TransactionPayControllerMessenger;
+  normalizedParams: TransactionParams[];
+  quote: TransactionPayQuote<RelayQuote>;
+  transaction: TransactionMeta;
+}): TransactionBatchRequest {
+  const { from, sourceChainId, sourceTokenAddress } = quote.request;
+  const { metamask } = quote.original;
+  const networkClientId = getNetworkClientId(messenger, sourceChainId);
+  const gasFeeToken = quote.fees?.isSourceGasFeeToken
+    ? sourceTokenAddress
+    : undefined;
+  const gasLimit7702 = getGasLimit7702(quote);
+
+  return {
+    from,
+    disable7702: !gasLimit7702,
+    disableHook: Boolean(gasLimit7702),
+    disableSequential: Boolean(gasLimit7702),
+    gasFeeToken,
+    gasLimit7702,
+    networkClientId,
+    origin: ORIGIN_METAMASK,
+    isInternal: true,
+    isGasFeeSponsored,
+    overwriteUpgrade: true,
+    requireApproval: false,
+    transactions: buildRelayBatchTransactions({
+      allParams,
+      gasLimit7702,
+      gasLimits: metamask.gasLimits,
+      normalizedParams,
+      transaction,
+    }),
+  };
+}
+
+function buildRelayBatchTransactions({
+  allParams,
+  gasLimit7702,
+  gasLimits,
+  normalizedParams,
+  transaction,
+}: {
+  allParams: TransactionParams[];
+  gasLimit7702?: Hex;
+  gasLimits: number[];
+  normalizedParams: TransactionParams[];
+  transaction: TransactionMeta;
+}): TransactionBatchSingleRequest[] {
+  const prependCount = allParams.length - normalizedParams.length;
+
+  return allParams.map((singleParams, index) => {
+    const gasLimit = gasLimits[index];
+    const gas =
+      gasLimit === undefined || gasLimit7702 ? undefined : toHex(gasLimit);
+
+    return {
+      params: {
+        data: singleParams.data as Hex,
+        gas,
+        maxFeePerGas: singleParams.maxFeePerGas as Hex,
+        maxPriorityFeePerGas: singleParams.maxPriorityFeePerGas as Hex,
+        to: singleParams.to as Hex,
+        value: singleParams.value as Hex,
+      },
+      type: getTransactionType(
+        prependCount,
+        index,
+        getEffectiveTransactionType(transaction),
+        normalizedParams.length,
+      ),
+    };
+  });
+}
+
+function getGasLimit7702(
+  quote: TransactionPayQuote<RelayQuote>,
+): Hex | undefined {
+  const { gasLimits, is7702 } = quote.original.metamask;
+  const gasLimit = gasLimits[0];
+
+  return is7702 && gasLimit !== undefined ? toHex(gasLimit) : undefined;
 }
 
 /**

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-validation.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-validation.test.ts
@@ -1,0 +1,659 @@
+import { generateEIP7702BatchTransaction } from '@metamask/transaction-controller';
+import type { TransactionMeta } from '@metamask/transaction-controller';
+import type { Hex } from '@metamask/utils';
+
+import { getDefaultRemoteFeatureFlagControllerState } from '../../../../remote-feature-flag-controller/src/remote-feature-flag-controller.js';
+import { getMessengerMock } from '../../tests/messenger-mock.js';
+import type { TransactionPayQuote } from '../../types.js';
+import { QuoteError } from '../../utils/validation.js';
+import { getRelayExecuteRequest } from './relay-submit-execute.js';
+import { getRelaySubmitCalls } from './relay-submit.js';
+import { validateRelayQuotes } from './relay-validation.js';
+import type { RelayQuote } from './types.js';
+
+jest.mock('./relay-submit');
+jest.mock('./relay-submit-execute');
+jest.mock('../../utils/validation', () => ({
+  ...jest.requireActual('../../utils/validation'),
+  validateQuoteExecution: jest.fn(),
+}));
+jest.mock('@metamask/transaction-controller', () => ({
+  ...jest.requireActual('@metamask/transaction-controller'),
+  generateEIP7702BatchTransaction: jest.fn(),
+}));
+
+const { validateQuoteExecution } = jest.requireMock<
+  typeof import('../../utils/validation')
+>('../../utils/validation');
+
+const FROM_MOCK = '0xabcdef1234567890abcdef1234567890abcdef12' as Hex;
+const REQUEST_ID_MOCK = '0xreqid1234' as string;
+const CHAIN_ID_MOCK = '0x1' as Hex;
+const TOKEN_ADDRESS_MOCK = '0xtoken' as Hex;
+
+function buildQuote(
+  overrides: Partial<TransactionPayQuote<RelayQuote>['request']> = {},
+  originalOverrides: Partial<RelayQuote> = {},
+): TransactionPayQuote<RelayQuote> {
+  return {
+    original: {
+      metamask: { gasLimits: [], is7702: false, isExecute: false },
+      request: {},
+      steps: [
+        {
+          requestId: REQUEST_ID_MOCK,
+          id: 'step-1',
+          kind: 'transaction',
+          items: [],
+        },
+      ],
+      details: {
+        currencyIn: { currency: { chainId: 1 } },
+        currencyOut: { currency: { chainId: 2 } },
+      },
+      ...originalOverrides,
+    } as unknown as RelayQuote,
+    request: {
+      from: FROM_MOCK,
+      sourceChainId: CHAIN_ID_MOCK,
+      sourceTokenAddress: TOKEN_ADDRESS_MOCK,
+      sourceBalanceRaw: '1000',
+      sourceTokenAmount: '100',
+      targetAmountMinimum: '100',
+      targetChainId: '0x2' as Hex,
+      targetTokenAddress: '0xtarget' as Hex,
+      ...overrides,
+    },
+    fees: {
+      sourceNetwork: {
+        estimate: { raw: '0', human: '0', usd: '0', fiat: '0' },
+        max: { raw: '0', human: '0', usd: '0', fiat: '0' },
+      },
+      metaMask: { usd: '0', fiat: '0' },
+      provider: { usd: '0', fiat: '0' },
+      targetNetwork: { usd: '0', fiat: '0' },
+    },
+    sourceAmount: { raw: '100', human: '0.0001', usd: '0.1', fiat: '0.1' },
+    targetAmount: { usd: '0.1', fiat: '0.1' },
+    dust: { usd: '0', fiat: '0' },
+    estimatedDuration: 30,
+    strategy: 'relay' as never,
+  } as TransactionPayQuote<RelayQuote>;
+}
+
+const TRANSACTION_MOCK = {
+  id: 'tx-id',
+  txParams: { from: FROM_MOCK },
+} as TransactionMeta;
+
+const getRelaySubmitCallsMock = jest.mocked(getRelaySubmitCalls);
+const getRelayExecuteRequestMock = jest.mocked(getRelayExecuteRequest);
+const validateQuoteExecutionMock = jest.mocked(validateQuoteExecution);
+const generateEIP7702BatchTransactionMock = jest.mocked(
+  generateEIP7702BatchTransaction,
+);
+
+describe('validateRelayQuotes', () => {
+  const { messenger, getRemoteFeatureFlagControllerStateMock } =
+    getMessengerMock();
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+      ...getDefaultRemoteFeatureFlagControllerState(),
+      remoteFeatureFlags: {
+        confirmations_pay_extended: {
+          payStrategies: { relay: { validationEnabled: true } },
+        },
+      },
+    });
+
+    getRelaySubmitCallsMock.mockResolvedValue({
+      calls: [],
+    });
+    getRelayExecuteRequestMock.mockResolvedValue(undefined as never);
+    validateQuoteExecutionMock.mockResolvedValue(undefined);
+    generateEIP7702BatchTransactionMock.mockReturnValue({
+      data: '0xbatchdata' as Hex,
+      to: '0xbatchto' as Hex,
+      value: '0x0' as Hex,
+    } as never);
+  });
+
+  it('skips validation for Hyperliquid source quotes', async () => {
+    const quote = buildQuote({ isHyperliquidSource: true });
+
+    await validateRelayQuotes({
+      messenger,
+      quotes: [quote],
+      transaction: TRANSACTION_MOCK,
+    });
+
+    expect(getRelaySubmitCallsMock).not.toHaveBeenCalled();
+    expect(validateQuoteExecutionMock).not.toHaveBeenCalled();
+  });
+
+  it('skips validation for Polymarket deposit wallet quotes', async () => {
+    const quote = buildQuote({ isPolymarketDepositWallet: true });
+
+    await validateRelayQuotes({
+      messenger,
+      quotes: [quote],
+      transaction: TRANSACTION_MOCK,
+    });
+
+    expect(getRelaySubmitCallsMock).not.toHaveBeenCalled();
+    expect(validateQuoteExecutionMock).not.toHaveBeenCalled();
+  });
+
+  it('re-throws error as-is when signal is aborted', async () => {
+    const controller = new AbortController();
+    const abortError = new Error('Quote validation aborted');
+
+    validateQuoteExecutionMock.mockImplementation(async () => {
+      controller.abort();
+      throw abortError;
+    });
+
+    const quote = buildQuote();
+
+    await expect(
+      validateRelayQuotes({
+        messenger,
+        quotes: [quote],
+        signal: controller.signal,
+        transaction: TRANSACTION_MOCK,
+      }),
+    ).rejects.toThrow('Quote validation aborted');
+  });
+
+  it('wraps unknown errors in QuoteError via toQuoteError', async () => {
+    validateQuoteExecutionMock.mockRejectedValue(new Error('unexpected error'));
+
+    const quote = buildQuote();
+
+    await expect(
+      validateRelayQuotes({
+        messenger,
+        quotes: [quote],
+        transaction: TRANSACTION_MOCK,
+      }),
+    ).rejects.toMatchObject({
+      info: {
+        message: 'Quote simulation failed',
+        reason: 'simulation-failed',
+        detail: ['unexpected error'],
+      },
+    });
+  });
+
+  it('passes through existing QuoteError unchanged', async () => {
+    const quoteError = new QuoteError({
+      message: 'Insufficient source balance for quote',
+      reason: 'insufficient-source-balance',
+    });
+
+    validateQuoteExecutionMock.mockRejectedValue(quoteError);
+
+    const quote = buildQuote();
+
+    await expect(
+      validateRelayQuotes({
+        messenger,
+        quotes: [quote],
+        transaction: TRANSACTION_MOCK,
+      }),
+    ).rejects.toMatchObject({
+      info: {
+        message: 'Insufficient source balance for quote',
+        reason: 'insufficient-source-balance',
+      },
+    });
+  });
+
+  it('validates multiple quotes sequentially', async () => {
+    const quote1 = buildQuote();
+    const quote2 = buildQuote();
+
+    await validateRelayQuotes({
+      messenger,
+      quotes: [quote1, quote2],
+      transaction: TRANSACTION_MOCK,
+    });
+
+    expect(validateQuoteExecutionMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips Hyperliquid but validates normal quotes in the same batch', async () => {
+    const hyperliquidQuote = buildQuote({ isHyperliquidSource: true });
+    const normalQuote = buildQuote();
+
+    await validateRelayQuotes({
+      messenger,
+      quotes: [hyperliquidQuote, normalQuote],
+      transaction: TRANSACTION_MOCK,
+    });
+
+    expect(validateQuoteExecutionMock).toHaveBeenCalledTimes(1);
+  });
+
+  describe('buildRelayValidationSimulation', () => {
+    describe('normal simulation (no executeRequest, no is7702)', () => {
+      it('passes normal simulation to validateQuoteExecution', async () => {
+        const calls = [
+          {
+            data: '0xdata' as Hex,
+            from: FROM_MOCK,
+            gas: '0x5208' as Hex,
+            maxFeePerGas: '0x5d21dba00' as Hex,
+            maxPriorityFeePerGas: '0x3b9aca00' as Hex,
+            to: '0xdest' as Hex,
+            value: '0x4d2' as Hex,
+          },
+        ];
+
+        getRelaySubmitCallsMock.mockResolvedValue({ calls });
+
+        const quote = buildQuote();
+
+        await validateRelayQuotes({
+          messenger,
+          quotes: [quote],
+          transaction: TRANSACTION_MOCK,
+        });
+
+        expect(validateQuoteExecutionMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            simulation: {
+              transactions: [
+                {
+                  data: '0xdata',
+                  from: FROM_MOCK,
+                  gas: '0x5208',
+                  maxFeePerGas: '0x5d21dba00',
+                  maxPriorityFeePerGas: '0x3b9aca00',
+                  to: '0xdest',
+                  value: '0x4d2',
+                },
+              ],
+            },
+          }),
+        );
+      });
+    });
+
+    describe('7702 batch simulation (is7702 true, no executeRequest)', () => {
+      it('passes 7702 batch simulation to validateQuoteExecution', async () => {
+        const calls = [
+          {
+            data: '0xdata' as Hex,
+            from: FROM_MOCK,
+            to: '0xdest' as Hex,
+            value: '0x4d2' as Hex,
+          },
+        ];
+
+        getRelaySubmitCallsMock.mockResolvedValue({ calls });
+
+        const quote = buildQuote({}, {
+          metamask: { gasLimits: [21000], is7702: true, isExecute: false },
+          request: {},
+        } as Partial<RelayQuote>);
+
+        await validateRelayQuotes({
+          messenger,
+          quotes: [quote],
+          transaction: TRANSACTION_MOCK,
+        });
+
+        expect(generateEIP7702BatchTransactionMock).toHaveBeenCalledTimes(1);
+        expect(validateQuoteExecutionMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            simulation: expect.objectContaining({
+              transactions: [
+                expect.objectContaining({
+                  data: '0xbatchdata',
+                  to: '0xbatchto',
+                  value: '0x0',
+                  gas: '0x5208',
+                }),
+              ],
+            }),
+          }),
+        );
+      });
+
+      it('omits gas in 7702 batch simulation when gasLimits[0] is undefined', async () => {
+        const calls = [
+          {
+            data: '0xdata' as Hex,
+            from: FROM_MOCK,
+            to: '0xdest' as Hex,
+            value: '0x4d2' as Hex,
+          },
+        ];
+
+        getRelaySubmitCallsMock.mockResolvedValue({ calls });
+
+        const quote = buildQuote({}, {
+          metamask: { gasLimits: [], is7702: true, isExecute: false },
+          request: {},
+        } as Partial<RelayQuote>);
+
+        await validateRelayQuotes({
+          messenger,
+          quotes: [quote],
+          transaction: TRANSACTION_MOCK,
+        });
+
+        expect(validateQuoteExecutionMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            simulation: expect.objectContaining({
+              transactions: [
+                expect.not.objectContaining({ gas: expect.anything() }),
+              ],
+            }),
+          }),
+        );
+      });
+
+      it('includes authorizationList on transaction when authorizationList is present', async () => {
+        const calls = [
+          {
+            data: '0xdata' as Hex,
+            from: FROM_MOCK,
+            to: '0xdest' as Hex,
+            value: '0x4d2' as Hex,
+          },
+        ];
+
+        getRelaySubmitCallsMock.mockResolvedValue({ calls });
+
+        const quote = buildQuote({}, {
+          metamask: { gasLimits: [21000], is7702: true, isExecute: false },
+          request: {
+            authorizationList: [
+              {
+                address: '0xabc' as Hex,
+                chainId: 1,
+                nonce: 1,
+                r: '0xr' as Hex,
+                s: '0xs' as Hex,
+                yParity: 0,
+              },
+            ],
+          },
+        } as Partial<RelayQuote>);
+
+        await validateRelayQuotes({
+          messenger,
+          quotes: [quote],
+          transaction: TRANSACTION_MOCK,
+        });
+
+        expect(validateQuoteExecutionMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            simulation: expect.objectContaining({
+              transactions: [
+                expect.objectContaining({
+                  authorizationList: [{ address: '0xabc', from: FROM_MOCK }],
+                }),
+              ],
+            }),
+          }),
+        );
+      });
+
+      it('omits authorizationList on transaction when authorizationList is absent', async () => {
+        const calls = [
+          {
+            data: '0xdata' as Hex,
+            from: FROM_MOCK,
+            to: '0xdest' as Hex,
+            value: '0x4d2' as Hex,
+          },
+        ];
+
+        getRelaySubmitCallsMock.mockResolvedValue({ calls });
+
+        const quote = buildQuote({}, {
+          metamask: { gasLimits: [21000], is7702: true, isExecute: false },
+          request: {},
+        } as Partial<RelayQuote>);
+
+        await validateRelayQuotes({
+          messenger,
+          quotes: [quote],
+          transaction: TRANSACTION_MOCK,
+        });
+
+        expect(validateQuoteExecutionMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            simulation: expect.objectContaining({
+              transactions: [
+                expect.not.objectContaining({
+                  authorizationList: expect.anything(),
+                }),
+              ],
+            }),
+          }),
+        );
+      });
+
+      it('does not set mock7702From on simulation', async () => {
+        const calls = [
+          {
+            data: '0xdata' as Hex,
+            from: FROM_MOCK,
+            to: '0xdest' as Hex,
+            value: '0x4d2' as Hex,
+          },
+        ];
+
+        getRelaySubmitCallsMock.mockResolvedValue({ calls });
+
+        const quote = buildQuote({}, {
+          metamask: { gasLimits: [21000], is7702: true, isExecute: false },
+          request: {
+            authorizationList: [
+              {
+                address: '0xabc' as Hex,
+                chainId: 1,
+                nonce: 1,
+                r: '0xr' as Hex,
+                s: '0xs' as Hex,
+                yParity: 0,
+              },
+            ],
+          },
+        } as Partial<RelayQuote>);
+
+        await validateRelayQuotes({
+          messenger,
+          quotes: [quote],
+          transaction: TRANSACTION_MOCK,
+        });
+
+        expect(validateQuoteExecutionMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            simulation: expect.not.objectContaining({
+              mock7702From: expect.anything(),
+            }),
+          }),
+        );
+      });
+    });
+
+    describe('execute simulation (isExecute true)', () => {
+      const EXECUTE_REQUEST_MOCK = {
+        executionKind: 'rawCalls' as const,
+        data: {
+          chainId: 1,
+          to: '0xdelegationManager' as Hex,
+          data: '0xdelegationdata' as Hex,
+          value: '0',
+        },
+        executionOptions: { subsidizeFees: false },
+        requestId: '0xreqid',
+      };
+
+      it('passes execute simulation to validateQuoteExecution', async () => {
+        getRelaySubmitCallsMock.mockResolvedValue({ calls: [] });
+        getRelayExecuteRequestMock.mockResolvedValue(EXECUTE_REQUEST_MOCK);
+
+        const quote = buildQuote({}, {
+          metamask: { gasLimits: [], is7702: false, isExecute: true },
+        } as Partial<RelayQuote>);
+
+        await validateRelayQuotes({
+          messenger,
+          quotes: [quote],
+          transaction: TRANSACTION_MOCK,
+        });
+
+        expect(getRelayExecuteRequestMock).toHaveBeenCalledWith({
+          allParams: [],
+          messenger,
+          quote,
+          requestId: REQUEST_ID_MOCK,
+          transaction: TRANSACTION_MOCK,
+        });
+
+        expect(validateQuoteExecutionMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            simulation: expect.objectContaining({
+              transactions: [
+                expect.objectContaining({
+                  data: '0xdelegationdata',
+                  from: FROM_MOCK,
+                  to: '0xdelegationManager',
+                }),
+              ],
+            }),
+          }),
+        );
+      });
+
+      it('includes authorizationList on execute simulation transaction when authorizationList is present', async () => {
+        const executeRequestWithAuth = {
+          ...EXECUTE_REQUEST_MOCK,
+          data: {
+            ...EXECUTE_REQUEST_MOCK.data,
+            authorizationList: [
+              {
+                address: '0xabc' as Hex,
+                chainId: 1,
+                nonce: 1,
+                yParity: 0,
+                r: '0xr' as Hex,
+                s: '0xs' as Hex,
+              },
+            ],
+          },
+        };
+
+        getRelaySubmitCallsMock.mockResolvedValue({ calls: [] });
+        getRelayExecuteRequestMock.mockResolvedValue(executeRequestWithAuth);
+
+        const quote = buildQuote({}, {
+          metamask: { gasLimits: [], is7702: false, isExecute: true },
+        } as Partial<RelayQuote>);
+
+        await validateRelayQuotes({
+          messenger,
+          quotes: [quote],
+          transaction: TRANSACTION_MOCK,
+        });
+
+        expect(validateQuoteExecutionMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            simulation: expect.objectContaining({
+              transactions: [
+                expect.objectContaining({
+                  authorizationList: [{ address: '0xabc', from: FROM_MOCK }],
+                }),
+              ],
+            }),
+          }),
+        );
+      });
+
+      it('does not set mock7702From on execute simulation', async () => {
+        const executeRequestWithAuth = {
+          ...EXECUTE_REQUEST_MOCK,
+          data: {
+            ...EXECUTE_REQUEST_MOCK.data,
+            authorizationList: [
+              {
+                address: '0xabc' as Hex,
+                chainId: 1,
+                nonce: 1,
+                yParity: 0,
+                r: '0xr' as Hex,
+                s: '0xs' as Hex,
+              },
+            ],
+          },
+        };
+
+        getRelaySubmitCallsMock.mockResolvedValue({ calls: [] });
+        getRelayExecuteRequestMock.mockResolvedValue(executeRequestWithAuth);
+
+        const quote = buildQuote({}, {
+          metamask: { gasLimits: [], is7702: false, isExecute: true },
+        } as Partial<RelayQuote>);
+
+        await validateRelayQuotes({
+          messenger,
+          quotes: [quote],
+          transaction: TRANSACTION_MOCK,
+        });
+
+        expect(validateQuoteExecutionMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            simulation: expect.not.objectContaining({
+              mock7702From: expect.anything(),
+            }),
+          }),
+        );
+      });
+
+      it('does not call getRelayExecuteRequest when isExecute is false', async () => {
+        getRelaySubmitCallsMock.mockResolvedValue({ calls: [] });
+
+        const quote = buildQuote();
+
+        await validateRelayQuotes({
+          messenger,
+          quotes: [quote],
+          transaction: TRANSACTION_MOCK,
+        });
+
+        expect(getRelayExecuteRequestMock).not.toHaveBeenCalled();
+        expect(validateQuoteExecutionMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            simulation: expect.objectContaining({
+              transactions: expect.any(Array),
+            }),
+          }),
+        );
+      });
+    });
+  });
+
+  it('returns early without validating when Relay validation is disabled', async () => {
+    getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+      ...getDefaultRemoteFeatureFlagControllerState(),
+    });
+
+    await validateRelayQuotes({
+      messenger,
+      quotes: [buildQuote()],
+      transaction: TRANSACTION_MOCK,
+    });
+
+    expect(getRelaySubmitCallsMock).not.toHaveBeenCalled();
+    expect(validateQuoteExecutionMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-validation.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-validation.ts
@@ -1,0 +1,198 @@
+import { toHex } from '@metamask/controller-utils';
+import { generateEIP7702BatchTransaction } from '@metamask/transaction-controller';
+import type {
+  TransactionMeta,
+  TransactionParams,
+} from '@metamask/transaction-controller';
+import { createModuleLogger } from '@metamask/utils';
+import type { Hex } from '@metamask/utils';
+import { BigNumber } from 'bignumber.js';
+
+import { projectLogger } from '../../logger.js';
+import type {
+  TransactionPayControllerMessenger,
+  TransactionPayQuote,
+} from '../../types.js';
+import { isRelayValidationEnabled } from '../../utils/feature-flags.js';
+import {
+  validateQuoteExecution,
+  QuoteError,
+  isQuoteError,
+} from '../../utils/validation.js';
+import type { QuoteSimulation } from '../../utils/validation.js';
+import { getRelayExecuteRequest } from './relay-submit-execute.js';
+import { getRelaySubmitCalls } from './relay-submit.js';
+import type { RelayExecuteRequest, RelayQuote } from './types.js';
+
+const log = createModuleLogger(projectLogger, 'relay-validation');
+
+export type ValidateRelayQuotesRequest = {
+  messenger: TransactionPayControllerMessenger;
+  quotes: TransactionPayQuote<RelayQuote>[];
+  signal?: AbortSignal;
+  transaction: TransactionMeta;
+};
+
+export async function validateRelayQuotes(
+  request: ValidateRelayQuotesRequest,
+): Promise<void> {
+  if (!isRelayValidationEnabled(request.messenger)) {
+    return;
+  }
+
+  for (const quote of request.quotes) {
+    if (shouldSkipValidation(quote)) {
+      continue;
+    }
+
+    try {
+      const { calls } = await getRelaySubmitCalls({
+        messenger: request.messenger,
+        quote,
+        transaction: request.transaction,
+      });
+
+      const executeRequest = quote.original.metamask.isExecute
+        ? await getRelayExecuteRequest({
+            allParams: calls,
+            messenger: request.messenger,
+            quote,
+            requestId: quote.original.steps[0].requestId,
+            transaction: request.transaction,
+          })
+        : undefined;
+
+      await validateQuoteExecution({
+        messenger: request.messenger,
+        quote,
+        signal: request.signal,
+        simulation: buildRelayValidationSimulation(
+          quote,
+          calls,
+          executeRequest,
+        ),
+      });
+    } catch (error) {
+      if (request.signal?.aborted) {
+        throw error;
+      }
+      throw toQuoteError(error);
+    }
+  }
+}
+
+function shouldSkipValidation(quote: TransactionPayQuote<RelayQuote>): boolean {
+  const { request } = quote;
+  return Boolean(
+    request.isHyperliquidSource ?? request.isPolymarketDepositWallet ?? false,
+  );
+}
+
+function toQuoteError(error: unknown): QuoteError {
+  if (isQuoteError(error)) {
+    return error;
+  }
+  return new QuoteError({
+    message: 'Quote simulation failed',
+    reason: 'simulation-failed',
+    detail: [(error as Error).message],
+  });
+}
+
+function buildRelayValidationSimulation(
+  quote: TransactionPayQuote<RelayQuote>,
+  calls: TransactionParams[],
+  executeRequest?: Omit<RelayExecuteRequest, 'metamask'>,
+): QuoteSimulation {
+  const { from, sourceChainId, targetChainId } = quote.request;
+  const context = { from, sourceChainId, targetChainId };
+
+  if (executeRequest) {
+    log('Building execute simulation', context);
+    return buildRelayExecuteSimulation(quote, executeRequest);
+  }
+  if (quote.original.metamask.is7702) {
+    log('Building 7702 batch simulation', context);
+    return buildRelay7702BatchSimulation(quote, calls);
+  }
+  log('Building normal simulation', context);
+  return buildRelayNormalSimulation(calls);
+}
+
+function buildRelayExecuteSimulation(
+  quote: TransactionPayQuote<RelayQuote>,
+  executeRequest: Omit<RelayExecuteRequest, 'metamask'>,
+): QuoteSimulation {
+  const { value } = executeRequest.data;
+  const valueHex = new BigNumber(value).toString(16).replace(/^/u, '0x') as Hex;
+  return {
+    transactions: [
+      {
+        ...(executeRequest.data.authorizationList?.length
+          ? {
+              authorizationList: executeRequest.data.authorizationList.map(
+                (auth) => ({ address: auth.address, from: quote.request.from }),
+              ),
+            }
+          : {}),
+        data: executeRequest.data.data,
+        from: quote.request.from,
+        to: executeRequest.data.to,
+        value: valueHex,
+      },
+    ],
+  };
+}
+
+function buildRelay7702BatchSimulation(
+  quote: TransactionPayQuote<RelayQuote>,
+  calls: TransactionParams[],
+): QuoteSimulation {
+  const { from } = quote.request;
+  const gas = quote.original.metamask.gasLimits[0];
+
+  const batchTx = generateEIP7702BatchTransaction(
+    from,
+    calls.map((params) => ({
+      to: params.to as Hex,
+      data: params.data as Hex,
+      value: params.value as Hex,
+    })),
+  );
+
+  const authList = quote.original.request.authorizationList?.length
+    ? quote.original.request.authorizationList.map((auth) => ({
+        address: auth.address,
+        from,
+      }))
+    : undefined;
+
+  return {
+    transactions: [
+      {
+        ...(authList ? { authorizationList: authList } : {}),
+        data: batchTx.data,
+        from,
+        ...(gas === undefined ? {} : { gas: toHex(gas) }),
+        to: batchTx.to as Hex,
+        value: '0x0',
+      },
+    ],
+  };
+}
+
+function buildRelayNormalSimulation(
+  calls: TransactionParams[],
+): QuoteSimulation {
+  return {
+    transactions: calls.map((params) => ({
+      data: params.data as Hex | undefined,
+      from: params.from as Hex,
+      gas: params.gas as Hex | undefined,
+      maxFeePerGas: params.maxFeePerGas as Hex | undefined,
+      maxPriorityFeePerGas: params.maxPriorityFeePerGas as Hex | undefined,
+      to: params.to as Hex | undefined,
+      value: params.value as Hex,
+    })),
+  };
+}

--- a/packages/transaction-pay-controller/src/tests/messenger-mock.ts
+++ b/packages/transaction-pay-controller/src/tests/messenger-mock.ts
@@ -13,6 +13,7 @@ import type { NetworkControllerGetNetworkClientByIdAction } from '@metamask/netw
 import type { NetworkControllerFindNetworkClientIdByChainIdAction } from '@metamask/network-controller';
 import type { NetworkControllerGetNetworkConfigurationByChainIdAction } from '@metamask/network-controller';
 import type { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
+import type { SentinelApiServiceSimulateTransactionsAction } from '@metamask/sentinel-api-service';
 import type {
   TransactionControllerAddTransactionAction,
   TransactionControllerAddTransactionBatchAction,
@@ -139,6 +140,10 @@ export function getMessengerMock({
 
   const estimateGasBatchMock: jest.MockedFn<
     TransactionControllerEstimateGasBatchAction['handler']
+  > = jest.fn();
+
+  const simulateTransactionsMock: jest.MockedFn<
+    SentinelApiServiceSimulateTransactionsAction['handler']
   > = jest.fn();
 
   const getAssetsControllerStateMock = jest.fn();
@@ -282,6 +287,11 @@ export function getMessengerMock({
     );
 
     messenger.registerActionHandler(
+      'SentinelApiService:simulateTransactions',
+      simulateTransactionsMock,
+    );
+
+    messenger.registerActionHandler(
       'AssetsController:getStateForTransactionPay',
       getAssetsControllerStateMock,
     );
@@ -322,6 +332,7 @@ export function getMessengerMock({
     polymarketGetDepositWalletAddressMock,
     polymarketSubmitDepositWalletBatchMock,
     publish,
+    simulateTransactionsMock,
     updateTransactionMock,
   };
 }

--- a/packages/transaction-pay-controller/src/types.ts
+++ b/packages/transaction-pay-controller/src/types.ts
@@ -33,6 +33,7 @@ import type {
   RampsControllerGetQuotesAction,
 } from '@metamask/ramps-controller';
 import type { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
+import type { SentinelApiServiceActions } from '@metamask/sentinel-api-service';
 import type {
   AuthorizationList,
   TransactionControllerAddTransactionBatchAction,
@@ -76,6 +77,7 @@ export type AllowedActions =
   | TokenBalancesControllerGetStateAction
   | TokenRatesControllerGetStateAction
   | TokensControllerGetStateAction
+  | SentinelApiServiceActions
   | TransactionControllerAddTransactionAction
   | TransactionControllerAddTransactionBatchAction
   | TransactionControllerEstimateGasAction
@@ -339,6 +341,9 @@ export type TransactionData = {
   /** Quotes retrieved for the transaction. */
   quotes?: TransactionPayQuote<Json>[];
 
+  /** Most relevant structured validation error from the latest quote attempt. */
+  quoteError?: QuoteErrorInfo;
+
   /** Timestamp of when quotes were last updated. */
   quotesLastUpdated?: number;
 
@@ -434,6 +439,36 @@ export type TransactionPaySourceAmount = {
 
   /** Address of the target token. */
   targetTokenAddress: Hex;
+};
+
+/**
+ * Machine-readable discriminator for a quote validation failure.
+ *
+ * Used for analytics and tests. Human-readable copy is carried by `message`
+ * and `detail` on {@link QuoteErrorInfo}.
+ */
+export type QuoteErrorReason =
+  | 'balance-unavailable'
+  | 'insufficient-source-balance'
+  | 'insufficient-transfer-balance'
+  | 'no-quotes'
+  | 'simulation-failed';
+
+/**
+ * Structured description of why a quote failed validation.
+ *
+ * `message` and `detail` are formatted (English) copy ready to display; `reason`
+ * is a machine-readable discriminator for analytics and tests.
+ */
+export type QuoteErrorInfo = {
+  /** Short, display-ready summary of the failure. */
+  message: string;
+
+  /** Machine-readable discriminator for the failure. */
+  reason: QuoteErrorReason;
+
+  /** Optional display-ready detail rows (e.g. Required / Current / Missing). */
+  detail?: string[];
 };
 
 /** Source token used to pay for required tokens. */

--- a/packages/transaction-pay-controller/src/utils/feature-flags.test.ts
+++ b/packages/transaction-pay-controller/src/utils/feature-flags.test.ts
@@ -35,6 +35,7 @@ import {
   isChainExcludedFromInfura,
   isEIP7702Chain,
   isRelayExecuteEnabled,
+  isRelayValidationEnabled,
   getFeatureFlags,
   getGasBuffer,
   getHyperliquidActivationFeeConfig,
@@ -511,6 +512,36 @@ describe('Feature Flags Utils', () => {
       });
 
       expect(isRelayExecuteEnabled(messenger)).toBe(false);
+    });
+  });
+
+  describe('isRelayValidationEnabled', () => {
+    it('returns false when no feature flags are set', () => {
+      expect(isRelayValidationEnabled(messenger)).toBe(false);
+    });
+
+    it('returns true when validationEnabled is true', () => {
+      getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+        ...getDefaultRemoteFeatureFlagControllerState(),
+        remoteFeatureFlags: {
+          confirmations_pay_extended: {
+            payStrategies: { relay: { validationEnabled: true } },
+          },
+        },
+      });
+      expect(isRelayValidationEnabled(messenger)).toBe(true);
+    });
+
+    it('returns false when validationEnabled is false', () => {
+      getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+        ...getDefaultRemoteFeatureFlagControllerState(),
+        remoteFeatureFlags: {
+          confirmations_pay_extended: {
+            payStrategies: { relay: { validationEnabled: false } },
+          },
+        },
+      });
+      expect(isRelayValidationEnabled(messenger)).toBe(false);
     });
   });
 

--- a/packages/transaction-pay-controller/src/utils/feature-flags.ts
+++ b/packages/transaction-pay-controller/src/utils/feature-flags.ts
@@ -191,6 +191,7 @@ type FeatureFlagsExtendedRaw = {
   payStrategies?: {
     relay?: {
       gaslessEnabled?: boolean;
+      validationEnabled?: boolean;
     };
     server?: {
       enabled?: boolean;
@@ -628,6 +629,26 @@ export function isRelayExecuteEnabled(
       | FeatureFlagsExtendedRaw
       | undefined) ?? {};
   return featureFlags.payStrategies?.relay?.gaslessEnabled ?? false;
+}
+
+/**
+ * Whether Relay quote validation is enabled.
+ *
+ * Acts as an emergency kill switch: when disabled (default), Relay quotes are
+ * surfaced without being simulated/validated.
+ *
+ * @param messenger - Controller messenger.
+ * @returns True if Relay quote validation is enabled.
+ */
+export function isRelayValidationEnabled(
+  messenger: TransactionPayControllerMessenger,
+): boolean {
+  const state = messenger.call('RemoteFeatureFlagController:getState');
+  const featureFlags =
+    (state.remoteFeatureFlags?.confirmations_pay_extended as
+      | FeatureFlagsExtendedRaw
+      | undefined) ?? {};
+  return featureFlags.payStrategies?.relay?.validationEnabled ?? false;
 }
 
 /**

--- a/packages/transaction-pay-controller/src/utils/quotes.test.ts
+++ b/packages/transaction-pay-controller/src/utils/quotes.test.ts
@@ -25,6 +25,7 @@ import {
 import { getLiveTokenBalance, getTokenFiatRate } from './token.js';
 import { calculateTotals } from './totals.js';
 import { getTransaction, updateTransaction } from './transaction.js';
+import { QuoteError } from './validation.js';
 
 jest.mock('./strategy');
 jest.mock('./transaction');
@@ -213,6 +214,43 @@ describe('Quotes Utils', () => {
       });
     });
 
+    it('stores no quote validation error when quotes are rejected by post-quote support check', async () => {
+      checkStrategyQuoteSupportMock.mockResolvedValue(false);
+
+      await run();
+
+      const transactionDataMock = {};
+
+      updateTransactionDataMock.mock.calls.map((call) =>
+        call[1](transactionDataMock),
+      );
+
+      expect(transactionDataMock).toMatchObject({
+        quotes: [],
+        quoteError: undefined,
+      });
+    });
+
+    it('clears quote validation error when quote loading starts', async () => {
+      const validationError = {
+        message: 'Insufficient source balance for quote',
+        reason: 'insufficient-source-balance' as const,
+      };
+
+      await run();
+
+      const transactionDataMock = {
+        quoteError: validationError,
+      };
+
+      updateTransactionDataMock.mock.calls[0][1](transactionDataMock);
+
+      expect(transactionDataMock).toStrictEqual({
+        isLoading: true,
+        quoteError: undefined,
+      });
+    });
+
     it('stores no-op quote in state if no source amounts and payment token selected', async () => {
       await run({
         transactionData: {
@@ -301,6 +339,30 @@ describe('Quotes Utils', () => {
       getTransactionMock.mockReturnValue(undefined);
 
       await expect(run()).rejects.toThrow('Transaction not found');
+    });
+
+    it('preserves structured QuoteError info when strategy throws one', async () => {
+      const error = new QuoteError({
+        message: 'Insufficient source balance for quote',
+        reason: 'insufficient-source-balance',
+        detail: ['Required: 1 USDC', 'Current: 0.5 USDC'],
+      });
+      getQuotesMock.mockRejectedValue(error);
+
+      await run();
+
+      const transactionDataMock = {} as Record<string, unknown>;
+      updateTransactionDataMock.mock.calls.map((call) =>
+        call[1](transactionDataMock),
+      );
+
+      expect(transactionDataMock).toMatchObject({
+        quoteError: {
+          message: 'Insufficient source balance for quote',
+          reason: 'insufficient-source-balance',
+          detail: ['Required: 1 USDC', 'Current: 0.5 USDC'],
+        },
+      });
     });
 
     it('clears quotes in state if strategy throws', async () => {

--- a/packages/transaction-pay-controller/src/utils/quotes.ts
+++ b/packages/transaction-pay-controller/src/utils/quotes.ts
@@ -8,6 +8,7 @@ import { PaymentOverride, TransactionPayStrategy } from '../constants.js';
 import { projectLogger } from '../logger.js';
 import type {
   QuoteRequest,
+  QuoteErrorInfo,
   TransactionData,
   TransactionPayControllerMessenger,
   TransactionPayQuote,
@@ -32,6 +33,7 @@ import {
 } from './token.js';
 import { calculateTotals } from './totals.js';
 import { getTransaction, updateTransaction } from './transaction.js';
+import { isQuoteError } from './validation.js';
 
 const DEFAULT_REFRESH_INTERVAL = 30 * 1000; // 30 Seconds
 
@@ -103,6 +105,7 @@ export async function updateQuotes(
 
   updateTransactionData(transactionId, (data) => {
     data.isLoading = true;
+    data.quoteError = undefined;
   });
 
   try {
@@ -136,7 +139,7 @@ export async function updateQuotes(
 
     const supports7702 = accountSupports7702(messenger, from);
 
-    const { batchTransactions, quotes } = await getQuotes(
+    const { batchTransactions, error, quotes } = await getQuotes(
       transaction,
       from,
       requests,
@@ -185,6 +188,7 @@ export async function updateQuotes(
 
     updateTransactionData(transactionId, (data) => {
       data.quotes = quotes as never;
+      data.quoteError = quotes.length ? undefined : error;
       data.quotesLastUpdated = Date.now();
       data.totals = totals;
     });
@@ -630,6 +634,7 @@ async function getQuotes(
   signal?: AbortSignal,
 ): Promise<{
   batchTransactions: BatchTransaction[];
+  error?: QuoteErrorInfo;
   quotes: TransactionPayQuote<Json>[];
 }> {
   const { id: transactionId } = transaction;
@@ -674,6 +679,8 @@ async function getQuotes(
     transaction,
   };
 
+  let error: QuoteErrorInfo | undefined;
+
   for (const { name, strategy } of strategies) {
     try {
       const support = await checkStrategySupport(strategy, request);
@@ -695,14 +702,14 @@ async function getQuotes(
         continue;
       }
 
-      const quoteSupport = await checkStrategyQuoteSupport(strategy, {
+      const isQuoteSupported = await checkStrategyQuoteSupport(strategy, {
         messenger,
         quotes,
         signal,
         transaction,
       });
 
-      if (!quoteSupport) {
+      if (!isQuoteSupported) {
         log('Strategy does not support quotes', {
           strategy: name,
           transactionId,
@@ -726,13 +733,17 @@ async function getQuotes(
         batchTransactions,
         quotes,
       };
-    } catch (error) {
+    } catch (caughtError) {
       if (signal?.aborted) {
-        throw error;
+        throw caughtError;
       }
 
+      error ??= isQuoteError(caughtError)
+        ? caughtError.info
+        : { message: (caughtError as Error).message, reason: 'no-quotes' };
+
       log('Strategy failed, trying next', {
-        error,
+        error: caughtError,
         strategy: name,
         transactionId,
       });
@@ -744,6 +755,7 @@ async function getQuotes(
 
   return {
     batchTransactions: [],
+    error,
     quotes: [],
   };
 }

--- a/packages/transaction-pay-controller/src/utils/simulation.test.ts
+++ b/packages/transaction-pay-controller/src/utils/simulation.test.ts
@@ -1,0 +1,140 @@
+import { SentinelChainNotSupportedError } from '@metamask/sentinel-api-service';
+import type { SentinelSimulationResponse } from '@metamask/sentinel-api-service';
+import type { Hex } from '@metamask/utils';
+
+import { getMessengerMock } from '../tests/messenger-mock.js';
+import { simulateQuoteTransactions } from './simulation.js';
+import type { SimulationRequest } from './simulation.js';
+
+const CHAIN_ID_MOCK = '0x38' as Hex;
+const FROM_MOCK = '0x1111111111111111111111111111111111111111' as Hex;
+const TOKEN_ADDRESS_MOCK = '0x2222222222222222222222222222222222222222' as Hex;
+
+const CHAIN_UNSUPPORTED_ERROR = new SentinelChainNotSupportedError(
+  CHAIN_ID_MOCK,
+);
+
+describe('simulateQuoteTransactions', () => {
+  let messengerMock: ReturnType<typeof getMessengerMock>;
+
+  function buildRequest(
+    overrides?: Partial<SimulationRequest>,
+  ): SimulationRequest {
+    return {
+      chainId: CHAIN_ID_MOCK,
+      messenger: messengerMock.messenger,
+      transactions: [{ from: FROM_MOCK, to: TOKEN_ADDRESS_MOCK }],
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    messengerMock = getMessengerMock();
+    messengerMock.simulateTransactionsMock.mockResolvedValue({
+      transactions: [{}],
+    } as unknown as SentinelSimulationResponse);
+  });
+
+  describe('Sentinel throws', () => {
+    it('skips validation when Sentinel throws chain-unsupported error', async () => {
+      messengerMock.simulateTransactionsMock.mockRejectedValue(
+        CHAIN_UNSUPPORTED_ERROR,
+      );
+
+      expect(await simulateQuoteTransactions(buildRequest())).toBeUndefined();
+    });
+
+    it('throws TransactionPaySimulationError when Sentinel throws a generic error', async () => {
+      messengerMock.simulateTransactionsMock.mockRejectedValue(
+        new Error('network timeout'),
+      );
+
+      await expect(
+        simulateQuoteTransactions(buildRequest()),
+      ).rejects.toMatchObject({
+        name: 'TransactionPaySimulationError',
+        message: 'network timeout',
+      });
+    });
+
+    it('throws TransactionPaySimulationError when Sentinel throws a non-chain-unsupported error', async () => {
+      messengerMock.simulateTransactionsMock.mockRejectedValue(
+        new Error('Internal server error'),
+      );
+
+      await expect(
+        simulateQuoteTransactions(buildRequest()),
+      ).rejects.toMatchObject({
+        name: 'TransactionPaySimulationError',
+        message: 'Internal server error',
+      });
+    });
+
+    it('throws with String() when the thrown value is not an Error instance', async () => {
+      messengerMock.simulateTransactionsMock.mockRejectedValue({
+        code: 999,
+        message: 'x',
+      });
+
+      await expect(
+        simulateQuoteTransactions(buildRequest()),
+      ).rejects.toMatchObject({
+        name: 'TransactionPaySimulationError',
+        message: '[object Object]',
+      });
+    });
+  });
+
+  describe('Sentinel response errors', () => {
+    it('throws when Sentinel returns a direct error on a response transaction', async () => {
+      messengerMock.simulateTransactionsMock.mockResolvedValue({
+        transactions: [{ error: 'tx route error' }],
+      } as unknown as SentinelSimulationResponse);
+
+      await expect(
+        simulateQuoteTransactions(buildRequest()),
+      ).rejects.toMatchObject({
+        name: 'TransactionPaySimulationError',
+        message: 'tx route error',
+      });
+    });
+
+    it('throws when Sentinel returns an error on the second response transaction', async () => {
+      messengerMock.simulateTransactionsMock.mockResolvedValue({
+        transactions: [{}, { error: 'tx2 route error' }],
+      } as unknown as SentinelSimulationResponse);
+
+      await expect(
+        simulateQuoteTransactions(buildRequest()),
+      ).rejects.toMatchObject({
+        message: 'tx2 route error',
+      });
+    });
+  });
+
+  describe('Sentinel call', () => {
+    it('calls Sentinel without overrides', async () => {
+      await simulateQuoteTransactions(buildRequest());
+
+      expect(messengerMock.simulateTransactionsMock).toHaveBeenCalledWith(
+        CHAIN_ID_MOCK,
+        expect.not.objectContaining({ overrides: expect.anything() }),
+      );
+    });
+
+    it('passes transactions and withLogs to Sentinel', async () => {
+      const transactions = [{ from: FROM_MOCK, to: TOKEN_ADDRESS_MOCK }];
+
+      await simulateQuoteTransactions(buildRequest({ transactions }));
+
+      expect(messengerMock.simulateTransactionsMock).toHaveBeenCalledWith(
+        CHAIN_ID_MOCK,
+        expect.objectContaining({
+          transactions,
+          withLogs: true,
+        }),
+      );
+    });
+  });
+});

--- a/packages/transaction-pay-controller/src/utils/simulation.ts
+++ b/packages/transaction-pay-controller/src/utils/simulation.ts
@@ -1,0 +1,79 @@
+import { SentinelChainNotSupportedError } from '@metamask/sentinel-api-service';
+import type {
+  SentinelSimulationRequest,
+  SentinelSimulationResponseTransaction,
+  SentinelSimulationTransaction,
+} from '@metamask/sentinel-api-service';
+import { createModuleLogger } from '@metamask/utils';
+import type { Hex } from '@metamask/utils';
+
+import { projectLogger } from '../logger.js';
+import type { TransactionPayControllerMessenger } from '../types.js';
+
+export type { SentinelSimulationTransaction };
+
+const log = createModuleLogger(projectLogger, 'simulation');
+
+export type SimulationTransaction = SentinelSimulationTransaction;
+
+export type SimulationRequest = {
+  chainId: Hex;
+  messenger: TransactionPayControllerMessenger;
+  transactions: SimulationTransaction[];
+};
+
+export class TransactionPaySimulationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TransactionPaySimulationError';
+  }
+}
+
+export async function simulateQuoteTransactions(
+  request: SimulationRequest,
+): Promise<void> {
+  log('Simulating quote transactions', {
+    chainId: request.chainId,
+    transactions: request.transactions,
+  });
+
+  let responseTransactions: SentinelSimulationResponseTransaction[];
+
+  try {
+    const response = await request.messenger.call(
+      'SentinelApiService:simulateTransactions',
+      request.chainId,
+      {
+        transactions: request.transactions,
+        withLogs: true,
+      } as SentinelSimulationRequest,
+    );
+
+    responseTransactions = response.transactions;
+
+    log('Sentinel simulation succeeded', { responseTransactions });
+  } catch (error) {
+    log('Sentinel simulation failed', { error });
+
+    if (error instanceof SentinelChainNotSupportedError) {
+      log('Skipping validation for Sentinel-unsupported chain');
+      return;
+    }
+
+    throw new TransactionPaySimulationError(getErrorMessage(error));
+  }
+
+  for (const responseTransaction of responseTransactions) {
+    if (responseTransaction.error) {
+      throw new TransactionPaySimulationError(responseTransaction.error);
+    }
+  }
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+}

--- a/packages/transaction-pay-controller/src/utils/strategy.test.ts
+++ b/packages/transaction-pay-controller/src/utils/strategy.test.ts
@@ -120,7 +120,7 @@ describe('Strategy Utils', () => {
       quotes: [],
     } as never;
 
-    it('uses checkQuoteSupport when available', async () => {
+    it('returns false when checkQuoteSupport returns false', async () => {
       const strategy = {
         checkQuoteSupport: jest.fn().mockReturnValue(false),
         getQuotes: jest.fn(),
@@ -128,7 +128,16 @@ describe('Strategy Utils', () => {
       };
 
       expect(await checkStrategyQuoteSupport(strategy, request)).toBe(false);
-      expect(strategy.checkQuoteSupport).toHaveBeenCalledWith(request);
+    });
+
+    it('returns true when checkQuoteSupport returns true', async () => {
+      const strategy = {
+        checkQuoteSupport: jest.fn().mockReturnValue(true),
+        getQuotes: jest.fn(),
+        execute: jest.fn(),
+      };
+
+      expect(await checkStrategyQuoteSupport(strategy, request)).toBe(true);
     });
 
     it('defaults to supported when no post-quote support check is provided', async () => {

--- a/packages/transaction-pay-controller/src/utils/token.test.ts
+++ b/packages/transaction-pay-controller/src/utils/token.test.ts
@@ -846,6 +846,57 @@ describe('Token Utils', () => {
       );
       expect(findNetworkClientIdByChainIdMock).not.toHaveBeenCalled();
     });
+
+    it('falls back to latest block when pending native balance query throws', async () => {
+      PROVIDER_MOCK.request
+        .mockRejectedValueOnce(new Error('pending not supported'))
+        .mockResolvedValueOnce('0xde0b6b3a7640000');
+
+      const result = await getLiveTokenBalance(
+        messenger,
+        ACCOUNT_MOCK,
+        CHAIN_ID_MOCK,
+        NATIVE_TOKEN_ADDRESS,
+      );
+
+      expect(result).toBe('1000000000000000000');
+      expect(PROVIDER_MOCK.request).toHaveBeenNthCalledWith(1, {
+        method: 'eth_getBalance',
+        params: [ACCOUNT_MOCK, 'pending'],
+      });
+      expect(PROVIDER_MOCK.request).toHaveBeenNthCalledWith(2, {
+        method: 'eth_getBalance',
+        params: [ACCOUNT_MOCK, 'latest'],
+      });
+    });
+
+    it('falls back to latest block when pending ERC-20 balance query throws', async () => {
+      PROVIDER_MOCK.request
+        .mockRejectedValueOnce(new Error('pending not supported'))
+        .mockResolvedValueOnce('0x4C4B40');
+
+      const result = await getLiveTokenBalance(
+        messenger,
+        ACCOUNT_MOCK,
+        CHAIN_ID_MOCK,
+        ERC20_ADDRESS_MOCK,
+      );
+
+      expect(result).toBe('5000000');
+
+      const calldata = new Interface(abiERC20).encodeFunctionData('balanceOf', [
+        ACCOUNT_MOCK,
+      ]);
+
+      expect(PROVIDER_MOCK.request).toHaveBeenNthCalledWith(1, {
+        method: 'eth_call',
+        params: [{ to: ERC20_ADDRESS_MOCK, data: calldata }, 'pending'],
+      });
+      expect(PROVIDER_MOCK.request).toHaveBeenNthCalledWith(2, {
+        method: 'eth_call',
+        params: [{ to: ERC20_ADDRESS_MOCK, data: calldata }, 'latest'],
+      });
+    });
   });
 
   describe('computeTokenAmounts', () => {

--- a/packages/transaction-pay-controller/src/utils/token.ts
+++ b/packages/transaction-pay-controller/src/utils/token.ts
@@ -2,6 +2,7 @@ import { Interface } from '@ethersproject/abi';
 import { TokensControllerState } from '@metamask/assets-controllers';
 import { toChecksumHexAddress } from '@metamask/controller-utils';
 import { abiERC20 } from '@metamask/metamask-eth-abis';
+import { createModuleLogger } from '@metamask/utils';
 import type { CaipAssetType, Hex } from '@metamask/utils';
 import { hexToBigInt, toCaipAssetType } from '@metamask/utils';
 import { BigNumber } from 'bignumber.js';
@@ -11,6 +12,7 @@ import {
   NATIVE_TOKEN_ADDRESS,
   SLIP44_COIN_TYPE_BY_CHAIN,
 } from '../constants.js';
+import { projectLogger } from '../logger.js';
 import type { FiatRates, TransactionPayControllerMessenger } from '../types.js';
 import {
   getAssetsUnifyStateFeature,
@@ -18,6 +20,8 @@ import {
   isChainExcludedFromInfura,
 } from './feature-flags.js';
 import { getNetworkClientId, rpcRequest } from './provider.js';
+
+const log = createModuleLogger(projectLogger, 'token');
 
 /**
  * Check if two tokens are the same (same address and chain).
@@ -332,13 +336,15 @@ export async function getLiveTokenBalance(
     tokenAddress.toLowerCase() === getNativeToken(chainId).toLowerCase();
 
   if (isNative) {
-    const result = await rpcRequest<string>({
-      messenger,
-      chainId,
-      method: 'eth_getBalance',
-      params: [account, 'pending'],
-      options,
-    });
+    const result = await requestBalanceWithFallback((blockTag) =>
+      rpcRequest<string>({
+        messenger,
+        chainId,
+        method: 'eth_getBalance',
+        params: [account, blockTag],
+        options,
+      }),
+    );
 
     return new BigNumber(result, 16).toString(10);
   }
@@ -347,15 +353,40 @@ export async function getLiveTokenBalance(
     account,
   ]) as Hex;
 
-  const result = await rpcRequest<string>({
-    messenger,
-    chainId,
-    method: 'eth_call',
-    params: [{ to: tokenAddress, data: calldata }, 'pending'],
-    options,
-  });
+  const result = await requestBalanceWithFallback((blockTag) =>
+    rpcRequest<string>({
+      messenger,
+      chainId,
+      method: 'eth_call',
+      params: [{ to: tokenAddress, data: calldata }, blockTag],
+      options,
+    }),
+  );
 
   return new BigNumber(result, 16).toString(10);
+}
+
+/**
+ * Request a balance using the `pending` block tag, falling back to `latest`
+ * if the `pending` query throws.
+ *
+ * Some custom RPC endpoints do not support `pending` block queries. When the
+ * `pending` request fails, retry with `latest` so a live balance can still be
+ * resolved.
+ *
+ * @param request - Function that performs the balance request for a given
+ * block tag.
+ * @returns Raw balance result as a hex string.
+ */
+async function requestBalanceWithFallback(
+  request: (blockTag: 'pending' | 'latest') => Promise<string>,
+): Promise<string> {
+  try {
+    return await request('pending');
+  } catch (error) {
+    log('Pending balance query failed, falling back to latest', error);
+    return request('latest');
+  }
 }
 
 /**

--- a/packages/transaction-pay-controller/src/utils/validation.test.ts
+++ b/packages/transaction-pay-controller/src/utils/validation.test.ts
@@ -1,0 +1,414 @@
+import type { Hex } from '@metamask/utils';
+
+import { getMessengerMock } from '../tests/messenger-mock.js';
+import type { TransactionPayQuote } from '../types.js';
+import {
+  simulateQuoteTransactions,
+  TransactionPaySimulationError,
+} from './simulation.js';
+import * as tokenModule from './token.js';
+import {
+  isQuoteError,
+  QuoteError,
+  validateQuoteExecution,
+} from './validation.js';
+import type { QuoteSimulation } from './validation.js';
+
+jest.mock('./simulation', () => ({
+  ...jest.requireActual('./simulation'),
+  simulateQuoteTransactions: jest.fn(),
+}));
+jest.mock('./token');
+
+const CHAIN_ID_MOCK = '0x38' as Hex;
+const FROM_MOCK = '0x1111111111111111111111111111111111111111' as Hex;
+const TOKEN_ADDRESS_MOCK = '0x2222222222222222222222222222222222222222' as Hex;
+const RECIPIENT_MOCK = '0x3333333333333333333333333333333333333333' as Hex;
+
+// ERC-20 transfer(address,uint256) selector + padded args
+// transfer(RECIPIENT_MOCK, 500)
+const TRANSFER_DATA_MOCK = `0xa9059cbb${RECIPIENT_MOCK.slice(2).padStart(64, '0')}${BigInt(500).toString(16).padStart(64, '0')}`;
+
+function buildQuote(
+  overrides: Partial<TransactionPayQuote<unknown>['request']> = {},
+  sourceAmountRaw = '500',
+): TransactionPayQuote<unknown> {
+  return {
+    original: {},
+    request: {
+      from: FROM_MOCK,
+      sourceBalanceRaw: '1000',
+      sourceChainId: CHAIN_ID_MOCK,
+      sourceTokenAddress: TOKEN_ADDRESS_MOCK,
+      sourceTokenAmount: sourceAmountRaw,
+      targetAmountMinimum: '0',
+      targetChainId: '0x1' as Hex,
+      targetTokenAddress: '0x4444444444444444444444444444444444444444' as Hex,
+      ...overrides,
+    },
+    sourceAmount: { fiat: '0', human: '0', raw: sourceAmountRaw, usd: '0' },
+    strategy: 'relay' as never,
+  };
+}
+
+function buildSimulation(
+  overrides: Partial<QuoteSimulation> = {},
+): QuoteSimulation {
+  return {
+    transactions: [
+      {
+        data: TRANSFER_DATA_MOCK as Hex,
+        from: FROM_MOCK,
+        to: TOKEN_ADDRESS_MOCK,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('validateQuoteExecution', () => {
+  let messengerMock: ReturnType<typeof getMessengerMock>;
+  const simulateQuoteTransactionsMock = jest.mocked(simulateQuoteTransactions);
+  const getLiveTokenBalanceMock = jest.mocked(tokenModule.getLiveTokenBalance);
+  const getNativeTokenMock = jest.mocked(tokenModule.getNativeToken);
+  const getTokenInfoMock = jest.mocked(tokenModule.getTokenInfo);
+  const normalizeTokenAddressMock = jest.mocked(
+    tokenModule.normalizeTokenAddress,
+  );
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    messengerMock = getMessengerMock();
+
+    // Default: balance is sufficient
+    getLiveTokenBalanceMock.mockResolvedValue('1000');
+    // Default: simulation passes
+    simulateQuoteTransactionsMock.mockResolvedValue(undefined);
+    // Default: native token is ETH (not the source token)
+    getNativeTokenMock.mockReturnValue(
+      '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+    );
+    // Default: normalizeTokenAddress returns the address unchanged
+    normalizeTokenAddressMock.mockImplementation((addr) => addr);
+    // Default: no token info
+    getTokenInfoMock.mockReturnValue(undefined);
+  });
+
+  describe('balance check', () => {
+    it('passes when live balance equals required amount', async () => {
+      getLiveTokenBalanceMock.mockResolvedValue('500');
+
+      expect(
+        await validateQuoteExecution({
+          messenger: messengerMock.messenger,
+          quote: buildQuote({}, '500'),
+          simulation: buildSimulation(),
+        }),
+      ).toBeUndefined();
+    });
+
+    it('passes when live balance exceeds required amount', async () => {
+      getLiveTokenBalanceMock.mockResolvedValue('9999');
+
+      expect(
+        await validateQuoteExecution({
+          messenger: messengerMock.messenger,
+          quote: buildQuote({}, '500'),
+          simulation: buildSimulation(),
+        }),
+      ).toBeUndefined();
+    });
+
+    it('throws insufficient-source-balance when live balance is too low', async () => {
+      getLiveTokenBalanceMock.mockResolvedValue('100');
+
+      await expect(
+        validateQuoteExecution({
+          messenger: messengerMock.messenger,
+          quote: buildQuote({}, '500'),
+          simulation: buildSimulation(),
+        }),
+      ).rejects.toMatchObject({
+        info: {
+          reason: 'insufficient-source-balance',
+          message: 'Insufficient source balance for quote',
+        },
+      });
+    });
+
+    it('includes formatted shortfall detail rows when token info is available', async () => {
+      getLiveTokenBalanceMock.mockResolvedValue('100');
+      getTokenInfoMock.mockReturnValue({ decimals: 6, symbol: 'USDC' });
+
+      await expect(
+        validateQuoteExecution({
+          messenger: messengerMock.messenger,
+          quote: buildQuote({}, '500'),
+          simulation: buildSimulation(),
+        }),
+      ).rejects.toMatchObject({
+        info: {
+          reason: 'insufficient-source-balance',
+          detail: [
+            'Required: 0.0005 USDC',
+            'Current: 0.0001 USDC',
+            'Missing: 0.0004 USDC',
+          ],
+        },
+      });
+    });
+
+    it('includes raw shortfall detail rows when token info is unavailable', async () => {
+      getLiveTokenBalanceMock.mockResolvedValue('100');
+      getTokenInfoMock.mockReturnValue(undefined);
+
+      await expect(
+        validateQuoteExecution({
+          messenger: messengerMock.messenger,
+          quote: buildQuote({}, '500'),
+          simulation: buildSimulation(),
+        }),
+      ).rejects.toMatchObject({
+        info: {
+          reason: 'insufficient-source-balance',
+          detail: ['Required: 500', 'Current: 100', 'Missing: 400'],
+        },
+      });
+    });
+
+    it('skips balance check when isPostQuote is true', async () => {
+      getLiveTokenBalanceMock.mockResolvedValue('0');
+
+      expect(
+        await validateQuoteExecution({
+          messenger: messengerMock.messenger,
+          quote: buildQuote({ isPostQuote: true }, '500'),
+          simulation: buildSimulation({ transactions: [] }),
+        }),
+      ).toBeUndefined();
+    });
+
+    it('skips balance check when paymentOverride is set', async () => {
+      getLiveTokenBalanceMock.mockResolvedValue('0');
+
+      expect(
+        await validateQuoteExecution({
+          messenger: messengerMock.messenger,
+          quote: buildQuote(
+            { paymentOverride: { amount: '0', token: {} as never } },
+            '500',
+          ),
+          simulation: buildSimulation({ transactions: [] }),
+        }),
+      ).toBeUndefined();
+    });
+
+    it('throws balance-unavailable when getLiveTokenBalance rejects', async () => {
+      getLiveTokenBalanceMock.mockRejectedValue(new Error('RPC timeout'));
+
+      await expect(
+        validateQuoteExecution({
+          messenger: messengerMock.messenger,
+          quote: buildQuote(),
+          simulation: buildSimulation(),
+        }),
+      ).rejects.toMatchObject({
+        info: {
+          reason: 'balance-unavailable',
+          message: 'Unable to verify balance',
+          detail: ['RPC timeout'],
+        },
+      });
+    });
+  });
+
+  describe('decoded transfer check', () => {
+    it('throws insufficient-transfer-balance when decoded transfer exceeds live balance', async () => {
+      getLiveTokenBalanceMock.mockResolvedValue('100');
+
+      // Build a simulation with a transfer of 500 to the source token address
+      const simulation = buildSimulation({
+        transactions: [
+          {
+            data: TRANSFER_DATA_MOCK as Hex,
+            from: FROM_MOCK,
+            to: TOKEN_ADDRESS_MOCK,
+          },
+        ],
+      });
+
+      // Make balance check pass but decoded transfer check fail
+      // by making the required source amount small but the decoded transfer large
+      await expect(
+        validateQuoteExecution({
+          messenger: messengerMock.messenger,
+          quote: buildQuote({}, '50'), // source amount 50 < balance 100 → passes
+          simulation,
+        }),
+      ).rejects.toMatchObject({
+        info: {
+          reason: 'insufficient-transfer-balance',
+          message: 'Insufficient source balance for decoded transfer',
+        },
+      });
+    });
+
+    it('skips decoded transfer check for native source token', async () => {
+      const nativeAddress = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+      getNativeTokenMock.mockReturnValue(nativeAddress);
+
+      expect(
+        await validateQuoteExecution({
+          messenger: messengerMock.messenger,
+          quote: buildQuote({ sourceTokenAddress: nativeAddress }, '50'),
+          simulation: buildSimulation({
+            transactions: [
+              {
+                data: TRANSFER_DATA_MOCK as Hex,
+                from: FROM_MOCK,
+                to: nativeAddress as Hex,
+              },
+            ],
+          }),
+        }),
+      ).toBeUndefined();
+    });
+
+    it('ignores transactions with no data when decoding transfers', async () => {
+      getLiveTokenBalanceMock.mockResolvedValue('1000');
+
+      expect(
+        await validateQuoteExecution({
+          messenger: messengerMock.messenger,
+          quote: buildQuote({}, '50'),
+          simulation: buildSimulation({
+            transactions: [
+              { from: FROM_MOCK, to: TOKEN_ADDRESS_MOCK }, // no data
+            ],
+          }),
+        }),
+      ).toBeUndefined();
+    });
+
+    it('ignores transactions with non-transfer data', async () => {
+      getLiveTokenBalanceMock.mockResolvedValue('1000');
+
+      expect(
+        await validateQuoteExecution({
+          messenger: messengerMock.messenger,
+          quote: buildQuote({}, '50'),
+          simulation: buildSimulation({
+            transactions: [
+              {
+                data: '0xdeadbeef' as Hex, // not a transfer selector
+                from: FROM_MOCK,
+                to: TOKEN_ADDRESS_MOCK,
+              },
+            ],
+          }),
+        }),
+      ).toBeUndefined();
+    });
+  });
+
+  describe('simulation', () => {
+    it('passes when simulation succeeds', async () => {
+      simulateQuoteTransactionsMock.mockResolvedValue(undefined);
+
+      expect(
+        await validateQuoteExecution({
+          messenger: messengerMock.messenger,
+          quote: buildQuote(),
+          simulation: buildSimulation(),
+        }),
+      ).toBeUndefined();
+    });
+
+    it('throws simulation-failed QuoteError when simulation throws TransactionPaySimulationError', async () => {
+      simulateQuoteTransactionsMock.mockRejectedValue(
+        new TransactionPaySimulationError('execution reverted'),
+      );
+
+      await expect(
+        validateQuoteExecution({
+          messenger: messengerMock.messenger,
+          quote: buildQuote(),
+          simulation: buildSimulation(),
+        }),
+      ).rejects.toMatchObject({
+        info: {
+          reason: 'simulation-failed',
+          message: 'Quote simulation failed',
+          detail: ['execution reverted'],
+        },
+      });
+    });
+
+    it('re-throws non-simulation errors from simulation step', async () => {
+      const unexpectedError = new Error('unexpected');
+      simulateQuoteTransactionsMock.mockRejectedValue(unexpectedError);
+
+      await expect(
+        validateQuoteExecution({
+          messenger: messengerMock.messenger,
+          quote: buildQuote(),
+          simulation: buildSimulation(),
+        }),
+      ).rejects.toThrow('unexpected');
+    });
+  });
+
+  describe('abort signal', () => {
+    it('throws when signal is already aborted before validation starts', async () => {
+      const controller = new AbortController();
+      controller.abort();
+
+      await expect(
+        validateQuoteExecution({
+          messenger: messengerMock.messenger,
+          quote: buildQuote(),
+          signal: controller.signal,
+          simulation: buildSimulation(),
+        }),
+      ).rejects.toThrow('Quote validation aborted');
+    });
+
+    it('throws when signal is aborted after simulation throws', async () => {
+      const controller = new AbortController();
+
+      simulateQuoteTransactionsMock.mockImplementation(async () => {
+        controller.abort();
+        throw new TransactionPaySimulationError('sim error');
+      });
+
+      await expect(
+        validateQuoteExecution({
+          messenger: messengerMock.messenger,
+          quote: buildQuote(),
+          signal: controller.signal,
+          simulation: buildSimulation(),
+        }),
+      ).rejects.toThrow('Quote validation aborted');
+    });
+  });
+});
+
+describe('isQuoteError', () => {
+  it('returns true for a QuoteError instance', () => {
+    const error = new QuoteError({
+      message: 'test',
+      reason: 'simulation-failed',
+    });
+    expect(isQuoteError(error)).toBe(true);
+  });
+
+  it('returns false for a plain Error', () => {
+    expect(isQuoteError(new Error('plain'))).toBe(false);
+  });
+
+  it('returns false for a non-error value', () => {
+    expect(isQuoteError('string error')).toBe(false);
+    expect(isQuoteError(null)).toBe(false);
+    expect(isQuoteError(undefined)).toBe(false);
+  });
+});

--- a/packages/transaction-pay-controller/src/utils/validation.ts
+++ b/packages/transaction-pay-controller/src/utils/validation.ts
@@ -1,0 +1,324 @@
+import { Interface } from '@ethersproject/abi';
+import { abiERC20 } from '@metamask/metamask-eth-abis';
+import type { Hex } from '@metamask/utils';
+import { BigNumber } from 'bignumber.js';
+
+import { createModuleLogger, projectLogger } from '../logger.js';
+import type {
+  QuoteErrorInfo,
+  TransactionPayControllerMessenger,
+  TransactionPayQuote,
+} from '../types.js';
+import {
+  SimulationTransaction,
+  simulateQuoteTransactions,
+  TransactionPaySimulationError,
+} from './simulation.js';
+import {
+  getLiveTokenBalance,
+  getNativeToken,
+  getTokenInfo,
+  normalizeTokenAddress,
+  TokenAddressTarget,
+} from './token.js';
+
+const log = createModuleLogger(projectLogger, 'validation');
+
+const erc20Interface = new Interface(abiERC20);
+
+export type QuoteSimulation = {
+  transactions: SimulationTransaction[];
+};
+
+export type QuoteExecutionRequest = {
+  messenger: TransactionPayControllerMessenger;
+  quote: TransactionPayQuote<unknown>;
+  signal?: AbortSignal;
+  simulation: QuoteSimulation;
+};
+
+export class QuoteError extends Error {
+  readonly info: QuoteErrorInfo;
+
+  constructor(info: QuoteErrorInfo) {
+    super(info.message);
+    this.name = 'QuoteError';
+    this.info = info;
+  }
+}
+
+export async function validateQuoteExecution({
+  messenger,
+  quote,
+  signal,
+  simulation,
+}: QuoteExecutionRequest): Promise<void> {
+  throwIfAborted(signal);
+
+  const liveBalance = await getLiveSourceBalance(quote, messenger);
+
+  log('Live source balance', {
+    from: quote.request.from,
+    liveBalance,
+    sourceChainId: quote.request.sourceChainId,
+    sourceTokenAddress: quote.request.sourceTokenAddress,
+  });
+
+  throwIfAborted(signal);
+
+  log('Checking quote source amount', {
+    hasPaymentOverride: Boolean(quote.request.paymentOverride),
+    isPostQuote: Boolean(quote.request.isPostQuote),
+    liveBalance,
+    requiredAmount: quote.sourceAmount.raw,
+  });
+
+  validateRequiredSourceAmount(messenger, quote, liveBalance);
+
+  log('Quote source amount check passed');
+
+  log('Checking decoded source transfers', {
+    sourceChainId: quote.request.sourceChainId,
+    sourceTokenAddress: quote.request.sourceTokenAddress,
+    transactionCount: simulation.transactions.length,
+  });
+
+  validateDecodedSourceTransfers(
+    messenger,
+    quote,
+    liveBalance,
+    simulation.transactions,
+  );
+
+  log('Decoded source transfers check passed');
+
+  throwIfAborted(signal);
+
+  log('Starting simulation', {
+    chainId: quote.request.sourceChainId,
+    transactions: simulation.transactions,
+  });
+
+  try {
+    await simulateQuoteTransactions({
+      chainId: quote.request.sourceChainId,
+      messenger,
+      transactions: simulation.transactions,
+    });
+
+    log('Simulation passed');
+  } catch (error) {
+    throwIfAborted(signal);
+
+    if (error instanceof TransactionPaySimulationError) {
+      throw new QuoteError({
+        message: 'Quote simulation failed',
+        reason: 'simulation-failed',
+        detail: [error.message],
+      });
+    }
+
+    throw error;
+  }
+}
+
+export function isQuoteError(error: unknown): error is QuoteError {
+  return error instanceof QuoteError;
+}
+
+/**
+ * Format an amount shortfall into display-ready detail rows.
+ *
+ * Amounts are formatted using the source token decimals and symbol when
+ * available (e.g. `Required: 1.5 USDC`), falling back to the raw atomic values
+ * otherwise.
+ *
+ * @param messenger - Controller messenger.
+ * @param quote - Quote being validated.
+ * @param required - Required amount (raw string).
+ * @param balance - Current balance (raw string).
+ * @returns Detail rows: Required / Current / Missing.
+ */
+function formatBalanceShortfall(
+  messenger: TransactionPayControllerMessenger,
+  quote: TransactionPayQuote<unknown>,
+  required: string,
+  balance: string,
+): string[] {
+  const { sourceChainId, sourceTokenAddress } = quote.request;
+  const tokenInfo = getTokenInfo(messenger, sourceTokenAddress, sourceChainId);
+
+  const requiredBn = new BigNumber(required);
+  const balanceBn = new BigNumber(balance);
+
+  // Only ever called when balance < required, so the shortfall is positive.
+  const missing = requiredBn.minus(balanceBn);
+
+  return [
+    `Required: ${formatTokenAmount(requiredBn, tokenInfo)}`,
+    `Current: ${formatTokenAmount(balanceBn, tokenInfo)}`,
+    `Missing: ${formatTokenAmount(missing, tokenInfo)}`,
+  ];
+}
+
+/**
+ * Format an atomic token amount as a human-readable string with symbol.
+ *
+ * @param rawAmount - Amount in atomic units.
+ * @param tokenInfo - Source token decimals and symbol, if available.
+ * @returns Human-readable amount suffixed with the token symbol when known,
+ * otherwise the raw atomic value.
+ */
+function formatTokenAmount(
+  rawAmount: BigNumber,
+  tokenInfo: { decimals: number; symbol: string } | undefined,
+): string {
+  if (!tokenInfo) {
+    return rawAmount.toFixed();
+  }
+
+  const human = rawAmount.shiftedBy(-tokenInfo.decimals).toFixed();
+
+  return `${human} ${tokenInfo.symbol}`;
+}
+
+async function getLiveSourceBalance(
+  quote: TransactionPayQuote<unknown>,
+  messenger: TransactionPayControllerMessenger,
+): Promise<string> {
+  const { from, sourceChainId, sourceTokenAddress } = quote.request;
+  const normalizedSourceTokenAddress = normalizeTokenAddress(
+    sourceTokenAddress,
+    sourceChainId,
+    TokenAddressTarget.MetaMask,
+  );
+
+  try {
+    return await getLiveTokenBalance(
+      messenger,
+      from,
+      sourceChainId,
+      normalizedSourceTokenAddress,
+    );
+  } catch (error) {
+    throw new QuoteError({
+      message: 'Unable to verify balance',
+      reason: 'balance-unavailable',
+      detail: [(error as Error).message],
+    });
+  }
+}
+
+function validateRequiredSourceAmount(
+  messenger: TransactionPayControllerMessenger,
+  quote: TransactionPayQuote<unknown>,
+  liveBalance: string,
+): void {
+  if (quote.request.isPostQuote || quote.request.paymentOverride) {
+    return;
+  }
+
+  const requiredAmount = new BigNumber(quote.sourceAmount.raw);
+  const balance = new BigNumber(liveBalance);
+
+  if (balance.isGreaterThanOrEqualTo(requiredAmount)) {
+    return;
+  }
+
+  throw new QuoteError({
+    message: 'Insufficient source balance for quote',
+    reason: 'insufficient-source-balance',
+    detail: formatBalanceShortfall(
+      messenger,
+      quote,
+      requiredAmount.toFixed(),
+      balance.toFixed(),
+    ),
+  });
+}
+
+function validateDecodedSourceTransfers(
+  messenger: TransactionPayControllerMessenger,
+  quote: TransactionPayQuote<unknown>,
+  liveBalance: string,
+  transactions: SimulationTransaction[],
+): void {
+  const decodedAmounts = getDecodedSourceTransferAmounts(quote, transactions);
+
+  const requiredAmount = decodedAmounts
+    .reduce((total, amount) => total.plus(amount), new BigNumber(0))
+    .toString(10);
+
+  const balance = new BigNumber(liveBalance);
+
+  log('Decoded source transfer amounts', {
+    decodedAmounts,
+    liveBalance,
+    requiredAmount,
+  });
+
+  if (balance.isGreaterThanOrEqualTo(requiredAmount)) {
+    return;
+  }
+
+  throw new QuoteError({
+    message: 'Insufficient source balance for decoded transfer',
+    reason: 'insufficient-transfer-balance',
+    detail: formatBalanceShortfall(
+      messenger,
+      quote,
+      requiredAmount,
+      liveBalance,
+    ),
+  });
+}
+
+function getDecodedSourceTransferAmounts(
+  quote: TransactionPayQuote<unknown>,
+  transactions: SimulationTransaction[],
+): string[] {
+  const { sourceChainId, sourceTokenAddress } = quote.request;
+  const isNativeSource =
+    sourceTokenAddress.toLowerCase() ===
+    getNativeToken(sourceChainId).toLowerCase();
+
+  if (isNativeSource) {
+    return [];
+  }
+
+  const normalizedSourceTokenAddress = normalizeTokenAddress(
+    sourceTokenAddress,
+    sourceChainId,
+    TokenAddressTarget.MetaMask,
+  ).toLowerCase();
+
+  return transactions
+    .filter(
+      (transaction) =>
+        transaction.to &&
+        normalizeTokenAddress(
+          transaction.to,
+          sourceChainId,
+          TokenAddressTarget.MetaMask,
+        ).toLowerCase() === normalizedSourceTokenAddress,
+    )
+    .map((transaction) =>
+      transaction.data ? decodeTransferAmount(transaction.data) : undefined,
+    )
+    .filter((amount): amount is string => amount !== undefined);
+}
+
+function decodeTransferAmount(data: Hex): string | undefined {
+  try {
+    const result = erc20Interface.decodeFunctionData('transfer', data);
+    return new BigNumber(result._value.toString()).toString(10);
+  } catch {
+    return undefined;
+  }
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw new Error('Quote validation aborted');
+  }
+}

--- a/packages/transaction-pay-controller/tsconfig.build.json
+++ b/packages/transaction-pay-controller/tsconfig.build.json
@@ -38,6 +38,9 @@
     },
     {
       "path": "../messenger/tsconfig.build.json"
+    },
+    {
+      "path": "../sentinel-api-service/tsconfig.build.json"
     }
   ],
   "include": ["../../types", "./src"]

--- a/packages/transaction-pay-controller/tsconfig.json
+++ b/packages/transaction-pay-controller/tsconfig.json
@@ -36,6 +36,9 @@
     },
     {
       "path": "../messenger"
+    },
+    {
+      "path": "../sentinel-api-service"
     }
   ],
   "include": ["../../types", "./src"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -8593,7 +8593,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/sentinel-api-service@workspace:packages/sentinel-api-service":
+"@metamask/sentinel-api-service@npm:^1.0.0, @metamask/sentinel-api-service@workspace:packages/sentinel-api-service":
   version: 0.0.0-use.local
   resolution: "@metamask/sentinel-api-service@workspace:packages/sentinel-api-service"
   dependencies:
@@ -9094,6 +9094,7 @@ __metadata:
     "@metamask/network-controller": "npm:^34.0.0"
     "@metamask/ramps-controller": "npm:^17.0.0"
     "@metamask/remote-feature-flag-controller": "npm:^4.2.2"
+    "@metamask/sentinel-api-service": "npm:^1.0.0"
     "@metamask/transaction-controller": "npm:^69.2.1"
     "@metamask/utils": "npm:^11.11.0"
     "@ts-bridge/cli": "npm:^0.6.4"


### PR DESCRIPTION
## Explanation

Transaction Pay surfaces Relay quotes without checking that their execution path is still executable, so clients can end up with quotes that only fail later at submission or simulation.

This PR validates Relay quotes while they are being fetched, before they are surfaced as executable. Each quote is converted into normalized execution transactions, then shared validation utilities check:
- Source balance sufficiency
- Decoded source-token transfer balance
- Execution simulation (via `@metamask/sentinel-api-service`)

When validation fails, no executable quote is surfaced and `TransactionData` carries a structured `quoteError: QuoteErrorInfo` describing why. `message`/`detail` are display-ready copy and `reason` is a machine-readable discriminant (`'simulation-failed' | 'insufficient-source-balance' | 'insufficient-transfer-balance' | 'balance-unavailable' | 'no-quotes'`) for analytics and for conditionally surfacing alerts in clients.

Simulation and validation live in generic utilities so other strategies can opt in, and the Relay execute-request building is unified into a single `getRelayExecuteRequest` helper shared by the validation and submit paths.

**BREAKING:** `TransactionPayControllerMessenger` now requires the `SentinelApiService:simulateTransactions` action. Consumers must include `SentinelApiServiceActions` in the `AllowedActions` type passed to the `TransactionPayController` messenger.

## References

<!-- Add issue/ticket links here -->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking messenger/dependency change plus new execution-path validation that can block quotes; touches payment simulation, balances, and Relay submit/execute building.
> 
> **Overview**
> Adds **pre-surface Relay quote validation** (balance checks + Sentinel transaction simulation) and wires failures into **`TransactionData.quoteError`** (`QuoteErrorInfo` / `QuoteErrorReason` exported). Validation runs after quotes are fetched in `getRelayQuotes` via new `validateRelayQuotes`, gated by **`payStrategies.relay.validationEnabled`** (off by default).
> 
> **Breaking:** depends on `@metamask/sentinel-api-service` and the messenger must allow **`SentinelApiService:simulateTransactions`**. Shared helpers include `validateQuoteExecution`, `simulateQuoteTransactions`, and Relay **`getRelayExecuteRequest`** / **`getRelaySubmitCalls`** so validation and submit paths build the same execution payloads (normal, EIP-7702 batch, execute). Relay fetch errors are re-thrown without the old `Failed to fetch Relay quotes` wrapper.
> 
> Quote refresh clears `quoteError` on load and preserves structured `QuoteError` when strategies throw; empty quote sets can still carry the last validation error. Live balance reads fall back from `pending` to `latest` when RPCs reject pending queries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83dcb56805edf4d8bbc6173c290b4cd099435847. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->