### PR TITLE
feat(remote-feature-flag-controller): merge localOverrides into remoteFeatureFlags

### DIFF
--- a/packages/remote-feature-flag-controller/CHANGELOG.md
+++ b/packages/remote-feature-flag-controller/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Merge `localOverrides` into `remoteFeatureFlags` at the controller level so consumers receive effective flag values directly
 - Bump `@metamask/utils` from `^11.9.0` to `^11.11.0` ([#9074](https://github.com/MetaMask/core/pull/9074))
 - Bump `@metamask/controller-utils` from `^12.1.0` to `^12.3.0` ([#9058](https://github.com/MetaMask/core/pull/9058), [#9083](https://github.com/MetaMask/core/pull/9083), [#9218](https://github.com/MetaMask/core/pull/9218))
 

--- a/packages/remote-feature-flag-controller/CHANGELOG.md
+++ b/packages/remote-feature-flag-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Merge `localOverrides` into `remoteFeatureFlags` at the controller level so consumers receive effective flag values directly
+- Merge `localOverrides` into `remoteFeatureFlags` at the controller level so consumers receive effective flag values directly ([#9259](https://github.com/MetaMask/core/pull/9259))
 - Bump `@metamask/utils` from `^11.9.0` to `^11.11.0` ([#9074](https://github.com/MetaMask/core/pull/9074))
 - Bump `@metamask/controller-utils` from `^12.1.0` to `^12.3.0` ([#9058](https://github.com/MetaMask/core/pull/9058), [#9083](https://github.com/MetaMask/core/pull/9083), [#9218](https://github.com/MetaMask/core/pull/9218))
 

--- a/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.test.ts
+++ b/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.test.ts
@@ -1093,6 +1093,9 @@ describe('RemoteFeatureFlagController', () => {
         expect(controller.state.localOverrides).toStrictEqual({
           testFlag: true,
         });
+        expect(controller.state.remoteFeatureFlags).toStrictEqual({
+          testFlag: true,
+        });
       });
 
       it('overwrites existing override for the same flag', () => {
@@ -1113,11 +1116,17 @@ describe('RemoteFeatureFlagController', () => {
         expect(controller.state.localOverrides).toStrictEqual({
           testFlag: false,
         });
+        expect(controller.state.remoteFeatureFlags).toStrictEqual({
+          testFlag: false,
+        });
       });
 
       it('preserves other overrides when setting a new one', () => {
         const { controller, messenger } = createController({
           state: {
+            remoteFeatureFlags: {
+              flag1: 'value1',
+            },
             localOverrides: {
               flag1: 'value1',
             },
@@ -1134,6 +1143,10 @@ describe('RemoteFeatureFlagController', () => {
           flag1: 'value1',
           flag2: 'value2',
         });
+        expect(controller.state.remoteFeatureFlags).toStrictEqual({
+          flag1: 'value1',
+          flag2: 'value2',
+        });
       });
     });
 
@@ -1141,6 +1154,11 @@ describe('RemoteFeatureFlagController', () => {
       it('removes a specific override', () => {
         const { controller, messenger } = createController({
           state: {
+            remoteFeatureFlags: {
+              remoteFlag: 'remoteValue',
+              flag1: 'value1',
+              flag2: 'value2',
+            },
             localOverrides: {
               flag1: 'value1',
               flag2: 'value2',
@@ -1156,11 +1174,18 @@ describe('RemoteFeatureFlagController', () => {
         expect(controller.state.localOverrides).toStrictEqual({
           flag2: 'value2',
         });
+        expect(controller.state.remoteFeatureFlags).toStrictEqual({
+          remoteFlag: 'remoteValue',
+          flag2: 'value2',
+        });
       });
 
       it('does not affect state when clearing non-existent override', () => {
         const { controller, messenger } = createController({
           state: {
+            remoteFeatureFlags: {
+              flag1: 'value1',
+            },
             localOverrides: {
               flag1: 'value1',
             },
@@ -1175,6 +1200,9 @@ describe('RemoteFeatureFlagController', () => {
         expect(controller.state.localOverrides).toStrictEqual({
           flag1: 'value1',
         });
+        expect(controller.state.remoteFeatureFlags).toStrictEqual({
+          flag1: 'value1',
+        });
       });
     });
 
@@ -1182,6 +1210,11 @@ describe('RemoteFeatureFlagController', () => {
       it('removes all overrides', () => {
         const { controller, messenger } = createController({
           state: {
+            remoteFeatureFlags: {
+              remoteFlag: 'remoteValue',
+              flag1: 'value1',
+              flag2: 'value2',
+            },
             localOverrides: {
               flag1: 'value1',
               flag2: 'value2',
@@ -1192,6 +1225,9 @@ describe('RemoteFeatureFlagController', () => {
         messenger.call('RemoteFeatureFlagController:clearAllFlagOverrides');
 
         expect(controller.state.localOverrides).toStrictEqual({});
+        expect(controller.state.remoteFeatureFlags).toStrictEqual({
+          remoteFlag: 'remoteValue',
+        });
       });
 
       it('does not affect state when no overrides exist', () => {
@@ -1232,6 +1268,29 @@ describe('RemoteFeatureFlagController', () => {
         expect(controller.state.localOverrides).toStrictEqual({
           overrideFlag: 'overrideValue',
           remoteFlag: 'updatedRemoteValue',
+        });
+        expect(controller.state.remoteFeatureFlags).toStrictEqual({
+          remoteFlag: 'updatedRemoteValue',
+          overrideFlag: 'overrideValue',
+        });
+      });
+
+      it('uses persisted remoteFeatureFlags with overrides on init', () => {
+        const { controller } = createController({
+          state: {
+            remoteFeatureFlags: {
+              remoteFlag: 'remoteValue',
+              overrideFlag: 'overrideValue',
+            },
+            localOverrides: {
+              overrideFlag: 'overrideValue',
+            },
+          },
+        });
+
+        expect(controller.state.remoteFeatureFlags).toStrictEqual({
+          remoteFlag: 'remoteValue',
+          overrideFlag: 'overrideValue',
         });
       });
     });

--- a/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.test.ts
+++ b/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.test.ts
@@ -124,6 +124,18 @@ describe('RemoteFeatureFlagController', () => {
       expect(controller.state).toStrictEqual(customState);
     });
 
+    it('merges undefined localOverrides into remoteFeatureFlags on init', () => {
+      const { controller } = createController({
+        state: {
+          remoteFeatureFlags: { flag: true },
+          localOverrides: undefined,
+        },
+      });
+
+      expect(controller.state.remoteFeatureFlags).toStrictEqual({ flag: true });
+      expect(controller.state.localOverrides).toBeUndefined();
+    });
+
     it('accepts valid 3-part SemVer clientVersion', () => {
       expect(() =>
         createController({ clientVersion: MOCK_BASE_VERSION }),
@@ -1291,6 +1303,35 @@ describe('RemoteFeatureFlagController', () => {
         expect(controller.state.remoteFeatureFlags).toStrictEqual({
           remoteFlag: 'remoteValue',
           overrideFlag: 'overrideValue',
+        });
+      });
+
+      it('merges legacy persisted localOverrides into remoteFeatureFlags on init', () => {
+        const { controller, messenger } = createController({
+          state: {
+            remoteFeatureFlags: {
+              remoteFlag: 'remoteValue',
+              overrideFlag: 'remoteOnlyValue',
+            },
+            localOverrides: {
+              overrideFlag: 'overrideValue',
+            },
+          },
+        });
+
+        expect(controller.state.remoteFeatureFlags).toStrictEqual({
+          remoteFlag: 'remoteValue',
+          overrideFlag: 'overrideValue',
+        });
+
+        messenger.call(
+          'RemoteFeatureFlagController:removeFlagOverride',
+          'overrideFlag',
+        );
+
+        expect(controller.state.remoteFeatureFlags).toStrictEqual({
+          remoteFlag: 'remoteValue',
+          overrideFlag: 'remoteOnlyValue',
         });
       });
     });

--- a/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.ts
+++ b/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.ts
@@ -204,21 +204,31 @@ export class RemoteFeatureFlagController extends BaseController<
       isValidSemVerVersion(prevClientVersion) &&
       prevClientVersion !== clientVersion;
 
+    const localOverrides = initialState.localOverrides ?? {};
+
     super({
       name: controllerName,
       metadata: remoteFeatureFlagControllerMetadata,
       messenger,
       state: {
         ...initialState,
+        remoteFeatureFlags: {
+          ...initialState.remoteFeatureFlags,
+          ...localOverrides,
+        },
         cacheTimestamp: hasClientVersionChanged
           ? 0
           : initialState.cacheTimestamp,
       },
     });
 
-    this.#processedRemoteFeatureFlags = { ...initialState.remoteFeatureFlags };
-    for (const flagName of Object.keys(initialState.localOverrides ?? {})) {
-      delete this.#processedRemoteFeatureFlags[flagName];
+    this.#processedRemoteFeatureFlags = {
+      ...initialState.remoteFeatureFlags,
+    };
+    for (const [flagName, overrideValue] of Object.entries(localOverrides)) {
+      if (this.#processedRemoteFeatureFlags[flagName] === overrideValue) {
+        delete this.#processedRemoteFeatureFlags[flagName];
+      }
     }
 
     this.#fetchInterval = fetchInterval;
@@ -459,10 +469,10 @@ export class RemoteFeatureFlagController extends BaseController<
     const remoteFeatureFlags = { ...this.state.remoteFeatureFlags };
     const processedValue = this.#processedRemoteFeatureFlags[flagName];
 
-    if (processedValue !== undefined) {
-      remoteFeatureFlags[flagName] = processedValue;
-    } else {
+    if (processedValue === undefined) {
       delete remoteFeatureFlags[flagName];
+    } else {
+      remoteFeatureFlags[flagName] = processedValue;
     }
 
     this.update(() => {

--- a/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.ts
+++ b/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.ts
@@ -155,6 +155,8 @@ export class RemoteFeatureFlagController extends BaseController<
 
   readonly #clientVersion: SemVerVersion;
 
+  #processedRemoteFeatureFlags: FeatureFlags = {};
+
   /**
    * Constructs a new RemoteFeatureFlagController instance.
    *
@@ -213,6 +215,11 @@ export class RemoteFeatureFlagController extends BaseController<
           : initialState.cacheTimestamp,
       },
     });
+
+    this.#processedRemoteFeatureFlags = { ...initialState.remoteFeatureFlags };
+    for (const flagName of Object.keys(initialState.localOverrides ?? {})) {
+      delete this.#processedRemoteFeatureFlags[flagName];
+    }
 
     this.#fetchInterval = fetchInterval;
     this.#disabled = disabled;
@@ -298,10 +305,15 @@ export class RemoteFeatureFlagController extends BaseController<
     }
 
     // Single state update with all changes batched together
+    this.#processedRemoteFeatureFlags = processedFlags;
+
     this.update(() => {
       return {
         ...this.state,
-        remoteFeatureFlags: processedFlags,
+        remoteFeatureFlags: {
+          ...processedFlags,
+          ...this.state.localOverrides,
+        },
         rawRemoteFeatureFlags: remoteFeatureFlags,
         cacheTimestamp: Date.now(),
         thresholdCache: updatedThresholdCache,
@@ -419,10 +431,16 @@ export class RemoteFeatureFlagController extends BaseController<
    */
   setFlagOverride(flagName: string, value: Json): void {
     this.update(() => {
+      const localOverrides = {
+        ...this.state.localOverrides,
+        [flagName]: value,
+      };
+
       return {
         ...this.state,
-        localOverrides: {
-          ...this.state.localOverrides,
+        localOverrides,
+        remoteFeatureFlags: {
+          ...this.state.remoteFeatureFlags,
           [flagName]: value,
         },
       };
@@ -437,10 +455,21 @@ export class RemoteFeatureFlagController extends BaseController<
   removeFlagOverride(flagName: string): void {
     const newLocalOverrides = { ...this.state.localOverrides };
     delete newLocalOverrides[flagName];
+
+    const remoteFeatureFlags = { ...this.state.remoteFeatureFlags };
+    const processedValue = this.#processedRemoteFeatureFlags[flagName];
+
+    if (processedValue !== undefined) {
+      remoteFeatureFlags[flagName] = processedValue;
+    } else {
+      delete remoteFeatureFlags[flagName];
+    }
+
     this.update(() => {
       return {
         ...this.state,
         localOverrides: newLocalOverrides,
+        remoteFeatureFlags,
       };
     });
   }
@@ -453,6 +482,7 @@ export class RemoteFeatureFlagController extends BaseController<
       return {
         ...this.state,
         localOverrides: {},
+        remoteFeatureFlags: { ...this.#processedRemoteFeatureFlags },
       };
     });
   }


### PR DESCRIPTION
## Summary

- `remoteFeatureFlags` now exposes the **effective** flag values consumers should read: processed remote flags merged with `localOverrides`
- Override mutations (`setFlagOverride`, `removeFlagOverride`, `clearAllFlagOverrides`) update `remoteFeatureFlags` directly instead of requiring callers to merge state themselves
- Remote flag fetches re-apply active overrides after processing so cached overrides survive refresh

## Behavior

Previously, `remoteFeatureFlags` contained only processed remote values and `localOverrides` was a separate map. Consumers that needed the effective value had to merge both manually, e.g. `{ ...remoteFeatureFlags, ...localOverrides }`.

With this change, the controller owns that merge:

| State field | Purpose |
|-------------|---------|
| `remoteFeatureFlags` | Effective values (`{ ...processedRemote, ...localOverrides }`) — **read this** |
| `localOverrides` | Which flags are locally overridden and their override values |
| `rawRemoteFeatureFlags` | Unprocessed API response |

### When merging happens

- **`updateRemoteFeatureFlags()`** — after version/threshold processing, overrides are spread onto the processed result
- **`setFlagOverride()`** — writes the override value directly into `remoteFeatureFlags`
- **`removeFlagOverride()` / `clearAllFlagOverrides()`** — restores processed remote values (tracked in a private in-memory cache refreshed on fetch)

### Consumer impact

- **Before:** merge `remoteFeatureFlags` + `localOverrides` at the call site
- **After:** read `remoteFeatureFlags` directly for effective values
- Call sites that already merge manually should drop the extra merge to avoid double-applying overrides

## Test plan

- [x] `yarn workspace @metamask/remote-feature-flag-controller run jest --no-coverage remote-feature-flag-controller.test.ts`
- [ ] Verify extension/mobile consumers that read `remoteFeatureFlags` no longer need a manual merge with `localOverrides`


Made with [Cursor](https://cursor.com)