### PR TITLE
fix: require EIP-7702 for direct mUSD vault batches

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -13,8 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Prevent EIP-7702-only transaction batches from falling back to hook or sequential publishing ([#9240](https://github.com/MetaMask/core/pull/9240))
-  - Batches submitted with both hook and sequential fallback disabled now fail when EIP-7702 is unavailable for the account or chain.
+- Add explicit error when submitting a batch that requires EIP-7702 but the account or chain does not support it ([#9240](https://github.com/MetaMask/core/pull/9240))
 
 ## [68.1.1]
 

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/accounts-controller` from `^39.0.2` to `^39.0.3` ([#9231](https://github.com/MetaMask/core/pull/9231))
 
+### Fixed
+
+- Prevent EIP-7702-only transaction batches from falling back to hook or sequential publishing ([#9240](https://github.com/MetaMask/core/pull/9240))
+  - Batches submitted with both hook and sequential fallback disabled now fail when EIP-7702 is unavailable for the account or chain.
+
 ## [68.1.1]
 
 ### Changed

--- a/packages/transaction-controller/src/utils/batch.test.ts
+++ b/packages/transaction-controller/src/utils/batch.test.ts
@@ -630,6 +630,48 @@ describe('Batch Utils', () => {
       ).toBe(TransactionType.bridgeApproval);
     });
 
+    it('throws if EIP-7702 is required but the account does not support it', async () => {
+      const publishBatchHook: jest.MockedFn<PublishBatchHook> = jest.fn();
+
+      doesAccountSupportEIP7702Mock.mockReturnValueOnce(false);
+
+      await expect(
+        addTransactionBatch({
+          ...request,
+          publishBatchHook,
+          request: {
+            ...request.request,
+            disableHook: true,
+            disableSequential: true,
+          },
+        }),
+      ).rejects.toThrow('Account does not support EIP-7702');
+
+      expect(addTransactionMock).not.toHaveBeenCalled();
+      expect(publishBatchHook).not.toHaveBeenCalled();
+    });
+
+    it('throws if EIP-7702 is required but the chain does not support it', async () => {
+      const publishBatchHook: jest.MockedFn<PublishBatchHook> = jest.fn();
+
+      doesChainSupportEIP7702Mock.mockReturnValueOnce(false);
+
+      await expect(
+        addTransactionBatch({
+          ...request,
+          publishBatchHook,
+          request: {
+            ...request.request,
+            disableHook: true,
+            disableSequential: true,
+          },
+        }),
+      ).rejects.toThrow('Chain does not support EIP-7702');
+
+      expect(addTransactionMock).not.toHaveBeenCalled();
+      expect(publishBatchHook).not.toHaveBeenCalled();
+    });
+
     it('returns provided batch ID', async () => {
       isAccountUpgradedToEIP7702Mock.mockResolvedValueOnce({
         delegationAddress: undefined,

--- a/packages/transaction-controller/src/utils/batch.ts
+++ b/packages/transaction-controller/src/utils/batch.ts
@@ -127,6 +127,10 @@ export async function addTransactionBatch(
     messenger,
     request: transactionBatchRequest,
   } = request;
+
+  const { disableHook, disable7702, disableSequential } =
+    transactionBatchRequest;
+
   const sizeLimit = getBatchSizeLimit(messenger);
 
   validateBatchRequest({
@@ -143,7 +147,11 @@ export async function addTransactionBatch(
     transactionBatchRequest.from,
   );
 
-  if (!transactionBatchRequest.disable7702 && accountCanUse7702) {
+  if (disableHook && disableSequential && !disable7702 && !accountCanUse7702) {
+    throw rpcErrors.internal('Account does not support EIP-7702');
+  }
+
+  if (!disable7702 && accountCanUse7702) {
     try {
       return await addTransactionBatchWith7702(request);
     } catch (error: unknown) {
@@ -151,7 +159,7 @@ export async function addTransactionBatch(
         error instanceof JsonRpcError &&
         error.message === 'Chain does not support EIP-7702';
 
-      if (!isEIP7702NotSupportedError) {
+      if (!isEIP7702NotSupportedError || (disableHook && disableSequential)) {
         throw error;
       }
     }

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/assets-controllers` from `^109.2.1` to `^109.2.2` ([#9231](https://github.com/MetaMask/core/pull/9231))
 
+### Fixed
+
+- Prevent direct mUSD Money Account vault submissions from falling back to standalone child transactions ([#9240](https://github.com/MetaMask/core/pull/9240))
+  - Direct mUSD vault batches now require EIP-7702 submission and always stop collecting submitted transaction IDs after the batch attempt completes.
+
 ## [23.14.0]
 
 ### Changed

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -13,8 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Prevent direct mUSD Money Account vault submissions from falling back to standalone child transactions ([#9240](https://github.com/MetaMask/core/pull/9240))
-  - Direct mUSD vault batches now require EIP-7702 submission and always stop collecting submitted transaction IDs after the batch attempt completes.
+- Require EIP-7702 for direct mUSD vault deposits and ensure transaction ID collection always stops after the batch attempt ([#9240](https://github.com/MetaMask/core/pull/9240))
 
 ## [23.14.0]
 

--- a/packages/transaction-pay-controller/src/strategy/fiat/fiat-direct-musd.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/fiat-direct-musd.test.ts
@@ -464,7 +464,8 @@ describe('fiat-direct-musd', () => {
       ).rejects.toThrow('Missing nested transactions');
     });
 
-    it('prefixes addTransactionBatch errors with Vault', async () => {
+    it('prefixes addTransactionBatch errors with Vault and stops collecting transaction IDs', async () => {
+      const endMock = jest.fn();
       const callMock = jest.fn((action: string) => {
         if (action === 'TransactionPayController:getAmountData') {
           return Promise.resolve({
@@ -478,6 +479,7 @@ describe('fiat-direct-musd', () => {
 
         throw new Error(`Unexpected action: ${action}`);
       });
+      collectTransactionIdsMock.mockReturnValue({ end: endMock });
 
       await expect(
         submitDirectMusdVaultDeposit({
@@ -486,6 +488,7 @@ describe('fiat-direct-musd', () => {
           transaction: TRANSACTION_MOCK,
         }),
       ).rejects.toThrow('Vault: batch failed');
+      expect(endMock).toHaveBeenCalledTimes(1);
     });
 
     it('throws when no vault transactions are collected', async () => {

--- a/packages/transaction-pay-controller/src/strategy/fiat/fiat-direct-musd.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/fiat-direct-musd.ts
@@ -286,6 +286,8 @@ export async function submitDirectMusdVaultDeposit({
 
   try {
     await messenger.call('TransactionController:addTransactionBatch', {
+      disableHook: true,
+      disableSequential: true,
       from: moneyAccountAddress,
       isGasFeeSponsored: true,
       isInternal: true,
@@ -306,9 +308,9 @@ export async function submitDirectMusdVaultDeposit({
     });
   } catch (error) {
     throw prefixError(error, VAULT_ERROR_PREFIX);
+  } finally {
+    end();
   }
-
-  end();
 
   log('Submitted direct mUSD vault deposit', {
     moneyAccountAddress,


### PR DESCRIPTION
## Explanation

Direct mUSD Money Account vault submission is intended to be an EIP-7702-only flow: the refreshed vault approve/deposit calls need to remain a sponsored atomic batch instead of being materialized as standalone child transactions. TransactionController previously preferred EIP-7702, but callers that depended on that path could still fall back to hook or sequential batch publishing when EIP-7702 was unavailable.

This PR makes that contract explicit. `TransactionPayController` submits direct mUSD vault batches with hook and sequential fallbacks disabled, while `TransactionController` now fails closed for those EIP-7702-only batch requests when account or chain support is unavailable. The direct mUSD submit path also always stops collecting submitted transaction IDs after the batch attempt completes, preventing later retries from being associated with a failed parent transaction.

## References

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes batch routing and error behavior for EIP-7702-only internal flows (mUSD vault); incorrect handling could block deposits or leave stale transaction associations, but scope is limited to callers using both disable flags.
> 
> **Overview**
> Direct mUSD vault deposits are now **EIP-7702-only**: `TransactionPayController` passes `disableHook: true` and `disableSequential: true` on `addTransactionBatch`, so approve/deposit stay a sponsored atomic batch instead of falling back to hook or sequential publishing.
> 
> **TransactionController** treats that flag combination as fail-closed: it throws when the account cannot use EIP-7702, and it no longer swallows a **Chain does not support EIP-7702** error to continue on the hook path. Tests cover both account and chain rejection without creating transactions.
> 
> The direct mUSD submit path moves `end()` for transaction-ID collection into a **`finally`** block so collection always stops after the batch attempt, including on failure—avoiding stray IDs on retries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5e597dc1ca2df5c67094cee2d30bab757ecdf42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->