### PR TITLE
fix(network-controller): Remove MegaETH v1 default configuration

### DIFF
--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -35,7 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **BREAKING:** Remove `initializeProvider` in favor of `init` ([#9034](https://github.com/MetaMask/core/pull/9034))
   - `init` does not call `lookupNetwork`, if this is required it must be called manually.
-- **BREAKING:** Remove `additionalDefaultNetworks` constructor option ([#9035](https://github.com/MetaMask/core/pull/9035))
+- **BREAKING:** Remove `additionalDefaultNetworks` constructor option ([#9035](https://github.com/MetaMask/core/pull/9035), [#9183](https://github.com/MetaMask/core/pull/9183))
+  - MegaETH v1 is no longer a default network.
 
 ### Fixed
 

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -849,9 +849,6 @@ function getDefaultCustomNetworkConfigurationsByChainId(): Record<
   // Because it is not always guaranteed that the custom networks are included in the
   // default networks.
   return {
-    [ChainId['megaeth-testnet']]: getCustomNetworkConfiguration(
-      CustomNetworkType['megaeth-testnet'],
-    ),
     [ChainId['megaeth-testnet-v2']]: getCustomNetworkConfiguration(
       CustomNetworkType['megaeth-testnet-v2'],
     ),

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -504,247 +504,229 @@ describe('NetworkController', () => {
         { initializeController: false },
         ({ controller }) => {
           expect(controller.state).toMatchInlineSnapshot(`
-          {
-            "networkConfigurationsByChainId": {
-              "0x1": {
-                "blockExplorerUrls": [
-                  "https://etherscan.io",
-                ],
-                "chainId": "0x1",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Ethereum",
-                "nativeCurrency": "ETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "mainnet",
-                    "type": "infura",
-                    "url": "https://mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
+            {
+              "networkConfigurationsByChainId": {
+                "0x1": {
+                  "blockExplorerUrls": [
+                    "https://etherscan.io",
+                  ],
+                  "chainId": "0x1",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "Ethereum",
+                  "nativeCurrency": "ETH",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "mainnet",
+                      "type": "infura",
+                      "url": "https://mainnet.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
+                "0x18c7": {
+                  "blockExplorerUrls": [
+                    "https://megaeth-testnet-v2.blockscout.com",
+                  ],
+                  "chainId": "0x18c7",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "MegaETH Testnet",
+                  "nativeCurrency": "MegaETH",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "megaeth-testnet-v2",
+                      "type": "custom",
+                      "url": "https://carrot.megaeth.com/rpc",
+                    },
+                  ],
+                },
+                "0x2105": {
+                  "blockExplorerUrls": [
+                    "https://basescan.org",
+                  ],
+                  "chainId": "0x2105",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "Base",
+                  "nativeCurrency": "ETH",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "base-mainnet",
+                      "type": "infura",
+                      "url": "https://base-mainnet.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
+                "0x279f": {
+                  "blockExplorerUrls": [
+                    "https://testnet.monadexplorer.com",
+                  ],
+                  "chainId": "0x279f",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "Monad Testnet",
+                  "nativeCurrency": "MON",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "monad-testnet",
+                      "type": "custom",
+                      "url": "https://testnet-rpc.monad.xyz",
+                    },
+                  ],
+                },
+                "0x38": {
+                  "blockExplorerUrls": [
+                    "https://bscscan.com",
+                  ],
+                  "chainId": "0x38",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "BNB Chain",
+                  "nativeCurrency": "BNB",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "bsc-mainnet",
+                      "type": "infura",
+                      "url": "https://bsc-mainnet.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
+                "0x89": {
+                  "blockExplorerUrls": [
+                    "https://polygonscan.com",
+                  ],
+                  "chainId": "0x89",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "Polygon",
+                  "nativeCurrency": "POL",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "polygon-mainnet",
+                      "type": "infura",
+                      "url": "https://polygon-mainnet.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
+                "0x8f": {
+                  "blockExplorerUrls": [
+                    "https://monadscan.com",
+                  ],
+                  "chainId": "0x8f",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "Monad",
+                  "nativeCurrency": "MON",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "monad-mainnet",
+                      "type": "infura",
+                      "url": "https://monad-mainnet.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
+                "0xa": {
+                  "blockExplorerUrls": [
+                    "https://optimistic.etherscan.io",
+                  ],
+                  "chainId": "0xa",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "OP",
+                  "nativeCurrency": "ETH",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "optimism-mainnet",
+                      "type": "infura",
+                      "url": "https://optimism-mainnet.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
+                "0xa4b1": {
+                  "blockExplorerUrls": [
+                    "https://arbiscan.io",
+                  ],
+                  "chainId": "0xa4b1",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "Arbitrum",
+                  "nativeCurrency": "ETH",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "arbitrum-mainnet",
+                      "type": "infura",
+                      "url": "https://arbitrum-mainnet.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
+                "0xaa36a7": {
+                  "blockExplorerUrls": [
+                    "https://sepolia.etherscan.io",
+                  ],
+                  "chainId": "0xaa36a7",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "Sepolia",
+                  "nativeCurrency": "SepoliaETH",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "sepolia",
+                      "type": "infura",
+                      "url": "https://sepolia.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
+                "0xe705": {
+                  "blockExplorerUrls": [
+                    "https://sepolia.lineascan.build",
+                  ],
+                  "chainId": "0xe705",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "Linea Sepolia",
+                  "nativeCurrency": "LineaETH",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "linea-sepolia",
+                      "type": "infura",
+                      "url": "https://linea-sepolia.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
+                "0xe708": {
+                  "blockExplorerUrls": [
+                    "https://lineascan.build",
+                  ],
+                  "chainId": "0xe708",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "Linea",
+                  "nativeCurrency": "ETH",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "linea-mainnet",
+                      "type": "infura",
+                      "url": "https://linea-mainnet.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
               },
-              "0x18c6": {
-                "blockExplorerUrls": [
-                  "https://megaexplorer.xyz",
-                ],
-                "chainId": "0x18c6",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Mega Testnet",
-                "nativeCurrency": "MegaETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "megaeth-testnet",
-                    "type": "custom",
-                    "url": "https://carrot.megaeth.com/rpc",
-                  },
-                ],
-              },
-              "0x18c7": {
-                "blockExplorerUrls": [
-                  "https://megaeth-testnet-v2.blockscout.com",
-                ],
-                "chainId": "0x18c7",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "MegaETH Testnet",
-                "nativeCurrency": "MegaETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "megaeth-testnet-v2",
-                    "type": "custom",
-                    "url": "https://carrot.megaeth.com/rpc",
-                  },
-                ],
-              },
-              "0x2105": {
-                "blockExplorerUrls": [
-                  "https://basescan.org",
-                ],
-                "chainId": "0x2105",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Base",
-                "nativeCurrency": "ETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "base-mainnet",
-                    "type": "infura",
-                    "url": "https://base-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0x279f": {
-                "blockExplorerUrls": [
-                  "https://testnet.monadexplorer.com",
-                ],
-                "chainId": "0x279f",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Monad Testnet",
-                "nativeCurrency": "MON",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "monad-testnet",
-                    "type": "custom",
-                    "url": "https://testnet-rpc.monad.xyz",
-                  },
-                ],
-              },
-              "0x38": {
-                "blockExplorerUrls": [
-                  "https://bscscan.com",
-                ],
-                "chainId": "0x38",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "BNB Chain",
-                "nativeCurrency": "BNB",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "bsc-mainnet",
-                    "type": "infura",
-                    "url": "https://bsc-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0x89": {
-                "blockExplorerUrls": [
-                  "https://polygonscan.com",
-                ],
-                "chainId": "0x89",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Polygon",
-                "nativeCurrency": "POL",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "polygon-mainnet",
-                    "type": "infura",
-                    "url": "https://polygon-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0x8f": {
-                "blockExplorerUrls": [
-                  "https://monadscan.com",
-                ],
-                "chainId": "0x8f",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Monad",
-                "nativeCurrency": "MON",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "monad-mainnet",
-                    "type": "infura",
-                    "url": "https://monad-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0xa": {
-                "blockExplorerUrls": [
-                  "https://optimistic.etherscan.io",
-                ],
-                "chainId": "0xa",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "OP",
-                "nativeCurrency": "ETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "optimism-mainnet",
-                    "type": "infura",
-                    "url": "https://optimism-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0xa4b1": {
-                "blockExplorerUrls": [
-                  "https://arbiscan.io",
-                ],
-                "chainId": "0xa4b1",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Arbitrum",
-                "nativeCurrency": "ETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "arbitrum-mainnet",
-                    "type": "infura",
-                    "url": "https://arbitrum-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0xaa36a7": {
-                "blockExplorerUrls": [
-                  "https://sepolia.etherscan.io",
-                ],
-                "chainId": "0xaa36a7",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Sepolia",
-                "nativeCurrency": "SepoliaETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "sepolia",
-                    "type": "infura",
-                    "url": "https://sepolia.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0xe705": {
-                "blockExplorerUrls": [
-                  "https://sepolia.lineascan.build",
-                ],
-                "chainId": "0xe705",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Linea Sepolia",
-                "nativeCurrency": "LineaETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "linea-sepolia",
-                    "type": "infura",
-                    "url": "https://linea-sepolia.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0xe708": {
-                "blockExplorerUrls": [
-                  "https://lineascan.build",
-                ],
-                "chainId": "0xe708",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Linea",
-                "nativeCurrency": "ETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "linea-mainnet",
-                    "type": "infura",
-                    "url": "https://linea-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-            },
-            "networksMetadata": {},
-            "selectedNetworkClientId": "mainnet",
-          }
-        `);
+              "networksMetadata": {},
+              "selectedNetworkClientId": "mainnet",
+            }
+          `);
         },
       );
     });
@@ -1747,20 +1729,6 @@ describe('NetworkController', () => {
                   chainId: '0x1',
                   ticker: 'ETH',
                   network: InfuraNetworkType.mainnet,
-                },
-                provider: expect.anything(),
-                destroy: expect.any(Function),
-                enableRpcFailover: expect.any(Function),
-                disableRpcFailover: expect.any(Function),
-              },
-              'megaeth-testnet': {
-                blockTracker: expect.anything(),
-                configuration: {
-                  type: NetworkClientType.Custom,
-                  failoverRpcUrls: [],
-                  chainId: '0x18c6',
-                  ticker: 'MegaETH',
-                  rpcUrl: 'https://carrot.megaeth.com/rpc',
                 },
                 provider: expect.anything(),
                 destroy: expect.any(Function),
@@ -14906,247 +14874,229 @@ describe('NetworkController', () => {
               'includeInStateLogs',
             ),
           ).toMatchInlineSnapshot(`
-          {
-            "networkConfigurationsByChainId": {
-              "0x1": {
-                "blockExplorerUrls": [
-                  "https://etherscan.io",
-                ],
-                "chainId": "0x1",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Ethereum",
-                "nativeCurrency": "ETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "mainnet",
-                    "type": "infura",
-                    "url": "https://mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
+            {
+              "networkConfigurationsByChainId": {
+                "0x1": {
+                  "blockExplorerUrls": [
+                    "https://etherscan.io",
+                  ],
+                  "chainId": "0x1",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "Ethereum",
+                  "nativeCurrency": "ETH",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "mainnet",
+                      "type": "infura",
+                      "url": "https://mainnet.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
+                "0x18c7": {
+                  "blockExplorerUrls": [
+                    "https://megaeth-testnet-v2.blockscout.com",
+                  ],
+                  "chainId": "0x18c7",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "MegaETH Testnet",
+                  "nativeCurrency": "MegaETH",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "megaeth-testnet-v2",
+                      "type": "custom",
+                      "url": "https://carrot.megaeth.com/rpc",
+                    },
+                  ],
+                },
+                "0x2105": {
+                  "blockExplorerUrls": [
+                    "https://basescan.org",
+                  ],
+                  "chainId": "0x2105",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "Base",
+                  "nativeCurrency": "ETH",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "base-mainnet",
+                      "type": "infura",
+                      "url": "https://base-mainnet.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
+                "0x279f": {
+                  "blockExplorerUrls": [
+                    "https://testnet.monadexplorer.com",
+                  ],
+                  "chainId": "0x279f",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "Monad Testnet",
+                  "nativeCurrency": "MON",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "monad-testnet",
+                      "type": "custom",
+                      "url": "https://testnet-rpc.monad.xyz",
+                    },
+                  ],
+                },
+                "0x38": {
+                  "blockExplorerUrls": [
+                    "https://bscscan.com",
+                  ],
+                  "chainId": "0x38",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "BNB Chain",
+                  "nativeCurrency": "BNB",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "bsc-mainnet",
+                      "type": "infura",
+                      "url": "https://bsc-mainnet.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
+                "0x89": {
+                  "blockExplorerUrls": [
+                    "https://polygonscan.com",
+                  ],
+                  "chainId": "0x89",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "Polygon",
+                  "nativeCurrency": "POL",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "polygon-mainnet",
+                      "type": "infura",
+                      "url": "https://polygon-mainnet.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
+                "0x8f": {
+                  "blockExplorerUrls": [
+                    "https://monadscan.com",
+                  ],
+                  "chainId": "0x8f",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "Monad",
+                  "nativeCurrency": "MON",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "monad-mainnet",
+                      "type": "infura",
+                      "url": "https://monad-mainnet.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
+                "0xa": {
+                  "blockExplorerUrls": [
+                    "https://optimistic.etherscan.io",
+                  ],
+                  "chainId": "0xa",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "OP",
+                  "nativeCurrency": "ETH",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "optimism-mainnet",
+                      "type": "infura",
+                      "url": "https://optimism-mainnet.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
+                "0xa4b1": {
+                  "blockExplorerUrls": [
+                    "https://arbiscan.io",
+                  ],
+                  "chainId": "0xa4b1",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "Arbitrum",
+                  "nativeCurrency": "ETH",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "arbitrum-mainnet",
+                      "type": "infura",
+                      "url": "https://arbitrum-mainnet.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
+                "0xaa36a7": {
+                  "blockExplorerUrls": [
+                    "https://sepolia.etherscan.io",
+                  ],
+                  "chainId": "0xaa36a7",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "Sepolia",
+                  "nativeCurrency": "SepoliaETH",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "sepolia",
+                      "type": "infura",
+                      "url": "https://sepolia.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
+                "0xe705": {
+                  "blockExplorerUrls": [
+                    "https://sepolia.lineascan.build",
+                  ],
+                  "chainId": "0xe705",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "Linea Sepolia",
+                  "nativeCurrency": "LineaETH",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "linea-sepolia",
+                      "type": "infura",
+                      "url": "https://linea-sepolia.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
+                "0xe708": {
+                  "blockExplorerUrls": [
+                    "https://lineascan.build",
+                  ],
+                  "chainId": "0xe708",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "Linea",
+                  "nativeCurrency": "ETH",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "linea-mainnet",
+                      "type": "infura",
+                      "url": "https://linea-mainnet.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
               },
-              "0x18c6": {
-                "blockExplorerUrls": [
-                  "https://megaexplorer.xyz",
-                ],
-                "chainId": "0x18c6",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Mega Testnet",
-                "nativeCurrency": "MegaETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "megaeth-testnet",
-                    "type": "custom",
-                    "url": "https://carrot.megaeth.com/rpc",
-                  },
-                ],
-              },
-              "0x18c7": {
-                "blockExplorerUrls": [
-                  "https://megaeth-testnet-v2.blockscout.com",
-                ],
-                "chainId": "0x18c7",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "MegaETH Testnet",
-                "nativeCurrency": "MegaETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "megaeth-testnet-v2",
-                    "type": "custom",
-                    "url": "https://carrot.megaeth.com/rpc",
-                  },
-                ],
-              },
-              "0x2105": {
-                "blockExplorerUrls": [
-                  "https://basescan.org",
-                ],
-                "chainId": "0x2105",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Base",
-                "nativeCurrency": "ETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "base-mainnet",
-                    "type": "infura",
-                    "url": "https://base-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0x279f": {
-                "blockExplorerUrls": [
-                  "https://testnet.monadexplorer.com",
-                ],
-                "chainId": "0x279f",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Monad Testnet",
-                "nativeCurrency": "MON",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "monad-testnet",
-                    "type": "custom",
-                    "url": "https://testnet-rpc.monad.xyz",
-                  },
-                ],
-              },
-              "0x38": {
-                "blockExplorerUrls": [
-                  "https://bscscan.com",
-                ],
-                "chainId": "0x38",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "BNB Chain",
-                "nativeCurrency": "BNB",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "bsc-mainnet",
-                    "type": "infura",
-                    "url": "https://bsc-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0x89": {
-                "blockExplorerUrls": [
-                  "https://polygonscan.com",
-                ],
-                "chainId": "0x89",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Polygon",
-                "nativeCurrency": "POL",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "polygon-mainnet",
-                    "type": "infura",
-                    "url": "https://polygon-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0x8f": {
-                "blockExplorerUrls": [
-                  "https://monadscan.com",
-                ],
-                "chainId": "0x8f",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Monad",
-                "nativeCurrency": "MON",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "monad-mainnet",
-                    "type": "infura",
-                    "url": "https://monad-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0xa": {
-                "blockExplorerUrls": [
-                  "https://optimistic.etherscan.io",
-                ],
-                "chainId": "0xa",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "OP",
-                "nativeCurrency": "ETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "optimism-mainnet",
-                    "type": "infura",
-                    "url": "https://optimism-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0xa4b1": {
-                "blockExplorerUrls": [
-                  "https://arbiscan.io",
-                ],
-                "chainId": "0xa4b1",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Arbitrum",
-                "nativeCurrency": "ETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "arbitrum-mainnet",
-                    "type": "infura",
-                    "url": "https://arbitrum-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0xaa36a7": {
-                "blockExplorerUrls": [
-                  "https://sepolia.etherscan.io",
-                ],
-                "chainId": "0xaa36a7",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Sepolia",
-                "nativeCurrency": "SepoliaETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "sepolia",
-                    "type": "infura",
-                    "url": "https://sepolia.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0xe705": {
-                "blockExplorerUrls": [
-                  "https://sepolia.lineascan.build",
-                ],
-                "chainId": "0xe705",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Linea Sepolia",
-                "nativeCurrency": "LineaETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "linea-sepolia",
-                    "type": "infura",
-                    "url": "https://linea-sepolia.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0xe708": {
-                "blockExplorerUrls": [
-                  "https://lineascan.build",
-                ],
-                "chainId": "0xe708",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Linea",
-                "nativeCurrency": "ETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "linea-mainnet",
-                    "type": "infura",
-                    "url": "https://linea-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-            },
-            "networksMetadata": {},
-            "selectedNetworkClientId": "mainnet",
-          }
-        `);
+              "networksMetadata": {},
+              "selectedNetworkClientId": "mainnet",
+            }
+          `);
         },
       );
     });
@@ -15162,247 +15112,229 @@ describe('NetworkController', () => {
               'persist',
             ),
           ).toMatchInlineSnapshot(`
-          {
-            "networkConfigurationsByChainId": {
-              "0x1": {
-                "blockExplorerUrls": [
-                  "https://etherscan.io",
-                ],
-                "chainId": "0x1",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Ethereum",
-                "nativeCurrency": "ETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "mainnet",
-                    "type": "infura",
-                    "url": "https://mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
+            {
+              "networkConfigurationsByChainId": {
+                "0x1": {
+                  "blockExplorerUrls": [
+                    "https://etherscan.io",
+                  ],
+                  "chainId": "0x1",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "Ethereum",
+                  "nativeCurrency": "ETH",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "mainnet",
+                      "type": "infura",
+                      "url": "https://mainnet.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
+                "0x18c7": {
+                  "blockExplorerUrls": [
+                    "https://megaeth-testnet-v2.blockscout.com",
+                  ],
+                  "chainId": "0x18c7",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "MegaETH Testnet",
+                  "nativeCurrency": "MegaETH",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "megaeth-testnet-v2",
+                      "type": "custom",
+                      "url": "https://carrot.megaeth.com/rpc",
+                    },
+                  ],
+                },
+                "0x2105": {
+                  "blockExplorerUrls": [
+                    "https://basescan.org",
+                  ],
+                  "chainId": "0x2105",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "Base",
+                  "nativeCurrency": "ETH",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "base-mainnet",
+                      "type": "infura",
+                      "url": "https://base-mainnet.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
+                "0x279f": {
+                  "blockExplorerUrls": [
+                    "https://testnet.monadexplorer.com",
+                  ],
+                  "chainId": "0x279f",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "Monad Testnet",
+                  "nativeCurrency": "MON",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "monad-testnet",
+                      "type": "custom",
+                      "url": "https://testnet-rpc.monad.xyz",
+                    },
+                  ],
+                },
+                "0x38": {
+                  "blockExplorerUrls": [
+                    "https://bscscan.com",
+                  ],
+                  "chainId": "0x38",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "BNB Chain",
+                  "nativeCurrency": "BNB",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "bsc-mainnet",
+                      "type": "infura",
+                      "url": "https://bsc-mainnet.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
+                "0x89": {
+                  "blockExplorerUrls": [
+                    "https://polygonscan.com",
+                  ],
+                  "chainId": "0x89",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "Polygon",
+                  "nativeCurrency": "POL",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "polygon-mainnet",
+                      "type": "infura",
+                      "url": "https://polygon-mainnet.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
+                "0x8f": {
+                  "blockExplorerUrls": [
+                    "https://monadscan.com",
+                  ],
+                  "chainId": "0x8f",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "Monad",
+                  "nativeCurrency": "MON",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "monad-mainnet",
+                      "type": "infura",
+                      "url": "https://monad-mainnet.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
+                "0xa": {
+                  "blockExplorerUrls": [
+                    "https://optimistic.etherscan.io",
+                  ],
+                  "chainId": "0xa",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "OP",
+                  "nativeCurrency": "ETH",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "optimism-mainnet",
+                      "type": "infura",
+                      "url": "https://optimism-mainnet.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
+                "0xa4b1": {
+                  "blockExplorerUrls": [
+                    "https://arbiscan.io",
+                  ],
+                  "chainId": "0xa4b1",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "Arbitrum",
+                  "nativeCurrency": "ETH",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "arbitrum-mainnet",
+                      "type": "infura",
+                      "url": "https://arbitrum-mainnet.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
+                "0xaa36a7": {
+                  "blockExplorerUrls": [
+                    "https://sepolia.etherscan.io",
+                  ],
+                  "chainId": "0xaa36a7",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "Sepolia",
+                  "nativeCurrency": "SepoliaETH",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "sepolia",
+                      "type": "infura",
+                      "url": "https://sepolia.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
+                "0xe705": {
+                  "blockExplorerUrls": [
+                    "https://sepolia.lineascan.build",
+                  ],
+                  "chainId": "0xe705",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "Linea Sepolia",
+                  "nativeCurrency": "LineaETH",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "linea-sepolia",
+                      "type": "infura",
+                      "url": "https://linea-sepolia.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
+                "0xe708": {
+                  "blockExplorerUrls": [
+                    "https://lineascan.build",
+                  ],
+                  "chainId": "0xe708",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "Linea",
+                  "nativeCurrency": "ETH",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "linea-mainnet",
+                      "type": "infura",
+                      "url": "https://linea-mainnet.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
               },
-              "0x18c6": {
-                "blockExplorerUrls": [
-                  "https://megaexplorer.xyz",
-                ],
-                "chainId": "0x18c6",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Mega Testnet",
-                "nativeCurrency": "MegaETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "megaeth-testnet",
-                    "type": "custom",
-                    "url": "https://carrot.megaeth.com/rpc",
-                  },
-                ],
-              },
-              "0x18c7": {
-                "blockExplorerUrls": [
-                  "https://megaeth-testnet-v2.blockscout.com",
-                ],
-                "chainId": "0x18c7",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "MegaETH Testnet",
-                "nativeCurrency": "MegaETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "megaeth-testnet-v2",
-                    "type": "custom",
-                    "url": "https://carrot.megaeth.com/rpc",
-                  },
-                ],
-              },
-              "0x2105": {
-                "blockExplorerUrls": [
-                  "https://basescan.org",
-                ],
-                "chainId": "0x2105",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Base",
-                "nativeCurrency": "ETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "base-mainnet",
-                    "type": "infura",
-                    "url": "https://base-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0x279f": {
-                "blockExplorerUrls": [
-                  "https://testnet.monadexplorer.com",
-                ],
-                "chainId": "0x279f",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Monad Testnet",
-                "nativeCurrency": "MON",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "monad-testnet",
-                    "type": "custom",
-                    "url": "https://testnet-rpc.monad.xyz",
-                  },
-                ],
-              },
-              "0x38": {
-                "blockExplorerUrls": [
-                  "https://bscscan.com",
-                ],
-                "chainId": "0x38",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "BNB Chain",
-                "nativeCurrency": "BNB",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "bsc-mainnet",
-                    "type": "infura",
-                    "url": "https://bsc-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0x89": {
-                "blockExplorerUrls": [
-                  "https://polygonscan.com",
-                ],
-                "chainId": "0x89",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Polygon",
-                "nativeCurrency": "POL",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "polygon-mainnet",
-                    "type": "infura",
-                    "url": "https://polygon-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0x8f": {
-                "blockExplorerUrls": [
-                  "https://monadscan.com",
-                ],
-                "chainId": "0x8f",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Monad",
-                "nativeCurrency": "MON",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "monad-mainnet",
-                    "type": "infura",
-                    "url": "https://monad-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0xa": {
-                "blockExplorerUrls": [
-                  "https://optimistic.etherscan.io",
-                ],
-                "chainId": "0xa",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "OP",
-                "nativeCurrency": "ETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "optimism-mainnet",
-                    "type": "infura",
-                    "url": "https://optimism-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0xa4b1": {
-                "blockExplorerUrls": [
-                  "https://arbiscan.io",
-                ],
-                "chainId": "0xa4b1",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Arbitrum",
-                "nativeCurrency": "ETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "arbitrum-mainnet",
-                    "type": "infura",
-                    "url": "https://arbitrum-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0xaa36a7": {
-                "blockExplorerUrls": [
-                  "https://sepolia.etherscan.io",
-                ],
-                "chainId": "0xaa36a7",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Sepolia",
-                "nativeCurrency": "SepoliaETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "sepolia",
-                    "type": "infura",
-                    "url": "https://sepolia.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0xe705": {
-                "blockExplorerUrls": [
-                  "https://sepolia.lineascan.build",
-                ],
-                "chainId": "0xe705",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Linea Sepolia",
-                "nativeCurrency": "LineaETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "linea-sepolia",
-                    "type": "infura",
-                    "url": "https://linea-sepolia.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0xe708": {
-                "blockExplorerUrls": [
-                  "https://lineascan.build",
-                ],
-                "chainId": "0xe708",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Linea",
-                "nativeCurrency": "ETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "linea-mainnet",
-                    "type": "infura",
-                    "url": "https://linea-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-            },
-            "networksMetadata": {},
-            "selectedNetworkClientId": "mainnet",
-          }
-        `);
+              "networksMetadata": {},
+              "selectedNetworkClientId": "mainnet",
+            }
+          `);
         },
       );
     });
@@ -15418,247 +15350,229 @@ describe('NetworkController', () => {
               'usedInUi',
             ),
           ).toMatchInlineSnapshot(`
-          {
-            "networkConfigurationsByChainId": {
-              "0x1": {
-                "blockExplorerUrls": [
-                  "https://etherscan.io",
-                ],
-                "chainId": "0x1",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Ethereum",
-                "nativeCurrency": "ETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "mainnet",
-                    "type": "infura",
-                    "url": "https://mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
+            {
+              "networkConfigurationsByChainId": {
+                "0x1": {
+                  "blockExplorerUrls": [
+                    "https://etherscan.io",
+                  ],
+                  "chainId": "0x1",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "Ethereum",
+                  "nativeCurrency": "ETH",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "mainnet",
+                      "type": "infura",
+                      "url": "https://mainnet.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
+                "0x18c7": {
+                  "blockExplorerUrls": [
+                    "https://megaeth-testnet-v2.blockscout.com",
+                  ],
+                  "chainId": "0x18c7",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "MegaETH Testnet",
+                  "nativeCurrency": "MegaETH",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "megaeth-testnet-v2",
+                      "type": "custom",
+                      "url": "https://carrot.megaeth.com/rpc",
+                    },
+                  ],
+                },
+                "0x2105": {
+                  "blockExplorerUrls": [
+                    "https://basescan.org",
+                  ],
+                  "chainId": "0x2105",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "Base",
+                  "nativeCurrency": "ETH",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "base-mainnet",
+                      "type": "infura",
+                      "url": "https://base-mainnet.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
+                "0x279f": {
+                  "blockExplorerUrls": [
+                    "https://testnet.monadexplorer.com",
+                  ],
+                  "chainId": "0x279f",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "Monad Testnet",
+                  "nativeCurrency": "MON",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "monad-testnet",
+                      "type": "custom",
+                      "url": "https://testnet-rpc.monad.xyz",
+                    },
+                  ],
+                },
+                "0x38": {
+                  "blockExplorerUrls": [
+                    "https://bscscan.com",
+                  ],
+                  "chainId": "0x38",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "BNB Chain",
+                  "nativeCurrency": "BNB",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "bsc-mainnet",
+                      "type": "infura",
+                      "url": "https://bsc-mainnet.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
+                "0x89": {
+                  "blockExplorerUrls": [
+                    "https://polygonscan.com",
+                  ],
+                  "chainId": "0x89",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "Polygon",
+                  "nativeCurrency": "POL",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "polygon-mainnet",
+                      "type": "infura",
+                      "url": "https://polygon-mainnet.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
+                "0x8f": {
+                  "blockExplorerUrls": [
+                    "https://monadscan.com",
+                  ],
+                  "chainId": "0x8f",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "Monad",
+                  "nativeCurrency": "MON",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "monad-mainnet",
+                      "type": "infura",
+                      "url": "https://monad-mainnet.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
+                "0xa": {
+                  "blockExplorerUrls": [
+                    "https://optimistic.etherscan.io",
+                  ],
+                  "chainId": "0xa",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "OP",
+                  "nativeCurrency": "ETH",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "optimism-mainnet",
+                      "type": "infura",
+                      "url": "https://optimism-mainnet.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
+                "0xa4b1": {
+                  "blockExplorerUrls": [
+                    "https://arbiscan.io",
+                  ],
+                  "chainId": "0xa4b1",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "Arbitrum",
+                  "nativeCurrency": "ETH",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "arbitrum-mainnet",
+                      "type": "infura",
+                      "url": "https://arbitrum-mainnet.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
+                "0xaa36a7": {
+                  "blockExplorerUrls": [
+                    "https://sepolia.etherscan.io",
+                  ],
+                  "chainId": "0xaa36a7",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "Sepolia",
+                  "nativeCurrency": "SepoliaETH",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "sepolia",
+                      "type": "infura",
+                      "url": "https://sepolia.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
+                "0xe705": {
+                  "blockExplorerUrls": [
+                    "https://sepolia.lineascan.build",
+                  ],
+                  "chainId": "0xe705",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "Linea Sepolia",
+                  "nativeCurrency": "LineaETH",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "linea-sepolia",
+                      "type": "infura",
+                      "url": "https://linea-sepolia.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
+                "0xe708": {
+                  "blockExplorerUrls": [
+                    "https://lineascan.build",
+                  ],
+                  "chainId": "0xe708",
+                  "defaultBlockExplorerUrlIndex": 0,
+                  "defaultRpcEndpointIndex": 0,
+                  "name": "Linea",
+                  "nativeCurrency": "ETH",
+                  "rpcEndpoints": [
+                    {
+                      "failoverUrls": [],
+                      "networkClientId": "linea-mainnet",
+                      "type": "infura",
+                      "url": "https://linea-mainnet.infura.io/v3/{infuraProjectId}",
+                    },
+                  ],
+                },
               },
-              "0x18c6": {
-                "blockExplorerUrls": [
-                  "https://megaexplorer.xyz",
-                ],
-                "chainId": "0x18c6",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Mega Testnet",
-                "nativeCurrency": "MegaETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "megaeth-testnet",
-                    "type": "custom",
-                    "url": "https://carrot.megaeth.com/rpc",
-                  },
-                ],
-              },
-              "0x18c7": {
-                "blockExplorerUrls": [
-                  "https://megaeth-testnet-v2.blockscout.com",
-                ],
-                "chainId": "0x18c7",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "MegaETH Testnet",
-                "nativeCurrency": "MegaETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "megaeth-testnet-v2",
-                    "type": "custom",
-                    "url": "https://carrot.megaeth.com/rpc",
-                  },
-                ],
-              },
-              "0x2105": {
-                "blockExplorerUrls": [
-                  "https://basescan.org",
-                ],
-                "chainId": "0x2105",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Base",
-                "nativeCurrency": "ETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "base-mainnet",
-                    "type": "infura",
-                    "url": "https://base-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0x279f": {
-                "blockExplorerUrls": [
-                  "https://testnet.monadexplorer.com",
-                ],
-                "chainId": "0x279f",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Monad Testnet",
-                "nativeCurrency": "MON",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "monad-testnet",
-                    "type": "custom",
-                    "url": "https://testnet-rpc.monad.xyz",
-                  },
-                ],
-              },
-              "0x38": {
-                "blockExplorerUrls": [
-                  "https://bscscan.com",
-                ],
-                "chainId": "0x38",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "BNB Chain",
-                "nativeCurrency": "BNB",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "bsc-mainnet",
-                    "type": "infura",
-                    "url": "https://bsc-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0x89": {
-                "blockExplorerUrls": [
-                  "https://polygonscan.com",
-                ],
-                "chainId": "0x89",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Polygon",
-                "nativeCurrency": "POL",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "polygon-mainnet",
-                    "type": "infura",
-                    "url": "https://polygon-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0x8f": {
-                "blockExplorerUrls": [
-                  "https://monadscan.com",
-                ],
-                "chainId": "0x8f",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Monad",
-                "nativeCurrency": "MON",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "monad-mainnet",
-                    "type": "infura",
-                    "url": "https://monad-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0xa": {
-                "blockExplorerUrls": [
-                  "https://optimistic.etherscan.io",
-                ],
-                "chainId": "0xa",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "OP",
-                "nativeCurrency": "ETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "optimism-mainnet",
-                    "type": "infura",
-                    "url": "https://optimism-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0xa4b1": {
-                "blockExplorerUrls": [
-                  "https://arbiscan.io",
-                ],
-                "chainId": "0xa4b1",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Arbitrum",
-                "nativeCurrency": "ETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "arbitrum-mainnet",
-                    "type": "infura",
-                    "url": "https://arbitrum-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0xaa36a7": {
-                "blockExplorerUrls": [
-                  "https://sepolia.etherscan.io",
-                ],
-                "chainId": "0xaa36a7",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Sepolia",
-                "nativeCurrency": "SepoliaETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "sepolia",
-                    "type": "infura",
-                    "url": "https://sepolia.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0xe705": {
-                "blockExplorerUrls": [
-                  "https://sepolia.lineascan.build",
-                ],
-                "chainId": "0xe705",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Linea Sepolia",
-                "nativeCurrency": "LineaETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "linea-sepolia",
-                    "type": "infura",
-                    "url": "https://linea-sepolia.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-              "0xe708": {
-                "blockExplorerUrls": [
-                  "https://lineascan.build",
-                ],
-                "chainId": "0xe708",
-                "defaultBlockExplorerUrlIndex": 0,
-                "defaultRpcEndpointIndex": 0,
-                "name": "Linea",
-                "nativeCurrency": "ETH",
-                "rpcEndpoints": [
-                  {
-                    "failoverUrls": [],
-                    "networkClientId": "linea-mainnet",
-                    "type": "infura",
-                    "url": "https://linea-mainnet.infura.io/v3/{infuraProjectId}",
-                  },
-                ],
-              },
-            },
-            "networksMetadata": {},
-            "selectedNetworkClientId": "mainnet",
-          }
-        `);
+              "networksMetadata": {},
+              "selectedNetworkClientId": "mainnet",
+            }
+          `);
         },
       );
     });


### PR DESCRIPTION
## Explanation

Following https://github.com/MetaMask/core/pull/9035, the `NetworkController` automatically adds all default networks hardcoded into the controller. Before this change one of the three added networks was explicitly excluded by all MetaMask clients. To match this behaviour, we should have removed the configuration in the previous PR. Instead we do it now.

## References

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking default `networkConfigurationsByChainId` for new or unmigrated installs: users on MegaETH v1 must add the network manually. Scope is limited to one deprecated testnet default.
> 
> **Overview**
> **Removes MegaETH Testnet v1** (chain `0x18c6`, client id `megaeth-testnet`) from the default networks the controller seeds on fresh state, so behavior matches MetaMask clients that had already excluded it after default networks were auto-populated in #9035.
> 
> `getDefaultCustomNetworkConfigurationsByChainId` no longer includes the v1 entry; **MegaETH Testnet v2** (`0x18c7`) and other defaults are unchanged. The unreleased changelog notes this under the breaking `additionalDefaultNetworks` removal (#9183). Tests and inline snapshots were updated to drop `0x18c6` / `megaeth-testnet` from default state, registry, and metadata expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22ab7e3ba88aecbaaf1a4eb16c42c9e25b72e74f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->