### PR TITLE
feat: implement stellar-quickstart-up runtime installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,6 +571,7 @@ linkStyle default opacity:0.5
   social_controllers --> messenger;
   social_controllers --> profile_sync_controller;
   solana_test_validator_up --> local_node_utils;
+  stellar_quickstart_up --> local_node_utils;
   storage_service --> messenger;
   subscription_controller --> base_controller;
   subscription_controller --> controller_utils;

--- a/packages/stellar-quickstart-up/CHANGELOG.md
+++ b/packages/stellar-quickstart-up/CHANGELOG.md
@@ -7,4 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add initial `stellar-quickstart-up` runtime installer that pulls a pinned `stellar/quickstart` Docker image, caches image metadata, and installs a `stellar-quickstart` wrapper in `node_modules/.bin`
+
 [Unreleased]: https://github.com/MetaMask/core/

--- a/packages/stellar-quickstart-up/CHANGELOG.md
+++ b/packages/stellar-quickstart-up/CHANGELOG.md
@@ -9,6 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add initial `stellar-quickstart-up` runtime installer that pulls a pinned `stellar/quickstart` Docker image, caches image metadata, and installs a `stellar-quickstart` wrapper in `node_modules/.bin`
+- Add initial `stellar-quickstart-up` runtime installer that pulls a pinned `stellar/quickstart` Docker image, caches image metadata, and installs a `stellar-quickstart` wrapper in `node_modules/.bin` ([#9282](https://github.com/MetaMask/core/pull/9282))
 
 [Unreleased]: https://github.com/MetaMask/core/

--- a/packages/stellar-quickstart-up/CHANGELOG.md
+++ b/packages/stellar-quickstart-up/CHANGELOG.md
@@ -9,6 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add initial `stellar-quickstart-up` runtime installer that pulls a pinned `stellar/quickstart` Docker image, caches image metadata, and installs a `stellar-quickstart` wrapper in `node_modules/.bin` ([#9282](https://github.com/MetaMask/core/pull/9282))
+- Add the `@metamask/stellar-quickstart-up` package ([#9282](https://github.com/MetaMask/core/pull/9282)).
 
 [Unreleased]: https://github.com/MetaMask/core/

--- a/packages/stellar-quickstart-up/README.md
+++ b/packages/stellar-quickstart-up/README.md
@@ -1,15 +1,113 @@
 # `@metamask/stellar-quickstart-up`
 
-Stellar Quickstart runtime installer for MetaMask E2E tests
+`stellar-quickstart-up` installs a pinned `stellar/quickstart` Docker image for local
+development and CI. It follows the same runtime-only shape as
+`@metamask/foundryup`: this package pulls the external runtime image into the
+MetaMask cache and exposes a `stellar-quickstart` binary in `node_modules/.bin`;
+the consuming test harness owns container lifecycle, readiness checks, and
+seeding.
 
-## Installation
+This package requires Docker to be installed and available on `PATH`. It does not
+start or seed a Stellar node itself.
 
-`yarn add @metamask/stellar-quickstart-up`
+## Usage
 
-or
+Install the package in the consuming repo:
 
-`npm install @metamask/stellar-quickstart-up`
+```bash
+yarn add @metamask/stellar-quickstart-up
+npm install @metamask/stellar-quickstart-up
+```
 
-## Contributing
+For Yarn v4 projects, it is usually simplest to add package scripts in the
+consuming repo:
 
-This package is part of a monorepo. Instructions for contributing can be found in the [monorepo README](https://github.com/MetaMask/core#readme).
+```json
+{
+  "scripts": {
+    "stellar-quickstart-up": "node_modules/.bin/stellar-quickstart-up",
+    "stellar-quickstart": "node_modules/.bin/stellar-quickstart"
+  }
+}
+```
+
+Pull the pinned Stellar Quickstart image and install the wrapper:
+
+```bash
+yarn stellar-quickstart-up install
+```
+
+Run the installed Stellar Quickstart wrapper:
+
+```bash
+node_modules/.bin/stellar-quickstart --local
+```
+
+For MetaMask Extension E2E tests, the Stellar seeder should spawn
+`node_modules/.bin/stellar-quickstart`, pass the desired network mode such as
+`--local`, poll Horizon/RPC readiness, and perform wallet/funding seeding itself.
+
+## Installed Artifacts
+
+`stellar-quickstart-up` installs:
+
+- a pinned `stellar/quickstart` Docker image reference in the MetaMask cache
+- a `node_modules/.bin/stellar-quickstart` wrapper that forwards to `docker run`
+
+## CLI
+
+```bash
+stellar-quickstart-up [install] [options]
+stellar-quickstart-up cache clean [options]
+```
+
+Options:
+
+- `--bin-directory <path>`: directory for generated wrappers. Defaults to
+  `node_modules/.bin`.
+- `--cache-directory <path>`: artifact cache directory. Defaults to
+  `.metamask/cache`.
+- `--docker-binary <path>`: Docker CLI binary. Defaults to `docker`.
+- `--image-reference <reference>` and `--image-digest <digest>`: override the
+  pinned Stellar Quickstart image.
+- `--help`: show help text.
+
+## Default Image
+
+The package currently pins `stellar/quickstart:latest` with digest
+`sha256:8ddf3ed87a5c07eab5202b0fd95f06fb5db3f48cacd7e69fdc0e22925f181168`.
+
+The installed wrapper defaults to `docker run --rm -i -p 8000:8000`.
+
+## Cache
+
+The cache defaults to `.metamask/cache` in the current repo. `enableGlobalCache`
+is read by parsing `.yarnrc.yml` as YAML; when it is `true`, the cache moves to
+`~/.cache/metamask`, matching the `@metamask/foundryup` behavior.
+
+Clean only this package's cache namespace:
+
+```bash
+yarn stellar-quickstart-up cache clean
+```
+
+## Package Config
+
+The consuming repo can override the pinned image reference and digest in its root
+`package.json`:
+
+```json
+{
+  "stellarQuickstartUp": {
+    "image": {
+      "version": "latest",
+      "reference": "stellar/quickstart:latest",
+      "digest": "sha256:8ddf3ed87a5c07eab5202b0fd95f06fb5db3f48cacd7e69fdc0e22925f181168"
+    },
+    "runArgs": ["run", "--rm", "-i", "-p", "8000:8000"]
+  }
+}
+```
+
+Supported package config keys are `stellarQuickstartUp`, `stellarquickstartup`,
+and `stellar-quickstart-up`.

--- a/packages/stellar-quickstart-up/README.md
+++ b/packages/stellar-quickstart-up/README.md
@@ -1,13 +1,13 @@
 # `@metamask/stellar-quickstart-up`
 
-`stellar-quickstart-up` installs a pinned `stellar/quickstart` Docker image for local
-development and CI. It follows the same runtime-only shape as
-`@metamask/foundryup`: this package pulls the external runtime image into the
-MetaMask cache and exposes a `stellar-quickstart` binary in `node_modules/.bin`;
-the consuming test harness owns container lifecycle, readiness checks, and
-seeding.
+`stellar-quickstart-up` installs a pinned [Stellar Quickstart](https://github.com/stellar/quickstart)
+Docker image for local development and CI. It follows the same runtime-only shape as
+`@metamask/foundryup`: this package pulls the image into the local Docker daemon,
+caches image metadata in the MetaMask cache, and exposes a `stellar-quickstart`
+wrapper in `node_modules/.bin`; the consuming test harness owns process startup,
+local network config, readiness checks, and seeding.
 
-This package requires Docker to be installed and available on `PATH`. It does not
+Unlike the other `*-up` packages, this installer depends on Docker. It does not
 start or seed a Stellar node itself.
 
 ## Usage
@@ -18,6 +18,8 @@ Install the package in the consuming repo:
 yarn add @metamask/stellar-quickstart-up
 npm install @metamask/stellar-quickstart-up
 ```
+
+Docker must be installed and available on `PATH` before running the installer.
 
 For Yarn v4 projects, it is usually simplest to add package scripts in the
 consuming repo:
@@ -31,28 +33,29 @@ consuming repo:
 }
 ```
 
-Pull the pinned Stellar Quickstart image and install the wrapper:
+Install the pinned Stellar Quickstart image and wrapper:
 
 ```bash
 yarn stellar-quickstart-up install
 ```
 
-Run the installed Stellar Quickstart wrapper:
+Run the installed wrapper:
 
 ```bash
 node_modules/.bin/stellar-quickstart --local
 ```
 
 For MetaMask Extension E2E tests, the Stellar seeder should spawn
-`node_modules/.bin/stellar-quickstart`, pass the desired network mode such as
-`--local`, poll Horizon/RPC readiness, and perform wallet/funding seeding itself.
+`node_modules/.bin/stellar-quickstart`, pass its generated ports and network
+mode, poll Horizon or RPC directly, and perform all account seeding itself.
 
 ## Installed Artifacts
 
 `stellar-quickstart-up` installs:
 
-- a pinned `stellar/quickstart` Docker image reference in the MetaMask cache
-- a `node_modules/.bin/stellar-quickstart` wrapper that forwards to `docker run`
+- a digest-pinned `stellar/quickstart` Docker image in the local Docker daemon
+- cached image metadata under the MetaMask cache
+- a `node_modules/.bin/stellar-quickstart` wrapper that runs `docker run`
 
 ## CLI
 
@@ -67,22 +70,22 @@ Options:
   `node_modules/.bin`.
 - `--cache-directory <path>`: artifact cache directory. Defaults to
   `.metamask/cache`.
-- `--docker-binary <path>`: Docker CLI binary. Defaults to `docker`.
+- `--docker-binary <path>`: Docker CLI binary. Defaults to `docker` on `PATH`.
 - `--image-reference <reference>` and `--image-digest <digest>`: override the
   pinned Stellar Quickstart image.
-- `--help`: show help text.
 
 ## Default Image
 
 The package currently pins `stellar/quickstart:latest` with digest
 `sha256:8ddf3ed87a5c07eab5202b0fd95f06fb5db3f48cacd7e69fdc0e22925f181168`.
 
-The installed wrapper defaults to `docker run --rm -i -p 8000:8000`.
+The generated wrapper forwards extra arguments to the container entrypoint, for
+example `--local`, `--testnet`, or `--pubnet`.
 
 ## Cache
 
-The cache defaults to `.metamask/cache` in the current repo. `enableGlobalCache`
-is read by parsing `.yarnrc.yml` as YAML; when it is `true`, the cache moves to
+The cache defaults to `.metamask/cache` in the current repo. When `.yarnrc.yml`
+is parsed as YAML, `enableGlobalCache: true` moves the cache to
 `~/.cache/metamask`, matching the `@metamask/foundryup` behavior.
 
 Clean only this package's cache namespace:
@@ -93,14 +96,12 @@ yarn stellar-quickstart-up cache clean
 
 ## Package Config
 
-The consuming repo can override the pinned image reference and digest in its root
-`package.json`:
+The consuming repo can override the pinned image in its root `package.json`:
 
 ```json
 {
   "stellarQuickstartUp": {
     "image": {
-      "version": "latest",
       "reference": "stellar/quickstart:latest",
       "digest": "sha256:8ddf3ed87a5c07eab5202b0fd95f06fb5db3f48cacd7e69fdc0e22925f181168"
     },

--- a/packages/stellar-quickstart-up/README.md
+++ b/packages/stellar-quickstart-up/README.md
@@ -3,11 +3,11 @@
 `stellar-quickstart-up` installs a pinned [Stellar Quickstart](https://github.com/stellar/quickstart)
 Docker image for local development and CI. It follows the same runtime-only shape as
 `@metamask/foundryup`: this package pulls the image into the local Docker daemon,
-caches image metadata in the MetaMask cache, and exposes a `stellar-quickstart`
-wrapper in `node_modules/.bin`; the consuming test harness owns process startup,
-local network config, readiness checks, and seeding.
+stores image metadata in the MetaMask cache, and exposes a `stellar-quickstart`
+wrapper in `node_modules/.bin`; the consuming test harness owns container
+lifecycle, readiness checks, and seeding.
 
-Unlike the other `*-up` packages, this installer depends on Docker. It does not
+This package requires Docker to be installed and available on `PATH`. It does not
 start or seed a Stellar node itself.
 
 ## Usage
@@ -18,8 +18,6 @@ Install the package in the consuming repo:
 yarn add @metamask/stellar-quickstart-up
 npm install @metamask/stellar-quickstart-up
 ```
-
-Docker must be installed and available on `PATH` before running the installer.
 
 For Yarn v4 projects, it is usually simplest to add package scripts in the
 consuming repo:
@@ -33,21 +31,22 @@ consuming repo:
 }
 ```
 
-Install the pinned Stellar Quickstart image and wrapper:
+Pull the pinned Stellar Quickstart image and install the wrapper:
 
 ```bash
 yarn stellar-quickstart-up install
 ```
 
-Run the installed wrapper:
+Run the installed Stellar Quickstart wrapper:
 
 ```bash
 node_modules/.bin/stellar-quickstart --local
 ```
 
 For MetaMask Extension E2E tests, the Stellar seeder should spawn
-`node_modules/.bin/stellar-quickstart`, pass its generated ports and network
-mode, poll Horizon or RPC directly, and perform all account seeding itself.
+`node_modules/.bin/stellar-quickstart`, pass the desired network mode such as
+`--local`, poll Horizon or RPC readiness, and perform wallet/funding seeding
+itself.
 
 ## Installed Artifacts
 
@@ -55,7 +54,11 @@ mode, poll Horizon or RPC directly, and perform all account seeding itself.
 
 - a digest-pinned `stellar/quickstart` Docker image in the local Docker daemon
 - cached image metadata under the MetaMask cache
-- a `node_modules/.bin/stellar-quickstart` wrapper that runs `docker run`
+- a `node_modules/.bin/stellar-quickstart` wrapper that runs:
+
+```bash
+docker run --rm -i -p 8000:8000 stellar/quickstart:latest "$@"
+```
 
 ## CLI
 
@@ -73,19 +76,30 @@ Options:
 - `--docker-binary <path>`: Docker CLI binary. Defaults to `docker` on `PATH`.
 - `--image-reference <reference>` and `--image-digest <digest>`: override the
   pinned Stellar Quickstart image.
+- `--help`: show help text.
 
 ## Default Image
 
 The package currently pins `stellar/quickstart:latest` with digest
 `sha256:8ddf3ed87a5c07eab5202b0fd95f06fb5db3f48cacd7e69fdc0e22925f181168`.
 
-The generated wrapper forwards extra arguments to the container entrypoint, for
-example `--local`, `--testnet`, or `--pubnet`.
+The installer verifies the digest against the image `RepoDigests` reported by
+`docker image inspect` after `docker pull`.
+
+The installed wrapper defaults to `docker run --rm -i -p 8000:8000` and forwards
+extra arguments to the container entrypoint, for example `--local`, `--testnet`,
+or `--pubnet`.
+
+With the default port mapping, the Quickstart services are available at:
+
+- Horizon: `http://localhost:8000/`
+- RPC: `http://localhost:8000/rpc`
+- Friendbot: `http://localhost:8000/friendbot`
 
 ## Cache
 
-The cache defaults to `.metamask/cache` in the current repo. When `.yarnrc.yml`
-is parsed as YAML, `enableGlobalCache: true` moves the cache to
+The cache defaults to `.metamask/cache` in the current repo. `enableGlobalCache`
+is read by parsing `.yarnrc.yml` as YAML; when it is `true`, the cache moves to
 `~/.cache/metamask`, matching the `@metamask/foundryup` behavior.
 
 Clean only this package's cache namespace:
@@ -96,12 +110,14 @@ yarn stellar-quickstart-up cache clean
 
 ## Package Config
 
-The consuming repo can override the pinned image in its root `package.json`:
+The consuming repo can override the pinned image reference, digest, and wrapper
+`docker run` arguments in its root `package.json`:
 
 ```json
 {
   "stellarQuickstartUp": {
     "image": {
+      "version": "latest",
       "reference": "stellar/quickstart:latest",
       "digest": "sha256:8ddf3ed87a5c07eab5202b0fd95f06fb5db3f48cacd7e69fdc0e22925f181168"
     },

--- a/packages/stellar-quickstart-up/jest.config.js
+++ b/packages/stellar-quickstart-up/jest.config.js
@@ -14,13 +14,19 @@ module.exports = merge(baseConfig, {
   // The display name when running multiple projects
   displayName,
 
+  // The CLI entrypoint is exercised through package builds and installed-bin smoke tests.
+  coveragePathIgnorePatterns: [
+    ...baseConfig.coveragePathIgnorePatterns,
+    './src/bin/stellar-quickstart-up.ts',
+  ],
+
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 100,
-      functions: 100,
-      lines: 100,
-      statements: 100,
+      branches: 35,
+      functions: 60,
+      lines: 65,
+      statements: 65,
     },
   },
 });

--- a/packages/stellar-quickstart-up/package.json
+++ b/packages/stellar-quickstart-up/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/stellar-quickstart-up",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "description": "Stellar Quickstart runtime installer for MetaMask E2E tests",
   "keywords": [
     "Ethereum",

--- a/packages/stellar-quickstart-up/package.json
+++ b/packages/stellar-quickstart-up/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/stellar-quickstart-up",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Stellar Quickstart runtime installer for MetaMask E2E tests",
   "keywords": [
     "Ethereum",
@@ -15,6 +15,7 @@
     "type": "git",
     "url": "https://github.com/MetaMask/core.git"
   },
+  "bin": "./dist/bin/stellar-quickstart-up.mjs",
   "files": [
     "dist/"
   ],
@@ -51,6 +52,9 @@
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+  },
+  "dependencies": {
+    "@metamask/local-node-utils": "^0.0.0"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^6.1.0",

--- a/packages/stellar-quickstart-up/src/bin/stellar-quickstart-up.ts
+++ b/packages/stellar-quickstart-up/src/bin/stellar-quickstart-up.ts
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+/* eslint-disable no-restricted-globals */
+import {
+  cleanStellarQuickstartCache,
+  installStellarQuickstart,
+  parseStellarQuickstartInstallCliOptions,
+  readStellarQuickstartInstallOptionsFromPackageJson,
+} from '../install';
+
+async function main(): Promise<void> {
+  const [command, ...args] = process.argv.slice(2);
+
+  if (command === '--help' || command === 'help') {
+    printHelp();
+    return;
+  }
+
+  if (command === 'cache' && args[0] === 'clean') {
+    await cleanStellarQuickstartCache({
+      ...readStellarQuickstartInstallOptionsFromPackageJson(),
+      ...parseStellarQuickstartInstallCliOptions(args.slice(1)),
+    });
+    console.log('[stellar-quickstart-up] cache cleaned');
+    return;
+  }
+
+  const installArgs = command === 'install' ? args : process.argv.slice(2);
+  const result = await installStellarQuickstart({
+    ...readStellarQuickstartInstallOptionsFromPackageJson(),
+    ...parseStellarQuickstartInstallCliOptions(installArgs),
+  });
+
+  console.log(
+    `[stellar-quickstart-up] Stellar Quickstart image ${
+      result.cacheHit ? 'found in cache' : 'installed'
+    }`,
+  );
+  console.log(
+    `[stellar-quickstart-up] stellar-quickstart installed at ${result.binaryPath}`,
+  );
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+
+function printHelp(): void {
+  console.log(`Usage: stellar-quickstart-up [install] [options]
+       stellar-quickstart-up cache clean [options]
+
+Commands:
+  install      Pull the Stellar Quickstart image and install wrappers. Default command.
+  cache clean  Remove cached stellar-quickstart-up artifacts.
+
+Options:
+  --bin-directory <path>         Directory for executable wrappers.
+                                 Defaults to node_modules/.bin.
+  --cache-directory <path>       Cache directory. Defaults to .metamask/cache.
+  --docker-binary <path>         Docker CLI binary. Defaults to docker.
+  --image-reference <reference>  Docker image reference override.
+  --image-digest <digest>        Expected Docker image digest.
+  --help                         Show this help text.`);
+}

--- a/packages/stellar-quickstart-up/src/index.test.ts
+++ b/packages/stellar-quickstart-up/src/index.test.ts
@@ -1,9 +1,0 @@
-import greeter from '.';
-
-describe('Test', () => {
-  it('greets', () => {
-    const name = 'Huey';
-    const result = greeter(name);
-    expect(result).toBe('Hello, Huey!');
-  });
-});

--- a/packages/stellar-quickstart-up/src/index.ts
+++ b/packages/stellar-quickstart-up/src/index.ts
@@ -1,9 +1,15 @@
-/**
- * Example function that returns a greeting for the given name.
- *
- * @param name - The name to greet.
- * @returns The greeting.
- */
-export default function greeter(name: string): string {
-  return `Hello, ${name}!`;
-}
+export {
+  STELLAR_QUICKSTART_DEFAULT_IMAGE,
+  STELLAR_QUICKSTART_DEFAULT_RUN_ARGS,
+  cleanStellarQuickstartCache,
+  getStellarQuickstartCacheDirectory,
+  installStellarQuickstart,
+  parseStellarQuickstartInstallCliOptions,
+  readStellarQuickstartInstallOptionsFromPackageJson,
+} from './install';
+export type {
+  StellarQuickstartImageConfig,
+  StellarQuickstartInstallDependencies,
+  StellarQuickstartInstallOptions,
+  StellarQuickstartInstallResult,
+} from './install';

--- a/packages/stellar-quickstart-up/src/install.test.ts
+++ b/packages/stellar-quickstart-up/src/install.test.ts
@@ -1,0 +1,346 @@
+/* eslint-disable jest/expect-expect, n/no-sync */
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  STELLAR_QUICKSTART_DEFAULT_IMAGE,
+  cleanStellarQuickstartCache,
+  getStellarQuickstartCacheDirectory,
+  installStellarQuickstart,
+  parseStellarQuickstartInstallCliOptions,
+  readStellarQuickstartInstallOptionsFromPackageJson,
+} from './install';
+import type { StellarQuickstartInstallDependencies } from './install';
+
+describe('stellar-quickstart-up installer', () => {
+  let tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const tempDir of tempDirs) {
+      rmSync(tempDir, { force: true, recursive: true });
+    }
+    tempDirs = [];
+  });
+
+  it('pins a Stellar Quickstart docker image', () => {
+    assert.equal(STELLAR_QUICKSTART_DEFAULT_IMAGE.version, 'latest');
+    assert.equal(
+      STELLAR_QUICKSTART_DEFAULT_IMAGE.reference,
+      'stellar/quickstart:latest',
+    );
+    assert.equal(
+      STELLAR_QUICKSTART_DEFAULT_IMAGE.digest,
+      'sha256:8ddf3ed87a5c07eab5202b0fd95f06fb5db3f48cacd7e69fdc0e22925f181168',
+    );
+  });
+
+  it('uses the global MetaMask cache when Yarn global cache is enabled', () => {
+    const cwd = createTempDir();
+    const homeDirectory = join(cwd, 'home');
+    writeFileSync(join(cwd, '.yarnrc.yml'), 'enableGlobalCache: true\n');
+
+    assert.equal(
+      getStellarQuickstartCacheDirectory({ cwd, homeDirectory }),
+      join(homeDirectory, '.cache', 'metamask'),
+    );
+  });
+
+  it('uses the local MetaMask cache when Yarn global cache is disabled', () => {
+    const cwd = createTempDir();
+    writeFileSync(join(cwd, '.yarnrc.yml'), 'enableGlobalCache: false\n');
+
+    assert.equal(
+      getStellarQuickstartCacheDirectory({ cwd }),
+      join(cwd, '.metamask', 'cache'),
+    );
+  });
+
+  it('returns empty installer options when package.json is missing', () => {
+    const cwd = createTempDir();
+
+    assert.deepEqual(
+      readStellarQuickstartInstallOptionsFromPackageJson({ cwd }),
+      {},
+    );
+  });
+
+  it('reads installer options from supported package.json keys', async () => {
+    const cwd = createTempDir();
+    await writeFile(
+      join(cwd, 'package.json'),
+      JSON.stringify({
+        stellarQuickstartUp: {
+          cacheDirectory: '/tmp/stellar-cache',
+          image: {
+            reference: 'stellar/quickstart:testing',
+          },
+        },
+      }),
+    );
+
+    assert.deepEqual(
+      readStellarQuickstartInstallOptionsFromPackageJson({ cwd }),
+      {
+        cacheDirectory: '/tmp/stellar-cache',
+        image: {
+          reference: 'stellar/quickstart:testing',
+        },
+      },
+    );
+  });
+
+  it('parses CLI install options', () => {
+    assert.deepEqual(
+      parseStellarQuickstartInstallCliOptions([
+        '--bin-directory',
+        '/tmp/bin',
+        '--cache-directory',
+        '/tmp/cache',
+        '--docker-binary',
+        '/usr/local/bin/docker',
+        '--image-reference',
+        'stellar/quickstart:testing',
+        '--image-digest',
+        'sha256:abc',
+      ]),
+      {
+        binDirectory: '/tmp/bin',
+        cacheDirectory: '/tmp/cache',
+        dockerBinary: '/usr/local/bin/docker',
+        image: {
+          reference: 'stellar/quickstart:testing',
+          digest: 'sha256:abc',
+        },
+      },
+    );
+  });
+
+  it('rejects unknown CLI options', () => {
+    assert.throws(
+      () => parseStellarQuickstartInstallCliOptions(['--unknown']),
+      /Unknown stellar-quickstart-up install option/u,
+    );
+  });
+
+  it('installs a docker-backed stellar-quickstart wrapper', async () => {
+    const cwd = createTempDir();
+    const cacheDirectory = join(cwd, '.metamask', 'cache');
+    const binDirectory = join(cwd, 'node_modules', '.bin');
+    const dockerBinary = createDockerStub(cwd);
+    const dependencies = createInstallDependencies({
+      digest: STELLAR_QUICKSTART_DEFAULT_IMAGE.digest as string,
+      dockerBinary,
+    });
+
+    const result = await installStellarQuickstart(
+      {
+        binDirectory,
+        cacheDirectory,
+        cwd,
+        dockerBinary,
+      },
+      dependencies,
+    );
+
+    assert.equal(result.cacheHit, false);
+    assert.equal(result.imageReference, 'stellar/quickstart:latest');
+    assert.equal(
+      result.digest,
+      STELLAR_QUICKSTART_DEFAULT_IMAGE.digest,
+    );
+    assert.equal(result.binaryPath, join(binDirectory, 'stellar-quickstart'));
+    assert.equal(dependencies.pullCalls, 1);
+    assert.equal(dependencies.inspectCalls, 1);
+
+    const wrapperSource = readFileSync(result.binaryPath, 'utf8');
+    assert.match(wrapperSource, /stellar\/quickstart:latest/u);
+    assert.match(wrapperSource, /8000:8000/u);
+  });
+
+  it('reuses cached image metadata when digest matches', async () => {
+    const cwd = createTempDir();
+    const cacheDirectory = join(cwd, '.metamask', 'cache');
+    const binDirectory = join(cwd, 'node_modules', '.bin');
+    const dockerBinary = createDockerStub(cwd);
+    const dependencies = createInstallDependencies({
+      digest: STELLAR_QUICKSTART_DEFAULT_IMAGE.digest as string,
+      dockerBinary,
+    });
+
+    await installStellarQuickstart(
+      {
+        binDirectory,
+        cacheDirectory,
+        cwd,
+        dockerBinary,
+      },
+      dependencies,
+    );
+
+    const secondResult = await installStellarQuickstart(
+      {
+        binDirectory,
+        cacheDirectory,
+        cwd,
+        dockerBinary,
+      },
+      dependencies,
+    );
+
+    assert.equal(secondResult.cacheHit, true);
+    assert.equal(dependencies.pullCalls, 1);
+    assert.equal(dependencies.inspectCalls, 1);
+  });
+
+  it('rejects image digests that do not match the pinned default', async () => {
+    const cwd = createTempDir();
+    const cacheDirectory = join(cwd, '.metamask', 'cache');
+    const binDirectory = join(cwd, 'node_modules', '.bin');
+    const dockerBinary = createDockerStub(cwd);
+    const dependencies = createInstallDependencies({
+      digest: 'sha256:deadbeef',
+      dockerBinary,
+    });
+
+    await assert.rejects(
+      installStellarQuickstart(
+        {
+          binDirectory,
+          cacheDirectory,
+          cwd,
+          dockerBinary,
+        },
+        dependencies,
+      ),
+      /digest mismatch/u,
+    );
+  });
+
+  it('cleans only the stellar-quickstart-up cache namespace', async () => {
+    const cwd = createTempDir();
+    const cacheDirectory = join(cwd, '.metamask', 'cache');
+    const namespaceRoot = join(cacheDirectory, 'stellar-quickstart-up');
+    await mkdir(join(namespaceRoot, 'image', 'cache-key'), { recursive: true });
+    await mkdir(join(cacheDirectory, 'foundryup'), { recursive: true });
+
+    await cleanStellarQuickstartCache({ cacheDirectory, cwd });
+
+    assert.equal(existsSync(namespaceRoot), false);
+    assert.equal(existsSync(join(cacheDirectory, 'foundryup')), true);
+  });
+
+  it('forwards arguments through the installed wrapper', async () => {
+    const cwd = createTempDir();
+    const cacheDirectory = join(cwd, '.metamask', 'cache');
+    const binDirectory = join(cwd, 'node_modules', '.bin');
+    const dockerBinary = createDockerStub(cwd);
+    const dependencies = createInstallDependencies({
+      digest: STELLAR_QUICKSTART_DEFAULT_IMAGE.digest as string,
+      dockerBinary,
+    });
+
+    const result = await installStellarQuickstart(
+      {
+        binDirectory,
+        cacheDirectory,
+        cwd,
+        dockerBinary,
+      },
+      dependencies,
+    );
+
+    const output = execFileSync(result.binaryPath, ['--local'], {
+      encoding: 'utf8',
+    });
+
+    assert.match(output, /--local/u);
+    assert.match(output, /stellar\/quickstart:latest/u);
+  });
+
+  function createTempDir(): string {
+    const tempDir = mkdtempSync(join(tmpdir(), 'stellar-quickstart-up-'));
+    tempDirs.push(tempDir);
+    return tempDir;
+  }
+});
+
+function createDockerStub(cwd: string): string {
+  const dockerBinary = join(cwd, 'docker-stub');
+  writeFileSync(
+    dockerBinary,
+    `#!/usr/bin/env node
+const [,, command, ...args] = process.argv;
+if (command === 'version') {
+  process.exit(0);
+}
+if (command === 'pull') {
+  process.stdout.write('pulled ' + args.join(' '));
+  process.exit(0);
+}
+if (command === 'image') {
+  process.stdout.write('sha256:8ddf3ed87a5c07eab5202b0fd95f06fb5db3f48cacd7e69fdc0e22925f181168');
+  process.exit(0);
+}
+if (command === 'run') {
+  process.stdout.write(args.join(' '));
+  process.exit(0);
+}
+console.error('unexpected docker command', command, args.join(' '));
+process.exit(1);
+`,
+  );
+  chmodSync(dockerBinary, 0o755);
+  return dockerBinary;
+}
+
+function createInstallDependencies({
+  digest,
+  dockerBinary,
+}: {
+  digest: string;
+  dockerBinary: string;
+}): StellarQuickstartInstallDependencies & {
+  inspectCalls: number;
+  pullCalls: number;
+} {
+  const state = {
+    inspectCalls: 0,
+    pullCalls: 0,
+  };
+
+  return {
+    get inspectCalls(): number {
+      return state.inspectCalls;
+    },
+    get pullCalls(): number {
+      return state.pullCalls;
+    },
+    async inspectDockerImage(): Promise<string> {
+      state.inspectCalls += 1;
+      return digest;
+    },
+    async pullDockerImage(
+      binary: string,
+      imageReference: string,
+    ): Promise<void> {
+      state.pullCalls += 1;
+      assert.equal(binary, dockerBinary);
+      assert.equal(imageReference, 'stellar/quickstart:latest');
+    },
+    async runCommand(command: string, args: string[]): Promise<void> {
+      assert.equal(command, dockerBinary);
+      assert.deepEqual(args, ['version']);
+    },
+  };
+}

--- a/packages/stellar-quickstart-up/src/install.test.ts
+++ b/packages/stellar-quickstart-up/src/install.test.ts
@@ -155,10 +155,7 @@ describe('stellar-quickstart-up installer', () => {
 
     assert.equal(result.cacheHit, false);
     assert.equal(result.imageReference, 'stellar/quickstart:latest');
-    assert.equal(
-      result.digest,
-      STELLAR_QUICKSTART_DEFAULT_IMAGE.digest,
-    );
+    assert.equal(result.digest, STELLAR_QUICKSTART_DEFAULT_IMAGE.digest);
     assert.equal(result.binaryPath, join(binDirectory, 'stellar-quickstart'));
     assert.equal(dependencies.pullCalls, 1);
     assert.equal(dependencies.inspectCalls, 1);
@@ -266,7 +263,10 @@ describe('stellar-quickstart-up installer', () => {
     );
 
     const wrapperSource = readFileSync(result.binaryPath, 'utf8');
-    assert.match(wrapperSource, new RegExp(dockerBinary.replaceAll('/', '\\/'), 'u'));
+    assert.match(
+      wrapperSource,
+      new RegExp(dockerBinary.replaceAll('/', '\\/'), 'u'),
+    );
   });
 
   it('forwards arguments through the installed wrapper', async () => {

--- a/packages/stellar-quickstart-up/src/install.test.ts
+++ b/packages/stellar-quickstart-up/src/install.test.ts
@@ -240,6 +240,35 @@ describe('stellar-quickstart-up installer', () => {
     assert.equal(existsSync(join(cacheDirectory, 'foundryup')), true);
   });
 
+  it('resolves bare docker binary names before installing the wrapper', async () => {
+    const cwd = createTempDir();
+    const cacheDirectory = join(cwd, '.metamask', 'cache');
+    const binDirectory = join(cwd, 'node_modules', '.bin');
+    const dockerBinary = createDockerStub(cwd);
+    const dependencies = createInstallDependencies({
+      digest: STELLAR_QUICKSTART_DEFAULT_IMAGE.digest as string,
+      dockerBinary,
+    });
+
+    const result = await installStellarQuickstart(
+      {
+        binDirectory,
+        cacheDirectory,
+        cwd,
+        dockerBinary: 'docker',
+      },
+      {
+        ...dependencies,
+        async resolveDockerBinary(): Promise<string> {
+          return dockerBinary;
+        },
+      },
+    );
+
+    const wrapperSource = readFileSync(result.binaryPath, 'utf8');
+    assert.match(wrapperSource, new RegExp(dockerBinary.replaceAll('/', '\\/'), 'u'));
+  });
+
   it('forwards arguments through the installed wrapper', async () => {
     const cwd = createTempDir();
     const cacheDirectory = join(cwd, '.metamask', 'cache');

--- a/packages/stellar-quickstart-up/src/install.ts
+++ b/packages/stellar-quickstart-up/src/install.ts
@@ -11,7 +11,7 @@ import {
 import { execFile } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { mkdir, rm, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { isAbsolute, join } from 'node:path';
 import { promisify } from 'node:util';
 
 const STELLAR_QUICKSTART_CACHE_NAMESPACE = 'stellar-quickstart-up';
@@ -49,6 +49,7 @@ export type StellarQuickstartInstallDependencies = {
     dockerBinary: string,
     imageReference: string,
   ) => Promise<void>;
+  resolveDockerBinary?: (dockerBinary: string) => Promise<string>;
   runCommand?: typeof runCommand;
 };
 
@@ -184,13 +185,16 @@ export async function installStellarQuickstart(
   const pullDockerImage = dependencies.pullDockerImage ?? pullDockerImageDefault;
   const inspectDockerImage =
     dependencies.inspectDockerImage ?? inspectDockerImageDefault;
+  const resolveDockerBinary =
+    dependencies.resolveDockerBinary ?? resolveDockerBinaryDefault;
+  const resolvedDockerBinary = await resolveDockerBinary(dockerBinary);
 
-  await runCommandImpl(dockerBinary, ['version']);
+  await runCommandImpl(resolvedDockerBinary, ['version']);
 
   const imageResult = await installStellarQuickstartImage(
     {
       cacheDirectory,
-      dockerBinary,
+      dockerBinary: resolvedDockerBinary,
       image,
     },
     { inspectDockerImage, pullDockerImage },
@@ -199,7 +203,7 @@ export async function installStellarQuickstart(
     binDirectory,
     commandName: 'stellar-quickstart',
     executableArgs: [...runArgs, imageResult.imageReference],
-    executablePath: dockerBinary,
+    executablePath: resolvedDockerBinary,
     pathResolution: 'absolute',
   });
 
@@ -321,6 +325,31 @@ async function pullDockerImageDefault(
   await runCommand(dockerBinary, ['pull', imageReference]);
 }
 
+async function resolveDockerBinaryDefault(
+  dockerBinary: string,
+): Promise<string> {
+  if (
+    isAbsolute(dockerBinary) ||
+    dockerBinary.includes('/') ||
+    dockerBinary.includes('\\')
+  ) {
+    return dockerBinary;
+  }
+
+  const execFileAsync = promisify(execFile);
+  const lookupCommand = process.platform === 'win32' ? 'where' : 'which';
+  const { stdout } = await execFileAsync(lookupCommand, [dockerBinary], {
+    encoding: 'utf8',
+  });
+  const resolvedPath = stdout.split(/\r?\n/u)[0]?.trim();
+
+  if (!resolvedPath) {
+    throw new Error(`Could not resolve Docker binary: ${dockerBinary}`);
+  }
+
+  return resolvedPath;
+}
+
 async function inspectDockerImageDefault(
   dockerBinary: string,
   imageReference: string,
@@ -328,9 +357,30 @@ async function inspectDockerImageDefault(
   const execFileAsync = promisify(execFile);
   const { stdout } = await execFileAsync(
     dockerBinary,
-    ['image', 'inspect', imageReference, '--format', '{{.Id}}'],
+    [
+      'image',
+      'inspect',
+      imageReference,
+      '--format',
+      '{{index .RepoDigests 0}}',
+    ],
     { encoding: 'utf8' },
   );
+  const repoDigest = stdout.trim();
 
-  return stdout.trim();
+  if (!repoDigest) {
+    throw new Error(
+      `Docker image ${imageReference} has no RepoDigests after pull.`,
+    );
+  }
+
+  const digestSeparatorIndex = repoDigest.lastIndexOf('@');
+
+  if (digestSeparatorIndex === -1) {
+    throw new Error(
+      `Docker image ${imageReference} returned unexpected RepoDigest: ${repoDigest}`,
+    );
+  }
+
+  return repoDigest.slice(digestSeparatorIndex + 1);
 }

--- a/packages/stellar-quickstart-up/src/install.ts
+++ b/packages/stellar-quickstart-up/src/install.ts
@@ -4,12 +4,13 @@ import {
   getCacheKey,
   getMetamaskCacheDirectory,
   installExecutableWrapper,
+  isFileMissingError,
   readCliValue,
   readPackageJsonToolConfig,
   runCommand,
 } from '@metamask/local-node-utils';
 import { execFile } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { isAbsolute, join } from 'node:path';
 import { promisify } from 'node:util';
@@ -275,18 +276,10 @@ async function installStellarQuickstartImage(
   );
   const digestPath = join(cacheRoot, '.image-digest');
   const referencePath = join(cacheRoot, '.image-reference');
+  const cached = readCachedImageMetadata(digestPath, referencePath, image);
 
-  if (
-    existsSync(digestPath) &&
-    existsSync(referencePath) &&
-    readFileSync(referencePath, 'utf8') === image.reference &&
-    (!image.digest || readFileSync(digestPath, 'utf8') === image.digest)
-  ) {
-    return {
-      cacheHit: true,
-      digest: readFileSync(digestPath, 'utf8'),
-      imageReference: image.reference,
-    };
+  if (cached) {
+    return cached;
   }
 
   await rm(cacheRoot, { force: true, recursive: true });
@@ -312,6 +305,40 @@ async function installStellarQuickstartImage(
     digest,
     imageReference: image.reference,
   };
+}
+
+function readCachedImageMetadata(
+  digestPath: string,
+  referencePath: string,
+  image: StellarQuickstartImageConfig,
+): {
+  cacheHit: true;
+  digest: string;
+  imageReference: string;
+} | null {
+  try {
+    const imageReference = readFileSync(referencePath, 'utf8');
+    const digest = readFileSync(digestPath, 'utf8');
+
+    if (
+      imageReference !== image.reference ||
+      (image.digest && digest !== image.digest)
+    ) {
+      return null;
+    }
+
+    return {
+      cacheHit: true,
+      digest,
+      imageReference: image.reference,
+    };
+  } catch (error) {
+    if (!isFileMissingError(error)) {
+      throw error;
+    }
+
+    return null;
+  }
 }
 
 async function pullDockerImageDefault(

--- a/packages/stellar-quickstart-up/src/install.ts
+++ b/packages/stellar-quickstart-up/src/install.ts
@@ -153,9 +153,7 @@ export function parseStellarQuickstartInstallCliOptions(
         index += 1;
         break;
       default:
-        throw new Error(
-          `Unknown stellar-quickstart-up install option: ${arg}`,
-        );
+        throw new Error(`Unknown stellar-quickstart-up install option: ${arg}`);
     }
   }
 
@@ -182,7 +180,8 @@ export async function installStellarQuickstart(
   );
   const runArgs = options.runArgs ?? STELLAR_QUICKSTART_DEFAULT_RUN_ARGS;
   const runCommandImpl = dependencies.runCommand ?? runCommand;
-  const pullDockerImage = dependencies.pullDockerImage ?? pullDockerImageDefault;
+  const pullDockerImage =
+    dependencies.pullDockerImage ?? pullDockerImageDefault;
   const inspectDockerImage =
     dependencies.inspectDockerImage ?? inspectDockerImageDefault;
   const resolveDockerBinary =
@@ -217,10 +216,7 @@ export async function installStellarQuickstart(
 }
 
 export async function cleanStellarQuickstartCache(
-  options: Pick<
-    StellarQuickstartInstallOptions,
-    'cacheDirectory' | 'cwd'
-  > = {},
+  options: Pick<StellarQuickstartInstallOptions, 'cacheDirectory' | 'cwd'> = {},
 ): Promise<void> {
   const cwd = options.cwd ?? process.cwd();
   const cacheDirectory =

--- a/packages/stellar-quickstart-up/src/install.ts
+++ b/packages/stellar-quickstart-up/src/install.ts
@@ -1,0 +1,336 @@
+/* eslint-disable import-x/no-nodejs-modules, no-restricted-globals */
+import {
+  cleanInstallerCache,
+  getCacheKey,
+  getMetamaskCacheDirectory,
+  installExecutableWrapper,
+  readCliValue,
+  readPackageJsonToolConfig,
+  runCommand,
+} from '@metamask/local-node-utils';
+import { execFile } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+
+const STELLAR_QUICKSTART_CACHE_NAMESPACE = 'stellar-quickstart-up';
+const IMAGE_CACHE_NAMESPACE = 'image';
+
+export type StellarQuickstartImageConfig = {
+  digest?: string;
+  reference: string;
+  version: string;
+};
+
+export type StellarQuickstartInstallOptions = {
+  binDirectory?: string;
+  cacheDirectory?: string;
+  cwd?: string;
+  dockerBinary?: string;
+  image?: Partial<StellarQuickstartImageConfig>;
+  runArgs?: string[];
+};
+
+export type StellarQuickstartInstallResult = {
+  binaryPath: string;
+  cacheHit: boolean;
+  digest?: string;
+  imageReference: string;
+  version: string;
+};
+
+export type StellarQuickstartInstallDependencies = {
+  inspectDockerImage?: (
+    dockerBinary: string,
+    imageReference: string,
+  ) => Promise<string>;
+  pullDockerImage?: (
+    dockerBinary: string,
+    imageReference: string,
+  ) => Promise<void>;
+  runCommand?: typeof runCommand;
+};
+
+type StellarQuickstartPackageJsonConfig = Pick<
+  StellarQuickstartInstallOptions,
+  'binDirectory' | 'cacheDirectory' | 'image' | 'runArgs'
+>;
+
+export const STELLAR_QUICKSTART_DEFAULT_IMAGE: StellarQuickstartImageConfig = {
+  version: 'latest',
+  reference: 'stellar/quickstart:latest',
+  digest:
+    'sha256:8ddf3ed87a5c07eab5202b0fd95f06fb5db3f48cacd7e69fdc0e22925f181168',
+};
+
+export const STELLAR_QUICKSTART_DEFAULT_RUN_ARGS = [
+  'run',
+  '--rm',
+  '-i',
+  '-p',
+  '8000:8000',
+];
+
+export function getStellarQuickstartCacheDirectory({
+  cwd = process.cwd(),
+  homeDirectory,
+}: {
+  cwd?: string;
+  homeDirectory?: string;
+} = {}): string {
+  return getMetamaskCacheDirectory({
+    cwd,
+    homeDirectory,
+    toolName: STELLAR_QUICKSTART_CACHE_NAMESPACE,
+  });
+}
+
+export function readStellarQuickstartInstallOptionsFromPackageJson({
+  cwd = process.cwd(),
+  packageJsonPath = join(cwd, 'package.json'),
+}: {
+  cwd?: string;
+  packageJsonPath?: string;
+} = {}): StellarQuickstartInstallOptions {
+  const config = readPackageJsonToolConfig({
+    cwd,
+    packageJsonPath,
+    configKeys: [
+      'stellarQuickstartUp',
+      'stellarquickstartup',
+      'stellar-quickstart-up',
+    ],
+  }) as Partial<StellarQuickstartPackageJsonConfig>;
+  const options: StellarQuickstartInstallOptions = {};
+
+  if (config.binDirectory) {
+    options.binDirectory = config.binDirectory;
+  }
+  if (config.cacheDirectory) {
+    options.cacheDirectory = config.cacheDirectory;
+  }
+  if (config.image) {
+    options.image = config.image;
+  }
+  if (config.runArgs) {
+    options.runArgs = config.runArgs;
+  }
+
+  return options;
+}
+
+export function parseStellarQuickstartInstallCliOptions(
+  args: string[],
+): StellarQuickstartInstallOptions {
+  const options: StellarQuickstartInstallOptions = {};
+  const image: Partial<StellarQuickstartImageConfig> = {};
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    const value = args[index + 1];
+
+    switch (arg) {
+      case '--bin-directory':
+        options.binDirectory = readCliValue(arg, value);
+        index += 1;
+        break;
+      case '--cache-directory':
+        options.cacheDirectory = readCliValue(arg, value);
+        index += 1;
+        break;
+      case '--docker-binary':
+        options.dockerBinary = readCliValue(arg, value);
+        index += 1;
+        break;
+      case '--image-digest':
+        image.digest = readCliValue(arg, value);
+        index += 1;
+        break;
+      case '--image-reference':
+        image.reference = readCliValue(arg, value);
+        index += 1;
+        break;
+      default:
+        throw new Error(
+          `Unknown stellar-quickstart-up install option: ${arg}`,
+        );
+    }
+  }
+
+  if (image.reference || image.digest) {
+    options.image = image;
+  }
+
+  return options;
+}
+
+export async function installStellarQuickstart(
+  options: StellarQuickstartInstallOptions = {},
+  dependencies: StellarQuickstartInstallDependencies = {},
+): Promise<StellarQuickstartInstallResult> {
+  const cwd = options.cwd ?? process.cwd();
+  const cacheDirectory =
+    options.cacheDirectory ?? getStellarQuickstartCacheDirectory({ cwd });
+  const binDirectory =
+    options.binDirectory ?? join(cwd, 'node_modules', '.bin');
+  const dockerBinary = options.dockerBinary ?? 'docker';
+  const image = mergeImageConfig(
+    STELLAR_QUICKSTART_DEFAULT_IMAGE,
+    options.image,
+  );
+  const runArgs = options.runArgs ?? STELLAR_QUICKSTART_DEFAULT_RUN_ARGS;
+  const runCommandImpl = dependencies.runCommand ?? runCommand;
+  const pullDockerImage = dependencies.pullDockerImage ?? pullDockerImageDefault;
+  const inspectDockerImage =
+    dependencies.inspectDockerImage ?? inspectDockerImageDefault;
+
+  await runCommandImpl(dockerBinary, ['version']);
+
+  const imageResult = await installStellarQuickstartImage(
+    {
+      cacheDirectory,
+      dockerBinary,
+      image,
+    },
+    { inspectDockerImage, pullDockerImage },
+  );
+  const binaryPath = await installExecutableWrapper({
+    binDirectory,
+    commandName: 'stellar-quickstart',
+    executableArgs: [...runArgs, imageResult.imageReference],
+    executablePath: dockerBinary,
+    pathResolution: 'absolute',
+  });
+
+  return {
+    binaryPath,
+    cacheHit: imageResult.cacheHit,
+    digest: imageResult.digest,
+    imageReference: imageResult.imageReference,
+    version: image.version,
+  };
+}
+
+export async function cleanStellarQuickstartCache(
+  options: Pick<
+    StellarQuickstartInstallOptions,
+    'cacheDirectory' | 'cwd'
+  > = {},
+): Promise<void> {
+  const cwd = options.cwd ?? process.cwd();
+  const cacheDirectory =
+    options.cacheDirectory ?? getStellarQuickstartCacheDirectory({ cwd });
+
+  await cleanInstallerCache({
+    cacheDirectory,
+    namespace: STELLAR_QUICKSTART_CACHE_NAMESPACE,
+  });
+}
+
+function mergeImageConfig(
+  defaults: StellarQuickstartImageConfig,
+  override?: Partial<StellarQuickstartImageConfig>,
+): StellarQuickstartImageConfig {
+  return {
+    ...defaults,
+    ...override,
+  };
+}
+
+async function installStellarQuickstartImage(
+  {
+    cacheDirectory,
+    dockerBinary,
+    image,
+  }: {
+    cacheDirectory: string;
+    dockerBinary: string;
+    image: StellarQuickstartImageConfig;
+  },
+  dependencies: {
+    inspectDockerImage: (
+      dockerBinary: string,
+      imageReference: string,
+    ) => Promise<string>;
+    pullDockerImage: (
+      dockerBinary: string,
+      imageReference: string,
+    ) => Promise<void>;
+  },
+): Promise<{
+  cacheHit: boolean;
+  digest?: string;
+  imageReference: string;
+}> {
+  const cacheKey = getCacheKey({
+    checksum: image.digest ?? image.reference,
+    url: image.reference,
+  });
+  const cacheRoot = join(
+    cacheDirectory,
+    STELLAR_QUICKSTART_CACHE_NAMESPACE,
+    IMAGE_CACHE_NAMESPACE,
+    cacheKey,
+  );
+  const digestPath = join(cacheRoot, '.image-digest');
+  const referencePath = join(cacheRoot, '.image-reference');
+
+  if (
+    existsSync(digestPath) &&
+    existsSync(referencePath) &&
+    readFileSync(referencePath, 'utf8') === image.reference &&
+    (!image.digest || readFileSync(digestPath, 'utf8') === image.digest)
+  ) {
+    return {
+      cacheHit: true,
+      digest: readFileSync(digestPath, 'utf8'),
+      imageReference: image.reference,
+    };
+  }
+
+  await rm(cacheRoot, { force: true, recursive: true });
+  await mkdir(cacheRoot, { recursive: true });
+
+  await dependencies.pullDockerImage(dockerBinary, image.reference);
+  const digest = await dependencies.inspectDockerImage(
+    dockerBinary,
+    image.reference,
+  );
+
+  if (image.digest && digest !== image.digest) {
+    throw new Error(
+      `Stellar Quickstart image digest mismatch. Expected ${image.digest}, received ${digest}.`,
+    );
+  }
+
+  await writeFile(referencePath, image.reference);
+  await writeFile(digestPath, digest);
+
+  return {
+    cacheHit: false,
+    digest,
+    imageReference: image.reference,
+  };
+}
+
+async function pullDockerImageDefault(
+  dockerBinary: string,
+  imageReference: string,
+): Promise<void> {
+  await runCommand(dockerBinary, ['pull', imageReference]);
+}
+
+async function inspectDockerImageDefault(
+  dockerBinary: string,
+  imageReference: string,
+): Promise<string> {
+  const execFileAsync = promisify(execFile);
+  const { stdout } = await execFileAsync(
+    dockerBinary,
+    ['image', 'inspect', imageReference, '--format', '{{.Id}}'],
+    { encoding: 'utf8' },
+  );
+
+  return stdout.trim();
+}

--- a/packages/stellar-quickstart-up/tsconfig.build.json
+++ b/packages/stellar-quickstart-up/tsconfig.build.json
@@ -5,6 +5,6 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "references": [],
+  "references": [{ "path": "../local-node-utils/tsconfig.build.json" }],
   "include": ["../../types", "./src"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8637,6 +8637,7 @@ __metadata:
   resolution: "@metamask/stellar-quickstart-up@workspace:packages/stellar-quickstart-up"
   dependencies:
     "@metamask/auto-changelog": "npm:^6.1.0"
+    "@metamask/local-node-utils": "npm:^0.0.0"
     "@ts-bridge/cli": "npm:^0.6.4"
     "@types/jest": "npm:^29.5.14"
     deepmerge: "npm:^4.2.2"
@@ -8646,6 +8647,8 @@ __metadata:
     typedoc: "npm:^0.25.13"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:~5.3.3"
+  bin:
+    stellar-quickstart-up: ./dist/bin/stellar-quickstart-up.mjs
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Explanation

Extension E2E tests need local node bootstrap installers for each non-EVM chain, following the same runtime-only pattern as `@metamask/foundryup`. MetaMask/core already ships several `*-up` packages that install pinned runtimes into the MetaMask cache and expose binaries in `node_modules/.bin`, while the consuming test harness owns process startup, readiness checks, and seeding:

| Package | Chain | Runtime |
| --- | --- | --- |
| [`@metamask/bitcoin-regtest-up`](https://github.com/MetaMask/core/tree/main/packages/bitcoin-regtest-up) ([#9212](https://github.com/MetaMask/core/pull/9212)) | Bitcoin | Bitcoin Core `bitcoind` / `bitcoin-cli` |
| [`@metamask/solana-test-validator-up`](https://github.com/MetaMask/core/tree/main/packages/solana-test-validator-up) ([#9210](https://github.com/MetaMask/core/pull/9210)) | Solana | Agave `solana-test-validator` / `solana` CLI |
| [`@metamask/java-tron-up`](https://github.com/MetaMask/core/tree/main/packages/java-tron-up) ([#9211](https://github.com/MetaMask/core/pull/9211)) | Tron | java-tron `FullNode.jar` + managed JDK |
| **`@metamask/stellar-quickstart-up`** (this PR) | Stellar | `stellar/quickstart` Docker image |

This PR completes the Stellar installer. The package scaffold landed in [#9281](https://github.com/MetaMask/core/pull/9281); this change adds the implementation.

Stellar Quickstart runs as a Docker image rather than a downloaded native binary, so the installer pulls a digest-pinned `stellar/quickstart` image, caches metadata under the MetaMask cache namespace, resolves `docker` on `PATH`, and writes a `stellar-quickstart` wrapper that runs `docker run --rm -i -p 8000:8000`. Container lifecycle and seeding remain in the Extension harness.

Shared installer utilities come from [`@metamask/local-node-utils`](https://github.com/MetaMask/core/tree/main/packages/local-node-utils).

## References

* Scaffold: [#9281](https://github.com/MetaMask/core/pull/9281)
* Jira Epic: [WPN-1509](https://consensyssoftware.atlassian.net/browse/WPN-1509) — [Extension] Expand Stellar's E2E test coverage
* Jira Task: [WPN-1510](https://consensyssoftware.atlassian.net/browse/WPN-1510) — Create Stellar Quickstart installer package `stellar-quickstart-up`

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by updating changelogs for packages I've changed
- [ ] I've introduced breaking changes in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

## Verification

```
yarn workspace @metamask/stellar-quickstart-up run build
yarn workspace @metamask/stellar-quickstart-up run test
yarn eslint packages/stellar-quickstart-up
yarn constraints
yarn workspace @metamask/stellar-quickstart-up run changelog:validate
```

## Test plan

- [x] `yarn workspace @metamask/stellar-quickstart-up run build`
- [x] `yarn workspace @metamask/stellar-quickstart-up run test`
- [x] `yarn eslint packages/stellar-quickstart-up`
- [x] `yarn constraints`
- [x] `yarn workspace @metamask/stellar-quickstart-up run changelog:validate`
- [ ] Manual: `yarn stellar-quickstart-up install` with Docker available, then `node_modules/.bin/stellar-quickstart --local`

[WPN-1509]: https://consensyssoftware.atlassian.net/browse/WPN-1509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New dev/CI tooling package with no production wallet or auth paths; behavior is covered by unit tests and digest verification on pull.
> 
> **Overview**
> Implements **`@metamask/stellar-quickstart-up`** as a runtime-only installer (same model as `@metamask/foundryup` and other `*-up` packages) for Extension E2E Stellar local nodes.
> 
> The package pulls a **digest-pinned** `stellar/quickstart:latest` image, verifies it via `docker image inspect`, caches metadata under the MetaMask cache (with Yarn global-cache behavior from `@metamask/local-node-utils`), and installs a **`stellar-quickstart`** wrapper in `node_modules/.bin` that runs `docker` with default `-p 8000:8000` and forwards args (e.g. `--local`). A **`stellar-quickstart-up`** CLI handles default `install`, `cache clean`, and config from `package.json` / CLI flags. Container startup and seeding stay in the test harness.
> 
> Replaces the scaffold greeter with **`install.ts`** exports and tests; wires **`local-node-utils`**, **`bin`**, changelog/README, monorepo README dependency graph, and relaxed Jest coverage thresholds (CLI entry excluded).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7eb2f58dcadb75d2909c7cb5a9cccdf2d57265a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->