### PR TITLE
ci: split test workflow into per-Node.js-version jobs

### DIFF
--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -135,13 +135,62 @@ jobs:
             exit 1
           fi
 
-  test:
-    name: Test
+  # The following `test-*` jobs are duplicated because a single job may only
+  # create a maximum of 256 matrix combinations, and we have more than 256 total
+  # test combinations across all Node.js versions.
+  test-18:
+    name: Test (Node.js 18)
     runs-on: ubuntu-latest
     needs: prepare
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [18.x]
+        package-name: ${{ fromJson(needs.prepare.outputs.child-workspace-package-names) }}
+    steps:
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v2
+        with:
+          is-high-risk-environment: false
+          node-version: ${{ matrix.node-version }}
+      - run: yarn workspace ${{ matrix.package-name }} run test
+      - name: Require clean working directory
+        shell: bash
+        run: |
+          if ! git diff --exit-code; then
+            echo "Working tree dirty at end of job"
+            exit 1
+          fi
+
+  test-20:
+    name: Test (Node.js 20)
+    runs-on: ubuntu-latest
+    needs: prepare
+    strategy:
+      matrix:
+        node-version: [20.x]
+        package-name: ${{ fromJson(needs.prepare.outputs.child-workspace-package-names) }}
+    steps:
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v2
+        with:
+          is-high-risk-environment: false
+          node-version: ${{ matrix.node-version }}
+      - run: yarn workspace ${{ matrix.package-name }} run test
+      - name: Require clean working directory
+        shell: bash
+        run: |
+          if ! git diff --exit-code; then
+            echo "Working tree dirty at end of job"
+            exit 1
+          fi
+
+  test-22:
+    name: Test (Node.js 22)
+    runs-on: ubuntu-latest
+    needs: prepare
+    strategy:
+      matrix:
+        node-version: [22.x]
         package-name: ${{ fromJson(needs.prepare.outputs.child-workspace-package-names) }}
     steps:
       - name: Checkout and setup environment

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -139,19 +139,18 @@ jobs:
   # create a maximum of 256 matrix combinations, and we have more than 256 total
   # test combinations across all Node.js versions.
   test-18:
-    name: Test (Node.js 18)
+    name: Test (18.x)
     runs-on: ubuntu-latest
     needs: prepare
     strategy:
       matrix:
-        node-version: [18.x]
         package-name: ${{ fromJson(needs.prepare.outputs.child-workspace-package-names) }}
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v2
         with:
           is-high-risk-environment: false
-          node-version: ${{ matrix.node-version }}
+          node-version: 18.x
       - run: yarn workspace ${{ matrix.package-name }} run test
       - name: Require clean working directory
         shell: bash
@@ -162,19 +161,18 @@ jobs:
           fi
 
   test-20:
-    name: Test (Node.js 20)
+    name: Test (20.x)
     runs-on: ubuntu-latest
     needs: prepare
     strategy:
       matrix:
-        node-version: [20.x]
         package-name: ${{ fromJson(needs.prepare.outputs.child-workspace-package-names) }}
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v2
         with:
           is-high-risk-environment: false
-          node-version: ${{ matrix.node-version }}
+          node-version: 20.x
       - run: yarn workspace ${{ matrix.package-name }} run test
       - name: Require clean working directory
         shell: bash
@@ -185,19 +183,18 @@ jobs:
           fi
 
   test-22:
-    name: Test (Node.js 22)
+    name: Test (22.x)
     runs-on: ubuntu-latest
     needs: prepare
     strategy:
       matrix:
-        node-version: [22.x]
         package-name: ${{ fromJson(needs.prepare.outputs.child-workspace-package-names) }}
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v2
         with:
           is-high-risk-environment: false
-          node-version: ${{ matrix.node-version }}
+          node-version: 22.x
       - run: yarn workspace ${{ matrix.package-name }} run test
       - name: Require clean working directory
         shell: bash


### PR DESCRIPTION
## Explanation

GitHub Actions limits a single job to 256 matrix combinations. As the number of packages in the monorepo has grown, the combined matrix of Node.js versions (18, 20, 22) and packages exceeds that limit, causing the `test` job to fail before any tests run.

This PR splits the single `test` job into three jobs — `test-18`, `test-20`, and `test-22` — each running the package matrix against a single Node.js version. This keeps every job comfortably under the 256-combination limit while preserving identical test coverage across Node.js versions.

## References

N/A

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them