### PR TITLE
feat(messenger): add getRegisteredActionTypes accessor

### DIFF
--- a/packages/messenger/CHANGELOG.md
+++ b/packages/messenger/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `Messenger.getRegisteredActionTypes` method, which returns the action types the messenger can call directly ([#9271](https://github.com/MetaMask/core/pull/9271))
+
 ### Changed
 
 - Bump `@metamask/utils` from `^11.9.0` to `^11.11.0` ([#9074](https://github.com/MetaMask/core/pull/9074))

--- a/packages/messenger/src/Messenger.test.ts
+++ b/packages/messenger/src/Messenger.test.ts
@@ -345,6 +345,70 @@ describe('Messenger', () => {
     });
   });
 
+  describe('getRegisteredActionTypes', () => {
+    it('returns an empty array when no actions are registered', () => {
+      type PingAction = { type: 'Fixture:ping'; handler: () => void };
+      const messenger = new Messenger<'Fixture', PingAction, never>({
+        namespace: 'Fixture',
+      });
+
+      expect(messenger.getRegisteredActionTypes()).toStrictEqual([]);
+    });
+
+    it('returns the types of registered actions', () => {
+      type MessageAction =
+        | { type: 'Fixture:concat'; handler: (message: string) => void }
+        | { type: 'Fixture:reset'; handler: (initialMessage: string) => void };
+      const messenger = new Messenger<'Fixture', MessageAction, never>({
+        namespace: 'Fixture',
+      });
+
+      messenger.registerActionHandler('Fixture:concat', () => undefined);
+      messenger.registerActionHandler('Fixture:reset', () => undefined);
+
+      expect(messenger.getRegisteredActionTypes()).toStrictEqual([
+        'Fixture:concat',
+        'Fixture:reset',
+      ]);
+    });
+
+    it('no longer includes an action type after it is unregistered', () => {
+      type MessageAction =
+        | { type: 'Fixture:concat'; handler: (message: string) => void }
+        | { type: 'Fixture:reset'; handler: (initialMessage: string) => void };
+      const messenger = new Messenger<'Fixture', MessageAction, never>({
+        namespace: 'Fixture',
+      });
+
+      messenger.registerActionHandler('Fixture:concat', () => undefined);
+      messenger.registerActionHandler('Fixture:reset', () => undefined);
+      messenger.unregisterActionHandler('Fixture:concat');
+
+      expect(messenger.getRegisteredActionTypes()).toStrictEqual([
+        'Fixture:reset',
+      ]);
+    });
+
+    it('includes actions delegated in from another messenger', () => {
+      type CountAction = {
+        type: 'Source:count';
+        handler: (increment: number) => void;
+      };
+      const sourceMessenger = new Messenger<'Source', CountAction, never>({
+        namespace: 'Source',
+      });
+      const messenger = new Messenger<'Destination', CountAction, never>({
+        namespace: 'Destination',
+      });
+      sourceMessenger.registerActionHandler('Source:count', () => undefined);
+      sourceMessenger.delegate({ actions: ['Source:count'], messenger });
+
+      expect(messenger.getRegisteredActionTypes()).toStrictEqual([
+        'Source:count',
+      ]);
+    });
+  });
+
   describe('publish and subscribe', () => {
     it('publishes event to subscriber', () => {
       type MessageEvent = { type: 'Fixture:message'; payload: [string] };

--- a/packages/messenger/src/Messenger.ts
+++ b/packages/messenger/src/Messenger.ts
@@ -403,8 +403,7 @@ export class Messenger<
    * Get the types of all actions that this messenger can call directly.
    *
    * This includes actions registered on this messenger as well as actions that
-   * have been delegated into it from another messenger. It does not include
-   * actions this messenger has delegated out to other messengers.
+   * have been delegated to it from another messenger.
    *
    * Note that this reflects the registrations on this specific messenger
    * instance.

--- a/packages/messenger/src/Messenger.ts
+++ b/packages/messenger/src/Messenger.ts
@@ -400,6 +400,22 @@ export class Messenger<
   }
 
   /**
+   * Get the types of all actions that this messenger can call directly.
+   *
+   * This includes actions registered on this messenger as well as actions that
+   * have been delegated into it from another messenger. It does not include
+   * actions this messenger has delegated out to other messengers.
+   *
+   * Note that this reflects the registrations on this specific messenger
+   * instance.
+   *
+   * @returns An array of every action type this messenger can call directly.
+   */
+  getRegisteredActionTypes(): string[] {
+    return [...this.#actions.keys()];
+  }
+
+  /**
    * Get the action handler for a given action type.
    *
    * This is a protected method to allow subclasses to override the way action


### PR DESCRIPTION
## Explanation

Adds a public, read-only accessor `Messenger.getRegisteredActionTypes()` that returns the action types a messenger can `call()` directly — actions registered on it plus actions delegated into it from a child messenger. It returns `[...this.#actions.keys()]`.

There is no public way to enumerate a messenger's callable actions today.

### Why `string[]` and not `Action['type'][]`

The first instinct is to type the return as the messenger's action-type union for nicer caller types. That's not safe here: it would make `Action` appear in a **covariant (return) position** — the first such member on the class. Every existing `Action`-dependent method (`call`, `registerActionHandler`) deliberately keeps `Action` behind a bounded generic to avoid this. A covariant `Action` member breaks assigning a messenger to a **narrower-typed** one (e.g. passing a controller's full messenger to a service typed against only a subset of its actions) — a pattern consumers rely on (`@metamask/perps-controller` does exactly this and fails to compile with the union return). No union-derived return type avoids this; only a constant return type does. `string[]` is sufficient for the consumer below, which just lists/prints the types.

## Why

`@metamask/wallet-cli` is gaining an `mm daemon list` command to enumerate the actions on the wallet's root messenger (sibling to the existing `mm daemon call <Controller>:<method>`). That needs a public accessor on the messenger, which this PR adds. The command itself is a separate wallet-cli follow-up.

## Notes for reviewers

- Non-breaking and purely additive — new read-only method, no behavior change. Verified with a full monorepo build.
- Method name is open to bikeshedding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive read-only API with no change to `call` or registration behavior; return type is intentionally loose to preserve existing messenger assignability patterns.
> 
> **Overview**
> Adds **`Messenger.getRegisteredActionTypes()`**, a read-only API that lists action types the instance can **`call()`** directly—local registrations plus actions delegated into that messenger. It returns **`[...this.#actions.keys()]`** as **`string[]`** (not the messenger’s action-type union) so callers can enumerate actions without introducing a covariant **`Action`** return that would break assigning messengers to narrower action typings.
> 
> Unit tests cover empty messengers, register/unregister, and delegated actions. **`packages/messenger/CHANGELOG.md`** documents the addition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 832a80432c4642a47f88810008eca4a29c2936d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


