### PR TITLE
fix(perps-controller): add fetch timeout and prevent name downgrade in Terminal API integration

### DIFF
--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -20,8 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Replace unsafe `as` type cast with runtime schema validation (`@metamask/superstruct`) in `TerminalMarketService` ([#9137](https://github.com/MetaMask/core/pull/9137))
-  - Each item in the Terminal API response is now individually validated; items that fail validation are filtered out and logged instead of silently accepted.
 - Bump `@metamask/controller-utils` from `^12.2.0` to `^12.3.0` ([#9218](https://github.com/MetaMask/core/pull/9218))
 
 ## [8.2.0]

--- a/packages/perps-controller/src/constants/perpsConfig.ts
+++ b/packages/perps-controller/src/constants/perpsConfig.ts
@@ -336,6 +336,7 @@ export const DATA_LAKE_API_CONFIG = {
  */
 export const TERMINAL_API_CONFIG = {
   CacheTtlMs: 5 * 60 * 1000, // 5 minutes
+  FetchTimeoutMs: 10_000, // 10 seconds – degrade to provider on slow Terminal
 } as const;
 
 /**

--- a/packages/perps-controller/src/services/MarketDataService.ts
+++ b/packages/perps-controller/src/services/MarketDataService.ts
@@ -1375,7 +1375,7 @@ export class MarketDataService {
 
       return {
         ...market,
-        name: meta.name,
+        ...(meta.name !== undefined && { name: meta.name }),
         ...(meta.marketType !== undefined && { marketType: meta.marketType }),
         ...(meta.keywords !== undefined && { keywords: meta.keywords }),
         ...(meta.tags !== undefined && { tags: meta.tags }),

--- a/packages/perps-controller/src/services/TerminalMarketService.ts
+++ b/packages/perps-controller/src/services/TerminalMarketService.ts
@@ -98,10 +98,22 @@ export class TerminalMarketService {
     }
 
     const url = this.#deps.terminalApiUrl;
-    const response = await fetch(url, {
-      method: 'GET',
-      headers: { 'Content-Type': 'application/json' },
-    });
+    const controller = new AbortController();
+    const timeoutId = setTimeout(
+      () => controller.abort(new Error('Terminal API fetch timed out')),
+      TERMINAL_API_CONFIG.FetchTimeoutMs,
+    );
+
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timeoutId);
+    }
 
     if (!response.ok) {
       throw new Error(
@@ -212,9 +224,11 @@ export class TerminalMarketService {
         continue;
       }
 
-      const entry: TerminalAssetMetadata = {
-        name: item.name ?? item.symbol,
-      };
+      const entry: TerminalAssetMetadata = {};
+
+      if (typeof item.name === 'string' && item.name.length > 0) {
+        entry.name = item.name;
+      }
 
       if (Array.isArray(item.keywords) && item.keywords.length > 0) {
         entry.keywords = item.keywords;

--- a/packages/perps-controller/src/types/index.ts
+++ b/packages/perps-controller/src/types/index.ts
@@ -91,7 +91,7 @@ export type MarketType = `${MarketCategory}`;
  * Used downstream to enrich PerpsMarketData with name, keywords, tags, etc.
  */
 export type TerminalAssetMetadata = {
-  name: string;
+  name?: string;
   keywords?: string[];
   tags?: string[];
   categories?: string[];
@@ -853,7 +853,7 @@ export type GetMarketsParams = {
   dex?: string; // HyperLiquid HIP-3: DEX name (empty string '' or undefined for main DEX). Other protocols: ignored.
   skipFilters?: boolean; // Skip market filtering (both allowlist and blocklist, default: false). When true, returns all markets without filtering.
   standalone?: boolean; // Lightweight mode: skip full initialization, only fetch market metadata (no wallet/WebSocket needed). Only main DEX markets returned. Use for discovery use cases like checking if a perps market exists.
-  useTerminalApi?: boolean; // When true, force Terminal API as market data source regardless of remote feature flag.
+  useTerminalApi?: boolean; // When true, use Terminal API as market data source.
 };
 
 /**
@@ -868,7 +868,7 @@ export type GetMarketDataWithPricesParams = {
   sortBy?: SortField; // Sort results by this field
   direction?: SortDirection; // Sort direction (default: desc)
   limit?: number; // Maximum number of results to return
-  useTerminalApi?: boolean; // When true, force Terminal API as market data source regardless of remote feature flag.
+  useTerminalApi?: boolean; // When true, use Terminal API as market data source.
 };
 
 export type SubscribePricesParams = {

--- a/packages/perps-controller/tests/src/services/MarketDataService.test.ts
+++ b/packages/perps-controller/tests/src/services/MarketDataService.test.ts
@@ -1356,6 +1356,47 @@ describe('MarketDataService', () => {
         expect(result[1]?.keywords).toEqual(['defi']);
       });
 
+      it('preserves provider name when terminal metadata omits name', async () => {
+        const metadataWithoutName = new Map<string, TerminalAssetMetadata>([
+          ['BTC', { keywords: ['crypto'] }],
+          ['ETH', { name: 'Ethereum' }],
+        ]);
+        mockTerminalService.fetchMarkets.mockResolvedValue({
+          markets: terminalMarkets,
+          metadata: metadataWithoutName,
+        });
+        mockProvider.getMarketDataWithPrices.mockResolvedValue([
+          {
+            symbol: 'BTC',
+            name: 'Bitcoin',
+            maxLeverage: '50x',
+            price: '$50000.00',
+            change24h: '+$500.00',
+            change24hPercent: '+1.00%',
+            volume: '$1000000',
+          },
+          {
+            symbol: 'ETH',
+            name: 'ETH',
+            maxLeverage: '25x',
+            price: '$3000.00',
+            change24h: '+$30.00',
+            change24hPercent: '+1.00%',
+            volume: '$500000',
+          },
+        ]);
+
+        const result = await serviceWithTerminal.getMarketDataWithPrices({
+          provider: mockProvider,
+          params: { useTerminalApi: true },
+          context: mockContext,
+        });
+
+        expect(result[0]?.name).toBe('Bitcoin');
+        expect(result[0]?.keywords).toEqual(['crypto']);
+        expect(result[1]?.name).toBe('Ethereum');
+      });
+
       it('returns provider data unchanged when terminal API fails', async () => {
         mockTerminalService.fetchMarkets.mockRejectedValue(
           new Error('Network error'),

--- a/packages/perps-controller/tests/src/services/TerminalMarketService.test.ts
+++ b/packages/perps-controller/tests/src/services/TerminalMarketService.test.ts
@@ -1,3 +1,4 @@
+import { TERMINAL_API_CONFIG } from '../../../src/constants/perpsConfig';
 import { TerminalMarketService } from '../../../src/services/TerminalMarketService';
 import type { PerpsPlatformDependencies } from '../../../src/types';
 import { createMockInfrastructure } from '../../helpers/serviceMocks';
@@ -62,7 +63,10 @@ describe('TerminalMarketService', () => {
 
       expect(globalThis.fetch).toHaveBeenCalledWith(
         'https://terminal.test-api.cx.metamask.io/v1/perpetuals',
-        expect.objectContaining({ method: 'GET' }),
+        expect.objectContaining({
+          method: 'GET',
+          signal: expect.any(AbortSignal),
+        }),
       );
 
       expect(markets).toHaveLength(3);
@@ -153,6 +157,28 @@ describe('TerminalMarketService', () => {
       await expect(service.fetchMarkets()).rejects.toThrow(
         'Network request failed',
       );
+    });
+
+    it('aborts fetch when timeout elapses', async () => {
+      jest.useFakeTimers();
+
+      jest.spyOn(globalThis, 'fetch').mockImplementation(
+        (_url, init) =>
+          new Promise((_resolve, reject) => {
+            (init?.signal as AbortSignal)?.addEventListener('abort', () => {
+              const { reason } = init?.signal as AbortSignal;
+              reject(reason instanceof Error ? reason : new Error(String(reason)));
+            });
+          }),
+      );
+
+      const promise = service.fetchMarkets();
+
+      jest.advanceTimersByTime(TERMINAL_API_CONFIG.FetchTimeoutMs);
+
+      await expect(promise).rejects.toThrow('Terminal API fetch timed out');
+
+      jest.useRealTimers();
     });
 
     it('returns empty arrays for empty API response', async () => {
@@ -298,7 +324,7 @@ describe('TerminalMarketService', () => {
       });
     });
 
-    it('falls back to symbol when name is not provided in metadata', async () => {
+    it('omits name from metadata when Terminal does not supply one', async () => {
       jest.spyOn(globalThis, 'fetch').mockResolvedValue({
         ok: true,
         status: 200,
@@ -308,7 +334,7 @@ describe('TerminalMarketService', () => {
 
       const { metadata } = await service.fetchMarkets();
 
-      expect(metadata.get('UNKNOWN')?.name).toBe('UNKNOWN');
+      expect(metadata.get('UNKNOWN')?.name).toBeUndefined();
     });
   });
 

--- a/packages/perps-controller/tests/src/services/TerminalMarketService.test.ts
+++ b/packages/perps-controller/tests/src/services/TerminalMarketService.test.ts
@@ -167,7 +167,9 @@ describe('TerminalMarketService', () => {
           new Promise((_resolve, reject) => {
             (init?.signal as AbortSignal)?.addEventListener('abort', () => {
               const { reason } = init?.signal as AbortSignal;
-              reject(reason instanceof Error ? reason : new Error(String(reason)));
+              reject(
+                reason instanceof Error ? reason : new Error(String(reason)),
+              );
             });
           }),
       );


### PR DESCRIPTION
## Explanation

Follow-up to #9137 (Terminal API integration). Addresses review findings around resilience and data correctness:

1. **Fetch timeout** — `TerminalMarketService.fetchMarkets()` used a bare `fetch` with no `AbortController` or timeout. A hung/slow Terminal endpoint would block live price loading on each cache-miss window. Now uses a 10-second `AbortController` timeout (`TERMINAL_API_CONFIG.FetchTimeoutMs`) so a stalled Terminal API degrades to the provider promptly.

2. **Name enrichment guard** — `#enrichWithTerminalMetadata` unconditionally set `name: meta.name`, and `#extractMetadata` fell back to the raw symbol (`item.name ?? item.symbol`) when Terminal returned a null/missing name. This could downgrade a good provider name (e.g. "Bitcoin") to the raw symbol ("BTC"). Now `TerminalAssetMetadata.name` is optional; metadata only carries `name` when Terminal supplies a non-null string, and enrichment only overrides the provider name when present.

3. **Changelog cleanup** — Removed an intra-PR "Changed" entry about replacing `as` casts with schema validation. `TerminalMarketService` is new in this Unreleased cycle, so no released `as` cast ever existed; the "Added" section already documents the validation behavior.

4. **Doc fix** — Corrected `useTerminalApi` param docs that referenced a non-existent "remote feature flag".

## References

- Follow-up to #9137

## Changelog

### `@metamask/perps-controller`

#### Fixed

- Added 10-second fetch timeout to `TerminalMarketService` so a stalled Terminal API degrades to the provider promptly instead of blocking indefinitely
- Fixed Terminal metadata enrichment to only override the provider display name when Terminal supplies a non-null value, preventing symbol fallback from replacing good provider names

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category in my changelog

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted resilience and display-name fixes in optional Terminal enrichment with existing provider fallback; no auth or payment paths touched.
> 
> **Overview**
> Hardens **Terminal API** market loading in `@metamask/perps-controller` after the initial integration.
> 
> **`TerminalMarketService.fetchMarkets()`** now uses **`AbortController`** with **`TERMINAL_API_CONFIG.FetchTimeoutMs` (10s)** so a hung Terminal request fails fast; **`MarketDataService`** already catches Terminal errors and falls back to the HyperLiquid provider, so slow endpoints should no longer block live prices on cache misses.
> 
> **Display name handling** changes so Terminal metadata no longer forces a name: **`TerminalAssetMetadata.name`** is optional, **`#extractMetadata`** only sets `name` when Terminal returns a non-empty string (no symbol fallback), and **`#enrichWithTerminalMetadata`** overrides the provider **`name`** only when Terminal supplies one—avoiding cases like **"Bitcoin" → "BTC"**.
> 
> Also trims an inaccurate **CHANGELOG** “Changed” bullet, bumps **`@metamask/controller-utils`**, and fixes **`useTerminalApi`** JSDoc that referenced a non-existent remote feature flag. Tests cover timeout abort and preserving provider names when Terminal omits `name`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3032edc04916e6652584db7f2d89517c503a44a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->