### PR TITLE
fix: skip poo for accounts without entropy source

### DIFF
--- a/packages/profile-metrics-controller/CHANGELOG.md
+++ b/packages/profile-metrics-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Skip proof-of-ownership signing for accounts with no entropy source ([#XXX](https://github.com/MetaMask/core/pull/XXX))
+- Skip proof-of-ownership signing for accounts with no entropy source ([#9286](https://github.com/MetaMask/core/pull/9286))
   - They are still submitted to the metrics endpoint, just without a `proof` field.
 
 ### Changed

--- a/packages/profile-metrics-controller/CHANGELOG.md
+++ b/packages/profile-metrics-controller/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Skip proof-of-ownership signing for accounts with no entropy source ([#XXX](https://github.com/MetaMask/core/pull/XXX))
+  - They are still submitted to the metrics endpoint, just without a `proof` field.
+
 ### Changed
 
 - Bump `@metamask/accounts-controller` from `^39.0.2` to `^39.0.3` ([#9231](https://github.com/MetaMask/core/pull/9231))

--- a/packages/profile-metrics-controller/CHANGELOG.md
+++ b/packages/profile-metrics-controller/CHANGELOG.md
@@ -7,15 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Skip proof-of-ownership signing for accounts with no entropy source ([#9286](https://github.com/MetaMask/core/pull/9286))
-  - They are still submitted to the metrics endpoint, just without a `proof` field.
-
 ### Changed
 
 - Bump `@metamask/accounts-controller` from `^39.0.2` to `^39.0.3` ([#9231](https://github.com/MetaMask/core/pull/9231))
 - Bump `@metamask/transaction-controller` from `^68.1.1` to `^68.2.0` ([#9253](https://github.com/MetaMask/core/pull/9253))
+
+### Fixed
+
+- Skip proof-of-ownership signing for accounts with no entropy source ([#9286](https://github.com/MetaMask/core/pull/9286))
+  - They are still submitted to the metrics endpoint, just without a `proof` field.
 
 ## [4.0.0]
 

--- a/packages/profile-metrics-controller/src/ProfileMetricsController.test.ts
+++ b/packages/profile-metrics-controller/src/ProfileMetricsController.test.ts
@@ -725,7 +725,7 @@ describe('ProfileMetricsController', () => {
             );
           });
 
-          it('passes `entropySourceId: null` to fetchNonces for the unaffiliated batch', async () => {
+          it('skips proof-of-ownership entirely for accounts with no entropy source', async () => {
             const address = '0x71C7656EC7ab88b098defB751B7401B5f6d8976F';
             const accounts: Record<string, AccountWithScopes[]> = {
               null: [{ address: address.toLowerCase(), scopes: ['eip155:1'] }],
@@ -738,6 +738,8 @@ describe('ProfileMetricsController', () => {
               },
               async ({
                 controller,
+                getMetaMetricsId,
+                mockSubmitMetrics,
                 mockFetchNonces,
                 mockSignProof,
                 registerAccounts,
@@ -745,18 +747,19 @@ describe('ProfileMetricsController', () => {
                 registerAccounts([
                   createMockAccount(address.toLowerCase(), false),
                 ]);
-                mockFetchNonces.mockResolvedValueOnce({ [address]: 'n' });
-                mockSignProof.mockResolvedValueOnce({
-                  nonce: 'n',
-                  signature: '0xsig',
-                });
 
                 await controller._executePoll();
 
-                expect(mockFetchNonces).toHaveBeenCalledWith({
-                  identifiers: [address],
+                expect(mockFetchNonces).not.toHaveBeenCalled();
+                expect(mockSignProof).not.toHaveBeenCalled();
+                expect(mockSubmitMetrics).toHaveBeenCalledWith({
+                  metametricsId: getMetaMetricsId(),
                   entropySourceId: null,
+                  accounts: [
+                    { address: address.toLowerCase(), scopes: ['eip155:1'] },
+                  ],
                 });
+                expect(controller.state.syncQueue).toStrictEqual({});
               },
             );
           });
@@ -1027,36 +1030,6 @@ describe('ProfileMetricsController', () => {
                 );
                 // Batch is dropped from the queue on a successful submit.
                 expect(controller.state.syncQueue).toStrictEqual({});
-              },
-            );
-          });
-
-          it('logs `null` in the fetchNonces failure message when the batch has no entropy source', async () => {
-            const address = '0x71C7656EC7ab88b098defB751B7401B5f6d8976F';
-            const accounts: Record<string, AccountWithScopes[]> = {
-              null: [{ address: address.toLowerCase(), scopes: ['eip155:1'] }],
-            };
-            await withController(
-              {
-                options: {
-                  state: { syncQueue: accounts, initialDelayEndTimestamp: 0 },
-                },
-              },
-              async ({ controller, mockFetchNonces, registerAccounts }) => {
-                const consoleErrorSpy = jest
-                  .spyOn(console, 'error')
-                  .mockImplementation();
-                registerAccounts([
-                  createMockAccount(address.toLowerCase(), false),
-                ]);
-                mockFetchNonces.mockRejectedValueOnce(new Error('boom'));
-
-                await controller._executePoll();
-
-                expect(consoleErrorSpy).toHaveBeenCalledWith(
-                  'Failed to fetch proof-of-ownership nonces for entropy source ID null:',
-                  expect.any(Error),
-                );
               },
             );
           });

--- a/packages/profile-metrics-controller/src/ProfileMetricsController.ts
+++ b/packages/profile-metrics-controller/src/ProfileMetricsController.ts
@@ -319,11 +319,15 @@ export class ProfileMetricsController extends StaticIntervalPollingController()<
       )) {
         const normalizedEntropySourceId =
           entropySourceId === 'null' ? null : entropySourceId;
-        const accountsWithProofs = await this.#attachProofs(
-          accounts,
-          fullAccountsByAddress,
-          normalizedEntropySourceId,
-        );
+        // Skip proof-of-ownership for accounts without an entropy source
+        const accountsWithProofs =
+          normalizedEntropySourceId === null
+            ? accounts
+            : await this.#attachProofs(
+                accounts,
+                fullAccountsByAddress,
+                normalizedEntropySourceId,
+              );
         try {
           await this.messenger.call('ProfileMetricsService:submitMetrics', {
             metametricsId: this.#getMetaMetricsId(),
@@ -355,13 +359,15 @@ export class ProfileMetricsController extends StaticIntervalPollingController()<
    *
    * @param accounts - The queued accounts for a single batch.
    * @param fullAccountsByAddress - Live `InternalAccount` lookup keyed by address.
-   * @param entropySourceId - The entropy source ID for this batch.
+   * @param entropySourceId - The entropy source ID for this batch. Callers
+   * are expected to short-circuit before invoking this method when the
+   * batch has no entropy source; see `_executePoll` for why.
    * @returns The accounts with `proof` populated where signing succeeded.
    */
   async #attachProofs(
     accounts: AccountWithScopes[],
     fullAccountsByAddress: Map<string, InternalAccount>,
-    entropySourceId: string | null,
+    entropySourceId: string,
   ): Promise<AccountWithScopes[]> {
     const candidates = new Map<
       string,
@@ -409,7 +415,7 @@ export class ProfileMetricsController extends StaticIntervalPollingController()<
       });
     } catch (error) {
       console.error(
-        `Failed to fetch proof-of-ownership nonces for entropy source ID ${entropySourceId ?? 'null'}:`,
+        `Failed to fetch proof-of-ownership nonces for entropy source ID ${entropySourceId}:`,
         error,
       );
     }


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow behavior change for unaffiliated accounts only; avoids unnecessary signing calls without altering proof flow for keyed accounts.
> 
> **Overview**
> **Profile metrics** batches keyed with no entropy source (`entropySourceId: null`) are no longer run through nonce fetch or proof signing in `_executePoll`; they are submitted to `ProfileMetricsService:submitMetrics` unchanged (no `proof` field).
> 
> `#attachProofs` is now typed for a non-null entropy source only, with the null batch handled upstream. Tests and changelog reflect the new behavior and drop the obsolete null-batch nonce failure case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54fb3b24acb65c9f2fa6857864d71cc2352394b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->