### PR TITLE
fix(transaction-pay-controller): inherit isGasFeeSponsored for same-chain relay transactions

### DIFF
--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Require EIP-7702 for direct mUSD vault deposits and ensure transaction ID collection always stops after the batch attempt ([#9240](https://github.com/MetaMask/core/pull/9240))
+- Inherit `isGasFeeSponsored` from the parent transaction into same-chain Relay source-network fees and submission options ([#9216](https://github.com/MetaMask/core/pull/9216))
 
 ## [23.14.0]
 
@@ -37,6 +38,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/gas-fee-controller` from `^26.2.2` to `^26.2.3` ([#9218](https://github.com/MetaMask/core/pull/9218))
 - Bump `@metamask/network-controller` from `^32.0.0` to `^33.0.0` ([#9218](https://github.com/MetaMask/core/pull/9218))
 - Bump `@metamask/transaction-controller` from `^68.1.0` to `^68.1.1` ([#9218](https://github.com/MetaMask/core/pull/9218))
+
+### Fixed
+
+- Inherit `isGasFeeSponsored` from the parent transaction into same-chain Relay source-network fees and submission options ([#9216](https://github.com/MetaMask/core/pull/9216))
 
 ## [23.13.0]
 

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -39,10 +39,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/network-controller` from `^32.0.0` to `^33.0.0` ([#9218](https://github.com/MetaMask/core/pull/9218))
 - Bump `@metamask/transaction-controller` from `^68.1.0` to `^68.1.1` ([#9218](https://github.com/MetaMask/core/pull/9218))
 
-### Fixed
-
-- Inherit `isGasFeeSponsored` from the parent transaction into same-chain Relay source-network fees and submission options ([#9216](https://github.com/MetaMask/core/pull/9216))
-
 ## [23.13.0]
 
 ### Changed

--- a/packages/transaction-pay-controller/src/strategy/fiat/fiat-direct-musd.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/fiat-direct-musd.test.ts
@@ -390,6 +390,7 @@ describe('fiat-direct-musd', () => {
           networkClientId: NETWORK_CLIENT_ID_MOCK,
           origin: 'metamask',
           requireApproval: false,
+          skipInitialGasEstimate: true,
           transactions: [
             {
               params: { data: '0xnewApprove', to: '0xapprove', value: '0x0' },

--- a/packages/transaction-pay-controller/src/strategy/fiat/fiat-direct-musd.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/fiat-direct-musd.ts
@@ -294,6 +294,7 @@ export async function submitDirectMusdVaultDeposit({
       networkClientId,
       origin: ORIGIN_METAMASK,
       requireApproval: false,
+      skipInitialGasEstimate: true,
       transactions: nestedTransactions.map((nestedTransaction, index) => ({
         params: {
           data: nestedTransaction.data,

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.test.ts
@@ -2529,6 +2529,64 @@ describe('Relay Quotes Utils', () => {
         );
       });
 
+      it('zeroes source network fees and gas limits when parent sponsorship applies', async () => {
+        successfulFetchMock.mockResolvedValue({
+          ok: true,
+          json: async () => QUOTE_MOCK,
+        } as never);
+
+        const result = await getRelayQuotes({
+          accountSupports7702: true,
+          messenger,
+          requests: [
+            {
+              ...QUOTE_REQUEST_MOCK,
+              targetChainId: QUOTE_REQUEST_MOCK.sourceChainId,
+            },
+          ],
+          transaction: {
+            ...TRANSACTION_META_MOCK,
+            chainId: QUOTE_REQUEST_MOCK.sourceChainId,
+            isGasFeeSponsored: true,
+          },
+        });
+
+        const zeroAmount = { fiat: '0', human: '0', raw: '0', usd: '0' };
+
+        expect(result[0].fees.sourceNetwork.estimate).toStrictEqual(zeroAmount);
+        expect(result[0].fees.sourceNetwork.max).toStrictEqual(zeroAmount);
+        expect(result[0].original.metamask.gasLimits).toStrictEqual([0]);
+      });
+
+      it('does not zero source network fees when parent sponsorship is missing', async () => {
+        successfulFetchMock.mockResolvedValue({
+          ok: true,
+          json: async () => QUOTE_MOCK,
+        } as never);
+
+        const result = await getRelayQuotes({
+          accountSupports7702: true,
+          messenger,
+          requests: [
+            {
+              ...QUOTE_REQUEST_MOCK,
+              targetChainId: QUOTE_REQUEST_MOCK.sourceChainId,
+            },
+          ],
+          transaction: {
+            ...TRANSACTION_META_MOCK,
+            chainId: QUOTE_REQUEST_MOCK.sourceChainId,
+          },
+        });
+
+        expect(result[0].fees.sourceNetwork.estimate).toStrictEqual({
+          fiat: '4.56',
+          human: '1.725',
+          raw: '1725000000000000',
+          usd: '3.45',
+        });
+      });
+
       it('using gas total from multiple transactions', async () => {
         const quoteMock = cloneDeep(QUOTE_MOCK);
 

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.ts
@@ -75,6 +75,16 @@ const POST_QUOTE_GAS_BUFFER = 1.1;
 
 // Hardcoded gas allowance for the prepended payment override transaction(s).
 const PAYMENT_OVERRIDE_GAS = 75_000;
+const ZERO_AMOUNT = { fiat: '0', human: '0', raw: '0', usd: '0' };
+
+type RelayStepData = RelayTransactionStep['items'][0]['data'];
+
+type RelayGasResult = {
+  totalGasEstimate: number;
+  totalGasLimit: number;
+  gasLimits: number[];
+  is7702: boolean;
+};
 
 /**
  * Fetches Relay quotes.
@@ -749,11 +759,9 @@ async function calculateSourceNetworkCost(
   if (quote.metamask?.isExecute) {
     log('Zeroing network fees for execute flow');
 
-    const zeroAmount = { fiat: '0', human: '0', raw: '0', usd: '0' };
-
     return {
-      estimate: zeroAmount,
-      max: zeroAmount,
+      estimate: ZERO_AMOUNT,
+      max: ZERO_AMOUNT,
       gasLimits: [],
       is7702: false,
     };
@@ -764,13 +772,28 @@ async function calculateSourceNetworkCost(
   if (request.isHyperliquidSource) {
     log('Zeroing network fees for HyperLiquid withdrawal (gasless)');
 
-    const zeroAmount = { fiat: '0', human: '0', raw: '0', usd: '0' };
-
     return {
-      estimate: zeroAmount,
-      max: zeroAmount,
+      estimate: ZERO_AMOUNT,
+      max: ZERO_AMOUNT,
       gasLimits: [],
       is7702: false,
+    };
+  }
+
+  if (
+    transaction.isGasFeeSponsored &&
+    request.sourceChainId === transaction.chainId &&
+    request.targetChainId === transaction.chainId
+  ) {
+    log('Zeroing source network fees for sponsored same-chain Relay route');
+
+    // Gas limit is zero as sponsored transactions go through the EIP-7702
+    // gas station hook and do not require user-paid gas.
+    return {
+      estimate: ZERO_AMOUNT,
+      max: ZERO_AMOUNT,
+      gasLimits: [0],
+      is7702: true,
     };
   }
 
@@ -1019,8 +1042,6 @@ function toRelayQuoteGasTransaction(
   };
 }
 
-type RelayStepData = RelayTransactionStep['items'][0]['data'];
-
 function getOriginalTxGasParams(
   request: QuoteRequest,
   transaction: TransactionMeta,
@@ -1057,13 +1078,6 @@ function getOriginalTxGasParams(
     value: (txParams.value as string) ?? '0',
   };
 }
-
-type RelayGasResult = {
-  totalGasEstimate: number;
-  totalGasLimit: number;
-  gasLimits: number[];
-  is7702: boolean;
-};
 
 function combinePrependedGas(
   relayOnlyGas: RelayGasResult,

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-submit.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-submit.test.ts
@@ -239,6 +239,22 @@ describe('Relay Submit Utils', () => {
       );
     });
 
+    it('passes sponsored gas options when parent sponsorship applies to same-chain quote', async () => {
+      request.transaction.chainId = CHAIN_ID_MOCK;
+      request.transaction.isGasFeeSponsored = true;
+      request.quotes[0].request.targetChainId = CHAIN_ID_MOCK;
+      request.quotes[0].original.details.currencyOut.currency.chainId = 1;
+
+      await submitRelayQuotes(request);
+
+      expect(addTransactionMock).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.objectContaining({
+          isGasFeeSponsored: true,
+        }),
+      );
+    });
+
     it('uses predictRelayDeposit type when parent transaction is predictDeposit', async () => {
       request.transaction = {
         ...request.transaction,
@@ -1176,25 +1192,6 @@ describe('Relay Submit Utils', () => {
         );
       });
 
-      it('sets gas to undefined when gasLimits entry is missing', async () => {
-        request.quotes[0].original.metamask.gasLimits = [];
-
-        await submitRelayQuotes(request);
-
-        expect(addTransactionBatchMock).toHaveBeenCalledWith(
-          expect.objectContaining({
-            transactions: expect.arrayContaining([
-              expect.objectContaining({
-                params: expect.objectContaining({
-                  gas: undefined,
-                }),
-                type: TransactionType.relayDeposit,
-              }),
-            ]),
-          }),
-        );
-      });
-
       it('does not activate 7702 mode with multiple post-quote gas limits', async () => {
         request.quotes[0].original.metamask.gasLimits = [21000, 21000];
 
@@ -1381,6 +1378,24 @@ describe('Relay Submit Utils', () => {
               }),
             }),
           ],
+        }),
+      );
+    });
+
+    it('passes sponsored gas options to same-chain batch submissions', async () => {
+      request.transaction.chainId = CHAIN_ID_MOCK;
+      request.transaction.isGasFeeSponsored = true;
+      request.quotes[0].request.targetChainId = CHAIN_ID_MOCK;
+      request.quotes[0].original.details.currencyOut.currency.chainId = 1;
+      request.quotes[0].original.steps[0].items.push({
+        ...request.quotes[0].original.steps[0].items[0],
+      });
+
+      await submitRelayQuotes(request);
+
+      expect(addTransactionBatchMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isGasFeeSponsored: true,
         }),
       );
     });

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-submit.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-submit.ts
@@ -661,9 +661,15 @@ async function submitViaTransactionController(
 
   let result: { result: Promise<string> } | undefined;
 
-  const gasFeeToken = quote.fees.isSourceGasFeeToken
-    ? sourceTokenAddress
-    : undefined;
+  const isSourceGasFeeSponsored =
+    transaction.isGasFeeSponsored &&
+    quote.request.sourceChainId === transaction.chainId &&
+    quote.request.targetChainId === transaction.chainId;
+
+  const gasFeeToken =
+    !isSourceGasFeeSponsored && quote.fees.isSourceGasFeeToken
+      ? sourceTokenAddress
+      : undefined;
 
   log('Submitting transactions', {
     isPostQuote,
@@ -701,6 +707,7 @@ async function submitViaTransactionController(
         networkClientId,
         origin: ORIGIN_METAMASK,
         isInternal: true,
+        isGasFeeSponsored: isSourceGasFeeSponsored,
         requireApproval: false,
         type: getRelayDepositType(getEffectiveTransactionType(transaction)),
       },
@@ -745,6 +752,7 @@ async function submitViaTransactionController(
       networkClientId,
       origin: ORIGIN_METAMASK,
       isInternal: true,
+      isGasFeeSponsored: isSourceGasFeeSponsored,
       overwriteUpgrade: true,
       requireApproval: false,
       transactions,


### PR DESCRIPTION
## Explanation

When a parent transaction has `isGasFeeSponsored: true` and the Relay quote is same-chain (source and target chain match the parent), the TPC was not carrying that sponsorship through to either the source-network fee display or the submission options passed to `TransactionController`.

This PR fixes that in two places:

- **Quote time** (`calculateSourceNetworkCost`): same-chain sponsored routes now early-return with zeroed fees and `gasLimits: [0], is7702: true`, skipping the full gas estimation. Sponsored transactions go through the EIP-7702 gas station hook so user-paid gas is not needed.
- **Submit time** (`submitViaTransactionController`): `isGasFeeSponsored` is now derived from the parent transaction and passed directly into both `addTransaction` and `addTransactionBatch` options, and `gasFeeToken` is suppressed when sponsored.

Additionally, `skipInitialGasEstimate: true` is added to direct mUSD vault deposit submissions, which follow the same sponsored path.

## References

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes gas fee display and TransactionController options for sponsored same-chain Relay and mUSD paths; wrong gating could mis-price fees or submit without sponsorship.
> 
> **Overview**
> When the parent transaction is **`isGasFeeSponsored`** and the Relay route is **same-chain** (source/target match the parent chain), sponsorship now flows through quoting and submission instead of treating Relay like a user-paid gas path.
> 
> At **quote time**, `calculateSourceNetworkCost` short-circuits to zero source-network fees and **`gasLimits: [0]`** with **`is7702: true`**, skipping full gas estimation (aligned with EIP-7702 gas-station handling). At **submit time**, the same condition sets **`isGasFeeSponsored`** on both **`addTransaction`** and **`addTransactionBatch`**, and **`gasFeeToken`** is not used when sponsored.
> 
> Direct **mUSD vault** batch deposits also pass **`skipInitialGasEstimate: true`** alongside existing sponsored batch options. Changelog and tests cover the sponsored vs non-sponsored same-chain cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 053da4a40adda236f619e8ec0ca0fee06feb8fb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->