### PR TITLE
fix(assets-controller): Dedup assets price requests

### DIFF
--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `priceFreshnessTtlMs` option to `PriceDataSourceConfig` controlling how long a fetched price is considered fresh before it is re-fetched (defaults to the poll interval, 60 000 ms) ([#9189](https://github.com/MetaMask/core/pull/9189))
+- Add `PriceDataSource.invalidatePriceCache()` to force the next fetch to bypass the freshness cache; `AssetsController` now calls it when the selected currency changes so cached prices in the previous currency are refreshed ([#9189](https://github.com/MetaMask/core/pull/9189))
+
+### Fixed
+
+- Deduplicate price fetches in `PriceDataSource` so overlapping triggers (enrichment middleware, subscription polls, and manual refreshes) no longer issue duplicate price API requests for the same asset; assets fetched within the freshness TTL are skipped and concurrent in-flight fetches are joined ([#9189](https://github.com/MetaMask/core/pull/9189))
+- Remove a redundant one-time balance fetch in `AssetsController` when the enabled network list changes, since subscription refresh and the enabled-networks handler already cover those fetches ([#9189](https://github.com/MetaMask/core/pull/9189))
+
 ## [9.0.2]
 
 ### Changed

--- a/packages/assets-controller/src/AssetsController.test.ts
+++ b/packages/assets-controller/src/AssetsController.test.ts
@@ -1267,45 +1267,48 @@ describe('AssetsController', () => {
   });
 
   describe('handleActiveChainsUpdate', () => {
-    it('calls getAssets with added enabled chains when chains are added', async () => {
+    it('re-subscribes assets when chains are added', async () => {
+      await withController(async ({ controller }) => {
+        const subscribeSpy = jest.spyOn(controller, 'subscribeAssetsPrice');
+
+        const onActiveChainsUpdated = controller.getOnActiveChainsUpdated();
+        onActiveChainsUpdated('TestDataSource', ['eip155:1'], []);
+
+        expect(subscribeSpy).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('does not fetch balances directly when chains are added', async () => {
       await withController(async ({ controller }) => {
         const getAssetsSpy = jest.spyOn(controller, 'getAssets');
 
         const onActiveChainsUpdated = controller.getOnActiveChainsUpdated();
         onActiveChainsUpdated('TestDataSource', ['eip155:1'], []);
 
-        expect(getAssetsSpy).toHaveBeenCalledTimes(1);
-        expect(getAssetsSpy).toHaveBeenCalledWith(
-          expect.any(Array),
-          expect.objectContaining({
-            chainIds: ['eip155:1'],
-            forceUpdate: true,
-            updateMode: 'merge',
-          }),
-        );
+        expect(getAssetsSpy).not.toHaveBeenCalled();
       });
     });
 
-    it('does not call getAssets when no chains are added', async () => {
+    it('does not re-subscribe when no chains change', async () => {
       await withController(async ({ controller }) => {
-        const getAssetsSpy = jest.spyOn(controller, 'getAssets');
+        const subscribeSpy = jest.spyOn(controller, 'subscribeAssetsPrice');
 
         const onActiveChainsUpdated = controller.getOnActiveChainsUpdated();
         onActiveChainsUpdated('TestDataSource', [], []);
         onActiveChainsUpdated('TestDataSource', ['eip155:1'], ['eip155:1']);
 
-        expect(getAssetsSpy).not.toHaveBeenCalled();
+        expect(subscribeSpy).not.toHaveBeenCalled();
       });
     });
 
-    it('does not call getAssets when only chains are removed', async () => {
+    it('re-subscribes assets when chains are removed', async () => {
       await withController(async ({ controller }) => {
-        const getAssetsSpy = jest.spyOn(controller, 'getAssets');
+        const subscribeSpy = jest.spyOn(controller, 'subscribeAssetsPrice');
 
         const onActiveChainsUpdated = controller.getOnActiveChainsUpdated();
         onActiveChainsUpdated('TestDataSource', [], ['eip155:1']);
 
-        expect(getAssetsSpy).not.toHaveBeenCalled();
+        expect(subscribeSpy).toHaveBeenCalledTimes(1);
       });
     });
 
@@ -1315,12 +1318,12 @@ describe('AssetsController', () => {
           controllerOptions: { isEnabled: (): boolean => false },
         },
         async ({ controller }) => {
-          const getAssetsSpy = jest.spyOn(controller, 'getAssets');
+          const subscribeSpy = jest.spyOn(controller, 'subscribeAssetsPrice');
           const onActiveChainsUpdated = controller.getOnActiveChainsUpdated();
 
           onActiveChainsUpdated('TestDataSource', ['eip155:1'], []);
 
-          expect(getAssetsSpy).not.toHaveBeenCalled();
+          expect(subscribeSpy).not.toHaveBeenCalled();
         },
       );
     });
@@ -1333,13 +1336,13 @@ describe('AssetsController', () => {
           controllerOptions: { isEnabled: (): boolean => enabled },
         },
         async ({ controller }) => {
-          const getAssetsSpy = jest.spyOn(controller, 'getAssets');
+          const subscribeSpy = jest.spyOn(controller, 'subscribeAssetsPrice');
           enabled = false;
 
           const onActiveChainsUpdated = controller.getOnActiveChainsUpdated();
           onActiveChainsUpdated('TestDataSource', ['eip155:1'], []);
 
-          expect(getAssetsSpy).not.toHaveBeenCalled();
+          expect(subscribeSpy).not.toHaveBeenCalled();
         },
       );
     });

--- a/packages/assets-controller/src/AssetsController.ts
+++ b/packages/assets-controller/src/AssetsController.ts
@@ -1204,25 +1204,11 @@ export class AssetsController extends BaseController<
     const removedChains = previous.filter((ch) => !activeChains.includes(ch));
 
     if (addedChains.length > 0 || removedChains.length > 0) {
-      // Refresh subscriptions to use updated data source availability
+      // Refresh subscriptions to use updated data source availability.
+      // No one-time fetch needed here — #handleEnabledNetworksChanged
+      // handles fetches when the user enables a network, and
+      // #subscribeAssets re-subscribes with the correct chain assignment.
       this.#subscribeAssets();
-    }
-
-    // If chains were added and we have selected accounts, do one-time fetch
-    if (addedChains.length > 0 && this.#getSelectedAccounts().length > 0) {
-      const addedEnabledChains = addedChains.filter((chain) =>
-        this.#enabledChains.has(chain),
-      );
-      if (addedEnabledChains.length > 0) {
-        log('Fetching balances for newly added chains', { addedEnabledChains });
-        this.getAssets(this.#getSelectedAccounts(), {
-          chainIds: addedEnabledChains,
-          forceUpdate: true,
-          updateMode: 'merge',
-        }).catch((error) => {
-          log('Failed to fetch balance for added chains', { error });
-        });
-      }
     }
   }
 
@@ -1828,6 +1814,9 @@ export class AssetsController extends BaseController<
     if (!this.#isBasicFunctionality()) {
       return;
     }
+
+    // Currency changed — old cached prices are in the wrong currency.
+    this.#priceDataSource.invalidatePriceCache();
 
     this.getAssets(this.#getSelectedAccounts(), {
       forceUpdate: true,

--- a/packages/assets-controller/src/data-sources/PriceDataSource.test.ts
+++ b/packages/assets-controller/src/data-sources/PriceDataSource.test.ts
@@ -556,13 +556,12 @@ describe('PriceDataSource', () => {
 
     expect(apiClient.prices.fetchV3SpotPrices).toHaveBeenCalledTimes(1);
 
-    jest.advanceTimersByTime(10000);
-    await Promise.resolve();
-
-    expect(apiClient.prices.fetchV3SpotPrices).toHaveBeenCalledTimes(2);
-
-    jest.advanceTimersByTime(50000);
-    await Promise.resolve();
+    // Advance one tick at a time, flushing microtasks between each so the
+    // async pollFn completes and inflight promises settle before the next tick.
+    for (let i = 2; i <= 7; i++) {
+      jest.advanceTimersByTime(10000);
+      await jest.advanceTimersByTimeAsync(0);
+    }
 
     expect(apiClient.prices.fetchV3SpotPrices).toHaveBeenCalledTimes(7);
 
@@ -855,6 +854,267 @@ describe('PriceDataSource', () => {
     expect(context.response.assetsPrice?.[MOCK_TOKEN_ASSET]).toBeDefined();
 
     controller.destroy();
+  });
+
+  it('skips fetching prices for assets fetched within the freshness TTL', async () => {
+    const { controller, apiClient, getAssetsState } = setupController({
+      balanceState: {
+        'mock-account-id': {
+          [MOCK_NATIVE_ASSET]: { amount: '1000000000000000000' },
+        },
+      },
+      priceResponse: {
+        [MOCK_NATIVE_ASSET]: createMockPriceData(2500),
+      },
+    });
+
+    // First fetch — asset is stale, API is called
+    await controller.fetch(createDataRequest(), getAssetsState);
+    expect(apiClient.prices.fetchV3SpotPrices).toHaveBeenCalledTimes(1);
+
+    // Second fetch immediately after — asset is fresh, API is NOT called again
+    await controller.fetch(createDataRequest(), getAssetsState);
+    expect(apiClient.prices.fetchV3SpotPrices).toHaveBeenCalledTimes(1);
+
+    controller.destroy();
+  });
+
+  it('re-fetches prices after the freshness TTL expires', async () => {
+    const { controller, apiClient, getAssetsState } = setupController({
+      pollInterval: 10_000,
+      balanceState: {
+        'mock-account-id': {
+          [MOCK_NATIVE_ASSET]: { amount: '1000000000000000000' },
+        },
+      },
+      priceResponse: {
+        [MOCK_NATIVE_ASSET]: createMockPriceData(2500),
+      },
+    });
+
+    await controller.fetch(createDataRequest(), getAssetsState);
+    expect(apiClient.prices.fetchV3SpotPrices).toHaveBeenCalledTimes(1);
+
+    // Advance past the TTL (pollInterval = 10s is used as freshness TTL)
+    jest.advanceTimersByTime(11_000);
+
+    await controller.fetch(createDataRequest(), getAssetsState);
+    expect(apiClient.prices.fetchV3SpotPrices).toHaveBeenCalledTimes(2);
+
+    controller.destroy();
+  });
+
+  it('caps the freshness TTL below the poll interval so fetch latency does not skip every other poll', async () => {
+    const pollInterval = 10_000;
+    // `fetchedAt` is stamped when a fetch completes, i.e. slightly after the
+    // tick that triggered it. Simulate that latency so the timestamp lands
+    // inside the (tick - tick + pollInterval) window. With a TTL equal to the
+    // poll interval the asset would still read as "fresh" on the next tick and
+    // be skipped, making the subscription re-fetch only every other poll.
+    const fetchLatencyMs = 500;
+
+    jest.setSystemTime(fetchLatencyMs);
+
+    const { controller, apiClient, getAssetsState } = setupController({
+      pollInterval,
+      balanceState: {
+        'mock-account-id': {
+          [MOCK_NATIVE_ASSET]: { amount: '1000000000000000000' },
+        },
+      },
+      priceResponse: {
+        [MOCK_NATIVE_ASSET]: createMockPriceData(2500),
+      },
+    });
+
+    // Initial poll: completes at t = fetchLatencyMs, stamping that as the
+    // fetched-at time. The cap (0.9 * pollInterval = 9000ms) is applied here.
+    await controller.subscribe({
+      subscriptionId: 'sub-1',
+      request: createDataRequest(),
+      isUpdate: false,
+      onAssetsUpdate: jest.fn(),
+      getAssetsState,
+    });
+    expect(apiClient.prices.fetchV3SpotPrices).toHaveBeenCalledTimes(1);
+
+    // Next tick fires one full interval after the logical tick (t = 0), so
+    // now - fetchedAt = pollInterval - fetchLatencyMs = 9500ms. That is below
+    // the poll interval but above the capped TTL (9000ms), so the asset is
+    // stale and must be re-fetched rather than skipped.
+    jest.setSystemTime(pollInterval);
+    await controller.fetch(createDataRequest(), getAssetsState);
+    expect(apiClient.prices.fetchV3SpotPrices).toHaveBeenCalledTimes(2);
+
+    controller.destroy();
+  });
+
+  it('invalidatePriceCache allows re-fetching assets that were fresh', async () => {
+    const { controller, apiClient } = setupController({
+      priceResponse: {
+        [MOCK_TOKEN_ASSET]: createMockPriceData(1.0),
+      },
+    });
+
+    const next = jest.fn().mockResolvedValue(undefined);
+
+    // First call — populates freshness cache
+    const context1 = createMiddlewareContext({
+      request: createDataRequest({ assetsForPriceUpdate: [MOCK_TOKEN_ASSET] }),
+      response: {},
+    });
+    await controller.assetsMiddleware(context1, next);
+    expect(apiClient.prices.fetchV3SpotPrices).toHaveBeenCalledTimes(1);
+
+    // Second call — skipped (fresh)
+    const context2 = createMiddlewareContext({
+      request: createDataRequest({ assetsForPriceUpdate: [MOCK_TOKEN_ASSET] }),
+      response: {},
+    });
+    await controller.assetsMiddleware(context2, next);
+    expect(apiClient.prices.fetchV3SpotPrices).toHaveBeenCalledTimes(1);
+
+    // Invalidate cache, then fetch again — API is called
+    controller.invalidatePriceCache();
+    const context3 = createMiddlewareContext({
+      request: createDataRequest({ assetsForPriceUpdate: [MOCK_TOKEN_ASSET] }),
+      response: {},
+    });
+    await controller.assetsMiddleware(context3, next);
+    expect(apiClient.prices.fetchV3SpotPrices).toHaveBeenCalledTimes(2);
+
+    controller.destroy();
+  });
+
+  it('coalesces parallel fetches for the same asset into a single API call', async () => {
+    let resolveApi: ((value: Record<string, unknown>) => void) | undefined;
+    const apiPromise = new Promise<Record<string, unknown>>((resolve) => {
+      resolveApi = resolve;
+    });
+
+    const { controller, apiClient } = setupController({
+      priceResponse: {
+        [MOCK_TOKEN_ASSET]: createMockPriceData(1.0),
+      },
+    });
+
+    // Make the API call hang until we resolve manually
+    apiClient.prices.fetchV3SpotPrices.mockReturnValue(apiPromise);
+
+    const next = jest.fn().mockResolvedValue(undefined);
+
+    // Fire two parallel middleware calls for the same asset
+    const context1 = createMiddlewareContext({
+      request: createDataRequest({ assetsForPriceUpdate: [MOCK_TOKEN_ASSET] }),
+      response: {},
+    });
+    const context2 = createMiddlewareContext({
+      request: createDataRequest({ assetsForPriceUpdate: [MOCK_TOKEN_ASSET] }),
+      response: {},
+    });
+
+    const promise1 = controller.assetsMiddleware(context1, next);
+    const promise2 = controller.assetsMiddleware(context2, next);
+
+    // Only ONE API call should have been made (second call joins inflight)
+    expect(apiClient.prices.fetchV3SpotPrices).toHaveBeenCalledTimes(1);
+
+    // Resolve the API
+    expect(resolveApi).toBeDefined();
+    if (resolveApi) {
+      resolveApi({ [MOCK_TOKEN_ASSET]: createMockPriceData(1.0) });
+    }
+    await Promise.all([promise1, promise2]);
+
+    // Still only one API call total
+    expect(apiClient.prices.fetchV3SpotPrices).toHaveBeenCalledTimes(1);
+
+    // Both contexts received the price
+    expect(context1.response.assetsPrice?.[MOCK_TOKEN_ASSET]).toBeDefined();
+    expect(context2.response.assetsPrice?.[MOCK_TOKEN_ASSET]).toBeDefined();
+
+    controller.destroy();
+  });
+
+  it('freshness is per-asset — stale assets are fetched while fresh ones are skipped', async () => {
+    const { controller, apiClient, getAssetsState } = setupController({
+      balanceState: {
+        'mock-account-id': {
+          [MOCK_NATIVE_ASSET]: { amount: '1000000000000000000' },
+        },
+      },
+      priceResponse: {
+        [MOCK_NATIVE_ASSET]: createMockPriceData(2500),
+        [MOCK_TOKEN_ASSET]: createMockPriceData(1.0),
+      },
+    });
+
+    // Fetch only MOCK_NATIVE_ASSET via balance state
+    await controller.fetch(createDataRequest(), getAssetsState);
+    expect(apiClient.prices.fetchV3SpotPrices).toHaveBeenCalledTimes(1);
+    expect(apiClient.prices.fetchV3SpotPrices).toHaveBeenCalledWith(
+      [MOCK_NATIVE_ASSET],
+      expect.anything(),
+    );
+
+    // Now middleware requests MOCK_TOKEN_ASSET (not yet fetched) and MOCK_NATIVE_ASSET (fresh)
+    const next = jest.fn().mockResolvedValue(undefined);
+    const context = createMiddlewareContext({
+      request: createDataRequest({
+        assetsForPriceUpdate: [MOCK_TOKEN_ASSET, MOCK_NATIVE_ASSET],
+      }),
+      response: {},
+    });
+    await controller.assetsMiddleware(context, next);
+
+    // Only MOCK_TOKEN_ASSET should be sent to the API (MOCK_NATIVE_ASSET is fresh)
+    expect(apiClient.prices.fetchV3SpotPrices).toHaveBeenCalledTimes(2);
+    expect(apiClient.prices.fetchV3SpotPrices).toHaveBeenLastCalledWith(
+      [MOCK_TOKEN_ASSET],
+      expect.anything(),
+    );
+
+    controller.destroy();
+  });
+
+  it('destroy clears the freshness cache', async () => {
+    const { controller, apiClient, getAssetsState } = setupController({
+      balanceState: {
+        'mock-account-id': {
+          [MOCK_NATIVE_ASSET]: { amount: '1000000000000000000' },
+        },
+      },
+      priceResponse: {
+        [MOCK_NATIVE_ASSET]: createMockPriceData(2500),
+      },
+    });
+
+    await controller.fetch(createDataRequest(), getAssetsState);
+    expect(apiClient.prices.fetchV3SpotPrices).toHaveBeenCalledTimes(1);
+
+    controller.destroy();
+
+    // Re-create a new controller instance to verify state is gone
+    // (destroy clears the priceFetchedAt map — for the same instance it won't poll after destroy)
+    const controller2 = new PriceDataSource({
+      queryApiClient:
+        apiClient as unknown as PriceDataSourceOptions['queryApiClient'],
+      getSelectedCurrency: (): SupportedCurrency => 'usd',
+    });
+
+    const getAssetsState2 = (): AssetsControllerStateInternal =>
+      ({
+        assetsBalance: {
+          'mock-account-id': {
+            [MOCK_NATIVE_ASSET]: { amount: '1000000000000000000' },
+          },
+        },
+      }) as unknown as AssetsControllerStateInternal;
+
+    await controller2.fetch(createDataRequest(), getAssetsState2);
+    expect(apiClient.prices.fetchV3SpotPrices).toHaveBeenCalledTimes(2);
+
+    controller2.destroy();
   });
 
   it('destroy cleans up all subscriptions', async () => {

--- a/packages/assets-controller/src/data-sources/PriceDataSource.ts
+++ b/packages/assets-controller/src/data-sources/PriceDataSource.ts
@@ -16,6 +16,7 @@ import type {
   AssetsControllerStateInternal,
 } from '../types';
 import { fetchWithTimeout } from '../utils';
+import { DedupingBatchFetcher } from '../utils/dedupingBatchFetcher';
 import type { SubscriptionRequest } from './AbstractDataSource';
 import { reduceInBatchesSerially } from './evm-rpc-services';
 
@@ -26,6 +27,14 @@ import { reduceInBatchesSerially } from './evm-rpc-services';
 const CONTROLLER_NAME = 'PriceDataSource';
 const DEFAULT_POLL_INTERVAL = 60_000; // 1 minute for price updates
 const DEFAULT_FETCH_TIMEOUT_MS = 15_000;
+
+/**
+ * Fraction of the poll interval used to cap the freshness TTL. Kept strictly
+ * below 1 so an asset fetched on one poll is reliably stale by the next poll;
+ * the margin absorbs network latency and timer jitter (see the cap in
+ * `subscribe`).
+ */
+const FRESHNESS_TTL_POLL_RATIO = 0.9;
 
 /** Maximum number of asset IDs per Price API request. */
 const PRICE_API_BATCH_SIZE = 50;
@@ -45,6 +54,13 @@ export type PriceDataSourceConfig = {
    * the batch rejects so the caller can proceed without prices.
    */
   fetchTimeoutMs?: number;
+  /**
+   * Minimum age (ms) before a price is considered stale and re-fetched.
+   * Assets fetched more recently than this are skipped to avoid redundant
+   * API calls from overlapping middleware / subscription / manual triggers.
+   * Defaults to pollInterval (60 000 ms).
+   */
+  priceFreshnessTtlMs?: number;
 };
 
 export type PriceDataSourceOptions = PriceDataSourceConfig & {
@@ -137,6 +153,14 @@ export class PriceDataSource {
 
   readonly #fetchTimeoutMs: number;
 
+  /**
+   * Deduplicates price fetches by asset ID: skips assets fetched within the
+   * freshness TTL and joins concurrent in-flight fetches for the same asset so
+   * overlapping triggers (middleware + subscription poll) don't issue duplicate
+   * API requests.
+   */
+  readonly #deduper: DedupingBatchFetcher<Caip19AssetId, FungibleAssetPrice>;
+
   /** Active subscriptions by ID */
   readonly #activeSubscriptions: Map<
     string,
@@ -153,6 +177,13 @@ export class PriceDataSource {
     this.#pollInterval = options.pollInterval ?? DEFAULT_POLL_INTERVAL;
     this.#apiClient = options.queryApiClient;
     this.#fetchTimeoutMs = options.fetchTimeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
+    this.#deduper = new DedupingBatchFetcher({
+      fetchBatch: (
+        assetIds,
+      ): Promise<Record<Caip19AssetId, FungibleAssetPrice>> =>
+        this.#executeBatchFetch(assetIds),
+      freshnessTtlMs: options.priceFreshnessTtlMs ?? this.#pollInterval,
+    });
   }
 
   // ============================================================================
@@ -277,14 +308,16 @@ export class PriceDataSource {
   }
 
   /**
-   * Fetch spot prices for all provided asset IDs, splitting into batches of
-   * PRICE_API_BATCH_SIZE to respect API limits.
+   * Execute the actual batched API call for a set of asset IDs and return
+   * parsed price results. Used as the `fetchBatch` callback for the deduper,
+   * so it does NOT check freshness or inflight state — that is handled by
+   * {@link DedupingBatchFetcher}.
    *
-   * @param assetIds - Array of CAIP-19 asset IDs
-   * @returns Spot prices response
+   * @param assetIds - Asset IDs to fetch (already filtered/deduplicated).
+   * @returns Parsed prices keyed by CAIP-19 asset ID.
    */
-  async #fetchSpotPrices(
-    assetIds: string[],
+  async #executeBatchFetch(
+    assetIds: Caip19AssetId[],
   ): Promise<Record<Caip19AssetId, FungibleAssetPrice>> {
     const selectedCurrency = this.#getSelectedCurrency();
 
@@ -306,6 +339,7 @@ export class PriceDataSource {
       initialResult: [],
     });
 
+    const fetchedAt = Date.now();
     const prices: Record<Caip19AssetId, FungibleAssetPrice> = {};
 
     for (const { selectedCurrencyPrices, usdPrices } of batchResults) {
@@ -321,17 +355,30 @@ export class PriceDataSource {
           continue;
         }
 
-        const caipAssetId = assetId as Caip19AssetId;
-        prices[caipAssetId] = {
+        prices[assetId as Caip19AssetId] = {
           ...marketData,
           assetPriceType: 'fungible',
           usdPrice: usdMarketData.price,
-          lastUpdated: Date.now(),
+          lastUpdated: fetchedAt,
         };
       }
     }
 
     return prices;
+  }
+
+  /**
+   * Fetch spot prices for all provided asset IDs, deduplicating via the
+   * deduper (freshness TTL + per-asset inflight coalescing).
+   *
+   * @param assetIds - Array of CAIP-19 asset IDs.
+   * @returns Spot prices response (only contains entries for assets that were
+   * actually fetched or joined from inflight).
+   */
+  async #fetchSpotPrices(
+    assetIds: Caip19AssetId[],
+  ): Promise<Record<Caip19AssetId, FungibleAssetPrice>> {
+    return this.#deduper.fetch(assetIds);
   }
 
   /**
@@ -474,7 +521,22 @@ export class PriceDataSource {
 
     const pollInterval = request.updateInterval ?? this.#pollInterval;
 
-    // Create poll function - fetches prices using getAssetsState from subscription
+    // Cap the freshness TTL strictly below the effective poll interval.
+    // `fetchedAt` is stamped when a fetch completes (slightly after the tick
+    // that triggered it), so a TTL equal to the poll interval would leave the
+    // asset still "fresh" at the next tick, making the subscription re-fetch
+    // only every other poll. The margin also absorbs network latency / jitter.
+    this.#deduper.freshnessTtlMs = Math.min(
+      this.#deduper.freshnessTtlMs,
+      Math.floor(pollInterval * FRESHNESS_TTL_POLL_RATIO),
+    );
+
+    // Create poll function - fetches prices using getAssetsState from subscription.
+    // The freshness TTL naturally gates re-fetches: assets fetched less than
+    // `priceFreshnessTtlMs` ago are skipped, preventing duplicates when middleware
+    // or other triggers already fetched the same assets between polls.
+    // Concurrent middleware calls will join the inflight promise rather than
+    // issuing duplicate requests.
     const pollFn = async (): Promise<void> => {
       try {
         const subscription = this.#activeSubscriptions.get(subscriptionId);
@@ -482,7 +544,6 @@ export class PriceDataSource {
           return;
         }
 
-        // Fetch prices for all assets in balance state (uses subscription's getAssetsState)
         const fetchResponse = await this.fetch(
           subscription.request,
           subscription.getAssetsState,
@@ -536,6 +597,15 @@ export class PriceDataSource {
   }
 
   /**
+   * Invalidate the price freshness cache, forcing the next fetch to call the
+   * API regardless of TTL. Use when external state changes (e.g. selected
+   * currency) require a full refresh.
+   */
+  invalidatePriceCache(): void {
+    this.#deduper.invalidate();
+  }
+
+  /**
    * Destroy the data source and clean up all subscriptions.
    */
   destroy(): void {
@@ -543,5 +613,6 @@ export class PriceDataSource {
       subscription.cleanup();
     }
     this.#activeSubscriptions.clear();
+    this.#deduper.destroy();
   }
 }

--- a/packages/assets-controller/src/utils/dedupingBatchFetcher.ts
+++ b/packages/assets-controller/src/utils/dedupingBatchFetcher.ts
@@ -1,0 +1,218 @@
+/**
+ * Executes the underlying batched fetch for a set of keys. Only keys that have
+ * a value need to be present in the returned record; keys the source had no
+ * data for are simply omitted (they are still marked fresh — see
+ * {@link DedupingBatchFetcher.fetch}).
+ *
+ * @param keys - The keys to fetch (already filtered to stale, not-inflight keys).
+ * @returns The fetched values keyed by key.
+ */
+export type BatchFetchFn<Key extends string, Value> = (
+  keys: Key[],
+) => Promise<Record<Key, Value>>;
+
+export type DedupingBatchFetcherOptions<Key extends string, Value> = {
+  /** Performs the actual batched fetch for stale, not-inflight keys. */
+  fetchBatch: BatchFetchFn<Key, Value>;
+  /**
+   * Minimum age (ms) before a key is considered stale and re-fetched. Keys
+   * fetched more recently than this are skipped entirely.
+   */
+  freshnessTtlMs: number;
+};
+
+/**
+ * Deduplicates batched fetches by key across two dimensions:
+ *
+ * 1. **Freshness TTL** — keys fetched within `freshnessTtlMs` are skipped
+ *    entirely. Note the freshness window only starts once a fetch *completes*,
+ *    so it does not cover requests that are still in flight.
+ * 2. **Inflight coalescing** — if a fetch is already in progress for a key,
+ *    concurrent callers join the existing promise instead of issuing a new
+ *    request. This covers the request-in-flight window the freshness TTL
+ *    structurally cannot.
+ *
+ * Both layers are per-key, so a call for a partially-overlapping set of keys
+ * reuses the fresh/inflight keys and only fetches the genuinely-missing ones.
+ *
+ * The fetch is batched: all stale, not-inflight keys from a single `fetch()`
+ * call are passed to `fetchBatch` together, then split into per-key results so
+ * each key can be joined independently.
+ */
+export class DedupingBatchFetcher<Key extends string, Value> {
+  readonly #fetchBatch: BatchFetchFn<Key, Value>;
+
+  #freshnessTtlMs: number;
+
+  /** Tracks the last successful fetch time per key (freshness gating). */
+  readonly #fetchedAt = new Map<Key, number>();
+
+  /**
+   * Per-key inflight fetch promises. Each resolves to the value, or `undefined`
+   * if the batch failed or returned no data for that key.
+   */
+  readonly #inflight = new Map<Key, Promise<Value | undefined>>();
+
+  constructor(options: DedupingBatchFetcherOptions<Key, Value>) {
+    this.#fetchBatch = options.fetchBatch;
+    this.#freshnessTtlMs = options.freshnessTtlMs;
+  }
+
+  /**
+   * Minimum age (ms) before a key is re-fetched.
+   *
+   * @returns The current freshness TTL in milliseconds.
+   */
+  get freshnessTtlMs(): number {
+    return this.#freshnessTtlMs;
+  }
+
+  set freshnessTtlMs(ms: number) {
+    this.#freshnessTtlMs = ms;
+  }
+
+  /**
+   * Fetch values for the given keys, deduplicating against fresh and inflight
+   * fetches.
+   *
+   * @param keys - The keys to fetch.
+   * @returns Values keyed by key. Only contains entries for keys that were
+   * actually fetched (or joined from inflight) and had a value.
+   */
+  async fetch(keys: Key[]): Promise<Record<Key, Value>> {
+    const { staleKeys, inflightKeys } = this.#partition(keys);
+
+    if (staleKeys.length === 0 && inflightKeys.length === 0) {
+      return {} as Record<Key, Value>;
+    }
+
+    // Start a fetch for stale keys and join any fetches already in progress.
+    const batchPromise =
+      staleKeys.length > 0 ? this.#startBatchFetch(staleKeys) : undefined;
+    const values = await this.#joinInflight(inflightKeys);
+
+    if (batchPromise) {
+      Object.assign(values, await batchPromise);
+    }
+
+    return values;
+  }
+
+  /**
+   * Clear the freshness cache, forcing the next fetch to re-request every key
+   * regardless of TTL. Does not affect inflight fetches.
+   */
+  invalidate(): void {
+    this.#fetchedAt.clear();
+  }
+
+  /** Clear all freshness and inflight state. */
+  destroy(): void {
+    this.#fetchedAt.clear();
+    this.#inflight.clear();
+  }
+
+  /**
+   * Split keys into those that need a fresh fetch and those already being
+   * fetched by another caller. Keys still within the freshness TTL are dropped.
+   *
+   * @param keys - The keys to classify.
+   * @returns `staleKeys` (need fetching) and `inflightKeys` (join existing fetch).
+   */
+  #partition(keys: Key[]): { staleKeys: Key[]; inflightKeys: Key[] } {
+    const now = Date.now();
+    const staleKeys: Key[] = [];
+    const inflightKeys: Key[] = [];
+
+    for (const key of keys) {
+      if (this.#isFresh(key, now)) {
+        continue;
+      }
+      if (this.#inflight.has(key)) {
+        inflightKeys.push(key);
+      } else {
+        staleKeys.push(key);
+      }
+    }
+
+    return { staleKeys, inflightKeys };
+  }
+
+  /**
+   * Returns true if the key's last fetch is still within the freshness TTL.
+   *
+   * @param key - The key to check.
+   * @param now - Current timestamp (avoids repeated clock reads).
+   * @returns True if the key was fetched within the freshness TTL.
+   */
+  #isFresh(key: Key, now: number): boolean {
+    const fetchedAt = this.#fetchedAt.get(key);
+    return fetchedAt !== undefined && now - fetchedAt < this.#freshnessTtlMs;
+  }
+
+  /**
+   * Launch a batch fetch and register a per-key inflight promise for each key
+   * so concurrent callers can join. On success, all requested keys are marked
+   * fresh — including keys the source returned no value for, since the absence
+   * of a value is itself a valid answer that should not be re-asked until the
+   * TTL expires. A failed batch leaves keys stale so they are retried.
+   *
+   * @param staleKeys - Keys to fetch (none of which are already inflight).
+   * @returns The batch fetch promise.
+   */
+  #startBatchFetch(staleKeys: Key[]): Promise<Record<Key, Value>> {
+    const batchPromise = this.#fetchBatch(staleKeys).then((values) => {
+      const fetchedAt = Date.now();
+      for (const key of staleKeys) {
+        this.#fetchedAt.set(key, fetchedAt);
+      }
+      return values;
+    });
+
+    for (const key of staleKeys) {
+      const perKey = batchPromise.then(
+        (values) => values[key],
+        () => undefined,
+      );
+      this.#inflight.set(key, perKey);
+    }
+
+    // Clean up inflight entries once the batch settles (success or failure).
+    // Rejection is already surfaced to the caller via the returned batchPromise.
+    batchPromise
+      .finally(() => {
+        for (const key of staleKeys) {
+          this.#inflight.delete(key);
+        }
+      })
+      .catch(() => undefined);
+
+    return batchPromise;
+  }
+
+  /**
+   * Join the inflight fetches for the given keys and collect their values. Keys
+   * whose inflight fetch produced no value are omitted.
+   *
+   * @param inflightKeys - Keys whose fetches are already in progress.
+   * @returns Values keyed by key.
+   */
+  async #joinInflight(inflightKeys: Key[]): Promise<Record<Key, Value>> {
+    const values = {} as Record<Key, Value>;
+
+    const results = await Promise.all(
+      inflightKeys.map(async (key) => {
+        const value = await this.#inflight.get(key);
+        return [key, value] as const;
+      }),
+    );
+
+    for (const [key, value] of results) {
+      if (value !== undefined) {
+        values[key] = value;
+      }
+    }
+
+    return values;
+  }
+}


### PR DESCRIPTION
## Explanation

### Problem

`PriceDataSource` fetches spot prices from multiple, independently-triggered
paths: enrichment middleware (on balance/metadata updates), the per-subscription
polling loop, currency changes, and manual refreshes. These triggers frequently
overlap, so the same asset's price was requested from the Price API multiple
times within a few seconds, producing redundant network traffic and load.

### Solution

This PR introduces a small, reusable `DedupingBatchFetcher` utility and routes
all `PriceDataSource` price fetches through it. The fetcher deduplicates by key
across two dimensions:

- **Freshness TTL** — a key fetched within `freshnessTtlMs` is skipped entirely
  (the absence of a value is also cached, so we don't re-ask for assets the API
  had no price for until the TTL expires).
- **In-flight coalescing** — concurrent callers requesting a key that already has
  a fetch in progress join the existing promise instead of issuing a new request.

Stale, not-in-flight keys from a single call are batched into one `fetchBatch`
invocation and then split back into per-key results so each key resolves
independently.

Wiring in `PriceDataSource`:

- New `priceFreshnessTtlMs` option on `PriceDataSourceConfig` (defaults to the
  poll interval) controls how long a fetched price is considered fresh.
- New `PriceDataSource.invalidatePriceCache()` clears the freshness cache;
  `AssetsController` calls it when the selected currency changes, since cached
  prices are denominated in the previous currency and must be refreshed.

### Non-obvious detail: freshness TTL must stay *below* the poll interval

The subscription poll fires on a fixed `setInterval(pollInterval)`, but a key's
`fetchedAt` is stamped when the fetch *completes* — slightly after the tick that
triggered it. If the TTL equals the poll interval, then at the next tick
`now - fetchedAt` is `pollInterval - latency`, which is still within the TTL, so
the asset reads as "fresh" and the poll is skipped. The net effect is the
subscription only issues a real request every *other* poll (e.g. an observed
~2-minute cadence for a 1-minute poll interval).

To fix this, the TTL is capped at `0.9 * pollInterval` (via
`FRESHNESS_TTL_POLL_RATIO`) rather than the previous `Math.min(ttl, pollInterval)`,
giving enough headroom to absorb network latency and timer jitter. A regression
test reproduces the every-other-poll skip by simulating fetch latency with
`jest.setSystemTime` (it fails with the old cap and passes with the new one).

### Also in this PR

- `AssetsController` no longer triggers a redundant one-time balance fetch when
  the enabled-network list changes; subscription refresh and the
  enabled-networks handler already cover those fetches.

## References

- Related to the assets-controller price-fetch deduplication effort.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core price-fetch timing and caching; incorrect TTL or invalidation could delay price updates or leave stale currency-denominated prices, though behavior is heavily covered by new tests.
> 
> **Overview**
> Introduces **`DedupingBatchFetcher`** and routes all **`PriceDataSource`** spot-price fetches through it so middleware, subscription polls, currency changes, and manual refreshes no longer hammer the Price API for the same asset.
> 
> **Freshness TTL** (`priceFreshnessTtlMs`, default poll interval) skips re-fetching recently completed prices; **in-flight coalescing** joins parallel callers on one batch. On subscribe, TTL is capped at **0.9 × poll interval** so completion latency does not make every other poll a no-op.
> 
> Adds **`invalidatePriceCache()`**; **`AssetsController`** calls it on selected-currency change before the price-only **`getAssets`** refresh.
> 
> **`handleActiveChainsUpdate`** drops the extra one-time **`getAssets`** when chains are added; it only re-subscribes (tests updated accordingly).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8633f7f2a6f709f62bc2aaae78357b1d05cfe5b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->