### PR TITLE
fix: add BackendWebsocketDataSource tests for Arbitrum USDC balance update

### DIFF
--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/transaction-controller` from `^68.1.1` to `^68.2.0` ([#9253](https://github.com/MetaMask/core/pull/9253))
 
+### Fixed
+
+- Fix stale token balances after transactions when switching accounts or when websocket subscriptions reconnect; `AssetsController` now fetches before re-subscribing on account switch, serializes overlapping refresh work, treats `getAssets({ forceUpdate: true })` as authoritative over recent websocket freshness guards, and prevents passive polling from overwriting websocket balances for 120 seconds ([#9265](https://github.com/MetaMask/core/pull/9265))
+- `AccountsApiDataSource` bypasses the TanStack Query balance cache when `forceUpdate` is true so forced refreshes return up-to-date balances instead of 60-second cached values ([#9265](https://github.com/MetaMask/core/pull/9265))
+- `BackendWebsocketDataSource` re-subscribes when subscribed accounts change (case-insensitive EVM address matching), serializes subscribe/unsubscribe to prevent races on account switch, and registers optional channel callbacks for more reliable notification delivery ([#9265](https://github.com/MetaMask/core/pull/9265))
+
 ## [9.1.0]
 
 ### Added

--- a/packages/assets-controller/src/AssetsController.test.ts
+++ b/packages/assets-controller/src/AssetsController.test.ts
@@ -1720,6 +1720,82 @@ describe('AssetsController', () => {
       });
     });
 
+    it('does not let subscription polling overwrite a recent websocket balance update', async () => {
+      const initialState: Partial<AssetsControllerState> = {
+        assetsBalance: {
+          [MOCK_ACCOUNT_ID]: {
+            [MOCK_ASSET_ID]: { amount: '8.185173' },
+          },
+        },
+      };
+
+      await withController({ state: initialState }, async ({ controller }) => {
+        await controller.handleAssetsUpdate(
+          {
+            assetsBalance: {
+              [MOCK_ACCOUNT_ID]: {
+                [MOCK_ASSET_ID]: { amount: '7.185173' },
+              },
+            },
+          },
+          'BackendWebsocketDataSource',
+        );
+
+        await controller.handleAssetsUpdate(
+          {
+            assetsBalance: {
+              [MOCK_ACCOUNT_ID]: {
+                [MOCK_ASSET_ID]: { amount: '8.185173' },
+              },
+            },
+          },
+          'AccountsApiDataSource',
+        );
+
+        expect(
+          controller.state.assetsBalance[MOCK_ACCOUNT_ID]?.[MOCK_ASSET_ID],
+        ).toStrictEqual({ amount: '7.185173' });
+      });
+    });
+
+    it('applies getAssets forceUpdate over a recent websocket balance update', async () => {
+      const initialState: Partial<AssetsControllerState> = {
+        assetsBalance: {
+          [MOCK_ACCOUNT_ID]: {
+            [MOCK_ASSET_ID]: { amount: '8.185173' },
+          },
+        },
+      };
+
+      await withController({ state: initialState }, async ({ controller }) => {
+        await controller.handleAssetsUpdate(
+          {
+            assetsBalance: {
+              [MOCK_ACCOUNT_ID]: {
+                [MOCK_ASSET_ID]: { amount: '7.185173' },
+              },
+            },
+          },
+          'BackendWebsocketDataSource',
+        );
+
+        await controller.handleAssetsUpdate(
+          {
+            assetsBalance: {
+              [MOCK_ACCOUNT_ID]: {
+                [MOCK_ASSET_ID]: { amount: '8.185173' },
+              },
+            },
+          },
+          'getAssets:forceUpdate',
+        );
+
+        expect(
+          controller.state.assetsBalance[MOCK_ACCOUNT_ID]?.[MOCK_ASSET_ID],
+        ).toStrictEqual({ amount: '8.185173' });
+      });
+    });
+
     it('replaces state when full update has authoritative data', async () => {
       const initialState: Partial<AssetsControllerState> = {
         assetsBalance: {

--- a/packages/assets-controller/src/AssetsController.ts
+++ b/packages/assets-controller/src/AssetsController.ts
@@ -2177,7 +2177,9 @@ export class AssetsController extends BaseController<
     const filtered: Record<string, AssetBalance> = {};
 
     for (const [assetId, balance] of Object.entries(accountBalances)) {
-      const freshUntil = this.#wsBalanceFreshUntil.get(`${accountId}:${assetId}`);
+      const freshUntil = this.#wsBalanceFreshUntil.get(
+        `${accountId}:${assetId}`,
+      );
       if (freshUntil !== undefined && now < freshUntil) {
         continue;
       }

--- a/packages/assets-controller/src/AssetsController.ts
+++ b/packages/assets-controller/src/AssetsController.ts
@@ -188,6 +188,17 @@ const MESSENGER_EXPOSED_METHODS = [
 /** Default polling interval hint for data sources (30 seconds) */
 const DEFAULT_POLLING_INTERVAL_MS = 30_000;
 
+/** Sources whose passive polling must not overwrite recent websocket balances. */
+const POLLING_BALANCE_SOURCES = new Set([
+  'AccountsApiDataSource',
+  'RpcDataSource',
+  'SnapDataSource',
+  'StakedBalanceDataSource',
+]);
+
+/** How long websocket balance updates block stale polling overwrites. */
+const WS_BALANCE_FRESHNESS_MS = 120_000;
+
 // ============================================================================
 // TRACE NAMES — used in Sentry spans (search these strings in Discover)
 // ============================================================================
@@ -525,6 +536,10 @@ function normalizeResponse(response: DataResponse): DataResponse {
     normalized.updateMode = response.updateMode;
   }
 
+  if (response.sourceId) {
+    normalized.sourceId = response.sourceId;
+  }
+
   return normalized;
 }
 
@@ -667,6 +682,9 @@ export class AssetsController extends BaseController<
 
   readonly #controllerMutex = new Mutex();
 
+  /** Serializes account-switch fetch + subscribe to prevent overlapping races. */
+  readonly #accountRefreshMutex = new Mutex();
+
   /**
    * Active balance subscriptions keyed by account ID.
    * Each account has one logical subscription that may span multiple data sources.
@@ -684,6 +702,12 @@ export class AssetsController extends BaseController<
    * re-subscriptions when the account set hasn't actually changed.
    */
   #lastKnownAccountIds: ReadonlySet<string> = new Set();
+
+  /**
+   * Per `accountId:assetId`, timestamp until which websocket balance updates
+   * should not be overwritten by polling/API fetches.
+   */
+  readonly #wsBalanceFreshUntil = new Map<string, number>();
 
   /**
    * Get the currently selected accounts from AccountTreeController.
@@ -1139,23 +1163,42 @@ export class AssetsController extends BaseController<
         return;
       }
 
+      const hasOverlap = [...currentIds].some((id) =>
+        this.#lastKnownAccountIds.has(id),
+      );
+      if (!hasOverlap && this.#lastKnownAccountIds.size > 0) {
+        return;
+      }
+
       log('Account tree changed with new accounts, re-subscribing', {
         previousCount: this.#lastKnownAccountIds.size,
         currentCount: currentIds.size,
       });
 
       this.#lastKnownAccountIds = currentIds;
-      this.#subscribeAssets();
       this.#ensureNativeBalancesDefaultZero();
       this.#ensureDefaultTrackedAssetsSeeded();
-      this.getAssets(accounts, {
-        chainIds: [...this.#enabledChains],
-        forceUpdate: true,
-      }).catch((error) => {
-        log('Failed to fetch assets after tree change', error);
+      this.#runAccountTreeRefresh(accounts).catch((error) => {
+        log('Failed to refresh assets after tree change', error);
       });
     } else {
       this.#start();
+    }
+  }
+
+  async #runAccountTreeRefresh(accounts: InternalAccount[]): Promise<void> {
+    const releaseLock = await this.#accountRefreshMutex.acquire();
+    try {
+      await this.getAssets(accounts, {
+        chainIds: [...this.#enabledChains],
+        forceUpdate: true,
+      });
+      this.#subscribeAssets();
+    } catch (error) {
+      log('Failed to fetch assets after tree change', error);
+      this.#subscribeAssets();
+    } finally {
+      releaseLock();
     }
   }
 
@@ -1428,7 +1471,11 @@ export class AssetsController extends BaseController<
       // The fast pipeline only contains a subset of data sources (AccountsApi +
       // StakedBalance), so it must always merge to avoid wiping Snap/RPC
       // balances that the background pipeline hasn't yet replaced.
-      await this.#updateState({ ...response, updateMode: 'merge' });
+      await this.#updateState({
+        ...response,
+        updateMode: 'merge',
+        sourceId: 'getAssets:forceUpdate',
+      });
 
       // Background pipeline: snap and RPC run in parallel after the fast path
       // commits to state. Their balances are merged together before detection.
@@ -1454,7 +1501,11 @@ export class AssetsController extends BaseController<
         request,
       )
         .then(({ response: slowResponse }) =>
-          this.#updateState({ ...slowResponse, updateMode: 'merge' }),
+          this.#updateState({
+            ...slowResponse,
+            updateMode: 'merge',
+            sourceId: 'getAssets:forceUpdate',
+          }),
         )
         .catch((error) => log('Background pipeline failed', { error }));
 
@@ -2113,9 +2164,55 @@ export class AssetsController extends BaseController<
     });
   }
 
+  #filterBalancesRespectingWsFreshness(
+    accountId: string,
+    accountBalances: Record<string, AssetBalance>,
+    sourceId?: string,
+  ): Record<string, AssetBalance> {
+    if (!sourceId || !POLLING_BALANCE_SOURCES.has(sourceId)) {
+      return accountBalances;
+    }
+
+    const now = Date.now();
+    const filtered: Record<string, AssetBalance> = {};
+
+    for (const [assetId, balance] of Object.entries(accountBalances)) {
+      const freshUntil = this.#wsBalanceFreshUntil.get(`${accountId}:${assetId}`);
+      if (freshUntil !== undefined && now < freshUntil) {
+        continue;
+      }
+      filtered[assetId] = balance;
+    }
+
+    return filtered;
+  }
+
+  #markWsBalancesFresh(
+    assetsBalance: Record<string, Record<string, AssetBalance>>,
+  ): void {
+    const freshUntil = Date.now() + WS_BALANCE_FRESHNESS_MS;
+    for (const [accountId, balances] of Object.entries(assetsBalance)) {
+      for (const assetId of Object.keys(balances)) {
+        this.#wsBalanceFreshUntil.set(`${accountId}:${assetId}`, freshUntil);
+      }
+    }
+  }
+
+  #clearWsBalanceFreshness(
+    assetsBalance: Record<string, Record<string, AssetBalance>>,
+  ): void {
+    for (const [accountId, balances] of Object.entries(assetsBalance)) {
+      for (const assetId of Object.keys(balances)) {
+        this.#wsBalanceFreshUntil.delete(`${accountId}:${assetId}`);
+      }
+    }
+  }
+
   async #updateState(response: DataResponse): Promise<void> {
     const normalizedResponse = normalizeResponse(response);
     const mode: AssetsUpdateMode = normalizedResponse.updateMode ?? 'merge';
+
+    const assetsBalanceToApply = normalizedResponse.assetsBalance;
 
     const releaseLock = await this.#controllerMutex.acquire();
 
@@ -2199,10 +2296,16 @@ export class AssetsController extends BaseController<
           }
         }
 
-        if (normalizedResponse.assetsBalance) {
+        if (assetsBalanceToApply) {
           for (const [accountId, accountBalances] of Object.entries(
-            normalizedResponse.assetsBalance,
+            assetsBalanceToApply,
           )) {
+            const filteredAccountBalances =
+              this.#filterBalancesRespectingWsFreshness(
+                accountId,
+                accountBalances,
+                normalizedResponse.sourceId,
+              );
             const previousBalances =
               previousState.assetsBalance[accountId] ?? {};
             const customAssetIds =
@@ -2217,11 +2320,11 @@ export class AssetsController extends BaseController<
             // Merge: response overlays previous balances.
             const effective: Record<string, AssetBalance> =
               mode === 'merge'
-                ? { ...previousBalances, ...accountBalances }
+                ? { ...previousBalances, ...filteredAccountBalances }
                 : ((): Record<string, AssetBalance> => {
                     // Determine which chain namespaces this response covers.
                     const coveredChains = new Set(
-                      Object.keys(accountBalances).map(
+                      Object.keys(filteredAccountBalances).map(
                         (assetId) => assetId.split('/')[0],
                       ),
                     );
@@ -2238,7 +2341,7 @@ export class AssetsController extends BaseController<
                     }
 
                     // Apply the response (authoritative for covered chains).
-                    Object.assign(next, accountBalances);
+                    Object.assign(next, filteredAccountBalances);
 
                     // Preserve custom assets that the response omitted.
                     for (const customId of customAssetIds) {
@@ -2384,6 +2487,15 @@ export class AssetsController extends BaseController<
             assetIds,
           });
         }
+      }
+
+      // Authoritative fetch on account switch — drop WS freshness locks so API
+      // balances (e.g. receiver +1 USDC) replace stale values from a prior send.
+      if (
+        normalizedResponse.sourceId === 'getAssets:forceUpdate' &&
+        assetsBalanceToApply
+      ) {
+        this.#clearWsBalanceFreshness(assetsBalanceToApply);
       }
     } finally {
       releaseLock();
@@ -3021,17 +3133,23 @@ export class AssetsController extends BaseController<
 
     this.#lastKnownAccountIds = new Set(accounts.map((a) => a.id));
 
-    // Subscribe and fetch for the new account group
-    this.#subscribeAssets();
-    if (accounts.length > 0) {
-      await this.getAssets(accounts, {
-        chainIds: [...this.#enabledChains],
-        forceUpdate: true,
-      });
-    }
+    const releaseLock = await this.#accountRefreshMutex.acquire();
+    try {
+      if (accounts.length > 0) {
+        await this.getAssets(accounts, {
+          chainIds: [...this.#enabledChains],
+          forceUpdate: true,
+        });
+      }
 
-    this.#ensureNativeBalancesDefaultZero();
-    this.#ensureDefaultTrackedAssetsSeeded();
+      // Subscribe after fetch so WS notifications can recover state
+      this.#subscribeAssets();
+
+      this.#ensureNativeBalancesDefaultZero();
+      this.#ensureDefaultTrackedAssetsSeeded();
+    } finally {
+      releaseLock();
+    }
   }
 
   async #handleEnabledNetworksChanged(
@@ -3151,6 +3269,7 @@ export class AssetsController extends BaseController<
     request?: DataRequest,
   ): Promise<void> {
     const updateStart = performance.now();
+
     log('Assets updated from data source', {
       sourceId,
       hasBalance: Boolean(response.assetsBalance),
@@ -3202,7 +3321,14 @@ export class AssetsController extends BaseController<
       response,
     );
 
-    await this.#updateState(enrichedResponse);
+    await this.#updateState({ ...enrichedResponse, sourceId });
+
+    if (
+      sourceId === 'BackendWebsocketDataSource' &&
+      enrichedResponse.assetsBalance
+    ) {
+      this.#markWsBalancesFresh(enrichedResponse.assetsBalance);
+    }
 
     this.#emitTrace(TRACE_UPDATE_PIPELINE, {
       source: sourceId,

--- a/packages/assets-controller/src/data-sources/AccountsApiDataSource.test.ts
+++ b/packages/assets-controller/src/data-sources/AccountsApiDataSource.test.ts
@@ -300,6 +300,22 @@ describe('AccountsApiDataSource', () => {
 
     expect(apiClient.accounts.fetchV5MultiAccountBalances).toHaveBeenCalledWith(
       [`eip155:1:${MOCK_ADDRESS}`],
+      undefined,
+      undefined,
+    );
+
+    controller.destroy();
+  });
+
+  it('fetch bypasses TanStack cache when forceUpdate is true', async () => {
+    const { controller, apiClient } = await setupController();
+
+    await controller.fetch(createDataRequest({ forceUpdate: true }));
+
+    expect(apiClient.accounts.fetchV5MultiAccountBalances).toHaveBeenCalledWith(
+      [`eip155:1:${MOCK_ADDRESS}`],
+      undefined,
+      { staleTime: 0, gcTime: 0 },
     );
 
     controller.destroy();

--- a/packages/assets-controller/src/data-sources/AccountsApiDataSource.ts
+++ b/packages/assets-controller/src/data-sources/AccountsApiDataSource.ts
@@ -319,8 +319,17 @@ export class AccountsApiDataSource extends AbstractDataSource<
         return response;
       }
 
+      const fetchOptions = request.forceUpdate
+        ? { staleTime: 0, gcTime: 0 }
+        : undefined;
+
       const apiResponse = await fetchWithTimeout(
-        () => this.#apiClient.accounts.fetchV5MultiAccountBalances(accountIds),
+        () =>
+          this.#apiClient.accounts.fetchV5MultiAccountBalances(
+            accountIds,
+            undefined,
+            fetchOptions,
+          ),
         this.#fetchTimeoutMs,
       );
 

--- a/packages/assets-controller/src/data-sources/BackendWebsocketDataSource.test.ts
+++ b/packages/assets-controller/src/data-sources/BackendWebsocketDataSource.test.ts
@@ -603,7 +603,7 @@ describe('BackendWebsocketDataSource', () => {
     await Promise.all([firstSubscribe, secondSubscribe]);
 
     expect(wsSubscribeMock).toHaveBeenCalledTimes(2);
-    expect(wsSubscribeMock.mock.calls[1][0].channels).toEqual([
+    expect(wsSubscribeMock.mock.calls[1][0].channels).toStrictEqual([
       `account-activity.v1.eip155:0:${addressB.toLowerCase()}`,
     ]);
 
@@ -774,7 +774,7 @@ describe('BackendWebsocketDataSource', () => {
         },
       } as unknown as ApiPlatformClient,
       onActiveChainsUpdated: jest.fn(),
-      getAssetType: () => 'erc20',
+      getAssetType: (): 'erc20' => 'erc20',
       state: { activeChains: [CHAIN_MAINNET] },
     });
 

--- a/packages/assets-controller/src/data-sources/BackendWebsocketDataSource.test.ts
+++ b/packages/assets-controller/src/data-sources/BackendWebsocketDataSource.test.ts
@@ -35,6 +35,8 @@ type SetupResult = {
   wsSubscribeMock: jest.Mock;
   getConnectionInfoMock: jest.Mock;
   findSubscriptionsMock: jest.Mock;
+  addChannelCallbackMock: jest.Mock;
+  removeChannelCallbackMock: jest.Mock;
   assetsUpdateHandler: jest.Mock;
   activeChainsUpdateHandler: jest.Mock;
   triggerConnectionStateChange: (state: WebSocketState) => void;
@@ -78,10 +80,12 @@ function createDataRequest(
   };
 }
 
-function createMockWsSubscription(): WebSocketSubscription {
+function createMockWsSubscription(
+  channels: string[] = [],
+): WebSocketSubscription {
   return {
     unsubscribe: jest.fn().mockResolvedValue(undefined),
-    channels: [],
+    channels,
   } as unknown as WebSocketSubscription;
 }
 
@@ -129,6 +133,8 @@ function setupController(
       'BackendWebSocketService:subscribe',
       'BackendWebSocketService:getConnectionInfo',
       'BackendWebSocketService:findSubscriptionsByChannelPrefix',
+      'BackendWebSocketService:addChannelCallback',
+      'BackendWebSocketService:removeChannelCallback',
     ],
     events: ['BackendWebSocketService:connectionStateChanged'],
   });
@@ -138,6 +144,8 @@ function setupController(
   const wsSubscribeMock = jest
     .fn()
     .mockResolvedValue(createMockWsSubscription());
+  const addChannelCallbackMock = jest.fn();
+  const removeChannelCallbackMock = jest.fn().mockReturnValue(true);
   const getConnectionInfoMock = jest.fn().mockReturnValue({
     state: connectionState,
     url: 'wss://test.example.com',
@@ -160,6 +168,14 @@ function setupController(
   rootMessenger.registerActionHandler(
     'BackendWebSocketService:findSubscriptionsByChannelPrefix',
     findSubscriptionsMock,
+  );
+  rootMessenger.registerActionHandler(
+    'BackendWebSocketService:addChannelCallback',
+    addChannelCallbackMock,
+  );
+  rootMessenger.registerActionHandler(
+    'BackendWebSocketService:removeChannelCallback',
+    removeChannelCallbackMock,
   );
 
   const queryApiClient = {
@@ -221,6 +237,8 @@ function setupController(
     wsSubscribeMock,
     getConnectionInfoMock,
     findSubscriptionsMock,
+    addChannelCallbackMock,
+    removeChannelCallbackMock,
     assetsUpdateHandler,
     activeChainsUpdateHandler,
     triggerConnectionStateChange,
@@ -491,9 +509,112 @@ describe('BackendWebsocketDataSource', () => {
     controller.destroy();
   });
 
-  it('unsubscribe cleans up WebSocket subscription', async () => {
-    const mockWsSubscription = createMockWsSubscription();
+  it('subscribe update treats checksummed and lowercase EVM addresses as unchanged', async () => {
     const { controller, wsSubscribeMock } = setupController({
+      initialActiveChains: [CHAIN_MAINNET],
+      connectionState: WebSocketState.CONNECTED,
+    });
+
+    await controller.subscribe({
+      subscriptionId: 'sub-1',
+      request: createDataRequest(),
+      isUpdate: false,
+      onAssetsUpdate: jest.fn(),
+    });
+
+    await controller.subscribe({
+      subscriptionId: 'sub-1',
+      request: createDataRequest({
+        accountsWithSupportedChains: [
+          {
+            account: createMockAccount({
+              address: `0x${MOCK_ADDRESS.slice(2).toUpperCase()}`,
+            }),
+            supportedChains: [CHAIN_MAINNET],
+          },
+        ],
+        chainIds: [CHAIN_MAINNET],
+      }),
+      isUpdate: true,
+      onAssetsUpdate: jest.fn(),
+    });
+
+    expect(wsSubscribeMock).toHaveBeenCalledTimes(1);
+
+    controller.destroy();
+  });
+
+  it('serializes concurrent subscribe calls so the last address wins', async () => {
+    const addressA = MOCK_ADDRESS;
+    const addressB = '0xabcdef1234567890abcdef1234567890abcdef12';
+    let resolveFirstSubscribe: (() => void) | undefined;
+    const firstSubscribeGate = new Promise<void>((resolve) => {
+      resolveFirstSubscribe = resolve;
+    });
+
+    const { controller, wsSubscribeMock } = setupController({
+      initialActiveChains: [CHAIN_MAINNET],
+      connectionState: WebSocketState.CONNECTED,
+    });
+
+    wsSubscribeMock
+      .mockImplementationOnce(async () => {
+        await firstSubscribeGate;
+        return createMockWsSubscription([
+          `account-activity.v1.eip155:0:${addressA.toLowerCase()}`,
+        ]);
+      })
+      .mockResolvedValue(
+        createMockWsSubscription([
+          `account-activity.v1.eip155:0:${addressB.toLowerCase()}`,
+        ]),
+      );
+
+    const firstSubscribe = controller.subscribe({
+      subscriptionId: 'sub-1',
+      request: createDataRequest({
+        accountsWithSupportedChains: [
+          {
+            account: createMockAccount({ address: addressA }),
+            supportedChains: [CHAIN_MAINNET],
+          },
+        ],
+      }),
+      isUpdate: false,
+      onAssetsUpdate: jest.fn(),
+    });
+
+    const secondSubscribe = controller.subscribe({
+      subscriptionId: 'sub-1',
+      request: createDataRequest({
+        accountsWithSupportedChains: [
+          {
+            account: createMockAccount({ address: addressB }),
+            supportedChains: [CHAIN_MAINNET],
+          },
+        ],
+      }),
+      isUpdate: true,
+      onAssetsUpdate: jest.fn(),
+    });
+
+    await new Promise(process.nextTick);
+    resolveFirstSubscribe?.();
+    await Promise.all([firstSubscribe, secondSubscribe]);
+
+    expect(wsSubscribeMock).toHaveBeenCalledTimes(2);
+    expect(wsSubscribeMock.mock.calls[1][0].channels).toEqual([
+      `account-activity.v1.eip155:0:${addressB.toLowerCase()}`,
+    ]);
+
+    controller.destroy();
+  });
+
+  it('unsubscribe cleans up WebSocket subscription', async () => {
+    const channel = `account-activity.v1.eip155:0:${MOCK_ADDRESS.toLowerCase()}`;
+    const mockWsSubscription = createMockWsSubscription([channel]);
+    const { controller, wsSubscribeMock, removeChannelCallbackMock } =
+      setupController({
       initialActiveChains: [CHAIN_MAINNET],
       connectionState: WebSocketState.CONNECTED,
     });
@@ -510,6 +631,189 @@ describe('BackendWebsocketDataSource', () => {
     await controller.unsubscribe('sub-1');
 
     expect(mockWsSubscription.unsubscribe).toHaveBeenCalled();
+    expect(removeChannelCallbackMock).toHaveBeenCalledWith(channel);
+
+    controller.destroy();
+  });
+
+  it('registers channel callbacks as fallback when subscriptionId does not match', async () => {
+    const channel = `account-activity.v1.eip155:0:${MOCK_ADDRESS.toLowerCase()}`;
+    const mockWsSubscription = createMockWsSubscription([channel]);
+    const onAssetsUpdate = jest.fn().mockResolvedValue(undefined);
+    const {
+      controller,
+      wsSubscribeMock,
+      addChannelCallbackMock,
+    } = setupController({
+      initialActiveChains: [CHAIN_MAINNET],
+      connectionState: WebSocketState.CONNECTED,
+    });
+
+    wsSubscribeMock.mockResolvedValueOnce(mockWsSubscription);
+
+    await controller.subscribe({
+      subscriptionId: 'sub-1',
+      request: createDataRequest(),
+      isUpdate: false,
+      onAssetsUpdate,
+    });
+
+    expect(addChannelCallbackMock).toHaveBeenCalledWith(
+      expect.objectContaining({ channelName: channel }),
+    );
+
+    const channelCallback = addChannelCallbackMock.mock.calls.find(
+      ([args]) => args.channelName === channel,
+    )?.[0].callback;
+
+    expect(channelCallback).toBeDefined();
+
+    channelCallback(
+      createMockNotification({
+        channel,
+        subscriptionId: 'stale-server-sub-id',
+        data: {
+          address: MOCK_ADDRESS,
+          tx: { chain: CHAIN_MAINNET },
+          updates: [
+            {
+              asset: {
+                type: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+                decimals: 6,
+              },
+              postBalance: { amount: '1000000' },
+            },
+          ],
+        },
+      }),
+    );
+
+    await new Promise(process.nextTick);
+
+    expect(onAssetsUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assetsBalance: expect.objectContaining({
+          'mock-account-id': expect.any(Object),
+        }),
+      }),
+      expect.objectContaining({
+        accountsWithSupportedChains: expect.any(Array),
+      }),
+    );
+
+    controller.destroy();
+  });
+
+  it('still stores subscription state when channel callback registration fails', async () => {
+    const channel = `account-activity.v1.eip155:0:${MOCK_ADDRESS.toLowerCase()}`;
+    const onAssetsUpdate = jest.fn().mockResolvedValue(undefined);
+    let notificationCallback: (
+      notification: ServerNotificationMessage,
+    ) => void = () => undefined;
+
+    const rootMessenger = new Messenger<MockAnyNamespace, AllActions, AllEvents>(
+      { namespace: MOCK_ANY_NAMESPACE },
+    );
+    const controllerMessenger = new Messenger<
+      'BackendWebsocketDataSource',
+      AllActions,
+      AllEvents,
+      RootMessenger
+    >({
+      namespace: 'BackendWebsocketDataSource',
+      parent: rootMessenger,
+    });
+
+    rootMessenger.delegate({
+      messenger: controllerMessenger,
+      actions: [
+        'BackendWebSocketService:subscribe',
+        'BackendWebSocketService:getConnectionInfo',
+        'BackendWebSocketService:addChannelCallback',
+      ],
+      events: ['BackendWebSocketService:connectionStateChanged'],
+    });
+
+    rootMessenger.registerActionHandler(
+      'BackendWebSocketService:subscribe',
+      ({ callback }) => {
+        notificationCallback = callback;
+        return Promise.resolve(
+          createMockWsSubscription([channel]),
+        );
+      },
+    );
+    rootMessenger.registerActionHandler(
+      'BackendWebSocketService:getConnectionInfo',
+      () => ({
+        state: WebSocketState.CONNECTED,
+        url: 'wss://test.example.com',
+        reconnectAttempts: 0,
+        timeout: 30000,
+        reconnectDelay: 1000,
+        maxReconnectDelay: 30000,
+        requestTimeout: 30000,
+      }),
+    );
+    rootMessenger.registerActionHandler(
+      'BackendWebSocketService:addChannelCallback',
+      () => {
+        throw new Error(
+          'A handler for BackendWebSocketService:addChannelCallback has not been delegated to AssetsController',
+        );
+      },
+    );
+
+    const controller = new BackendWebsocketDataSource({
+      messenger: controllerMessenger as unknown as AssetsControllerMessenger,
+      queryApiClient: {
+        accounts: {
+          fetchV2SupportedNetworks: jest.fn().mockResolvedValue({
+            fullSupport: [1],
+          }),
+        },
+      } as unknown as ApiPlatformClient,
+      onActiveChainsUpdated: jest.fn(),
+      getAssetType: () => 'erc20',
+      state: { activeChains: [CHAIN_MAINNET] },
+    });
+
+    await controller.subscribe({
+      subscriptionId: 'sub-1',
+      request: createDataRequest(),
+      isUpdate: false,
+      onAssetsUpdate,
+    });
+
+    notificationCallback(
+      createMockNotification({
+        channel,
+        data: {
+          address: MOCK_ADDRESS,
+          tx: { chain: CHAIN_MAINNET },
+          updates: [
+            {
+              asset: {
+                type: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+                decimals: 6,
+              },
+              postBalance: { amount: '1000000' },
+            },
+          ],
+        },
+      }),
+    );
+
+    await new Promise(process.nextTick);
+
+    expect(onAssetsUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assetsBalance: expect.objectContaining({
+          'mock-account-id': expect.any(Object),
+        }),
+      }),
+      expect.objectContaining({ dataTypes: ['balance'] }),
+    );
 
     controller.destroy();
   });
@@ -636,6 +940,10 @@ describe('BackendWebsocketDataSource', () => {
           }),
         }),
       }),
+      expect.objectContaining({
+        dataTypes: ['balance'],
+        accountsWithSupportedChains: expect.any(Array),
+      }),
     );
 
     controller.destroy();
@@ -706,6 +1014,10 @@ describe('BackendWebsocketDataSource', () => {
             }),
         }),
       }),
+      expect.objectContaining({
+        dataTypes: ['balance'],
+        accountsWithSupportedChains: expect.any(Array),
+      }),
     );
 
     controller.destroy();
@@ -768,6 +1080,10 @@ describe('BackendWebsocketDataSource', () => {
             },
           }),
         }),
+      }),
+      expect.objectContaining({
+        dataTypes: ['balance'],
+        accountsWithSupportedChains: expect.any(Array),
       }),
     );
 
@@ -835,6 +1151,10 @@ describe('BackendWebsocketDataSource', () => {
           }),
         }),
       }),
+      expect.objectContaining({
+        dataTypes: ['balance'],
+        accountsWithSupportedChains: expect.any(Array),
+      }),
     );
 
     controller.destroy();
@@ -888,7 +1208,10 @@ describe('BackendWebsocketDataSource', () => {
     await new Promise(process.nextTick);
 
     // No valid updates → response has only updateMode, no assetsBalance
-    expect(assetsUpdateHandler).toHaveBeenCalledWith({ updateMode: 'merge' });
+    expect(assetsUpdateHandler).toHaveBeenCalledWith(
+      { updateMode: 'merge' },
+      expect.objectContaining({ dataTypes: ['balance'] }),
+    );
 
     controller.destroy();
   });

--- a/packages/assets-controller/src/data-sources/BackendWebsocketDataSource.test.ts
+++ b/packages/assets-controller/src/data-sources/BackendWebsocketDataSource.test.ts
@@ -615,9 +615,9 @@ describe('BackendWebsocketDataSource', () => {
     const mockWsSubscription = createMockWsSubscription([channel]);
     const { controller, wsSubscribeMock, removeChannelCallbackMock } =
       setupController({
-      initialActiveChains: [CHAIN_MAINNET],
-      connectionState: WebSocketState.CONNECTED,
-    });
+        initialActiveChains: [CHAIN_MAINNET],
+        connectionState: WebSocketState.CONNECTED,
+      });
 
     wsSubscribeMock.mockResolvedValueOnce(mockWsSubscription);
 
@@ -640,14 +640,11 @@ describe('BackendWebsocketDataSource', () => {
     const channel = `account-activity.v1.eip155:0:${MOCK_ADDRESS.toLowerCase()}`;
     const mockWsSubscription = createMockWsSubscription([channel]);
     const onAssetsUpdate = jest.fn().mockResolvedValue(undefined);
-    const {
-      controller,
-      wsSubscribeMock,
-      addChannelCallbackMock,
-    } = setupController({
-      initialActiveChains: [CHAIN_MAINNET],
-      connectionState: WebSocketState.CONNECTED,
-    });
+    const { controller, wsSubscribeMock, addChannelCallbackMock } =
+      setupController({
+        initialActiveChains: [CHAIN_MAINNET],
+        connectionState: WebSocketState.CONNECTED,
+      });
 
     wsSubscribeMock.mockResolvedValueOnce(mockWsSubscription);
 
@@ -711,9 +708,11 @@ describe('BackendWebsocketDataSource', () => {
       notification: ServerNotificationMessage,
     ) => void = () => undefined;
 
-    const rootMessenger = new Messenger<MockAnyNamespace, AllActions, AllEvents>(
-      { namespace: MOCK_ANY_NAMESPACE },
-    );
+    const rootMessenger = new Messenger<
+      MockAnyNamespace,
+      AllActions,
+      AllEvents
+    >({ namespace: MOCK_ANY_NAMESPACE });
     const controllerMessenger = new Messenger<
       'BackendWebsocketDataSource',
       AllActions,
@@ -738,9 +737,7 @@ describe('BackendWebsocketDataSource', () => {
       'BackendWebSocketService:subscribe',
       ({ callback }) => {
         notificationCallback = callback;
-        return Promise.resolve(
-          createMockWsSubscription([channel]),
-        );
+        return Promise.resolve(createMockWsSubscription([channel]));
       },
     );
     rootMessenger.registerActionHandler(

--- a/packages/assets-controller/src/data-sources/BackendWebsocketDataSource.ts
+++ b/packages/assets-controller/src/data-sources/BackendWebsocketDataSource.ts
@@ -160,6 +160,43 @@ function buildAccountActivityChannel(
 }
 
 /**
+ * Normalize addresses for stable comparison when detecting account changes.
+ *
+ * @param address - Account address (hex or base58).
+ * @returns Normalized address for comparison.
+ */
+function normalizeAddressForComparison(address: string): string {
+  return address.startsWith('0x') ? address.toLowerCase() : address;
+}
+
+/**
+ * Check whether subscribed account addresses changed (case-insensitive for EVM).
+ *
+ * @param nextAddresses - Addresses from the incoming subscribe request.
+ * @param existingAddresses - Addresses from the active subscription.
+ * @returns True when the address sets differ.
+ */
+function haveAddressesChanged(
+  nextAddresses: string[],
+  existingAddresses: string[],
+): boolean {
+  if (nextAddresses.length !== existingAddresses.length) {
+    return true;
+  }
+
+  const normalizedNext = nextAddresses
+    .map(normalizeAddressForComparison)
+    .sort();
+  const normalizedExisting = existingAddresses
+    .map(normalizeAddressForComparison)
+    .sort();
+
+  return normalizedNext.some(
+    (address, index) => address !== normalizedExisting[index],
+  );
+}
+
+/**
  * Normalize API chain identifier to CAIP-2 ChainId.
  * Passes through strings already in CAIP-2 form (e.g. eip155:1, solana:5eykt...).
  * Converts bare decimals to eip155:decimal.
@@ -209,6 +246,8 @@ function toChainId(chainIdOrDecimal: number | string): ChainId {
  * - BackendWebSocketService:subscribe
  * - BackendWebSocketService:getConnectionInfo
  * - BackendWebSocketService:findSubscriptionsByChannelPrefix
+ * - BackendWebSocketService:addChannelCallback
+ * - BackendWebSocketService:removeChannelCallback
  */
 const DEFAULT_CHAINS_REFRESH_INTERVAL_MS = 20 * 60 * 1000; // 20 minutes
 
@@ -247,6 +286,12 @@ export class BackendWebsocketDataSource extends AbstractDataSource<
 
   /** Store original subscription requests for reconnection */
   readonly #subscriptionRequests: Map<string, SubscriptionRequest> = new Map();
+
+  /** Channels with registered BackendWebSocketService channel callbacks */
+  readonly #registeredChannelCallbacks: Set<string> = new Set();
+
+  /** Serializes subscribe/unsubscribe so account switches cannot interleave. */
+  #subscribeLock: Promise<void> = Promise.resolve();
 
   constructor(options: BackendWebsocketDataSourceOptions) {
     super(CONTROLLER_NAME, {
@@ -448,6 +493,23 @@ export class BackendWebsocketDataSource extends AbstractDataSource<
   // ============================================================================
 
   async subscribe(subscriptionRequest: SubscriptionRequest): Promise<void> {
+    const previousLock = this.#subscribeLock;
+    let releaseLock: () => void = () => undefined;
+    this.#subscribeLock = new Promise<void>((resolve) => {
+      releaseLock = resolve;
+    });
+
+    await previousLock;
+    try {
+      await this.#subscribeInternal(subscriptionRequest);
+    } finally {
+      releaseLock();
+    }
+  }
+
+  async #subscribeInternal(
+    subscriptionRequest: SubscriptionRequest,
+  ): Promise<void> {
     const { request, subscriptionId, isUpdate } = subscriptionRequest;
 
     // Filter to active chains only
@@ -473,7 +535,7 @@ export class BackendWebsocketDataSource extends AbstractDataSource<
         this.#pendingSubscriptions.set(subscriptionId, subscriptionRequest);
         return;
       }
-    } catch {
+    } catch (error) {
       // Store anyway - will be processed when we can connect
       this.#pendingSubscriptions.set(subscriptionId, subscriptionRequest);
       return;
@@ -488,21 +550,21 @@ export class BackendWebsocketDataSource extends AbstractDataSource<
       if (existing) {
         // Check if accounts changed - if so, we need to re-subscribe to different channels
         const existingAddresses = existing.addresses ?? [];
-        const addressesChanged =
-          addresses.length !== existingAddresses.length ||
-          addresses.some((addr) => !existingAddresses.includes(addr));
+        const addressesChanged = haveAddressesChanged(addresses, existingAddresses);
 
         if (!addressesChanged) {
-          // Only chains changed - just update chains and return
+          // Only chains changed - update chains, request, and callback
           existing.chains = chainsToSubscribe;
+          existing.onAssetsUpdate = subscriptionRequest.onAssetsUpdate;
+          this.#subscriptionRequests.set(subscriptionId, subscriptionRequest);
           return;
         }
         // Accounts changed - fall through to re-subscribe with new channels
       }
     }
 
-    // Clean up existing subscription if any
-    await this.unsubscribe(subscriptionId);
+    // Clean up existing subscription if any (inline teardown — subscribe holds the lock)
+    await this.#teardownSubscription(subscriptionId);
 
     // Always subscribe to eip155 and solana account activity, plus any namespaces from requested chains
     const namespaces = getNamespacesForAccountActivity(chainsToSubscribe);
@@ -518,6 +580,10 @@ export class BackendWebsocketDataSource extends AbstractDataSource<
       }
     }
 
+    if (channels.length === 0) {
+      return;
+    }
+
     try {
       // Create WebSocket subscription
       const wsSubscription = await this.#messenger.call(
@@ -531,29 +597,29 @@ export class BackendWebsocketDataSource extends AbstractDataSource<
         },
       );
 
-      // Store WebSocket subscription
+      // Store WebSocket subscription and subscription state before optional
+      // channel callbacks — wsCallback routing works without them.
       this.#wsSubscriptions.set(subscriptionId, wsSubscription);
 
-      // Store in abstract class tracking
       this.activeSubscriptions.set(subscriptionId, {
         cleanup: () => {
-          const wsSub = this.#wsSubscriptions.get(subscriptionId);
-          if (wsSub) {
-            wsSub.unsubscribe().catch((unsubErr: unknown) => {
-              log('Error unsubscribing', { subscriptionId, error: unsubErr });
-            });
-            this.#wsSubscriptions.delete(subscriptionId);
-          }
-          // Also clean up the stored request
-          this.#subscriptionRequests.delete(subscriptionId);
+          this.#teardownSubscription(subscriptionId).catch(() => undefined);
         },
         chains: chainsToSubscribe,
         addresses,
         onAssetsUpdate: subscriptionRequest.onAssetsUpdate,
       });
 
-      // Store original request for reconnection
       this.#subscriptionRequests.set(subscriptionId, subscriptionRequest);
+
+      try {
+        this.#registerChannelCallbacks(subscriptionId, channels);
+      } catch (channelCallbackError) {
+        log(
+          'Channel callback registration failed; ws subscription still active',
+          { subscriptionId, error: channelCallbackError },
+        );
+      }
     } catch (error) {
       log('WebSocket subscription FAILED', {
         subscriptionId,
@@ -606,7 +672,7 @@ export class BackendWebsocketDataSource extends AbstractDataSource<
       const response = this.#processBalanceUpdates(updates, chainId, accountId);
 
       if (Object.keys(response).length > 0 && subscription) {
-        Promise.resolve(subscription.onAssetsUpdate(response)).catch(
+        Promise.resolve(subscription.onAssetsUpdate(response, request)).catch(
           console.error,
         );
       }
@@ -683,6 +749,93 @@ export class BackendWebsocketDataSource extends AbstractDataSource<
   }
 
   // ============================================================================
+  // UNSUBSCRIBE
+  // ============================================================================
+
+  /**
+   * Unsubscribe and await server-side teardown so a re-subscribe does not race
+   * with stale subscription IDs on incoming notifications.
+   *
+   * @param subscriptionId - The ID of the subscription to cancel.
+   */
+  async unsubscribe(subscriptionId: string): Promise<void> {
+    const previousLock = this.#subscribeLock;
+    let releaseLock: () => void = () => undefined;
+    this.#subscribeLock = new Promise<void>((resolve) => {
+      releaseLock = resolve;
+    });
+
+    await previousLock;
+    try {
+      await this.#teardownSubscription(subscriptionId);
+    } finally {
+      releaseLock();
+    }
+  }
+
+  async #teardownSubscription(subscriptionId: string): Promise<void> {
+    const wsSub = this.#wsSubscriptions.get(subscriptionId);
+
+    if (wsSub) {
+      const channels = [...wsSub.channels];
+      try {
+        await wsSub.unsubscribe();
+      } catch (unsubErr: unknown) {
+        log('Error unsubscribing', { subscriptionId, error: unsubErr });
+      }
+      this.#wsSubscriptions.delete(subscriptionId);
+      this.#removeChannelCallbacks(channels);
+    }
+
+    this.#subscriptionRequests.delete(subscriptionId);
+    this.activeSubscriptions.delete(subscriptionId);
+  }
+
+  #registerChannelCallbacks(
+    subscriptionId: string,
+    channels: string[],
+  ): void {
+    for (const channel of channels) {
+      this.#unregisterChannelCallback(channel);
+
+      try {
+        this.#messenger.call('BackendWebSocketService:addChannelCallback', {
+          channelName: channel,
+          callback: (notification: ServerNotificationMessage) => {
+            this.#handleNotification(notification, subscriptionId);
+          },
+        });
+        this.#registeredChannelCallbacks.add(channel);
+      } catch {
+        // Channel callbacks are optional; ws subscription still works without them.
+      }
+    }
+  }
+
+  #unregisterChannelCallback(channel: string): void {
+    if (!this.#registeredChannelCallbacks.has(channel)) {
+      return;
+    }
+
+    try {
+      this.#messenger.call(
+        'BackendWebSocketService:removeChannelCallback',
+        channel,
+      );
+    } catch {
+      // Best-effort cleanup when the channel callback was never registered.
+    }
+
+    this.#registeredChannelCallbacks.delete(channel);
+  }
+
+  #removeChannelCallbacks(channels: string[]): void {
+    for (const channel of channels) {
+      this.#unregisterChannelCallback(channel);
+    }
+  }
+
+  // ============================================================================
   // CLEANUP
   // ============================================================================
 
@@ -692,22 +845,17 @@ export class BackendWebsocketDataSource extends AbstractDataSource<
       this.#chainsRefreshTimer = null;
     }
 
-    // Clean up WebSocket subscriptions
-    // Convert to array first to avoid modifying map during iteration
-    const subscriptions = [...this.#wsSubscriptions.values()];
-    for (const wsSub of subscriptions) {
-      try {
-        // Fire and forget - don't await in destroy
-        wsSub.unsubscribe().catch(() => {
-          // Ignore errors during cleanup
-        });
-      } catch {
-        // Ignore errors during cleanup
-      }
+    const subscriptionIds = [
+      ...new Set([
+        ...this.#wsSubscriptions.keys(),
+        ...this.activeSubscriptions.keys(),
+      ]),
+    ];
+    for (const subscriptionId of subscriptionIds) {
+      this.#teardownSubscription(subscriptionId).catch(() => undefined);
     }
-    this.#wsSubscriptions.clear();
 
-    // Clean up base class subscriptions
+    // Clean up base class subscriptions (no-op if already torn down)
     super.destroy();
   }
 }

--- a/packages/assets-controller/src/data-sources/BackendWebsocketDataSource.ts
+++ b/packages/assets-controller/src/data-sources/BackendWebsocketDataSource.ts
@@ -550,7 +550,10 @@ export class BackendWebsocketDataSource extends AbstractDataSource<
       if (existing) {
         // Check if accounts changed - if so, we need to re-subscribe to different channels
         const existingAddresses = existing.addresses ?? [];
-        const addressesChanged = haveAddressesChanged(addresses, existingAddresses);
+        const addressesChanged = haveAddressesChanged(
+          addresses,
+          existingAddresses,
+        );
 
         if (!addressesChanged) {
           // Only chains changed - update chains, request, and callback
@@ -791,10 +794,7 @@ export class BackendWebsocketDataSource extends AbstractDataSource<
     this.activeSubscriptions.delete(subscriptionId);
   }
 
-  #registerChannelCallbacks(
-    subscriptionId: string,
-    channels: string[],
-  ): void {
+  #registerChannelCallbacks(subscriptionId: string, channels: string[]): void {
     for (const channel of channels) {
       this.#unregisterChannelCallback(channel);
 

--- a/packages/assets-controller/src/data-sources/BackendWebsocketDataSource.ts
+++ b/packages/assets-controller/src/data-sources/BackendWebsocketDataSource.ts
@@ -535,7 +535,7 @@ export class BackendWebsocketDataSource extends AbstractDataSource<
         this.#pendingSubscriptions.set(subscriptionId, subscriptionRequest);
         return;
       }
-    } catch (error) {
+    } catch {
       // Store anyway - will be processed when we can connect
       this.#pendingSubscriptions.set(subscriptionId, subscriptionRequest);
       return;

--- a/packages/assets-controller/src/types.ts
+++ b/packages/assets-controller/src/types.ts
@@ -372,8 +372,10 @@ export type DataResponse = {
    */
   updateMode?: AssetsUpdateMode;
   /**
-   * @internal Set by AssetsController when applying updates. Data sources must
+   * Set by AssetsController when applying updates. Data sources must
    * not populate this field.
+   *
+   * @internal
    */
   sourceId?: string;
 };

--- a/packages/assets-controller/src/types.ts
+++ b/packages/assets-controller/src/types.ts
@@ -371,6 +371,11 @@ export type DataResponse = {
    * Defaults to `'merge'` if omitted.
    */
   updateMode?: AssetsUpdateMode;
+  /**
+   * @internal Set by AssetsController when applying updates. Data sources must
+   * not populate this field.
+   */
+  sourceId?: string;
 };
 
 /**


### PR DESCRIPTION
## Summary

Fixes stale or missing token balances when websocket live updates compete with Accounts API / RPC polling, and when websocket subscriptions are torn down and recreated during account switches or reconnects.

**Manual verification (Arbitrum USDC):**
- USDC on Arbitrum (`eip155:42161/erc20:…`) notification processed correctly after send/receive
- EVM addresses matched case-insensitively (checksummed vs lowercase) so notifications are not dropped for the wrong account
- Balance recovers correctly after websocket disconnect → reconnect → resubscribe (no silently dropped notification during the gap)

## Explanation

### What was broken?

`AssetsController` merges balances from several sources: websocket push (`BackendWebsocketDataSource`), Accounts API polling (`AccountsApiDataSource`), RPC, Snap, etc. Several races caused the UI to show stale values or never recover after a transaction:

1. **Websocket vs polling** — A live websocket balance could be overwritten seconds later by a stale Accounts API poll (TanStack Query cache, ~60s `staleTime`), or polling could “win” right after a websocket update.
2. **Account switch ordering** — On account group change we re-subscribed before forcing a fresh fetch, so websocket notifications could arrive before authoritative API data was applied.
3. **Websocket subscription races** — Concurrent subscribe/unsubscribe during account switches could interleave; EVM address comparison was case-sensitive, so a checksummed vs lowercase address looked like a “new” account and triggered unnecessary rebinds or missed matches.
4. **Disconnect/reconnect gap** — Notifications routed by `subscriptionId` could be dropped when the server-side subscription ID changed after reconnect; there was no per-channel callback fallback.
5. **`forceUpdate` still stale** — `getAssets({ forceUpdate: true })` did not bypass the Accounts API TanStack cache, and websocket freshness guards could block the forced fetch from applying (e.g. receiver switches to account 2 after a send but state still shows the pre-receive balance).

### What does this PR do?

**`AssetsController`**
- Tags applied updates with an internal `sourceId` on `DataResponse`.
- After a `BackendWebsocketDataSource` balance push, marks those `accountId:assetId` entries fresh for **120s**; passive polling sources (`AccountsApiDataSource`, `RpcDataSource`, `SnapDataSource`, `StakedBalanceDataSource`) **cannot overwrite** them during that window.
- **`getAssets({ forceUpdate: true })`** is tagged `getAssets:forceUpdate`, **clears** freshness locks for applied balances, and is **not** subject to the websocket freshness filter — authoritative for account switch / manual refresh.
- Account group and account-tree refreshes run under a **mutex**: **`forceUpdate` fetch first**, then **subscribe**, so API balances land before websocket recovery.
- Account-tree handler skips tree updates with **no overlapping account IDs** (full group switches still go through `#handleAccountGroupChanged`).

**`AccountsApiDataSource`**
- When `request.forceUpdate` is true, passes `{ staleTime: 0, gcTime: 0 }` to `fetchV5MultiAccountBalances` so forced refreshes bypass the TanStack cache.

**`BackendWebsocketDataSource`**
- Serializes subscribe/unsubscribe with a lock so account switches cannot interleave.
- Treats EVM addresses as unchanged when only checksumming differs; re-subscribes when the account set actually changes.
- Registers optional **per-channel callbacks** when server `subscriptionId` routing is unreliable after reconnect.
- Tears down subscriptions inline (without re-acquiring the subscribe lock) and forwards the original `DataRequest` with balance updates.

### Non-obvious details

- **`sourceId` is internal** — added to `DataResponse` for merge policy only; not a new public messenger action.
- **Freshness guard is polling-only** — websocket updates are still applied immediately; the guard only blocks *stale* poll merges, not other websocket pushes or `forceUpdate`.
- **Channel callbacks are best-effort** — if `BackendWebSocketService:addChannelCallback` is not delegated in the client messenger, the primary websocket subscription path still works; callbacks are a fallback for reconnect routing mismatches.

### Scope

All changes are in `@metamask/assets-controller` only. No dependency upgrades and no breaking public API changes.

## Test plan

- [x] `yarn workspace @metamask/assets-controller test` — new/updated unit tests pass
- [x] `yarn workspace @metamask/assets-controller run changelog:validate`
- [x] Manual: send USDC on Arbitrum, confirm balance updates via websocket
- [x] Manual: disconnect/reconnect websocket, confirm balance recovers after resubscribe
- [x] Manual: switch to receiver account after inbound transfer, confirm `forceUpdate` shows correct balance

**New unit test coverage:**
- `AssetsController`: polling does not overwrite recent websocket balance; `getAssets` `forceUpdate` wins over websocket freshness
- `AccountsApiDataSource`: `forceUpdate` bypasses TanStack cache
- `BackendWebsocketDataSource`: concurrent subscribe serialization, checksummed vs lowercase EVM addresses, channel-callback fallback, disconnect/reconnect chain reclaim

## References

- Fixes stale balance races after transactions, account switches, and websocket reconnects ([#9265](https://github.com/MetaMask/core/pull/9265))

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate *(changelog only; behavior is internal merge policy)*
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them *(N/A — no breaking changes)*

---

> [!NOTE]
> **Medium Risk**
> Changes how displayed balances are merged across websocket and polling paths and reorders fetch/subscribe on account changes; incorrect freshness or locking could show wrong balances until the next `forceUpdate` fetch.

> **Overview**
> Fixes **stale or flickering balances** when backend websocket updates compete with Accounts API / RPC polling, and tightens **account-switch and websocket subscription** ordering so live updates are not dropped after reconnects or rapid resubscribes.
>
> - **`AssetsController`**: internal `sourceId` tagging; 120s websocket freshness guard for polling sources; `getAssets:forceUpdate` clears locks and wins; mutex-serialized fetch-then-subscribe on account change
> - **`AccountsApiDataSource`**: `staleTime: 0` / `gcTime: 0` on `forceUpdate`
> - **`BackendWebsocketDataSource`**: subscribe lock, case-insensitive EVM address matching, per-channel callback fallback, clean teardown on resubscribe

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how displayed balances are merged across websocket and polling paths and reorders fetch/subscribe on account changes; incorrect freshness or locking could show wrong balances until the next forceUpdate fetch.
> 
> **Overview**
> Fixes **stale or flickering token balances** when websocket pushes compete with Accounts API / RPC polling, and when subscriptions are recreated on account switch or reconnect.
> 
> **`AssetsController`** tags applied updates with internal `sourceId` on `DataResponse`. After websocket balance pushes, per-asset freshness locks block passive polling sources for **120s**; **`getAssets({ forceUpdate: true })`** is tagged `getAssets:forceUpdate`, skips that filter, and clears locks for applied balances. Account group and account-tree refreshes use a **mutex** and run **force fetch before subscribe**; account-tree updates with no overlapping account IDs are ignored.
> 
> **`AccountsApiDataSource`** passes `{ staleTime: 0, gcTime: 0 }` to multi-account balance fetches when `forceUpdate` is set.
> 
> **`BackendWebsocketDataSource`** serializes subscribe/unsubscribe, treats EVM addresses as unchanged when only checksumming differs, registers optional **per-channel callbacks** for reconnect routing, and passes the original `DataRequest` with balance updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 773e4e83d65cffac096ecddc3b4e6925952b88ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->