### PR TITLE
fix(transaction-controller): resimulate latest transaction data instead of stale captured data

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Resimulate the latest transaction data instead of stale data captured when resimulation started, fixing flickering simulation results after a transaction is updated ([#9287](https://github.com/MetaMask/core/pull/9287))
+
 ## [68.2.0]
 
 ### Added

--- a/packages/transaction-controller/src/helpers/ResimulateHelper.test.ts
+++ b/packages/transaction-controller/src/helpers/ResimulateHelper.test.ts
@@ -99,12 +99,24 @@ describe('ResimulateHelper', () => {
   }
 
   /**
-   * Mocks getTransactions to return given transactions argument
+   * Flushes the microtask queue so the resimulation promise chain settles and
+   * the next timer is scheduled before advancing fake timers again.
+   */
+  async function flushPromises(): Promise<void> {
+    for (let i = 0; i < 5; i++) {
+      await Promise.resolve();
+    }
+  }
+
+  /**
+   * Mocks getTransactions to always return the given transactions argument.
+   * The resimulation timer reads the latest state on each tick, so the mock
+   * must persist across calls rather than returning a value only once.
    *
    * @param transactions - Transactions to be returned
    */
-  function mockGetTransactionsOnce(transactions: TransactionMeta[]): void {
-    getTransactionsMock.mockReturnValueOnce(
+  function mockGetTransactions(transactions: TransactionMeta[]): void {
+    getTransactionsMock.mockReturnValue(
       transactions as unknown as ResimulateHelperOptions['getTransactions'],
     );
   }
@@ -128,30 +140,60 @@ describe('ResimulateHelper', () => {
   });
 
   it(`resimulates unapproved active transaction every ${RESIMULATE_INTERVAL_MS} milliseconds`, async () => {
-    mockGetTransactionsOnce([mockTransactionMeta]);
+    mockGetTransactions([mockTransactionMeta]);
     triggerStateChange();
 
     jest.advanceTimersByTime(RESIMULATE_INTERVAL_MS);
-    await Promise.resolve();
+    await flushPromises();
 
     jest.advanceTimersByTime(RESIMULATE_INTERVAL_MS);
-    await Promise.resolve();
-
-    jest.runAllTimers();
+    await flushPromises();
 
     expect(simulateTransactionMock).toHaveBeenCalledWith(mockTransactionMeta);
     expect(simulateTransactionMock).toHaveBeenCalledTimes(2);
   });
 
+  it('resimulates with the latest transaction after it is updated', async () => {
+    const updatedTransactionMeta = {
+      ...mockTransactionMeta,
+      txParams: {
+        ...mockTransactionMeta.txParams,
+        data: '0x2',
+      },
+    } as TransactionMeta;
+
+    mockGetTransactions([mockTransactionMeta]);
+    triggerStateChange();
+
+    jest.advanceTimersByTime(RESIMULATE_INTERVAL_MS);
+    await flushPromises();
+
+    expect(simulateTransactionMock).toHaveBeenNthCalledWith(
+      1,
+      mockTransactionMeta,
+    );
+
+    mockGetTransactions([updatedTransactionMeta]);
+    triggerStateChange();
+
+    jest.advanceTimersByTime(RESIMULATE_INTERVAL_MS);
+    await flushPromises();
+
+    expect(simulateTransactionMock).toHaveBeenNthCalledWith(
+      2,
+      updatedTransactionMeta,
+    );
+    expect(simulateTransactionMock).toHaveBeenCalledTimes(2);
+  });
+
   it(`does not resimulate twice the same transaction even if state change is triggered twice`, async () => {
-    mockGetTransactionsOnce([mockTransactionMeta]);
+    mockGetTransactions([mockTransactionMeta]);
     triggerStateChange();
 
     // Halfway through the interval
     jest.advanceTimersByTime(RESIMULATE_INTERVAL_MS / 2);
 
     // Assume state change is triggered again
-    mockGetTransactionsOnce([mockTransactionMeta]);
     triggerStateChange();
 
     // Halfway through the interval
@@ -161,7 +203,7 @@ describe('ResimulateHelper', () => {
   });
 
   it('does not resimulate a transaction that is no longer active', () => {
-    mockGetTransactionsOnce([mockTransactionMeta]);
+    mockGetTransactions([mockTransactionMeta]);
     triggerStateChange();
 
     // Halfway through the interval
@@ -172,7 +214,7 @@ describe('ResimulateHelper', () => {
       isActive: false,
     } as TransactionMeta;
 
-    mockGetTransactionsOnce([inactiveTransactionMeta]);
+    mockGetTransactions([inactiveTransactionMeta]);
     triggerStateChange();
 
     jest.advanceTimersByTime(RESIMULATE_INTERVAL_MS / 2);
@@ -186,7 +228,7 @@ describe('ResimulateHelper', () => {
       isActive: false,
     } as TransactionMeta;
 
-    mockGetTransactionsOnce([inactiveTransactionMeta]);
+    mockGetTransactions([inactiveTransactionMeta]);
     triggerStateChange();
 
     jest.advanceTimersByTime(2 * RESIMULATE_INTERVAL_MS);
@@ -195,15 +237,34 @@ describe('ResimulateHelper', () => {
   });
 
   it('stops resimulating a transaction that is no longer in the transaction list', () => {
-    mockGetTransactionsOnce([mockTransactionMeta]);
+    mockGetTransactions([mockTransactionMeta]);
     triggerStateChange();
 
     jest.advanceTimersByTime(RESIMULATE_INTERVAL_MS);
 
-    mockGetTransactionsOnce([]);
+    mockGetTransactions([]);
     triggerStateChange();
 
     jest.advanceTimersByTime(RESIMULATE_INTERVAL_MS);
+
+    expect(simulateTransactionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops resimulating when the transaction disappears between ticks', async () => {
+    mockGetTransactions([mockTransactionMeta]);
+    triggerStateChange();
+
+    jest.advanceTimersByTime(RESIMULATE_INTERVAL_MS);
+    await flushPromises();
+
+    expect(simulateTransactionMock).toHaveBeenCalledTimes(1);
+
+    // The transaction is removed without a state change being triggered, so
+    // the running timer must detect this on its next tick and stop itself.
+    mockGetTransactions([]);
+
+    jest.advanceTimersByTime(RESIMULATE_INTERVAL_MS);
+    await flushPromises();
 
     expect(simulateTransactionMock).toHaveBeenCalledTimes(1);
   });

--- a/packages/transaction-controller/src/helpers/ResimulateHelper.ts
+++ b/packages/transaction-controller/src/helpers/ResimulateHelper.ts
@@ -54,40 +54,50 @@ export class ResimulateHelper {
   }
 
   #onTransactionsUpdate(): void {
-    const unapprovedTransactions = this.#getTransactions().filter(
-      (tx) => tx.status === TransactionStatus.unapproved,
+    const resimulatableTransactionIds = new Set(
+      this.#getResimulatableTransactions().map((tx) => tx.id),
     );
 
-    const unapprovedTransactionIds = new Set(
-      unapprovedTransactions.map((tx) => tx.id),
-    );
-
-    // Combine unapproved transaction IDs and currently active resimulations
+    // Combine resimulatable transaction IDs and currently active resimulations
     const allTransactionIds = new Set([
-      ...unapprovedTransactionIds,
+      ...resimulatableTransactionIds,
       ...this.#timeoutIds.keys(),
     ]);
 
     allTransactionIds.forEach((transactionId) => {
-      const transactionMeta = unapprovedTransactions.find(
-        (tx) => tx.id === transactionId,
-      ) as TransactionMeta;
-
-      if (transactionMeta?.isActive) {
-        this.#start(transactionMeta);
+      if (resimulatableTransactionIds.has(transactionId)) {
+        this.#start(transactionId);
       } else {
         this.#stop(transactionId);
       }
     });
   }
 
-  #start(transactionMeta: TransactionMeta): void {
-    const { id: transactionId } = transactionMeta;
+  #getResimulatableTransactions(): TransactionMeta[] {
+    return this.#getTransactions().filter(
+      (tx) => tx.status === TransactionStatus.unapproved && tx.isActive,
+    );
+  }
+
+  #start(transactionId: string): void {
     if (this.#timeoutIds.has(transactionId)) {
       return;
     }
 
     const listener = (): void => {
+      // Read the latest transaction on each tick rather than capturing it in
+      // the closure. Otherwise an update to the transaction (e.g. editing a
+      // batch approval amount) would keep resimulating the stale data, as
+      // `#start` returns early when a timer already exists for the id.
+      const transactionMeta = this.#getResimulatableTransactions().find(
+        (tx) => tx.id === transactionId,
+      );
+
+      if (!transactionMeta) {
+        this.#stop(transactionId);
+        return;
+      }
+
       this.#simulateTransaction(transactionMeta)
         .catch((error) => {
           /* istanbul ignore next */


### PR DESCRIPTION
## Explanation

`ResimulateHelper` re-simulates active unapproved transactions every 3 seconds. The timer's `#start` captured the `transactionMeta` in a closure and, because it returns early when a timer already exists for the id, never refreshed it. When a transaction was updated after resimulation began (e.g. editing a batch approval amount), the loop kept simulating the stale parameters, causing the simulation result to flicker between the old and new outcomes.

`#start` now takes a `transactionId` and the timer reads the latest transaction from state on each tick (via a new `#getResimulatableTransactions` helper), stopping itself if the transaction is gone or no longer active.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

- Fixes https://github.com/MetaMask/metamask-extension/issues/43673
- Related https://github.com/MetaMask/metamask-extension/pull/43956
- Draft PR extension https://github.com/MetaMask/metamask-extension/pull/43956

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped fix to periodic resimulation timing in `ResimulateHelper`; behavior change is to read fresh transaction state each tick, with expanded unit tests and no public API changes.
> 
> **Overview**
> Fixes **flickering simulation results** when an unapproved transaction is edited after periodic resimulation has already started (e.g. changing batch approval `data`).
> 
> `ResimulateHelper` used to pass the full `transactionMeta` into `#start` and reuse it in the timer closure; because `#start` no-ops when a timer already exists for that id, later state updates never refreshed what got simulated. **`#start` now keys timers by `transactionId` only**, and each interval tick loads the current meta via **`#getResimulatableTransactions()`** (unapproved + `isActive`). If the tx is gone or no longer resimulatable, the tick **stops** the timer instead of simulating stale params.
> 
> State-change handling is aligned with that model: it tracks resimulatable ids from live state and still merges in ids with active timers so removals/inactivity can tear down polling. Tests use persistent `getTransactions` mocks, `flushPromises` for async timer chains, and cover updated params plus disappearance between ticks without a state callback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b862bd6fd4a2e210551d87f26b8e5aa85a01ba04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->