### PR TITLE
fix: ARC native to point to ERC20 + format CAIP ERC20

### DIFF
--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add optional `environment_type` property to the `ButtonClicked` unified swap/bridge event context ([#9121](https://github.com/MetaMask/core/pull/9121))
+- Add support for ERC20 as native token, starting with Arc USDC ([#9196](https://github.com/MetaMask/core/pull/9196))
 
 ### Changed
 

--- a/packages/bridge-controller/src/constants/tokens.ts
+++ b/packages/bridge-controller/src/constants/tokens.ts
@@ -192,10 +192,10 @@ const MEGAETH_SWAPS_TOKEN_OBJECT = {
 
 // Leaving for code consistency but we won't display it in the asset picker
 const ARC_SWAPS_TOKEN_OBJECT = {
-  symbol: 'USDC-native',
-  name: 'USDC-native',
-  address: '0x0000000000000000000000000000000000000000',
-  decimals: 18,
+  symbol: 'USDC',
+  name: 'USDC',
+  address: '0x3600000000000000000000000000000000000000',
+  decimals: 6,
   iconUrl: '',
 } as const;
 
@@ -247,6 +247,5 @@ export const SYMBOL_TO_SLIP44_MAP: Record<
   TRX: 'slip44:195',
   MON: 'slip44:268435779',
   HYPE: 'slip44:2457',
-  // It won't be displayed - hidden on UI client side
-  'USDC-native': 'erc20:0x0000000000000000000000000000000000000000',
+  USDC: 'erc20:0x3600000000000000000000000000000000000000',
 };

--- a/packages/bridge-controller/src/selectors.ts
+++ b/packages/bridge-controller/src/selectors.ts
@@ -148,14 +148,10 @@ const getEvmTokenExchangeRateForAddress = (
   evmTokenExchangeRates: EvmTokenExchangeRates | undefined,
   address: string,
 ): EvmTokenExchangeRate | null | undefined => {
-  try {
-    return isStrictHexString(address)
-      ? (evmTokenExchangeRates?.[getAddress(address)] ??
-          evmTokenExchangeRates?.[address.toLowerCase()])
-      : null;
-  } catch {
-    return null;
-  }
+  return isStrictHexString(address)
+    ? (evmTokenExchangeRates?.[getAddress(address)] ??
+        evmTokenExchangeRates?.[address.toLowerCase()])
+    : null;
 };
 
 /**
@@ -227,7 +223,16 @@ export const selectExchangeRateByAssetId = (
     return {};
   }
 
-  const address = formatAddressToCaipReference(assetId);
+  let address;
+  try {
+    address = formatAddressToCaipReference(assetId);
+  } catch (error) {
+    console.log(
+      `selectExchangeRateByAssetId: formatAddressToCaipReference thrown with assetId ${assetId}. Returning empty object.`,
+      error,
+    );
+    return {};
+  }
 
   // If the chain is an EVM chain, use the conversion rate from the currency rates controller
   if (isNativeAddress(address)) {

--- a/packages/bridge-controller/src/utils/balance.ts
+++ b/packages/bridge-controller/src/utils/balance.ts
@@ -1,5 +1,6 @@
 import { getAddress } from '@ethersproject/address';
 import type { BigNumber } from '@ethersproject/bignumber';
+import { AddressZero } from '@ethersproject/constants';
 import { Contract } from '@ethersproject/contracts';
 import { Web3Provider } from '@ethersproject/providers';
 import { abiERC20 } from '@metamask/metamask-eth-abis';
@@ -29,7 +30,7 @@ export const calcLatestSrcBalance = async (
   chainId: Hex,
 ): Promise<BigNumber | undefined> => {
   if (tokenAddress && chainId) {
-    if (isNativeAddress(tokenAddress)) {
+    if (isNativeAddress(tokenAddress) && tokenAddress === AddressZero) {
       const ethersProvider = new Web3Provider(provider);
       return await ethersProvider.getBalance(getAddress(selectedAddress));
     }

--- a/packages/bridge-controller/src/utils/bridge.ts
+++ b/packages/bridge-controller/src/utils/bridge.ts
@@ -2,7 +2,7 @@ import { AddressZero } from '@ethersproject/constants';
 import { Contract } from '@ethersproject/contracts';
 import { BtcScope, SolScope, TrxScope } from '@metamask/keyring-api';
 import { abiERC20 } from '@metamask/metamask-eth-abis';
-import { isCaipChainId, isStrictHexString } from '@metamask/utils';
+import { isCaipChainId } from '@metamask/utils';
 import type { CaipAssetType, CaipChainId, Hex } from '@metamask/utils';
 
 import {
@@ -189,15 +189,24 @@ export const isSwapsDefaultTokenSymbol = (
  * @param address - The address to check
  * @returns Whether the address is a native asset
  */
-export const isNativeAddress = (address?: string | null) =>
-  address === AddressZero || // bridge and swap apis set the native asset address to zero
-  address === '' || // assets controllers set the native asset address to an empty string
-  !address ||
-  (!isStrictHexString(address) &&
-    Object.values(SYMBOL_TO_SLIP44_MAP).some(
-      // check if it matches any supported SLIP44 references
-      (reference) => address.includes(reference) || reference.endsWith(address),
-    ));
+export const isNativeAddress = (address?: string | null) => {
+  if (
+    address === AddressZero || // bridge and swap apis set the native asset address to zero
+    address === '' || // assets controllers set the native asset address to an empty string
+    !address
+  ) {
+    return true;
+  }
+  // address may be a bare reference or a full CAIP-19 assetId (e.g.
+  // "eip155:5042/erc20:0x...."); only the segment after the last "/" matters
+  const suffix = address.includes('/') ? address.split('/').at(-1) : address;
+  return Object.values(SYMBOL_TO_SLIP44_MAP).some(
+    (reference) =>
+      reference === suffix ||
+      reference === `slip44:${suffix}` ||
+      reference === `erc20:${suffix}`,
+  );
+};
 
 /**
  * Checks whether the chainId matches Solana in CaipChainId or number format

--- a/packages/bridge-controller/src/utils/caip-formatters.test.ts
+++ b/packages/bridge-controller/src/utils/caip-formatters.test.ts
@@ -143,6 +143,14 @@ describe('CAIP Formatters', () => {
       ).toBe('0x1234567890123456789012345678901234567890');
     });
 
+    it('should extract address from standard CAIP-19 format when ERC20', () => {
+      expect(
+        formatAddressToCaipReference(
+          'eip155:5042/erc20:0x3600000000000000000000000000000000000000',
+        ),
+      ).toBe('0x3600000000000000000000000000000000000000');
+    });
+
     it('should handle Bitcoin addresses without prefix', () => {
       const btcAddress = 'bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh';
       expect(formatAddressToCaipReference(btcAddress)).toBe(btcAddress);

--- a/packages/bridge-controller/src/utils/caip-formatters.ts
+++ b/packages/bridge-controller/src/utils/caip-formatters.ts
@@ -119,15 +119,15 @@ export const formatChainIdToHex = (
  * @returns The converted address
  */
 export const formatAddressToCaipReference = (address: string) => {
-  if (isStrictHexString(address)) {
-    return getAddress(address);
+  const addressWithoutPrefix = address.split(':').at(-1);
+  if (isStrictHexString(addressWithoutPrefix)) {
+    return getAddress(addressWithoutPrefix);
   }
   // If the address looks like a native token, return the zero address because it's
   // what bridge-api uses to represent a native asset
   if (isNativeAddress(address)) {
     return AddressZero;
   }
-  const addressWithoutPrefix = address.split(':').at(-1);
   // If the address is not a valid hex string or CAIP address, throw an error
   // This should never happen, but it's a sanity check
   if (!addressWithoutPrefix) {


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

**Context:**

- On Arc, there are two USDC:
  - Native one, 18 decimals.
  - ERC20 one, 6 decimals.

After some back-and-forth, the deduplication approach is now the following:
- For Asset list / Send features: We show the native USDC.
- For Bridge/Swap: We show the ERC20 USDC.

For Swap/Bridge the "quick approach" taken was to:
- Declare the actual native USDC as native in `packages/bridge-controller/src/constants/tokens.ts`.
- But make changes in the UI to ensure that USDC native is never actually presented to the user.
This is because setting USDC to the ERC20 version in the `bridge-controller` led to unexpected behavior that we didn't have the bandwidth to address or to de-risk. For example, this was causing the Bridge API to be called with the `zeroAddress` and never the ERC20 address one - which we'd want.

**New approach goals:** 

The goal now is to make in sort that it becomes possible to properly set an ERC20 as "native" token through the `bridge-controller`, making acceptable adjustments in the logic.
Goals:
- Solve remaining issues with Swap/Bridge on ARC: Most importantly the "max swap" behavior (since the current approach doesn't consider USDC as native, which leaves "max" button visible).
- Remove as many "quick fixes" as possible from the codebase.

**Changes:**

It looks like one of the important changes would be in `formatAddressToCaipReference` to treat `erc20:0x3600000000000000000000000000000000000000` as a ERC20 address.
Previous logic of the function:
- If address matches what is defined in `SYMBOL_TO_SLIP44_MAP`, overwrite to `zeroAddress` --> This allows to have formats like `slip44:60` to be converted in a ERC20 address but the problem is that even `erc20:0x3600000000000000000000000000000000000000` gets taken by that part of the logic and is turned to the `zeroAddress` before asking for a quote to the Bridge API.
New logic of the function:
- Check first if the part after the `:` is an ERC20 address, if yes use that. Otherwise proceed with the previous logic of the function. This way, when asking for a quote on Arc, `srcToken` will be set to `0x3600000000000000000000000000000000000000` instead of `0x0000000000000000000000000000000000000000`.

If accepted, QA and non-regression on existing chains would be done to ensure this doesn't break anything.
Also open to other ways to rewrite this function.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core token identity, native detection, and Bridge API address formatting across all chains; incorrect `isNativeAddress` or CAIP parsing could mis-route quotes or balances outside Arc.
> 
> **Overview**
> **Arc swap/bridge** now treats the chain default as **USDC at `0x3600…`** (6 decimals) instead of a hidden zero-address “USDC-native,” and maps it in `SYMBOL_TO_SLIP44_MAP` as `erc20:0x3600…`.
> 
> **Address handling** is updated so Arc’s “native” USDC is not collapsed to `0x000…` when building Bridge API requests or exchange-rate lookups: `formatAddressToCaipReference` resolves a trailing hex segment (including CAIP-19 `erc20:…`) before the native-token path, and `isNativeAddress` matches SLIP44/erc20 references on the asset suffix. **Balances** use on-chain ETH balance only for literal `AddressZero`; Arc USDC uses ERC20 `balanceOf`.
> 
> `selectExchangeRateByAssetId` catches failures from `formatAddressToCaipReference` instead of relying on the removed try/catch in the EVM rate helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c09cc9479848d577a26d42c2c5c95af413f34a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->