### PR TITLE
feat: use pending blockTag for balance calls in money-account-balance-service

### DIFF
--- a/packages/money-account-balance-service/CHANGELOG.md
+++ b/packages/money-account-balance-service/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fetch on-chain Money account balances at the `pending` block tag instead of `latest`, so a balance refetch triggered by `TransactionController:transactionConfirmed` returns the post-transaction balance immediately rather than stale data for up to ~20 seconds. ([#9163](https://github.com/MetaMask/core/pull/9163))
+  - Applies to `getMoneyAccountBalance`, `getMusdBalance`, `getVmusdBalance`, and `getMusdEquivalentValue`. As a result these reads now reflect pending (mempool-inclusive) state. `getExchangeRate` and the on-chain `Accountant.base()` token-address lookup intentionally remain on `latest`.
+
 ## [2.0.0]
 
 ### Added

--- a/packages/money-account-balance-service/src/money-account-balance-service.test.ts
+++ b/packages/money-account-balance-service/src/money-account-balance-service.test.ts
@@ -377,10 +377,11 @@ function mockMoneyAccountBalanceMulticall({
               encodeFunctionData: jest.fn().mockReturnValue('0xcalldata'),
               decodeFunctionResult: jest
                 .fn()
-                .mockImplementation((_functionFragment: string, data: string) =>
-                  data === MUSD_RETURN_DATA
-                    ? [makeMockBN(musdBalance)]
-                    : [makeMockBN(vmusdValueInMusd)],
+                .mockImplementation(
+                  (_functionFragment: string, data: string) =>
+                    data === MUSD_RETURN_DATA
+                      ? [makeMockBN(musdBalance)]
+                      : [makeMockBN(vmusdValueInMusd)],
                 ),
             },
           }) as unknown as Contract,
@@ -820,6 +821,29 @@ describe('MoneyAccountBalanceService', () => {
         'client-at-index-0',
       );
     });
+
+    it('reads the ERC-20 balance at the pending block tag', async () => {
+      const mockBalanceOf = jest
+        .fn()
+        .mockResolvedValue({ toString: () => '5000000' });
+      MockContract.mockImplementation(
+        () => ({ balanceOf: mockBalanceOf }) as unknown as Contract,
+      );
+      const { service } = createService({
+        rffcFlags: {
+          [VAULT_CONFIG_FEATURE_FLAG_KEY]: {
+            ...MOCK_VAULT_CONFIG,
+            underlyingToken: MOCK_UNDERLYING_TOKEN_ADDRESS,
+          },
+        },
+      });
+
+      await service.getMusdBalance(MOCK_ACCOUNT_ADDRESS);
+
+      expect(mockBalanceOf).toHaveBeenCalledWith(MOCK_ACCOUNT_ADDRESS, {
+        blockTag: 'pending',
+      });
+    });
   });
 
   // ----------------------------------------------------------
@@ -1011,6 +1035,7 @@ describe('MoneyAccountBalanceService', () => {
         MOCK_ACCOUNT_ADDRESS,
         MOCK_VAULT_ADDRESS,
         MOCK_ACCOUNTANT_ADDRESS,
+        { blockTag: 'pending' },
       );
     });
 
@@ -1139,17 +1164,21 @@ describe('MoneyAccountBalanceService', () => {
 
       await service.getMoneyAccountBalance(MOCK_ACCOUNT_ADDRESS);
 
-      // A single batched request containing exactly the two balance reads.
-      expect(aggregate3).toHaveBeenCalledWith([
-        expect.objectContaining({
-          target: MOCK_UNDERLYING_TOKEN_ADDRESS,
-          allowFailure: false,
-        }),
-        expect.objectContaining({
-          target: MOCK_LENS_ADDRESS,
-          allowFailure: false,
-        }),
-      ]);
+      // A single batched request containing exactly the two balance reads,
+      // read at the pending block tag.
+      expect(aggregate3).toHaveBeenCalledWith(
+        [
+          expect.objectContaining({
+            target: MOCK_UNDERLYING_TOKEN_ADDRESS,
+            allowFailure: false,
+          }),
+          expect.objectContaining({
+            target: MOCK_LENS_ADDRESS,
+            allowFailure: false,
+          }),
+        ],
+        { blockTag: 'pending' },
+      );
       // The Multicall3 contract is instantiated at the canonical address.
       expect(MockContract).toHaveBeenCalledWith(
         MULTICALL3_ADDRESS_BY_CHAIN_ID[MOCK_VAULT_CONFIG.chainId],
@@ -1180,10 +1209,13 @@ describe('MoneyAccountBalanceService', () => {
         expect.anything(),
       );
       // ...and the resolved underlying token is used as the mUSD read target.
-      expect(aggregate3).toHaveBeenCalledWith([
-        expect.objectContaining({ target: MOCK_UNDERLYING_TOKEN_ADDRESS }),
-        expect.objectContaining({ target: MOCK_LENS_ADDRESS }),
-      ]);
+      expect(aggregate3).toHaveBeenCalledWith(
+        [
+          expect.objectContaining({ target: MOCK_UNDERLYING_TOKEN_ADDRESS }),
+          expect.objectContaining({ target: MOCK_LENS_ADDRESS }),
+        ],
+        { blockTag: 'pending' },
+      );
     });
 
     it('is also callable via the messenger action', async () => {

--- a/packages/money-account-balance-service/src/money-account-balance-service.test.ts
+++ b/packages/money-account-balance-service/src/money-account-balance-service.test.ts
@@ -377,11 +377,10 @@ function mockMoneyAccountBalanceMulticall({
               encodeFunctionData: jest.fn().mockReturnValue('0xcalldata'),
               decodeFunctionResult: jest
                 .fn()
-                .mockImplementation(
-                  (_functionFragment: string, data: string) =>
-                    data === MUSD_RETURN_DATA
-                      ? [makeMockBN(musdBalance)]
-                      : [makeMockBN(vmusdValueInMusd)],
+                .mockImplementation((_functionFragment: string, data: string) =>
+                  data === MUSD_RETURN_DATA
+                    ? [makeMockBN(musdBalance)]
+                    : [makeMockBN(vmusdValueInMusd)],
                 ),
             },
           }) as unknown as Contract,

--- a/packages/money-account-balance-service/src/money-account-balance-service.ts
+++ b/packages/money-account-balance-service/src/money-account-balance-service.ts
@@ -62,6 +62,13 @@ type Multicall3Result = {
 };
 
 /**
+ * ethers `CallOverrides` used for BALANCE reads (mUSD, vmUSD, Lens).
+ *
+ * We deliberately read at `pending` rather than `latest` to bypass the provider's block cache middleware.
+ */
+const PENDING_READ_OVERRIDES = { blockTag: 'pending' } as const;
+
+/**
  * The name of the {@link MoneyAccountBalanceService}, used to namespace the
  * service's actions and events.
  */
@@ -438,7 +445,10 @@ export class MoneyAccountBalanceService extends BaseDataService<
   ): Promise<string> {
     const provider = this.#getProvider(chainId);
     const contract = new Contract(contractAddress, abiERC20, provider);
-    const balance = await contract.balanceOf(accountAddress);
+    const balance = await contract.balanceOf(
+      accountAddress,
+      PENDING_READ_OVERRIDES,
+    );
     return balance.toString();
   }
 
@@ -569,10 +579,10 @@ export class MoneyAccountBalanceService extends BaseDataService<
           provider,
         );
         const [musdResult, vmusdResult] =
-          (await multicall3.callStatic.aggregate3(calls)) as [
-            Multicall3Result,
-            Multicall3Result,
-          ];
+          (await multicall3.callStatic.aggregate3(
+            calls,
+            PENDING_READ_OVERRIDES,
+          )) as [Multicall3Result, Multicall3Result];
 
         const musdBalanceBN = erc20.interface.decodeFunctionResult(
           'balanceOf',
@@ -669,6 +679,7 @@ export class MoneyAccountBalanceService extends BaseDataService<
           accountAddress,
           boringVault,
           accountantAddress,
+          PENDING_READ_OVERRIDES,
         );
 
         return { balanceOfInAssets: balanceOfInAssets.toString() };


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->
Update `@metamask/money-account-balance-service` to use `pending` blockTag for balance calls
## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them
