### PR TITLE
fix(transaction-pay-controller): skip EIP-7702 upgrade check for direct mUSD vault deposits

### DIFF
--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Require EIP-7702 for direct mUSD vault deposits and ensure transaction ID collection always stops after the batch attempt ([#9240](https://github.com/MetaMask/core/pull/9240))
 - Inherit `isGasFeeSponsored` from the parent transaction into same-chain Relay source-network fees and submission options ([#9216](https://github.com/MetaMask/core/pull/9216))
+- Skip EIP-7702 upgrade check for direct mUSD vault deposits since the Money Account is always already upgraded on Monad ([#9250](https://github.com/MetaMask/core/pull/9250))
 
 ## [23.14.0]
 

--- a/packages/transaction-pay-controller/src/strategy/fiat/fiat-direct-musd.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/fiat-direct-musd.test.ts
@@ -384,6 +384,9 @@ describe('fiat-direct-musd', () => {
       expect(callMock).toHaveBeenCalledWith(
         'TransactionController:addTransactionBatch',
         expect.objectContaining({
+          disableHook: true,
+          disableSequential: true,
+          disableUpgrade: true,
           from: MONEY_ACCOUNT_ADDRESS_MOCK,
           isGasFeeSponsored: true,
           isInternal: true,

--- a/packages/transaction-pay-controller/src/strategy/fiat/fiat-direct-musd.ts
+++ b/packages/transaction-pay-controller/src/strategy/fiat/fiat-direct-musd.ts
@@ -288,6 +288,7 @@ export async function submitDirectMusdVaultDeposit({
     await messenger.call('TransactionController:addTransactionBatch', {
       disableHook: true,
       disableSequential: true,
+      disableUpgrade: true,
       from: moneyAccountAddress,
       isGasFeeSponsored: true,
       isInternal: true,


### PR DESCRIPTION
## Summary

Adds `disableUpgrade: true` to the `addTransactionBatch` call in the direct mUSD Money Account vault deposit path.

The Money Account is always already upgraded to EIP-7702 on Monad, so the upgrade check (`isAccountUpgradedToEIP7702`) is unnecessary and adds latency. This skips it entirely.

Also updates the test assertion to explicitly verify `disableHook: true`, `disableSequential: true`, and `disableUpgrade: true` are passed to the batch.

## Related

Builds on top of #9240 (`disableHook: true`, `disableSequential: true`, `finally` block for `end()`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to batch submission flags on a fiat path that already assumes a pre-upgraded Money Account; wrong assumption would only affect this deposit flow.
> 
> **Overview**
> Direct mUSD Money Account vault deposits now pass **`disableUpgrade: true`** on `TransactionController:addTransactionBatch`, alongside the existing `disableHook` and `disableSequential` flags. That skips the redundant EIP-7702 upgrade probe (`isAccountUpgradedToEIP7702`) because the Money Account is already upgraded on Monad.
> 
> The direct mUSD vault test now asserts all three batch options explicitly, and the changelog records the fix under **Fixed**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84d28a30dd48b6befca02229eb425387729dc522. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->