### PR TITLE
fix(transaction-pay-controller): fail closed on missing submit hashes

### DIFF
--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Preserve original error stack traces while prefixing MetaMask Pay, Relay, and Fiat submission errors, and fail closed when Relay or direct mUSD Fiat vault submissions complete without a transaction hash ([#9201](https://github.com/MetaMask/core/pull/9201))
+- Preserve original error stack traces while prefixing MetaMask Pay, Relay, and Fiat submission errors, return submitted transaction hashes for same-chain Relay routes when status polling is skipped, and fail closed when Relay or direct mUSD Fiat vault submissions complete without a transaction hash ([#9201](https://github.com/MetaMask/core/pull/9201))
 
 ## [23.12.0]
 

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/ramps-controller` from `^14.2.0` to `^14.3.0` ([#9199](https://github.com/MetaMask/core/pull/9199))
 
+### Fixed
+
+- Preserve original error stack traces while prefixing MetaMask Pay, Relay, and Fiat submission errors, and fail closed when Relay or direct mUSD Fiat vault submissions complete without a transaction hash ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
+
 ## [23.12.0]
 
 ### Changed

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Preserve original error stack traces while prefixing MetaMask Pay, Relay, and Fiat submission errors, return submitted transaction hashes for same-chain Relay routes when status polling is skipped, and fail closed when Relay or direct mUSD Fiat vault submissions complete without a transaction hash ([#9201](https://github.com/MetaMask/core/pull/9201))
+- Preserve original error stack traces while prefixing MetaMask Pay, Relay, and Fiat submission errors, and fail closed when Relay or direct mUSD Fiat vault submissions complete without a transaction hash ([#9201](https://github.com/MetaMask/core/pull/9201))
 
 ## [23.12.0]
 

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Preserve original error stack traces while prefixing MetaMask Pay, Relay, and Fiat submission errors, and fail closed when Relay or direct mUSD Fiat vault submissions complete without a transaction hash ([#9201](https://github.com/MetaMask/core/pull/9201))
+- Preserve original error stack traces while prefixing MetaMask Pay, Relay, and Fiat submission errors, and fail closed when Fiat submission has no quote or when Relay or direct mUSD Fiat vault submissions complete without a transaction hash ([#9201](https://github.com/MetaMask/core/pull/9201))
 
 ## [23.12.0]
 

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Preserve original error stack traces while prefixing MetaMask Pay, Relay, and Fiat submission errors, and fail closed when Relay or direct mUSD Fiat vault submissions complete without a transaction hash ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
+- Preserve original error stack traces while prefixing MetaMask Pay, Relay, and Fiat submission errors, and fail closed when Relay or direct mUSD Fiat vault submissions complete without a transaction hash ([#9201](https://github.com/MetaMask/core/pull/9201))
 
 ## [23.12.0]
 

--- a/packages/transaction-pay-controller/src/helpers/TransactionPayPublishHook.test.ts
+++ b/packages/transaction-pay-controller/src/helpers/TransactionPayPublishHook.test.ts
@@ -212,18 +212,20 @@ describe('TransactionPayPublishHook', () => {
   });
 
   it('throws errors from submit prefixed with MetaMask Pay', async () => {
-    executeMock.mockRejectedValue(new Error('Test error'));
+    const error = new Error('Test error');
+    executeMock.mockRejectedValue(error);
 
-    await expect(runHook()).rejects.toThrow('MetaMask Pay: Test error');
+    const thrown = await runHook().catch((caught) => caught);
+
+    expect(thrown).toBe(error);
+    expect(thrown.message).toBe('MetaMask Pay: Test error');
   });
 
   it('cascades MetaMask Pay prefix on top of strategy-level prefixes', async () => {
-    executeMock.mockRejectedValue(
-      new Error('Relay submit: Relay execute: backend boom'),
-    );
+    executeMock.mockRejectedValue(new Error('Relay: Execute: backend boom'));
 
     await expect(runHook()).rejects.toThrow(
-      'MetaMask Pay: Relay submit: Relay execute: backend boom',
+      'MetaMask Pay: Relay: Execute: backend boom',
     );
   });
 

--- a/packages/transaction-pay-controller/src/helpers/TransactionPayPublishHook.test.ts
+++ b/packages/transaction-pay-controller/src/helpers/TransactionPayPublishHook.test.ts
@@ -115,6 +115,26 @@ describe('TransactionPayPublishHook', () => {
     expect(executeMock).not.toHaveBeenCalled();
   });
 
+  it('throws if fiat payment is selected but no quotes are in state', async () => {
+    getControllerStateMock.mockReturnValue({
+      transactionData: {
+        [TRANSACTION_META_MOCK.id]: {
+          fiatPayment: {
+            selectedPaymentMethodId: 'debit-card',
+          },
+          isLoading: false,
+          tokens: [],
+        },
+      },
+    } as TransactionPayControllerState);
+
+    await expect(runHook()).rejects.toThrow(
+      'MetaMask Pay: Fiat: Missing quote',
+    );
+    expect(executeMock).not.toHaveBeenCalled();
+    expect(updateTransactionMock).not.toHaveBeenCalled();
+  });
+
   it('sets submittedTime on the transaction before executing strategy', async () => {
     await runHook();
 

--- a/packages/transaction-pay-controller/src/helpers/TransactionPayPublishHook.ts
+++ b/packages/transaction-pay-controller/src/helpers/TransactionPayPublishHook.ts
@@ -63,11 +63,18 @@ export class TransactionPayPublishHook {
       'TransactionPayController:getState',
     );
 
+    const transactionData = controllerState.transactionData?.[transactionId];
     const quotes =
-      (controllerState.transactionData?.[transactionId]
-        ?.quotes as TransactionPayQuote<unknown>[]) ?? [];
+      (transactionData?.quotes as TransactionPayQuote<unknown>[]) ?? [];
+    const isFiatSelected = Boolean(
+      transactionData?.fiatPayment?.selectedPaymentMethodId,
+    );
 
     if (!quotes?.length) {
+      if (isFiatSelected) {
+        throw new Error('Fiat: Missing quote');
+      }
+
       log('Skipping as no quotes found');
       return EMPTY_RESULT;
     }

--- a/packages/transaction-pay-controller/src/helpers/TransactionPayPublishHook.ts
+++ b/packages/transaction-pay-controller/src/helpers/TransactionPayPublishHook.ts
@@ -10,10 +10,12 @@ import type {
   TransactionPayQuote,
 } from '../types';
 import { accountSupports7702 } from '../utils/7702';
+import { prefixError } from '../utils/error-prefix';
 import { getStrategyByName } from '../utils/strategy';
 import { updateTransaction } from '../utils/transaction';
 
 const log = createModuleLogger(projectLogger, 'pay-publish-hook');
+const ERROR_PREFIX = 'MetaMask Pay: ';
 
 const EMPTY_RESULT = {
   transactionHash: undefined,
@@ -47,8 +49,7 @@ export class TransactionPayPublishHook {
       return await this.#publishHook(transactionMeta, _signedTx);
     } catch (error) {
       log('Error', error);
-      const message = error instanceof Error ? error.message : String(error);
-      throw new Error(`MetaMask Pay: ${message}`);
+      throw prefixError(error, ERROR_PREFIX);
     }
   }
 

--- a/packages/transaction-pay-controller/src/strategy/fiat/FiatStrategy.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/FiatStrategy.test.ts
@@ -44,6 +44,8 @@ describe('FiatStrategy', () => {
 
   describe('execute', () => {
     it('delegates to submitFiatQuotes', async () => {
+      submitFiatQuotesMock.mockResolvedValue({ transactionHash: '0x1234' });
+
       await new FiatStrategy().execute({
         isSmartTransaction: () => false,
         quotes: [QUOTE_MOCK],
@@ -55,6 +57,51 @@ describe('FiatStrategy', () => {
       expect(
         submitFiatQuotesMock.mock.calls[0][0].transaction.txParams.from,
       ).toBe('0x1');
+    });
+
+    it('prefixes execute errors with the Fiat prefix without replacing the Error object', async () => {
+      const error = new Error('Missing order ID for fiat submission');
+      submitFiatQuotesMock.mockRejectedValue(error);
+
+      const thrown = await new FiatStrategy()
+        .execute({
+          isSmartTransaction: () => false,
+          quotes: [QUOTE_MOCK],
+          messenger: {} as TransactionPayControllerMessenger,
+          transaction: { txParams: { from: '0x1' } } as TransactionMeta,
+        })
+        .catch((caught) => caught);
+
+      expect(thrown).toBe(error);
+      expect(thrown.message).toBe('Fiat: Missing order ID for fiat submission');
+    });
+
+    it('throws if fiat submission returns no transaction hash', async () => {
+      submitFiatQuotesMock.mockResolvedValue({ transactionHash: undefined });
+
+      await expect(
+        new FiatStrategy().execute({
+          isSmartTransaction: () => false,
+          quotes: [QUOTE_MOCK],
+          messenger: {} as TransactionPayControllerMessenger,
+          transaction: { txParams: { from: '0x1' } } as TransactionMeta,
+        }),
+      ).rejects.toThrow('Fiat: Missing transaction hash for fiat submission');
+    });
+
+    it('preserves nested Post-Ramp and Vault prefixes', async () => {
+      submitFiatQuotesMock.mockRejectedValue(
+        new Error('Post-Ramp: Vault: Missing transaction hash'),
+      );
+
+      await expect(
+        new FiatStrategy().execute({
+          isSmartTransaction: () => false,
+          quotes: [QUOTE_MOCK],
+          messenger: {} as TransactionPayControllerMessenger,
+          transaction: { txParams: { from: '0x1' } } as TransactionMeta,
+        }),
+      ).rejects.toThrow('Fiat: Post-Ramp: Vault: Missing transaction hash');
     });
   });
 });

--- a/packages/transaction-pay-controller/src/strategy/fiat/FiatStrategy.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/FiatStrategy.test.ts
@@ -60,7 +60,7 @@ describe('FiatStrategy', () => {
     });
 
     it('prefixes execute errors with the Fiat prefix without replacing the Error object', async () => {
-      const error = new Error('Missing order ID for fiat submission');
+      const error = new Error('Missing order ID');
       submitFiatQuotesMock.mockRejectedValue(error);
 
       const thrown = await new FiatStrategy()
@@ -73,7 +73,7 @@ describe('FiatStrategy', () => {
         .catch((caught) => caught);
 
       expect(thrown).toBe(error);
-      expect(thrown.message).toBe('Fiat: Missing order ID for fiat submission');
+      expect(thrown.message).toBe('Fiat: Missing order ID');
     });
 
     it('throws if fiat submission returns no transaction hash', async () => {
@@ -86,12 +86,12 @@ describe('FiatStrategy', () => {
           messenger: {} as TransactionPayControllerMessenger,
           transaction: { txParams: { from: '0x1' } } as TransactionMeta,
         }),
-      ).rejects.toThrow('Fiat: Missing transaction hash for fiat submission');
+      ).rejects.toThrow('Fiat: Missing transaction hash');
     });
 
     it('preserves nested Post-Ramp and Vault prefixes', async () => {
       submitFiatQuotesMock.mockRejectedValue(
-        new Error('Post-Ramp: Vault: Missing transaction hash'),
+        new Error('Post-Ramp: Direct mUSD: Vault: Missing transaction hash'),
       );
 
       await expect(
@@ -101,7 +101,9 @@ describe('FiatStrategy', () => {
           messenger: {} as TransactionPayControllerMessenger,
           transaction: { txParams: { from: '0x1' } } as TransactionMeta,
         }),
-      ).rejects.toThrow('Fiat: Post-Ramp: Vault: Missing transaction hash');
+      ).rejects.toThrow(
+        'Fiat: Post-Ramp: Direct mUSD: Vault: Missing transaction hash',
+      );
     });
   });
 });

--- a/packages/transaction-pay-controller/src/strategy/fiat/FiatStrategy.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/FiatStrategy.ts
@@ -4,9 +4,12 @@ import type {
   PayStrategyGetQuotesRequest,
   TransactionPayQuote,
 } from '../../types';
+import { prefixError } from '../../utils/error-prefix';
 import { getFiatQuotes } from './fiat-quotes';
 import { submitFiatQuotes } from './fiat-submit';
 import type { FiatQuote } from './types';
+
+const ERROR_PREFIX = 'Fiat: ';
 
 export class FiatStrategy implements PayStrategy<FiatQuote> {
   async getQuotes(
@@ -18,6 +21,16 @@ export class FiatStrategy implements PayStrategy<FiatQuote> {
   async execute(
     request: PayStrategyExecuteRequest<FiatQuote>,
   ): ReturnType<PayStrategy<FiatQuote>['execute']> {
-    return await submitFiatQuotes(request);
+    try {
+      const result = await submitFiatQuotes(request);
+
+      if (result.transactionHash === undefined) {
+        throw new Error('Missing transaction hash for fiat submission');
+      }
+
+      return result;
+    } catch (error) {
+      throw prefixError(error, ERROR_PREFIX);
+    }
   }
 }

--- a/packages/transaction-pay-controller/src/strategy/fiat/FiatStrategy.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/FiatStrategy.ts
@@ -25,7 +25,7 @@ export class FiatStrategy implements PayStrategy<FiatQuote> {
       const result = await submitFiatQuotes(request);
 
       if (result.transactionHash === undefined) {
-        throw new Error('Missing transaction hash for fiat submission');
+        throw new Error('Missing transaction hash');
       }
 
       return result;

--- a/packages/transaction-pay-controller/src/strategy/fiat/fiat-direct-musd.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/fiat-direct-musd.test.ts
@@ -436,7 +436,7 @@ describe('fiat-direct-musd', () => {
           transaction: TRANSACTION_MOCK,
         }),
       ).rejects.toThrow(
-        'getAmountData returned no updates for direct mUSD submit',
+        'Vault: getAmountData returned no updates for direct mUSD submit',
       );
     });
 
@@ -463,7 +463,71 @@ describe('fiat-direct-musd', () => {
           sourceAmountRaw: '5000000',
           transaction,
         }),
-      ).rejects.toThrow('Missing nested transactions for direct mUSD submit');
+      ).rejects.toThrow(
+        'Vault: Missing nested transactions for direct mUSD submit',
+      );
+    });
+
+    it('throws when no vault transactions are collected', async () => {
+      const callMock = jest.fn((action: string) => {
+        if (action === 'TransactionPayController:getAmountData') {
+          return Promise.resolve({
+            updates: [{ data: '0xnewApprove', nestedTransactionIndex: 0 }],
+          });
+        }
+
+        if (action === 'TransactionController:addTransactionBatch') {
+          return Promise.resolve({ batchId: 'batch-id' });
+        }
+
+        throw new Error(`Unexpected action: ${action}`);
+      });
+
+      collectTransactionIdsMock.mockReturnValue({ end: jest.fn() });
+
+      await expect(
+        submitDirectMusdVaultDeposit({
+          request: getExecuteRequest({ callMock }),
+          sourceAmountRaw: '5000000',
+          transaction: TRANSACTION_MOCK,
+        }),
+      ).rejects.toThrow(
+        'Vault: No vault transactions were submitted for direct mUSD submit',
+      );
+    });
+
+    it('throws when the confirmed vault transaction has no hash', async () => {
+      const callMock = jest.fn((action: string) => {
+        if (action === 'TransactionPayController:getAmountData') {
+          return Promise.resolve({
+            updates: [{ data: '0xnewApprove', nestedTransactionIndex: 0 }],
+          });
+        }
+
+        if (action === 'TransactionController:addTransactionBatch') {
+          return Promise.resolve({ batchId: 'batch-id' });
+        }
+
+        throw new Error(`Unexpected action: ${action}`);
+      });
+
+      getTransactionMock.mockImplementation((transactionId) => {
+        if (transactionId === TRANSACTION_ID_MOCK) {
+          return TRANSACTION_MOCK;
+        }
+
+        return undefined;
+      });
+
+      await expect(
+        submitDirectMusdVaultDeposit({
+          request: getExecuteRequest({ callMock }),
+          sourceAmountRaw: '5000000',
+          transaction: TRANSACTION_MOCK,
+        }),
+      ).rejects.toThrow(
+        'Vault: Missing transaction hash for direct mUSD vault submission',
+      );
     });
 
     it('skips the vault batch when vaultDisabled is enabled', async () => {
@@ -495,7 +559,9 @@ describe('fiat-direct-musd', () => {
           sourceAmountRaw: '5000000',
           transaction,
         }),
-      ).rejects.toThrow('Missing Money Account address for direct mUSD submit');
+      ).rejects.toThrow(
+        'Vault: Missing Money Account address for direct mUSD submit',
+      );
     });
   });
 });

--- a/packages/transaction-pay-controller/src/strategy/fiat/fiat-direct-musd.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/fiat-direct-musd.test.ts
@@ -435,7 +435,7 @@ describe('fiat-direct-musd', () => {
           sourceAmountRaw: '5000000',
           transaction: TRANSACTION_MOCK,
         }),
-      ).rejects.toThrow('Vault: No amount updates');
+      ).rejects.toThrow('No amount updates');
     });
 
     it('throws when nested transactions are missing', async () => {
@@ -461,7 +461,31 @@ describe('fiat-direct-musd', () => {
           sourceAmountRaw: '5000000',
           transaction,
         }),
-      ).rejects.toThrow('Vault: Missing nested transactions');
+      ).rejects.toThrow('Missing nested transactions');
+    });
+
+    it('prefixes addTransactionBatch errors with Vault', async () => {
+      const callMock = jest.fn((action: string) => {
+        if (action === 'TransactionPayController:getAmountData') {
+          return Promise.resolve({
+            updates: [{ data: '0xnewApprove', nestedTransactionIndex: 0 }],
+          });
+        }
+
+        if (action === 'TransactionController:addTransactionBatch') {
+          throw new Error('batch failed');
+        }
+
+        throw new Error(`Unexpected action: ${action}`);
+      });
+
+      await expect(
+        submitDirectMusdVaultDeposit({
+          request: getExecuteRequest({ callMock }),
+          sourceAmountRaw: '5000000',
+          transaction: TRANSACTION_MOCK,
+        }),
+      ).rejects.toThrow('Vault: batch failed');
     });
 
     it('throws when no vault transactions are collected', async () => {
@@ -487,7 +511,7 @@ describe('fiat-direct-musd', () => {
           sourceAmountRaw: '5000000',
           transaction: TRANSACTION_MOCK,
         }),
-      ).rejects.toThrow('Vault: No transactions submitted');
+      ).rejects.toThrow('No transactions submitted');
     });
 
     it('throws when the confirmed vault transaction has no hash', async () => {
@@ -519,7 +543,7 @@ describe('fiat-direct-musd', () => {
           sourceAmountRaw: '5000000',
           transaction: TRANSACTION_MOCK,
         }),
-      ).rejects.toThrow('Vault: Missing transaction hash');
+      ).rejects.toThrow('Missing transaction hash');
     });
 
     it('skips the vault batch when vaultDisabled is enabled', async () => {
@@ -551,7 +575,7 @@ describe('fiat-direct-musd', () => {
           sourceAmountRaw: '5000000',
           transaction,
         }),
-      ).rejects.toThrow('Vault: Missing Money Account address');
+      ).rejects.toThrow('Missing Money Account address');
     });
   });
 });

--- a/packages/transaction-pay-controller/src/strategy/fiat/fiat-direct-musd.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/fiat-direct-musd.test.ts
@@ -435,9 +435,7 @@ describe('fiat-direct-musd', () => {
           sourceAmountRaw: '5000000',
           transaction: TRANSACTION_MOCK,
         }),
-      ).rejects.toThrow(
-        'Vault: getAmountData returned no updates for direct mUSD submit',
-      );
+      ).rejects.toThrow('Vault: No amount updates');
     });
 
     it('throws when nested transactions are missing', async () => {
@@ -463,9 +461,7 @@ describe('fiat-direct-musd', () => {
           sourceAmountRaw: '5000000',
           transaction,
         }),
-      ).rejects.toThrow(
-        'Vault: Missing nested transactions for direct mUSD submit',
-      );
+      ).rejects.toThrow('Vault: Missing nested transactions');
     });
 
     it('throws when no vault transactions are collected', async () => {
@@ -491,9 +487,7 @@ describe('fiat-direct-musd', () => {
           sourceAmountRaw: '5000000',
           transaction: TRANSACTION_MOCK,
         }),
-      ).rejects.toThrow(
-        'Vault: No vault transactions were submitted for direct mUSD submit',
-      );
+      ).rejects.toThrow('Vault: No transactions submitted');
     });
 
     it('throws when the confirmed vault transaction has no hash', async () => {
@@ -525,9 +519,7 @@ describe('fiat-direct-musd', () => {
           sourceAmountRaw: '5000000',
           transaction: TRANSACTION_MOCK,
         }),
-      ).rejects.toThrow(
-        'Vault: Missing transaction hash for direct mUSD vault submission',
-      );
+      ).rejects.toThrow('Vault: Missing transaction hash');
     });
 
     it('skips the vault batch when vaultDisabled is enabled', async () => {
@@ -559,9 +551,7 @@ describe('fiat-direct-musd', () => {
           sourceAmountRaw: '5000000',
           transaction,
         }),
-      ).rejects.toThrow(
-        'Vault: Missing Money Account address for direct mUSD submit',
-      );
+      ).rejects.toThrow('Vault: Missing Money Account address');
     });
   });
 });

--- a/packages/transaction-pay-controller/src/strategy/fiat/fiat-direct-musd.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/fiat-direct-musd.ts
@@ -14,6 +14,7 @@ import type {
   TransactionPayRequiredToken,
   TransactionPayQuote,
 } from '../../types';
+import { prefixError } from '../../utils/error-prefix';
 import { getFiatVaultDisabled } from '../../utils/feature-flags';
 import { getNetworkClientId } from '../../utils/provider';
 import { buildCaipAssetType, getTokenInfo } from '../../utils/token';
@@ -31,6 +32,7 @@ import {
 } from './utils';
 
 const log = createModuleLogger(projectLogger, 'fiat-direct-musd');
+const VAULT_ERROR_PREFIX = 'Vault: ';
 
 /**
  * Returns a direct mUSD fiat quote to the Money Account.
@@ -127,6 +129,26 @@ export function isDirectMusdMoneyAccountQuote(
  * @returns Hash of the final submitted child transaction, if available.
  */
 export async function submitDirectMusdVaultDeposit({
+  request,
+  sourceAmountRaw,
+  transaction,
+}: {
+  request: PayStrategyExecuteRequest<FiatQuote>;
+  sourceAmountRaw: string;
+  transaction: PayStrategyExecuteRequest<FiatQuote>['transaction'];
+}): Promise<{ transactionHash?: Hex }> {
+  try {
+    return await submitDirectMusdVaultDepositInternal({
+      request,
+      sourceAmountRaw,
+      transaction,
+    });
+  } catch (error) {
+    throw prefixError(error, VAULT_ERROR_PREFIX);
+  }
+}
+
+async function submitDirectMusdVaultDepositInternal({
   request,
   sourceAmountRaw,
   transaction,
@@ -262,11 +284,23 @@ export async function submitDirectMusdVaultDeposit({
     transactionIds,
   });
 
+  if (!transactionIds.length) {
+    throw new Error(
+      'No vault transactions were submitted for direct mUSD submit',
+    );
+  }
+
   await Promise.all(
     transactionIds.map((id) => waitForTransactionConfirmed(id, messenger)),
   );
 
   const hash = getTransaction(transactionIds.slice(-1)[0], messenger)?.hash;
+
+  if (!hash) {
+    throw new Error(
+      'Missing transaction hash for direct mUSD vault submission',
+    );
+  }
 
   log('Confirmed direct mUSD vault deposit', {
     hash,
@@ -278,7 +312,7 @@ export async function submitDirectMusdVaultDeposit({
     transactionIds,
   });
 
-  return { transactionHash: hash as Hex | undefined };
+  return { transactionHash: hash as Hex };
 }
 
 function combineDirectMusdFiatQuote({

--- a/packages/transaction-pay-controller/src/strategy/fiat/fiat-direct-musd.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/fiat-direct-musd.ts
@@ -1,5 +1,8 @@
 import { ORIGIN_METAMASK } from '@metamask/controller-utils';
-import type { Quote as RampsQuote } from '@metamask/ramps-controller';
+import type {
+  Quote as RampsQuote,
+  RampsOrder,
+} from '@metamask/ramps-controller';
 import { TransactionType } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 import { createModuleLogger } from '@metamask/utils';
@@ -29,9 +32,12 @@ import type { FiatQuote } from './types';
 import {
   getRampsQuote,
   getRawSourceAmountFromOrderCryptoAmount,
+  resolveSourceAmountRaw,
+  validateOrderAsset,
 } from './utils';
 
 const log = createModuleLogger(projectLogger, 'fiat-direct-musd');
+const DIRECT_MUSD_ERROR_PREFIX = 'Direct mUSD: ';
 const VAULT_ERROR_PREFIX = 'Vault: ';
 
 /**
@@ -120,6 +126,47 @@ export function isDirectMusdMoneyAccountQuote(
 }
 
 /**
+ * Submits the direct mUSD post-Ramp path after fiat settlement.
+ *
+ * @param options - Submit options.
+ * @param options.order - Completed fiat order.
+ * @param options.request - Strategy execute request.
+ * @returns Hash of the submitted direct mUSD transaction, if available.
+ */
+export async function submitDirectMusdAfterFiatCompletion({
+  order,
+  request,
+}: {
+  order: RampsOrder;
+  request: PayStrategyExecuteRequest<FiatQuote>;
+}): Promise<{ transactionHash?: Hex }> {
+  const { messenger, transaction } = request;
+
+  try {
+    validateOrderAsset({
+      expectedAsset: MUSD_MONAD_FIAT_ASSET,
+      orderCrypto: order.cryptoCurrency,
+      transactionId: transaction.id,
+    });
+
+    const sourceAmountRaw = await resolveSourceAmountRaw({
+      messenger,
+      order,
+      fiatAsset: MUSD_MONAD_FIAT_ASSET,
+      walletAddress: transaction.txParams.from as Hex,
+    });
+
+    return await submitDirectMusdVaultDeposit({
+      request,
+      sourceAmountRaw,
+      transaction,
+    });
+  } catch (error) {
+    throw prefixError(error, DIRECT_MUSD_ERROR_PREFIX);
+  }
+}
+
+/**
  * Submits the direct mUSD Money Account vault batch after fiat settlement.
  *
  * @param options - Submit options.
@@ -137,110 +184,107 @@ export async function submitDirectMusdVaultDeposit({
   sourceAmountRaw: string;
   transaction: PayStrategyExecuteRequest<FiatQuote>['transaction'];
 }): Promise<{ transactionHash?: Hex }> {
-  try {
-    const { messenger } = request;
-    const transactionId = transaction.id;
-    const moneyAccountAddress = transaction.txParams.from as Hex | undefined;
+  const { messenger } = request;
+  const transactionId = transaction.id;
+  const moneyAccountAddress = transaction.txParams.from as Hex | undefined;
 
-    if (!moneyAccountAddress) {
-      throw new Error('Missing Money Account address');
-    }
+  if (!moneyAccountAddress) {
+    throw new Error('Missing Money Account address');
+  }
 
-    if (getFiatVaultDisabled(messenger)) {
-      log(
-        'Skipping direct mUSD vault deposit because vaultDisabled is enabled',
-        {
-          moneyAccountAddress,
-          sourceAmountRaw,
-          transactionId,
-        },
-      );
-
-      return { transactionHash: '0x' };
-    }
-
-    const updatedTransaction =
-      getTransaction(transactionId, messenger) ?? transaction;
-    const { updates } = await messenger.call(
-      'TransactionPayController:getAmountData',
-      {
-        amount: sourceAmountRaw,
-        transaction: updatedTransaction,
-      },
-    );
-
-    if (!updates.length) {
-      throw new Error('No amount updates');
-    }
-
-    const nestedTransactions = updatedTransaction.nestedTransactions?.map(
-      (nestedTransaction) => ({ ...nestedTransaction }),
-    );
-
-    if (!nestedTransactions?.length) {
-      throw new Error('Missing nested transactions');
-    }
-
-    for (const { nestedTransactionIndex, data } of updates) {
-      if (nestedTransactions[nestedTransactionIndex]) {
-        nestedTransactions[nestedTransactionIndex].data = data;
-      }
-    }
-
-    updateTransaction(
-      {
-        transactionId,
-        messenger,
-        note: 'Direct mUSD fiat: update vault amount',
-      },
-      (tx) => {
-        for (const { nestedTransactionIndex, data } of updates) {
-          if (tx.nestedTransactions?.[nestedTransactionIndex]) {
-            tx.nestedTransactions[nestedTransactionIndex].data = data;
-          }
-        }
-
-        if (tx.requiredAssets?.[0]) {
-          tx.requiredAssets[0].amount = `0x${BigInt(sourceAmountRaw).toString(
-            16,
-          )}`;
-        }
-      },
-    );
-
-    const networkClientId = getNetworkClientId(
-      messenger,
-      MUSD_MONAD_FIAT_ASSET.chainId,
-    );
-    const transactionIds: string[] = [];
-    const { end } = collectTransactionIds(
-      MUSD_MONAD_FIAT_ASSET.chainId,
+  if (getFiatVaultDisabled(messenger)) {
+    log('Skipping direct mUSD vault deposit because vaultDisabled is enabled', {
       moneyAccountAddress,
-      messenger,
-      (id) => {
-        transactionIds.push(id);
-        updateTransaction(
-          {
-            transactionId,
-            messenger,
-            note: 'Add required transaction ID from direct mUSD vault submission',
-          },
-          (tx) => {
-            tx.requiredTransactionIds ??= [];
-            tx.requiredTransactionIds.push(id);
-          },
-        );
-      },
-    );
-
-    log('Submitting direct mUSD vault deposit', {
-      moneyAccountAddress,
-      nestedTransactionCount: nestedTransactions.length,
-      networkClientId,
       sourceAmountRaw,
       transactionId,
     });
 
+    return { transactionHash: '0x' };
+  }
+
+  const updatedTransaction =
+    getTransaction(transactionId, messenger) ?? transaction;
+  const { updates } = await messenger.call(
+    'TransactionPayController:getAmountData',
+    {
+      amount: sourceAmountRaw,
+      transaction: updatedTransaction,
+    },
+  );
+
+  if (!updates.length) {
+    throw new Error('No amount updates');
+  }
+
+  const nestedTransactions = updatedTransaction.nestedTransactions?.map(
+    (nestedTransaction) => ({ ...nestedTransaction }),
+  );
+
+  if (!nestedTransactions?.length) {
+    throw new Error('Missing nested transactions');
+  }
+
+  for (const { nestedTransactionIndex, data } of updates) {
+    if (nestedTransactions[nestedTransactionIndex]) {
+      nestedTransactions[nestedTransactionIndex].data = data;
+    }
+  }
+
+  updateTransaction(
+    {
+      transactionId,
+      messenger,
+      note: 'Direct mUSD fiat: update vault amount',
+    },
+    (tx) => {
+      for (const { nestedTransactionIndex, data } of updates) {
+        if (tx.nestedTransactions?.[nestedTransactionIndex]) {
+          tx.nestedTransactions[nestedTransactionIndex].data = data;
+        }
+      }
+
+      if (tx.requiredAssets?.[0]) {
+        tx.requiredAssets[0].amount = `0x${BigInt(sourceAmountRaw).toString(
+          16,
+        )}`;
+      }
+    },
+  );
+
+  const networkClientId = getNetworkClientId(
+    messenger,
+    MUSD_MONAD_FIAT_ASSET.chainId,
+  );
+  const transactionIds: string[] = [];
+  const { end } = collectTransactionIds(
+    MUSD_MONAD_FIAT_ASSET.chainId,
+    moneyAccountAddress,
+    messenger,
+    (id) => {
+      transactionIds.push(id);
+      updateTransaction(
+        {
+          transactionId,
+          messenger,
+          note: 'Add required transaction ID from direct mUSD vault submission',
+        },
+        (tx) => {
+          tx.requiredTransactionIds ??= [];
+          tx.requiredTransactionIds.push(id);
+        },
+      );
+    },
+  );
+
+  log('Submitting direct mUSD vault deposit', {
+    moneyAccountAddress,
+    nestedTransactionCount: nestedTransactions.length,
+    networkClientId,
+    sourceAmountRaw,
+    transactionId,
+  });
+
+  try {
     await messenger.call('TransactionController:addTransactionBatch', {
       from: moneyAccountAddress,
       isGasFeeSponsored: true,
@@ -260,46 +304,46 @@ export async function submitDirectMusdVaultDeposit({
             : TransactionType.contractInteraction,
       })),
     });
-
-    end();
-
-    log('Submitted direct mUSD vault deposit', {
-      moneyAccountAddress,
-      nestedTransactionCount: nestedTransactions.length,
-      networkClientId,
-      sourceAmountRaw,
-      transactionId,
-      transactionIds,
-    });
-
-    if (!transactionIds.length) {
-      throw new Error('No transactions submitted');
-    }
-
-    await Promise.all(
-      transactionIds.map((id) => waitForTransactionConfirmed(id, messenger)),
-    );
-
-    const hash = getTransaction(transactionIds.slice(-1)[0], messenger)?.hash;
-
-    if (!hash) {
-      throw new Error('Missing transaction hash');
-    }
-
-    log('Confirmed direct mUSD vault deposit', {
-      hash,
-      moneyAccountAddress,
-      nestedTransactionCount: nestedTransactions.length,
-      networkClientId,
-      sourceAmountRaw,
-      transactionId,
-      transactionIds,
-    });
-
-    return { transactionHash: hash as Hex };
   } catch (error) {
     throw prefixError(error, VAULT_ERROR_PREFIX);
   }
+
+  end();
+
+  log('Submitted direct mUSD vault deposit', {
+    moneyAccountAddress,
+    nestedTransactionCount: nestedTransactions.length,
+    networkClientId,
+    sourceAmountRaw,
+    transactionId,
+    transactionIds,
+  });
+
+  if (!transactionIds.length) {
+    throw new Error('No transactions submitted');
+  }
+
+  await Promise.all(
+    transactionIds.map((id) => waitForTransactionConfirmed(id, messenger)),
+  );
+
+  const hash = getTransaction(transactionIds.slice(-1)[0], messenger)?.hash;
+
+  if (!hash) {
+    throw new Error('Missing transaction hash');
+  }
+
+  log('Confirmed direct mUSD vault deposit', {
+    hash,
+    moneyAccountAddress,
+    nestedTransactionCount: nestedTransactions.length,
+    networkClientId,
+    sourceAmountRaw,
+    transactionId,
+    transactionIds,
+  });
+
+  return { transactionHash: hash as Hex };
 }
 
 function combineDirectMusdFiatQuote({

--- a/packages/transaction-pay-controller/src/strategy/fiat/fiat-direct-musd.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/fiat-direct-musd.ts
@@ -138,181 +138,168 @@ export async function submitDirectMusdVaultDeposit({
   transaction: PayStrategyExecuteRequest<FiatQuote>['transaction'];
 }): Promise<{ transactionHash?: Hex }> {
   try {
-    return await submitDirectMusdVaultDepositInternal({
-      request,
-      sourceAmountRaw,
-      transaction,
-    });
-  } catch (error) {
-    throw prefixError(error, VAULT_ERROR_PREFIX);
-  }
-}
+    const { messenger } = request;
+    const transactionId = transaction.id;
+    const moneyAccountAddress = transaction.txParams.from as Hex | undefined;
 
-async function submitDirectMusdVaultDepositInternal({
-  request,
-  sourceAmountRaw,
-  transaction,
-}: {
-  request: PayStrategyExecuteRequest<FiatQuote>;
-  sourceAmountRaw: string;
-  transaction: PayStrategyExecuteRequest<FiatQuote>['transaction'];
-}): Promise<{ transactionHash?: Hex }> {
-  const { messenger } = request;
-  const transactionId = transaction.id;
-  const moneyAccountAddress = transaction.txParams.from as Hex | undefined;
+    if (!moneyAccountAddress) {
+      throw new Error('Missing Money Account address');
+    }
 
-  if (!moneyAccountAddress) {
-    throw new Error('Missing Money Account address for direct mUSD submit');
-  }
+    if (getFiatVaultDisabled(messenger)) {
+      log(
+        'Skipping direct mUSD vault deposit because vaultDisabled is enabled',
+        {
+          moneyAccountAddress,
+          sourceAmountRaw,
+          transactionId,
+        },
+      );
 
-  if (getFiatVaultDisabled(messenger)) {
-    log('Skipping direct mUSD vault deposit because vaultDisabled is enabled', {
+      return { transactionHash: '0x' };
+    }
+
+    const updatedTransaction =
+      getTransaction(transactionId, messenger) ?? transaction;
+    const { updates } = await messenger.call(
+      'TransactionPayController:getAmountData',
+      {
+        amount: sourceAmountRaw,
+        transaction: updatedTransaction,
+      },
+    );
+
+    if (!updates.length) {
+      throw new Error('No amount updates');
+    }
+
+    const nestedTransactions = updatedTransaction.nestedTransactions?.map(
+      (nestedTransaction) => ({ ...nestedTransaction }),
+    );
+
+    if (!nestedTransactions?.length) {
+      throw new Error('Missing nested transactions');
+    }
+
+    for (const { nestedTransactionIndex, data } of updates) {
+      if (nestedTransactions[nestedTransactionIndex]) {
+        nestedTransactions[nestedTransactionIndex].data = data;
+      }
+    }
+
+    updateTransaction(
+      {
+        transactionId,
+        messenger,
+        note: 'Direct mUSD fiat: update vault amount',
+      },
+      (tx) => {
+        for (const { nestedTransactionIndex, data } of updates) {
+          if (tx.nestedTransactions?.[nestedTransactionIndex]) {
+            tx.nestedTransactions[nestedTransactionIndex].data = data;
+          }
+        }
+
+        if (tx.requiredAssets?.[0]) {
+          tx.requiredAssets[0].amount = `0x${BigInt(sourceAmountRaw).toString(
+            16,
+          )}`;
+        }
+      },
+    );
+
+    const networkClientId = getNetworkClientId(
+      messenger,
+      MUSD_MONAD_FIAT_ASSET.chainId,
+    );
+    const transactionIds: string[] = [];
+    const { end } = collectTransactionIds(
+      MUSD_MONAD_FIAT_ASSET.chainId,
       moneyAccountAddress,
+      messenger,
+      (id) => {
+        transactionIds.push(id);
+        updateTransaction(
+          {
+            transactionId,
+            messenger,
+            note: 'Add required transaction ID from direct mUSD vault submission',
+          },
+          (tx) => {
+            tx.requiredTransactionIds ??= [];
+            tx.requiredTransactionIds.push(id);
+          },
+        );
+      },
+    );
+
+    log('Submitting direct mUSD vault deposit', {
+      moneyAccountAddress,
+      nestedTransactionCount: nestedTransactions.length,
+      networkClientId,
       sourceAmountRaw,
       transactionId,
     });
 
-    return { transactionHash: '0x' };
-  }
+    await messenger.call('TransactionController:addTransactionBatch', {
+      from: moneyAccountAddress,
+      isGasFeeSponsored: true,
+      isInternal: true,
+      networkClientId,
+      origin: ORIGIN_METAMASK,
+      requireApproval: false,
+      transactions: nestedTransactions.map((nestedTransaction, index) => ({
+        params: {
+          data: nestedTransaction.data,
+          to: nestedTransaction.to,
+          value: nestedTransaction.value ?? '0x0',
+        },
+        type:
+          index === 0
+            ? (nestedTransaction.type ?? TransactionType.tokenMethodApprove)
+            : TransactionType.contractInteraction,
+      })),
+    });
 
-  const updatedTransaction =
-    getTransaction(transactionId, messenger) ?? transaction;
-  const { updates } = await messenger.call(
-    'TransactionPayController:getAmountData',
-    {
-      amount: sourceAmountRaw,
-      transaction: updatedTransaction,
-    },
-  );
+    end();
 
-  if (!updates.length) {
-    throw new Error('getAmountData returned no updates for direct mUSD submit');
-  }
+    log('Submitted direct mUSD vault deposit', {
+      moneyAccountAddress,
+      nestedTransactionCount: nestedTransactions.length,
+      networkClientId,
+      sourceAmountRaw,
+      transactionId,
+      transactionIds,
+    });
 
-  const nestedTransactions = updatedTransaction.nestedTransactions?.map(
-    (nestedTransaction) => ({ ...nestedTransaction }),
-  );
-
-  if (!nestedTransactions?.length) {
-    throw new Error('Missing nested transactions for direct mUSD submit');
-  }
-
-  for (const { nestedTransactionIndex, data } of updates) {
-    if (nestedTransactions[nestedTransactionIndex]) {
-      nestedTransactions[nestedTransactionIndex].data = data;
+    if (!transactionIds.length) {
+      throw new Error('No transactions submitted');
     }
-  }
 
-  updateTransaction(
-    { transactionId, messenger, note: 'Direct mUSD fiat: update vault amount' },
-    (tx) => {
-      for (const { nestedTransactionIndex, data } of updates) {
-        if (tx.nestedTransactions?.[nestedTransactionIndex]) {
-          tx.nestedTransactions[nestedTransactionIndex].data = data;
-        }
-      }
-
-      if (tx.requiredAssets?.[0]) {
-        tx.requiredAssets[0].amount = `0x${BigInt(sourceAmountRaw).toString(
-          16,
-        )}`;
-      }
-    },
-  );
-
-  const networkClientId = getNetworkClientId(
-    messenger,
-    MUSD_MONAD_FIAT_ASSET.chainId,
-  );
-  const transactionIds: string[] = [];
-  const { end } = collectTransactionIds(
-    MUSD_MONAD_FIAT_ASSET.chainId,
-    moneyAccountAddress,
-    messenger,
-    (id) => {
-      transactionIds.push(id);
-      updateTransaction(
-        {
-          transactionId,
-          messenger,
-          note: 'Add required transaction ID from direct mUSD vault submission',
-        },
-        (tx) => {
-          tx.requiredTransactionIds ??= [];
-          tx.requiredTransactionIds.push(id);
-        },
-      );
-    },
-  );
-
-  log('Submitting direct mUSD vault deposit', {
-    moneyAccountAddress,
-    nestedTransactionCount: nestedTransactions.length,
-    networkClientId,
-    sourceAmountRaw,
-    transactionId,
-  });
-
-  await messenger.call('TransactionController:addTransactionBatch', {
-    from: moneyAccountAddress,
-    isGasFeeSponsored: true,
-    isInternal: true,
-    networkClientId,
-    origin: ORIGIN_METAMASK,
-    requireApproval: false,
-    transactions: nestedTransactions.map((nestedTransaction, index) => ({
-      params: {
-        data: nestedTransaction.data,
-        to: nestedTransaction.to,
-        value: nestedTransaction.value ?? '0x0',
-      },
-      type:
-        index === 0
-          ? (nestedTransaction.type ?? TransactionType.tokenMethodApprove)
-          : TransactionType.contractInteraction,
-    })),
-  });
-
-  end();
-
-  log('Submitted direct mUSD vault deposit', {
-    moneyAccountAddress,
-    nestedTransactionCount: nestedTransactions.length,
-    networkClientId,
-    sourceAmountRaw,
-    transactionId,
-    transactionIds,
-  });
-
-  if (!transactionIds.length) {
-    throw new Error(
-      'No vault transactions were submitted for direct mUSD submit',
+    await Promise.all(
+      transactionIds.map((id) => waitForTransactionConfirmed(id, messenger)),
     );
+
+    const hash = getTransaction(transactionIds.slice(-1)[0], messenger)?.hash;
+
+    if (!hash) {
+      throw new Error('Missing transaction hash');
+    }
+
+    log('Confirmed direct mUSD vault deposit', {
+      hash,
+      moneyAccountAddress,
+      nestedTransactionCount: nestedTransactions.length,
+      networkClientId,
+      sourceAmountRaw,
+      transactionId,
+      transactionIds,
+    });
+
+    return { transactionHash: hash as Hex };
+  } catch (error) {
+    throw prefixError(error, VAULT_ERROR_PREFIX);
   }
-
-  await Promise.all(
-    transactionIds.map((id) => waitForTransactionConfirmed(id, messenger)),
-  );
-
-  const hash = getTransaction(transactionIds.slice(-1)[0], messenger)?.hash;
-
-  if (!hash) {
-    throw new Error(
-      'Missing transaction hash for direct mUSD vault submission',
-    );
-  }
-
-  log('Confirmed direct mUSD vault deposit', {
-    hash,
-    moneyAccountAddress,
-    nestedTransactionCount: nestedTransactions.length,
-    networkClientId,
-    sourceAmountRaw,
-    transactionId,
-    transactionIds,
-  });
-
-  return { transactionHash: hash as Hex };
 }
 
 function combineDirectMusdFiatQuote({

--- a/packages/transaction-pay-controller/src/strategy/fiat/fiat-submit-simple.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/fiat-submit-simple.test.ts
@@ -172,7 +172,7 @@ describe('submitSimpleRelay', () => {
         sourceAmountRaw: '1000000000000000000',
         transaction: TRANSACTION_MOCK,
       }),
-    ).rejects.toThrow('Missing Relay quote for fiat submission');
+    ).rejects.toThrow('Missing Relay quote');
   });
 
   it('throws when rate drift exceeds configured threshold', async () => {

--- a/packages/transaction-pay-controller/src/strategy/fiat/fiat-submit-simple.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/fiat-submit-simple.ts
@@ -39,7 +39,7 @@ export async function submitSimpleRelay({
   const originalRelayQuote = request.quotes[0].original.relayQuote;
 
   if (!originalRelayQuote) {
-    throw new Error('Missing Relay quote for fiat submission');
+    throw new Error('Missing Relay quote');
   }
 
   const relayRequest: QuoteRequest = {

--- a/packages/transaction-pay-controller/src/strategy/fiat/fiat-submit-with-transaction-data.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/fiat-submit-with-transaction-data.test.ts
@@ -409,7 +409,7 @@ describe('submitWithCalldataReEncoding', () => {
         sourceAmountRaw: '1000000000000000000',
         transaction: TRANSACTION_MOCK,
       }),
-    ).rejects.toThrow('Missing Relay quote for fiat submission');
+    ).rejects.toThrow('Missing Relay quote');
   });
 
   it('falls back to original transaction when getTransaction returns undefined', async () => {

--- a/packages/transaction-pay-controller/src/strategy/fiat/fiat-submit-with-transaction-data.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/fiat-submit-with-transaction-data.ts
@@ -48,7 +48,7 @@ export async function submitWithTransactionData({
   const originalRelayQuote = request.quotes[0].original.relayQuote;
 
   if (!originalRelayQuote) {
-    throw new Error('Missing Relay quote for fiat submission');
+    throw new Error('Missing Relay quote');
   }
 
   const feeReserveRaw = calculateFeeReserve({

--- a/packages/transaction-pay-controller/src/strategy/fiat/fiat-submit.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/fiat-submit.test.ts
@@ -563,16 +563,14 @@ describe('submitFiatQuotes', () => {
     });
 
     await expect(submitFiatQuotes(request)).rejects.toThrow(
-      'Missing wallet address for fiat submission',
+      'Missing wallet address',
     );
   });
 
   it('throws if order ID is missing', async () => {
     const { request } = getRequest({ orderId: '' });
 
-    await expect(submitFiatQuotes(request)).rejects.toThrow(
-      'Missing order ID for fiat submission',
-    );
+    await expect(submitFiatQuotes(request)).rejects.toThrow('Missing order ID');
   });
 
   it('throws if ramps quote is missing from fiat payment state', async () => {
@@ -606,7 +604,7 @@ describe('submitFiatQuotes', () => {
     };
 
     await expect(submitFiatQuotes(request)).rejects.toThrow(
-      'Missing provider code for fiat submission',
+      'Missing provider code',
     );
   });
 
@@ -616,7 +614,7 @@ describe('submitFiatQuotes', () => {
     });
 
     await expect(submitFiatQuotes(request)).rejects.toThrow(
-      'Missing provider code for fiat submission',
+      'Missing provider code',
     );
   });
 
@@ -626,7 +624,7 @@ describe('submitFiatQuotes', () => {
     });
 
     await expect(submitFiatQuotes(request)).rejects.toThrow(
-      'Missing provider code for fiat submission',
+      'Missing provider code',
     );
   });
 
@@ -898,7 +896,7 @@ describe('submitFiatQuotes', () => {
     });
 
     await expect(submitFiatQuotes(request)).rejects.toThrow(
-      `Post-Ramp: Fiat order asset mismatch for transaction ${TRANSACTION_ID_MOCK}: expected ${FIAT_ASSET_CAIP_ID_MOCK.toLowerCase()}, got eip155:137/slip44:60`,
+      `Post-Ramp: Order asset mismatch for transaction ${TRANSACTION_ID_MOCK}: expected ${FIAT_ASSET_CAIP_ID_MOCK.toLowerCase()}, got eip155:137/slip44:60`,
     );
   });
 
@@ -913,7 +911,7 @@ describe('submitFiatQuotes', () => {
     });
 
     await expect(submitFiatQuotes(request)).rejects.toThrow(
-      `Post-Ramp: Fiat order chain mismatch for transaction ${TRANSACTION_ID_MOCK}: expected eip155:137, got eip155:1`,
+      `Post-Ramp: Order chain mismatch for transaction ${TRANSACTION_ID_MOCK}: expected eip155:137, got eip155:1`,
     );
   });
 
@@ -932,9 +930,7 @@ describe('submitFiatQuotes', () => {
     const { request } = getRequest();
     request.quotes = [];
 
-    await expect(submitFiatQuotes(request)).rejects.toThrow(
-      'Missing fiat quote for relay submission',
-    );
+    await expect(submitFiatQuotes(request)).rejects.toThrow('Missing quote');
   });
 
   it('throws if request has multiple fiat quotes', async () => {
@@ -952,7 +948,7 @@ describe('submitFiatQuotes', () => {
     });
 
     await expect(submitFiatQuotes(request)).rejects.toThrow(
-      'Post-Ramp: Missing Relay quote for fiat submission',
+      'Post-Ramp: Missing Relay quote',
     );
   });
 
@@ -972,7 +968,7 @@ describe('submitFiatQuotes', () => {
     const { request } = getRequest();
 
     await expect(submitFiatQuotes(request)).rejects.toThrow(
-      'Post-Ramp: Missing transaction hash for fiat post-Ramp submission',
+      'Post-Ramp: Missing transaction hash',
     );
   });
 
@@ -1123,6 +1119,27 @@ describe('submitFiatQuotes', () => {
             action === 'TransactionPayController:getPaymentOverrideData',
         ),
       ).toBe(false);
+    });
+
+    it('prefixes direct mUSD vault errors', async () => {
+      getTransactionMock.mockImplementation((transactionId) =>
+        transactionId === TRANSACTION_ID_MOCK
+          ? MUSD_TRANSACTION_MOCK
+          : undefined,
+      );
+      const { request } = getRequest({
+        quotes: [
+          getFiatQuoteMock({
+            includeRelayQuote: false,
+            request: MUSD_QUOTE_REQUEST,
+          }),
+        ],
+        transaction: MUSD_TRANSACTION_MOCK,
+      });
+
+      await expect(submitFiatQuotes(request)).rejects.toThrow(
+        'Post-Ramp: Direct mUSD: Vault: Missing transaction hash',
+      );
     });
 
     it('skips the vault batch and returns an empty hash when vaultDisabled is enabled', async () => {

--- a/packages/transaction-pay-controller/src/strategy/fiat/fiat-submit.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/fiat-submit.test.ts
@@ -1138,7 +1138,68 @@ describe('submitFiatQuotes', () => {
       });
 
       await expect(submitFiatQuotes(request)).rejects.toThrow(
-        'Post-Ramp: Direct mUSD: Vault: Missing transaction hash',
+        'Post-Ramp: Direct mUSD: Missing transaction hash',
+      );
+    });
+
+    it('prefixes direct mUSD addTransactionBatch errors as Vault errors', async () => {
+      const { callMock, request } = getRequest({
+        quotes: [
+          getFiatQuoteMock({
+            includeRelayQuote: false,
+            request: MUSD_QUOTE_REQUEST,
+          }),
+        ],
+        transaction: MUSD_TRANSACTION_MOCK,
+      });
+
+      callMock.mockImplementation((action: string) => {
+        if (action === 'TransactionPayController:getState') {
+          return {
+            transactionData: {
+              [MUSD_TRANSACTION_MOCK.id]: {
+                fiatPayment: {
+                  orderId: ORDER_ID_MOCK,
+                  rampsQuote: RAMPS_QUOTE_MOCK,
+                },
+                isLoading: false,
+                tokens: [],
+              },
+            },
+          };
+        }
+
+        if (action === 'TransactionPayController:getFiatOptions') {
+          return undefined;
+        }
+
+        if (action === 'RampsController:getOrder') {
+          return getFiatOrderMock();
+        }
+
+        if (action === 'TransactionPayController:getAmountData') {
+          return Promise.resolve({
+            updates: [{ nestedTransactionIndex: 0, data: '0xapprove' }],
+          });
+        }
+
+        if (action === 'NetworkController:findNetworkClientIdByChainId') {
+          return 'network-client-id-mock';
+        }
+
+        if (action === 'TransactionController:addTransactionBatch') {
+          throw new Error('batch failed');
+        }
+
+        if (action === 'RemoteFeatureFlagController:getState') {
+          return { remoteFeatureFlags: {} };
+        }
+
+        throw new Error(`Unexpected action: ${action}`);
+      });
+
+      await expect(submitFiatQuotes(request)).rejects.toThrow(
+        'Post-Ramp: Direct mUSD: Vault: batch failed',
       );
     });
 

--- a/packages/transaction-pay-controller/src/strategy/fiat/fiat-submit.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/fiat-submit.test.ts
@@ -883,7 +883,7 @@ describe('submitFiatQuotes', () => {
     const { request } = getRequest();
 
     await expect(submitFiatQuotes(request)).rejects.toThrow(
-      `Unable to resolve token info for fiat asset ${FIAT_ASSET_MOCK.address} on chain ${FIAT_ASSET_MOCK.chainId}`,
+      `Post-Ramp: Unable to resolve token info for fiat asset ${FIAT_ASSET_MOCK.address} on chain ${FIAT_ASSET_MOCK.chainId}`,
     );
   });
 
@@ -898,7 +898,7 @@ describe('submitFiatQuotes', () => {
     });
 
     await expect(submitFiatQuotes(request)).rejects.toThrow(
-      `Fiat order asset mismatch for transaction ${TRANSACTION_ID_MOCK}: expected ${FIAT_ASSET_CAIP_ID_MOCK.toLowerCase()}, got eip155:137/slip44:60`,
+      `Post-Ramp: Fiat order asset mismatch for transaction ${TRANSACTION_ID_MOCK}: expected ${FIAT_ASSET_CAIP_ID_MOCK.toLowerCase()}, got eip155:137/slip44:60`,
     );
   });
 
@@ -913,7 +913,7 @@ describe('submitFiatQuotes', () => {
     });
 
     await expect(submitFiatQuotes(request)).rejects.toThrow(
-      `Fiat order chain mismatch for transaction ${TRANSACTION_ID_MOCK}: expected eip155:137, got eip155:1`,
+      `Post-Ramp: Fiat order chain mismatch for transaction ${TRANSACTION_ID_MOCK}: expected eip155:137, got eip155:1`,
     );
   });
 
@@ -924,7 +924,7 @@ describe('submitFiatQuotes', () => {
     const { request } = getRequest();
 
     await expect(submitFiatQuotes(request)).rejects.toThrow(
-      'Invalid fiat order crypto amount: 0',
+      'Post-Ramp: Invalid fiat order crypto amount: 0',
     );
   });
 
@@ -942,7 +942,7 @@ describe('submitFiatQuotes', () => {
     request.quotes = [getFiatQuoteMock(), getFiatQuoteMock()];
 
     await expect(submitFiatQuotes(request)).rejects.toThrow(
-      'Multiple fiat quotes are not supported for submission',
+      'Post-Ramp: Multiple fiat quotes are not supported for submission',
     );
   });
 
@@ -952,7 +952,7 @@ describe('submitFiatQuotes', () => {
     });
 
     await expect(submitFiatQuotes(request)).rejects.toThrow(
-      'Missing Relay quote for fiat submission',
+      'Post-Ramp: Missing Relay quote for fiat submission',
     );
   });
 
@@ -963,7 +963,16 @@ describe('submitFiatQuotes', () => {
     const { request } = getRequest();
 
     await expect(submitFiatQuotes(request)).rejects.toThrow(
-      'Computed fiat order source amount is not positive',
+      'Post-Ramp: Computed fiat order source amount is not positive',
+    );
+  });
+
+  it('throws if post-Ramp submission returns no transaction hash', async () => {
+    submitRelayQuotesMock.mockResolvedValue({ transactionHash: undefined });
+    const { request } = getRequest();
+
+    await expect(submitFiatQuotes(request)).rejects.toThrow(
+      'Post-Ramp: Missing transaction hash for fiat post-Ramp submission',
     );
   });
 

--- a/packages/transaction-pay-controller/src/strategy/fiat/fiat-submit.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/fiat-submit.ts
@@ -13,6 +13,7 @@ import type {
   TransactionPayFiatOptions,
   TransactionPayControllerMessenger,
 } from '../../types';
+import { prefixError } from '../../utils/error-prefix';
 import {
   getFiatOrderPollIntervalMs,
   getFiatOrderPollTimeoutMs,
@@ -36,6 +37,7 @@ import {
 } from './utils';
 
 const log = createModuleLogger(projectLogger, 'fiat-submit');
+const POST_RAMP_ERROR_PREFIX = 'Post-Ramp: ';
 
 const TERMINAL_FAILURE_STATUSES: RampsOrderStatus[] = [
   RampsOrderStatus.Cancelled,
@@ -128,7 +130,17 @@ export async function submitFiatQuotes(
     transactionId,
   });
 
-  return await submitRelayAfterFiatCompletion({ order, request });
+  try {
+    const result = await submitRelayAfterFiatCompletion({ order, request });
+
+    if (result.transactionHash === undefined) {
+      throw new Error('Missing transaction hash for fiat post-Ramp submission');
+    }
+
+    return result;
+  } catch (error) {
+    throw prefixError(error, POST_RAMP_ERROR_PREFIX);
+  }
 }
 
 function getFiatOptions(

--- a/packages/transaction-pay-controller/src/strategy/fiat/fiat-submit.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/fiat-submit.ts
@@ -1,7 +1,4 @@
-import type {
-  RampsOrder,
-  RampsOrderCryptoCurrency,
-} from '@metamask/ramps-controller';
+import type { RampsOrder } from '@metamask/ramps-controller';
 import { RampsOrderStatus } from '@metamask/ramps-controller';
 import type { Hex } from '@metamask/utils';
 import { createModuleLogger } from '@metamask/utils';
@@ -18,13 +15,10 @@ import {
   getFiatOrderPollIntervalMs,
   getFiatOrderPollTimeoutMs,
 } from '../../utils/feature-flags';
-import { buildCaipAssetType } from '../../utils/token';
 import { updateTransaction } from '../../utils/transaction';
-import type { TransactionPayFiatAsset } from './constants';
-import { MUSD_MONAD_FIAT_ASSET } from './constants';
 import {
   isDirectMusdMoneyAccountQuote,
-  submitDirectMusdVaultDeposit,
+  submitDirectMusdAfterFiatCompletion,
 } from './fiat-direct-musd';
 import { submitSimpleRelay } from './fiat-submit-simple';
 import { submitWithTransactionData } from './fiat-submit-with-transaction-data';
@@ -34,10 +28,10 @@ import {
   deriveFiatAssetForFiatPayment,
   extractProviderCode,
   resolveSourceAmountRaw,
+  validateOrderAsset,
 } from './utils';
 
 const log = createModuleLogger(projectLogger, 'fiat-submit');
-const DIRECT_MUSD_ERROR_PREFIX = 'Direct mUSD: ';
 const POST_RAMP_ERROR_PREFIX = 'Post-Ramp: ';
 
 const TERMINAL_FAILURE_STATUSES: RampsOrderStatus[] = [
@@ -156,46 +150,6 @@ function getFiatOptions(
 }
 
 /**
- * Validates that the completed order's crypto asset matches the expected fiat asset.
- *
- * @param options - The validation options.
- * @param options.expectedAsset - The expected fiat asset derived from the transaction type.
- * @param options.orderCrypto - The crypto currency information from the completed order.
- * @param options.transactionId - Transaction ID for error reporting.
- */
-function validateOrderAsset({
-  expectedAsset,
-  orderCrypto,
-  transactionId,
-}: {
-  expectedAsset: TransactionPayFiatAsset;
-  orderCrypto: RampsOrderCryptoCurrency | undefined;
-  transactionId: string;
-}): void {
-  const orderAssetId = orderCrypto?.assetId?.toLowerCase();
-  const expectedAssetId = buildCaipAssetType(
-    expectedAsset.chainId,
-    expectedAsset.address,
-  ).toLowerCase();
-  const expectedChainId = expectedAssetId.split('/')[0];
-  const orderChainId = orderCrypto?.chainId?.toLowerCase();
-
-  if (orderAssetId && orderAssetId !== expectedAssetId) {
-    throw new Error(
-      `Order asset mismatch for transaction ${transactionId}: ` +
-        `expected ${expectedAssetId}, got ${orderAssetId}`,
-    );
-  }
-
-  if (orderChainId && orderChainId !== expectedChainId) {
-    throw new Error(
-      `Order chain mismatch for transaction ${transactionId}: ` +
-        `expected ${expectedChainId}, got ${orderChainId}`,
-    );
-  }
-}
-
-/**
  * Polls the on-ramp order until it reaches a terminal status.
  *
  * @param options - The polling options.
@@ -292,28 +246,7 @@ async function submitRelayAfterFiatCompletion({
   const isDirectMusd = isDirectMusdMoneyAccountQuote(fiatQuote);
 
   if (isDirectMusd) {
-    try {
-      validateOrderAsset({
-        expectedAsset: MUSD_MONAD_FIAT_ASSET,
-        orderCrypto: order.cryptoCurrency,
-        transactionId,
-      });
-
-      const sourceAmountRaw = await resolveSourceAmountRaw({
-        messenger,
-        order,
-        fiatAsset: MUSD_MONAD_FIAT_ASSET,
-        walletAddress: transaction.txParams.from as Hex,
-      });
-
-      return await submitDirectMusdVaultDeposit({
-        request,
-        sourceAmountRaw,
-        transaction,
-      });
-    } catch (error) {
-      throw prefixError(error, DIRECT_MUSD_ERROR_PREFIX);
-    }
+    return await submitDirectMusdAfterFiatCompletion({ order, request });
   }
 
   const fiatAsset = deriveFiatAssetForFiatPayment(transaction, messenger);

--- a/packages/transaction-pay-controller/src/strategy/fiat/fiat-submit.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/fiat-submit.ts
@@ -37,6 +37,7 @@ import {
 } from './utils';
 
 const log = createModuleLogger(projectLogger, 'fiat-submit');
+const DIRECT_MUSD_ERROR_PREFIX = 'Direct mUSD: ';
 const POST_RAMP_ERROR_PREFIX = 'Post-Ramp: ';
 
 const TERMINAL_FAILURE_STATUSES: RampsOrderStatus[] = [
@@ -74,13 +75,13 @@ export async function submitFiatQuotes(
   const orderId = fiatPayment?.orderId;
 
   if (!orderId) {
-    throw new Error('Missing order ID for fiat submission');
+    throw new Error('Missing order ID');
   }
 
   const providerCode = extractProviderCode(fiatPayment?.rampsQuote?.provider);
 
   if (!providerCode) {
-    throw new Error('Missing provider code for fiat submission');
+    throw new Error('Missing provider code');
   }
 
   updateTransaction(
@@ -104,7 +105,7 @@ export async function submitFiatQuotes(
   const fiatQuote = request.quotes[0];
 
   if (!fiatQuote) {
-    throw new Error('Missing fiat quote for relay submission');
+    throw new Error('Missing quote');
   }
 
   const fiatOptions = getFiatOptions(messenger);
@@ -134,7 +135,7 @@ export async function submitFiatQuotes(
     const result = await submitRelayAfterFiatCompletion({ order, request });
 
     if (result.transactionHash === undefined) {
-      throw new Error('Missing transaction hash for fiat post-Ramp submission');
+      throw new Error('Missing transaction hash');
     }
 
     return result;
@@ -181,14 +182,14 @@ function validateOrderAsset({
 
   if (orderAssetId && orderAssetId !== expectedAssetId) {
     throw new Error(
-      `Fiat order asset mismatch for transaction ${transactionId}: ` +
+      `Order asset mismatch for transaction ${transactionId}: ` +
         `expected ${expectedAssetId}, got ${orderAssetId}`,
     );
   }
 
   if (orderChainId && orderChainId !== expectedChainId) {
     throw new Error(
-      `Fiat order chain mismatch for transaction ${transactionId}: ` +
+      `Order chain mismatch for transaction ${transactionId}: ` +
         `expected ${expectedChainId}, got ${orderChainId}`,
     );
   }
@@ -291,24 +292,28 @@ async function submitRelayAfterFiatCompletion({
   const isDirectMusd = isDirectMusdMoneyAccountQuote(fiatQuote);
 
   if (isDirectMusd) {
-    validateOrderAsset({
-      expectedAsset: MUSD_MONAD_FIAT_ASSET,
-      orderCrypto: order.cryptoCurrency,
-      transactionId,
-    });
+    try {
+      validateOrderAsset({
+        expectedAsset: MUSD_MONAD_FIAT_ASSET,
+        orderCrypto: order.cryptoCurrency,
+        transactionId,
+      });
 
-    const sourceAmountRaw = await resolveSourceAmountRaw({
-      messenger,
-      order,
-      fiatAsset: MUSD_MONAD_FIAT_ASSET,
-      walletAddress: transaction.txParams.from as Hex,
-    });
+      const sourceAmountRaw = await resolveSourceAmountRaw({
+        messenger,
+        order,
+        fiatAsset: MUSD_MONAD_FIAT_ASSET,
+        walletAddress: transaction.txParams.from as Hex,
+      });
 
-    return await submitDirectMusdVaultDeposit({
-      request,
-      sourceAmountRaw,
-      transaction,
-    });
+      return await submitDirectMusdVaultDeposit({
+        request,
+        sourceAmountRaw,
+        transaction,
+      });
+    } catch (error) {
+      throw prefixError(error, DIRECT_MUSD_ERROR_PREFIX);
+    }
   }
 
   const fiatAsset = deriveFiatAssetForFiatPayment(transaction, messenger);
@@ -329,7 +334,7 @@ async function submitRelayAfterFiatCompletion({
   });
 
   if (!fiatQuote.original.relayQuote) {
-    throw new Error('Missing Relay quote for fiat submission');
+    throw new Error('Missing Relay quote');
   }
 
   const hasNestedCalldata = (transaction.nestedTransactions?.length ?? 0) >= 2;
@@ -370,7 +375,7 @@ function getWalletAddress({
     : (accountOverride ?? transaction.txParams.from);
 
   if (!address) {
-    throw new Error('Missing wallet address for fiat submission');
+    throw new Error('Missing wallet address');
   }
 
   return address as Hex;

--- a/packages/transaction-pay-controller/src/strategy/fiat/utils.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/utils.ts
@@ -1,6 +1,7 @@
 import type {
   Quote as RampsQuote,
   RampsOrder,
+  RampsOrderCryptoCurrency,
 } from '@metamask/ramps-controller';
 import type { TransactionMeta } from '@metamask/transaction-controller';
 import { TransactionType } from '@metamask/transaction-controller';
@@ -127,6 +128,46 @@ export async function getRampsQuote({
   }
 
   return quote;
+}
+
+/**
+ * Validates that a completed order's crypto asset matches the expected fiat asset.
+ *
+ * @param options - The validation options.
+ * @param options.expectedAsset - The expected fiat asset derived from the transaction type.
+ * @param options.orderCrypto - The crypto currency information from the completed order.
+ * @param options.transactionId - Transaction ID for error reporting.
+ */
+export function validateOrderAsset({
+  expectedAsset,
+  orderCrypto,
+  transactionId,
+}: {
+  expectedAsset: TransactionPayFiatAsset;
+  orderCrypto: RampsOrderCryptoCurrency | undefined;
+  transactionId: string;
+}): void {
+  const orderAssetId = orderCrypto?.assetId?.toLowerCase();
+  const expectedAssetId = buildCaipAssetType(
+    expectedAsset.chainId,
+    expectedAsset.address,
+  ).toLowerCase();
+  const expectedChainId = expectedAssetId.split('/')[0];
+  const orderChainId = orderCrypto?.chainId?.toLowerCase();
+
+  if (orderAssetId && orderAssetId !== expectedAssetId) {
+    throw new Error(
+      `Order asset mismatch for transaction ${transactionId}: ` +
+        `expected ${expectedAssetId}, got ${orderAssetId}`,
+    );
+  }
+
+  if (orderChainId && orderChainId !== expectedChainId) {
+    throw new Error(
+      `Order chain mismatch for transaction ${transactionId}: ` +
+        `expected ${expectedChainId}, got ${orderChainId}`,
+    );
+  }
 }
 
 /**

--- a/packages/transaction-pay-controller/src/strategy/relay/RelayBridge.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/RelayBridge.test.ts
@@ -37,6 +37,8 @@ describe('RelayStrategy', () => {
 
   describe('execute', () => {
     it('calls util', async () => {
+      submitRelayQuotesMock.mockResolvedValue({ transactionHash: '0x1234' });
+
       await new RelayStrategy().execute({
         isSmartTransaction: () => false,
         quotes: [QUOTE_MOCK],

--- a/packages/transaction-pay-controller/src/strategy/relay/RelayStrategy.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/RelayStrategy.test.ts
@@ -177,7 +177,7 @@ describe('RelayStrategy', () => {
     const strategy = new RelayStrategy();
 
     await expect(strategy.execute(executeRequest)).rejects.toThrow(
-      'Relay: Missing transaction hash for Relay submission',
+      'Relay: Missing transaction hash',
     );
   });
 });

--- a/packages/transaction-pay-controller/src/strategy/relay/RelayStrategy.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/RelayStrategy.test.ts
@@ -109,7 +109,27 @@ describe('RelayStrategy', () => {
     expect(submitRelayQuotesMock).toHaveBeenCalledWith(executeRequest);
   });
 
-  it('wraps execute errors with the Relay submit prefix', async () => {
+  it('prefixes execute errors with the Relay prefix without replacing the Error object', async () => {
+    const executeRequest = {
+      messenger,
+      quotes: [],
+      transaction: request.transaction,
+      isSmartTransaction: jest.fn(),
+    } as PayStrategyExecuteRequest<RelayQuote>;
+    const error = new Error('Insufficient liquidity');
+
+    submitRelayQuotesMock.mockRejectedValue(error);
+
+    const strategy = new RelayStrategy();
+    const thrown = await strategy
+      .execute(executeRequest)
+      .catch((caught) => caught);
+
+    expect(thrown).toBe(error);
+    expect(thrown.message).toBe('Relay: Insufficient liquidity');
+  });
+
+  it('does not duplicate the Relay prefix for nested Relay errors', async () => {
     const executeRequest = {
       messenger,
       quotes: [],
@@ -118,12 +138,13 @@ describe('RelayStrategy', () => {
     } as PayStrategyExecuteRequest<RelayQuote>;
 
     submitRelayQuotesMock.mockRejectedValue(
-      new Error('Relay execute: 422 - Insufficient liquidity'),
+      new Error('Relay: Execute: 422 - Insufficient liquidity'),
     );
 
     const strategy = new RelayStrategy();
+
     await expect(strategy.execute(executeRequest)).rejects.toThrow(
-      'Relay submit: Relay execute: 422 - Insufficient liquidity',
+      'Relay: Execute: 422 - Insufficient liquidity',
     );
   });
 
@@ -139,7 +160,24 @@ describe('RelayStrategy', () => {
 
     const strategy = new RelayStrategy();
     await expect(strategy.execute(executeRequest)).rejects.toThrow(
-      'Relay submit: boom',
+      'Relay: boom',
+    );
+  });
+
+  it('throws if Relay submission returns no transaction hash', async () => {
+    const executeRequest = {
+      messenger,
+      quotes: [],
+      transaction: request.transaction,
+      isSmartTransaction: jest.fn(),
+    } as PayStrategyExecuteRequest<RelayQuote>;
+
+    submitRelayQuotesMock.mockResolvedValue({ transactionHash: undefined });
+
+    const strategy = new RelayStrategy();
+
+    await expect(strategy.execute(executeRequest)).rejects.toThrow(
+      'Relay: Missing transaction hash for Relay submission',
     );
   });
 });

--- a/packages/transaction-pay-controller/src/strategy/relay/RelayStrategy.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/RelayStrategy.test.ts
@@ -109,7 +109,7 @@ describe('RelayStrategy', () => {
     expect(submitRelayQuotesMock).toHaveBeenCalledWith(executeRequest);
   });
 
-  it('prefixes execute errors with the Relay prefix without replacing the Error object', async () => {
+  it('propagates execute errors without replacing the Error object', async () => {
     const executeRequest = {
       messenger,
       quotes: [],
@@ -126,10 +126,10 @@ describe('RelayStrategy', () => {
       .catch((caught) => caught);
 
     expect(thrown).toBe(error);
-    expect(thrown.message).toBe('Relay: Insufficient liquidity');
+    expect(thrown.message).toBe('Insufficient liquidity');
   });
 
-  it('does not duplicate the Relay prefix for nested Relay errors', async () => {
+  it('propagates Relay-prefixed execute errors from submitRelayQuotes', async () => {
     const executeRequest = {
       messenger,
       quotes: [],
@@ -145,39 +145,6 @@ describe('RelayStrategy', () => {
 
     await expect(strategy.execute(executeRequest)).rejects.toThrow(
       'Relay: Execute: 422 - Insufficient liquidity',
-    );
-  });
-
-  it('wraps non-Error throws with the Relay submit prefix', async () => {
-    const executeRequest = {
-      messenger,
-      quotes: [],
-      transaction: request.transaction,
-      isSmartTransaction: jest.fn(),
-    } as PayStrategyExecuteRequest<RelayQuote>;
-
-    submitRelayQuotesMock.mockRejectedValue('boom');
-
-    const strategy = new RelayStrategy();
-    await expect(strategy.execute(executeRequest)).rejects.toThrow(
-      'Relay: boom',
-    );
-  });
-
-  it('throws if Relay submission returns no transaction hash', async () => {
-    const executeRequest = {
-      messenger,
-      quotes: [],
-      transaction: request.transaction,
-      isSmartTransaction: jest.fn(),
-    } as PayStrategyExecuteRequest<RelayQuote>;
-
-    submitRelayQuotesMock.mockResolvedValue({ transactionHash: undefined });
-
-    const strategy = new RelayStrategy();
-
-    await expect(strategy.execute(executeRequest)).rejects.toThrow(
-      'Relay: Missing transaction hash',
     );
   });
 });

--- a/packages/transaction-pay-controller/src/strategy/relay/RelayStrategy.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/RelayStrategy.ts
@@ -4,10 +4,13 @@ import type {
   PayStrategyGetQuotesRequest,
   TransactionPayQuote,
 } from '../../types';
+import { prefixError } from '../../utils/error-prefix';
 import { getPayStrategiesConfig } from '../../utils/feature-flags';
 import { getRelayQuotes } from './relay-quotes';
 import { submitRelayQuotes } from './relay-submit';
 import type { RelayQuote } from './types';
+
+const ERROR_PREFIX = 'Relay: ';
 
 export class RelayStrategy implements PayStrategy<RelayQuote> {
   supports(request: PayStrategyGetQuotesRequest): boolean {
@@ -25,10 +28,15 @@ export class RelayStrategy implements PayStrategy<RelayQuote> {
     request: PayStrategyExecuteRequest<RelayQuote>,
   ): ReturnType<PayStrategy<RelayQuote>['execute']> {
     try {
-      return await submitRelayQuotes(request);
+      const result = await submitRelayQuotes(request);
+
+      if (result.transactionHash === undefined) {
+        throw new Error('Missing transaction hash for Relay submission');
+      }
+
+      return result;
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      throw new Error(`Relay submit: ${message}`);
+      throw prefixError(error, ERROR_PREFIX);
     }
   }
 }

--- a/packages/transaction-pay-controller/src/strategy/relay/RelayStrategy.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/RelayStrategy.ts
@@ -31,7 +31,7 @@ export class RelayStrategy implements PayStrategy<RelayQuote> {
       const result = await submitRelayQuotes(request);
 
       if (result.transactionHash === undefined) {
-        throw new Error('Missing transaction hash for Relay submission');
+        throw new Error('Missing transaction hash');
       }
 
       return result;

--- a/packages/transaction-pay-controller/src/strategy/relay/RelayStrategy.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/RelayStrategy.ts
@@ -4,13 +4,10 @@ import type {
   PayStrategyGetQuotesRequest,
   TransactionPayQuote,
 } from '../../types';
-import { prefixError } from '../../utils/error-prefix';
 import { getPayStrategiesConfig } from '../../utils/feature-flags';
 import { getRelayQuotes } from './relay-quotes';
 import { submitRelayQuotes } from './relay-submit';
 import type { RelayQuote } from './types';
-
-const ERROR_PREFIX = 'Relay: ';
 
 export class RelayStrategy implements PayStrategy<RelayQuote> {
   supports(request: PayStrategyGetQuotesRequest): boolean {
@@ -27,16 +24,6 @@ export class RelayStrategy implements PayStrategy<RelayQuote> {
   async execute(
     request: PayStrategyExecuteRequest<RelayQuote>,
   ): ReturnType<PayStrategy<RelayQuote>['execute']> {
-    try {
-      const result = await submitRelayQuotes(request);
-
-      if (result.transactionHash === undefined) {
-        throw new Error('Missing transaction hash');
-      }
-
-      return result;
-    } catch (error) {
-      throw prefixError(error, ERROR_PREFIX);
-    }
+    return await submitRelayQuotes(request);
   }
 }

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-submit.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-submit.test.ts
@@ -1759,7 +1759,7 @@ describe('Relay Submit Utils', () => {
         } as Response);
 
         await expect(submitRelayQuotes(request)).rejects.toThrow(
-          'Relay execute: 422 - failed to decode param in array[0] invalid JSON input',
+          'Relay: Execute: 422 - failed to decode param in array[0] invalid JSON input',
         );
       });
 
@@ -1768,7 +1768,7 @@ describe('Relay Submit Utils', () => {
         successfulFetchMock.mockRejectedValueOnce('network down');
 
         await expect(submitRelayQuotes(request)).rejects.toThrow(
-          'Relay execute: network down',
+          'Relay: Execute: network down',
         );
       });
 

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-submit.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-submit.test.ts
@@ -627,11 +627,11 @@ describe('Relay Submit Utils', () => {
 
       const result = await submitRelayQuotes(request);
 
-      expect(result.transactionHash).toBe(TRANSACTION_HASH_MOCK);
+      expect(result.transactionHash).toBe('0x0');
       expect(successfulFetchMock).toHaveBeenCalledTimes(0);
     });
 
-    it('returns submitted hash if same-chain polling returns no target hash', async () => {
+    it('returns fallback hash if same-chain polling returns no target hash', async () => {
       request.quotes[0].original.details.currencyOut.currency.chainId = 1;
       request.quotes[0].original.steps = [
         {
@@ -649,7 +649,7 @@ describe('Relay Submit Utils', () => {
 
       const result = await submitRelayQuotes(request);
 
-      expect(result.transactionHash).toBe(TRANSACTION_HASH_MOCK);
+      expect(result.transactionHash).toBe('0x0');
     });
 
     it('waits for relay status if same chain with single deposit step', async () => {

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-submit.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-submit.test.ts
@@ -206,6 +206,14 @@ describe('Relay Submit Utils', () => {
   });
 
   describe('submitRelayQuotes', () => {
+    it('throws if there are no Relay quotes to submit', async () => {
+      request.quotes = [];
+
+      await expect(submitRelayQuotes(request)).rejects.toThrow(
+        'No quotes to submit',
+      );
+    });
+
     it('adds transaction', async () => {
       await submitRelayQuotes(request);
 
@@ -689,6 +697,22 @@ describe('Relay Submit Utils', () => {
 
       await expect(submitRelayQuotes(request)).rejects.toThrow(
         'addTransaction boom',
+      );
+    });
+
+    it('throws if no Relay child transactions are collected', async () => {
+      collectTransactionIdsMock.mockReturnValue({ end: jest.fn() });
+
+      await expect(submitRelayQuotes(request)).rejects.toThrow(
+        'No transactions submitted',
+      );
+    });
+
+    it('throws if the confirmed Relay child transaction has no hash', async () => {
+      getTransactionMock.mockReturnValue({} as TransactionMeta);
+
+      await expect(submitRelayQuotes(request)).rejects.toThrow(
+        'Missing transaction hash',
       );
     });
 

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-submit.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-submit.test.ts
@@ -210,7 +210,7 @@ describe('Relay Submit Utils', () => {
       request.quotes = [];
 
       await expect(submitRelayQuotes(request)).rejects.toThrow(
-        'No quotes to submit',
+        'Relay: No quotes to submit',
       );
     });
 
@@ -609,7 +609,7 @@ describe('Relay Submit Utils', () => {
       request.quotes[0].original.steps[0].kind = 'unsupported' as never;
 
       await expect(submitRelayQuotes(request)).rejects.toThrow(
-        'Unsupported step kind: unsupported',
+        'Relay: Unsupported step kind: unsupported',
       );
     });
 
@@ -686,7 +686,7 @@ describe('Relay Submit Utils', () => {
       );
 
       await expect(submitRelayQuotes(request)).rejects.toThrow(
-        'Transaction failed',
+        'Relay: Transaction failed',
       );
     });
 
@@ -696,7 +696,7 @@ describe('Relay Submit Utils', () => {
       );
 
       await expect(submitRelayQuotes(request)).rejects.toThrow(
-        'addTransaction boom',
+        'Relay: addTransaction boom',
       );
     });
 
@@ -704,7 +704,7 @@ describe('Relay Submit Utils', () => {
       collectTransactionIdsMock.mockReturnValue({ end: jest.fn() });
 
       await expect(submitRelayQuotes(request)).rejects.toThrow(
-        'No transactions submitted',
+        'Relay: No transactions submitted',
       );
     });
 
@@ -712,7 +712,7 @@ describe('Relay Submit Utils', () => {
       getTransactionMock.mockReturnValue({} as TransactionMeta);
 
       await expect(submitRelayQuotes(request)).rejects.toThrow(
-        'Missing transaction hash',
+        'Relay: Missing transaction hash',
       );
     });
 
@@ -725,7 +725,7 @@ describe('Relay Submit Utils', () => {
         } as Response);
 
         await expect(submitRelayQuotes(request)).rejects.toThrow(
-          `Request failed with status: ${status}`,
+          `Relay: Request failed with status: ${status}`,
         );
       },
     );
@@ -737,7 +737,7 @@ describe('Relay Submit Utils', () => {
       } as Response);
 
       await expect(submitRelayQuotes(request)).rejects.toThrow(
-        'Unrecognized status: unknown_status',
+        'Relay: Unrecognized status: unknown_status',
       );
     });
 
@@ -792,7 +792,7 @@ describe('Relay Submit Utils', () => {
         });
 
       await expect(submitRelayQuotes(request)).rejects.toThrow(
-        'Relay polling timed out',
+        'Relay: Polling timed out',
       );
     });
 
@@ -814,7 +814,7 @@ describe('Relay Submit Utils', () => {
         });
 
       await expect(submitRelayQuotes(request)).rejects.toThrow(
-        'Relay polling timed out (last status: pending)',
+        'Relay: Polling timed out (last status: pending)',
       );
     });
 
@@ -1415,7 +1415,7 @@ describe('Relay Submit Utils', () => {
       getLiveTokenBalanceMock.mockResolvedValue('500000');
 
       await expect(submitRelayQuotes(request)).rejects.toThrow(
-        'Insufficient source token balance for relay deposit. Required: 1000000, Available: 500000',
+        'Relay: Insufficient source token balance for relay deposit. Required: 1000000, Available: 500000',
       );
 
       expect(addTransactionMock).not.toHaveBeenCalled();
@@ -1429,7 +1429,7 @@ describe('Relay Submit Utils', () => {
       getLiveTokenBalanceMock.mockResolvedValue('500000');
 
       await expect(submitRelayQuotes(request)).rejects.toThrow(
-        'Insufficient source token balance for relay deposit. Required: 1000000, Available: 500000',
+        'Relay: Insufficient source token balance for relay deposit. Required: 1000000, Available: 500000',
       );
 
       expect(addTransactionBatchMock).not.toHaveBeenCalled();
@@ -1439,7 +1439,7 @@ describe('Relay Submit Utils', () => {
       getLiveTokenBalanceMock.mockResolvedValue('0');
 
       await expect(submitRelayQuotes(request)).rejects.toThrow(
-        'Insufficient source token balance for relay deposit. Required: 1000000, Available: 0',
+        'Relay: Insufficient source token balance for relay deposit. Required: 1000000, Available: 0',
       );
 
       expect(addTransactionMock).not.toHaveBeenCalled();
@@ -1465,7 +1465,7 @@ describe('Relay Submit Utils', () => {
       getLiveTokenBalanceMock.mockRejectedValue(new Error('RPC timeout'));
 
       await expect(submitRelayQuotes(request)).rejects.toThrow(
-        'Cannot validate payment token balance - RPC timeout',
+        'Relay: Cannot validate payment token balance - RPC timeout',
       );
     });
 
@@ -1608,7 +1608,7 @@ describe('Relay Submit Utils', () => {
         } as Response);
 
         await expect(submitRelayQuotes(request)).rejects.toThrow(
-          'Request failed with status: refund',
+          'Relay: Request failed with status: refund',
         );
         expect(sweepPolymarketDepositWallet).toHaveBeenCalledWith(
           FROM_MOCK,
@@ -1630,7 +1630,7 @@ describe('Relay Submit Utils', () => {
         } as Response);
 
         await expect(submitRelayQuotes(request)).rejects.toThrow(
-          'Request failed with status: refunded',
+          'Relay: Request failed with status: refunded',
         );
         expect(sweepPolymarketDepositWallet).toHaveBeenCalledWith(
           FROM_MOCK,
@@ -1648,7 +1648,7 @@ describe('Relay Submit Utils', () => {
         } as Response);
 
         await expect(submitRelayQuotes(request)).rejects.toThrow(
-          'Request failed with status: timeout',
+          'Relay: Request failed with status: timeout',
         );
         expect(sweepPolymarketDepositWallet).toHaveBeenCalledWith(
           FROM_MOCK,

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-submit.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-submit.test.ts
@@ -625,9 +625,31 @@ describe('Relay Submit Utils', () => {
     it('does not wait for relay status if same chain', async () => {
       request.quotes[0].original.details.currencyOut.currency.chainId = 1;
 
-      await submitRelayQuotes(request);
+      const result = await submitRelayQuotes(request);
 
+      expect(result.transactionHash).toBe(TRANSACTION_HASH_MOCK);
       expect(successfulFetchMock).toHaveBeenCalledTimes(0);
+    });
+
+    it('returns submitted hash if same-chain polling returns no target hash', async () => {
+      request.quotes[0].original.details.currencyOut.currency.chainId = 1;
+      request.quotes[0].original.steps = [
+        {
+          ...request.quotes[0].original.steps[0],
+          id: 'deposit',
+        },
+      ];
+      successfulFetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          ...STATUS_RESPONSE_MOCK,
+          txHashes: [],
+        }),
+      } as Response);
+
+      const result = await submitRelayQuotes(request);
+
+      expect(result.transactionHash).toBe(TRANSACTION_HASH_MOCK);
     });
 
     it('waits for relay status if same chain with single deposit step', async () => {
@@ -679,7 +701,7 @@ describe('Relay Submit Utils', () => {
         } as Response);
 
         await expect(submitRelayQuotes(request)).rejects.toThrow(
-          `Relay request failed with status: ${status}`,
+          `Request failed with status: ${status}`,
         );
       },
     );
@@ -691,7 +713,7 @@ describe('Relay Submit Utils', () => {
       } as Response);
 
       await expect(submitRelayQuotes(request)).rejects.toThrow(
-        'Relay returned unrecognized status: unknown_status',
+        'Unrecognized status: unknown_status',
       );
     });
 
@@ -1562,7 +1584,7 @@ describe('Relay Submit Utils', () => {
         } as Response);
 
         await expect(submitRelayQuotes(request)).rejects.toThrow(
-          'Relay request failed with status: refund',
+          'Request failed with status: refund',
         );
         expect(sweepPolymarketDepositWallet).toHaveBeenCalledWith(
           FROM_MOCK,
@@ -1584,7 +1606,7 @@ describe('Relay Submit Utils', () => {
         } as Response);
 
         await expect(submitRelayQuotes(request)).rejects.toThrow(
-          'Relay request failed with status: refunded',
+          'Request failed with status: refunded',
         );
         expect(sweepPolymarketDepositWallet).toHaveBeenCalledWith(
           FROM_MOCK,
@@ -1602,7 +1624,7 @@ describe('Relay Submit Utils', () => {
         } as Response);
 
         await expect(submitRelayQuotes(request)).rejects.toThrow(
-          'Relay request failed with status: timeout',
+          'Request failed with status: timeout',
         );
         expect(sweepPolymarketDepositWallet).toHaveBeenCalledWith(
           FROM_MOCK,

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-submit.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-submit.ts
@@ -95,6 +95,11 @@ async function submitRelayQuotesInternal(
     ));
   }
 
+  /* istanbul ignore if: concrete Relay submit paths return a hash/fallback or throw. */
+  if (transactionHash === undefined) {
+    throw new Error('Missing transaction hash');
+  }
+
   return { transactionHash };
 }
 

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-submit.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-submit.ts
@@ -71,7 +71,7 @@ export async function submitRelayQuotes(
   const { quotes, messenger, transaction } = request;
 
   if (!quotes.length) {
-    throw new Error('No Relay quotes to submit');
+    throw new Error('No quotes to submit');
   }
 
   let transactionHash: Hex | undefined;
@@ -85,7 +85,7 @@ export async function submitRelayQuotes(
   }
 
   if (transactionHash === undefined) {
-    throw new Error('Missing transaction hash for Relay submission');
+    throw new Error('Missing transaction hash');
   }
 
   return { transactionHash };
@@ -120,6 +120,7 @@ async function executeSingleQuote(
   );
 
   let polymarketPreSubmitUsdceBalance = 0n;
+  let submittedHash: Hex | undefined;
 
   if (quote.request.isHyperliquidSource) {
     await submitHyperliquidWithdraw(quote, quote.request.from, messenger);
@@ -127,9 +128,10 @@ async function executeSingleQuote(
     const { sourceHash, preSubmitUsdceBalance } =
       await submitPolymarketWithdraw(quote, quote.request.from, messenger);
     polymarketPreSubmitUsdceBalance = preSubmitUsdceBalance;
+    submittedHash = sourceHash;
     setRelaySourceHash(transaction, messenger, sourceHash);
   } else {
-    await submitTransactions(quote, transaction, messenger);
+    submittedHash = await submitTransactions(quote, transaction, messenger);
   }
 
   const completion = await waitForRelayCompletion(quote.original, messenger, {
@@ -137,6 +139,7 @@ async function executeSingleQuote(
       log('Source hash received', hash);
       setRelaySourceHash(transaction, messenger, hash);
     },
+    submittedHash,
     tolerateFailure: isPolymarket,
   });
 
@@ -149,7 +152,7 @@ async function executeSingleQuote(
     });
 
     if (completion.status !== 'success') {
-      throw new Error(`Relay request failed with status: ${completion.status}`);
+      throw new Error(`Request failed with status: ${completion.status}`);
     }
   }
 
@@ -195,10 +198,11 @@ async function waitForRelayCompletion(
   messenger: TransactionPayControllerMessenger,
   options: {
     onSourceHash?: (hash: Hex) => void;
+    submittedHash?: Hex;
     tolerateFailure?: boolean;
   },
 ): Promise<RelayCompletionOutcome> {
-  const { onSourceHash, tolerateFailure } = options;
+  const { onSourceHash, submittedHash, tolerateFailure } = options;
 
   const isSameChain =
     quote.details.currencyIn.currency.chainId ===
@@ -209,7 +213,7 @@ async function waitForRelayCompletion(
 
   if (isSameChain && !isSingleDepositStep) {
     log('Skipping polling as same chain');
-    return { status: 'success', targetHash: FALLBACK_HASH };
+    return { status: 'success', targetHash: submittedHash ?? FALLBACK_HASH };
   }
 
   const { requestId } = quote.steps[0];
@@ -244,7 +248,9 @@ async function waitForRelayCompletion(
 
       if (status.status === 'success') {
         const targetHash =
-          (status.txHashes?.slice(-1)[0] as Hex) ?? FALLBACK_HASH;
+          (status.txHashes?.slice(-1)[0] as Hex | undefined) ??
+          (isSameChain ? submittedHash : undefined) ??
+          FALLBACK_HASH;
         return { status: 'success', targetHash };
       }
 
@@ -254,9 +260,9 @@ async function waitForRelayCompletion(
             log('Relay ended in failure status (tolerated)', status.status);
             return { status: status.status };
           }
-          throw new Error(`Relay request failed with status: ${status.status}`);
+          throw new Error(`Request failed with status: ${status.status}`);
         }
-        throw new Error(`Relay returned unrecognized status: ${status.status}`);
+        throw new Error(`Unrecognized status: ${status.status}`);
       }
     }
 
@@ -744,7 +750,7 @@ async function submitViaTransactionController(
   log('Added transactions', transactionIds);
 
   if (!transactionIds.length) {
-    throw new Error('No Relay transactions were submitted');
+    throw new Error('No transactions submitted');
   }
 
   if (result) {
@@ -761,7 +767,7 @@ async function submitViaTransactionController(
   const hash = getTransaction(transactionIds.slice(-1)[0], messenger)?.hash;
 
   if (!hash) {
-    throw new Error('Missing transaction hash for Relay submission');
+    throw new Error('Missing transaction hash');
   }
 
   return hash as Hex;

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-submit.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-submit.ts
@@ -84,10 +84,6 @@ export async function submitRelayQuotes(
     ));
   }
 
-  if (transactionHash === undefined) {
-    throw new Error('Missing transaction hash');
-  }
-
   return { transactionHash };
 }
 

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-submit.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-submit.ts
@@ -120,7 +120,6 @@ async function executeSingleQuote(
   );
 
   let polymarketPreSubmitUsdceBalance = 0n;
-  let submittedHash: Hex | undefined;
 
   if (quote.request.isHyperliquidSource) {
     await submitHyperliquidWithdraw(quote, quote.request.from, messenger);
@@ -128,10 +127,9 @@ async function executeSingleQuote(
     const { sourceHash, preSubmitUsdceBalance } =
       await submitPolymarketWithdraw(quote, quote.request.from, messenger);
     polymarketPreSubmitUsdceBalance = preSubmitUsdceBalance;
-    submittedHash = sourceHash;
     setRelaySourceHash(transaction, messenger, sourceHash);
   } else {
-    submittedHash = await submitTransactions(quote, transaction, messenger);
+    await submitTransactions(quote, transaction, messenger);
   }
 
   const completion = await waitForRelayCompletion(quote.original, messenger, {
@@ -139,7 +137,6 @@ async function executeSingleQuote(
       log('Source hash received', hash);
       setRelaySourceHash(transaction, messenger, hash);
     },
-    submittedHash,
     tolerateFailure: isPolymarket,
   });
 
@@ -198,11 +195,10 @@ async function waitForRelayCompletion(
   messenger: TransactionPayControllerMessenger,
   options: {
     onSourceHash?: (hash: Hex) => void;
-    submittedHash?: Hex;
     tolerateFailure?: boolean;
   },
 ): Promise<RelayCompletionOutcome> {
-  const { onSourceHash, submittedHash, tolerateFailure } = options;
+  const { onSourceHash, tolerateFailure } = options;
 
   const isSameChain =
     quote.details.currencyIn.currency.chainId ===
@@ -213,7 +209,7 @@ async function waitForRelayCompletion(
 
   if (isSameChain && !isSingleDepositStep) {
     log('Skipping polling as same chain');
-    return { status: 'success', targetHash: submittedHash ?? FALLBACK_HASH };
+    return { status: 'success', targetHash: FALLBACK_HASH };
   }
 
   const { requestId } = quote.steps[0];
@@ -248,9 +244,7 @@ async function waitForRelayCompletion(
 
       if (status.status === 'success') {
         const targetHash =
-          (status.txHashes?.slice(-1)[0] as Hex | undefined) ??
-          (isSameChain ? submittedHash : undefined) ??
-          FALLBACK_HASH;
+          (status.txHashes?.slice(-1)[0] as Hex | undefined) ?? FALLBACK_HASH;
         return { status: 'success', targetHash };
       }
 

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-submit.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-submit.ts
@@ -15,6 +15,7 @@ import type {
   TransactionPayControllerMessenger,
   TransactionPayQuote,
 } from '../../types';
+import { prefixError } from '../../utils/error-prefix';
 import {
   getFeatureFlags,
   getRelayPollingInterval,
@@ -54,6 +55,7 @@ import type {
 const FALLBACK_HASH = '0x0' as Hex;
 
 const log = createModuleLogger(projectLogger, 'relay-strategy');
+const RELAY_EXECUTE_ERROR_PREFIX = 'Relay: Execute: ';
 
 /**
  * Submits Relay quotes.
@@ -68,6 +70,10 @@ export async function submitRelayQuotes(
 
   const { quotes, messenger, transaction } = request;
 
+  if (!quotes.length) {
+    throw new Error('No Relay quotes to submit');
+  }
+
   let transactionHash: Hex | undefined;
 
   for (const quote of quotes) {
@@ -76,6 +82,10 @@ export async function submitRelayQuotes(
       messenger,
       transaction,
     ));
+  }
+
+  if (transactionHash === undefined) {
+    throw new Error('Missing transaction hash for Relay submission');
   }
 
   return { transactionHash };
@@ -575,8 +585,7 @@ async function submitViaRelayExecute(
   try {
     result = await submitRelayExecute(messenger, executeBody);
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`Relay execute: ${message}`);
+    throw prefixError(error, RELAY_EXECUTE_ERROR_PREFIX);
   }
 
   log('Relay execute response', result);
@@ -734,6 +743,10 @@ async function submitViaTransactionController(
 
   log('Added transactions', transactionIds);
 
+  if (!transactionIds.length) {
+    throw new Error('No Relay transactions were submitted');
+  }
+
   if (result) {
     const txHash = await result.result;
     log('Submitted transaction', txHash);
@@ -746,6 +759,10 @@ async function submitViaTransactionController(
   log('All transactions confirmed', transactionIds);
 
   const hash = getTransaction(transactionIds.slice(-1)[0], messenger)?.hash;
+
+  if (!hash) {
+    throw new Error('Missing transaction hash for Relay submission');
+  }
 
   return hash as Hex;
 }

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-submit.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-submit.ts
@@ -55,7 +55,8 @@ import type {
 const FALLBACK_HASH = '0x0' as Hex;
 
 const log = createModuleLogger(projectLogger, 'relay-strategy');
-const RELAY_EXECUTE_ERROR_PREFIX = 'Relay: Execute: ';
+const RELAY_ERROR_PREFIX = 'Relay: ';
+const RELAY_EXECUTE_ERROR_PREFIX = 'Execute: ';
 
 /**
  * Submits Relay quotes.
@@ -64,6 +65,16 @@ const RELAY_EXECUTE_ERROR_PREFIX = 'Relay: Execute: ';
  * @returns An object containing the transaction hash if available.
  */
 export async function submitRelayQuotes(
+  request: PayStrategyExecuteRequest<RelayQuote>,
+): Promise<{ transactionHash?: Hex }> {
+  try {
+    return await submitRelayQuotesInternal(request);
+  } catch (error) {
+    throw prefixError(error, RELAY_ERROR_PREFIX);
+  }
+}
+
+async function submitRelayQuotesInternal(
   request: PayStrategyExecuteRequest<RelayQuote>,
 ): Promise<{ transactionHash?: Hex }> {
   log('Executing quotes', request);
@@ -262,7 +273,7 @@ async function waitForRelayCompletion(
         log('Relay polling timed out (tolerated)', statusDetail);
         return { status: 'timeout' };
       }
-      throw new Error(`Relay polling timed out${statusDetail}`);
+      throw new Error(`Polling timed out${statusDetail}`);
     }
 
     await new Promise((resolve) => setTimeout(resolve, pollingInterval));

--- a/packages/transaction-pay-controller/src/utils/error-prefix.test.ts
+++ b/packages/transaction-pay-controller/src/utils/error-prefix.test.ts
@@ -1,0 +1,29 @@
+import { prefixError } from './error-prefix';
+
+describe('prefixError', () => {
+  it('prefixes Error messages without replacing the Error object', () => {
+    const error = new Error('boom');
+    const { stack } = error;
+
+    const result = prefixError(error, 'Test: ');
+
+    expect(result).toBe(error);
+    expect(result.message).toBe('Test: boom');
+    expect(result.stack).toBe(stack);
+  });
+
+  it('does not duplicate prefixes', () => {
+    const error = new Error('Test: boom');
+
+    const result = prefixError(error, 'Test: ');
+
+    expect(result.message).toBe('Test: boom');
+  });
+
+  it('converts non-Error throws to prefixed Errors', () => {
+    const result = prefixError('boom', 'Test: ');
+
+    expect(result).toBeInstanceOf(Error);
+    expect(result.message).toBe('Test: boom');
+  });
+});

--- a/packages/transaction-pay-controller/src/utils/error-prefix.ts
+++ b/packages/transaction-pay-controller/src/utils/error-prefix.ts
@@ -1,0 +1,18 @@
+/**
+ * Prefix an error message while preserving the original Error object and stack.
+ *
+ * @param error - Error or thrown value to prefix.
+ * @param prefix - Prefix to prepend when missing.
+ * @returns The prefixed Error object.
+ */
+export function prefixError(error: unknown, prefix: string): Error {
+  if (error instanceof Error) {
+    if (!error.message.startsWith(prefix)) {
+      error.message = `${prefix}${error.message}`;
+    }
+
+    return error;
+  }
+
+  return new Error(`${prefix}${String(error)}`);
+}


### PR DESCRIPTION
## Explanation

Relay and Fiat submit paths should never silently complete without the transaction hash they are expected to produce. This PR makes those paths fail closed with explicit errors when required child transactions are not collected, a final submitted transaction has no hash, or Fiat is selected without an executable quote.

The publish-hook fallback remains available for non-Fiat no-quote routes that intentionally skip Pay. Fiat is treated as an explicit Pay route, so a selected Fiat payment method with no quote now throws instead of allowing raw fallback.

As supporting cleanup, submit errors now preserve the original `Error` object and stack while adding source prefixes at the Pay, Relay, Fiat, Post-Ramp, Direct mUSD, and vault batch-submission boundaries.

## References

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core MetaMask Pay publish and submit behavior for Relay/Fiat paths, including a new hard failure when Fiat is selected without quotes; incorrect edge-case handling could block legitimate payments.
> 
> **Overview**
> Relay and Fiat submit paths now **fail closed** when they would previously return without a required transaction hash—empty quote lists, no collected child transactions, or confirmed txs missing a hash all throw explicit errors. The publish hook still skips Pay when there are no quotes for non-Fiat flows, but **Fiat with a selected payment method and no quote** now errors (`Fiat: Missing quote`) instead of falling through.
> 
> Submit failures use a shared **`prefixError`** helper so layered messages (`MetaMask Pay:`, `Relay:`, `Fiat:`, `Post-Ramp:`, `Direct mUSD:`, `Vault:`, `Execute:`) are applied **in place** on the original `Error` (stack preserved); `RelayStrategy` no longer adds an extra submit wrapper. Direct mUSD post-ramp submission is refactored through `submitDirectMusdAfterFiatCompletion`, and order asset validation moves to shared `validateOrderAsset` in fiat utils.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7e9093f5d89d3c6c39da9d512c1930f25341eae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->