### PR TITLE
fix(transaction-pay-controller): preserve isExternalSign on gas-sponsored transactions when no quotes

### DIFF
--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserve `isExternalSign` on gas-sponsored transactions when no Pay quotes exist ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
+  - `syncTransaction` previously cleared `isExternalSign` unconditionally when quote fetches returned no results (e.g. same source and target token). For gas-sponsored transactions, `TransactionController` owns this flag based on the Sentinel simulation result; TPC no longer overrides it.
+
 ## [23.17.0]
 
 ### Added

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Preserve `isExternalSign` on gas-sponsored transactions when no Pay quotes exist ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
+- Preserve `isExternalSign` on gas-sponsored transactions when no Pay quotes exist ([#9279](https://github.com/MetaMask/core/pull/9279))
   - `syncTransaction` previously cleared `isExternalSign` unconditionally when quote fetches returned no results (e.g. same source and target token). For gas-sponsored transactions, `TransactionController` owns this flag based on the Sentinel simulation result; TPC no longer overrides it.
 
 ## [23.17.0]

--- a/packages/transaction-pay-controller/src/utils/quotes.test.ts
+++ b/packages/transaction-pay-controller/src/utils/quotes.test.ts
@@ -754,6 +754,23 @@ describe('Quotes Utils', () => {
       );
     });
 
+    it('preserves the externally signed flag when no quotes are returned but gas is sponsored', async () => {
+      getQuotesMock.mockResolvedValue([]);
+
+      await run();
+
+      const transactionMetaMock = {
+        isExternalSign: true,
+        isGasFeeSponsored: true,
+      } as TransactionMeta;
+
+      updateTransactionMock.mock.calls[0][1](transactionMetaMock);
+
+      expect(transactionMetaMock).toMatchObject(
+        expect.objectContaining({ isExternalSign: true }),
+      );
+    });
+
     it('updates metrics in metadata', async () => {
       await run();
 

--- a/packages/transaction-pay-controller/src/utils/quotes.ts
+++ b/packages/transaction-pay-controller/src/utils/quotes.ts
@@ -247,7 +247,14 @@ function syncTransaction({
       // When there are no quotes (e.g. user selected the target token as the
       // payment token in a Predict flow), the transaction falls back to normal
       // local signing, so the flag is cleared to allow that.
-      tx.isExternalSign = hasQuotes;
+      // If gas is sponsored, TC owns this field — it is set based on the
+      // Sentinel simulation result and must not be cleared here. Same-token
+      // flows (e.g. Monad mUSD withdrawal via a Money Account) produce no
+      // quotes but still need external sign because the account cannot sign
+      // locally.
+      if (!tx.isGasFeeSponsored) {
+        tx.isExternalSign = hasQuotes;
+      }
 
       tx.metamaskPay = {
         bridgeFeeFiat: totals.fees.provider.usd,


### PR DESCRIPTION
## Explanation

When a transaction's gas is sponsored, `TransactionController` owns the `isExternalSign` flag — it is set to `true` based on the Sentinel simulation result (or immediately at `addTransaction` time when `isGasFeeSponsored: true` is passed explicitly). `TransactionPayController`'s `syncTransaction` function was unconditionally writing `isExternalSign = hasQuotes`, which cleared the flag to `false` whenever no Pay quotes were found.

For same-source-and-target-token flows (e.g. a Monad mUSD withdrawal via a Money Account), TPC produces no quotes by design — the `isSameToken` filter in `source-amounts.ts` short-circuits quote fetching. Because the account cannot sign locally, `isExternalSign` must stay `true`. The unconditional clear caused a race where TPC set it to `false`, then ~2 seconds later TC's Sentinel simulation set it back to `true`, then the next amount change triggered TPC to clear it again — oscillating on every edit.

The fix: `syncTransaction` now skips the `isExternalSign` write entirely when `tx.isGasFeeSponsored` is set. TC already handles that field correctly for sponsored transactions; TPC no longer needs to touch it.

## References

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transaction submission/signing metadata coordination between Transaction Pay and Transaction Controller; wrong behavior could break gas-sponsored same-token withdrawals but the change is narrowly scoped.
> 
> **Overview**
> **`syncTransaction` no longer overwrites `isExternalSign` when gas is sponsored.** Previously it always set `isExternalSign = hasQuotes`, which cleared the flag to `false` whenever Pay returned no quotes (e.g. same source/target token). For **gas-sponsored** txs, **TransactionController** sets that flag from Sentinel simulation; clearing it caused oscillation on amount edits.
> 
> The update only assigns `isExternalSign` from quote presence when **`isGasFeeSponsored` is not set**; sponsored flows with no quotes (e.g. Monad mUSD withdrawal via a Money Account) keep external signing. A unit test and changelog entry document the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4e0c0489719cde647ff5daf934f92fee3c0ef8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->