### PR TITLE
feat(wallet): wire `AddressBookController` into default initialization

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -137,6 +137,7 @@
 
 ## Initialization
 /packages/wallet/src/initialization/instances/accounts-controller/ @MetaMask/accounts-engineers
+/packages/wallet/src/initialization/instances/address-book-controller/ @MetaMask/confirmations
 /packages/wallet/src/initialization/instances/approval-controller/ @MetaMask/confirmations
 /packages/wallet/src/initialization/instances/connectivity-controller/ @MetaMask/core-platform
 /packages/wallet/src/initialization/instances/keyring-controller/ @MetaMask/accounts-engineers @MetaMask/core-platform

--- a/README.md
+++ b/README.md
@@ -612,6 +612,7 @@ linkStyle default opacity:0.5
   user_operation_controller --> transaction_controller;
   user_operation_controller --> eth_block_tracker;
   wallet --> accounts_controller;
+  wallet --> address_book_controller;
   wallet --> approval_controller;
   wallet --> base_controller;
   wallet --> connectivity_controller;

--- a/packages/wallet/CHANGELOG.md
+++ b/packages/wallet/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **BREAKING:** Wire `AddressBookController` into the default wallet initialization ([#9291](https://github.com/MetaMask/core/pull/9291))
+
 ## [5.0.0]
 
 ### Added

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -54,6 +54,7 @@
   },
   "dependencies": {
     "@metamask/accounts-controller": "^39.0.3",
+    "@metamask/address-book-controller": "^7.1.2",
     "@metamask/approval-controller": "^9.0.2",
     "@metamask/base-controller": "^9.1.0",
     "@metamask/browser-passworder": "^6.0.0",

--- a/packages/wallet/src/Wallet.test.ts
+++ b/packages/wallet/src/Wallet.test.ts
@@ -1,3 +1,4 @@
+import { getDefaultAddressBookControllerState } from '@metamask/address-book-controller';
 import { CONNECTIVITY_STATUSES } from '@metamask/connectivity-controller';
 import { Messenger } from '@metamask/messenger';
 import { InMemoryStorageAdapter } from '@metamask/storage-service';
@@ -259,6 +260,62 @@ describe('Wallet', () => {
       expect([...trackedAddresses].sort()).toStrictEqual(
         [...keyringAccounts].sort(),
       );
+    });
+  });
+
+  describe('AddressBookController', () => {
+    const ADDRESS = '0x1234567890123456789012345678901234567890';
+
+    it('is wired and exposes its state on the wallet messenger', async () => {
+      const wallet = await setupWallet();
+      const { messenger } = wallet;
+
+      expect(messenger.call('AddressBookController:getState')).toStrictEqual(
+        getDefaultAddressBookControllerState(),
+      );
+    });
+
+    it('applies initial state passed through the Wallet constructor', () => {
+      const entry = {
+        address: ADDRESS,
+        name: 'Alice',
+        chainId: '0x1' as const,
+        memo: '',
+        isEns: false,
+      };
+
+      const wallet = new Wallet({
+        state: {
+          AddressBookController: {
+            addressBook: { '0x1': { [ADDRESS]: entry } },
+          },
+        },
+        instanceOptions: {
+          connectivityController: {
+            connectivityAdapter: new AlwaysOnlineAdapter(),
+          },
+          networkController: {
+            infuraProjectId: 'fake-infura-project-id',
+          },
+          storageService: {
+            storage: new InMemoryStorageAdapter(),
+          },
+          remoteFeatureFlagController: REMOTE_FEATURE_FLAG_OPTIONS,
+        },
+      });
+
+      expect(
+        wallet.state.AddressBookController.addressBook['0x1'][ADDRESS],
+      ).toStrictEqual(entry);
+    });
+
+    it('routes its method actions through the wallet messenger', async () => {
+      const wallet = await setupWallet();
+      const { messenger } = wallet;
+
+      messenger.call('AddressBookController:set', ADDRESS, 'Alice');
+
+      expect(messenger.call('AddressBookController:list')).toHaveLength(1);
     });
   });
 

--- a/packages/wallet/src/initialization/instances/address-book-controller/address-book-controller.test.ts
+++ b/packages/wallet/src/initialization/instances/address-book-controller/address-book-controller.test.ts
@@ -1,0 +1,93 @@
+import {
+  AddressBookController,
+  getDefaultAddressBookControllerState,
+} from '@metamask/address-book-controller';
+import { Messenger } from '@metamask/messenger';
+
+import { defaultConfigurations } from '../../defaults';
+import type {
+  DefaultActions,
+  DefaultEvents,
+  RootMessenger,
+} from '../../defaults';
+import { addressBookController } from './address-book-controller';
+
+const ADDRESS = '0x1234567890123456789012345678901234567890';
+
+/**
+ * Creates a root messenger for use in tests.
+ *
+ * @returns A root messenger.
+ */
+function getRootMessenger(): RootMessenger<DefaultActions, DefaultEvents> {
+  return new Messenger({ namespace: 'Root' });
+}
+
+describe('addressBookController', () => {
+  it('is registered as a default initialization configuration', () => {
+    expect(Object.values(defaultConfigurations)).toContain(
+      addressBookController,
+    );
+  });
+
+  it('initializes an AddressBookController with default state', () => {
+    const messenger = addressBookController.getMessenger(getRootMessenger());
+
+    const instance = addressBookController.init({
+      state: undefined,
+      messenger,
+      options: {},
+    });
+
+    expect(instance).toBeInstanceOf(AddressBookController);
+    expect(instance.state).toStrictEqual(
+      getDefaultAddressBookControllerState(),
+    );
+  });
+
+  it('merges provided state over the defaults', () => {
+    const messenger = addressBookController.getMessenger(getRootMessenger());
+
+    const entry = {
+      address: ADDRESS,
+      name: 'Alice',
+      chainId: '0x1' as const,
+      memo: '',
+      isEns: false,
+    };
+
+    const instance = addressBookController.init({
+      state: { addressBook: { '0x1': { [ADDRESS]: entry } } },
+      messenger,
+      options: {},
+    });
+
+    expect(instance.state.addressBook['0x1'][ADDRESS]).toStrictEqual(entry);
+  });
+
+  it('exposes its state through the root messenger', () => {
+    const rootMessenger = getRootMessenger();
+    const messenger = addressBookController.getMessenger(rootMessenger);
+
+    addressBookController.init({ state: undefined, messenger, options: {} });
+
+    expect(rootMessenger.call('AddressBookController:getState')).toStrictEqual(
+      getDefaultAddressBookControllerState(),
+    );
+  });
+
+  it('registers its method actions on the root messenger', () => {
+    const rootMessenger = getRootMessenger();
+    const messenger = addressBookController.getMessenger(rootMessenger);
+
+    const instance = addressBookController.init({
+      state: undefined,
+      messenger,
+      options: {},
+    });
+
+    rootMessenger.call('AddressBookController:set', ADDRESS, 'Alice');
+
+    expect(instance.list()).toHaveLength(1);
+  });
+});

--- a/packages/wallet/src/initialization/instances/address-book-controller/address-book-controller.ts
+++ b/packages/wallet/src/initialization/instances/address-book-controller/address-book-controller.ts
@@ -1,0 +1,24 @@
+import {
+  AddressBookController,
+  AddressBookControllerMessenger,
+} from '@metamask/address-book-controller';
+import { Messenger } from '@metamask/messenger';
+
+import type { InitializationConfiguration } from '../../types';
+
+export const addressBookController: InitializationConfiguration<
+  AddressBookController,
+  AddressBookControllerMessenger
+> = {
+  name: 'AddressBookController',
+  init: ({ state, messenger }) =>
+    new AddressBookController({
+      state,
+      messenger,
+    }),
+  getMessenger: (parent) =>
+    new Messenger({
+      namespace: 'AddressBookController',
+      parent,
+    }),
+};

--- a/packages/wallet/src/initialization/instances/index.ts
+++ b/packages/wallet/src/initialization/instances/index.ts
@@ -1,4 +1,5 @@
 export { accountsController } from './accounts-controller/accounts-controller';
+export { addressBookController } from './address-book-controller/address-book-controller';
 export { approvalController } from './approval-controller/approval-controller';
 export { connectivityController } from './connectivity-controller/connectivity-controller';
 export { keyringController } from './keyring-controller/keyring-controller';

--- a/packages/wallet/tsconfig.build.json
+++ b/packages/wallet/tsconfig.build.json
@@ -7,6 +7,7 @@
   },
   "references": [
     { "path": "../accounts-controller/tsconfig.build.json" },
+    { "path": "../address-book-controller/tsconfig.build.json" },
     { "path": "../approval-controller/tsconfig.build.json" },
     { "path": "../base-controller/tsconfig.build.json" },
     { "path": "../connectivity-controller/tsconfig.build.json" },

--- a/packages/wallet/tsconfig.json
+++ b/packages/wallet/tsconfig.json
@@ -5,6 +5,7 @@
   },
   "references": [
     { "path": "../accounts-controller/tsconfig.json" },
+    { "path": "../address-book-controller/tsconfig.json" },
     { "path": "../approval-controller/tsconfig.json" },
     { "path": "../base-controller/tsconfig.json" },
     { "path": "../connectivity-controller/tsconfig.json" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8935,6 +8935,7 @@ __metadata:
   resolution: "@metamask/wallet@workspace:packages/wallet"
   dependencies:
     "@metamask/accounts-controller": "npm:^39.0.3"
+    "@metamask/address-book-controller": "npm:^7.1.2"
     "@metamask/approval-controller": "npm:^9.0.2"
     "@metamask/auto-changelog": "npm:^6.1.0"
     "@metamask/base-controller": "npm:^9.1.0"


### PR DESCRIPTION
## Explanation

Wires the `@metamask/address-book-controller` package into `@metamask/wallet`'s default initialization. The default `Wallet` now constructs an `AddressBookController` and exposes its `AddressBookController:*` messenger actions (`getState`/`stateChange` plus `list`/`set`/`delete`/`clear` and the `contactUpdated`/`contactDeleted` events).

The cross-platform compatibility audit found no client divergence: both extension and mobile construct `AddressBookController` from `@metamask/address-book-controller` with only `{ messenger, state }`, and the controller has no cross-controller messenger dependencies (its messenger carries only its own actions/events). So no injectable `instanceOptions` are needed and none were added — the instance mirrors the other wired default controllers (namespaced child messenger + constructor), and each client keeps supplying only its persisted `AddressBookController` state via `WalletOptions.state`.

## References

Client adoption PRs (integrate this default into each client): _follow-ups; not yet opened. With no divergence, adoption is a mechanical delete-of-local-init + resolve-from-wallet._

Client construction sites (live `main`):

- Extension — [init](https://github.com/MetaMask/metamask-extension/blob/main/app/scripts/messenger-client-init/confirmations/address-book-controller-init.ts), [messenger](https://github.com/MetaMask/metamask-extension/blob/main/app/scripts/messenger-client-init/messengers/address-book-controller-messenger.ts)
- Mobile — [init](https://github.com/MetaMask/metamask-mobile/blob/main/app/core/Engine/controllers/address-book-controller-init.ts), [messenger](https://github.com/MetaMask/metamask-mobile/blob/main/app/core/Engine/messengers/address-book-controller-messenger.ts)

Jira: N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [ ] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes (follow-up — extension and mobile adoption PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Marked breaking: duplicate AddressBookController registration will collide for extension/mobile until they drop local init; contact data is user-facing but the wiring pattern is low-complexity and well-tested.
> 
> **Overview**
> **BREAKING:** Default `Wallet` initialization now constructs `AddressBookController` and registers `AddressBookController:*` messenger actions on the root messenger, matching other wired controllers (namespaced child messenger, `{ state, messenger }` only—no new `instanceOptions`).
> 
> Adds `@metamask/address-book-controller` as a wallet dependency, a new initialization instance module, registration in default configurations/exports, TS project references, CODEOWNERS for the init path, README dependency graph edge, and unit/integration tests (including `Wallet` state hydration and messenger `set`/`list`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a74600037bcb8be6dbeb2b0a9aea606c3a7139c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->