### PR TITLE
feat: add batch sell metrics

### DIFF
--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/multichain-network-controller` from `^3.1.4` to `^3.2.0` ([#9264](https://github.com/MetaMask/core/pull/9264))
 
+### Fixed
+
+- Fix Batch Sell-only `sentAmount.usd` metadata calculations to use each quote's source token exchange rate ([#9272](https://github.com/MetaMask/core/pull/9272))
+
 ## [77.0.0]
 
 ### Added

--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add Batch Sell token and quote page analytics event types
+
 ### Changed
 
 - Bump `@metamask/multichain-network-controller` from `^3.1.4` to `^3.2.0` ([#9264](https://github.com/MetaMask/core/pull/9264))

--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add Batch Sell token and quote page analytics event types
+- Add Batch Sell analytics event types ([#9272](https://github.com/MetaMask/core/pull/9272))
+  - `Batch Sell Token Page Viewed`
+  - `Batch Sell Token Page Continue Clicked`
+  - `Batch Sell Quote Page Viewed`
+  - `Batch Sell Quote Page Review Clicked`
+  - `Batch Sell Review Modal Submitted`
 
 ### Changed
 

--- a/packages/bridge-controller/src/bridge-controller.test.ts
+++ b/packages/bridge-controller/src/bridge-controller.test.ts
@@ -3044,11 +3044,13 @@ describe('BridgeController', function () {
       });
     });
 
-    it('should track Batch Sell token page events with default chain fallback', async () => {
+    it('should track Batch Sell token page events with client chain ids', async () => {
       await withController(async ({ rootMessenger }) => {
+        const chainIdSource = formatChainIdToCaip(ChainId.POLYGON);
+        const chainIdDestination = formatChainIdToCaip(ChainId.BASE);
         const sourceTokenAddresses = [
-          'eip155:1/erc20:0x1111111111111111111111111111111111111111',
-          'eip155:1/erc20:0x2222222222222222222222222222222222222222',
+          'eip155:137/erc20:0x1111111111111111111111111111111111111111',
+          'eip155:137/erc20:0x2222222222222222222222222222222222222222',
         ] satisfies CaipAssetType[];
         const sourceTokenSymbols = ['LINK', 'UNI'];
 
@@ -3056,6 +3058,8 @@ describe('BridgeController', function () {
           'BridgeController:trackUnifiedSwapBridgeEvent',
           BatchSellMetricsEventName.BatchSellTokenPageViewed,
           {
+            chain_id_source: chainIdSource,
+            chain_id_destination: chainIdDestination,
             location: BatchSellMetricsLocation.TradeMenu,
           },
         );
@@ -3063,6 +3067,8 @@ describe('BridgeController', function () {
           'BridgeController:trackUnifiedSwapBridgeEvent',
           BatchSellMetricsEventName.BatchSellTokenPageContinueClicked,
           {
+            chain_id_source: chainIdSource,
+            chain_id_destination: chainIdDestination,
             location: BatchSellMetricsLocation.AssetPicker,
             source_token_symbols: sourceTokenSymbols,
             source_token_addresses: sourceTokenAddresses,
@@ -3073,8 +3079,8 @@ describe('BridgeController', function () {
           1,
           BatchSellMetricsEventName.BatchSellTokenPageViewed,
           {
-            chain_id_source: formatChainIdToCaip(ChainId.ETH),
-            chain_id_destination: null,
+            chain_id_source: chainIdSource,
+            chain_id_destination: chainIdDestination,
             location: BatchSellMetricsLocation.TradeMenu,
           },
         );
@@ -3082,8 +3088,8 @@ describe('BridgeController', function () {
           2,
           BatchSellMetricsEventName.BatchSellTokenPageContinueClicked,
           {
-            chain_id_source: formatChainIdToCaip(ChainId.ETH),
-            chain_id_destination: null,
+            chain_id_source: chainIdSource,
+            chain_id_destination: chainIdDestination,
             location: BatchSellMetricsLocation.AssetPicker,
             source_token_count: sourceTokenAddresses.length,
             source_token_symbols: sourceTokenSymbols,
@@ -3114,13 +3120,15 @@ describe('BridgeController', function () {
         );
         jest.clearAllMocks();
 
+        const chainIdSource = formatChainIdToCaip(ChainId.POLYGON);
+        const chainIdDestination = formatChainIdToCaip(ChainId.BASE);
         const sourceTokenAddresses = [
-          'eip155:10/erc20:0x1111111111111111111111111111111111111111',
-          'eip155:10/erc20:0x2222222222222222222222222222222222222222',
+          'eip155:137/erc20:0x1111111111111111111111111111111111111111',
+          'eip155:137/erc20:0x2222222222222222222222222222222222222222',
         ] satisfies CaipAssetType[];
         const destinationTokenAddress =
-          'eip155:10/erc20:0x3333333333333333333333333333333333333333' satisfies CaipAssetType;
-        const properties = {
+          'eip155:8453/erc20:0x3333333333333333333333333333333333333333' satisfies CaipAssetType;
+        const sharedProperties = {
           location: BatchSellMetricsLocation.Deeplink,
           source_token_symbols: ['WETH', 'OP'],
           source_token_addresses: sourceTokenAddresses,
@@ -3130,9 +3138,12 @@ describe('BridgeController', function () {
           usd_amount_source_total: 30,
           source_token_slippages: [0.5, 1],
         };
+        const properties = {
+          chain_id_source: chainIdSource,
+          chain_id_destination: chainIdDestination,
+          ...sharedProperties,
+        };
         const expectedProperties = {
-          chain_id_source: formatChainIdToCaip(ChainId.OPTIMISM),
-          chain_id_destination: formatChainIdToCaip(ChainId.OPTIMISM),
           source_token_count: sourceTokenAddresses.length,
           ...properties,
         };

--- a/packages/bridge-controller/src/bridge-controller.test.ts
+++ b/packages/bridge-controller/src/bridge-controller.test.ts
@@ -13,6 +13,7 @@ import type {
   MessengerEvents,
   MockAnyNamespace,
 } from '@metamask/messenger';
+import type { CaipAssetType } from '@metamask/utils';
 import nock from 'nock';
 
 import { flushPromises } from '../../../tests/helpers';
@@ -52,6 +53,8 @@ import {
 import * as featureFlagUtils from './utils/feature-flags';
 import * as fetchUtils from './utils/fetch';
 import {
+  BatchSellMetricsEventName,
+  BatchSellMetricsLocation,
   InputAmountPreset,
   MetaMetricsSwapsEventSource,
   MetricsActionType,
@@ -3029,6 +3032,121 @@ describe('BridgeController', function () {
         expect(trackMetaMetricsFn).toHaveBeenCalledTimes(1);
 
         expect(trackMetaMetricsFn.mock.calls).toMatchSnapshot();
+      });
+    });
+
+    it('should track Batch Sell token page events with default chain fallback', async () => {
+      await withController(async ({ rootMessenger }) => {
+        rootMessenger.call(
+          'BridgeController:trackUnifiedSwapBridgeEvent',
+          BatchSellMetricsEventName.BatchSellTokenPageViewed,
+          {
+            location: BatchSellMetricsLocation.TradeMenu,
+            feature_id: FeatureId.BATCH_SELL,
+          },
+        );
+        rootMessenger.call(
+          'BridgeController:trackUnifiedSwapBridgeEvent',
+          BatchSellMetricsEventName.BatchSellTokenPageSubmitted,
+          {
+            location: BatchSellMetricsLocation.AssetPicker,
+            feature_id: FeatureId.BATCH_SELL,
+          },
+        );
+
+        expect(trackMetaMetricsFn).toHaveBeenNthCalledWith(
+          1,
+          BatchSellMetricsEventName.BatchSellTokenPageViewed,
+          {
+            chain_id: formatChainIdToCaip(ChainId.ETH),
+            location: BatchSellMetricsLocation.TradeMenu,
+            feature_id: FeatureId.BATCH_SELL,
+            action_type: MetricsActionType.SWAPBRIDGE_V1,
+          },
+        );
+        expect(trackMetaMetricsFn).toHaveBeenNthCalledWith(
+          2,
+          BatchSellMetricsEventName.BatchSellTokenPageSubmitted,
+          {
+            chain_id: formatChainIdToCaip(ChainId.ETH),
+            location: BatchSellMetricsLocation.AssetPicker,
+            feature_id: FeatureId.BATCH_SELL,
+            action_type: MetricsActionType.SWAPBRIDGE_V1,
+          },
+        );
+      });
+    });
+
+    it('should track Batch Sell quote page events with selected token metadata', async () => {
+      await withController(async ({ rootMessenger }) => {
+        await rootMessenger.call(
+          'BridgeController:updateBridgeQuoteRequestParams',
+          {
+            walletAddress: '0x123',
+            srcChainId: ChainId.OPTIMISM,
+          },
+          {
+            stx_enabled: false,
+            security_warnings: [],
+            token_symbol_source: 'ETH',
+            token_symbol_destination: 'USDC',
+            usd_amount_source: 100,
+            token_security_type_destination: null,
+            feature_id: FeatureId.BATCH_SELL,
+          },
+        );
+        jest.clearAllMocks();
+
+        const selectedTokenAddressList = [
+          'eip155:10/erc20:0x1111111111111111111111111111111111111111',
+          'eip155:10/erc20:0x2222222222222222222222222222222222222222',
+        ] satisfies CaipAssetType[];
+        const properties = {
+          selected_token_address_list: selectedTokenAddressList,
+          target_token_symbol: 'USDC',
+          location: BatchSellMetricsLocation.Deeplink,
+          slider_percentages: [25, 75],
+          slippage_percentages: [0.5, 1],
+          feature_id: FeatureId.BATCH_SELL,
+        };
+        const expectedProperties = {
+          chain_id: formatChainIdToCaip(ChainId.OPTIMISM),
+          selected_tokens_count: selectedTokenAddressList.length,
+          ...properties,
+          action_type: MetricsActionType.SWAPBRIDGE_V1,
+        };
+
+        rootMessenger.call(
+          'BridgeController:trackUnifiedSwapBridgeEvent',
+          BatchSellMetricsEventName.BatchSellQuotePageViewed,
+          properties,
+        );
+        rootMessenger.call(
+          'BridgeController:trackUnifiedSwapBridgeEvent',
+          BatchSellMetricsEventName.BatchSellQuotesReviewed,
+          properties,
+        );
+        rootMessenger.call(
+          'BridgeController:trackUnifiedSwapBridgeEvent',
+          BatchSellMetricsEventName.BatchSellQuotePageSubmitted,
+          properties,
+        );
+
+        expect(trackMetaMetricsFn).toHaveBeenNthCalledWith(
+          1,
+          BatchSellMetricsEventName.BatchSellQuotePageViewed,
+          expectedProperties,
+        );
+        expect(trackMetaMetricsFn).toHaveBeenNthCalledWith(
+          2,
+          BatchSellMetricsEventName.BatchSellQuotesReviewed,
+          expectedProperties,
+        );
+        expect(trackMetaMetricsFn).toHaveBeenNthCalledWith(
+          3,
+          BatchSellMetricsEventName.BatchSellQuotePageSubmitted,
+          expectedProperties,
+        );
       });
     });
 

--- a/packages/bridge-controller/src/bridge-controller.test.ts
+++ b/packages/bridge-controller/src/bridge-controller.test.ts
@@ -3046,20 +3046,26 @@ describe('BridgeController', function () {
 
     it('should track Batch Sell token page events with default chain fallback', async () => {
       await withController(async ({ rootMessenger }) => {
+        const sourceTokenAddresses = [
+          'eip155:1/erc20:0x1111111111111111111111111111111111111111',
+          'eip155:1/erc20:0x2222222222222222222222222222222222222222',
+        ] satisfies CaipAssetType[];
+        const sourceTokenSymbols = ['LINK', 'UNI'];
+
         rootMessenger.call(
           'BridgeController:trackUnifiedSwapBridgeEvent',
           BatchSellMetricsEventName.BatchSellTokenPageViewed,
           {
             location: BatchSellMetricsLocation.TradeMenu,
-            feature_id: FeatureId.BATCH_SELL,
           },
         );
         rootMessenger.call(
           'BridgeController:trackUnifiedSwapBridgeEvent',
-          BatchSellMetricsEventName.BatchSellTokenPageSubmitted,
+          BatchSellMetricsEventName.BatchSellTokenPageContinueClicked,
           {
             location: BatchSellMetricsLocation.AssetPicker,
-            feature_id: FeatureId.BATCH_SELL,
+            source_token_symbols: sourceTokenSymbols,
+            source_token_addresses: sourceTokenAddresses,
           },
         );
 
@@ -3067,20 +3073,21 @@ describe('BridgeController', function () {
           1,
           BatchSellMetricsEventName.BatchSellTokenPageViewed,
           {
-            chain_id: formatChainIdToCaip(ChainId.ETH),
+            chain_id_source: formatChainIdToCaip(ChainId.ETH),
+            chain_id_destination: null,
             location: BatchSellMetricsLocation.TradeMenu,
-            feature_id: FeatureId.BATCH_SELL,
-            action_type: MetricsActionType.SWAPBRIDGE_V1,
           },
         );
         expect(trackMetaMetricsFn).toHaveBeenNthCalledWith(
           2,
-          BatchSellMetricsEventName.BatchSellTokenPageSubmitted,
+          BatchSellMetricsEventName.BatchSellTokenPageContinueClicked,
           {
-            chain_id: formatChainIdToCaip(ChainId.ETH),
+            chain_id_source: formatChainIdToCaip(ChainId.ETH),
+            chain_id_destination: null,
             location: BatchSellMetricsLocation.AssetPicker,
-            feature_id: FeatureId.BATCH_SELL,
-            action_type: MetricsActionType.SWAPBRIDGE_V1,
+            source_token_count: sourceTokenAddresses.length,
+            source_token_symbols: sourceTokenSymbols,
+            source_token_addresses: sourceTokenAddresses,
           },
         );
       });
@@ -3093,6 +3100,7 @@ describe('BridgeController', function () {
           {
             walletAddress: '0x123',
             srcChainId: ChainId.OPTIMISM,
+            destChainId: ChainId.OPTIMISM,
           },
           {
             stx_enabled: false,
@@ -3106,23 +3114,27 @@ describe('BridgeController', function () {
         );
         jest.clearAllMocks();
 
-        const selectedTokenAddressList = [
+        const sourceTokenAddresses = [
           'eip155:10/erc20:0x1111111111111111111111111111111111111111',
           'eip155:10/erc20:0x2222222222222222222222222222222222222222',
         ] satisfies CaipAssetType[];
+        const destinationTokenAddress =
+          'eip155:10/erc20:0x3333333333333333333333333333333333333333' satisfies CaipAssetType;
         const properties = {
-          selected_token_address_list: selectedTokenAddressList,
-          target_token_symbol: 'USDC',
           location: BatchSellMetricsLocation.Deeplink,
-          slider_percentages: [25, 75],
-          slippage_percentages: [0.5, 1],
-          feature_id: FeatureId.BATCH_SELL,
+          source_token_symbols: ['WETH', 'OP'],
+          source_token_addresses: sourceTokenAddresses,
+          destination_token_symbol: 'USDC',
+          destination_token_address: destinationTokenAddress,
+          usd_amount_source_tokens: [10, 20],
+          usd_amount_source_total: 30,
+          source_token_slippages: [0.5, 1],
         };
         const expectedProperties = {
-          chain_id: formatChainIdToCaip(ChainId.OPTIMISM),
-          selected_tokens_count: selectedTokenAddressList.length,
+          chain_id_source: formatChainIdToCaip(ChainId.OPTIMISM),
+          chain_id_destination: formatChainIdToCaip(ChainId.OPTIMISM),
+          source_token_count: sourceTokenAddresses.length,
           ...properties,
-          action_type: MetricsActionType.SWAPBRIDGE_V1,
         };
 
         rootMessenger.call(
@@ -3132,13 +3144,17 @@ describe('BridgeController', function () {
         );
         rootMessenger.call(
           'BridgeController:trackUnifiedSwapBridgeEvent',
-          BatchSellMetricsEventName.BatchSellQuotesReviewed,
+          BatchSellMetricsEventName.BatchSellQuotePageReviewClicked,
           properties,
         );
         rootMessenger.call(
           'BridgeController:trackUnifiedSwapBridgeEvent',
-          BatchSellMetricsEventName.BatchSellQuotePageSubmitted,
-          properties,
+          BatchSellMetricsEventName.BatchSellReviewModalSubmitted,
+          {
+            ...properties,
+            usd_quoted_gas: 1,
+            usd_quoted_return: 29,
+          },
         );
 
         expect(trackMetaMetricsFn).toHaveBeenNthCalledWith(
@@ -3148,13 +3164,17 @@ describe('BridgeController', function () {
         );
         expect(trackMetaMetricsFn).toHaveBeenNthCalledWith(
           2,
-          BatchSellMetricsEventName.BatchSellQuotesReviewed,
+          BatchSellMetricsEventName.BatchSellQuotePageReviewClicked,
           expectedProperties,
         );
         expect(trackMetaMetricsFn).toHaveBeenNthCalledWith(
           3,
-          BatchSellMetricsEventName.BatchSellQuotePageSubmitted,
-          expectedProperties,
+          BatchSellMetricsEventName.BatchSellReviewModalSubmitted,
+          {
+            ...expectedProperties,
+            usd_quoted_gas: 1,
+            usd_quoted_return: 29,
+          },
         );
       });
     });

--- a/packages/bridge-controller/src/bridge-controller.test.ts
+++ b/packages/bridge-controller/src/bridge-controller.test.ts
@@ -2914,6 +2914,15 @@ describe('BridgeController', function () {
         expect(rootMessenger.call('BridgeController:getLocation')).toBe(
           MetaMetricsSwapsEventSource.TokenView,
         );
+
+        rootMessenger.call(
+          'BridgeController:setLocation',
+          BatchSellMetricsLocation.AssetPicker,
+        );
+
+        expect(rootMessenger.call('BridgeController:getLocation')).toBe(
+          BatchSellMetricsLocation.AssetPicker,
+        );
       });
     });
   });

--- a/packages/bridge-controller/src/bridge-controller.ts
+++ b/packages/bridge-controller/src/bridge-controller.ts
@@ -25,7 +25,7 @@ import {
   ExchangeRateSourcesForLookup,
   selectIsAssetExchangeRateInState,
 } from './selectors';
-import { FeatureId, RequestStatus } from './types';
+import { ChainId, FeatureId, RequestStatus } from './types';
 import type {
   L1GasFees,
   GenericQuoteRequest,
@@ -63,10 +63,12 @@ import {
 } from './utils/fetch';
 import {
   AbortReason,
+  BatchSellMetricsEventName,
   MetaMetricsSwapsEventSource,
   MetricsActionType,
   UnifiedSwapBridgeEventName,
 } from './utils/metrics/constants';
+import type { BridgeControllerMetricsEventName } from './utils/metrics/constants';
 import {
   formatProviderLabel,
   getAccountHardwareType,
@@ -236,8 +238,7 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
   readonly #fetchFn: FetchFunction;
 
   readonly #trackMetaMetricsFn: <
-    EventName extends
-      (typeof UnifiedSwapBridgeEventName)[keyof typeof UnifiedSwapBridgeEventName],
+    EventName extends BridgeControllerMetricsEventName,
   >(
     eventName: EventName,
     properties: CrossChainSwapsEventProperties<EventName>,
@@ -279,8 +280,7 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
       customBridgeApiBaseUrl?: string;
     };
     trackMetaMetricsFn: <
-      EventName extends
-        (typeof UnifiedSwapBridgeEventName)[keyof typeof UnifiedSwapBridgeEventName],
+      EventName extends BridgeControllerMetricsEventName,
     >(
       eventName: EventName,
       properties: CrossChainSwapsEventProperties<EventName>,
@@ -1165,8 +1165,7 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
   };
 
   readonly #getEventProperties = <
-    EventName extends
-      (typeof UnifiedSwapBridgeEventName)[keyof typeof UnifiedSwapBridgeEventName],
+    EventName extends BridgeControllerMetricsEventName,
   >(
     eventName: EventName,
     propertiesFromClient: Pick<
@@ -1183,6 +1182,11 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
     };
     const inputPrimaryDenominationProperties = {
       input_primary_denomination: this.state.inputPrimaryDenomination,
+    };
+    const batchSellPageProperties = {
+      chain_id: formatChainIdToCaip(
+        this.state.quoteRequest[0]?.srcChainId ?? ChainId.ETH,
+      ),
     };
     const quoteRequest = this.state.quoteRequest[quoteRequestIndex];
     switch (eventName) {
@@ -1204,6 +1208,25 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
           ...inputPrimaryDenominationProperties,
           ...baseProperties,
         };
+      case BatchSellMetricsEventName.BatchSellTokenPageViewed:
+      case BatchSellMetricsEventName.BatchSellTokenPageSubmitted:
+        return {
+          ...batchSellPageProperties,
+          ...baseProperties,
+        };
+      case BatchSellMetricsEventName.BatchSellQuotePageViewed:
+      case BatchSellMetricsEventName.BatchSellQuotesReviewed:
+      case BatchSellMetricsEventName.BatchSellQuotePageSubmitted: {
+        const selectedTokenAddressList =
+          (
+            propertiesFromClient as RequiredEventContextFromClient[BatchSellMetricsEventName.BatchSellQuotePageViewed]
+          ).selected_token_address_list;
+        return {
+          ...batchSellPageProperties,
+          selected_tokens_count: selectedTokenAddressList.length,
+          ...baseProperties,
+        };
+      }
       case UnifiedSwapBridgeEventName.FiatCryptoToggleClicked:
         return {
           ...getRequestParams(
@@ -1349,8 +1372,7 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
    * });
    */
   trackUnifiedSwapBridgeEvent = <
-    EventName extends
-      (typeof UnifiedSwapBridgeEventName)[keyof typeof UnifiedSwapBridgeEventName],
+    EventName extends BridgeControllerMetricsEventName,
   >(
     eventName: EventName,
     propertiesFromClient: Pick<

--- a/packages/bridge-controller/src/bridge-controller.ts
+++ b/packages/bridge-controller/src/bridge-controller.ts
@@ -68,7 +68,10 @@ import {
   MetricsActionType,
   UnifiedSwapBridgeEventName,
 } from './utils/metrics/constants';
-import type { BridgeControllerMetricsEventName } from './utils/metrics/constants';
+import type {
+  BridgeControllerMetricsEventName,
+  BridgeControllerMetricsLocation,
+} from './utils/metrics/constants';
 import {
   formatProviderLabel,
   getAccountHardwareType,
@@ -227,7 +230,7 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
    * Set via setLocation() before navigating to the swap/bridge flow.
    * Used as default for all subsequent internal events.
    */
-  #location: MetaMetricsSwapsEventSource = MetaMetricsSwapsEventSource.Unknown;
+  #location: BridgeControllerMetricsLocation = MetaMetricsSwapsEventSource.Unknown;
 
   readonly #clientId: BridgeClientId;
 
@@ -716,7 +719,7 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
    *
    * @param location - The entry point from which the user initiated the flow
    */
-  setLocation = (location: MetaMetricsSwapsEventSource) => {
+  setLocation = (location: BridgeControllerMetricsLocation) => {
     this.#location = location;
   };
 
@@ -725,7 +728,7 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
    *
    * @returns The entry point from which the user initiated the flow
    */
-  getLocation = (): MetaMetricsSwapsEventSource => {
+  getLocation = (): BridgeControllerMetricsLocation => {
     return this.#location;
   };
 

--- a/packages/bridge-controller/src/bridge-controller.ts
+++ b/packages/bridge-controller/src/bridge-controller.ts
@@ -230,7 +230,8 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
    * Set via setLocation() before navigating to the swap/bridge flow.
    * Used as default for all subsequent internal events.
    */
-  #location: BridgeControllerMetricsLocation = MetaMetricsSwapsEventSource.Unknown;
+  #location: BridgeControllerMetricsLocation =
+    MetaMetricsSwapsEventSource.Unknown;
 
   readonly #clientId: BridgeClientId;
 
@@ -282,9 +283,7 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
     config?: {
       customBridgeApiBaseUrl?: string;
     };
-    trackMetaMetricsFn: <
-      EventName extends BridgeControllerMetricsEventName,
-    >(
+    trackMetaMetricsFn: <EventName extends BridgeControllerMetricsEventName>(
       eventName: EventName,
       properties: CrossChainSwapsEventProperties<EventName>,
     ) => void;
@@ -1186,11 +1185,10 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
     const inputPrimaryDenominationProperties = {
       input_primary_denomination: this.state.inputPrimaryDenomination,
     };
-    const batchSellClientChainProperties =
-      propertiesFromClient as Pick<
-        RequiredEventContextFromClient[BatchSellMetricsEventName.BatchSellTokenPageViewed],
-        'chain_id_source' | 'chain_id_destination'
-      >;
+    const batchSellClientChainProperties = propertiesFromClient as Pick<
+      RequiredEventContextFromClient[BatchSellMetricsEventName.BatchSellTokenPageViewed],
+      'chain_id_source' | 'chain_id_destination'
+    >;
     const batchSellBaseProperties = {
       chain_id_source: batchSellClientChainProperties.chain_id_source,
       chain_id_destination: batchSellClientChainProperties.chain_id_destination,
@@ -1223,8 +1221,7 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
           propertiesFromClient as RequiredEventContextFromClient[BatchSellMetricsEventName.BatchSellTokenPageContinueClicked];
         return {
           ...batchSellBaseProperties,
-          source_token_count:
-            propsFromClient.source_token_addresses.length,
+          source_token_count: propsFromClient.source_token_addresses.length,
           source_token_symbols: propsFromClient.source_token_symbols,
           source_token_addresses: propsFromClient.source_token_addresses,
         };
@@ -1238,12 +1235,9 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
           source_token_count: propsFromClient.source_token_addresses.length,
           source_token_symbols: propsFromClient.source_token_symbols,
           source_token_addresses: propsFromClient.source_token_addresses,
-          destination_token_symbol:
-            propsFromClient.destination_token_symbol,
-          destination_token_address:
-            propsFromClient.destination_token_address,
-          usd_amount_source_tokens:
-            propsFromClient.usd_amount_source_tokens,
+          destination_token_symbol: propsFromClient.destination_token_symbol,
+          destination_token_address: propsFromClient.destination_token_address,
+          usd_amount_source_tokens: propsFromClient.usd_amount_source_tokens,
           usd_amount_source_total: propsFromClient.usd_amount_source_total,
           source_token_slippages: propsFromClient.source_token_slippages,
         };
@@ -1265,8 +1259,7 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
             reviewModalProperties.usd_amount_source_tokens,
           usd_amount_source_total:
             reviewModalProperties.usd_amount_source_total,
-          source_token_slippages:
-            reviewModalProperties.source_token_slippages,
+          source_token_slippages: reviewModalProperties.source_token_slippages,
           usd_quoted_gas: reviewModalProperties.usd_quoted_gas,
           usd_quoted_return: reviewModalProperties.usd_quoted_return,
         };

--- a/packages/bridge-controller/src/bridge-controller.ts
+++ b/packages/bridge-controller/src/bridge-controller.ts
@@ -25,7 +25,7 @@ import {
   ExchangeRateSourcesForLookup,
   selectIsAssetExchangeRateInState,
 } from './selectors';
-import { ChainId, FeatureId, RequestStatus } from './types';
+import { FeatureId, RequestStatus } from './types';
 import type {
   L1GasFees,
   GenericQuoteRequest,
@@ -1186,14 +1186,14 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
     const inputPrimaryDenominationProperties = {
       input_primary_denomination: this.state.inputPrimaryDenomination,
     };
-    const batchSellQuoteRequest = this.state.quoteRequest[0];
+    const batchSellClientChainProperties =
+      propertiesFromClient as Pick<
+        RequiredEventContextFromClient[BatchSellMetricsEventName.BatchSellTokenPageViewed],
+        'chain_id_source' | 'chain_id_destination'
+      >;
     const batchSellBaseProperties = {
-      chain_id_source: formatChainIdToCaip(
-        batchSellQuoteRequest?.srcChainId ?? ChainId.ETH,
-      ),
-      chain_id_destination: batchSellQuoteRequest?.destChainId
-        ? formatChainIdToCaip(batchSellQuoteRequest.destChainId)
-        : null,
+      chain_id_source: batchSellClientChainProperties.chain_id_source,
+      chain_id_destination: batchSellClientChainProperties.chain_id_destination,
       location: clientProps?.location ?? this.#location,
     };
     const quoteRequest = this.state.quoteRequest[quoteRequestIndex];
@@ -1219,33 +1219,33 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
       case BatchSellMetricsEventName.BatchSellTokenPageViewed:
         return batchSellBaseProperties;
       case BatchSellMetricsEventName.BatchSellTokenPageContinueClicked: {
-        const sourceTokenProperties =
+        const propsFromClient =
           propertiesFromClient as RequiredEventContextFromClient[BatchSellMetricsEventName.BatchSellTokenPageContinueClicked];
         return {
           ...batchSellBaseProperties,
           source_token_count:
-            sourceTokenProperties.source_token_addresses.length,
-          source_token_symbols: sourceTokenProperties.source_token_symbols,
-          source_token_addresses: sourceTokenProperties.source_token_addresses,
+            propsFromClient.source_token_addresses.length,
+          source_token_symbols: propsFromClient.source_token_symbols,
+          source_token_addresses: propsFromClient.source_token_addresses,
         };
       }
       case BatchSellMetricsEventName.BatchSellQuotePageViewed:
       case BatchSellMetricsEventName.BatchSellQuotePageReviewClicked: {
-        const quotePageProperties =
+        const propsFromClient =
           propertiesFromClient as RequiredEventContextFromClient[BatchSellMetricsEventName.BatchSellQuotePageViewed];
         return {
           ...batchSellBaseProperties,
-          source_token_count: quotePageProperties.source_token_addresses.length,
-          source_token_symbols: quotePageProperties.source_token_symbols,
-          source_token_addresses: quotePageProperties.source_token_addresses,
+          source_token_count: propsFromClient.source_token_addresses.length,
+          source_token_symbols: propsFromClient.source_token_symbols,
+          source_token_addresses: propsFromClient.source_token_addresses,
           destination_token_symbol:
-            quotePageProperties.destination_token_symbol,
+            propsFromClient.destination_token_symbol,
           destination_token_address:
-            quotePageProperties.destination_token_address,
+            propsFromClient.destination_token_address,
           usd_amount_source_tokens:
-            quotePageProperties.usd_amount_source_tokens,
-          usd_amount_source_total: quotePageProperties.usd_amount_source_total,
-          source_token_slippages: quotePageProperties.source_token_slippages,
+            propsFromClient.usd_amount_source_tokens,
+          usd_amount_source_total: propsFromClient.usd_amount_source_total,
+          source_token_slippages: propsFromClient.source_token_slippages,
         };
       }
       case BatchSellMetricsEventName.BatchSellReviewModalSubmitted: {

--- a/packages/bridge-controller/src/bridge-controller.ts
+++ b/packages/bridge-controller/src/bridge-controller.ts
@@ -1176,7 +1176,7 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
       EventName
     >[EventName],
     quoteRequestIndex: number = 0,
-  ): CrossChainSwapsEventProperties<EventName> => {
+  ) => {
     const clientProps = propertiesFromClient as Record<string, unknown>;
     const baseProperties = {
       ...propertiesFromClient,
@@ -1186,10 +1186,15 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
     const inputPrimaryDenominationProperties = {
       input_primary_denomination: this.state.inputPrimaryDenomination,
     };
-    const batchSellPageProperties = {
-      chain_id: formatChainIdToCaip(
-        this.state.quoteRequest[0]?.srcChainId ?? ChainId.ETH,
+    const batchSellQuoteRequest = this.state.quoteRequest[0];
+    const batchSellBaseProperties = {
+      chain_id_source: formatChainIdToCaip(
+        batchSellQuoteRequest?.srcChainId ?? ChainId.ETH,
       ),
+      chain_id_destination: batchSellQuoteRequest?.destChainId
+        ? formatChainIdToCaip(batchSellQuoteRequest.destChainId)
+        : null,
+      location: clientProps?.location ?? this.#location,
     };
     const quoteRequest = this.state.quoteRequest[quoteRequestIndex];
     switch (eventName) {
@@ -1212,22 +1217,58 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
           ...baseProperties,
         };
       case BatchSellMetricsEventName.BatchSellTokenPageViewed:
-      case BatchSellMetricsEventName.BatchSellTokenPageSubmitted:
+        return batchSellBaseProperties;
+      case BatchSellMetricsEventName.BatchSellTokenPageContinueClicked: {
+        const sourceTokenProperties =
+          propertiesFromClient as RequiredEventContextFromClient[BatchSellMetricsEventName.BatchSellTokenPageContinueClicked];
         return {
-          ...batchSellPageProperties,
-          ...baseProperties,
+          ...batchSellBaseProperties,
+          source_token_count:
+            sourceTokenProperties.source_token_addresses.length,
+          source_token_symbols: sourceTokenProperties.source_token_symbols,
+          source_token_addresses: sourceTokenProperties.source_token_addresses,
         };
+      }
       case BatchSellMetricsEventName.BatchSellQuotePageViewed:
-      case BatchSellMetricsEventName.BatchSellQuotesReviewed:
-      case BatchSellMetricsEventName.BatchSellQuotePageSubmitted: {
-        const selectedTokenAddressList =
-          (
-            propertiesFromClient as RequiredEventContextFromClient[BatchSellMetricsEventName.BatchSellQuotePageViewed]
-          ).selected_token_address_list;
+      case BatchSellMetricsEventName.BatchSellQuotePageReviewClicked: {
+        const quotePageProperties =
+          propertiesFromClient as RequiredEventContextFromClient[BatchSellMetricsEventName.BatchSellQuotePageViewed];
         return {
-          ...batchSellPageProperties,
-          selected_tokens_count: selectedTokenAddressList.length,
-          ...baseProperties,
+          ...batchSellBaseProperties,
+          source_token_count: quotePageProperties.source_token_addresses.length,
+          source_token_symbols: quotePageProperties.source_token_symbols,
+          source_token_addresses: quotePageProperties.source_token_addresses,
+          destination_token_symbol:
+            quotePageProperties.destination_token_symbol,
+          destination_token_address:
+            quotePageProperties.destination_token_address,
+          usd_amount_source_tokens:
+            quotePageProperties.usd_amount_source_tokens,
+          usd_amount_source_total: quotePageProperties.usd_amount_source_total,
+          source_token_slippages: quotePageProperties.source_token_slippages,
+        };
+      }
+      case BatchSellMetricsEventName.BatchSellReviewModalSubmitted: {
+        const reviewModalProperties =
+          propertiesFromClient as RequiredEventContextFromClient[BatchSellMetricsEventName.BatchSellReviewModalSubmitted];
+        return {
+          ...batchSellBaseProperties,
+          source_token_count:
+            reviewModalProperties.source_token_addresses.length,
+          source_token_symbols: reviewModalProperties.source_token_symbols,
+          source_token_addresses: reviewModalProperties.source_token_addresses,
+          destination_token_symbol:
+            reviewModalProperties.destination_token_symbol,
+          destination_token_address:
+            reviewModalProperties.destination_token_address,
+          usd_amount_source_tokens:
+            reviewModalProperties.usd_amount_source_tokens,
+          usd_amount_source_total:
+            reviewModalProperties.usd_amount_source_total,
+          source_token_slippages:
+            reviewModalProperties.source_token_slippages,
+          usd_quoted_gas: reviewModalProperties.usd_quoted_gas,
+          usd_quoted_return: reviewModalProperties.usd_quoted_return,
         };
       }
       case UnifiedSwapBridgeEventName.FiatCryptoToggleClicked:
@@ -1391,7 +1432,10 @@ export class BridgeController extends StaticIntervalPollingController<BridgePoll
         quoteRequestIndex,
       );
 
-      this.#trackMetaMetricsFn(eventName, combinedPropertiesForEvent);
+      this.#trackMetaMetricsFn(
+        eventName,
+        combinedPropertiesForEvent as CrossChainSwapsEventProperties<EventName>,
+      );
     } catch (error) {
       console.error(
         `Error tracking cross-chain swaps MetaMetrics event ${eventName}`,

--- a/packages/bridge-controller/src/index.ts
+++ b/packages/bridge-controller/src/index.ts
@@ -12,6 +12,7 @@ export {
 } from './utils/metrics/constants';
 
 export type { BridgeControllerMetricsEventName } from './utils/metrics/constants';
+export type { BridgeControllerMetricsLocation } from './utils/metrics/constants';
 
 export type {
   AccountHardwareType,

--- a/packages/bridge-controller/src/index.ts
+++ b/packages/bridge-controller/src/index.ts
@@ -1,12 +1,17 @@
 export { BridgeController } from './bridge-controller';
 
 export {
+  BatchSellMetricsEventName,
   UnifiedSwapBridgeEventName,
+  BATCH_SELL_EVENT_CATEGORY,
   UNIFIED_SWAP_BRIDGE_EVENT_CATEGORY,
+  BatchSellMetricsLocation,
   InputAmountPreset,
   MetaMetricsSwapsEventSource,
   PollingStatus,
 } from './utils/metrics/constants';
+
+export type { BridgeControllerMetricsEventName } from './utils/metrics/constants';
 
 export type {
   AccountHardwareType,

--- a/packages/bridge-controller/src/selectors.test.ts
+++ b/packages/bridge-controller/src/selectors.test.ts
@@ -1980,8 +1980,9 @@ describe('Bridge Selectors', () => {
           "90ae8e69-f03a-4cf6-bab7-ed4e3431eb37",
         ]
       `);
-      expect(recommendedQuotes.map((quote) => quote?.sentAmount.usd))
-        .toStrictEqual(['18', '140']);
+      expect(
+        recommendedQuotes.map((quote) => quote?.sentAmount.usd),
+      ).toStrictEqual(['18', '140']);
     });
 
     it('should return metadata when quotes are empty', () => {

--- a/packages/bridge-controller/src/selectors.test.ts
+++ b/packages/bridge-controller/src/selectors.test.ts
@@ -1980,6 +1980,8 @@ describe('Bridge Selectors', () => {
           "90ae8e69-f03a-4cf6-bab7-ed4e3431eb37",
         ]
       `);
+      expect(recommendedQuotes.map((quote) => quote?.sentAmount.usd))
+        .toStrictEqual(['18', '140']);
     });
 
     it('should return metadata when quotes are empty', () => {

--- a/packages/bridge-controller/src/selectors.ts
+++ b/packages/bridge-controller/src/selectors.ts
@@ -329,16 +329,7 @@ const selectBridgeQuotesWithMetadata = createBridgeSelector(
   [
     ({ quotes }) => quotes,
     selectBridgeFeesPerGas,
-    createBridgeSelector(
-      [
-        (state) => state,
-        ({ quoteRequest: [{ srcChainId, srcTokenAddress }] }) =>
-          srcTokenAddress
-            ? formatAddressToAssetId(srcTokenAddress, srcChainId)
-            : undefined,
-      ],
-      selectExchangeRateByAssetId,
-    ),
+    (state) => state,
     createBridgeSelector(
       [
         (state) => state,
@@ -363,11 +354,20 @@ const selectBridgeQuotesWithMetadata = createBridgeSelector(
   (
     quotes,
     bridgeFeesPerGas,
-    srcTokenExchangeRate,
+    exchangeRateSources,
     destTokenExchangeRate,
     nativeExchangeRate,
   ) => {
     const newQuotes = quotes.map((quote) => {
+      const sourceAssetId =
+        formatAddressToAssetId(
+          quote.quote.srcAsset.address,
+          quote.quote.srcChainId,
+        ) ?? quote.quote.srcAsset.assetId;
+      const srcTokenExchangeRate = selectExchangeRateByAssetId(
+        exchangeRateSources,
+        sourceAssetId,
+      );
       const sentAmount = calcSentAmount(quote.quote, srcTokenExchangeRate);
       const toTokenAmount = calcToAmount(
         quote.quote.destTokenAmount,

--- a/packages/bridge-controller/src/utils/metrics/constants.ts
+++ b/packages/bridge-controller/src/utils/metrics/constants.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 export const UNIFIED_SWAP_BRIDGE_EVENT_CATEGORY = 'Unified SwapBridge';
+export const BATCH_SELL_EVENT_CATEGORY = 'Batch Sell';
 
 /**
  * These event names map to events defined in the segment-schema: https://github.com/Consensys/segment-schema/tree/main/libraries/events/metamask-cross-chain-swaps
@@ -25,6 +26,18 @@ export enum UnifiedSwapBridgeEventName {
   AssetPickerOpened = `${UNIFIED_SWAP_BRIDGE_EVENT_CATEGORY} Asset Picker Opened`,
   PollingStatusUpdated = `${UNIFIED_SWAP_BRIDGE_EVENT_CATEGORY} Polling Status Updated`,
 }
+
+export enum BatchSellMetricsEventName {
+  BatchSellTokenPageViewed = `${BATCH_SELL_EVENT_CATEGORY} Token Page Viewed`,
+  BatchSellTokenPageSubmitted = `${BATCH_SELL_EVENT_CATEGORY} Token Page Submitted`,
+  BatchSellQuotePageViewed = `${BATCH_SELL_EVENT_CATEGORY} Quote Page Viewed`,
+  BatchSellQuotesReviewed = `${BATCH_SELL_EVENT_CATEGORY} Quotes Reviewed`,
+  BatchSellQuotePageSubmitted = `${BATCH_SELL_EVENT_CATEGORY} Quote Page Submitted`,
+}
+
+export type BridgeControllerMetricsEventName =
+  | UnifiedSwapBridgeEventName
+  | BatchSellMetricsEventName;
 
 export enum PollingStatus {
   MaxPollingReached = 'max_polling_reached',
@@ -55,6 +68,12 @@ export enum MetaMetricsSwapsEventSource {
   TransactionDetails = 'Transaction Details',
   DeepLink = 'Deep Link',
   Unknown = 'Unknown',
+}
+
+export enum BatchSellMetricsLocation {
+  TradeMenu = 'trade_menu',
+  Deeplink = 'deeplink',
+  AssetPicker = 'asset_picker',
 }
 
 export enum InputAmountPreset {

--- a/packages/bridge-controller/src/utils/metrics/constants.ts
+++ b/packages/bridge-controller/src/utils/metrics/constants.ts
@@ -29,10 +29,10 @@ export enum UnifiedSwapBridgeEventName {
 
 export enum BatchSellMetricsEventName {
   BatchSellTokenPageViewed = `${BATCH_SELL_EVENT_CATEGORY} Token Page Viewed`,
-  BatchSellTokenPageSubmitted = `${BATCH_SELL_EVENT_CATEGORY} Token Page Submitted`,
+  BatchSellTokenPageContinueClicked = `${BATCH_SELL_EVENT_CATEGORY} Token Page Continue Clicked`,
   BatchSellQuotePageViewed = `${BATCH_SELL_EVENT_CATEGORY} Quote Page Viewed`,
-  BatchSellQuotesReviewed = `${BATCH_SELL_EVENT_CATEGORY} Quotes Reviewed`,
-  BatchSellQuotePageSubmitted = `${BATCH_SELL_EVENT_CATEGORY} Quote Page Submitted`,
+  BatchSellQuotePageReviewClicked = `${BATCH_SELL_EVENT_CATEGORY} Quote Page Review Clicked`,
+  BatchSellReviewModalSubmitted = `${BATCH_SELL_EVENT_CATEGORY} Review Modal Submitted`,
 }
 
 export type BridgeControllerMetricsEventName =

--- a/packages/bridge-controller/src/utils/metrics/constants.ts
+++ b/packages/bridge-controller/src/utils/metrics/constants.ts
@@ -74,7 +74,12 @@ export enum BatchSellMetricsLocation {
   TradeMenu = 'trade_menu',
   Deeplink = 'deeplink',
   AssetPicker = 'asset_picker',
+  Unknown = 'Unknown',
 }
+
+export type BridgeControllerMetricsLocation =
+  | MetaMetricsSwapsEventSource
+  | BatchSellMetricsLocation;
 
 export enum InputAmountPreset {
   PERCENT_25 = '25%',

--- a/packages/bridge-controller/src/utils/metrics/types.ts
+++ b/packages/bridge-controller/src/utils/metrics/types.ts
@@ -145,16 +145,15 @@ type BatchSellTokenPageEventProperties = BatchSellChainProperties &
 
 type BatchSellSourceTokenEventProperties = BatchSellChainProperties &
   BatchSellSourceTokenEventContext & {
-  source_token_count: number;
-};
+    source_token_count: number;
+  };
 
 type BatchSellQuotePageEventProperties = BatchSellChainProperties &
   BatchSellQuotePageEventContext & {
-  source_token_count: number;
-};
+    source_token_count: number;
+  };
 
-type BatchSellReviewModalSubmittedEventProperties =
-  BatchSellChainProperties &
+type BatchSellReviewModalSubmittedEventProperties = BatchSellChainProperties &
   BatchSellReviewModalSubmittedEventContext & {
     source_token_count: number;
   };

--- a/packages/bridge-controller/src/utils/metrics/types.ts
+++ b/packages/bridge-controller/src/utils/metrics/types.ts
@@ -114,7 +114,12 @@ export type QuoteWarning =
   | 'quote_expired'
   | 'tx_alert';
 
-type BatchSellTokenPageEventContext = {
+type BatchSellChainProperties = {
+  chain_id_source: CaipChainId;
+  chain_id_destination: CaipChainId | null;
+};
+
+type BatchSellTokenPageEventContext = BatchSellChainProperties & {
   location: BatchSellMetricsLocation;
 };
 
@@ -135,29 +140,24 @@ type BatchSellReviewModalSubmittedEventContext =
   BatchSellQuotePageEventContext &
     Pick<TradeData, 'usd_quoted_gas' | 'usd_quoted_return'>;
 
-type BatchSellChainProperties = {
-  chain_id_source: CaipChainId;
-  chain_id_destination: CaipChainId | null;
-};
-
 type BatchSellTokenPageEventProperties = BatchSellChainProperties &
   BatchSellTokenPageEventContext;
 
 type BatchSellSourceTokenEventProperties = BatchSellChainProperties &
   BatchSellSourceTokenEventContext & {
-    source_token_count: number;
-  };
+  source_token_count: number;
+};
 
 type BatchSellQuotePageEventProperties = BatchSellChainProperties &
   BatchSellQuotePageEventContext & {
-    source_token_count: number;
-  };
+  source_token_count: number;
+};
 
 type BatchSellReviewModalSubmittedEventProperties =
   BatchSellChainProperties &
-    BatchSellReviewModalSubmittedEventContext & {
-      source_token_count: number;
-    };
+  BatchSellReviewModalSubmittedEventContext & {
+    source_token_count: number;
+  };
 
 type SharedEventContextFromClient = {
   ab_tests?: Record<string, string>;

--- a/packages/bridge-controller/src/utils/metrics/types.ts
+++ b/packages/bridge-controller/src/utils/metrics/types.ts
@@ -9,6 +9,9 @@ import type {
 } from '../../types';
 import type {
   UnifiedSwapBridgeEventName,
+  BatchSellMetricsEventName,
+  BatchSellMetricsLocation,
+  BridgeControllerMetricsEventName,
   MetaMetricsSwapsEventSource,
   MetricsActionType,
   MetricsSwapType,
@@ -111,10 +114,33 @@ export type QuoteWarning =
   | 'quote_expired'
   | 'tx_alert';
 
+type BatchSellTokenPageEventContext = {
+  location: BatchSellMetricsLocation;
+};
+
+type BatchSellQuotePageEventContext = BatchSellTokenPageEventContext & {
+  selected_token_address_list: CaipAssetType[];
+  target_token_symbol: string;
+  slider_percentages: number[];
+  slippage_percentages: number[];
+};
+
+type SharedEventContextFromClient = {
+  ab_tests?: Record<string, string>;
+  active_ab_tests?: { key: string; value: string }[];
+  feature_id: FeatureId;
+};
+
+type OptionalLocationContextFromClient<T> = T extends {
+  location: unknown;
+}
+  ? object
+  : { location?: MetaMetricsSwapsEventSource };
+
 /**
  * Properties that are required to be provided when trackUnifiedSwapBridgeEvent is called.
- * This is the base type without the `location` property which is added to all events
- * via the RequiredEventContextFromClient mapped type.
+ * Most events receive an optional location via RequiredEventContextFromClient;
+ * Batch Sell events define their own required location enum.
  */
 type RequiredEventContextFromClientBase = {
   [UnifiedSwapBridgeEventName.ButtonClicked]: Pick<
@@ -287,6 +313,11 @@ type RequiredEventContextFromClientBase = {
   [UnifiedSwapBridgeEventName.AssetPickerOpened]: {
     asset_location: 'source' | 'destination';
   };
+  [BatchSellMetricsEventName.BatchSellTokenPageViewed]: BatchSellTokenPageEventContext;
+  [BatchSellMetricsEventName.BatchSellTokenPageSubmitted]: BatchSellTokenPageEventContext;
+  [BatchSellMetricsEventName.BatchSellQuotePageViewed]: BatchSellQuotePageEventContext;
+  [BatchSellMetricsEventName.BatchSellQuotesReviewed]: BatchSellQuotePageEventContext;
+  [BatchSellMetricsEventName.BatchSellQuotePageSubmitted]: BatchSellQuotePageEventContext;
 };
 
 /**
@@ -299,12 +330,9 @@ type RequiredEventContextFromClientBase = {
  * Both are kept for a migration window and are treated as separate payloads.
  */
 export type RequiredEventContextFromClient = {
-  [K in keyof RequiredEventContextFromClientBase]: RequiredEventContextFromClientBase[K] & {
-    location?: MetaMetricsSwapsEventSource;
-    ab_tests?: Record<string, string>;
-    active_ab_tests?: { key: string; value: string }[];
-    feature_id: FeatureId;
-  };
+  [K in keyof RequiredEventContextFromClientBase]: RequiredEventContextFromClientBase[K] &
+    OptionalLocationContextFromClient<RequiredEventContextFromClientBase[K]> &
+    SharedEventContextFromClient;
 };
 
 /**
@@ -379,6 +407,24 @@ export type EventPropertiesFromControllerState = {
     > & {
       batch_id?: string;
     };
+  [BatchSellMetricsEventName.BatchSellTokenPageViewed]: {
+    chain_id: CaipChainId;
+  };
+  [BatchSellMetricsEventName.BatchSellTokenPageSubmitted]: {
+    chain_id: CaipChainId;
+  };
+  [BatchSellMetricsEventName.BatchSellQuotePageViewed]: {
+    chain_id: CaipChainId;
+    selected_tokens_count: number;
+  };
+  [BatchSellMetricsEventName.BatchSellQuotesReviewed]: {
+    chain_id: CaipChainId;
+    selected_tokens_count: number;
+  };
+  [BatchSellMetricsEventName.BatchSellQuotePageSubmitted]: {
+    chain_id: CaipChainId;
+    selected_tokens_count: number;
+  };
 };
 
 /**
@@ -389,12 +435,12 @@ export type EventPropertiesFromControllerState = {
  * `ab_tests` and `active_ab_tests` intentionally coexist during migration.
  */
 export type CrossChainSwapsEventProperties<
-  T extends UnifiedSwapBridgeEventName,
+  T extends BridgeControllerMetricsEventName,
 > =
   | {
       feature_id: FeatureId;
       action_type: MetricsActionType;
-      location: MetaMetricsSwapsEventSource;
+      location: MetaMetricsSwapsEventSource | BatchSellMetricsLocation;
       ab_tests?: Record<string, string>;
       active_ab_tests?: { key: string; value: string }[];
     }

--- a/packages/bridge-controller/src/utils/metrics/types.ts
+++ b/packages/bridge-controller/src/utils/metrics/types.ts
@@ -12,7 +12,7 @@ import type {
   BatchSellMetricsEventName,
   BatchSellMetricsLocation,
   BridgeControllerMetricsEventName,
-  MetaMetricsSwapsEventSource,
+  BridgeControllerMetricsLocation,
   MetricsActionType,
   MetricsSwapType,
   PollingStatus,
@@ -135,7 +135,7 @@ type OptionalLocationContextFromClient<T> = T extends {
   location: unknown;
 }
   ? object
-  : { location?: MetaMetricsSwapsEventSource };
+  : { location?: BridgeControllerMetricsLocation };
 
 /**
  * Properties that are required to be provided when trackUnifiedSwapBridgeEvent is called.
@@ -440,7 +440,7 @@ export type CrossChainSwapsEventProperties<
   | {
       feature_id: FeatureId;
       action_type: MetricsActionType;
-      location: MetaMetricsSwapsEventSource | BatchSellMetricsLocation;
+      location: BridgeControllerMetricsLocation;
       ab_tests?: Record<string, string>;
       active_ab_tests?: { key: string; value: string }[];
     }

--- a/packages/bridge-controller/src/utils/metrics/types.ts
+++ b/packages/bridge-controller/src/utils/metrics/types.ts
@@ -118,12 +118,46 @@ type BatchSellTokenPageEventContext = {
   location: BatchSellMetricsLocation;
 };
 
-type BatchSellQuotePageEventContext = BatchSellTokenPageEventContext & {
-  selected_token_address_list: CaipAssetType[];
-  target_token_symbol: string;
-  slider_percentages: number[];
-  slippage_percentages: number[];
+type BatchSellSourceTokenEventContext = BatchSellTokenPageEventContext & {
+  source_token_symbols: string[];
+  source_token_addresses: CaipAssetType[];
 };
+
+type BatchSellQuotePageEventContext = BatchSellSourceTokenEventContext & {
+  destination_token_symbol: string;
+  destination_token_address: CaipAssetType;
+  usd_amount_source_tokens: number[];
+  usd_amount_source_total: number;
+  source_token_slippages: number[];
+};
+
+type BatchSellReviewModalSubmittedEventContext =
+  BatchSellQuotePageEventContext &
+    Pick<TradeData, 'usd_quoted_gas' | 'usd_quoted_return'>;
+
+type BatchSellChainProperties = {
+  chain_id_source: CaipChainId;
+  chain_id_destination: CaipChainId | null;
+};
+
+type BatchSellTokenPageEventProperties = BatchSellChainProperties &
+  BatchSellTokenPageEventContext;
+
+type BatchSellSourceTokenEventProperties = BatchSellChainProperties &
+  BatchSellSourceTokenEventContext & {
+    source_token_count: number;
+  };
+
+type BatchSellQuotePageEventProperties = BatchSellChainProperties &
+  BatchSellQuotePageEventContext & {
+    source_token_count: number;
+  };
+
+type BatchSellReviewModalSubmittedEventProperties =
+  BatchSellChainProperties &
+    BatchSellReviewModalSubmittedEventContext & {
+      source_token_count: number;
+    };
 
 type SharedEventContextFromClient = {
   ab_tests?: Record<string, string>;
@@ -314,10 +348,10 @@ type RequiredEventContextFromClientBase = {
     asset_location: 'source' | 'destination';
   };
   [BatchSellMetricsEventName.BatchSellTokenPageViewed]: BatchSellTokenPageEventContext;
-  [BatchSellMetricsEventName.BatchSellTokenPageSubmitted]: BatchSellTokenPageEventContext;
+  [BatchSellMetricsEventName.BatchSellTokenPageContinueClicked]: BatchSellSourceTokenEventContext;
   [BatchSellMetricsEventName.BatchSellQuotePageViewed]: BatchSellQuotePageEventContext;
-  [BatchSellMetricsEventName.BatchSellQuotesReviewed]: BatchSellQuotePageEventContext;
-  [BatchSellMetricsEventName.BatchSellQuotePageSubmitted]: BatchSellQuotePageEventContext;
+  [BatchSellMetricsEventName.BatchSellQuotePageReviewClicked]: BatchSellQuotePageEventContext;
+  [BatchSellMetricsEventName.BatchSellReviewModalSubmitted]: BatchSellReviewModalSubmittedEventContext;
 };
 
 /**
@@ -330,9 +364,13 @@ type RequiredEventContextFromClientBase = {
  * Both are kept for a migration window and are treated as separate payloads.
  */
 export type RequiredEventContextFromClient = {
-  [K in keyof RequiredEventContextFromClientBase]: RequiredEventContextFromClientBase[K] &
-    OptionalLocationContextFromClient<RequiredEventContextFromClientBase[K]> &
-    SharedEventContextFromClient;
+  [K in keyof RequiredEventContextFromClientBase]: K extends BatchSellMetricsEventName
+    ? RequiredEventContextFromClientBase[K]
+    : RequiredEventContextFromClientBase[K] &
+        OptionalLocationContextFromClient<
+          RequiredEventContextFromClientBase[K]
+        > &
+        SharedEventContextFromClient;
 };
 
 /**
@@ -407,34 +445,14 @@ export type EventPropertiesFromControllerState = {
     > & {
       batch_id?: string;
     };
-  [BatchSellMetricsEventName.BatchSellTokenPageViewed]: {
-    chain_id: CaipChainId;
-  };
-  [BatchSellMetricsEventName.BatchSellTokenPageSubmitted]: {
-    chain_id: CaipChainId;
-  };
-  [BatchSellMetricsEventName.BatchSellQuotePageViewed]: {
-    chain_id: CaipChainId;
-    selected_tokens_count: number;
-  };
-  [BatchSellMetricsEventName.BatchSellQuotesReviewed]: {
-    chain_id: CaipChainId;
-    selected_tokens_count: number;
-  };
-  [BatchSellMetricsEventName.BatchSellQuotePageSubmitted]: {
-    chain_id: CaipChainId;
-    selected_tokens_count: number;
-  };
+  [BatchSellMetricsEventName.BatchSellTokenPageViewed]: BatchSellTokenPageEventProperties;
+  [BatchSellMetricsEventName.BatchSellTokenPageContinueClicked]: BatchSellSourceTokenEventProperties;
+  [BatchSellMetricsEventName.BatchSellQuotePageViewed]: BatchSellQuotePageEventProperties;
+  [BatchSellMetricsEventName.BatchSellQuotePageReviewClicked]: BatchSellQuotePageEventProperties;
+  [BatchSellMetricsEventName.BatchSellReviewModalSubmitted]: BatchSellReviewModalSubmittedEventProperties;
 };
 
-/**
- * trackUnifiedSwapBridgeEvent payload properties consist of required properties from the client
- * and properties from the bridge controller
- *
- * `ab_tests` will be deprecated in favor of `active_ab_tests` in the future.
- * `ab_tests` and `active_ab_tests` intentionally coexist during migration.
- */
-export type CrossChainSwapsEventProperties<
+type SharedCrossChainSwapsEventProperties<
   T extends BridgeControllerMetricsEventName,
 > =
   | {
@@ -446,3 +464,16 @@ export type CrossChainSwapsEventProperties<
     }
   | Pick<EventPropertiesFromControllerState, T>[T]
   | Pick<RequiredEventContextFromClient, T>[T];
+
+/**
+ * trackUnifiedSwapBridgeEvent payload properties consist of required properties from the client
+ * and properties from the bridge controller
+ *
+ * `ab_tests` will be deprecated in favor of `active_ab_tests` in the future.
+ * `ab_tests` and `active_ab_tests` intentionally coexist during migration.
+ */
+export type CrossChainSwapsEventProperties<
+  T extends BridgeControllerMetricsEventName,
+> = T extends BatchSellMetricsEventName
+  ? Pick<EventPropertiesFromControllerState, T>[T]
+  : SharedCrossChainSwapsEventProperties<T>;


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

This PR revises Batch Sell analytics in `@metamask/bridge-controller`.

It narrows the Batch Sell metrics surface to the five supported events, updates the event payload types and controller assembly to emit the exact Batch Sell property schema, and removes legacy Batch Sell event names that are no longer used. Batch Sell chain IDs are now supplied by the client for these events so metrics can be emitted before quote request state exists.

It also fixes Batch Sell quote metadata so `sentAmount.usd` is calculated with each quote's own source token exchange rate. Previously, `selectBridgeQuotesWithMetadata` derived one source token rate from the first quote request and applied it to every quote, which made later Batch Sell source tokens incorrect when their prices differed from the first token.

Tests cover the revised Batch Sell event payloads and the per-source-token USD regression for `selectBatchSellQuotes`.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Related to: https://github.com/MetaMask/metamask-mobile/pull/32439/, https://github.com/Consensys/segment-schema/pull/639

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared metrics typing and quote USD calculation used by Batch Sell UI; consumers must adopt new event names and client chain/location fields, but scope is analytics and display metadata rather than transaction execution.
> 
> **Overview**
> Adds **five Batch Sell analytics events** (`BatchSellMetricsEventName`) with dedicated payload types, `BatchSellMetricsLocation`, and wiring through `trackUnifiedSwapBridgeEvent` / `#getEventProperties`. Batch Sell events use **client-supplied chain IDs** and their own location enum (not unified `feature_id` / swap-bridge context). `setLocation` / `getLocation` and metrics typing now use the broader `BridgeControllerMetricsEventName` and `BridgeControllerMetricsLocation` unions.
> 
> Fixes **Batch Sell quote metadata**: `selectBridgeQuotesWithMetadata` resolves **each quote’s source token exchange rate** from that quote’s `srcAsset` instead of reusing the first quote request’s source rate, so `sentAmount.usd` is correct when multiple source tokens differ in price.
> 
> Exports new constants/types from the package index; tests cover Batch Sell event payloads and per-token USD in `selectBatchSellQuotes`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97015b3a5a22e9dd6e66a27aa35c42a66d3a118b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->