### PR TITLE
feat: test lint issue - add agentic cli preferences (#8933)

### DIFF
--- a/packages/authenticated-user-storage/src/authenticated-user-storage.test.ts
+++ b/packages/authenticated-user-storage/src/authenticated-user-storage.test.ts
@@ -229,11 +229,10 @@ describe('AuthenticatedUserStorageService', () => {
       const result = await service.getNotificationPreferences();
 
       expect(result).not.toBeNull();
-      if (!result || !result.agenticCli) {
+      if (!result?.agenticCli) {
         throw new Error('Result is null');
-      } else {
-        result.agenticCli.inAppNotificationsEnabled = false;
       }
+      result.agenticCli.inAppNotificationsEnabled = false;
       expect(DEFAULT_AGENTIC_CLI_PREFERENCES.inAppNotificationsEnabled).toBe(
         true,
       );

--- a/packages/authenticated-user-storage/src/authenticated-user-storage.test.ts
+++ b/packages/authenticated-user-storage/src/authenticated-user-storage.test.ts
@@ -231,9 +231,9 @@ describe('AuthenticatedUserStorageService', () => {
       expect(result).not.toBeNull();
       if (!result || !result.agenticCli) {
         throw new Error('Result is null');
+      } else {
+        result.agenticCli.inAppNotificationsEnabled = false;
       }
-      result.agenticCli.inAppNotificationsEnabled = false;
-
       expect(DEFAULT_AGENTIC_CLI_PREFERENCES.inAppNotificationsEnabled).toBe(
         true,
       );

--- a/packages/authenticated-user-storage/src/authenticated-user-storage.test.ts
+++ b/packages/authenticated-user-storage/src/authenticated-user-storage.test.ts
@@ -229,7 +229,7 @@ describe('AuthenticatedUserStorageService', () => {
       const result = await service.getNotificationPreferences();
 
       expect(result).not.toBeNull();
-      if (!result) {
+      if (!result || !result.agenticCli) {
         throw new Error('Result is null');
       }
       result.agenticCli.inAppNotificationsEnabled = false;


### PR DESCRIPTION
## Explanation

Follow-up to #8933. The `does not mutate DEFAULT_AGENTIC_CLI_PREFERENCES when coercing legacy payloads` test in `@metamask/authenticated-user-storage` failed TypeScript and ESLint checks after `agenticCli` was added as an optional field on `NotificationPreferences`.

The guard now checks `result?.agenticCli` instead of only `result`, so TypeScript narrows correctly before the test mutates `result.agenticCli.inAppNotificationsEnabled`. No runtime or API behavior changes.

## References

* Follow-up to #8933

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them