### PR TITLE
feat: add metadata to stellar trades tx for tx history in bridge status controller

### DIFF
--- a/packages/bridge-status-controller/src/strategy/index.ts
+++ b/packages/bridge-status-controller/src/strategy/index.ts
@@ -6,7 +6,9 @@ import {
   isBitcoinTrade,
   isEvmTxData,
   isNonEvmChainId,
+  isStellarTrade,
   isTronTrade,
+  StellarTradeData,
   Trade,
   TronTradeData,
   TxData,
@@ -20,7 +22,12 @@ import { submitNonEvmHandler } from './non-evm-strategy';
 import type { SubmitStrategyParams, SubmitStepResult } from './types';
 
 const validateParams = <
-  TxDataType extends BitcoinTradeData | TronTradeData | string | TxData,
+  TxDataType extends
+    | BitcoinTradeData
+    | StellarTradeData
+    | TronTradeData
+    | string
+    | TxData,
 >(
   params: SubmitStrategyParams<Trade>,
 ): params is SubmitStrategyParams<TxDataType> => {
@@ -38,6 +45,8 @@ const validateParams = <
       return txs.every((tx) => typeof tx === 'string');
     case ChainId.BTC:
       return txs.every(isBitcoinTrade);
+    case ChainId.STELLAR:
+      return txs.every((tx) => typeof tx === 'string' || isStellarTrade(tx));
     case ChainId.TRON:
       return txs.every(isTronTrade);
     default:

--- a/packages/bridge-status-controller/src/strategy/non-evm-strategy.ts
+++ b/packages/bridge-status-controller/src/strategy/non-evm-strategy.ts
@@ -2,6 +2,7 @@
 import { isTronChainId } from '@metamask/bridge-controller';
 import type {
   BitcoinTradeData,
+  StellarTradeData,
   TronTradeData,
   TxData,
 } from '@metamask/bridge-controller';
@@ -20,7 +21,7 @@ import type { SubmitStrategyParams, SubmitStepResult } from './types';
  */
 const handleTronApproval = async (
   args: SubmitStrategyParams<
-    TronTradeData | BitcoinTradeData | string | TxData
+    TronTradeData | BitcoinTradeData | StellarTradeData | string | TxData
   >,
 ) => {
   const {
@@ -65,7 +66,7 @@ const handleTronApproval = async (
  */
 export async function* submitNonEvmHandler(
   args: SubmitStrategyParams<
-    BitcoinTradeData | TronTradeData | string | TxData
+    BitcoinTradeData | StellarTradeData | TronTradeData | string | TxData
   >,
 ): AsyncGenerator<SubmitStepResult, void, void> {
   const {

--- a/packages/bridge-status-controller/src/utils/snaps.ts
+++ b/packages/bridge-status-controller/src/utils/snaps.ts
@@ -88,14 +88,19 @@ export const getClientRequest = (
 
   const transaction = extractTradeData(trade);
 
-  let options: Record<string, unknown> = {
-    ...(sourceAssetId !== undefined && {
-      sourceAssetId,
-    }),
-    ...(destAssetId !== undefined && {
-      destAssetId,
-    }),
-  };
+  let options: Record<string, unknown> | undefined;
+
+  if (sourceAssetId !== undefined || destAssetId !== undefined) {
+    options = {
+      ...(sourceAssetId !== undefined && {
+        sourceAssetId,
+      }),
+      ...(destAssetId !== undefined && {
+        destAssetId,
+      }),
+    };
+  }
+
   if (isTronTrade(trade)) {
     // Tron trades need the visible flag and contract type to be included in the request options
     options = {

--- a/packages/bridge-status-controller/src/utils/snaps.ts
+++ b/packages/bridge-status-controller/src/utils/snaps.ts
@@ -10,6 +10,7 @@ import {
   formatChainIdToCaip,
   formatChainIdToHex,
   isCrossChain,
+  isStellarTrade,
   isTronTrade,
 } from '@metamask/bridge-controller';
 import { SnapController } from '@metamask/snaps-controllers';
@@ -72,6 +73,7 @@ export const createClientTransactionRequest = (
  * @param srcChainId - The source chain ID
  * @param accountId - The account ID
  * @param snapId - The snap ID
+ * @param destChainId - The destination chain ID
  * @returns The snap request object for signing and sending transaction
  */
 export const getClientRequest = (
@@ -79,18 +81,28 @@ export const getClientRequest = (
   srcChainId: number,
   accountId: AccountsControllerState['internalAccounts']['accounts'][string]['id'],
   snapId: string,
+  destChainId?: number,
 ): Parameters<SnapController['handleRequest']>[0] => {
   const scope = formatChainIdToCaip(srcChainId);
 
   const transaction = extractTradeData(trade);
 
-  // Tron trades need the visible flag and contract type to be included in the request options
-  const options = isTronTrade(trade)
-    ? {
-        visible: trade.visible,
-        type: trade.raw_data?.contract?.[0]?.type,
-      }
-    : undefined;
+  let options: Record<string, unknown> | undefined;
+  if (isTronTrade(trade)) {
+    // Tron trades need the visible flag and contract type to be included in the request options
+    options = {
+      visible: trade.visible,
+      type: trade.raw_data?.contract?.[0]?.type,
+    };
+  } else if (isStellarTrade(trade)) {
+    // Stellar trades need the source and destination chain IDs to be included as metadata
+    options = {
+      sourceChainId: scope,
+      ...(destChainId !== undefined && {
+        destChainId: formatChainIdToCaip(destChainId),
+      }),
+    };
+  }
 
   return createClientTransactionRequest(
     snapId,
@@ -250,6 +262,7 @@ export const handleNonEvmTx = async (
     quoteResponse.quote.srcChainId,
     selectedAccount.id,
     selectedAccount.metadata?.snap?.id,
+    quoteResponse.quote.destChainId,
   );
   const requestResponse = (await messenger.call(
     'SnapController:handleRequest',

--- a/packages/bridge-status-controller/src/utils/snaps.ts
+++ b/packages/bridge-status-controller/src/utils/snaps.ts
@@ -10,7 +10,6 @@ import {
   formatChainIdToCaip,
   formatChainIdToHex,
   isCrossChain,
-  isStellarTrade,
   isTronTrade,
 } from '@metamask/bridge-controller';
 import { SnapController } from '@metamask/snaps-controllers';
@@ -20,7 +19,7 @@ import {
   TransactionType,
 } from '@metamask/transaction-controller';
 import type { TransactionMeta } from '@metamask/transaction-controller';
-import type { CaipChainId, Hex } from '@metamask/utils';
+import type { CaipAssetType, CaipChainId, Hex } from '@metamask/utils';
 import { v4 as uuid } from 'uuid';
 
 import type {
@@ -73,7 +72,8 @@ export const createClientTransactionRequest = (
  * @param srcChainId - The source chain ID
  * @param accountId - The account ID
  * @param snapId - The snap ID
- * @param destChainId - The destination chain ID
+ * @param sourceAssetId - The source asset ID
+ * @param destAssetId - The destination asset ID
  * @returns The snap request object for signing and sending transaction
  */
 export const getClientRequest = (
@@ -81,26 +81,26 @@ export const getClientRequest = (
   srcChainId: number,
   accountId: AccountsControllerState['internalAccounts']['accounts'][string]['id'],
   snapId: string,
-  destChainId?: number,
+  sourceAssetId?: CaipAssetType,
+  destAssetId?: CaipAssetType,
 ): Parameters<SnapController['handleRequest']>[0] => {
   const scope = formatChainIdToCaip(srcChainId);
 
   const transaction = extractTradeData(trade);
 
-  let options: Record<string, unknown> | undefined;
+  let options: Record<string, unknown> = {
+    ...(sourceAssetId !== undefined && {
+      sourceAssetId,
+    }),
+    ...(destAssetId !== undefined && {
+      destAssetId,
+    }),
+  };
   if (isTronTrade(trade)) {
     // Tron trades need the visible flag and contract type to be included in the request options
     options = {
       visible: trade.visible,
       type: trade.raw_data?.contract?.[0]?.type,
-    };
-  } else if (isStellarTrade(trade)) {
-    // Stellar trades need the source and destination chain IDs to be included as metadata
-    options = {
-      sourceChainId: scope,
-      ...(destChainId !== undefined && {
-        destChainId: formatChainIdToCaip(destChainId),
-      }),
     };
   }
 
@@ -262,7 +262,8 @@ export const handleNonEvmTx = async (
     quoteResponse.quote.srcChainId,
     selectedAccount.id,
     selectedAccount.metadata?.snap?.id,
-    quoteResponse.quote.destChainId,
+    quoteResponse.quote.srcAsset.assetId,
+    quoteResponse.quote.destAsset.assetId,
   );
   const requestResponse = (await messenger.call(
     'SnapController:handleRequest',

--- a/packages/bridge-status-controller/src/utils/transaction.test.ts
+++ b/packages/bridge-status-controller/src/utils/transaction.test.ts
@@ -1669,6 +1669,80 @@ describe('Bridge Status Controller Transaction Utils', () => {
 
       createClientRequestSpy.mockRestore();
     });
+
+    it('should include Stellar source and destination chain IDs as options when trade is Stellar', () => {
+      const stellarTrade = {
+        xdrBase64: 'AAAABg==',
+      } as never;
+
+      const mockAccount = {
+        id: 'test-account-id',
+        metadata: {
+          snap: { id: 'test-snap-id' },
+        },
+      };
+
+      const result = snaps.getClientRequest(
+        stellarTrade,
+        ChainId.STELLAR,
+        mockAccount.id,
+        mockAccount.metadata.snap.id,
+        ChainId.ETH,
+      );
+
+      expect(result).toMatchObject({
+        origin: 'metamask',
+        snapId: 'test-snap-id',
+        handler: 'onClientRequest',
+        request: {
+          id: expect.any(String),
+          jsonrpc: '2.0',
+          method: 'signAndSendTransaction',
+          params: {
+            transaction: 'AAAABg==',
+            scope: formatChainIdToCaip(ChainId.STELLAR),
+            accountId: 'test-account-id',
+            options: {
+              sourceChainId: formatChainIdToCaip(ChainId.STELLAR),
+              destChainId: formatChainIdToCaip(ChainId.ETH),
+            },
+          },
+        },
+      });
+    });
+
+    it('should omit destChainId option for Stellar trades when destination chain ID is not provided', () => {
+      const stellarTrade = {
+        xdr: 'AAAABg==',
+      } as never;
+
+      const mockAccount = {
+        id: 'test-account-id',
+        metadata: {
+          snap: { id: 'test-snap-id' },
+        },
+      };
+
+      const result = snaps.getClientRequest(
+        stellarTrade,
+        ChainId.STELLAR,
+        mockAccount.id,
+        mockAccount.metadata.snap.id,
+      );
+
+      expect(result).toMatchObject({
+        request: {
+          params: {
+            options: {
+              sourceChainId: formatChainIdToCaip(ChainId.STELLAR),
+            },
+          },
+        },
+      });
+      expect(
+        (result.request.params as { options: Record<string, unknown> }).options,
+      ).not.toHaveProperty('destChainId');
+    });
   });
 
   describe('getAddTransactionBatchParams', () => {

--- a/packages/bridge-status-controller/src/utils/transaction.test.ts
+++ b/packages/bridge-status-controller/src/utils/transaction.test.ts
@@ -4,6 +4,7 @@ import {
   FeeType,
   formatChainIdToCaip,
   formatChainIdToHex,
+  getNativeAssetForChainId,
 } from '@metamask/bridge-controller';
 import type {
   QuoteMetadata,
@@ -1670,7 +1671,7 @@ describe('Bridge Status Controller Transaction Utils', () => {
       createClientRequestSpy.mockRestore();
     });
 
-    it('should include Stellar source and destination chain IDs as options when trade is Stellar', () => {
+    it('should include Stellar source and destination asset IDs as options when trade is not Tron', () => {
       const stellarTrade = {
         xdrBase64: 'AAAABg==',
       } as never;
@@ -1682,12 +1683,16 @@ describe('Bridge Status Controller Transaction Utils', () => {
         },
       };
 
+      const sourceAssetId = getNativeAssetForChainId(ChainId.STELLAR).assetId;
+      const destAssetId = getNativeAssetForChainId(ChainId.ETH).assetId;
+
       const result = snaps.getClientRequest(
         stellarTrade,
         ChainId.STELLAR,
         mockAccount.id,
         mockAccount.metadata.snap.id,
-        ChainId.ETH,
+        sourceAssetId,
+        destAssetId,
       );
 
       expect(result).toMatchObject({
@@ -1703,15 +1708,15 @@ describe('Bridge Status Controller Transaction Utils', () => {
             scope: formatChainIdToCaip(ChainId.STELLAR),
             accountId: 'test-account-id',
             options: {
-              sourceChainId: formatChainIdToCaip(ChainId.STELLAR),
-              destChainId: formatChainIdToCaip(ChainId.ETH),
+              sourceAssetId,
+              destAssetId,
             },
           },
         },
       });
     });
 
-    it('should omit destChainId option for Stellar trades when destination chain ID is not provided', () => {
+    it('should omit destAssetId option for Stellar trades when destination asset ID is not provided', () => {
       const stellarTrade = {
         xdr: 'AAAABg==',
       } as never;
@@ -1723,25 +1728,28 @@ describe('Bridge Status Controller Transaction Utils', () => {
         },
       };
 
+      const sourceAssetId = getNativeAssetForChainId(ChainId.STELLAR).assetId;
+
       const result = snaps.getClientRequest(
         stellarTrade,
         ChainId.STELLAR,
         mockAccount.id,
         mockAccount.metadata.snap.id,
+        sourceAssetId,
       );
 
       expect(result).toMatchObject({
         request: {
           params: {
             options: {
-              sourceChainId: formatChainIdToCaip(ChainId.STELLAR),
+              sourceAssetId,
             },
           },
         },
       });
       expect(
         (result.request.params as { options: Record<string, unknown> }).options,
-      ).not.toHaveProperty('destChainId');
+      ).not.toHaveProperty('destAssetId');
     });
   });
 


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the non-EVM snap request payload for all trades that pass asset IDs from quotes; Tron overwrites options so behavior there stays isolated, but Stellar and other non-Tron paths now depend on correct quote asset metadata.
> 
> **Overview**
> **Stellar bridge trades** are wired through submit validation and the non-EVM handler by treating `ChainId.STELLAR` like other snap chains (string XDR or `StellarTradeData`).
> 
> **Snap `signAndSendTransaction` requests** now optionally include `sourceAssetId` and `destAssetId` from the quote in `params.options`, passed from `handleNonEvmTx` via an extended `getClientRequest`. That gives the Stellar snap enough context for **transaction history** without changing the core request shape for chains that omit those args. **Tron** still sets `visible` and contract `type` in `options`, which replaces any asset-id options for Tron trades (unchanged Tron-specific behavior).
> 
> Tests cover Stellar asset ID options (full pair and source-only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd8bc27ed3d09639291fc9e1ac75fff93af1e7be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->