### PR TITLE
fix: skip already-aligned accounts during wallet alignment

### DIFF
--- a/packages/multichain-account-service/CHANGELOG.md
+++ b/packages/multichain-account-service/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Wallet alignment now only creates the missing `(provider, group index)` pairs instead of re-creating the whole range for every provider, avoiding redundant `createAccounts` calls (and their traces) ([#0000](https://github.com/MetaMask/core/pull/0000))
+- Wallet alignment now only creates the missing `(provider, group index)` pairs instead of re-creating the whole range for every provider, avoiding redundant `createAccounts` calls (and their traces) ([#9269](https://github.com/MetaMask/core/pull/9269))
   - Adds `MultichainAccountGroup.isProviderAligned(provider)` to check alignment per provider.
 
 ## [11.1.0]

--- a/packages/multichain-account-service/CHANGELOG.md
+++ b/packages/multichain-account-service/CHANGELOG.md
@@ -7,10 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
+### Added
+
+- Adds `MultichainAccountGroup.isProviderAligned(provider)` to check alignment per provider ([#9269](https://github.com/MetaMask/core/pull/9269))
+
+### Changed
 
 - Wallet alignment now only creates the missing `(provider, group index)` pairs instead of re-creating the whole range for every provider, avoiding redundant `createAccounts` calls (and their traces) ([#9269](https://github.com/MetaMask/core/pull/9269))
-  - Adds `MultichainAccountGroup.isProviderAligned(provider)` to check alignment per provider.
 
 ## [11.1.0]
 

--- a/packages/multichain-account-service/CHANGELOG.md
+++ b/packages/multichain-account-service/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Wallet alignment now only creates the missing `(provider, group index)` pairs instead of re-creating the whole range for every provider, avoiding redundant `createAccounts` calls (and their traces) ([#0000](https://github.com/MetaMask/core/pull/0000))
+  - Adds `MultichainAccountGroup.isProviderAligned(provider)` to check alignment per provider.
+
 ## [11.1.0]
 
 ### Added

--- a/packages/multichain-account-service/src/MultichainAccountGroup.ts
+++ b/packages/multichain-account-service/src/MultichainAccountGroup.ts
@@ -263,13 +263,27 @@ export class MultichainAccountGroup<
    */
   isAligned(): boolean {
     return this.#providers.every((provider) =>
-      provider.isAligned(
-        {
-          entropySource: this.#wallet.entropySource,
-          groupIndex: this.#groupIndex,
-        },
-        this.#providerToAccounts.get(provider) ?? [],
-      ),
+      this.isProviderAligned(provider),
+    );
+  }
+
+  /**
+   * Check whether a single provider has an aligned account in this group.
+   *
+   * A provider is aligned when the account IDs it contributed to this group are
+   * non-empty and owned by it. Disabled {@link AccountProviderWrapper} instances
+   * always report `true`.
+   *
+   * @param provider - The provider to check.
+   * @returns `true` when the provider is aligned for this group.
+   */
+  isProviderAligned(provider: Bip44AccountProvider<Account>): boolean {
+    return provider.isAligned(
+      {
+        entropySource: this.#wallet.entropySource,
+        groupIndex: this.#groupIndex,
+      },
+      this.#providerToAccounts.get(provider) ?? [],
     );
   }
 }

--- a/packages/multichain-account-service/src/MultichainAccountWallet.test.ts
+++ b/packages/multichain-account-service/src/MultichainAccountWallet.test.ts
@@ -883,12 +883,87 @@ describe('MultichainAccountWallet', () => {
 
       await wallet.alignAccounts();
 
-      // Sol provider is missing group 1; should be called via the batch range API covering all groups.
+      // Sol provider is missing group 1 only; it should be called for that
+      // missing sub-range only, NOT the already-aligned group 0.
       expect(providers[1].createAccounts).toHaveBeenCalledWith({
         type: AccountCreationType.Bip44DeriveIndexRange,
         entropySource: wallet.entropySource,
-        range: { from: 0, to: 1 },
+        range: { from: 1, to: 1 },
       });
+      expect(providers[1].createAccounts).not.toHaveBeenCalledWith(
+        expect.objectContaining({ range: { from: 0, to: 1 } }),
+      );
+
+      // EVM provider already has both groups aligned, so it must not be asked
+      // to create (or re-trace) any account during alignment.
+      expect(providers[0].createAccounts).not.toHaveBeenCalled();
+    });
+
+    it('does not re-create accounts for providers that are already aligned across the whole range', async () => {
+      // Both groups have EVM + SOL accounts already; nothing is missing for SOL,
+      // but EVM is missing group 1 to force the wallet out of the aligned state.
+      const mockEvmAccount0 = MockAccountBuilder.from(MOCK_HD_ACCOUNT_1)
+        .withEntropySource(MOCK_HD_KEYRING_1.metadata.id)
+        .withGroupIndex(0)
+        .get();
+      const mockSolAccount0 = MockAccountBuilder.from(MOCK_SOL_ACCOUNT_1)
+        .withEntropySource(MOCK_HD_KEYRING_1.metadata.id)
+        .withGroupIndex(0)
+        .get();
+      const mockSolAccount1 = MockAccountBuilder.from(MOCK_SOL_ACCOUNT_1)
+        .withEntropySource(MOCK_HD_KEYRING_1.metadata.id)
+        .withGroupIndex(1)
+        .withUuid()
+        .get();
+
+      const { wallet, providers } = setup({
+        // EVM only has group 0 (missing group 1), SOL has both groups.
+        accounts: [[mockEvmAccount0], [mockSolAccount0, mockSolAccount1]],
+      });
+
+      await wallet.alignAccounts();
+
+      // SOL is aligned for every group in the range, so it must be skipped
+      // entirely (no spans, no work).
+      expect(providers[1].createAccounts).not.toHaveBeenCalled();
+    });
+
+    it('creates accounts only for the non-contiguous missing sub-ranges', async () => {
+      // EVM present for groups 0, 1, 2, 3. SOL present for groups 0 and 2, so it
+      // is missing the non-contiguous indices 1 and 3.
+      const evmAccounts = [0, 1, 2, 3].map((groupIndex) =>
+        MockAccountBuilder.from(MOCK_HD_ACCOUNT_1)
+          .withEntropySource(MOCK_HD_KEYRING_1.metadata.id)
+          .withGroupIndex(groupIndex)
+          .withUuid()
+          .get(),
+      );
+      const solAccounts = [0, 2].map((groupIndex) =>
+        MockAccountBuilder.from(MOCK_SOL_ACCOUNT_1)
+          .withEntropySource(MOCK_HD_KEYRING_1.metadata.id)
+          .withGroupIndex(groupIndex)
+          .withUuid()
+          .get(),
+      );
+
+      const { wallet, providers } = setup({
+        accounts: [evmAccounts, solAccounts],
+      });
+
+      await wallet.alignAccounts();
+
+      // Two separate single-index sub-ranges, one per gap.
+      expect(providers[1].createAccounts).toHaveBeenCalledWith({
+        type: AccountCreationType.Bip44DeriveIndexRange,
+        entropySource: wallet.entropySource,
+        range: { from: 1, to: 1 },
+      });
+      expect(providers[1].createAccounts).toHaveBeenCalledWith({
+        type: AccountCreationType.Bip44DeriveIndexRange,
+        entropySource: wallet.entropySource,
+        range: { from: 3, to: 3 },
+      });
+      expect(providers[1].createAccounts).toHaveBeenCalledTimes(2);
     });
 
     it('updates a group when a provider returns accounts during alignment', async () => {

--- a/packages/multichain-account-service/src/MultichainAccountWallet.ts
+++ b/packages/multichain-account-service/src/MultichainAccountWallet.ts
@@ -63,8 +63,7 @@ type DiscoveredGroupsState = WalletState;
  */
 export class MultichainAccountWallet<
   Account extends Bip44Account<KeyringAccount>,
-> implements MultichainAccountWalletDefinition<Account>
-{
+> implements MultichainAccountWalletDefinition<Account> {
   readonly #lock = new Mutex();
 
   readonly #id: MultichainAccountWalletId;

--- a/packages/multichain-account-service/src/MultichainAccountWallet.ts
+++ b/packages/multichain-account-service/src/MultichainAccountWallet.ts
@@ -63,7 +63,8 @@ type DiscoveredGroupsState = WalletState;
  */
 export class MultichainAccountWallet<
   Account extends Bip44Account<KeyringAccount>,
-> implements MultichainAccountWalletDefinition<Account> {
+> implements MultichainAccountWalletDefinition<Account>
+{
   readonly #lock = new Mutex();
 
   readonly #id: MultichainAccountWalletId;
@@ -508,11 +509,10 @@ export class MultichainAccountWallet<
         },
       },
       async () => {
-        const { groupStateByGroupIndex, failures } = await this.#buildGroupState(
-          providers,
-          (provider) =>
+        const { groupStateByGroupIndex, failures } =
+          await this.#buildGroupState(providers, (provider) =>
             this.#getUnalignedSubRangesForProvider(provider, from, to),
-        );
+          );
 
         if (failures.length) {
           const error = failures.reduce(

--- a/packages/multichain-account-service/src/MultichainAccountWallet.ts
+++ b/packages/multichain-account-service/src/MultichainAccountWallet.ts
@@ -305,19 +305,23 @@ export class MultichainAccountWallet<
   }
 
   /**
-   * Build group state for a range of group indices by calling all providers in parallel.
+   * Build group state by calling all providers in parallel.
    *
    * This is a non-locking shared core used by both creation and alignment paths.
+   * Each provider is asked which contiguous sub-ranges of group indices it needs
+   * accounts created for via `getSubRanges`, so callers can skip indices that are
+   * already satisfied (e.g. during alignment).
    *
-   * @param from - Starting group index (inclusive).
-   * @param to - Ending group index (inclusive).
    * @param providers - The providers to create accounts for.
+   * @param getSubRanges - Resolver returning the sub-ranges to create for a
+   * given provider. Returning an empty array means the provider is skipped.
    * @returns The collected group state and any provider failure messages.
    */
-  async #buildGroupStateForRange(
-    from: number,
-    to: number,
+  async #buildGroupState(
     providers: Bip44AccountProvider<Account>[],
+    getSubRanges: (
+      provider: Bip44AccountProvider<Account>,
+    ) => Required<GroupIndexRange>[],
   ): Promise<{
     groupStateByGroupIndex: Map<number, GroupState>;
     failures: string[];
@@ -327,23 +331,27 @@ export class MultichainAccountWallet<
     const results = await Promise.allSettled(
       providers.map(async (provider) => {
         const providerName = provider.getName();
-        const accounts = await this.#createAccountsRangeForProvider(
-          provider,
-          from,
-          to,
-        );
-        accounts.forEach((account) => {
-          const { groupIndex } = account.options.entropy;
-          let groupState = groupStateByGroupIndex.get(groupIndex);
-          if (!groupState) {
-            groupState = {};
-            groupStateByGroupIndex.set(groupIndex, groupState);
-          }
-          if (!groupState[providerName]) {
-            groupState[providerName] = [];
-          }
-          groupState[providerName].push(account.id);
-        });
+        const subRanges = getSubRanges(provider);
+
+        for (const { from, to } of subRanges) {
+          const accounts = await this.#createAccountsRangeForProvider(
+            provider,
+            from,
+            to,
+          );
+          accounts.forEach((account) => {
+            const { groupIndex } = account.options.entropy;
+            let groupState = groupStateByGroupIndex.get(groupIndex);
+            if (!groupState) {
+              groupState = {};
+              groupStateByGroupIndex.set(groupIndex, groupState);
+            }
+            if (!groupState[providerName]) {
+              groupState[providerName] = [];
+            }
+            groupState[providerName].push(account.id);
+          });
+        }
       }),
     );
 
@@ -358,6 +366,46 @@ export class MultichainAccountWallet<
     }, []);
 
     return { groupStateByGroupIndex, failures };
+  }
+
+  /**
+   * Compute the contiguous sub-ranges of group indices in `[from, to]` for which
+   * the given provider is NOT aligned (i.e. is missing an account).
+   *
+   * Already-aligned indices are skipped so alignment never re-creates (or
+   * re-traces) accounts that already exist. A group that does not exist yet is
+   * treated as unaligned.
+   *
+   * @param provider - The provider to compute missing sub-ranges for.
+   * @param from - Starting group index (inclusive).
+   * @param to - Ending group index (inclusive).
+   * @returns The contiguous sub-ranges where the provider needs accounts.
+   */
+  #getUnalignedSubRangesForProvider(
+    provider: Bip44AccountProvider<Account>,
+    from: number,
+    to: number,
+  ): Required<GroupIndexRange>[] {
+    const subRanges: Required<GroupIndexRange>[] = [];
+
+    let runStart: number | undefined;
+    for (let groupIndex = from; groupIndex <= to; groupIndex++) {
+      const group = this.getMultichainAccountGroup(groupIndex);
+      const aligned = group ? group.isProviderAligned(provider) : false;
+
+      if (!aligned) {
+        runStart ??= groupIndex;
+      } else if (runStart !== undefined) {
+        subRanges.push({ from: runStart, to: groupIndex - 1 });
+        runStart = undefined;
+      }
+    }
+
+    if (runStart !== undefined) {
+      subRanges.push({ from: runStart, to });
+    }
+
+    return subRanges;
   }
 
   /**
@@ -395,7 +443,7 @@ export class MultichainAccountWallet<
         this.#log(`Creating groups from index ${from} to ${to}...`);
 
         const { groupStateByGroupIndex, failures } =
-          await this.#buildGroupStateForRange(from, to, providers);
+          await this.#buildGroupState(providers, () => [{ from, to }]);
 
         // Check for provider failures — always treated as hard errors.
         if (failures.length) {
@@ -460,8 +508,11 @@ export class MultichainAccountWallet<
         },
       },
       async () => {
-        const { groupStateByGroupIndex, failures } =
-          await this.#buildGroupStateForRange(from, to, providers);
+        const { groupStateByGroupIndex, failures } = await this.#buildGroupState(
+          providers,
+          (provider) =>
+            this.#getUnalignedSubRangesForProvider(provider, from, to),
+        );
 
         if (failures.length) {
           const error = failures.reduce(


### PR DESCRIPTION
## Explanation

This PR adds exact-range account group alignment. This is mainly done to fix Sentry unnecessary spam, but can also improve performance slightly. 

## References

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1939

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core wallet alignment and account-creation scheduling; behavior is more selective but miscomputed sub-ranges could leave groups misaligned until a later align run.
> 
> **Overview**
> Wallet **alignment** no longer calls `createAccounts` for every provider across the full group index range. It now derives **contiguous sub-ranges** where each provider is missing an account and only invokes creation for those gaps.
> 
> `MultichainAccountGroup` gains **`isProviderAligned(provider)`**, and group `isAligned()` is implemented via that helper. `MultichainAccountWallet` refactors the shared build path from `#buildGroupStateForRange` to **`#buildGroupState`** with a `getSubRanges` callback: alignment supplies **`#getUnalignedSubRangesForProvider`**, while group creation still passes the full `[from, to]` range. Providers that are already aligned for all indices in the range are skipped entirely (fewer traces / Sentry noise).
> 
> Tests cover single missing indices, fully aligned providers, and **non-contiguous** missing indices (separate `createAccounts` calls per gap).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 851ec05f66920a7b257813dabf55f5fcdaaefd85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->