### PR TITLE
feat(perps): introduce perps charts tracking

### DIFF
--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add an optional, protocol-agnostic `fallbackPriceDeviationLimit` to `PerpsControllerConfig` so clients can tune the deviation threshold; each provider applies its own default when omitted.
   - Export the pure `isMarketTradable` helper and add `HYPERLIQUID_CONFIG.OraclePriceDeviationLimit` (`0.95`, the HyperLiquid default).
 - Add Perps Advanced Chart analytics constants to `PERPS_EVENT_PROPERTY` and `PERPS_EVENT_VALUE` so mobile can import chart instrumentation keys from `@metamask/perps-controller` instead of maintaining a local mirror ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
-  - New `PERPS_EVENT_PROPERTY` keys: `CHART_LIBRARY`, `CHART_LOAD_LATENCY_MS`, `ASSET_TYPE`
+  - New `PERPS_EVENT_PROPERTY` keys: `CHART_LIBRARY`, `ASSET_TYPE`
   - New `PERPS_EVENT_VALUE.CHART_LIBRARY` group: `lightweight`, `advanced`
   - New `PERPS_EVENT_VALUE.ASSET_TYPE` group: `spot`, `perp`
 

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -38,6 +38,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add an `isTradable` boolean to `PriceUpdate` that defaults to `true`. It is `false` when a market's mid price has drifted past the protocol's oracle-deviation limit (HyperLiquid rejects orders more than 95% away from the reference price, which most often affects HIP-3 markets); a provider with no such rule, or that cannot yet assess tradability, reports `true`.
   - Add an optional, protocol-agnostic `fallbackPriceDeviationLimit` to `PerpsControllerConfig` so clients can tune the deviation threshold; each provider applies its own default when omitted.
   - Export the pure `isMarketTradable` helper and add `HYPERLIQUID_CONFIG.OraclePriceDeviationLimit` (`0.95`, the HyperLiquid default).
+- Add Perps Advanced Chart analytics constants to `PERPS_EVENT_PROPERTY` and `PERPS_EVENT_VALUE` so mobile can import chart instrumentation keys from `@metamask/perps-controller` instead of maintaining a local mirror ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
+  - New `PERPS_EVENT_PROPERTY` keys: `CHART_LIBRARY`, `CHART_LOAD_LATENCY_MS`, `ASSET_TYPE`
+  - New `PERPS_EVENT_VALUE.CHART_LIBRARY` group: `lightweight`, `advanced`
+  - New `PERPS_EVENT_VALUE.ASSET_TYPE` group: `spot`, `perp`
 
 ### Changed
 

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add an `isTradable` boolean to `PriceUpdate` that defaults to `true`. It is `false` when a market's mid price has drifted past the protocol's oracle-deviation limit (HyperLiquid rejects orders more than 95% away from the reference price, which most often affects HIP-3 markets); a provider with no such rule, or that cannot yet assess tradability, reports `true`.
   - Add an optional, protocol-agnostic `fallbackPriceDeviationLimit` to `PerpsControllerConfig` so clients can tune the deviation threshold; each provider applies its own default when omitted.
   - Export the pure `isMarketTradable` helper and add `HYPERLIQUID_CONFIG.OraclePriceDeviationLimit` (`0.95`, the HyperLiquid default).
+
 ### Changed
 
 - Bump `@metamask/controller-utils` from `^12.2.0` to `^12.3.0` ([#9218](https://github.com/MetaMask/core/pull/9218))

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When unauthenticated, or when the active provider is not mapped to an AUS exchange key (e.g. `'aggregated'`), the controller falls back to local-only state without surfacing errors to callers.
 - `toggleWatchlistMarket` return type changed from `void` to `Promise<void>` to allow callers to await the remote write.
 - Add `resolveWatchlistExchangeKey(activeProvider)` helper that maps a `PerpsActiveProviderMode` to the corresponding `PerpsWatchlistMarkets` exchange key, returning `null` for unsupported modes ([#9010](https://github.com/MetaMask/core/pull/9010))
+- Add Perps Advanced Chart analytics constants to `PERPS_EVENT_PROPERTY` and `PERPS_EVENT_VALUE` so mobile can import chart instrumentation keys from `@metamask/perps-controller` instead of maintaining a local mirror ([#9221](https://github.com/MetaMask/core/pull/9221))
+  - New `PERPS_EVENT_PROPERTY` keys: `CHART_LIBRARY`, `ASSET_TYPE`
+  - New `PERPS_EVENT_VALUE.CHART_LIBRARY` group: `lightweight`, `advanced`
+  - New `PERPS_EVENT_VALUE.ASSET_TYPE` group: `spot`, `perp`
 
 ### Fixed
 
@@ -38,11 +42,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add an `isTradable` boolean to `PriceUpdate` that defaults to `true`. It is `false` when a market's mid price has drifted past the protocol's oracle-deviation limit (HyperLiquid rejects orders more than 95% away from the reference price, which most often affects HIP-3 markets); a provider with no such rule, or that cannot yet assess tradability, reports `true`.
   - Add an optional, protocol-agnostic `fallbackPriceDeviationLimit` to `PerpsControllerConfig` so clients can tune the deviation threshold; each provider applies its own default when omitted.
   - Export the pure `isMarketTradable` helper and add `HYPERLIQUID_CONFIG.OraclePriceDeviationLimit` (`0.95`, the HyperLiquid default).
-- Add Perps Advanced Chart analytics constants to `PERPS_EVENT_PROPERTY` and `PERPS_EVENT_VALUE` so mobile can import chart instrumentation keys from `@metamask/perps-controller` instead of maintaining a local mirror ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
-  - New `PERPS_EVENT_PROPERTY` keys: `CHART_LIBRARY`, `ASSET_TYPE`
-  - New `PERPS_EVENT_VALUE.CHART_LIBRARY` group: `lightweight`, `advanced`
-  - New `PERPS_EVENT_VALUE.ASSET_TYPE` group: `spot`, `perp`
-
 ### Changed
 
 - Bump `@metamask/controller-utils` from `^12.2.0` to `^12.3.0` ([#9218](https://github.com/MetaMask/core/pull/9218))

--- a/packages/perps-controller/src/constants/eventNames.ts
+++ b/packages/perps-controller/src/constants/eventNames.ts
@@ -62,6 +62,9 @@ export const PERPS_EVENT_PROPERTY = {
   INTERACTION_TYPE: 'interaction_type',
   TIME_SERIE_SELECTED: 'time_serie_selected',
   CANDLE_PERIOD: 'candle_period',
+  CHART_LIBRARY: 'chart_library',
+  CHART_LOAD_LATENCY_MS: 'chart_load_latency_ms',
+  ASSET_TYPE: 'asset_type',
 
   // Risk management properties
   STOP_LOSS_PRICE: 'stop_loss_price',
@@ -193,6 +196,14 @@ export const PERPS_EVENT_VALUE = {
   ORDER_TYPE_CAPITALIZED: {
     MARKET: 'market',
     LIMIT: 'limit',
+  },
+  CHART_LIBRARY: {
+    LIGHTWEIGHT: 'lightweight',
+    ADVANCED: 'advanced',
+  },
+  ASSET_TYPE: {
+    SPOT: 'spot',
+    PERP: 'perp',
   },
   INPUT_METHOD: {
     SLIDER: 'slider',

--- a/packages/perps-controller/src/constants/eventNames.ts
+++ b/packages/perps-controller/src/constants/eventNames.ts
@@ -63,7 +63,6 @@ export const PERPS_EVENT_PROPERTY = {
   TIME_SERIE_SELECTED: 'time_serie_selected',
   CANDLE_PERIOD: 'candle_period',
   CHART_LIBRARY: 'chart_library',
-  CHART_LOAD_LATENCY_MS: 'chart_load_latency_ms',
   ASSET_TYPE: 'asset_type',
 
   // Risk management properties

--- a/packages/perps-controller/src/services/TradingService.ts
+++ b/packages/perps-controller/src/services/TradingService.ts
@@ -161,6 +161,10 @@ export class TradingService {
     if (params.trackingData?.source) {
       properties[PERPS_EVENT_PROPERTY.SOURCE] = params.trackingData.source;
     }
+    if (params.trackingData?.chartLibrary) {
+      properties[PERPS_EVENT_PROPERTY.CHART_LIBRARY] =
+        params.trackingData.chartLibrary;
+    }
     if (params.trackingData?.tradeAction) {
       properties[PERPS_EVENT_PROPERTY.ACTION] = params.trackingData.tradeAction;
     }

--- a/packages/perps-controller/src/types/index.ts
+++ b/packages/perps-controller/src/types/index.ts
@@ -159,6 +159,8 @@ export type TrackingData = {
 
   // Entry source for analytics (e.g., 'trending' for Trending page discovery)
   source?: string;
+  // Chart library active when the trade was initiated (e.g., lightweight, advanced)
+  chartLibrary?: string;
 
   // Pay with any token: true when user paid with a custom token (not Perps balance)
   tradeWithToken?: boolean;

--- a/packages/perps-controller/tests/src/constants/eventNames.test.ts
+++ b/packages/perps-controller/tests/src/constants/eventNames.test.ts
@@ -9,12 +9,6 @@ describe('PERPS_EVENT_PROPERTY', () => {
       expect(PERPS_EVENT_PROPERTY.CHART_LIBRARY).toBe('chart_library');
     });
 
-    it('exports CHART_LOAD_LATENCY_MS key', () => {
-      expect(PERPS_EVENT_PROPERTY.CHART_LOAD_LATENCY_MS).toBe(
-        'chart_load_latency_ms',
-      );
-    });
-
     it('exports ASSET_TYPE key', () => {
       expect(PERPS_EVENT_PROPERTY.ASSET_TYPE).toBe('asset_type');
     });

--- a/packages/perps-controller/tests/src/constants/eventNames.test.ts
+++ b/packages/perps-controller/tests/src/constants/eventNames.test.ts
@@ -4,6 +4,22 @@ import {
 } from '../../../src/constants/eventNames';
 
 describe('PERPS_EVENT_PROPERTY', () => {
+  describe('advanced chart analytics property keys', () => {
+    it('exports CHART_LIBRARY key', () => {
+      expect(PERPS_EVENT_PROPERTY.CHART_LIBRARY).toBe('chart_library');
+    });
+
+    it('exports CHART_LOAD_LATENCY_MS key', () => {
+      expect(PERPS_EVENT_PROPERTY.CHART_LOAD_LATENCY_MS).toBe(
+        'chart_load_latency_ms',
+      );
+    });
+
+    it('exports ASSET_TYPE key', () => {
+      expect(PERPS_EVENT_PROPERTY.ASSET_TYPE).toBe('asset_type');
+    });
+  });
+
   describe('discovery analytics property keys', () => {
     it('exports SOURCE_SECTION key', () => {
       expect(PERPS_EVENT_PROPERTY.SOURCE_SECTION).toBe('source_section');
@@ -34,6 +50,26 @@ describe('PERPS_EVENT_PROPERTY', () => {
     it('exports WATCHLIST_MARKETS key', () => {
       expect(PERPS_EVENT_PROPERTY.WATCHLIST_MARKETS).toBe('watchlist_markets');
     });
+  });
+});
+
+describe('PERPS_EVENT_VALUE.CHART_LIBRARY', () => {
+  it('exports LIGHTWEIGHT', () => {
+    expect(PERPS_EVENT_VALUE.CHART_LIBRARY.LIGHTWEIGHT).toBe('lightweight');
+  });
+
+  it('exports ADVANCED', () => {
+    expect(PERPS_EVENT_VALUE.CHART_LIBRARY.ADVANCED).toBe('advanced');
+  });
+});
+
+describe('PERPS_EVENT_VALUE.ASSET_TYPE', () => {
+  it('exports SPOT', () => {
+    expect(PERPS_EVENT_VALUE.ASSET_TYPE.SPOT).toBe('spot');
+  });
+
+  it('exports PERP', () => {
+    expect(PERPS_EVENT_VALUE.ASSET_TYPE.PERP).toBe('perp');
   });
 });
 

--- a/packages/perps-controller/tests/src/services/TradingService.test.ts
+++ b/packages/perps-controller/tests/src/services/TradingService.test.ts
@@ -323,6 +323,47 @@ describe('TradingService', () => {
       );
     });
 
+    it('includes chart_library when trackingData has chartLibrary', async () => {
+      const orderParams: OrderParams = {
+        symbol: 'BTC',
+        isBuy: true,
+        size: '0.1',
+        orderType: 'market',
+        leverage: 10,
+        trackingData: {
+          totalFee: 0,
+          marketPrice: 50000,
+          chartLibrary: PERPS_EVENT_VALUE.CHART_LIBRARY.ADVANCED,
+        },
+      };
+      const mockOrderResult: OrderResult = {
+        success: true,
+        orderId: 'order-123',
+        filledSize: '0.1',
+        averagePrice: '50000',
+      };
+
+      mockProvider.placeOrder.mockResolvedValue(mockOrderResult);
+      mockRewardsIntegrationService.calculateUserFeeDiscount.mockResolvedValue(
+        undefined,
+      );
+
+      await tradingService.placeOrder({
+        provider: mockProvider,
+        params: orderParams,
+        context: mockContext,
+        reportOrderToDataLake: mockReportOrderToDataLake,
+      });
+
+      expect(mockDeps.metrics.trackPerpsEvent).toHaveBeenCalledWith(
+        PerpsAnalyticsEvent.TradeTransaction,
+        expect.objectContaining({
+          status: 'executed',
+          chart_library: 'advanced',
+        }),
+      );
+    });
+
     it('includes mm_pay_token_selected "Perps Balance" when user uses perps balance', async () => {
       const orderParams: OrderParams = {
         symbol: 'BTC',


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->


This PR adds the chart analytics property and value constants to the Perps controller analytics exports:

- `PERPS_EVENT_PROPERTY.CHART_LIBRARY`
- `PERPS_EVENT_PROPERTY.ASSET_TYPE`
- `PERPS_EVENT_VALUE.CHART_LIBRARY.ADVANCED`
- `PERPS_EVENT_VALUE.CHART_LIBRARY.LIGHTWEIGHT`
- `PERPS_EVENT_VALUE.ASSET_TYPE.PERP`

The new constants are used by the Perps Advanced Charts migration to distinguish analytics emitted from the existing lightweight chart experience versus the new advanced chart experience.

`asset_type: perp` is included as a global analytics dimension for these chart events so Segment receives the same standardized value across Perps clients.

The related mobile changes replace local chart analytics constants with these controller exports. The related segment-schema changes ensure the emitted properties are accepted by the analytics schema.

The downstream mobile PR needs to consume the updated `@metamask/perps-controller` package so it can use these canonical analytics constants instead of local string literals.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive analytics constants and an optional trade event property; no trading, auth, or persistence behavior changes.
> 
> **Overview**
> Adds **canonical Perps advanced chart analytics keys** to `@metamask/perps-controller` so mobile can stop duplicating string literals: `PERPS_EVENT_PROPERTY.CHART_LIBRARY` / `ASSET_TYPE` and `PERPS_EVENT_VALUE` groups for chart library (`lightweight`, `advanced`) and asset type (`spot`, `perp`). Changelog documents the export for the Advanced Charts migration ([#9221](https://github.com/MetaMask/core/pull/9221)).
> 
> **Trade path:** `TrackingData` gains optional `chartLibrary`, and `TradingService` forwards it on **Perp Trade Transaction** events as `chart_library` when callers set it on order `trackingData` (e.g. trades initiated from the advanced chart). Unit tests cover the new constants and the trade analytics property.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4aa3b6769f4a59cc2e5a067a1f36a14194ae8418. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->