### PR TITLE
Release 1055.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "1054.0.0",
+  "version": "1055.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {

--- a/packages/ramps-controller/CHANGELOG.md
+++ b/packages/ramps-controller/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [14.3.0]
+
 ### Added
 
 - Export `getTransakApiMessage` and `isTransakPhoneRegisteredError` for consumers handling `TransakApiError`, and centralize known Transak API error codes in `transakErrorCodes.ts` ([#9135](https://github.com/MetaMask/core/pull/9135))
@@ -388,7 +390,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add `OnRampService` for interacting with the OnRamp API
   - Add geolocation detection via IP address lookup
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/ramps-controller@14.2.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/ramps-controller@14.3.0...HEAD
+[14.3.0]: https://github.com/MetaMask/core/compare/@metamask/ramps-controller@14.2.0...@metamask/ramps-controller@14.3.0
 [14.2.0]: https://github.com/MetaMask/core/compare/@metamask/ramps-controller@14.1.1...@metamask/ramps-controller@14.2.0
 [14.1.1]: https://github.com/MetaMask/core/compare/@metamask/ramps-controller@14.1.0...@metamask/ramps-controller@14.1.1
 [14.1.0]: https://github.com/MetaMask/core/compare/@metamask/ramps-controller@14.0.0...@metamask/ramps-controller@14.1.0

--- a/packages/ramps-controller/package.json
+++ b/packages/ramps-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/ramps-controller",
-  "version": "14.2.0",
+  "version": "14.3.0",
   "description": "A controller for managing cryptocurrency on/off ramps functionality",
   "keywords": [
     "Ethereum",

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `@metamask/ramps-controller` from `^14.2.0` to `^14.3.0` ([#9199](https://github.com/MetaMask/core/pull/9199))
+
 ## [23.12.0]
 
 ### Changed

--- a/packages/transaction-pay-controller/package.json
+++ b/packages/transaction-pay-controller/package.json
@@ -68,7 +68,7 @@
     "@metamask/messenger": "^1.2.0",
     "@metamask/metamask-eth-abis": "^3.1.1",
     "@metamask/network-controller": "^32.0.0",
-    "@metamask/ramps-controller": "^14.2.0",
+    "@metamask/ramps-controller": "^14.3.0",
     "@metamask/remote-feature-flag-controller": "^4.2.2",
     "@metamask/transaction-controller": "^68.0.1",
     "@metamask/utils": "^11.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8056,7 +8056,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/ramps-controller@npm:^14.2.0, @metamask/ramps-controller@workspace:packages/ramps-controller":
+"@metamask/ramps-controller@npm:^14.3.0, @metamask/ramps-controller@workspace:packages/ramps-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/ramps-controller@workspace:packages/ramps-controller"
   dependencies:
@@ -8703,7 +8703,7 @@ __metadata:
     "@metamask/messenger": "npm:^1.2.0"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
     "@metamask/network-controller": "npm:^32.0.0"
-    "@metamask/ramps-controller": "npm:^14.2.0"
+    "@metamask/ramps-controller": "npm:^14.3.0"
     "@metamask/remote-feature-flag-controller": "npm:^4.2.2"
     "@metamask/transaction-controller": "npm:^68.0.1"
     "@metamask/utils": "npm:^11.11.0"


### PR DESCRIPTION
## Explanation

**Current state:** `@metamask/ramps-controller@14.2.0` is the latest publish on npm. Since then, two consumer-facing changes merged to `main` but are not yet published:

- **#9159 (TRAM-3539)** — `RampsController` now merges orders on the internal MetaMask order code (from canonical `order.id`, e.g. `c-{guid}`) instead of `providerOrderId`. Without this, Moonpay redirect buys can produce duplicate Activity rows (precreate stub + provider callback row).
- **#9135** — exports `getTransakApiMessage`, `isTransakPhoneRegisteredError`, and centralized Transak API error codes for client-side error handling.

Mobile QA is currently blocked on a **preview build** (`@metamask-previews/ramps-controller`) for TestFlight; we need a real npm release to drop preview/resolution pins.

**Solution:** Release **1055.0.0** publishes **`@metamask/ramps-controller@14.3.0`**. This PR only versions and ships what is already on `main` — no new feature work in the diff.

**What's in 14.3.0:**

| Category | Change |
|----------|--------|
| **Fixed** | Compare internal order codes in `addOrder` / `getOrder` / `addPrecreatedOrder` ([#9159](https://github.com/MetaMask/core/pull/9159)) |
| **Added** | Transak API error helpers (`getTransakApiMessage`, `isTransakPhoneRegisteredError`, `transakErrorCodes.ts`) ([#9135](https://github.com/MetaMask/core/pull/9135)) |
| **Changed** | Bump `@metamask/profile-sync-controller` to `^28.2.0` ([#9119](https://github.com/MetaMask/core/pull/9119)) |

**SemVer:** Minor bump (14.2.0 → 14.3.0) — includes new exports plus a bug fix. No breaking API changes.

**Other packages / deps:** Only `@metamask/ramps-controller` is published in this release. Dependency bumps listed above were already merged separately and are included because they landed after 14.2.0.

**Worth noting for reviewers:** The fix normalizes stored `providerOrderId` to the internal order code for polling/lookup consistency. Order Details “copy id” may show the MetaMask `c-…` code rather than the provider-native UUID — support should use provider link / tx hash for native references.

## References

- TRAM-3539 — duplicate Moonpay Activity rows on redirect buys
- [#9159](https://github.com/MetaMask/core/pull/9159) — internal order id merge fix
- [#9135](https://github.com/MetaMask/core/pull/9135) — Transak API error helpers
- [#9119](https://github.com/MetaMask/core/pull/9119) — profile-sync-controller dep bump
- [MetaMask/metamask-mobile#31837](https://github.com/MetaMask/metamask-mobile/pull/31837) — mobile QA PR (preview pin; update to `^14.3.0` after this release)

**Mobile follow-up after merge + npm publish:**
1. Bump `@metamask/ramps-controller` to `^14.3.0`
2. Remove preview alias / `resolutions` / `previewBuilds`
3. Re-run TestFlight QA for Moonpay redirect buy (single Activity row)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them _(N/A — no breaking changes)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only version, changelog, and lockfile updates with no runtime code changes in this diff.
> 
> **Overview**
> Release **1055.0.0** publishes **`@metamask/ramps-controller@14.3.0`** to npm. The PR diff is versioning and dependency wiring only—no new feature code.
> 
> **`@metamask/ramps-controller`** goes **14.2.0 → 14.3.0** with changelog section **14.3.0** (content already on `main`): Transak error helpers (`getTransakApiMessage`, `isTransakPhoneRegisteredError`, `transakErrorCodes.ts`), bump to `@metamask/profile-sync-controller` ^28.2.0, and the documented order-id merge fix for duplicate Moonpay Activity rows.
> 
> Root **`package.json`** is bumped **1054.0.0 → 1055.0.0**. **`@metamask/transaction-pay-controller`** updates its dependency to **`@metamask/ramps-controller` ^14.3.0** and records that in its changelog; **`yarn.lock`** is updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4685db4f90a30baf35d858141637643cc83cf104. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->