### PR TITLE
fix(analytics-controller): preserve pre-consent queue on resetConsentDecision

### DIFF
--- a/packages/analytics-controller/CHANGELOG.md
+++ b/packages/analytics-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Preserve the pre-consent event queue when calling `resetConsentDecision`, matching extension behavior for undecided consent resets during onboarding restarts
+- Preserve the pre-consent event queue when calling `resetConsentDecision`, matching extension behavior for undecided consent resets during onboarding restarts ([#9284](https://github.com/MetaMask/core/pull/9284))
 
 ## [1.2.0]
 

--- a/packages/analytics-controller/CHANGELOG.md
+++ b/packages/analytics-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Preserve the pre-consent event queue when calling `resetConsentDecision`, matching extension behavior for undecided consent resets during onboarding restarts
+
 ## [1.2.0]
 
 ### Added

--- a/packages/analytics-controller/src/AnalyticsController-method-action-types.ts
+++ b/packages/analytics-controller/src/AnalyticsController-method-action-types.ts
@@ -67,9 +67,9 @@ export type AnalyticsControllerOptOutAction = {
  * Reset the consent decision back to undecided.
  *
  * Intended for client flows that restart onboarding. Clears the opt-in
- * preference and discards both the delivery queue and any pre-consent events,
- * so nothing captured before the reset is delivered and the user is treated
- * as undecided again.
+ * preference and discards the delivery queue, but preserves any pre-consent
+ * events so they can still be replayed if the user opts in again. The user is
+ * treated as undecided again.
  */
 export type AnalyticsControllerResetConsentDecisionAction = {
   type: `AnalyticsController:resetConsentDecision`;

--- a/packages/analytics-controller/src/AnalyticsController.test.ts
+++ b/packages/analytics-controller/src/AnalyticsController.test.ts
@@ -2138,19 +2138,20 @@ describe('AnalyticsController', () => {
       expect(mockAdapter.track).not.toHaveBeenCalled();
     });
 
-    it('clears the queue and resets the decision on resetConsentDecision', async () => {
+    it('preserves the pre-consent queue and resets the decision on resetConsentDecision', async () => {
       const { controller, mockAdapter } =
         await setupControllerWithQueuedEvent();
+      const queuedEvents = controller.state.preConsentEventQueue;
 
       controller.resetConsentDecision();
 
       expect(controller.state.optedIn).toBe(false);
       expect(controller.state.consentDecisionMade).toBe(false);
-      expect(controller.state.preConsentEventQueue).toStrictEqual({});
+      expect(controller.state.preConsentEventQueue).toStrictEqual(queuedEvents);
       expect(mockAdapter.track).not.toHaveBeenCalled();
     });
 
-    it('also clears the delivery queue on resetConsentDecision', async () => {
+    it('clears the delivery queue on resetConsentDecision', async () => {
       const mockAdapter = createMockAdapter();
       const { controller } = await setupController({
         state: {
@@ -2172,7 +2173,6 @@ describe('AnalyticsController', () => {
       expect(controller.state.optedIn).toBe(false);
       expect(controller.state.consentDecisionMade).toBe(false);
       expect(controller.state.eventQueue).toStrictEqual({});
-      expect(controller.state.preConsentEventQueue ?? {}).toStrictEqual({});
     });
 
     it('replays a persisted queue on init when already opted in', async () => {

--- a/packages/analytics-controller/src/AnalyticsController.ts
+++ b/packages/analytics-controller/src/AnalyticsController.ts
@@ -70,8 +70,10 @@ export type AnalyticsControllerState = {
   /**
    * Persisted queue of track events ({@link AnalyticsQueuedTrackEvent}) captured
    * while the user is undecided (no consent decision made yet). Replayed on
-   * opt-in and cleared on opt-out. This is only used when the pre-consent queue
-   * is enabled.
+   * opt-in and cleared on opt-out.
+   * Preserved across {@link AnalyticsController.resetConsentDecision} so onboarding
+   * restarts do not drop install-time events.
+   * This is only used when the pre-consent queue is enabled.
    */
   preConsentEventQueue?: Record<string, Json>;
 };
@@ -949,9 +951,9 @@ export class AnalyticsController extends BaseController<
    * Reset the consent decision back to undecided.
    *
    * Intended for client flows that restart onboarding. Clears the opt-in
-   * preference and discards both the delivery queue and any pre-consent events,
-   * so nothing captured before the reset is delivered and the user is treated
-   * as undecided again.
+   * preference and discards the delivery queue, but preserves any pre-consent
+   * events so they can still be replayed if the user opts in again. The user is
+   * treated as undecided again.
    */
   resetConsentDecision(): void {
     this.update((state) => {
@@ -960,6 +962,5 @@ export class AnalyticsController extends BaseController<
     });
 
     this.#clearQueuedEvents();
-    this.#clearPreConsentEvents();
   }
 }


### PR DESCRIPTION
## Explanation

Keep install-time events buffered across undecided consent resets during onboarding restarts, matching legacy MetaMetricsController behavior where `setParticipateInMetaMetrics(null)` did not clear `eventsBeforeMetricsOptIn`.

## References

None

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow behavior change in optional pre-consent analytics buffering; delivery queue clearing is unchanged and opt-out still clears pre-consent events.
> 
> **Overview**
> **`resetConsentDecision`** no longer wipes the pre-consent event buffer when onboarding restarts with consent still undecided. It still clears opt-in state, sets **`consentDecisionMade`** back to false, and empties the **delivery** queue—only the call to clear pre-consent events was removed.
> 
> That aligns **`AnalyticsController`** with extension / legacy MetaMetrics behavior so install-time events queued before a decision can replay if the user opts in after a reset. JSDoc, action types, changelog, and tests were updated to match (including asserting the pre-consent queue is unchanged while **`eventQueue`** is cleared).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12e7cab461ad9a047e6d13ddc036fbff4198e445. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->