### PR TITLE
feat(wallet): wire `PreferencesController` into default initialization

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -146,6 +146,7 @@
 /packages/wallet/src/initialization/instances/approval-controller/ @MetaMask/confirmations
 /packages/wallet/src/initialization/instances/connectivity-controller/ @MetaMask/core-platform
 /packages/wallet/src/initialization/instances/keyring-controller/ @MetaMask/accounts-engineers @MetaMask/core-platform
+/packages/wallet/src/initialization/instances/preferences-controller/ @MetaMask/core-platform
 /packages/wallet/src/initialization/instances/remote-feature-flag-controller/ @MetaMask/extension-platform @MetaMask/mobile-platform @MetaMask/core-platform
 /packages/wallet/src/initialization/instances/storage-service/ @MetaMask/extension-platform @MetaMask/mobile-platform @MetaMask/core-platform
 /packages/wallet/src/initialization/instances/transaction-controller/ @MetaMask/confirmations

--- a/README.md
+++ b/README.md
@@ -641,6 +641,7 @@ linkStyle default opacity:0.5
   wallet --> keyring_controller;
   wallet --> messenger;
   wallet --> network_controller;
+  wallet --> preferences_controller;
   wallet --> remote_feature_flag_controller;
   wallet --> storage_service;
   wallet --> transaction_controller;

--- a/packages/wallet/CHANGELOG.md
+++ b/packages/wallet/CHANGELOG.md
@@ -31,7 +31,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **BREAKING:** Wire `AddressBookController` into the default wallet initialization ([#9291](https://github.com/MetaMask/core/pull/9291))
 - **BREAKING:** Wire `PreferencesController` into the default wallet initialization ([#9232](https://github.com/MetaMask/core/pull/9232))
-  - The default `Wallet` now constructs a `PreferencesController` and registers its `PreferencesController:*` messenger actions. Consumers that pass their own `messenger` and already wire a `PreferencesController` must remove their own before upgrading, or the duplicate registration will collide.
 - Export the `InitializationConfiguration`, `InitFunctionArguments`, and `InstanceState` types so consumers can author initialization configurations that override a default controller ([#9232](https://github.com/MetaMask/core/pull/9232))
 
 ### Changed

--- a/packages/wallet/CHANGELOG.md
+++ b/packages/wallet/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** Wire `AddressBookController` into the default wallet initialization ([#9291](https://github.com/MetaMask/core/pull/9291))
 - **BREAKING:** Wire `PreferencesController` into the default wallet initialization ([#9232](https://github.com/MetaMask/core/pull/9232))
   - The default `Wallet` now constructs a `PreferencesController` and registers its `PreferencesController:*` messenger actions. Consumers that pass their own `messenger` and already wire a `PreferencesController` must remove their own before upgrading, or the duplicate registration will collide.
+- Export the `InitializationConfiguration`, `InitFunctionArguments`, and `InstanceState` types so consumers can author initialization configurations that override a default controller ([#9232](https://github.com/MetaMask/core/pull/9232))
 
 ### Changed
 

--- a/packages/wallet/CHANGELOG.md
+++ b/packages/wallet/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **BREAKING:** Wire `PreferencesController` into the default wallet initialization ([#9232](https://github.com/MetaMask/core/pull/9232))
+- Export the `InitializationConfiguration`, `InitFunctionArguments`, and `InstanceState` types so consumers can author initialization configurations that override a default controller ([#9232](https://github.com/MetaMask/core/pull/9232))
+
 ## [7.0.1]
 
 ### Changed
@@ -30,8 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **BREAKING:** Wire `AddressBookController` into the default wallet initialization ([#9291](https://github.com/MetaMask/core/pull/9291))
-- **BREAKING:** Wire `PreferencesController` into the default wallet initialization ([#9232](https://github.com/MetaMask/core/pull/9232))
-- Export the `InitializationConfiguration`, `InitFunctionArguments`, and `InstanceState` types so consumers can author initialization configurations that override a default controller ([#9232](https://github.com/MetaMask/core/pull/9232))
 
 ### Changed
 

--- a/packages/wallet/CHANGELOG.md
+++ b/packages/wallet/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **BREAKING:** Wire `AddressBookController` into the default wallet initialization ([#9291](https://github.com/MetaMask/core/pull/9291))
-- **BREAKING:** Wire `PreferencesController` into the default wallet initialization ([#9231](https://github.com/MetaMask/core/pull/9231))
+- **BREAKING:** Wire `PreferencesController` into the default wallet initialization ([#9232](https://github.com/MetaMask/core/pull/9232))
   - The default `Wallet` now constructs a `PreferencesController` and registers its `PreferencesController:*` messenger actions. Consumers that pass their own `messenger` and already wire a `PreferencesController` must remove their own before upgrading, or the duplicate registration will collide.
 
 ### Changed

--- a/packages/wallet/CHANGELOG.md
+++ b/packages/wallet/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **BREAKING:** Wire `AddressBookController` into the default wallet initialization ([#9291](https://github.com/MetaMask/core/pull/9291))
+- **BREAKING:** Wire `PreferencesController` into the default wallet initialization ([#9231](https://github.com/MetaMask/core/pull/9231))
+  - The default `Wallet` now constructs a `PreferencesController` and registers its `PreferencesController:*` messenger actions. Consumers that pass their own `messenger` and already wire a `PreferencesController` must remove their own before upgrading, or the duplicate registration will collide.
 
 ### Changed
 

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -63,6 +63,7 @@
     "@metamask/keyring-controller": "^27.1.0",
     "@metamask/messenger": "^2.0.0",
     "@metamask/network-controller": "^34.0.0",
+    "@metamask/preferences-controller": "^23.1.0",
     "@metamask/remote-feature-flag-controller": "^4.2.2",
     "@metamask/scure-bip39": "^2.1.1",
     "@metamask/storage-service": "^1.0.2",

--- a/packages/wallet/src/Wallet.test.ts
+++ b/packages/wallet/src/Wallet.test.ts
@@ -450,6 +450,57 @@ describe('Wallet', () => {
         'https://example.com/ipfs/',
       );
     });
+
+    it('lets a consumer override the default with a diverging superset controller', () => {
+      // A client (e.g. the extension) whose local PreferencesController is a
+      // superset of the package one can keep it by supplying its own
+      // `PreferencesController` initialization configuration. The same `name`
+      // overrides the package default, so the wallet constructs the superset
+      // instead of the package controller — no convergence required.
+      class SupersetPreferencesController {
+        state = {
+          ipfsGateway: 'https://superset.example/ipfs/',
+          currentLocale: 'en',
+          preferences: { showTestNetworks: true },
+        };
+      }
+
+      const wallet = new Wallet({
+        initializationConfigurations: [
+          {
+            name: 'PreferencesController',
+            getMessenger: (): Messenger<string> =>
+              new Messenger({ namespace: 'PreferencesController' }),
+            init: (): SupersetPreferencesController =>
+              new SupersetPreferencesController(),
+          },
+        ],
+        instanceOptions: {
+          connectivityController: {
+            connectivityAdapter: new AlwaysOnlineAdapter(),
+          },
+          networkController: {
+            infuraProjectId: 'fake-infura-project-id',
+          },
+          storageService: {
+            storage: new InMemoryStorageAdapter(),
+          },
+          remoteFeatureFlagController: REMOTE_FEATURE_FLAG_OPTIONS,
+        },
+      });
+
+      expect(wallet.getInstance('PreferencesController')).toBeInstanceOf(
+        SupersetPreferencesController,
+      );
+      // The superset's shape — including fields absent from the package
+      // controller (`currentLocale`, nested `preferences`) — is what the wallet
+      // exposes, not the package defaults.
+      expect(wallet.state.PreferencesController).toStrictEqual({
+        ipfsGateway: 'https://superset.example/ipfs/',
+        currentLocale: 'en',
+        preferences: { showTestNetworks: true },
+      });
+    });
   });
 
   describe('StorageService', () => {

--- a/packages/wallet/src/Wallet.test.ts
+++ b/packages/wallet/src/Wallet.test.ts
@@ -1,6 +1,7 @@
 import { getDefaultAddressBookControllerState } from '@metamask/address-book-controller';
 import { CONNECTIVITY_STATUSES } from '@metamask/connectivity-controller';
 import { Messenger } from '@metamask/messenger';
+import { getDefaultPreferencesState } from '@metamask/preferences-controller';
 import { InMemoryStorageAdapter } from '@metamask/storage-service';
 import { Json } from '@metamask/utils';
 import { webcrypto } from 'crypto';
@@ -401,6 +402,53 @@ describe('Wallet', () => {
         keyrings: [],
         vault: expect.any(String),
       });
+    });
+  });
+
+  describe('PreferencesController', () => {
+    it('is wired and exposes its state on the wallet messenger', async () => {
+      const wallet = await setupWallet();
+      const { messenger } = wallet;
+
+      expect(messenger.call('PreferencesController:getState')).toStrictEqual(
+        getDefaultPreferencesState(),
+      );
+    });
+
+    it('applies initial state passed through the Wallet constructor', () => {
+      const wallet = new Wallet({
+        state: {
+          PreferencesController: { privacyMode: true },
+        },
+        instanceOptions: {
+          connectivityController: {
+            connectivityAdapter: new AlwaysOnlineAdapter(),
+          },
+          networkController: {
+            infuraProjectId: 'fake-infura-project-id',
+          },
+          storageService: {
+            storage: new InMemoryStorageAdapter(),
+          },
+          remoteFeatureFlagController: REMOTE_FEATURE_FLAG_OPTIONS,
+        },
+      });
+
+      expect(wallet.state.PreferencesController.privacyMode).toBe(true);
+    });
+
+    it('routes its method actions through the wallet messenger', async () => {
+      const wallet = await setupWallet();
+      const { messenger } = wallet;
+
+      messenger.call(
+        'PreferencesController:setIpfsGateway',
+        'https://example.com/ipfs/',
+      );
+
+      expect(wallet.state.PreferencesController.ipfsGateway).toBe(
+        'https://example.com/ipfs/',
+      );
     });
   });
 

--- a/packages/wallet/src/index.ts
+++ b/packages/wallet/src/index.ts
@@ -9,3 +9,8 @@ export type {
   DefaultState,
   RootMessenger,
 } from './initialization/defaults';
+export type {
+  InitFunctionArguments,
+  InitializationConfiguration,
+  InstanceState,
+} from './initialization/types';

--- a/packages/wallet/src/initialization/instances/index.ts
+++ b/packages/wallet/src/initialization/instances/index.ts
@@ -4,6 +4,7 @@ export { approvalController } from './approval-controller/approval-controller';
 export { connectivityController } from './connectivity-controller/connectivity-controller';
 export { keyringController } from './keyring-controller/keyring-controller';
 export { networkController } from './network-controller/network-controller';
+export { preferencesController } from './preferences-controller/preferences-controller';
 export { remoteFeatureFlagController } from './remote-feature-flag-controller/remote-feature-flag-controller';
 export { storageService } from './storage-service/storage-service';
 export { transactionController } from './transaction-controller/transaction-controller';

--- a/packages/wallet/src/initialization/instances/preferences-controller/preferences-controller.test.ts
+++ b/packages/wallet/src/initialization/instances/preferences-controller/preferences-controller.test.ts
@@ -1,0 +1,88 @@
+import { Messenger } from '@metamask/messenger';
+import {
+  PreferencesController,
+  getDefaultPreferencesState,
+} from '@metamask/preferences-controller';
+
+import { defaultConfigurations } from '../../defaults';
+import type {
+  DefaultActions,
+  DefaultEvents,
+  RootMessenger,
+} from '../../defaults';
+import { preferencesController } from './preferences-controller';
+
+/**
+ * Creates a root messenger for use in tests.
+ *
+ * @returns A root messenger.
+ */
+function getRootMessenger(): RootMessenger<DefaultActions, DefaultEvents> {
+  return new Messenger({ namespace: 'Root' });
+}
+
+describe('preferencesController', () => {
+  it('is registered as a default initialization configuration', () => {
+    expect(Object.values(defaultConfigurations)).toContain(
+      preferencesController,
+    );
+  });
+
+  it('initializes a PreferencesController with default state', () => {
+    const messenger = preferencesController.getMessenger(getRootMessenger());
+
+    const instance = preferencesController.init({
+      state: undefined,
+      messenger,
+      options: {},
+    });
+
+    expect(instance).toBeInstanceOf(PreferencesController);
+    expect(instance.state).toStrictEqual(getDefaultPreferencesState());
+  });
+
+  it('merges provided state over the defaults', () => {
+    const messenger = preferencesController.getMessenger(getRootMessenger());
+
+    const instance = preferencesController.init({
+      state: { ipfsGateway: 'https://example.com/ipfs/', privacyMode: true },
+      messenger,
+      options: {},
+    });
+
+    expect(instance.state.ipfsGateway).toBe('https://example.com/ipfs/');
+    expect(instance.state.privacyMode).toBe(true);
+    expect(instance.state.useTokenDetection).toBe(
+      getDefaultPreferencesState().useTokenDetection,
+    );
+  });
+
+  it('exposes its state through the root messenger', () => {
+    const rootMessenger = getRootMessenger();
+    const messenger = preferencesController.getMessenger(rootMessenger);
+
+    preferencesController.init({ state: undefined, messenger, options: {} });
+
+    expect(rootMessenger.call('PreferencesController:getState')).toStrictEqual(
+      getDefaultPreferencesState(),
+    );
+  });
+
+  it('registers its method actions on the root messenger', () => {
+    const rootMessenger = getRootMessenger();
+    const messenger = preferencesController.getMessenger(rootMessenger);
+
+    const instance = preferencesController.init({
+      state: undefined,
+      messenger,
+      options: {},
+    });
+
+    rootMessenger.call(
+      'PreferencesController:setIpfsGateway',
+      'https://x/ipfs/',
+    );
+
+    expect(instance.state.ipfsGateway).toBe('https://x/ipfs/');
+  });
+});

--- a/packages/wallet/src/initialization/instances/preferences-controller/preferences-controller.ts
+++ b/packages/wallet/src/initialization/instances/preferences-controller/preferences-controller.ts
@@ -1,0 +1,24 @@
+import { Messenger } from '@metamask/messenger';
+import {
+  PreferencesController,
+  PreferencesControllerMessenger,
+} from '@metamask/preferences-controller';
+
+import type { InitializationConfiguration } from '../../types';
+
+export const preferencesController: InitializationConfiguration<
+  PreferencesController,
+  PreferencesControllerMessenger
+> = {
+  name: 'PreferencesController',
+  init: ({ state, messenger }) =>
+    new PreferencesController({
+      state,
+      messenger,
+    }),
+  getMessenger: (parent) =>
+    new Messenger({
+      namespace: 'PreferencesController',
+      parent,
+    }),
+};

--- a/packages/wallet/tsconfig.build.json
+++ b/packages/wallet/tsconfig.build.json
@@ -15,6 +15,7 @@
     { "path": "../keyring-controller/tsconfig.build.json" },
     { "path": "../messenger/tsconfig.build.json" },
     { "path": "../network-controller/tsconfig.build.json" },
+    { "path": "../preferences-controller/tsconfig.build.json" },
     { "path": "../remote-feature-flag-controller/tsconfig.build.json" },
     { "path": "../storage-service/tsconfig.build.json" },
     { "path": "../transaction-controller/tsconfig.build.json" }

--- a/packages/wallet/tsconfig.json
+++ b/packages/wallet/tsconfig.json
@@ -13,6 +13,7 @@
     { "path": "../keyring-controller/tsconfig.json" },
     { "path": "../messenger/tsconfig.json" },
     { "path": "../network-controller/tsconfig.json" },
+    { "path": "../preferences-controller/tsconfig.json" },
     { "path": "../remote-feature-flag-controller/tsconfig.json" },
     { "path": "../storage-service/tsconfig.json" },
     { "path": "../transaction-controller/tsconfig.json" }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9107,6 +9107,7 @@ __metadata:
     "@metamask/keyring-controller": "npm:^27.1.0"
     "@metamask/messenger": "npm:^2.0.0"
     "@metamask/network-controller": "npm:^34.0.0"
+    "@metamask/preferences-controller": "npm:^23.1.0"
     "@metamask/remote-feature-flag-controller": "npm:^4.2.2"
     "@metamask/scure-bip39": "npm:^2.1.1"
     "@metamask/storage-service": "npm:^1.0.2"


### PR DESCRIPTION
## Explanation

Wires the \`@metamask/preferences-controller\` package into \`@metamask/wallet\`'s default initialization. The default \`Wallet\` now constructs a \`PreferencesController\` and registers its \`PreferencesController:*\` messenger actions (\`getState\`/\`stateChange\` plus the preference setters), so \`wallet.state.PreferencesController\` and calls like \`PreferencesController:setIpfsGateway\` work out of the box.

\`@metamask/wallet\` is the shared controller-integration layer that the extension, mobile, and other clients adopt, so each controller is wired once here. \`PreferencesController\` takes no client-varying constructor values, so it needs no injectable \`instanceOptions\`.

Adoption paths differ by client:

- **Extension** — keeps its diverging superset \`PreferencesController\` (extra state fields, extra \`AccountsController\` messenger delegates) by supplying an \`initializationConfigurations\` override with \`name: 'PreferencesController'\`; the wallet constructs the superset instead of the package controller.
- **Mobile** — uses the package controller directly but seeds its different initial-state defaults (\`useNftDetection: true\`, \`displayNftMedia: true\`, \`securityAlertsEnabled: true\`) via \`WalletOptions.state.PreferencesController\`; persisted state wins on subsequent launches.

This PR also exports \`InitializationConfiguration\`, \`InitFunctionArguments\`, and \`InstanceState\` so consumers can author their own override.

**BREAKING:** Clients that pass their own \`messenger\` and already register a \`PreferencesController\` must drop that wiring before upgrading, or the duplicate messenger registration will collide. The adoption PRs below do exactly that.

## References

Client adoption PRs (construct \`PreferencesController\` through \`@metamask/wallet\` and delete the bespoke client init):

- Extension — [MetaMask/metamask-extension#43851](https://github.com/MetaMask/metamask-extension/pull/43851)
- Mobile — [MetaMask/metamask-mobile#32346](https://github.com/MetaMask/metamask-mobile/pull/32346)

Client construction sites (live \`main\`):

- Extension — [init](https://github.com/MetaMask/metamask-extension/blob/main/app/scripts/messenger-client-init/preferences-controller-init.ts), [messenger](https://github.com/MetaMask/metamask-extension/blob/main/app/scripts/messenger-client-init/messengers/preferences-controller-messenger.ts)
- Mobile — [init](https://github.com/MetaMask/metamask-mobile/blob/main/app/core/Engine/controllers/preferences-controller-init.ts), [messenger](https://github.com/MetaMask/metamask-mobile/blob/main/app/core/Engine/messengers/preferences-controller-messenger.ts)

Jira: N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes (extension [#43851](https://github.com/MetaMask/metamask-extension/pull/43851) + mobile [#32346](https://github.com/MetaMask/metamask-mobile/pull/32346))

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change for extension/mobile that already register PreferencesController on the wallet messenger; upgrade requires coordinated client PRs to avoid registration collisions.
> 
> **Overview**
> **BREAKING:** Default `Wallet` initialization now constructs `@metamask/preferences-controller` and registers `PreferencesController:*` on the root messenger, so `wallet.state.PreferencesController` and preference setters work without client-side wiring. Clients that already register `PreferencesController` on a shared messenger must remove that wiring before upgrading to avoid duplicate registration.
> 
> Adds a standard `preferencesController` init module (no new `instanceOptions` slot) and pulls in `@metamask/preferences-controller` as a dependency. Re-exports `InitializationConfiguration`, `InitFunctionArguments`, and `InstanceState` so consumers can supply an `initializationConfigurations` entry with `name: 'PreferencesController'` to replace the default (e.g. extension superset controllers) or seed state via `WalletOptions.state`.
> 
> Tests cover default wiring, constructor state, messenger actions, and override behavior; CODEOWNERS, changelog, and README dependency graph are updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5816ecffdf742bebdf24c35ae1e923188094b24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->