### PR TITLE
feat(social-controllers): expose optional 7-day per-chain breakdown

### DIFF
--- a/packages/social-controllers/CHANGELOG.md
+++ b/packages/social-controllers/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add optional 7-day per-chain fields to the `PerChainBreakdown` type (and `PerChainBreakdownStruct`): `perChainPnl7d` (`Record<string, number>`), `perChainRoi7d` (`Record<string, number | null>`), and `perChainVolume7d` (`Record<string, number>`) — exposing the 7-day Hyperliquid/per-chain breakdown alongside the existing 30-day fields. The unsuffixed fields (`perChainPnl`, `perChainRoi`, `perChainVolume`) remain the 30-day window; the new fields are optional for backward compatibility with social-api versions that only return the 30-day breakdown ([#9999](https://github.com/MetaMask/core/pull/9999))
+- Add optional 7-day per-chain fields to the `PerChainBreakdown` type (and `PerChainBreakdownStruct`): `perChainPnl7d` (`Record<string, number>`), `perChainRoi7d` (`Record<string, number | null>`), and `perChainVolume7d` (`Record<string, number>`) — exposing the 7-day Hyperliquid/per-chain breakdown alongside the existing 30-day fields. The unsuffixed fields (`perChainPnl`, `perChainRoi`, `perChainVolume`) remain the 30-day window; the new fields are optional for backward compatibility with social-api versions that only return the 30-day breakdown ([#9165](https://github.com/MetaMask/core/pull/9165))
 
 ## [2.3.0]
 

--- a/packages/social-controllers/CHANGELOG.md
+++ b/packages/social-controllers/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add optional 7-day per-chain fields to the `PerChainBreakdown` type (and `PerChainBreakdownStruct`): `perChainPnl7d` (`Record<string, number>`), `perChainRoi7d` (`Record<string, number | null>`), and `perChainVolume7d` (`Record<string, number>`) — exposing the 7-day Hyperliquid/per-chain breakdown alongside the existing 30-day fields. The unsuffixed fields (`perChainPnl`, `perChainRoi`, `perChainVolume`) remain the 30-day window; the new fields are optional for backward compatibility with social-api versions that only return the 30-day breakdown ([#9999](https://github.com/MetaMask/core/pull/9999))
+
 ## [2.3.0]
 
 ### Added

--- a/packages/social-controllers/src/SocialService.test.ts
+++ b/packages/social-controllers/src/SocialService.test.ts
@@ -404,6 +404,51 @@ describe('SocialService', () => {
 
       expect(result.stats).toStrictEqual({});
     });
+
+    it('accepts and returns the optional 7-day per-chain breakdown', async () => {
+      const withPerChain7d = {
+        ...mockProfileResponse,
+        perChainBreakdown: {
+          perChainPnl: { base: 30000, hyperliquid: 900000 },
+          perChainRoi: { base: 2.5, hyperliquid: null },
+          perChainVolume: { base: 100000, hyperliquid: 0 },
+          perChainPnl7d: { base: 5000, hyperliquid: 120000 },
+          perChainRoi7d: { base: 1.1, hyperliquid: null },
+          perChainVolume7d: { base: 20000, hyperliquid: 0 },
+        },
+      };
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(withPerChain7d),
+      });
+
+      const service = createService();
+      const result = await service.fetchTraderProfile({
+        addressOrId: '0x1234',
+      });
+
+      expect(result.perChainBreakdown).toStrictEqual(
+        withPerChain7d.perChainBreakdown,
+      );
+    });
+
+    it('accepts a profile without the optional 7-day per-chain breakdown', async () => {
+      // The 30-day-only shape older social-api versions return.
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(mockProfileResponse),
+      });
+
+      const service = createService();
+      const result = await service.fetchTraderProfile({
+        addressOrId: '0x1234',
+      });
+
+      expect(result.perChainBreakdown.perChainPnl7d).toBeUndefined();
+    });
   });
 
   describe('fetchOpenPositions', () => {

--- a/packages/social-controllers/src/SocialService.ts
+++ b/packages/social-controllers/src/SocialService.ts
@@ -134,6 +134,9 @@ const PerChainBreakdownStruct = structType({
   perChainPnl: record(string(), number()),
   perChainRoi: record(string(), nullable(number())),
   perChainVolume: record(string(), number()),
+  perChainPnl7d: optional(record(string(), number())),
+  perChainRoi7d: optional(record(string(), nullable(number()))),
+  perChainVolume7d: optional(record(string(), number())),
 });
 
 const TraderProfileResponseStruct = structType({

--- a/packages/social-controllers/src/social-types.ts
+++ b/packages/social-controllers/src/social-types.ts
@@ -123,6 +123,16 @@ export type PerChainBreakdown = {
   /** ROI can be null for chains with no trading activity (zero cost-basis). */
   perChainRoi: Record<string, number | null>;
   perChainVolume: Record<string, number>;
+  /**
+   * 7-day per-chain PnL in USD. Optional: older social-api versions only
+   * return the 30-day breakdown (`perChainPnl`). The unsuffixed fields above
+   * remain the 30-day window for backward compatibility.
+   */
+  perChainPnl7d?: Record<string, number>;
+  /** 7-day per-chain ROI. Null for chains with no trading activity. */
+  perChainRoi7d?: Record<string, number | null>;
+  /** 7-day per-chain volume in USD. */
+  perChainVolume7d?: Record<string, number>;
 };
 
 /**


### PR DESCRIPTION
## Explanation

The Social Leaderboard surfaces in MetaMask Mobile are switching their PnL displays from the 30-day window to the 7-day window (TSA-766). The trader-profile "Return" headline sums the **per-chain** PnL breakdown (rather than the global stat) so it includes Hyperliquid/perps and stays consistent with the position list. `TraderStats` already exposed scalar 7-day fields (`pnl7d`, `winRate7d`, `roiPercent7d`), but `PerChainBreakdown` only had the 30-day per-chain maps — so a 7-day, Hyperliquid-inclusive headline wasn't expressible.

This adds the 7-day per-chain breakdown to `PerChainBreakdown` (and its struct), alongside the matching social-api change that populates it (Clicker already returns these windows).

## References

- Mobile ticket: TSA-766 (Use 7d PnL)
- social-api counterpart: `va-mmcx-social-api` — exposes `perChainPnl7d` / `perChainRoi7d` / `perChainVolume7d` on the profile response and chain-scopes the leaderboard 7-day fields.

## Changes

- **Added**: optional `perChainPnl7d` (`Record<string, number>`), `perChainRoi7d` (`Record<string, number | null>`), and `perChainVolume7d` (`Record<string, number>`) to the `PerChainBreakdown` type and `PerChainBreakdownStruct`.
- The unsuffixed fields (`perChainPnl`, `perChainRoi`, `perChainVolume`) remain the **30-day** window.
- New fields are **optional** so the controller stays backward compatible with social-api versions that only return the 30-day breakdown.

## Non-breaking

Purely additive. The response struct uses `superstruct`'s non-exhaustive `type()`, and the new struct fields are `optional()`, so existing 30-day-only responses continue to validate unchanged. No public export was removed, renamed, or had its signature changed.

## Test plan

- `yarn workspace @metamask/social-controllers run jest --no-coverage SocialService.test.ts` — added cases asserting the 7-day per-chain breakdown round-trips, and that a profile omitting it still validates (`perChainPnl7d` is `undefined`). 45/45 pass.
- `yarn workspace @metamask/social-controllers run build` — type check passes.
- Changelog updated + `changelog:validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)