### PR TITLE
refactor(smart-transactions-controller): import AuthenticationController namespace

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2151,14 +2151,8 @@
     "@typescript-eslint/explicit-function-return-type": {
       "count": 10
     },
-    "@typescript-eslint/no-base-to-string": {
-      "count": 1
-    },
     "@typescript-eslint/no-floating-promises": {
       "count": 4
-    },
-    "@typescript-eslint/restrict-template-expressions": {
-      "count": 1
     },
     "no-restricted-syntax": {
       "count": 4

--- a/packages/smart-transactions-controller/src/SmartTransactionsController.test.ts
+++ b/packages/smart-transactions-controller/src/SmartTransactionsController.test.ts
@@ -20,8 +20,8 @@ import type {
   TransactionControllerGetNonceLockAction,
   TransactionControllerGetTransactionsAction,
   TransactionControllerUpdateTransactionAction,
+  TransactionParams,
 } from '@metamask/transaction-controller';
-import type { TransactionParams } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 import nock from 'nock';
 

--- a/packages/smart-transactions-controller/src/SmartTransactionsController.ts
+++ b/packages/smart-transactions-controller/src/SmartTransactionsController.ts
@@ -20,7 +20,7 @@ import type {
   NetworkControllerStateChangeEvent,
 } from '@metamask/network-controller';
 import { StaticIntervalPollingController } from '@metamask/polling-controller';
-import type { AuthenticationControllerGetBearerTokenAction } from '@metamask/profile-sync-controller/auth';
+import type { AuthenticationController } from '@metamask/profile-sync-controller';
 import type {
   RemoteFeatureFlagControllerGetStateAction,
   RemoteFeatureFlagControllerStateChangeEvent,
@@ -188,7 +188,7 @@ export type SmartTransactionsControllerActions =
   | SmartTransactionsControllerMethodActions;
 
 type AllowedActions =
-  | AuthenticationControllerGetBearerTokenAction
+  | AuthenticationController.AuthenticationControllerGetBearerTokenAction
   | NetworkControllerGetNetworkClientByIdAction
   | NetworkControllerGetStateAction
   | RemoteFeatureFlagControllerGetStateAction


### PR DESCRIPTION
## Explanation

The smart-transactions-controller imported the bearer token action type from the `@metamask/profile-sync-controller/auth` subpath. This change switches it to the `AuthenticationController` namespace exported from the package's main entry, which keeps the type reference aligned with how the rest of the namespace is consumed. While here, the `TransactionParams` type import was folded into the existing `@metamask/transaction-controller` import group instead of sitting on its own line.

This is an internal-only type import refactor. There is no change to runtime behavior or the public API surface, so no changelog entry is needed.

## References

<!-- none -->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them