### PR TITLE
fix: assets ctrl hide arc erc20 usdc

### DIFF
--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `MERGE_BALANCES_IGNORE_LIST` is `balances.ts` selectors with Arc ERC20 USDC to ignore in balance total ([#9277](https://github.com/MetaMask/core/pull/9277))
+
 ### Changed
 
 - Bump `@metamask/transaction-controller` from `^68.1.1` to `^68.2.0` ([#9253](https://github.com/MetaMask/core/pull/9253))

--- a/packages/assets-controller/src/selectors/balance.ts
+++ b/packages/assets-controller/src/selectors/balance.ts
@@ -25,6 +25,10 @@ import type {
 // ============================================================================
 const TRACE_AGGREGATED_BALANCE_SELECTOR = 'AggregatedBalanceSelector';
 
+const MERGE_BALANCES_IGNORE_LIST = [
+  'eip155:5042/erc20:0x3600000000000000000000000000000000000000',
+];
+
 export type EnabledNetworkMap =
   | Record<string, Record<string, boolean>>
   | undefined;
@@ -218,7 +222,10 @@ function mergeBalancesIntoMap(args: {
     }
     const typedAssetId = assetId as Caip19AssetId;
 
-    if (assetPreferences?.[typedAssetId]?.hidden) {
+    if (
+      assetPreferences?.[typedAssetId]?.hidden ||
+      MERGE_BALANCES_IGNORE_LIST.includes(typedAssetId)
+    ) {
       continue;
     }
 


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Arc chain has USDC as native coin, but also provides an ERC20 interface at address `0x3600000000000000000000000000000000000000` which follows the ERC20 standard.
However this ERC20 address points to the same balance as the native, leading to double counting total balance.

This PR adds a map in which some tokens can be explicitly ignored when computing balance total. The code acts at the same location as the Asset Preference "hide" feature.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, hardcoded exclusion in balance aggregation selectors only; no auth, persistence, or fetch pipeline changes.
> 
> **Overview**
> Prevents **Arc mainnet ERC20 USDC** (`eip155:5042/erc20:0x3600…0000`) from being included when balances are merged for portfolio totals and related selectors.
> 
> Adds `MERGE_BALANCES_IGNORE_LIST` in `balance.ts` and treats listed asset IDs like user-hidden assets in `mergeBalancesIntoMap`, so that token no longer inflates aggregated fiat totals when the same economic balance may already be represented elsewhere on Arc (e.g. native vs ERC20 USDC). Documents the change under **Unreleased** in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 574b60e35d1b4fc02c1937f840f8b628122c47b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->