### PR TITLE
docs(multichain-api-middleware): add wallet-side Multichain API reference

### DIFF
--- a/packages/multichain-api-middleware/CHANGELOG.md
+++ b/packages/multichain-api-middleware/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `MULTICHAIN_API.md`, a reference for the Multichain API: `wallet_createSession` and the other session methods, supported methods per namespace, error codes, and divergences from the current CAIP-25 spec ([#9258](https://github.com/MetaMask/core/pull/9258))
+
 ### Changed
 
 - Bump `@metamask/accounts-controller` from `^39.0.2` to `^39.0.3` ([#9231](https://github.com/MetaMask/core/pull/9231))

--- a/packages/multichain-api-middleware/MULTICHAIN_API.md
+++ b/packages/multichain-api-middleware/MULTICHAIN_API.md
@@ -1,8 +1,9 @@
 # The MetaMask Multichain API
 
-A readable, wallet-side reference for MetaMask's CAIP-25 / CAIP-27 based Multichain
-API, as actually implemented by `@metamask/multichain-api-middleware` and
-`@metamask/chain-agnostic-permission`.
+This is high-level reference documentation for MetaMask's CAIP-25 / CAIP-27 based
+Multichain API. The API is powered by `@metamask/multichain-api-middleware` and
+`@metamask/chain-agnostic-permission`, and is implemented on both the MetaMask
+extension and mobile clients.
 
 > **Audience.** This document describes the **wallet's JSON-RPC contract** — the
 > requests a caller (dapp / SDK) sends and the responses MetaMask returns. If you

--- a/packages/multichain-api-middleware/MULTICHAIN_API.md
+++ b/packages/multichain-api-middleware/MULTICHAIN_API.md
@@ -369,29 +369,13 @@ and this package's handlers:
 
 ## `scopedProperties`: abandoned
 
-`scopedProperties` was a request-side, per-scope metadata object (kept outside
-`sessionScopes`) intended to carry things like EIP-3085 chain-definition data so the
-wallet could add and authorize a not-yet-known EVM chain as part of session
-creation. It got **partway implemented and then deprioritized**:
-
-- It exists in the OpenRPC schema (`api-specs`, with error codes `5300`/`5301`) and
-  as an optional field on the `Caip25Authorization` type
-  (`chain-agnostic-permission` `src/scope/authorization.ts`).
-- But the `wallet_createSession` handler **never reads it** — `req.params` only
-  destructures `requiredScopes`, `optionalScopes`, and `sessionProperties`. The only
-  traces in the handler are comments (`// intended for future usage with eip3085
-  scopedProperties`) and the `isEvmChainIdSupportable: () => false` stub that was the
-  hook for it.
-
-Meanwhile, upstream CAIP-25 has **removed the concept from the request**:
-`scopedProperties` → `capabilities` (2025-07-30) → merged into the scope object
-(2025-08-04) → dropped from the request entirely (2025-08-07). (A wallet-advertised
-`capabilities` still exists in the *response*, but that is a separate, response-only
-feature.)
-
-Net result: `scopedProperties` is stranded — specced and typed but inert, and no
-longer part of the standard it was tracking. It is very unlikely to be implemented
-as-is and is a good candidate for removal from `api-specs`.
+A request-side, per-scope metadata object (intended for EIP-3085-style dynamic chain
+addition) that was partly implemented then deprioritized: it lives in the OpenRPC
+schema (error codes `5300`/`5301`) and the `Caip25Authorization` type, but the
+handler never reads it. Upstream CAIP-25 has since removed it from the request
+(`scopedProperties` → `capabilities`, 2025-07-30 → merged into the scope object,
+2025-08-04 → dropped, 2025-08-07). It is stranded and a candidate for removal from
+`api-specs`.
 
 ## Source-of-truth pointers
 

--- a/packages/multichain-api-middleware/MULTICHAIN_API.md
+++ b/packages/multichain-api-middleware/MULTICHAIN_API.md
@@ -60,7 +60,7 @@ For MetaMask's design rationale see
 is **historical**; it predates the current implementation and the upstream CAIP-25
 rewrite, so don't rely on it for current behavior.
 
-> ⚠️ **CAIP-25 moved; MetaMask did not (yet).** Upstream CAIP-25 was restructured
+> ⚠️ **CAIP-25 moved; MetaMask has not caught up (yet).** Upstream CAIP-25 was restructured
 > in July to August 2025 (single `scopes`, `properties`/`capabilities` renames, bare
 > accounts, chain-only scope keys). MetaMask still implements the **pre-rewrite**
 > shape (`requiredScopes`/`optionalScopes`, `sessionProperties`,

--- a/packages/multichain-api-middleware/MULTICHAIN_API.md
+++ b/packages/multichain-api-middleware/MULTICHAIN_API.md
@@ -82,7 +82,8 @@ rewrite, so don't rely on it for current behavior.
 - **`sessionProperties`** — global session metadata (allowlisted; see below).
 - **`scopedProperties`** — per-scope metadata kept **outside** `sessionScopes`
   (MetaMask's term; upstream renamed this to `capabilities` and moved it inside the
-  scope object).
+  scope object). Defined in the OpenRPC schema but **not currently read** by the
+  `wallet_createSession` handler — see [Error codes](#error-codes).
 
 ## Methods
 
@@ -180,8 +181,9 @@ ignored.
 Revokes the session for the origin. Returns `true`.
 
 - With no params (or empty `scopes`), revokes the entire CAIP-25 permission.
-- **MetaMask extension:** accepts an optional `params.scopes: string[]` for
-  **partial** revocation — each listed scope is removed; if no permitted accounts
+- Accepts an optional `params.scopes: string[]` for **partial** revocation
+  (implemented in this middleware handler, `partialRevokePermissions`) — each
+  listed scope is removed; if no permitted accounts
   remain afterward, the whole permission is revoked.
 - Returns `true` even when there was no active session. Any `sessionId` param is
   ignored.
@@ -301,7 +303,7 @@ allowlist; unknown keys are dropped. As of `@metamask/chain-agnostic-permission`
 
 | Key | Purpose |
 | --- | --- |
-| `eip1193-compatible` | Marks the connection as originating from an EIP-1193 client (injected `window.ethereum` middleware or `@metamask/connect-evm`). The extension uses it to gate EVM-connection UX such as the network picker on the dapp connection bar. Pure Multichain API connections — even EVM-only ones — do not set it. |
+| `eip1193-compatible` | Marks the connection as originating from an EIP-1193 client (injected `window.ethereum` middleware or `@metamask/connect-evm`). The extension uses it to gate EVM-connection UX such as the network picker on the dapp connection bar. Newly-created pure Multichain API sessions — even EVM-only ones — do not set it; note the extension also backfills it onto pre-existing connections with any `eip155:*` scope (migration 211), so older Multichain-only EVM connections may carry it. |
 | `solana_accountChanged_notifications` | Opt-in to `accountChanged` notifications for Solana scopes. |
 | `tron_accountChanged_notifications` | Opt-in to `accountChanged` notifications for Tron scopes. |
 | `bip122_accountChanged_notifications` | Opt-in to `accountChanged` notifications for Bitcoin scopes. |
@@ -316,15 +318,22 @@ allowlist; unknown keys are dropped. As of `@metamask/chain-agnostic-permission`
 | Code | Message | When |
 | --- | --- | --- |
 | `5000` | Unknown error with request | Generic failure. |
-| `5100` | Requested scopes are not supported | No supported scopes remain after filtering (and Solana opt-in not applicable). |
-| `5101` | Requested methods are not supported | (CAIP-25; see `chain-agnostic-permission`.) |
-| `5102` | Requested notifications are not supported | (CAIP-25.) |
-| `5201` | Unknown method(s) requested | Dev-mode strict validation. |
-| `5202` | Unknown notification(s) requested | Dev-mode strict validation. |
-| `5300` | Invalid scopedProperties requested | Malformed `scopedProperties`. |
-| `5301` | scopedProperties can only be outside of sessionScopes | `scopedProperties` placement. |
-| `5302` | Invalid sessionProperties requested | `sessionProperties` present but empty `{}`. |
-| `4100` | Unauthorized | `wallet_invokeMethod` on an unauthorized scope/method. |
+| `5100` | Requested scopes are not supported | Actually returned by `wallet_createSession` when no supported scopes remain after filtering (and the Solana opt-in does not apply). |
+| `5302` | Invalid sessionProperties requested | Returned by `wallet_createSession` when `sessionProperties` is present but an empty object `{}`. |
+| `4100` | Unauthorized | Returned by `wallet_invokeMethod` when the origin has no CAIP-25 session, or the requested scope/method is not authorized (`providerErrors.unauthorized()`). |
+
+The codes below are **defined** (in `@metamask/chain-agnostic-permission` and/or
+`@metamask/api-specs`) but are **not** thrown by the current `wallet_createSession`
+handler — included here so you don't expect them on the wire:
+
+| Code | Message | Status |
+| --- | --- | --- |
+| `5101` | Requested methods are not supported | **Not returned.** Unsupported methods are silently filtered out during scope bucketing (`chain-agnostic-permission` `scope/filter.ts`), not rejected. |
+| `5102` | Requested notifications are not supported | **Not returned.** Same as `5101` — filtered, not rejected. |
+| `5201` | Unknown method(s) requested | **Not returned.** Defined in `errors.ts` but currently only a `TODO` (intended for dev-mode strict validation). |
+| `5202` | Unknown notification(s) requested | **Not returned.** Same `TODO` status as `5201`. |
+| `5300` | Invalid scopedProperties requested | **Schema-only.** Present in `openrpc.yaml`, but the handler never reads `scopedProperties`, so this is never thrown. |
+| `5301` | scopedProperties can only be outside of sessionScopes | **Schema-only.** Same as `5300`. |
 
 > Note: code `5100`'s message is "Requested **scopes** are not supported" in this
 > handler, while `chain-agnostic-permission` and the OpenRPC schema phrase the same
@@ -340,9 +349,9 @@ and this package's handlers:
 
 | Concept | Current CAIP-25 | MetaMask implementation |
 | --- | --- | --- |
-| Request scopes | Single `scopes` (`requiredScopes` removed; `optionalScopes` → `scopes`, 2025-07-31) | Still `requiredScopes` + `optionalScopes`; **all treated as optional** |
+| Request scopes | Single `scopes` (`optionalScopes` → `scopes`, 2025-07-30; `requiredScopes` removed 2025-07-31) | Still `requiredScopes` + `optionalScopes`; **all treated as optional** |
 | Session metadata key | `properties` (renamed from `sessionProperties`, 2025-07-30) | Still `sessionProperties`; **allowlist-filtered** to known keys |
-| Per-scope extras | `capabilities`, merged **into** the scope object (2025-08-04) | Still `scopedProperties`, kept **outside** `sessionScopes` (errors `5300`/`5301`) |
+| Per-scope extras | `capabilities`, merged **into** the scope object (2025-08-04) | Still uses the older `scopedProperties` concept (kept **outside** `sessionScopes`); note the current `wallet_createSession` handler does not read `scopedProperties` at all — it is accepted and ignored, and codes `5300`/`5301` exist only in the OpenRPC schema |
 | Scope granularity | Chain-scoped only (namespace-scoped removed 2025-08-03) | Uses namespace-scoped objects (`wallet:eip155`) and a `references` shorthand array |
 | Accounts format | Bare addresses; CAIP-2 prefix removed (2025-08-07) | Fully-qualified **CAIP-10** (`eip155:1:0x…`) |
 | `sessionId` | Optional, supported (CAIP-171 / CAIP-316) | **Not** returned or accepted; one session per origin, tracked internally |

--- a/packages/multichain-api-middleware/MULTICHAIN_API.md
+++ b/packages/multichain-api-middleware/MULTICHAIN_API.md
@@ -5,7 +5,7 @@ Multichain API. The API is powered by `@metamask/multichain-api-middleware` and
 `@metamask/chain-agnostic-permission`, and is implemented on both the MetaMask
 extension and mobile clients.
 
-> **Audience.** This document describes the **wallet's JSON-RPC contract** — the
+> **Audience.** This document describes the **wallet's JSON-RPC contract**: the
 > requests a caller (dapp / SDK) sends and the responses MetaMask returns. If you
 > are integrating a dapp, you usually want the
 > [MetaMask Connect SDK](https://github.com/MetaMask/connect-monorepo) instead,
@@ -16,7 +16,7 @@ extension and mobile clients.
 > machine-readable schema lives in
 > [`@metamask/api-specs`](https://github.com/MetaMask/api-specs)
 > (`multichain/openrpc.yaml`). Where this prose and the OpenRPC schema disagree,
-> the handler code is authoritative — please file an issue so we can reconcile
+> the handler code is authoritative; please file an issue so we can reconcile
 > them.
 
 ## Contents
@@ -40,28 +40,28 @@ extension and mobile clients.
 ## Overview
 
 The Multichain API lets a caller negotiate a single **session** that spans
-multiple chains and ecosystems (EVM, Solana, Bitcoin, Tron) — and multiple accounts
-across those scopes — in one authorization, then invoke methods on any authorized
+multiple chains and ecosystems (EVM, Solana, Bitcoin, Tron), and multiple accounts
+across those scopes, in one authorization, then invoke methods on any authorized
 scope. It replaces the per-chain EIP-1193 model (`eth_requestAccounts` on one chain
 at a time) with a chain-agnostic, scope-based model.
 
 It is built on the CASA Chain Agnostic standards:
 
-- **[CAIP-25](https://chainagnostic.org/CAIPs/caip-25)** — `wallet_createSession`, session negotiation
-- **[CAIP-27](https://chainagnostic.org/CAIPs/caip-27)** — `wallet_invokeMethod`, invoking a method on a scope
-- **[CAIP-285](https://chainagnostic.org/CAIPs/caip-285)** — `wallet_revokeSession`
-- **[CAIP-311](https://chainagnostic.org/CAIPs/caip-311)** — `wallet_sessionChanged`
-- **[CAIP-312](https://chainagnostic.org/CAIPs/caip-312)** — `wallet_getSession`
-- **[CAIP-2](https://chainagnostic.org/CAIPs/caip-2)** / **[CAIP-10](https://chainagnostic.org/CAIPs/caip-10)** / **[CAIP-217](https://chainagnostic.org/CAIPs/caip-217)** — chain IDs, account IDs, scope objects
+- **[CAIP-25](https://chainagnostic.org/CAIPs/caip-25)**: `wallet_createSession`, session negotiation
+- **[CAIP-27](https://chainagnostic.org/CAIPs/caip-27)**: `wallet_invokeMethod`, invoking a method on a scope
+- **[CAIP-285](https://chainagnostic.org/CAIPs/caip-285)**: `wallet_revokeSession`
+- **[CAIP-311](https://chainagnostic.org/CAIPs/caip-311)**: `wallet_sessionChanged`
+- **[CAIP-312](https://chainagnostic.org/CAIPs/caip-312)**: `wallet_getSession`
+- **[CAIP-2](https://chainagnostic.org/CAIPs/caip-2)** / **[CAIP-10](https://chainagnostic.org/CAIPs/caip-10)** / **[CAIP-217](https://chainagnostic.org/CAIPs/caip-217)**: chain IDs, account IDs, scope objects
 
 For MetaMask's design rationale see
 [MIP-5](https://github.com/MetaMask/metamask-improvement-proposals/blob/main/MIPs/mip-5.md).
 [MIP-6](https://github.com/MetaMask/metamask-improvement-proposals/blob/main/MIPs/mip-6.md)
-is **historical** — it predates the current implementation and the upstream CAIP-25
+is **historical**; it predates the current implementation and the upstream CAIP-25
 rewrite, so don't rely on it for current behavior.
 
 > ⚠️ **CAIP-25 moved; MetaMask did not (yet).** Upstream CAIP-25 was restructured
-> in July–August 2025 (single `scopes`, `properties`/`capabilities` renames, bare
+> in July to August 2025 (single `scopes`, `properties`/`capabilities` renames, bare
 > accounts, chain-only scope keys). MetaMask still implements the **pre-rewrite**
 > shape (`requiredScopes`/`optionalScopes`, `sessionProperties`,
 > CAIP-10 accounts, namespace-scoped keys). See
@@ -69,18 +69,18 @@ rewrite, so don't rely on it for current behavior.
 
 ## Concepts
 
-- **Scope string** — a CAIP-2 chain id (`eip155:1`, `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`)
+- **Scope string**: a CAIP-2 chain id (`eip155:1`, `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`)
   or a CAIP-104 namespace-level scope (`wallet`, `wallet:eip155`). Pattern:
   `[-a-z0-9]{3,8}(:[-_a-zA-Z0-9]{1,32})?`.
-- **Scope object** — per CAIP-217, an object with `methods`, `notifications`, and
+- **Scope object**: per CAIP-217, an object with `methods`, `notifications`, and
   (in responses) `accounts`. In requests it may also carry `references` (namespace
   shorthand). Keyed by scope string.
-- **Account** — a fully-qualified **CAIP-10** id in MetaMask: `eip155:1:0xabc…`,
-  `solana:5eykt…:6Lm…`.
-- **Session** — the set of granted scopes for an origin. MetaMask stores this as a
+- **Account**: a fully-qualified **CAIP-10** id in MetaMask: `eip155:1:0xabc...`,
+  `solana:5eykt...:6Lm...`.
+- **Session**: the set of granted scopes for an origin. MetaMask stores this as a
   single CAIP-25 permission caveat per origin and **does not** issue or accept a
   `sessionId` (one session per origin, tracked internally).
-- **`sessionProperties`** — global session metadata (allowlisted; see below).
+- **`sessionProperties`**: global session metadata (allowlisted; see below).
 
 ## Methods
 
@@ -97,7 +97,7 @@ Prompts the user and grants a CAIP-25 session. `paramStructure: by-name`.
 | `sessionProperties` | `{ [key]: Json }`                | no          | Allowlist-filtered to [known keys](#supported-methods--notifications-per-namespace). An empty object is rejected with `5302`. |
 
 At least one of `requiredScopes` / `optionalScopes` must be present and resolve to
-a supported scope — a request with neither (or with only unsupported scopes) is
+a supported scope; a request with neither (or with only unsupported scopes) is
 rejected with `5100`.
 
 `ScopeObject` fields: `methods: string[]`, `notifications: string[]`,
@@ -175,7 +175,7 @@ Revokes the session for the origin. Returns `true`.
 
 - With no params (or empty `scopes`), revokes the entire CAIP-25 permission.
 - Accepts an optional `params.scopes: string[]` for **partial** revocation
-  (implemented in this middleware handler, `partialRevokePermissions`) — each
+  (implemented in this middleware handler, `partialRevokePermissions`); each
   listed scope is removed; if no permitted accounts
   remain afterward, the whole permission is revoked.
 - Returns `true` even when there was no active session. Any `sessionId` param is
@@ -201,7 +201,7 @@ Invokes a method on a previously authorized scope (CAIP-27). `paramStructure: by
 - EVM requests (`eip155:*`, or `wallet` / `wallet:eip155`) are routed to the
   resolved `networkClientId` and passed down the middleware stack; non-EVM
   requests are dispatched to the multichain router. Any `sessionId` param is
-  ignored — the origin's single session is used.
+  ignored; the origin's single session is used.
 
 **Example**
 
@@ -212,7 +212,10 @@ Invokes a method on a previously authorized scope (CAIP-27). `paramStructure: by
   "method": "wallet_invokeMethod",
   "params": {
     "scope": "eip155:1",
-    "request": { "method": "eth_getBalance", "params": ["0x5cfe…", "latest"] },
+    "request": {
+      "method": "eth_getBalance",
+      "params": ["0x5cfe...", "latest"],
+    },
   },
 }
 ```
@@ -235,7 +238,7 @@ subscription events such as `eth_subscription`.
 
 How a method gets into a session's `methods` array depends on the namespace.
 
-### EVM (`eip155`) — static, from `api-specs`
+### EVM (`eip155`): static, from `api-specs`
 
 EVM method support is enumerated statically in
 `@metamask/chain-agnostic-permission` (`src/scope/constants.ts`).
@@ -247,14 +250,14 @@ EVM method support is enumerated statically in
 | `KnownWalletRpcMethods`                 | `wallet`           | `wallet_registerOnboarding`, `wallet_scanQRCode`                                                                    |
 | `KnownNotifications.eip155`             | `eip155:<chainId>` | `eth_subscription`                                                                                                  |
 
-**EIP-1193-only methods** (`Eip1193OnlyMethods`) — explicitly **excluded** from the
+**EIP-1193-only methods** (`Eip1193OnlyMethods`): explicitly **excluded** from the
 Multichain API; available only via the injected EIP-1193 provider:
 `wallet_switchEthereumChain`, `wallet_getPermissions`, `wallet_requestPermissions`,
 `wallet_revokePermissions`, `eth_requestAccounts`, `eth_accounts`, `eth_coinbase`,
 `net_version`, `metamask_logWeb3ShimUsage`, `metamask_getProviderState`,
 `metamask_sendDomainMetadata`, `wallet_registerOnboarding`.
 
-### Non-EVM (`solana`, `bip122`, `tron`) — dynamic, from Snaps
+### Non-EVM (`solana`, `bip122`, `tron`): dynamic, from Snaps
 
 `KnownRpcMethods` / `KnownNotifications` are **empty** for non-EVM namespaces. Their
 supported methods are resolved **at runtime** through the handler's
@@ -265,10 +268,10 @@ In the extension, that hook calls
 `MultichainRoutingService:getSupportedMethods(scope)`
 (`@metamask/snaps-controllers`), which returns the **union** of:
 
-1. **Account-Snap methods** — methods declared by installed account-management
+1. **Account-Snap methods**: methods declared by installed account-management
    Snaps that hold an account for that scope (via
    `AccountsController:listMultichainAccounts`, filtered to runnable Snaps), and
-2. **Protocol-Snap methods** — methods declared by protocol Snaps that service the
+2. **Protocol-Snap methods**: methods declared by protocol Snaps that service the
    scope.
 
 ```text
@@ -278,7 +281,7 @@ getNonEvmSupportedMethods(scope)
 ```
 
 Consequently the non-EVM method set depends on which Snaps the user has installed
-and which accounts they hold — there is no fixed wallet-wide list. Scope support is
+and which accounts they hold; there is no fixed wallet-wide list. Scope support is
 likewise dynamic: `isNonEvmScopeSupported(scope)` is true when at least one Snap can
 service the scope.
 
@@ -291,20 +294,14 @@ the list as illustrative and verify against the installed Snap's manifest.
 ### Known `sessionProperties` keys
 
 `wallet_createSession` filters `sessionProperties` to the `KnownSessionProperties`
-allowlist; unknown keys are dropped. As of `@metamask/chain-agnostic-permission`
-1.6.0:
+allowlist; unknown keys are dropped:
 
-| Key                                   | Purpose                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `eip1193-compatible`                  | Marks the connection as originating from an EIP-1193 client (injected `window.ethereum` middleware or `@metamask/connect-evm`). The extension uses it to gate EVM-connection UX such as the network picker on the dapp connection bar. Newly-created pure Multichain API sessions — even EVM-only ones — do not set it; note the extension also backfills it onto pre-existing connections with any `eip155:*` scope (migration 211), so older Multichain-only EVM connections may carry it. |
-| `solana_accountChanged_notifications` | Opt-in to `accountChanged` notifications for Solana scopes.                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| `tron_accountChanged_notifications`   | Opt-in to `accountChanged` notifications for Tron scopes.                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| `bip122_accountChanged_notifications` | Opt-in to `accountChanged` notifications for Bitcoin scopes.                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-
-> **Version note.** `eip1193-compatible` was added to the allowlist in
-> `@metamask/chain-agnostic-permission` **1.6.0**. In 1.5.x (and earlier) only the
-> three `*_accountChanged_notifications` keys are known, so a 1.5.x wallet would
-> **drop** an incoming `eip1193-compatible` property.
+| Key                                   | Purpose                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `eip1193-compatible`                  | Marks the connection as originating from an EIP-1193 client (injected `window.ethereum` middleware or `@metamask/connect-evm`). The extension uses it to gate EVM-connection UX such as the network picker on the dapp connection bar. Newly-created pure Multichain API sessions (even EVM-only ones) do not set it; note the extension also backfills it onto pre-existing connections with any `eip155:*` scope (migration 211), so older Multichain-only EVM connections may carry it. |
+| `solana_accountChanged_notifications` | Opt-in to `accountChanged` notifications for Solana scopes.                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `tron_accountChanged_notifications`   | Opt-in to `accountChanged` notifications for Tron scopes.                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `bip122_accountChanged_notifications` | Opt-in to `accountChanged` notifications for Bitcoin scopes.                                                                                                                                                                                                                                                                                                                                                                                                                               |
 
 ## Error codes
 
@@ -315,41 +312,28 @@ allowlist; unknown keys are dropped. As of `@metamask/chain-agnostic-permission`
 | `5302` | Invalid sessionProperties requested | Returned by `wallet_createSession` when `sessionProperties` is present but an empty object `{}`.                                                             |
 | `4100` | Unauthorized                        | Returned by `wallet_invokeMethod` when the origin has no CAIP-25 session, or the requested scope/method is not authorized (`providerErrors.unauthorized()`). |
 
-The codes below are **defined** (in `@metamask/chain-agnostic-permission` and/or
-`@metamask/api-specs`) but are **not** thrown by the current `wallet_createSession`
-handler — included here so you don't expect them on the wire:
-
-| Code   | Message                                               | Status                                                                                                                                                |
-| ------ | ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `5101` | Requested methods are not supported                   | **Not returned.** Unsupported methods are silently filtered out during scope bucketing (`chain-agnostic-permission` `scope/filter.ts`), not rejected. |
-| `5102` | Requested notifications are not supported             | **Not returned.** Same as `5101` — filtered, not rejected.                                                                                            |
-| `5201` | Unknown method(s) requested                           | **Not returned.** Defined in `errors.ts` but currently only a `TODO` (intended for dev-mode strict validation).                                       |
-| `5202` | Unknown notification(s) requested                     | **Not returned.** Same `TODO` status as `5201`.                                                                                                       |
-| `5300` | Invalid scopedProperties requested                    | **Schema-only.** Present in `openrpc.yaml`, but the handler never reads `scopedProperties`, so this is never thrown.                                  |
-| `5301` | scopedProperties can only be outside of sessionScopes | **Schema-only.** Same as `5300`.                                                                                                                      |
-
-> Note: code `5100`'s message is "Requested **scopes** are not supported" in this
-> handler, while `chain-agnostic-permission` and the OpenRPC schema phrase the same
-> code as "Requested **chains/networks** are not supported." Same code, slightly
-> different wording.
+The OpenRPC schema and `@metamask/chain-agnostic-permission` define additional codes
+(`5101`, `5102`, `5201`, `5202`, `5300`, `5301`) that the current
+`wallet_createSession` handler does not emit, so callers should not expect them on
+the wire.
 
 ## Divergences from current CAIP-25
 
-CAIP-25 was restructured upstream in July–August 2025 (see the spec's own
+CAIP-25 was restructured upstream in July to August 2025 (see the spec's own
 changelog). MetaMask implements the **pre-rewrite** shape. Verified against the
 current [CAIP-25 spec](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-25.md)
 and this package's handlers:
 
-| Concept                                       | Current CAIP-25                                                                                                                                                                                                   | MetaMask implementation                                                                                                                                                                                                                                                                  |
-| --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Request scopes                                | Single `scopes` (`optionalScopes` → `scopes`, 2025-07-30; `requiredScopes` removed 2025-07-31)                                                                                                                    | Still `requiredScopes` + `optionalScopes`; **all treated as optional**                                                                                                                                                                                                                   |
-| Session metadata key                          | `properties` (renamed from `sessionProperties`, 2025-07-30)                                                                                                                                                       | Still `sessionProperties`; **allowlist-filtered** to known keys                                                                                                                                                                                                                          |
-| Per-scope request extras (`scopedProperties`) | Removed from the request — `scopedProperties` → `capabilities` (2025-07-30) → merged into the scope object (2025-08-04) → dropped from the request entirely (2025-08-07). A response-only `capabilities` remains. | **Abandoned.** Intended for EIP-3085-style dynamic chain addition; partly implemented then deprioritized. Lives in the OpenRPC schema (error codes `5300`/`5301`) and the `Caip25Authorization` type, but the handler never reads it. Stranded — candidate for removal from `api-specs`. |
-| Scope granularity                             | Chain-scoped only (namespace-scoped removed 2025-08-03)                                                                                                                                                           | Uses namespace-scoped objects (`wallet:eip155`) and a `references` shorthand array                                                                                                                                                                                                       |
-| Accounts format                               | Bare addresses; CAIP-2 prefix removed (2025-08-07)                                                                                                                                                                | Fully-qualified **CAIP-10** (`eip155:1:0x…`)                                                                                                                                                                                                                                             |
-| `sessionId`                                   | Optional, supported (CAIP-171 / CAIP-316)                                                                                                                                                                         | **Not** returned or accepted; one session per origin, tracked internally                                                                                                                                                                                                                 |
-| `chains` shorthand                            | `chains: string[]` inside the scope object                                                                                                                                                                        | `references: string[]` (older CAIP-217 shorthand)                                                                                                                                                                                                                                        |
-| Invalid input                                 | MAY error                                                                                                                                                                                                         | **Silently dropped** (invalid scopes/methods/accounts)                                                                                                                                                                                                                                   |
+| Concept                                       | Current CAIP-25                                                                                                                                                                                                          | MetaMask implementation                                                                                                                                                                                                                                                                 |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Request scopes                                | Single `scopes` (`optionalScopes` → `scopes`, 2025-07-30; `requiredScopes` removed 2025-07-31)                                                                                                                           | Still `requiredScopes` + `optionalScopes`; **all treated as optional**                                                                                                                                                                                                                  |
+| Session metadata key                          | `properties` (renamed from `sessionProperties`, 2025-07-30)                                                                                                                                                              | Still `sessionProperties`; **allowlist-filtered** to known keys                                                                                                                                                                                                                         |
+| Per-scope request extras (`scopedProperties`) | Removed from the request: `scopedProperties` became `capabilities` (2025-07-30), merged into the scope object (2025-08-04), then dropped from the request entirely (2025-08-07). A response-only `capabilities` remains. | **Abandoned.** Intended for EIP-3085-style dynamic chain addition; partly implemented then deprioritized. Lives in the OpenRPC schema (error codes `5300`/`5301`) and the `Caip25Authorization` type, but the handler never reads it. Stranded; candidate for removal from `api-specs`. |
+| Scope granularity                             | Chain-scoped only (namespace-scoped removed 2025-08-03)                                                                                                                                                                  | Uses namespace-scoped objects (`wallet:eip155`) and a `references` shorthand array                                                                                                                                                                                                      |
+| Accounts format                               | Bare addresses; CAIP-2 prefix removed (2025-08-07)                                                                                                                                                                       | Fully-qualified **CAIP-10** (`eip155:1:0x...`)                                                                                                                                                                                                                                          |
+| `sessionId`                                   | Optional, supported (CAIP-171 / CAIP-316)                                                                                                                                                                                | **Not** returned or accepted; one session per origin, tracked internally                                                                                                                                                                                                                |
+| `chains` shorthand                            | `chains: string[]` inside the scope object                                                                                                                                                                               | `references: string[]` (older CAIP-217 shorthand)                                                                                                                                                                                                                                       |
+| Invalid input                                 | MAY error                                                                                                                                                                                                                | **Silently dropped** (invalid scopes/methods/accounts)                                                                                                                                                                                                                                  |
 
 ## MetaMask-specific behavior
 

--- a/packages/multichain-api-middleware/MULTICHAIN_API.md
+++ b/packages/multichain-api-middleware/MULTICHAIN_API.md
@@ -94,9 +94,13 @@ Prompts the user and grants a CAIP-25 session. `paramStructure: by-name`.
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| `requiredScopes` | `{ [scopeString]: ScopeObject }` | no | Accepted but **treated as optional** (see divergences). |
-| `optionalScopes` | `{ [scopeString]: ScopeObject }` | no | |
+| `requiredScopes` | `{ [scopeString]: ScopeObject }` | conditional | Accepted but **treated as optional** (see divergences). |
+| `optionalScopes` | `{ [scopeString]: ScopeObject }` | conditional | |
 | `sessionProperties` | `{ [key]: Json }` | no | Allowlist-filtered to [known keys](#supported-methods--notifications-per-namespace). An empty object is rejected with `5302`. |
+
+At least one of `requiredScopes` / `optionalScopes` must be present and resolve to
+a supported scope — a request with neither (or with only unsupported scopes) is
+rejected with `5100`, unless it triggers the [Solana opt-in flow](#wallet_createsession).
 
 `ScopeObject` fields: `methods: string[]`, `notifications: string[]`,
 optionally `accounts: CaipAccountId[]` and `references: string[]`.
@@ -305,8 +309,7 @@ allowlist; unknown keys are dropped. As of `@metamask/chain-agnostic-permission`
 > **Version note.** `eip1193-compatible` was added to the allowlist in
 > `@metamask/chain-agnostic-permission` **1.6.0**. In 1.5.x (and earlier) only the
 > three `*_accountChanged_notifications` keys are known, so a 1.5.x wallet would
-> **drop** an incoming `eip1193-compatible` property. See
-> [the eip1193-compatible flow](#the-eip1193-compatible-session-property) below.
+> **drop** an incoming `eip1193-compatible` property.
 
 ## Error codes
 
@@ -364,42 +367,6 @@ and this package's handlers:
   active session.
 - **Partial revoke.** `wallet_revokeSession` accepts an optional `scopes` array to
   remove individual scopes; full revoke happens automatically if no accounts remain.
-
-### The `eip1193-compatible` session property
-
-This property is the bridge between the legacy EIP-1193 world and the Multichain
-session model, and it's a good worked example of how `sessionProperties` flows end
-to end:
-
-1. **Set on the request.** `@metamask/connect-evm` attaches
-   `sessionProperties: { 'eip1193-compatible': true }` to every
-   `wallet_createSession` it issues (`EIP1193_COMPATIBLE_SESSION_PROPERTY` /
-   `CONNECT_EVM_SESSION_PROPERTIES` in `connect-evm/src/constants.ts`). The
-   extension's own injected EIP-1193 middleware sets it too.
-2. **Filtered on the way in.** The `wallet_createSession` handler keeps only keys in
-   the `KnownSessionProperties` allowlist. `eip1193-compatible` is a known key **as
-   of `@metamask/chain-agnostic-permission` 1.6.0**, so it survives and is persisted
-   into the CAIP-25 caveat. On 1.5.x it would be silently dropped — this is the one
-   gotcha to watch for across versions.
-3. **Read by the wallet UI.** The extension selector
-   `getIsEip1193CompatibleConnection` (`ui/selectors/dapp.ts`) returns true when
-   `caveatValue.sessionProperties['eip1193-compatible'] === true`, which gates the
-   EVM network picker on the dapp connection bar. Pure Multichain API connections —
-   even EVM-only ones — omit the flag and therefore don't get that EIP-1193-specific
-   UX.
-4. **Backfilled for old connections.** Extension migration 211 sets
-   `eip1193-compatible: true` on every pre-existing CAIP-25 caveat that has any
-   `eip155:*` scope, so connections established before this property existed don't
-   lose their network picker after upgrade. Solana-only connections are left
-   untouched.
-
-> **Why the apparent mismatch?** If you compare a 1.5.x `chain-agnostic-permission`
-> checkout (whose `KnownSessionProperties` only lists the three
-> `*_accountChanged_notifications`) against `connect-evm` sending
-> `eip1193-compatible`, it looks like the property would always be filtered out. It
-> isn't, in shipping builds: the key was added to the allowlist in 1.6.0, and the
-> extension ships ≥1.6.x. The discrepancy is purely a version-skew artifact of
-> reading an older `core` checkout.
 
 ## Source-of-truth pointers
 

--- a/packages/multichain-api-middleware/MULTICHAIN_API.md
+++ b/packages/multichain-api-middleware/MULTICHAIN_API.md
@@ -63,7 +63,7 @@ rewrite, so don't rely on it for current behavior.
 > ⚠️ **CAIP-25 moved; MetaMask did not (yet).** Upstream CAIP-25 was restructured
 > in July–August 2025 (single `scopes`, `properties`/`capabilities` renames, bare
 > accounts, chain-only scope keys). MetaMask still implements the **pre-rewrite**
-> shape (`requiredScopes`/`optionalScopes`, `sessionProperties`/`scopedProperties`,
+> shape (`requiredScopes`/`optionalScopes`, `sessionProperties`,
 > CAIP-10 accounts, namespace-scoped keys). See
 > [Divergences from current CAIP-25](#divergences-from-current-caip-25).
 
@@ -81,10 +81,6 @@ rewrite, so don't rely on it for current behavior.
   single CAIP-25 permission caveat per origin and **does not** issue or accept a
   `sessionId` (one session per origin, tracked internally).
 - **`sessionProperties`** — global session metadata (allowlisted; see below).
-- **`scopedProperties`** — per-scope metadata kept **outside** `sessionScopes`
-  (MetaMask's term; upstream renamed this to `capabilities` and moved it inside the
-  scope object). Defined in the OpenRPC schema but **not currently read** by the
-  `wallet_createSession` handler — see [Error codes](#error-codes).
 
 ## Methods
 
@@ -352,7 +348,7 @@ and this package's handlers:
 | --- | --- | --- |
 | Request scopes | Single `scopes` (`optionalScopes` → `scopes`, 2025-07-30; `requiredScopes` removed 2025-07-31) | Still `requiredScopes` + `optionalScopes`; **all treated as optional** |
 | Session metadata key | `properties` (renamed from `sessionProperties`, 2025-07-30) | Still `sessionProperties`; **allowlist-filtered** to known keys |
-| Per-scope extras | `capabilities`, merged **into** the scope object (2025-08-04) | Still uses the older `scopedProperties` concept (kept **outside** `sessionScopes`); note the current `wallet_createSession` handler does not read `scopedProperties` at all — it is accepted and ignored, and codes `5300`/`5301` exist only in the OpenRPC schema |
+| Per-scope request extras | Removed from the request — `scopedProperties` was renamed to `capabilities` (2025-07-30), merged into the scope object (2025-08-04), then dropped from the request entirely (2025-08-07). A response-only `capabilities` remains. | Never fully implemented; spec/type-only and now stranded — see [`scopedProperties`: abandoned](#scopedproperties-abandoned) |
 | Scope granularity | Chain-scoped only (namespace-scoped removed 2025-08-03) | Uses namespace-scoped objects (`wallet:eip155`) and a `references` shorthand array |
 | Accounts format | Bare addresses; CAIP-2 prefix removed (2025-08-07) | Fully-qualified **CAIP-10** (`eip155:1:0x…`) |
 | `sessionId` | Optional, supported (CAIP-171 / CAIP-316) | **Not** returned or accepted; one session per origin, tracked internally |
@@ -377,6 +373,32 @@ and this package's handlers:
   active session.
 - **Partial revoke.** `wallet_revokeSession` accepts an optional `scopes` array to
   remove individual scopes; full revoke happens automatically if no accounts remain.
+
+## `scopedProperties`: abandoned
+
+`scopedProperties` was a request-side, per-scope metadata object (kept outside
+`sessionScopes`) intended to carry things like EIP-3085 chain-definition data so the
+wallet could add and authorize a not-yet-known EVM chain as part of session
+creation. It got **partway implemented and then deprioritized**:
+
+- It exists in the OpenRPC schema (`api-specs`, with error codes `5300`/`5301`) and
+  as an optional field on the `Caip25Authorization` type
+  (`chain-agnostic-permission` `src/scope/authorization.ts`).
+- But the `wallet_createSession` handler **never reads it** — `req.params` only
+  destructures `requiredScopes`, `optionalScopes`, and `sessionProperties`. The only
+  traces in the handler are comments (`// intended for future usage with eip3085
+  scopedProperties`) and the `isEvmChainIdSupportable: () => false` stub that was the
+  hook for it.
+
+Meanwhile, upstream CAIP-25 has **removed the concept from the request**:
+`scopedProperties` → `capabilities` (2025-07-30) → merged into the scope object
+(2025-08-04) → dropped from the request entirely (2025-08-07). (A wallet-advertised
+`capabilities` still exists in the *response*, but that is a separate, response-only
+feature.)
+
+Net result: `scopedProperties` is stranded — specced and typed but inert, and no
+longer part of the standard it was tracking. It is very unlikely to be implemented
+as-is and is a good candidate for removal from `api-specs`.
 
 ## Source-of-truth pointers
 

--- a/packages/multichain-api-middleware/MULTICHAIN_API.md
+++ b/packages/multichain-api-middleware/MULTICHAIN_API.md
@@ -1,0 +1,418 @@
+# The MetaMask Multichain API
+
+A readable, wallet-side reference for MetaMask's CAIP-25 / CAIP-27 based Multichain
+API, as actually implemented by `@metamask/multichain-api-middleware` and
+`@metamask/chain-agnostic-permission`.
+
+> **Audience.** This document describes the **wallet's JSON-RPC contract** — the
+> requests a caller (dapp / SDK) sends and the responses MetaMask returns. If you
+> are integrating a dapp, you usually want the
+> [MetaMask Connect SDK](https://github.com/MetaMask/connect-monorepo) instead,
+> which wraps this API. This is the layer underneath that.
+
+> **Source of truth.** Behavior is described from the implementation in this
+> package (`src/handlers/*.ts`) and `@metamask/chain-agnostic-permission`. The
+> machine-readable schema lives in
+> [`@metamask/api-specs`](https://github.com/MetaMask/api-specs)
+> (`multichain/openrpc.yaml`). Where this prose and the OpenRPC schema disagree,
+> the handler code is authoritative — please file an issue so we can reconcile
+> them.
+
+## Contents
+
+- [Overview](#overview)
+- [Concepts](#concepts)
+- [Methods](#methods)
+  - [`wallet_createSession`](#wallet_createsession)
+  - [`wallet_getSession`](#wallet_getsession)
+  - [`wallet_revokeSession`](#wallet_revokesession)
+  - [`wallet_invokeMethod`](#wallet_invokemethod)
+- [Notifications](#notifications)
+  - [`wallet_sessionChanged`](#wallet_sessionchanged)
+  - [`wallet_notify`](#wallet_notify)
+- [Supported methods & notifications per namespace](#supported-methods--notifications-per-namespace)
+- [Error codes](#error-codes)
+- [Divergences from current CAIP-25](#divergences-from-current-caip-25)
+- [MetaMask-specific behavior](#metamask-specific-behavior)
+- [Source-of-truth pointers](#source-of-truth-pointers)
+
+## Overview
+
+The Multichain API lets a caller negotiate a single **session** that spans
+multiple chains and ecosystems (EVM, Solana, Bitcoin, Tron) in one authorization,
+then invoke methods on any authorized scope. It replaces the per-chain EIP-1193
+model (`eth_requestAccounts` on one chain at a time) with a chain-agnostic,
+scope-based model.
+
+It is built on the CASA Chain Agnostic standards:
+
+- **[CAIP-25](https://chainagnostic.org/CAIPs/caip-25)** — `wallet_createSession`, session negotiation
+- **[CAIP-27](https://chainagnostic.org/CAIPs/caip-27)** — `wallet_invokeMethod`, invoking a method on a scope
+- **[CAIP-285](https://chainagnostic.org/CAIPs/caip-285)** — `wallet_revokeSession`
+- **[CAIP-311](https://chainagnostic.org/CAIPs/caip-311)** — `wallet_sessionChanged`
+- **[CAIP-312](https://chainagnostic.org/CAIPs/caip-312)** — `wallet_getSession`
+- **[CAIP-2](https://chainagnostic.org/CAIPs/caip-2)** / **[CAIP-10](https://chainagnostic.org/CAIPs/caip-10)** / **[CAIP-217](https://chainagnostic.org/CAIPs/caip-217)** — chain IDs, account IDs, scope objects
+
+For MetaMask's design rationale see
+[MIP-5](https://github.com/MetaMask/metamask-improvement-proposals/blob/main/MIPs/mip-5.md).
+[MIP-6](https://github.com/MetaMask/metamask-improvement-proposals/blob/main/MIPs/mip-6.md)
+is **historical** — it predates the current implementation and the upstream CAIP-25
+rewrite, so don't rely on it for current behavior.
+
+> ⚠️ **CAIP-25 moved; MetaMask did not (yet).** Upstream CAIP-25 was restructured
+> in July–August 2025 (single `scopes`, `properties`/`capabilities` renames, bare
+> accounts, chain-only scope keys). MetaMask still implements the **pre-rewrite**
+> shape (`requiredScopes`/`optionalScopes`, `sessionProperties`/`scopedProperties`,
+> CAIP-10 accounts, namespace-scoped keys). See
+> [Divergences from current CAIP-25](#divergences-from-current-caip-25).
+
+## Concepts
+
+- **Scope string** — a CAIP-2 chain id (`eip155:1`, `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`)
+  or a CAIP-104 namespace-level scope (`wallet`, `wallet:eip155`). Pattern:
+  `[-a-z0-9]{3,8}(:[-_a-zA-Z0-9]{1,32})?`.
+- **Scope object** — per CAIP-217, an object with `methods`, `notifications`, and
+  (in responses) `accounts`. In requests it may also carry `references` (namespace
+  shorthand). Keyed by scope string.
+- **Account** — a fully-qualified **CAIP-10** id in MetaMask: `eip155:1:0xabc…`,
+  `solana:5eykt…:6Lm…`.
+- **Session** — the set of granted scopes for an origin. MetaMask stores this as a
+  single CAIP-25 permission caveat per origin and **does not** issue or accept a
+  `sessionId` (one session per origin, tracked internally).
+- **`sessionProperties`** — global session metadata (allowlisted; see below).
+- **`scopedProperties`** — per-scope metadata kept **outside** `sessionScopes`
+  (MetaMask's term; upstream renamed this to `capabilities` and moved it inside the
+  scope object).
+
+## Methods
+
+### `wallet_createSession`
+
+Prompts the user and grants a CAIP-25 session. `paramStructure: by-name`.
+
+**Params**
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `requiredScopes` | `{ [scopeString]: ScopeObject }` | no | Accepted but **treated as optional** (see divergences). |
+| `optionalScopes` | `{ [scopeString]: ScopeObject }` | no | |
+| `sessionProperties` | `{ [key]: Json }` | no | Allowlist-filtered to [known keys](#supported-methods--notifications-per-namespace). An empty object is rejected with `5302`. |
+
+`ScopeObject` fields: `methods: string[]`, `notifications: string[]`,
+optionally `accounts: CaipAccountId[]` and `references: string[]`.
+
+**Result**
+
+```jsonc
+{
+  "sessionScopes": { "<scopeString>": { "accounts": [...], "methods": [...], "notifications": [...] } },
+  "sessionProperties": { /* approved, may be {} */ }
+}
+```
+
+**Example request**
+
+```jsonc
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "method": "wallet_createSession",
+  "params": {
+    "optionalScopes": {
+      "eip155:1": {
+        "methods": ["eth_sendTransaction", "personal_sign", "eth_getBalance"],
+        "notifications": ["eth_subscription"]
+      },
+      "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp": {
+        "methods": ["signMessage", "signAndSendTransaction"],
+        "notifications": []
+      }
+    }
+  }
+}
+```
+
+**Example response**
+
+```jsonc
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "result": {
+    "sessionProperties": {},
+    "sessionScopes": {
+      "eip155:1": {
+        "accounts": ["eip155:1:0x5cfe73b6021e818b776b421b1c4db2474086a7e1"],
+        "methods": ["eth_sendTransaction", "personal_sign", "eth_getBalance"],
+        "notifications": ["eth_subscription"]
+      }
+    }
+  }
+}
+```
+
+**Behavior notes**
+
+- All requested scopes are treated as optional; unsupported scopes, unknown
+  methods/notifications, and accounts not held by the wallet are **silently
+  dropped** rather than erroring.
+- If, after filtering, **no** scopes remain and Solana was not requested, it
+  returns `5100` (Requested scopes are not supported).
+- **Solana opt-in:** if a Solana scope is requested but the wallet has no Solana
+  account, the handler sets a `promptToCreateSolanaAccount` flag and injects an
+  empty `wallet` scope so the request can pass the CAIP-25 caveat validator (which
+  otherwise rejects zero-scope requests).
+
+### `wallet_getSession`
+
+Returns the active session for the origin. `params: []`.
+
+**Result:** `{ "sessionScopes": { ... } }`. If there is **no** active session,
+returns `{ "sessionScopes": {} }` (does **not** throw). Any `sessionId` param is
+ignored.
+
+### `wallet_revokeSession`
+
+Revokes the session for the origin. Returns `true`.
+
+- With no params (or empty `scopes`), revokes the entire CAIP-25 permission.
+- **MetaMask extension:** accepts an optional `params.scopes: string[]` for
+  **partial** revocation — each listed scope is removed; if no permitted accounts
+  remain afterward, the whole permission is revoked.
+- Returns `true` even when there was no active session. Any `sessionId` param is
+  ignored.
+
+### `wallet_invokeMethod`
+
+Invokes a method on a previously authorized scope (CAIP-27). `paramStructure: by-name`.
+
+**Params**
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `scope` | `ScopeString` | yes | Must be an authorized scope in the current session. |
+| `request` | `{ method: string, params?: Json }` | yes | The wrapped JSON-RPC request. |
+
+**Result:** whatever the underlying method returns.
+
+**Behavior notes**
+
+- If the origin has no CAIP-25 caveat, returns `4100` (unauthorized).
+- If `request.method` is not in the authorized scope's `methods`, returns `4100`.
+- EVM requests (`eip155:*`, or `wallet` / `wallet:eip155`) are routed to the
+  resolved `networkClientId` and passed down the middleware stack; non-EVM
+  requests are dispatched to the multichain router. Any `sessionId` param is
+  ignored — the origin's single session is used.
+
+**Example**
+
+```jsonc
+{
+  "id": 2,
+  "jsonrpc": "2.0",
+  "method": "wallet_invokeMethod",
+  "params": {
+    "scope": "eip155:1",
+    "request": { "method": "eth_getBalance", "params": ["0x5cfe…", "latest"] }
+  }
+}
+```
+
+## Notifications
+
+### `wallet_sessionChanged`
+
+Published by the wallet when a session's authorization scopes change (accounts,
+scopes added/removed, restoration). `paramStructure: by-name`. Payload:
+`{ "sessionScopes": { ... } }` with the full updated scopes.
+
+### `wallet_notify`
+
+Delivers a scope-bound notification to the caller. Params: `scope` (an authorized
+scope string) and `notification` (`{ method, params }`). Used to forward
+subscription events such as `eth_subscription`.
+
+## Supported methods & notifications per namespace
+
+How a method gets into a session's `methods` array depends on the namespace.
+
+### EVM (`eip155`) — static, from `api-specs`
+
+EVM method support is enumerated statically in
+`@metamask/chain-agnostic-permission` (`src/scope/constants.ts`).
+
+| List | Scope | Contents |
+| --- | --- | --- |
+| `KnownRpcMethods.eip155` | `eip155:<chainId>` | All MetaMask JSON-RPC methods from `@metamask/api-specs`, **minus** the wallet-scoped and EIP-1193-only lists below |
+| `KnownWalletNamespaceRpcMethods.eip155` | `wallet:eip155` | `wallet_addEthereumChain` |
+| `KnownWalletRpcMethods` | `wallet` | `wallet_registerOnboarding`, `wallet_scanQRCode` |
+| `KnownNotifications.eip155` | `eip155:<chainId>` | `eth_subscription` |
+
+**EIP-1193-only methods** (`Eip1193OnlyMethods`) — explicitly **excluded** from the
+Multichain API; available only via the injected EIP-1193 provider:
+`wallet_switchEthereumChain`, `wallet_getPermissions`, `wallet_requestPermissions`,
+`wallet_revokePermissions`, `eth_requestAccounts`, `eth_accounts`, `eth_coinbase`,
+`net_version`, `metamask_logWeb3ShimUsage`, `metamask_getProviderState`,
+`metamask_sendDomainMetadata`, `wallet_registerOnboarding`.
+
+### Non-EVM (`solana`, `bip122`, `tron`) — dynamic, from Snaps
+
+`KnownRpcMethods` / `KnownNotifications` are **empty** for non-EVM namespaces. Their
+supported methods are resolved **at runtime** through the handler's
+`getNonEvmSupportedMethods(scope)` hook, which the wallet wires to the Snaps
+subsystem.
+
+In the extension, that hook calls
+`MultichainRoutingService:getSupportedMethods(scope)`
+(`@metamask/snaps-controllers`), which returns the **union** of:
+
+1. **Account-Snap methods** — methods declared by installed account-management
+   Snaps that hold an account for that scope (via
+   `AccountsController:listMultichainAccounts`, filtered to runnable Snaps), and
+2. **Protocol-Snap methods** — methods declared by protocol Snaps that service the
+   scope.
+
+```text
+getNonEvmSupportedMethods(scope)
+  └─ MultichainRoutingService.getSupportedMethods(scope)
+       = unique( accountSnap.methods[] ∪ protocolSnap.methods[] )
+```
+
+Consequently the non-EVM method set depends on which Snaps the user has installed
+and which accounts they hold — there is no fixed wallet-wide list. Scope support is
+likewise dynamic: `isNonEvmScopeSupported(scope)` is true when at least one Snap can
+service the scope.
+
+**Example (Solana, via the MetaMask Solana Snap).** Methods are exposed using
+[Wallet Standard](https://github.com/wallet-standard/wallet-standard) naming, e.g.
+`signIn`, `signMessage`, `signTransaction`, `signAndSendTransaction`,
+`signAllTransactions`. These are provided by the Snap, not hardcoded here, so treat
+the list as illustrative and verify against the installed Snap's manifest.
+
+### Known `sessionProperties` keys
+
+`wallet_createSession` filters `sessionProperties` to the `KnownSessionProperties`
+allowlist; unknown keys are dropped. As of `@metamask/chain-agnostic-permission`
+1.6.0:
+
+| Key | Purpose |
+| --- | --- |
+| `eip1193-compatible` | Marks the connection as originating from an EIP-1193 client (injected `window.ethereum` middleware or `@metamask/connect-evm`). The extension uses it to gate EVM-connection UX such as the network picker on the dapp connection bar. Pure Multichain API connections — even EVM-only ones — do not set it. |
+| `solana_accountChanged_notifications` | Opt-in to `accountChanged` notifications for Solana scopes. |
+| `tron_accountChanged_notifications` | Opt-in to `accountChanged` notifications for Tron scopes. |
+| `bip122_accountChanged_notifications` | Opt-in to `accountChanged` notifications for Bitcoin scopes. |
+
+> **Version note.** `eip1193-compatible` was added to the allowlist in
+> `@metamask/chain-agnostic-permission` **1.6.0**. In 1.5.x (and earlier) only the
+> three `*_accountChanged_notifications` keys are known, so a 1.5.x wallet would
+> **drop** an incoming `eip1193-compatible` property. See
+> [the eip1193-compatible flow](#the-eip1193-compatible-session-property) below.
+
+## Error codes
+
+| Code | Message | When |
+| --- | --- | --- |
+| `5000` | Unknown error with request | Generic failure. |
+| `5100` | Requested scopes are not supported | No supported scopes remain after filtering (and Solana opt-in not applicable). |
+| `5101` | Requested methods are not supported | (CAIP-25; see `chain-agnostic-permission`.) |
+| `5102` | Requested notifications are not supported | (CAIP-25.) |
+| `5201` | Unknown method(s) requested | Dev-mode strict validation. |
+| `5202` | Unknown notification(s) requested | Dev-mode strict validation. |
+| `5300` | Invalid scopedProperties requested | Malformed `scopedProperties`. |
+| `5301` | scopedProperties can only be outside of sessionScopes | `scopedProperties` placement. |
+| `5302` | Invalid sessionProperties requested | `sessionProperties` present but empty `{}`. |
+| `4100` | Unauthorized | `wallet_invokeMethod` on an unauthorized scope/method. |
+
+> Note: code `5100`'s message is "Requested **scopes** are not supported" in this
+> handler, while `chain-agnostic-permission` and the OpenRPC schema phrase the same
+> code as "Requested **chains/networks** are not supported." Same code, slightly
+> different wording.
+
+## Divergences from current CAIP-25
+
+CAIP-25 was restructured upstream in July–August 2025 (see the spec's own
+changelog). MetaMask implements the **pre-rewrite** shape. Verified against the
+current [CAIP-25 spec](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-25.md)
+and this package's handlers:
+
+| Concept | Current CAIP-25 | MetaMask implementation |
+| --- | --- | --- |
+| Request scopes | Single `scopes` (`requiredScopes` removed; `optionalScopes` → `scopes`, 2025-07-31) | Still `requiredScopes` + `optionalScopes`; **all treated as optional** |
+| Session metadata key | `properties` (renamed from `sessionProperties`, 2025-07-30) | Still `sessionProperties`; **allowlist-filtered** to known keys |
+| Per-scope extras | `capabilities`, merged **into** the scope object (2025-08-04) | Still `scopedProperties`, kept **outside** `sessionScopes` (errors `5300`/`5301`) |
+| Scope granularity | Chain-scoped only (namespace-scoped removed 2025-08-03) | Uses namespace-scoped objects (`wallet:eip155`) and a `references` shorthand array |
+| Accounts format | Bare addresses; CAIP-2 prefix removed (2025-08-07) | Fully-qualified **CAIP-10** (`eip155:1:0x…`) |
+| `sessionId` | Optional, supported (CAIP-171 / CAIP-316) | **Not** returned or accepted; one session per origin, tracked internally |
+| `chains` shorthand | `chains: string[]` inside the scope object | `references: string[]` (older CAIP-217 shorthand) |
+| Invalid input | MAY error | **Silently dropped** (invalid scopes/methods/accounts) |
+
+## MetaMask-specific behavior
+
+- **All scopes optional.** `requiredScopes` are not enforced as required; the
+  handler buckets everything and grants whatever is supported.
+- **Lenient filtering.** Malformed scopes and unknown methods/notifications/accounts
+  are dropped instead of erroring (reduces fingerprinting and breakage).
+- **`sessionProperties` allowlist.** Only the keys in `KnownSessionProperties` are
+  retained; an explicitly empty `sessionProperties: {}` errors with `5302`.
+- **Solana opt-in flow.** Requesting a Solana scope with no Solana account sets
+  `promptToCreateSolanaAccount` and injects an empty `wallet` scope so the
+  zero-scope request passes the caveat validator.
+- **Single session per origin.** `sessionId` is ignored across `getSession`,
+  `revokeSession`, and `invokeMethod`.
+- **Graceful no-session results.** `wallet_getSession` returns
+  `{ sessionScopes: {} }` and `wallet_revokeSession` returns `true` even with no
+  active session.
+- **Partial revoke.** `wallet_revokeSession` accepts an optional `scopes` array to
+  remove individual scopes; full revoke happens automatically if no accounts remain.
+
+### The `eip1193-compatible` session property
+
+This property is the bridge between the legacy EIP-1193 world and the Multichain
+session model, and it's a good worked example of how `sessionProperties` flows end
+to end:
+
+1. **Set on the request.** `@metamask/connect-evm` attaches
+   `sessionProperties: { 'eip1193-compatible': true }` to every
+   `wallet_createSession` it issues (`EIP1193_COMPATIBLE_SESSION_PROPERTY` /
+   `CONNECT_EVM_SESSION_PROPERTIES` in `connect-evm/src/constants.ts`). The
+   extension's own injected EIP-1193 middleware sets it too.
+2. **Filtered on the way in.** The `wallet_createSession` handler keeps only keys in
+   the `KnownSessionProperties` allowlist. `eip1193-compatible` is a known key **as
+   of `@metamask/chain-agnostic-permission` 1.6.0**, so it survives and is persisted
+   into the CAIP-25 caveat. On 1.5.x it would be silently dropped — this is the one
+   gotcha to watch for across versions.
+3. **Read by the wallet UI.** The extension selector
+   `getIsEip1193CompatibleConnection` (`ui/selectors/dapp.ts`) returns true when
+   `caveatValue.sessionProperties['eip1193-compatible'] === true`, which gates the
+   EVM network picker on the dapp connection bar. Pure Multichain API connections —
+   even EVM-only ones — omit the flag and therefore don't get that EIP-1193-specific
+   UX.
+4. **Backfilled for old connections.** Extension migration 211 sets
+   `eip1193-compatible: true` on every pre-existing CAIP-25 caveat that has any
+   `eip155:*` scope, so connections established before this property existed don't
+   lose their network picker after upgrade. Solana-only connections are left
+   untouched.
+
+> **Why the apparent mismatch?** If you compare a 1.5.x `chain-agnostic-permission`
+> checkout (whose `KnownSessionProperties` only lists the three
+> `*_accountChanged_notifications`) against `connect-evm` sending
+> `eip1193-compatible`, it looks like the property would always be filtered out. It
+> isn't, in shipping builds: the key was added to the allowlist in 1.6.0, and the
+> extension ships ≥1.6.x. The discrepancy is purely a version-skew artifact of
+> reading an older `core` checkout.
+
+## Source-of-truth pointers
+
+- **Handlers:** `src/handlers/wallet-createSession.ts`, `wallet-getSession.ts`,
+  `wallet-revokeSession.ts`, `wallet-invokeMethod.ts`
+- **Scope/permission semantics, constants, error codes:**
+  [`@metamask/chain-agnostic-permission`](https://github.com/MetaMask/core/tree/main/packages/chain-agnostic-permission)
+  (`src/scope/constants.ts`, `src/scope/errors.ts`)
+- **OpenRPC schema:**
+  [`@metamask/api-specs`](https://github.com/MetaMask/api-specs) →
+  `multichain/openrpc.yaml`
+- **Design rationale:**
+  [MIP-5](https://github.com/MetaMask/metamask-improvement-proposals/blob/main/MIPs/mip-5.md)
+  (MIP-6 is historical)
+- **Dapp/SDK consumer docs:**
+  [MetaMask Connect](https://github.com/MetaMask/connect-monorepo)

--- a/packages/multichain-api-middleware/MULTICHAIN_API.md
+++ b/packages/multichain-api-middleware/MULTICHAIN_API.md
@@ -90,11 +90,11 @@ Prompts the user and grants a CAIP-25 session. `paramStructure: by-name`.
 
 **Params**
 
-| Field | Type | Required | Notes |
-| --- | --- | --- | --- |
-| `requiredScopes` | `{ [scopeString]: ScopeObject }` | conditional | Accepted but **treated as optional** (see divergences). |
-| `optionalScopes` | `{ [scopeString]: ScopeObject }` | conditional | |
-| `sessionProperties` | `{ [key]: Json }` | no | Allowlist-filtered to [known keys](#supported-methods--notifications-per-namespace). An empty object is rejected with `5302`. |
+| Field               | Type                             | Required    | Notes                                                                                                                         |
+| ------------------- | -------------------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `requiredScopes`    | `{ [scopeString]: ScopeObject }` | conditional | Accepted but **treated as optional** (see divergences).                                                                       |
+| `optionalScopes`    | `{ [scopeString]: ScopeObject }` | conditional |                                                                                                                               |
+| `sessionProperties` | `{ [key]: Json }`                | no          | Allowlist-filtered to [known keys](#supported-methods--notifications-per-namespace). An empty object is rejected with `5302`. |
 
 At least one of `requiredScopes` / `optionalScopes` must be present and resolve to
 a supported scope — a request with neither (or with only unsupported scopes) is
@@ -123,14 +123,14 @@ optionally `accounts: CaipAccountId[]` and `references: string[]`.
     "optionalScopes": {
       "eip155:1": {
         "methods": ["eth_sendTransaction", "personal_sign", "eth_getBalance"],
-        "notifications": ["eth_subscription"]
+        "notifications": ["eth_subscription"],
       },
       "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp": {
         "methods": ["signMessage", "signAndSendTransaction"],
-        "notifications": []
-      }
-    }
-  }
+        "notifications": [],
+      },
+    },
+  },
 }
 ```
 
@@ -146,10 +146,10 @@ optionally `accounts: CaipAccountId[]` and `references: string[]`.
       "eip155:1": {
         "accounts": ["eip155:1:0x5cfe73b6021e818b776b421b1c4db2474086a7e1"],
         "methods": ["eth_sendTransaction", "personal_sign", "eth_getBalance"],
-        "notifications": ["eth_subscription"]
-      }
-    }
-  }
+        "notifications": ["eth_subscription"],
+      },
+    },
+  },
 }
 ```
 
@@ -187,10 +187,10 @@ Invokes a method on a previously authorized scope (CAIP-27). `paramStructure: by
 
 **Params**
 
-| Field | Type | Required | Notes |
-| --- | --- | --- | --- |
-| `scope` | `ScopeString` | yes | Must be an authorized scope in the current session. |
-| `request` | `{ method: string, params?: Json }` | yes | The wrapped JSON-RPC request. |
+| Field     | Type                                | Required | Notes                                               |
+| --------- | ----------------------------------- | -------- | --------------------------------------------------- |
+| `scope`   | `ScopeString`                       | yes      | Must be an authorized scope in the current session. |
+| `request` | `{ method: string, params?: Json }` | yes      | The wrapped JSON-RPC request.                       |
 
 **Result:** whatever the underlying method returns.
 
@@ -212,8 +212,8 @@ Invokes a method on a previously authorized scope (CAIP-27). `paramStructure: by
   "method": "wallet_invokeMethod",
   "params": {
     "scope": "eip155:1",
-    "request": { "method": "eth_getBalance", "params": ["0x5cfe…", "latest"] }
-  }
+    "request": { "method": "eth_getBalance", "params": ["0x5cfe…", "latest"] },
+  },
 }
 ```
 
@@ -240,12 +240,12 @@ How a method gets into a session's `methods` array depends on the namespace.
 EVM method support is enumerated statically in
 `@metamask/chain-agnostic-permission` (`src/scope/constants.ts`).
 
-| List | Scope | Contents |
-| --- | --- | --- |
-| `KnownRpcMethods.eip155` | `eip155:<chainId>` | All MetaMask JSON-RPC methods from `@metamask/api-specs`, **minus** the wallet-scoped and EIP-1193-only lists below |
-| `KnownWalletNamespaceRpcMethods.eip155` | `wallet:eip155` | `wallet_addEthereumChain` |
-| `KnownWalletRpcMethods` | `wallet` | `wallet_registerOnboarding`, `wallet_scanQRCode` |
-| `KnownNotifications.eip155` | `eip155:<chainId>` | `eth_subscription` |
+| List                                    | Scope              | Contents                                                                                                            |
+| --------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------- |
+| `KnownRpcMethods.eip155`                | `eip155:<chainId>` | All MetaMask JSON-RPC methods from `@metamask/api-specs`, **minus** the wallet-scoped and EIP-1193-only lists below |
+| `KnownWalletNamespaceRpcMethods.eip155` | `wallet:eip155`    | `wallet_addEthereumChain`                                                                                           |
+| `KnownWalletRpcMethods`                 | `wallet`           | `wallet_registerOnboarding`, `wallet_scanQRCode`                                                                    |
+| `KnownNotifications.eip155`             | `eip155:<chainId>` | `eth_subscription`                                                                                                  |
 
 **EIP-1193-only methods** (`Eip1193OnlyMethods`) — explicitly **excluded** from the
 Multichain API; available only via the injected EIP-1193 provider:
@@ -294,12 +294,12 @@ the list as illustrative and verify against the installed Snap's manifest.
 allowlist; unknown keys are dropped. As of `@metamask/chain-agnostic-permission`
 1.6.0:
 
-| Key | Purpose |
-| --- | --- |
-| `eip1193-compatible` | Marks the connection as originating from an EIP-1193 client (injected `window.ethereum` middleware or `@metamask/connect-evm`). The extension uses it to gate EVM-connection UX such as the network picker on the dapp connection bar. Newly-created pure Multichain API sessions — even EVM-only ones — do not set it; note the extension also backfills it onto pre-existing connections with any `eip155:*` scope (migration 211), so older Multichain-only EVM connections may carry it. |
-| `solana_accountChanged_notifications` | Opt-in to `accountChanged` notifications for Solana scopes. |
-| `tron_accountChanged_notifications` | Opt-in to `accountChanged` notifications for Tron scopes. |
-| `bip122_accountChanged_notifications` | Opt-in to `accountChanged` notifications for Bitcoin scopes. |
+| Key                                   | Purpose                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `eip1193-compatible`                  | Marks the connection as originating from an EIP-1193 client (injected `window.ethereum` middleware or `@metamask/connect-evm`). The extension uses it to gate EVM-connection UX such as the network picker on the dapp connection bar. Newly-created pure Multichain API sessions — even EVM-only ones — do not set it; note the extension also backfills it onto pre-existing connections with any `eip155:*` scope (migration 211), so older Multichain-only EVM connections may carry it. |
+| `solana_accountChanged_notifications` | Opt-in to `accountChanged` notifications for Solana scopes.                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `tron_accountChanged_notifications`   | Opt-in to `accountChanged` notifications for Tron scopes.                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `bip122_accountChanged_notifications` | Opt-in to `accountChanged` notifications for Bitcoin scopes.                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 
 > **Version note.** `eip1193-compatible` was added to the allowlist in
 > `@metamask/chain-agnostic-permission` **1.6.0**. In 1.5.x (and earlier) only the
@@ -308,25 +308,25 @@ allowlist; unknown keys are dropped. As of `@metamask/chain-agnostic-permission`
 
 ## Error codes
 
-| Code | Message | When |
-| --- | --- | --- |
-| `5000` | Unknown error with request | Generic failure. |
-| `5100` | Requested scopes are not supported | Actually returned by `wallet_createSession` when no supported scopes remain after filtering. |
-| `5302` | Invalid sessionProperties requested | Returned by `wallet_createSession` when `sessionProperties` is present but an empty object `{}`. |
-| `4100` | Unauthorized | Returned by `wallet_invokeMethod` when the origin has no CAIP-25 session, or the requested scope/method is not authorized (`providerErrors.unauthorized()`). |
+| Code   | Message                             | When                                                                                                                                                         |
+| ------ | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `5000` | Unknown error with request          | Generic failure.                                                                                                                                             |
+| `5100` | Requested scopes are not supported  | Actually returned by `wallet_createSession` when no supported scopes remain after filtering.                                                                 |
+| `5302` | Invalid sessionProperties requested | Returned by `wallet_createSession` when `sessionProperties` is present but an empty object `{}`.                                                             |
+| `4100` | Unauthorized                        | Returned by `wallet_invokeMethod` when the origin has no CAIP-25 session, or the requested scope/method is not authorized (`providerErrors.unauthorized()`). |
 
 The codes below are **defined** (in `@metamask/chain-agnostic-permission` and/or
 `@metamask/api-specs`) but are **not** thrown by the current `wallet_createSession`
 handler — included here so you don't expect them on the wire:
 
-| Code | Message | Status |
-| --- | --- | --- |
-| `5101` | Requested methods are not supported | **Not returned.** Unsupported methods are silently filtered out during scope bucketing (`chain-agnostic-permission` `scope/filter.ts`), not rejected. |
-| `5102` | Requested notifications are not supported | **Not returned.** Same as `5101` — filtered, not rejected. |
-| `5201` | Unknown method(s) requested | **Not returned.** Defined in `errors.ts` but currently only a `TODO` (intended for dev-mode strict validation). |
-| `5202` | Unknown notification(s) requested | **Not returned.** Same `TODO` status as `5201`. |
-| `5300` | Invalid scopedProperties requested | **Schema-only.** Present in `openrpc.yaml`, but the handler never reads `scopedProperties`, so this is never thrown. |
-| `5301` | scopedProperties can only be outside of sessionScopes | **Schema-only.** Same as `5300`. |
+| Code   | Message                                               | Status                                                                                                                                                |
+| ------ | ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `5101` | Requested methods are not supported                   | **Not returned.** Unsupported methods are silently filtered out during scope bucketing (`chain-agnostic-permission` `scope/filter.ts`), not rejected. |
+| `5102` | Requested notifications are not supported             | **Not returned.** Same as `5101` — filtered, not rejected.                                                                                            |
+| `5201` | Unknown method(s) requested                           | **Not returned.** Defined in `errors.ts` but currently only a `TODO` (intended for dev-mode strict validation).                                       |
+| `5202` | Unknown notification(s) requested                     | **Not returned.** Same `TODO` status as `5201`.                                                                                                       |
+| `5300` | Invalid scopedProperties requested                    | **Schema-only.** Present in `openrpc.yaml`, but the handler never reads `scopedProperties`, so this is never thrown.                                  |
+| `5301` | scopedProperties can only be outside of sessionScopes | **Schema-only.** Same as `5300`.                                                                                                                      |
 
 > Note: code `5100`'s message is "Requested **scopes** are not supported" in this
 > handler, while `chain-agnostic-permission` and the OpenRPC schema phrase the same
@@ -340,16 +340,16 @@ changelog). MetaMask implements the **pre-rewrite** shape. Verified against the
 current [CAIP-25 spec](https://github.com/ChainAgnostic/CAIPs/blob/main/CAIPs/caip-25.md)
 and this package's handlers:
 
-| Concept | Current CAIP-25 | MetaMask implementation |
-| --- | --- | --- |
-| Request scopes | Single `scopes` (`optionalScopes` → `scopes`, 2025-07-30; `requiredScopes` removed 2025-07-31) | Still `requiredScopes` + `optionalScopes`; **all treated as optional** |
-| Session metadata key | `properties` (renamed from `sessionProperties`, 2025-07-30) | Still `sessionProperties`; **allowlist-filtered** to known keys |
-| Per-scope request extras | Removed from the request — `scopedProperties` was renamed to `capabilities` (2025-07-30), merged into the scope object (2025-08-04), then dropped from the request entirely (2025-08-07). A response-only `capabilities` remains. | Never fully implemented; spec/type-only and now stranded — see [`scopedProperties`: abandoned](#scopedproperties-abandoned) |
-| Scope granularity | Chain-scoped only (namespace-scoped removed 2025-08-03) | Uses namespace-scoped objects (`wallet:eip155`) and a `references` shorthand array |
-| Accounts format | Bare addresses; CAIP-2 prefix removed (2025-08-07) | Fully-qualified **CAIP-10** (`eip155:1:0x…`) |
-| `sessionId` | Optional, supported (CAIP-171 / CAIP-316) | **Not** returned or accepted; one session per origin, tracked internally |
-| `chains` shorthand | `chains: string[]` inside the scope object | `references: string[]` (older CAIP-217 shorthand) |
-| Invalid input | MAY error | **Silently dropped** (invalid scopes/methods/accounts) |
+| Concept                                       | Current CAIP-25                                                                                                                                                                                                   | MetaMask implementation                                                                                                                                                                                                                                                                  |
+| --------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Request scopes                                | Single `scopes` (`optionalScopes` → `scopes`, 2025-07-30; `requiredScopes` removed 2025-07-31)                                                                                                                    | Still `requiredScopes` + `optionalScopes`; **all treated as optional**                                                                                                                                                                                                                   |
+| Session metadata key                          | `properties` (renamed from `sessionProperties`, 2025-07-30)                                                                                                                                                       | Still `sessionProperties`; **allowlist-filtered** to known keys                                                                                                                                                                                                                          |
+| Per-scope request extras (`scopedProperties`) | Removed from the request — `scopedProperties` → `capabilities` (2025-07-30) → merged into the scope object (2025-08-04) → dropped from the request entirely (2025-08-07). A response-only `capabilities` remains. | **Abandoned.** Intended for EIP-3085-style dynamic chain addition; partly implemented then deprioritized. Lives in the OpenRPC schema (error codes `5300`/`5301`) and the `Caip25Authorization` type, but the handler never reads it. Stranded — candidate for removal from `api-specs`. |
+| Scope granularity                             | Chain-scoped only (namespace-scoped removed 2025-08-03)                                                                                                                                                           | Uses namespace-scoped objects (`wallet:eip155`) and a `references` shorthand array                                                                                                                                                                                                       |
+| Accounts format                               | Bare addresses; CAIP-2 prefix removed (2025-08-07)                                                                                                                                                                | Fully-qualified **CAIP-10** (`eip155:1:0x…`)                                                                                                                                                                                                                                             |
+| `sessionId`                                   | Optional, supported (CAIP-171 / CAIP-316)                                                                                                                                                                         | **Not** returned or accepted; one session per origin, tracked internally                                                                                                                                                                                                                 |
+| `chains` shorthand                            | `chains: string[]` inside the scope object                                                                                                                                                                        | `references: string[]` (older CAIP-217 shorthand)                                                                                                                                                                                                                                        |
+| Invalid input                                 | MAY error                                                                                                                                                                                                         | **Silently dropped** (invalid scopes/methods/accounts)                                                                                                                                                                                                                                   |
 
 ## MetaMask-specific behavior
 
@@ -366,16 +366,6 @@ and this package's handlers:
   active session.
 - **Partial revoke.** `wallet_revokeSession` accepts an optional `scopes` array to
   remove individual scopes; full revoke happens automatically if no accounts remain.
-
-## `scopedProperties`: abandoned
-
-A request-side, per-scope metadata object (intended for EIP-3085-style dynamic chain
-addition) that was partly implemented then deprioritized: it lives in the OpenRPC
-schema (error codes `5300`/`5301`) and the `Caip25Authorization` type, but the
-handler never reads it. Upstream CAIP-25 has since removed it from the request
-(`scopedProperties` → `capabilities`, 2025-07-30 → merged into the scope object,
-2025-08-04 → dropped, 2025-08-07). It is stranded and a candidate for removal from
-`api-specs`.
 
 ## Source-of-truth pointers
 

--- a/packages/multichain-api-middleware/MULTICHAIN_API.md
+++ b/packages/multichain-api-middleware/MULTICHAIN_API.md
@@ -98,7 +98,7 @@ Prompts the user and grants a CAIP-25 session. `paramStructure: by-name`.
 
 At least one of `requiredScopes` / `optionalScopes` must be present and resolve to
 a supported scope — a request with neither (or with only unsupported scopes) is
-rejected with `5100`, unless it triggers the [Solana opt-in flow](#wallet_createsession).
+rejected with `5100`.
 
 `ScopeObject` fields: `methods: string[]`, `notifications: string[]`,
 optionally `accounts: CaipAccountId[]` and `references: string[]`.
@@ -158,12 +158,8 @@ optionally `accounts: CaipAccountId[]` and `references: string[]`.
 - All requested scopes are treated as optional; unsupported scopes, unknown
   methods/notifications, and accounts not held by the wallet are **silently
   dropped** rather than erroring.
-- If, after filtering, **no** scopes remain and Solana was not requested, it
-  returns `5100` (Requested scopes are not supported).
-- **Solana opt-in:** if a Solana scope is requested but the wallet has no Solana
-  account, the handler sets a `promptToCreateSolanaAccount` flag and injects an
-  empty `wallet` scope so the request can pass the CAIP-25 caveat validator (which
-  otherwise rejects zero-scope requests).
+- If, after filtering, **no** scopes remain, it returns `5100` (Requested scopes
+  are not supported).
 
 ### `wallet_getSession`
 
@@ -315,7 +311,7 @@ allowlist; unknown keys are dropped. As of `@metamask/chain-agnostic-permission`
 | Code | Message | When |
 | --- | --- | --- |
 | `5000` | Unknown error with request | Generic failure. |
-| `5100` | Requested scopes are not supported | Actually returned by `wallet_createSession` when no supported scopes remain after filtering (and the Solana opt-in does not apply). |
+| `5100` | Requested scopes are not supported | Actually returned by `wallet_createSession` when no supported scopes remain after filtering. |
 | `5302` | Invalid sessionProperties requested | Returned by `wallet_createSession` when `sessionProperties` is present but an empty object `{}`. |
 | `4100` | Unauthorized | Returned by `wallet_invokeMethod` when the origin has no CAIP-25 session, or the requested scope/method is not authorized (`providerErrors.unauthorized()`). |
 
@@ -363,9 +359,6 @@ and this package's handlers:
   are dropped instead of erroring (reduces fingerprinting and breakage).
 - **`sessionProperties` allowlist.** Only the keys in `KnownSessionProperties` are
   retained; an explicitly empty `sessionProperties: {}` errors with `5302`.
-- **Solana opt-in flow.** Requesting a Solana scope with no Solana account sets
-  `promptToCreateSolanaAccount` and injects an empty `wallet` scope so the
-  zero-scope request passes the caveat validator.
 - **Single session per origin.** `sessionId` is ignored across `getSession`,
   `revokeSession`, and `invokeMethod`.
 - **Graceful no-session results.** `wallet_getSession` returns

--- a/packages/multichain-api-middleware/MULTICHAIN_API.md
+++ b/packages/multichain-api-middleware/MULTICHAIN_API.md
@@ -40,10 +40,10 @@ extension and mobile clients.
 ## Overview
 
 The Multichain API lets a caller negotiate a single **session** that spans
-multiple chains and ecosystems (EVM, Solana, Bitcoin, Tron) in one authorization,
-then invoke methods on any authorized scope. It replaces the per-chain EIP-1193
-model (`eth_requestAccounts` on one chain at a time) with a chain-agnostic,
-scope-based model.
+multiple chains and ecosystems (EVM, Solana, Bitcoin, Tron) — and multiple accounts
+across those scopes — in one authorization, then invoke methods on any authorized
+scope. It replaces the per-chain EIP-1193 model (`eth_requestAccounts` on one chain
+at a time) with a chain-agnostic, scope-based model.
 
 It is built on the CASA Chain Agnostic standards:
 

--- a/packages/multichain-api-middleware/README.md
+++ b/packages/multichain-api-middleware/README.md
@@ -2,6 +2,14 @@
 
 JSON-RPC methods and middleware to support the the [MetaMask Multichain API](https://github.com/MetaMask/metamask-improvement-proposals/blob/main/MIPs/mip-5.md).
 
+## Documentation
+
+See [`MULTICHAIN_API.md`](./MULTICHAIN_API.md) for a readable, wallet-side
+reference of the Multichain API as implemented here: `wallet_createSession` inputs
+and outputs, supported methods per namespace, error codes, and how MetaMask
+currently diverges from the latest CAIP-25. The machine-readable schema lives in
+[`@metamask/api-specs`](https://github.com/MetaMask/api-specs).
+
 ## Installation
 
 `yarn add @metamask/multichain-api-middleware`


### PR DESCRIPTION
## Explanation

`@metamask/multichain-api-middleware` is the implementation of MetaMask's CAIP-25 / CAIP-27 Multichain API, but it has had no prose documentation — only a stub README pointing at MIP-5. The machine-readable OpenRPC schema (`@metamask/api-specs`) is the source of truth but isn't easy to read, and upstream CAIP-25 has since diverged from what we implement.

This adds `MULTICHAIN_API.md`, a readable wallet-side reference, and links it from the package README.

It covers:
- `wallet_createSession` inputs/outputs (params, result shape, examples, behavior), plus `wallet_getSession`, `wallet_revokeSession`, `wallet_invokeMethod`, and the `wallet_sessionChanged` / `wallet_notify` notifications.
- Supported methods per namespace: static EVM lists (from `@metamask/chain-agnostic-permission` / `@metamask/api-specs`) vs. **Snap-resolved** non-EVM methods (via `MultichainRoutingService.getSupportedMethods` = account-Snap ∪ protocol-Snap methods).
- The `sessionProperties` allowlist, including a full walkthrough of the `eip1193-compatible` flow (set by `connect-evm` / injected EIP-1193 middleware, gates the EVM network picker, backfilled by extension migration 211) and the 1.6.0 allowlist addition.
- Error codes (5000–5302, 4100).
- A divergence table: how MetaMask's implementation differs from the current upstream CAIP-25 (single `scopes`, `properties`/`capabilities` renames, bare accounts, chain-only keys, `sessionId`, etc.).

Behavior is described from the handler source; the doc notes that handler code is authoritative where it disagrees with the OpenRPC schema.

## References

- Companion pointer PRs in `MetaMask/api-specs` and `MetaMask/connect-monorepo`.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [ ] I've prepared draft pull requests for downstream packages as appropriate

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no production code paths are modified.
> 
> **Overview**
> Adds **`MULTICHAIN_API.md`**, a wallet-side JSON-RPC reference for the Multichain API as implemented in this package, and links it from the package **README** with an **[Unreleased]** **CHANGELOG** entry.
> 
> The new doc documents session methods (`wallet_createSession`, `wallet_getSession`, `wallet_revokeSession`, `wallet_invokeMethod`), notifications, static vs Snap-resolved method lists, `sessionProperties`, error codes, MetaMask-specific behavior, and a **CAIP-25 divergence** table (handler code over OpenRPC when they disagree). **No runtime or API behavior changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3daa2f12d9f777224792ccdf0d6c6f3618cb57c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->