### PR TITLE
feat: add ARC mainnet in token scanning

### DIFF
--- a/packages/phishing-controller/CHANGELOG.md
+++ b/packages/phishing-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add support for Arc network (`0x13b2`) in token scanning ([#9248](https://github.com/MetaMask/core/pull/9248))
+
 ### Changed
 
 - Bump `@metamask/controller-utils` from `^12.1.0` to `^12.3.0` ([#9058](https://github.com/MetaMask/core/pull/9058), [#9083](https://github.com/MetaMask/core/pull/9083), [#9218](https://github.com/MetaMask/core/pull/9218))

--- a/packages/phishing-controller/src/types.ts
+++ b/packages/phishing-controller/src/types.ts
@@ -215,6 +215,7 @@ export const DEFAULT_CHAIN_ID_TO_NAME = {
   '0x2eb': 'flow-evm',
   '0x8f': 'monad',
   '0x3e7': 'hyperevm',
+  '0x13b2': 'arc',
   solana: 'solana',
 } as const;
 


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Adds ARC mainnet to Token Scanning in phishing-controller.

DO NOT MERGE until https://github.com/consensys-vertical-apps/va-mmcx-security-alerts-api/pull/194 (API) is merged.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single additive chain mapping with no auth or logic changes; effectiveness depends on the upstream API supporting `arc`.
> 
> **Overview**
> Adds **Arc mainnet** to phishing-controller token scanning by mapping chain id `0x13b2` to `arc` in `DEFAULT_CHAIN_ID_TO_NAME`, so `bulkScanTokens` and related flows can resolve the chain name when calling the security alerts API.
> 
> The unreleased changelog entry documents the new network support. **Deploy order:** the matching security-alerts API change should land before this is merged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 593d7c2d8882213db65bcb8e8f4a874131fc21d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->