### PR TITLE
feat: scaffold `@metamask/stellar-quickstart-up` package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -127,6 +127,7 @@
 /packages/java-tron-up                          @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/networks
 /packages/local-node-utils                      @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/networks
 /packages/solana-test-validator-up              @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/networks
+/packages/stellar-quickstart-up                 @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/networks
 /packages/keyring-controller                    @MetaMask/accounts-engineers @MetaMask/core-platform
 /packages/multichain-network-controller         @MetaMask/core-platform @MetaMask/accounts-engineers @MetaMask/metamask-assets
 /packages/network-controller                    @MetaMask/core-platform @MetaMask/metamask-assets
@@ -238,6 +239,8 @@
 /packages/local-node-utils/CHANGELOG.md @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/networks @MetaMask/core-platform
 /packages/solana-test-validator-up/package.json @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/networks @MetaMask/core-platform
 /packages/solana-test-validator-up/CHANGELOG.md @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/networks @MetaMask/core-platform
+/packages/stellar-quickstart-up/package.json @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/networks @MetaMask/core-platform
+/packages/stellar-quickstart-up/CHANGELOG.md @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/networks @MetaMask/core-platform
 /packages/seedless-onboarding-controller/package.json @MetaMask/web3auth @MetaMask/core-platform
 /packages/seedless-onboarding-controller/CHANGELOG.md @MetaMask/web3auth @MetaMask/core-platform
 /packages/shield-controller/package.json @MetaMask/web3auth @MetaMask/core-platform

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ yarn skills --reset                 # clear saved local selection
 - [`@metamask/snap-account-service`](packages/snap-account-service)
 - [`@metamask/social-controllers`](packages/social-controllers)
 - [`@metamask/solana-test-validator-up`](packages/solana-test-validator-up)
+- [`@metamask/stellar-quickstart-up`](packages/stellar-quickstart-up)
 - [`@metamask/storage-service`](packages/storage-service)
 - [`@metamask/subscription-controller`](packages/subscription-controller)
 - [`@metamask/transaction-controller`](packages/transaction-controller)
@@ -222,6 +223,7 @@ linkStyle default opacity:0.5
   snap_account_service(["@metamask/snap-account-service"]);
   social_controllers(["@metamask/social-controllers"]);
   solana_test_validator_up(["@metamask/solana-test-validator-up"]);
+  stellar_quickstart_up(["@metamask/stellar-quickstart-up"]);
   storage_service(["@metamask/storage-service"]);
   subscription_controller(["@metamask/subscription-controller"]);
   transaction_controller(["@metamask/transaction-controller"]);

--- a/packages/stellar-quickstart-up/CHANGELOG.md
+++ b/packages/stellar-quickstart-up/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+[Unreleased]: https://github.com/MetaMask/core/

--- a/packages/stellar-quickstart-up/LICENSE
+++ b/packages/stellar-quickstart-up/LICENSE
@@ -1,0 +1,6 @@
+This project is licensed under either of
+
+ * MIT license ([LICENSE.MIT](LICENSE.MIT))
+ * Apache License, Version 2.0 ([LICENSE.APACHE2](LICENSE.APACHE2))
+
+at your option.

--- a/packages/stellar-quickstart-up/LICENSE.APACHE2
+++ b/packages/stellar-quickstart-up/LICENSE.APACHE2
@@ -1,0 +1,201 @@
+ Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 MetaMask
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/stellar-quickstart-up/LICENSE.MIT
+++ b/packages/stellar-quickstart-up/LICENSE.MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 MetaMask
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/stellar-quickstart-up/README.md
+++ b/packages/stellar-quickstart-up/README.md
@@ -1,0 +1,15 @@
+# `@metamask/stellar-quickstart-up`
+
+Stellar Quickstart runtime installer for MetaMask E2E tests
+
+## Installation
+
+`yarn add @metamask/stellar-quickstart-up`
+
+or
+
+`npm install @metamask/stellar-quickstart-up`
+
+## Contributing
+
+This package is part of a monorepo. Instructions for contributing can be found in the [monorepo README](https://github.com/MetaMask/core#readme).

--- a/packages/stellar-quickstart-up/jest.config.js
+++ b/packages/stellar-quickstart-up/jest.config.js
@@ -1,0 +1,26 @@
+/*
+ * For a detailed explanation regarding each configuration property and type check, visit:
+ * https://jestjs.io/docs/configuration
+ */
+
+const merge = require('deepmerge');
+const path = require('path');
+
+const baseConfig = require('../../jest.config.packages');
+
+const displayName = path.basename(__dirname);
+
+module.exports = merge(baseConfig, {
+  // The display name when running multiple projects
+  displayName,
+
+  // An object that configures minimum threshold enforcement for coverage results
+  coverageThreshold: {
+    global: {
+      branches: 100,
+      functions: 100,
+      lines: 100,
+      statements: 100,
+    },
+  },
+});

--- a/packages/stellar-quickstart-up/package.json
+++ b/packages/stellar-quickstart-up/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@metamask/stellar-quickstart-up",
+  "version": "0.0.0",
+  "description": "Stellar Quickstart runtime installer for MetaMask E2E tests",
+  "keywords": [
+    "Ethereum",
+    "MetaMask"
+  ],
+  "homepage": "https://github.com/MetaMask/core/tree/main/packages/stellar-quickstart-up#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/core/issues"
+  },
+  "license": "(MIT OR Apache-2.0)",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MetaMask/core.git"
+  },
+  "files": [
+    "dist/"
+  ],
+  "sideEffects": false,
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.cts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "scripts": {
+    "build": "ts-bridge --project tsconfig.build.json --verbose --clean --no-references",
+    "build:all": "ts-bridge --project tsconfig.build.json --verbose --clean",
+    "build:docs": "typedoc",
+    "changelog:update": "../../scripts/update-changelog.sh @metamask/stellar-quickstart-up",
+    "changelog:validate": "../../scripts/validate-changelog.sh @metamask/stellar-quickstart-up",
+    "messenger-action-types:check": "tsx ../../packages/messenger-cli/src/cli.ts --formatter oxfmt --check",
+    "messenger-action-types:generate": "tsx ../../packages/messenger-cli/src/cli.ts --formatter oxfmt --generate",
+    "since-latest-release": "../../scripts/since-latest-release.sh",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
+    "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
+    "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+  },
+  "devDependencies": {
+    "@metamask/auto-changelog": "^6.1.0",
+    "@ts-bridge/cli": "^0.6.4",
+    "@types/jest": "^29.5.14",
+    "deepmerge": "^4.2.2",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.2.5",
+    "tsx": "^4.20.5",
+    "typedoc": "^0.25.13",
+    "typedoc-plugin-missing-exports": "^2.0.0",
+    "typescript": "~5.3.3"
+  },
+  "engines": {
+    "node": "^18.18 || >=20"
+  }
+}

--- a/packages/stellar-quickstart-up/src/index.test.ts
+++ b/packages/stellar-quickstart-up/src/index.test.ts
@@ -1,0 +1,9 @@
+import greeter from '.';
+
+describe('Test', () => {
+  it('greets', () => {
+    const name = 'Huey';
+    const result = greeter(name);
+    expect(result).toBe('Hello, Huey!');
+  });
+});

--- a/packages/stellar-quickstart-up/src/index.ts
+++ b/packages/stellar-quickstart-up/src/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Example function that returns a greeting for the given name.
+ *
+ * @param name - The name to greet.
+ * @returns The greeting.
+ */
+export default function greeter(name: string): string {
+  return `Hello, ${name}!`;
+}

--- a/packages/stellar-quickstart-up/tsconfig.build.json
+++ b/packages/stellar-quickstart-up/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.packages.build.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "references": [],
+  "include": ["../../types", "./src"]
+}

--- a/packages/stellar-quickstart-up/tsconfig.json
+++ b/packages/stellar-quickstart-up/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.packages.json",
+  "compilerOptions": {
+    "baseUrl": "./"
+  },
+  "references": [],
+  "include": ["../../types", "./src"]
+}

--- a/packages/stellar-quickstart-up/typedoc.json
+++ b/packages/stellar-quickstart-up/typedoc.json
@@ -1,0 +1,7 @@
+{
+  "entryPoints": ["./src/index.ts"],
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "out": "docs",
+  "tsconfig": "./tsconfig.build.json"
+}

--- a/teams.json
+++ b/teams.json
@@ -73,6 +73,7 @@
   "metamask/java-tron-up": "team-mobile-platform,team-extension-platform,team-networks",
   "metamask/local-node-utils": "team-mobile-platform,team-extension-platform,team-networks",
   "metamask/solana-test-validator-up": "team-mobile-platform,team-extension-platform,team-networks",
+  "metamask/stellar-quickstart-up": "team-mobile-platform,team-extension-platform,team-networks",
   "metamask/json-rpc-engine": "team-core-platform",
   "metamask/json-rpc-middleware-stream": "team-core-platform",
   "metamask/keyring-controller": "team-accounts-framework,team-core-platform",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -257,6 +257,9 @@
       "path": "./packages/solana-test-validator-up/tsconfig.build.json"
     },
     {
+      "path": "./packages/stellar-quickstart-up/tsconfig.build.json"
+    },
+    {
       "path": "./packages/storage-service/tsconfig.build.json"
     },
     {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -249,6 +249,9 @@
       "path": "./packages/solana-test-validator-up"
     },
     {
+      "path": "./packages/stellar-quickstart-up"
+    },
+    {
       "path": "./packages/subscription-controller"
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8632,6 +8632,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/stellar-quickstart-up@workspace:packages/stellar-quickstart-up":
+  version: 0.0.0-use.local
+  resolution: "@metamask/stellar-quickstart-up@workspace:packages/stellar-quickstart-up"
+  dependencies:
+    "@metamask/auto-changelog": "npm:^6.1.0"
+    "@ts-bridge/cli": "npm:^0.6.4"
+    "@types/jest": "npm:^29.5.14"
+    deepmerge: "npm:^4.2.2"
+    jest: "npm:^29.7.0"
+    ts-jest: "npm:^29.2.5"
+    tsx: "npm:^4.20.5"
+    typedoc: "npm:^0.25.13"
+    typedoc-plugin-missing-exports: "npm:^2.0.0"
+    typescript: "npm:~5.3.3"
+  languageName: unknown
+  linkType: soft
+
 "@metamask/storage-service@npm:^1.0.1, @metamask/storage-service@npm:^1.0.2, @metamask/storage-service@workspace:packages/storage-service":
   version: 0.0.0-use.local
   resolution: "@metamask/storage-service@workspace:packages/storage-service"


### PR DESCRIPTION
## Summary

This PR is the **first of two PRs** to add the Stellar Quickstart runtime installer package for Extension E2E tests.

It contains **only** the pure scaffold output of `yarn create-package` plus ownership configuration — zero implementation logic.

### What's included

- `packages/stellar-quickstart-up/` — scaffolded package skeleton (source placeholder, tests, CHANGELOG, README, LICENSE, jest/tsconfig configs) generated by `yarn create-package --name stellar-quickstart-up --description "Stellar Quickstart runtime installer for MetaMask E2E tests"`
- `tsconfig.json` / `tsconfig.build.json` — monorepo-level references updated by the tool
- `yarn.lock` — updated by `yarn install` run inside the tool
- `README.md` — package list updated by `yarn readme-content:update`
- `.github/CODEOWNERS` — ownership entries for the package (alphabetical list + Package Release section), mirroring the `java-tron-up` / `solana-test-validator-up` / `bitcoin-regtest-up` pattern with `@MetaMask/networks` added
- `teams.json` — issue-label routing entry after `solana-test-validator-up`

### What's NOT included

No implementation source, no `bin` field, no new runtime dependencies, no `knip.config.ts` changes, no unrelated monorepo churn.

### Stacked PR

The implementation (Docker image installer source, CLI bin, tests, full README) follows in a stacked PR based on this branch.

### Jira

- Epic: [WPN-1509](https://consensyssoftware.atlassian.net/browse/WPN-1509) — [Extension] Expand Stellar's E2E test coverage
- Task: [WPN-1510](https://consensyssoftware.atlassian.net/browse/WPN-1510) — Create Stellar Quickstart installer package "stellar-quickstart-up"

## Verification

```
yarn workspace @metamask/stellar-quickstart-up run build
yarn workspace @metamask/stellar-quickstart-up run test
yarn constraints
yarn lint:teams
yarn readme-content:check
```

All passed ✓

## Test plan

- [x] `yarn workspace @metamask/stellar-quickstart-up run build`
- [x] `yarn workspace @metamask/stellar-quickstart-up run test`
- [x] `yarn constraints`
- [x] `yarn lint:teams`
- [x] `yarn readme-content:check`

[WPN-1509]: https://consensyssoftware.atlassian.net/browse/WPN-1509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scaffold and metadata-only changes; no production runtime, auth, or wallet logic is introduced in this PR.
> 
> **Overview**
> Adds **`@metamask/stellar-quickstart-up`** to the monorepo as a scaffold-only package (from `yarn create-package`), intended as the Stellar Quickstart runtime installer for Extension E2E tests. **No installer logic yet**—only the default `greeter` placeholder, standard build/test/tsconfig/jest setup, licenses, and changelog.
> 
> Monorepo wiring is updated in parallel with sibling `*-up` packages: **`README.md`** package list and mermaid graph, **`tsconfig.json`** / **`tsconfig.build.json`** project references, **`yarn.lock`**, **`teams.json`**, and **`.github/CODEOWNERS`** (joint ownership with mobile/extension/networks teams plus package release entries).
> 
> Real Docker/CLI implementation is expected in a follow-up stacked PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bafa112ff8fcd81194bf8d9a02018b525831ad38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->