### PR TITLE
fix(transaction-pay-controller): mark MM Pay transactions as externally signed once a quote is available

### DIFF
--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Mark MM Pay transactions as externally signed when quotes are available, so the parent transaction is no longer locally signed by `KeyringController:signTransaction`. The flag is cleared when no quotes are returned (e.g. the payment token matches the target token) so the transaction falls back to normal local signing. Unblocks `MoneyKeyring`, which does not implement `signTransaction`. ([#9145](https://github.com/MetaMask/core/pull/9145))
+- Mark MM Pay transactions as externally signed when quotes are available ([#9145](https://github.com/MetaMask/core/pull/9145))
 
 ## [23.7.0]
 

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/keyring-controller` from `^27.0.0` to `^27.1.0` ([#9129](https://github.com/MetaMask/core/pull/9129))
 
+### Fixed
+
+- Mark MM Pay transactions as externally signed once a quote is available, so the parent transaction is no longer locally signed by `KeyringController:signTransaction`. Unblocks `MoneyKeyring`, which does not implement `signTransaction`.
+
 ## [23.7.0]
 
 ### Added

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Mark MM Pay transactions as externally signed once a quote is available, so the parent transaction is no longer locally signed by `KeyringController:signTransaction`. Unblocks `MoneyKeyring`, which does not implement `signTransaction`.
+- Mark MM Pay transactions as externally signed once a quote is available, so the parent transaction is no longer locally signed by `KeyringController:signTransaction`. Unblocks `MoneyKeyring`, which does not implement `signTransaction`. ([#9145](https://github.com/MetaMask/core/pull/9145))
 
 ## [23.7.0]
 

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Mark MM Pay transactions as externally signed once a quote is available, so the parent transaction is no longer locally signed by `KeyringController:signTransaction`. Unblocks `MoneyKeyring`, which does not implement `signTransaction`. ([#9145](https://github.com/MetaMask/core/pull/9145))
+- Mark MM Pay transactions as externally signed when quotes are available, so the parent transaction is no longer locally signed by `KeyringController:signTransaction`. The flag is cleared when no quotes are returned (e.g. the payment token matches the target token) so the transaction falls back to normal local signing. Unblocks `MoneyKeyring`, which does not implement `signTransaction`. ([#9145](https://github.com/MetaMask/core/pull/9145))
 
 ## [23.7.0]
 

--- a/packages/transaction-pay-controller/src/utils/quotes.test.ts
+++ b/packages/transaction-pay-controller/src/utils/quotes.test.ts
@@ -730,6 +730,17 @@ describe('Quotes Utils', () => {
       );
     });
 
+    it('marks the transaction as externally signed so the publish hook owns submission', async () => {
+      await run();
+
+      const transactionMetaMock = {} as TransactionMeta;
+      updateTransactionMock.mock.calls[0][1](transactionMetaMock);
+
+      expect(transactionMetaMock).toMatchObject(
+        expect.objectContaining({ isExternalSign: true }),
+      );
+    });
+
     it('updates metrics in metadata', async () => {
       await run();
 

--- a/packages/transaction-pay-controller/src/utils/quotes.test.ts
+++ b/packages/transaction-pay-controller/src/utils/quotes.test.ts
@@ -730,7 +730,7 @@ describe('Quotes Utils', () => {
       );
     });
 
-    it('marks the transaction as externally signed so the publish hook owns submission', async () => {
+    it('marks the transaction as externally signed when quotes are available so the publish hook owns submission', async () => {
       await run();
 
       const transactionMetaMock = {} as TransactionMeta;
@@ -738,6 +738,19 @@ describe('Quotes Utils', () => {
 
       expect(transactionMetaMock).toMatchObject(
         expect.objectContaining({ isExternalSign: true }),
+      );
+    });
+
+    it('clears the externally signed flag when no quotes are returned so the transaction falls back to local signing', async () => {
+      getQuotesMock.mockResolvedValue([]);
+
+      await run();
+
+      const transactionMetaMock = {} as TransactionMeta;
+      updateTransactionMock.mock.calls[0][1](transactionMetaMock);
+
+      expect(transactionMetaMock).toMatchObject(
+        expect.objectContaining({ isExternalSign: false }),
       );
     });
 

--- a/packages/transaction-pay-controller/src/utils/quotes.ts
+++ b/packages/transaction-pay-controller/src/utils/quotes.ts
@@ -233,6 +233,15 @@ function syncTransaction({
       tx.batchTransactions = batchTransactions;
       tx.batchTransactionsOptions = {};
 
+      // Once a quote has been calculated, MM Pay owns submission of the
+      // transaction via its strategy publish hook. Mark the parent as
+      // externally signed so the TransactionController skips the local
+      // `KeyringController:signTransaction` call. This is required for
+      // accounts whose keyring cannot sign raw transactions (e.g.
+      // `MoneyKeyring`, which only exposes EIP-7702 authorization and
+      // EIP-712 / personal message signing).
+      tx.isExternalSign = true;
+
       tx.metamaskPay = {
         bridgeFeeFiat: totals.fees.provider.usd,
         chainId: paymentToken.chainId,

--- a/packages/transaction-pay-controller/src/utils/quotes.ts
+++ b/packages/transaction-pay-controller/src/utils/quotes.ts
@@ -163,6 +163,7 @@ export async function updateQuotes(
 
     syncTransaction({
       batchTransactions,
+      hasQuotes: quotes.length > 0,
       isPostQuote,
       messenger: messenger as never,
       paymentToken,
@@ -198,6 +199,7 @@ export async function updateQuotes(
  *
  * @param request - Request object.
  * @param request.batchTransactions - Batch transactions to sync.
+ * @param request.hasQuotes - Whether MM Pay produced any quotes for this transaction.
  * @param request.isPostQuote - Whether this is a post-quote flow.
  * @param request.messenger - Messenger instance.
  * @param request.paymentToken - Payment token (source for standard flows, destination for post-quote).
@@ -206,6 +208,7 @@ export async function updateQuotes(
  */
 function syncTransaction({
   batchTransactions,
+  hasQuotes,
   isPostQuote,
   messenger,
   paymentToken,
@@ -213,6 +216,7 @@ function syncTransaction({
   transactionId,
 }: {
   batchTransactions: BatchTransaction[];
+  hasQuotes: boolean;
   isPostQuote?: boolean;
   messenger: TransactionPayControllerMessenger;
   paymentToken: TransactionPaymentToken | undefined;
@@ -233,14 +237,13 @@ function syncTransaction({
       tx.batchTransactions = batchTransactions;
       tx.batchTransactionsOptions = {};
 
-      // Once a quote has been calculated, MM Pay owns submission of the
-      // transaction via its strategy publish hook. Mark the parent as
-      // externally signed so the TransactionController skips the local
-      // `KeyringController:signTransaction` call. This is required for
-      // accounts whose keyring cannot sign raw transactions (e.g.
-      // `MoneyKeyring`, which only exposes EIP-7702 authorization and
-      // EIP-712 / personal message signing).
-      tx.isExternalSign = true;
+      // When MM Pay has produced quotes, it owns submission of this transaction
+      // via its strategy publish hook, so the parent must be marked externally
+      // signed to skip the local `KeyringController:signTransaction` call.
+      // When there are no quotes (e.g. user selected the target token as the
+      // payment token in a Predict flow), the transaction falls back to normal
+      // local signing, so the flag is cleared to allow that.
+      tx.isExternalSign = hasQuotes;
 
       tx.metamaskPay = {
         bridgeFeeFiat: totals.fees.provider.usd,


### PR DESCRIPTION
## Explanation

### Current state

For every transaction that MM Pay produces a quote for, `TransactionPayController` writes `batchTransactions`, `batchTransactionsOptions`, and `metamaskPay` onto the transaction meta inside `syncTransaction`. Submission is then driven by the strategy publish hook (`TransactionPayPublishHook` → `RelayStrategy.execute` / etc.) — the local RLP signature produced by `TransactionController.#signTransaction` is discarded.

For accounts whose keyring **can** RLP-sign (HD, Simple Key Pair, hardware), the wasted local sign is harmless. For `MoneyKeyring` it is fatal: `@metamask/eth-money-keyring@^3.0.0` does not implement `signTransaction` (only `signEip7702Authorization`, `signTypedData`, `signPersonalMessage`). The publish path therefore throws `KeyringController - The keyring for the current address does not support the method signTransaction.` before the publish hook is ever reached, so MM Pay never gets a chance to submit the transaction.

### Solution

Set `isExternalSign` in `syncTransaction` based on whether MM Pay actually produced quotes:

```ts
tx.isExternalSign = hasQuotes;
```

This is the moment MM Pay commits to publishing the transaction via its strategy hook, so it is also the moment the controller can opt out of local RLP signing. `TransactionController.#signTransaction` already short-circuits when `isExternalSign === true`, so this lets execution flow straight into the publish hook chain.

When there are no quotes (e.g. the user selected the target token as the payment token in a Predict flow) we clear the flag so the transaction falls back to normal local signing.

### Effects per flow

| Flow | Before | After |
| --- | --- | --- |
| Money Account deposit / withdraw (quotes exist) | Throws `UnsupportedSignTransaction` | Skips local sign, strategy publish hook submits |
| Predict / Perps / Across / Relay / Polymarket / Hyperliquid (quotes exist) | Sign locally, discard `rawTx`, strategy publishes | Skip local sign, strategy publishes (mild speedup, no behavior change) |
| MM Pay tracked transaction but no viable quote returned (e.g. Predict where payment token == target token) | Sign locally and publish | Unchanged — flag is `false`, falls back to local signing |
| Transactions outside MM Pay | Unchanged | Unchanged — never reach `syncTransaction` |

### Notes

- `hasQuotes` is derived from `quotes.length > 0`, which is the honest signal of "MM Pay owns submission". `batchTransactions.length` is not equivalent: `RelayStrategy` does not implement `getBatchTransactions`, so it would be `0` on the happy path.
- Quote refresh re-runs `syncTransaction`, so the flag self-heals if the user changes the payment token mid-flow.

## References

Fixes: MUL-1918

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them
