### PR TITLE
fix: add token_symbol_source, token_symbol_destination to Unified Swa…

### DIFF
--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Include `token_symbol_source` and `token_symbol_destination` in `getQuotesReceivedProperties` return value, derived from the active quote's asset metadata
+
 ### Added
 
 - Add optional `environment_type` property to the `ButtonClicked` unified swap/bridge event context ([#9121](https://github.com/MetaMask/core/pull/9121))
@@ -14,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `@metamask/assets-controllers` from `^109.0.0` to `^109.2.0` ([#9110](https://github.com/MetaMask/core/pull/9110), [#9202](https://github.com/MetaMask/core/pull/9202))
+- Bump `@metamask/assets-controllers` from `^109.0.0` to `^109.1.0` ([#9110](https://github.com/MetaMask/core/pull/9110))
 - Refactor selector unit tests to prepare for V2 QuoteResponse migration ([#9098](https://github.com/MetaMask/core/pull/9098))
 - Bump `@metamask/utils` from `^11.9.0` to `^11.11.0` ([#9074](https://github.com/MetaMask/core/pull/9074))
 - Bump `@metamask/assets-controller` from `^9.0.0` to `^9.0.1` ([#9083](https://github.com/MetaMask/core/pull/9083))

--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Include `token_symbol_source` and `token_symbol_destination` in `getQuotesReceivedProperties` return value, derived from the active quote's asset metadata
-
 ### Added
 
 - Add optional `environment_type` property to the `ButtonClicked` unified swap/bridge event context ([#9121](https://github.com/MetaMask/core/pull/9121))
@@ -25,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/controller-utils` from `^12.1.1` to `^12.2.0` ([#9083](https://github.com/MetaMask/core/pull/9083))
 - Bump `@metamask/transaction-controller` from `^67.1.0` to `^68.1.0` ([#9089](https://github.com/MetaMask/core/pull/9089), [#9177](https://github.com/MetaMask/core/pull/9177), [#9203](https://github.com/MetaMask/core/pull/9203))
 - Bump `@metamask/profile-sync-controller` from `^28.1.1` to `^28.2.0` ([#9119](https://github.com/MetaMask/core/pull/9119))
+
+### Fixed
+
+- Include `token_symbol_source` and `token_symbol_destination` in `getQuotesReceivedProperties` return value, derived from the active quote's asset metadata ([#9213](https://github.com/MetaMask/core/pull/9213))
 
 ## [75.1.1]
 

--- a/packages/bridge-controller/src/utils/metrics/properties.test.ts
+++ b/packages/bridge-controller/src/utils/metrics/properties.test.ts
@@ -1,7 +1,7 @@
 import { SolScope } from '@metamask/keyring-api';
 import type { CaipChainId } from '@metamask/utils';
 
-import type { QuoteResponseV1 } from '../../types';
+import type { QuoteMetadata, QuoteResponseV1 } from '../../types';
 import { getNativeAssetForChainId } from '../bridge';
 import { formatChainIdToCaip } from '../caip-formatters';
 import { MetricsSwapType } from './constants';
@@ -214,7 +214,7 @@ describe('properties', () => {
           chainId: 1,
           to: '0x789',
           from: '0xabc',
-          value: '0',
+          value: '0x0',
           data: '0x',
           gasLimit: 100000,
         },
@@ -361,8 +361,26 @@ describe('properties', () => {
   });
 
   describe('getQuotesReceivedProperties', () => {
+    const mockTokenAmount = { amount: '0', valueInCurrency: '0', usd: '0' };
+    const mockQuoteMetadata: QuoteMetadata = {
+      gasFee: {
+        effective: mockTokenAmount,
+        total: mockTokenAmount,
+        max: mockTokenAmount,
+      },
+      totalNetworkFee: mockTokenAmount,
+      totalMaxNetworkFee: mockTokenAmount,
+      toTokenAmount: mockTokenAmount,
+      minToTokenAmount: mockTokenAmount,
+      adjustedReturn: { valueInCurrency: '0', usd: '0' },
+      sentAmount: mockTokenAmount,
+      swapRate: '0',
+      cost: { valueInCurrency: '0', usd: '0' },
+    };
+
     it('should return quotes received properties correctly', () => {
-      const mockQuoteResponse: QuoteResponseV1 = {
+      const mockQuoteResponse: QuoteResponseV1 & QuoteMetadata = {
+        ...mockQuoteMetadata,
         quote: {
           requestId: 'request1',
           srcChainId: 1,
@@ -407,7 +425,7 @@ describe('properties', () => {
           chainId: 1,
           to: '0x789',
           from: '0xabc',
-          value: '0',
+          value: '0x0',
           data: '0x',
           gasLimit: 100000,
         },
@@ -441,6 +459,73 @@ describe('properties', () => {
           "warnings": [],
         }
       `);
+    });
+
+    it('should return empty source and null destination token symbols when activeQuote is null', () => {
+      const result = getQuotesReceivedProperties(null);
+
+      expect(result.token_symbol_source).toBe('');
+      expect(result.token_symbol_destination).toBeNull();
+    });
+
+    it('should derive token symbols from the active quote asset metadata', () => {
+      const mockQuoteResponse: QuoteResponseV1 & QuoteMetadata = {
+        ...mockQuoteMetadata,
+        quote: {
+          requestId: 'request1',
+          srcChainId: 1,
+          srcAsset: {
+            chainId: 1,
+            address: '0x123',
+            symbol: 'WETH',
+            name: 'Wrapped Ether',
+            decimals: 18,
+            assetId: 'eip155:1/erc20:0x123',
+          },
+          srcTokenAmount: '1000000000000000000',
+          destChainId: 1,
+          destAsset: {
+            chainId: 1,
+            address: '0x456',
+            symbol: 'DAI',
+            name: 'Dai Stablecoin',
+            decimals: 18,
+            assetId: 'eip155:1/erc20:0x456',
+          },
+          destTokenAmount: '1000000',
+          minDestTokenAmount: '950000',
+          feeData: {
+            metabridge: {
+              amount: '10000000000000000',
+              asset: {
+                chainId: 1,
+                address: '0x123',
+                symbol: 'WETH',
+                name: 'Wrapped Ether',
+                decimals: 18,
+                assetId: 'eip155:1/erc20:0x123',
+              },
+            },
+          },
+          bridgeId: 'bridge1',
+          bridges: ['bridge1'],
+          steps: [],
+        },
+        trade: {
+          chainId: 1,
+          to: '0x789',
+          from: '0xabc',
+          value: '0x0',
+          data: '0x',
+          gasLimit: 100000,
+        },
+        estimatedProcessingTimeInSeconds: 60,
+      };
+
+      const result = getQuotesReceivedProperties(mockQuoteResponse);
+
+      expect(result.token_symbol_source).toBe('WETH');
+      expect(result.token_symbol_destination).toBe('DAI');
     });
   });
 });

--- a/packages/bridge-controller/src/utils/metrics/properties.test.ts
+++ b/packages/bridge-controller/src/utils/metrics/properties.test.ts
@@ -433,6 +433,8 @@ describe('properties', () => {
           "price_impact": 0,
           "provider": "bridge1_bridge1",
           "quoted_time_minutes": 1,
+          "token_symbol_destination": "USDC",
+          "token_symbol_source": "ETH",
           "usd_balance_source": 0,
           "usd_quoted_gas": 0,
           "usd_quoted_return": 0,

--- a/packages/bridge-controller/src/utils/metrics/properties.ts
+++ b/packages/bridge-controller/src/utils/metrics/properties.ts
@@ -88,8 +88,9 @@ export const formatProviderLabel = ({
  * @param tokenSecurityTypeDestination - The security classification of the destination token,
  * supplied by the client (e.g. from token security/scanning data). Pass `null` when no
  * security data is available for the selected destination token.
- * @returns The analytics request params derived from the quote request, minus token symbols
- * which the caller provides separately.
+ * @returns The analytics request params derived from the quote request. Token symbols are
+ * omitted because the quote request only stores addresses; use
+ * {@link getQuotesReceivedProperties} when building a `QuotesReceived` payload.
  */
 export const getRequestParams = (
   {
@@ -178,6 +179,8 @@ export const getQuotesReceivedProperties = (
       ? formatProviderLabel(recommendedQuote.quote)
       : provider,
     provider,
+    token_symbol_source: activeQuote?.quote.srcAsset.symbol ?? '',
+    token_symbol_destination: activeQuote?.quote.destAsset.symbol ?? null,
     warnings,
     price_impact: Number(activeQuote?.quote.priceData?.priceImpact ?? 0),
     ...(hasSufficientGasForQuote !== undefined && {

--- a/packages/bridge-controller/src/utils/metrics/types.ts
+++ b/packages/bridge-controller/src/utils/metrics/types.ts
@@ -142,14 +142,15 @@ type RequiredEventContextFromClientBase = {
     token_symbol_destination: RequestParams['token_symbol_destination'];
     token_security_type_destination: RequestParams['token_security_type_destination'];
   };
-  [UnifiedSwapBridgeEventName.QuotesReceived]: TradeData & {
-    warnings: QuoteWarning[];
-    best_quote_provider: QuoteFetchData['best_quote_provider'];
-    price_impact: QuoteFetchData['price_impact'];
-    can_submit: QuoteFetchData['can_submit'];
-    usd_balance_source?: number;
-    has_sufficient_gas_for_quote?: boolean | null;
-  };
+  [UnifiedSwapBridgeEventName.QuotesReceived]: TradeData &
+    Pick<RequestParams, 'token_symbol_source' | 'token_symbol_destination'> & {
+      warnings: QuoteWarning[];
+      best_quote_provider: QuoteFetchData['best_quote_provider'];
+      price_impact: QuoteFetchData['price_impact'];
+      can_submit: QuoteFetchData['can_submit'];
+      usd_balance_source?: number;
+      has_sufficient_gas_for_quote?: boolean | null;
+    };
   [UnifiedSwapBridgeEventName.QuotesError]: Pick<
     RequestMetadata,
     'stx_enabled'

--- a/packages/bridge-status-controller/src/__snapshots__/bridge-status-controller.test.ts.snap
+++ b/packages/bridge-status-controller/src/__snapshots__/bridge-status-controller.test.ts.snap
@@ -1282,6 +1282,8 @@ exports[`BridgeStatusController submitTx: EVM bridge should handle smart transac
       "price_impact": 0,
       "provider": "lifi_across",
       "quoted_time_minutes": 0.25,
+      "token_symbol_destination": "ETH",
+      "token_symbol_source": "ETH",
       "usd_balance_source": 0,
       "usd_quoted_gas": 2.5778,
       "usd_quoted_return": 0.134214,


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

The `Unified SwapBridge Quotes Received` analytics event is expected to include `token_symbol_source` and `token_symbol_destination` as part of `RequestParams`, but clients building the event payload via `getQuotesReceivedProperties` were not getting those fields. The helper only returned quote/trade-specific properties (gas, provider, warnings, etc.).

`getQuotesReceivedProperties` now derives token symbols from the active quote's asset metadata (`activeQuote.quote.srcAsset.symbol` and `activeQuote.quote.destAsset.symbol`). When no active quote is available (e.g. polling stopped while quotes are still loading), fallbacks match `RequestParams`: `''` for source and `null` for destination.

`RequiredEventContextFromClient` for `QuotesReceived` is updated to include the symbol fields so the client context type aligns with the full event payload. The `getRequestParams` JSDoc is updated to point callers to `getQuotesReceivedProperties` for symbols, since the quote request only stores addresses.

No dependency upgrades in this PR.

Extension

<img width="853" height="941" alt="Screenshot 2026-06-19 at 12 06 35 PM" src="https://github.com/user-attachments/assets/9c6067b5-fbc3-457a-8472-33cecf971283" />

Mobile

<img width="1539" height="811" alt="Screenshot 2026-06-17 at 1 23 28 PM" src="https://github.com/user-attachments/assets/22ff0021-c8c7-47ae-a029-7e5d058564ec" />


## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Fixes [SWAPS-4538](https://consensyssoftware.atlassian.net/browse/SWAPS-4538)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


[SWAPS-4538]: https://consensyssoftware.atlassian.net/browse/SWAPS-4538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only payload fix in bridge metrics helpers; no transaction or auth logic changes.
> 
> **Overview**
> Fixes **Unified SwapBridge Quotes Received** analytics so `token_symbol_source` and `token_symbol_destination` are included when clients build the event via `getQuotesReceivedProperties`.
> 
> `getQuotesReceivedProperties` now sets those fields from the active quote’s `srcAsset` / `destAsset` symbols (`''` and `null` when there is no active quote). The `QuotesReceived` event context type is updated to require the symbol fields, and `getRequestParams` docs point callers at `getQuotesReceivedProperties` for symbols. Tests and a bridge-status-controller snapshot reflect the new payload shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1137f3eb5f2cd17a72417f903c302a7dfd75857. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->