### PR TITLE
fix: getQuoteUser function is broken if request is not postQuote

### DIFF
--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix relay quote `user` field for post-quote same-chain same-token transfers with an account override ([#9187](https://github.com/MetaMask/core/pull/9187))
+
 ## [23.10.0]
 
 ### Fixed

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.test.ts
@@ -1411,6 +1411,45 @@ describe('Relay Quotes Utils', () => {
       expect(body.user).toBe(txParamsFrom);
     });
 
+    it('keeps user as from when same token and chain with accountOverride and isPostQuote', async () => {
+      const txParamsFrom = '0xOriginalSender000000000000000000000000' as Hex;
+      const accountOverride =
+        '0xOverrideAccount0000000000000000000000000' as Hex;
+      const tokenAddress = '0xTokenAddress00000000000000000000000000' as Hex;
+      const chainId = '0x89' as Hex;
+
+      successfulFetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => QUOTE_MOCK,
+      } as never);
+
+      await getRelayQuotes({
+        accountSupports7702: true,
+        messenger,
+        requests: [
+          {
+            ...QUOTE_REQUEST_MOCK,
+            from: accountOverride,
+            isPostQuote: true,
+            sourceChainId: chainId,
+            sourceTokenAddress: tokenAddress,
+            targetChainId: chainId,
+            targetTokenAddress: tokenAddress,
+          },
+        ],
+        transaction: {
+          ...TRANSACTION_META_MOCK,
+          txParams: { from: txParamsFrom },
+        } as TransactionMeta,
+      });
+
+      const body = JSON.parse(
+        successfulFetchMock.mock.calls[0][1]?.body as string,
+      );
+
+      expect(body.user).toBe(accountOverride);
+    });
+
     it('keeps user as from when same token and chain with accountOverride but recipient differs', async () => {
       const txParamsFrom = '0xOriginalSender000000000000000000000000' as Hex;
       const accountOverride =

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.ts
@@ -1221,7 +1221,8 @@ function getQuoteUser(
 
   return isSameSourceAndTarget &&
     hasAccountOverride &&
-    isRecipientAccountOverride
+    isRecipientAccountOverride &&
+    !request.isPostQuote
     ? txParamsFrom
     : from;
 }


### PR DESCRIPTION
## Explanation

Fix small issue introduced by [PR](https://github.com/MetaMask/core/pull/9150)

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [X] I've updated the test suite for new or updated code as appropriate
- [X] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [X] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [X] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wrong Relay `user` can break quote or execute paths for MM Pay post-quote delegation flows; the change is narrow and covered by a new test.
> 
> **Overview**
> Fixes a regression from the post-quote same-chain/same-token work where **`getQuoteUser`** always rewrote the Relay request **`user`** to **`txParams.from`** when an account override matched the recipient.
> 
> **`getQuoteUser`** now only applies that rewrite when **`!request.isPostQuote`**, so post-quote same-chain/same-token transfers with an override keep **`user`** as the override account (`from`). A unit test covers the post-quote + override case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c8410b59adda4d96c6929bc3a72bfd74b0d9e51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->