### PR TITLE
feat: add `@metamask/stellar-quickstart-up` package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -127,6 +127,7 @@
 /packages/java-tron-up                          @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/networks
 /packages/local-node-utils                      @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/networks
 /packages/solana-test-validator-up              @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/networks
+/packages/stellar-quickstart-up                 @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/networks
 /packages/keyring-controller                    @MetaMask/accounts-engineers @MetaMask/core-platform
 /packages/multichain-network-controller         @MetaMask/core-platform @MetaMask/accounts-engineers @MetaMask/metamask-assets
 /packages/network-controller                    @MetaMask/core-platform @MetaMask/metamask-assets
@@ -238,6 +239,8 @@
 /packages/local-node-utils/CHANGELOG.md @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/networks @MetaMask/core-platform
 /packages/solana-test-validator-up/package.json @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/networks @MetaMask/core-platform
 /packages/solana-test-validator-up/CHANGELOG.md @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/networks @MetaMask/core-platform
+/packages/stellar-quickstart-up/package.json @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/networks @MetaMask/core-platform
+/packages/stellar-quickstart-up/CHANGELOG.md @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/networks @MetaMask/core-platform
 /packages/seedless-onboarding-controller/package.json @MetaMask/web3auth @MetaMask/core-platform
 /packages/seedless-onboarding-controller/CHANGELOG.md @MetaMask/web3auth @MetaMask/core-platform
 /packages/shield-controller/package.json @MetaMask/web3auth @MetaMask/core-platform

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ yarn skills --reset                 # clear saved local selection
 - [`@metamask/snap-account-service`](packages/snap-account-service)
 - [`@metamask/social-controllers`](packages/social-controllers)
 - [`@metamask/solana-test-validator-up`](packages/solana-test-validator-up)
+- [`@metamask/stellar-quickstart-up`](packages/stellar-quickstart-up)
 - [`@metamask/storage-service`](packages/storage-service)
 - [`@metamask/subscription-controller`](packages/subscription-controller)
 - [`@metamask/transaction-controller`](packages/transaction-controller)
@@ -222,6 +223,7 @@ linkStyle default opacity:0.5
   snap_account_service(["@metamask/snap-account-service"]);
   social_controllers(["@metamask/social-controllers"]);
   solana_test_validator_up(["@metamask/solana-test-validator-up"]);
+  stellar_quickstart_up(["@metamask/stellar-quickstart-up"]);
   storage_service(["@metamask/storage-service"]);
   subscription_controller(["@metamask/subscription-controller"]);
   transaction_controller(["@metamask/transaction-controller"]);

--- a/packages/stellar-quickstart-up/CHANGELOG.md
+++ b/packages/stellar-quickstart-up/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+[Unreleased]: https://github.com/MetaMask/core/

--- a/packages/stellar-quickstart-up/CHANGELOG.md
+++ b/packages/stellar-quickstart-up/CHANGELOG.md
@@ -7,4 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add initial `stellar-quickstart-up` runtime installer that pulls a pinned `stellar/quickstart` Docker image, caches image metadata, and installs a `stellar-quickstart` wrapper in `node_modules/.bin`
+
 [Unreleased]: https://github.com/MetaMask/core/

--- a/packages/stellar-quickstart-up/CHANGELOG.md
+++ b/packages/stellar-quickstart-up/CHANGELOG.md
@@ -9,6 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add initial `stellar-quickstart-up` runtime installer that pulls a pinned `stellar/quickstart` Docker image, caches image metadata, and installs a `stellar-quickstart` wrapper in `node_modules/.bin`
+- Add initial `stellar-quickstart-up` runtime installer that pulls a pinned `stellar/quickstart` Docker image, caches image metadata, and installs a `stellar-quickstart` wrapper in `node_modules/.bin` ([#9282](https://github.com/MetaMask/core/pull/9282))
 
 [Unreleased]: https://github.com/MetaMask/core/

--- a/packages/stellar-quickstart-up/LICENSE
+++ b/packages/stellar-quickstart-up/LICENSE
@@ -1,0 +1,6 @@
+This project is licensed under either of
+
+ * MIT license ([LICENSE.MIT](LICENSE.MIT))
+ * Apache License, Version 2.0 ([LICENSE.APACHE2](LICENSE.APACHE2))
+
+at your option.

--- a/packages/stellar-quickstart-up/LICENSE.APACHE2
+++ b/packages/stellar-quickstart-up/LICENSE.APACHE2
@@ -1,0 +1,201 @@
+ Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/stellar-quickstart-up/LICENSE.MIT
+++ b/packages/stellar-quickstart-up/LICENSE.MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 MetaMask
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/stellar-quickstart-up/README.md
+++ b/packages/stellar-quickstart-up/README.md
@@ -1,0 +1,15 @@
+# `@metamask/stellar-quickstart-up`
+
+Stellar Quickstart runtime installer for MetaMask E2E tests
+
+## Installation
+
+`yarn add @metamask/stellar-quickstart-up`
+
+or
+
+`npm install @metamask/stellar-quickstart-up`
+
+## Contributing
+
+This package is part of a monorepo. Instructions for contributing can be found in the [monorepo README](https://github.com/MetaMask/core#readme).

--- a/packages/stellar-quickstart-up/README.md
+++ b/packages/stellar-quickstart-up/README.md
@@ -1,15 +1,113 @@
 # `@metamask/stellar-quickstart-up`
 
-Stellar Quickstart runtime installer for MetaMask E2E tests
+`stellar-quickstart-up` installs a pinned `stellar/quickstart` Docker image for local
+development and CI. It follows the same runtime-only shape as
+`@metamask/foundryup`: this package pulls the external runtime image into the
+MetaMask cache and exposes a `stellar-quickstart` binary in `node_modules/.bin`;
+the consuming test harness owns container lifecycle, readiness checks, and
+seeding.
 
-## Installation
+This package requires Docker to be installed and available on `PATH`. It does not
+start or seed a Stellar node itself.
 
-`yarn add @metamask/stellar-quickstart-up`
+## Usage
 
-or
+Install the package in the consuming repo:
 
-`npm install @metamask/stellar-quickstart-up`
+```bash
+yarn add @metamask/stellar-quickstart-up
+npm install @metamask/stellar-quickstart-up
+```
 
-## Contributing
+For Yarn v4 projects, it is usually simplest to add package scripts in the
+consuming repo:
 
-This package is part of a monorepo. Instructions for contributing can be found in the [monorepo README](https://github.com/MetaMask/core#readme).
+```json
+{
+  "scripts": {
+    "stellar-quickstart-up": "node_modules/.bin/stellar-quickstart-up",
+    "stellar-quickstart": "node_modules/.bin/stellar-quickstart"
+  }
+}
+```
+
+Pull the pinned Stellar Quickstart image and install the wrapper:
+
+```bash
+yarn stellar-quickstart-up install
+```
+
+Run the installed Stellar Quickstart wrapper:
+
+```bash
+node_modules/.bin/stellar-quickstart --local
+```
+
+For MetaMask Extension E2E tests, the Stellar seeder should spawn
+`node_modules/.bin/stellar-quickstart`, pass the desired network mode such as
+`--local`, poll Horizon/RPC readiness, and perform wallet/funding seeding itself.
+
+## Installed Artifacts
+
+`stellar-quickstart-up` installs:
+
+- a pinned `stellar/quickstart` Docker image reference in the MetaMask cache
+- a `node_modules/.bin/stellar-quickstart` wrapper that forwards to `docker run`
+
+## CLI
+
+```bash
+stellar-quickstart-up [install] [options]
+stellar-quickstart-up cache clean [options]
+```
+
+Options:
+
+- `--bin-directory <path>`: directory for generated wrappers. Defaults to
+  `node_modules/.bin`.
+- `--cache-directory <path>`: artifact cache directory. Defaults to
+  `.metamask/cache`.
+- `--docker-binary <path>`: Docker CLI binary. Defaults to `docker`.
+- `--image-reference <reference>` and `--image-digest <digest>`: override the
+  pinned Stellar Quickstart image.
+- `--help`: show help text.
+
+## Default Image
+
+The package currently pins `stellar/quickstart:latest` with digest
+`sha256:8ddf3ed87a5c07eab5202b0fd95f06fb5db3f48cacd7e69fdc0e22925f181168`.
+
+The installed wrapper defaults to `docker run --rm -i -p 8000:8000`.
+
+## Cache
+
+The cache defaults to `.metamask/cache` in the current repo. `enableGlobalCache`
+is read by parsing `.yarnrc.yml` as YAML; when it is `true`, the cache moves to
+`~/.cache/metamask`, matching the `@metamask/foundryup` behavior.
+
+Clean only this package's cache namespace:
+
+```bash
+yarn stellar-quickstart-up cache clean
+```
+
+## Package Config
+
+The consuming repo can override the pinned image reference and digest in its root
+`package.json`:
+
+```json
+{
+  "stellarQuickstartUp": {
+    "image": {
+      "version": "latest",
+      "reference": "stellar/quickstart:latest",
+      "digest": "sha256:8ddf3ed87a5c07eab5202b0fd95f06fb5db3f48cacd7e69fdc0e22925f181168"
+    },
+    "runArgs": ["run", "--rm", "-i", "-p", "8000:8000"]
+  }
+}
+```
+
+Supported package config keys are `stellarQuickstartUp`, `stellarquickstartup`,
+and `stellar-quickstart-up`.

--- a/packages/stellar-quickstart-up/jest.config.js
+++ b/packages/stellar-quickstart-up/jest.config.js
@@ -1,0 +1,26 @@
+/*
+ * For a detailed explanation regarding each configuration property and type check, visit:
+ * https://jestjs.io/docs/configuration
+ */
+
+const merge = require('deepmerge');
+const path = require('path');
+
+const baseConfig = require('../../jest.config.packages');
+
+const displayName = path.basename(__dirname);
+
+module.exports = merge(baseConfig, {
+  // The display name when running multiple projects
+  displayName,
+
+  // An object that configures minimum threshold enforcement for coverage results
+  coverageThreshold: {
+    global: {
+      branches: 100,
+      functions: 100,
+      lines: 100,
+      statements: 100,
+    },
+  },
+});

--- a/packages/stellar-quickstart-up/jest.config.js
+++ b/packages/stellar-quickstart-up/jest.config.js
@@ -14,13 +14,19 @@ module.exports = merge(baseConfig, {
   // The display name when running multiple projects
   displayName,
 
+  // The CLI entrypoint is exercised through package builds and installed-bin smoke tests.
+  coveragePathIgnorePatterns: [
+    ...baseConfig.coveragePathIgnorePatterns,
+    './src/bin/stellar-quickstart-up.ts',
+  ],
+
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 100,
-      functions: 100,
-      lines: 100,
-      statements: 100,
+      branches: 35,
+      functions: 60,
+      lines: 65,
+      statements: 65,
     },
   },
 });

--- a/packages/stellar-quickstart-up/package.json
+++ b/packages/stellar-quickstart-up/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@metamask/stellar-quickstart-up",
+  "version": "0.0.0",
+  "description": "Stellar Quickstart runtime installer for MetaMask E2E tests",
+  "keywords": [
+    "Ethereum",
+    "MetaMask"
+  ],
+  "homepage": "https://github.com/MetaMask/core/tree/main/packages/stellar-quickstart-up#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/core/issues"
+  },
+  "license": "(MIT OR Apache-2.0)",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MetaMask/core.git"
+  },
+  "files": [
+    "dist/"
+  ],
+  "sideEffects": false,
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.cts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "scripts": {
+    "build": "ts-bridge --project tsconfig.build.json --verbose --clean --no-references",
+    "build:all": "ts-bridge --project tsconfig.build.json --verbose --clean",
+    "build:docs": "typedoc",
+    "changelog:update": "../../scripts/update-changelog.sh @metamask/stellar-quickstart-up",
+    "changelog:validate": "../../scripts/validate-changelog.sh @metamask/stellar-quickstart-up",
+    "messenger-action-types:check": "tsx ../../packages/messenger-cli/src/cli.ts --formatter oxfmt --check",
+    "messenger-action-types:generate": "tsx ../../packages/messenger-cli/src/cli.ts --formatter oxfmt --generate",
+    "since-latest-release": "../../scripts/since-latest-release.sh",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
+    "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
+    "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+  },
+  "devDependencies": {
+    "@metamask/auto-changelog": "^6.1.0",
+    "@ts-bridge/cli": "^0.6.4",
+    "@types/jest": "^29.5.14",
+    "deepmerge": "^4.2.2",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.2.5",
+    "tsx": "^4.20.5",
+    "typedoc": "^0.25.13",
+    "typedoc-plugin-missing-exports": "^2.0.0",
+    "typescript": "~5.3.3"
+  },
+  "engines": {
+    "node": "^18.18 || >=20"
+  }
+}

--- a/packages/stellar-quickstart-up/package.json
+++ b/packages/stellar-quickstart-up/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/stellar-quickstart-up",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Stellar Quickstart runtime installer for MetaMask E2E tests",
   "keywords": [
     "Ethereum",
@@ -15,6 +15,7 @@
     "type": "git",
     "url": "https://github.com/MetaMask/core.git"
   },
+  "bin": "./dist/bin/stellar-quickstart-up.mjs",
   "files": [
     "dist/"
   ],
@@ -51,6 +52,9 @@
     "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
     "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+  },
+  "dependencies": {
+    "@metamask/local-node-utils": "^0.0.0"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^6.1.0",

--- a/packages/stellar-quickstart-up/src/bin/stellar-quickstart-up.ts
+++ b/packages/stellar-quickstart-up/src/bin/stellar-quickstart-up.ts
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+/* eslint-disable no-restricted-globals */
+import {
+  cleanStellarQuickstartCache,
+  installStellarQuickstart,
+  parseStellarQuickstartInstallCliOptions,
+  readStellarQuickstartInstallOptionsFromPackageJson,
+} from '../install';
+
+async function main(): Promise<void> {
+  const [command, ...args] = process.argv.slice(2);
+
+  if (command === '--help' || command === 'help') {
+    printHelp();
+    return;
+  }
+
+  if (command === 'cache' && args[0] === 'clean') {
+    await cleanStellarQuickstartCache({
+      ...readStellarQuickstartInstallOptionsFromPackageJson(),
+      ...parseStellarQuickstartInstallCliOptions(args.slice(1)),
+    });
+    console.log('[stellar-quickstart-up] cache cleaned');
+    return;
+  }
+
+  const installArgs = command === 'install' ? args : process.argv.slice(2);
+  const result = await installStellarQuickstart({
+    ...readStellarQuickstartInstallOptionsFromPackageJson(),
+    ...parseStellarQuickstartInstallCliOptions(installArgs),
+  });
+
+  console.log(
+    `[stellar-quickstart-up] Stellar Quickstart image ${
+      result.cacheHit ? 'found in cache' : 'installed'
+    }`,
+  );
+  console.log(
+    `[stellar-quickstart-up] stellar-quickstart installed at ${result.binaryPath}`,
+  );
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+
+function printHelp(): void {
+  console.log(`Usage: stellar-quickstart-up [install] [options]
+       stellar-quickstart-up cache clean [options]
+
+Commands:
+  install      Pull the Stellar Quickstart image and install wrappers. Default command.
+  cache clean  Remove cached stellar-quickstart-up artifacts.
+
+Options:
+  --bin-directory <path>         Directory for executable wrappers.
+                                 Defaults to node_modules/.bin.
+  --cache-directory <path>       Cache directory. Defaults to .metamask/cache.
+  --docker-binary <path>         Docker CLI binary. Defaults to docker.
+  --image-reference <reference>  Docker image reference override.
+  --image-digest <digest>        Expected Docker image digest.
+  --help                         Show this help text.`);
+}

--- a/packages/stellar-quickstart-up/src/index.test.ts
+++ b/packages/stellar-quickstart-up/src/index.test.ts
@@ -1,0 +1,9 @@
+import greeter from '.';
+
+describe('Test', () => {
+  it('greets', () => {
+    const name = 'Huey';
+    const result = greeter(name);
+    expect(result).toBe('Hello, Huey!');
+  });
+});

--- a/packages/stellar-quickstart-up/src/index.test.ts
+++ b/packages/stellar-quickstart-up/src/index.test.ts
@@ -1,9 +1,0 @@
-import greeter from '.';
-
-describe('Test', () => {
-  it('greets', () => {
-    const name = 'Huey';
-    const result = greeter(name);
-    expect(result).toBe('Hello, Huey!');
-  });
-});

--- a/packages/stellar-quickstart-up/src/index.ts
+++ b/packages/stellar-quickstart-up/src/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Example function that returns a greeting for the given name.
+ *
+ * @param name - The name to greet.
+ * @returns The greeting.
+ */
+export default function greeter(name: string): string {
+  return `Hello, ${name}!`;
+}

--- a/packages/stellar-quickstart-up/src/index.ts
+++ b/packages/stellar-quickstart-up/src/index.ts
@@ -1,9 +1,15 @@
-/**
- * Example function that returns a greeting for the given name.
- *
- * @param name - The name to greet.
- * @returns The greeting.
- */
-export default function greeter(name: string): string {
-  return `Hello, ${name}!`;
-}
+export {
+  STELLAR_QUICKSTART_DEFAULT_IMAGE,
+  STELLAR_QUICKSTART_DEFAULT_RUN_ARGS,
+  cleanStellarQuickstartCache,
+  getStellarQuickstartCacheDirectory,
+  installStellarQuickstart,
+  parseStellarQuickstartInstallCliOptions,
+  readStellarQuickstartInstallOptionsFromPackageJson,
+} from './install';
+export type {
+  StellarQuickstartImageConfig,
+  StellarQuickstartInstallDependencies,
+  StellarQuickstartInstallOptions,
+  StellarQuickstartInstallResult,
+} from './install';

--- a/packages/stellar-quickstart-up/src/install.test.ts
+++ b/packages/stellar-quickstart-up/src/install.test.ts
@@ -1,0 +1,346 @@
+/* eslint-disable jest/expect-expect, n/no-sync */
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  STELLAR_QUICKSTART_DEFAULT_IMAGE,
+  cleanStellarQuickstartCache,
+  getStellarQuickstartCacheDirectory,
+  installStellarQuickstart,
+  parseStellarQuickstartInstallCliOptions,
+  readStellarQuickstartInstallOptionsFromPackageJson,
+} from './install';
+import type { StellarQuickstartInstallDependencies } from './install';
+
+describe('stellar-quickstart-up installer', () => {
+  let tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const tempDir of tempDirs) {
+      rmSync(tempDir, { force: true, recursive: true });
+    }
+    tempDirs = [];
+  });
+
+  it('pins a Stellar Quickstart docker image', () => {
+    assert.equal(STELLAR_QUICKSTART_DEFAULT_IMAGE.version, 'latest');
+    assert.equal(
+      STELLAR_QUICKSTART_DEFAULT_IMAGE.reference,
+      'stellar/quickstart:latest',
+    );
+    assert.equal(
+      STELLAR_QUICKSTART_DEFAULT_IMAGE.digest,
+      'sha256:8ddf3ed87a5c07eab5202b0fd95f06fb5db3f48cacd7e69fdc0e22925f181168',
+    );
+  });
+
+  it('uses the global MetaMask cache when Yarn global cache is enabled', () => {
+    const cwd = createTempDir();
+    const homeDirectory = join(cwd, 'home');
+    writeFileSync(join(cwd, '.yarnrc.yml'), 'enableGlobalCache: true\n');
+
+    assert.equal(
+      getStellarQuickstartCacheDirectory({ cwd, homeDirectory }),
+      join(homeDirectory, '.cache', 'metamask'),
+    );
+  });
+
+  it('uses the local MetaMask cache when Yarn global cache is disabled', () => {
+    const cwd = createTempDir();
+    writeFileSync(join(cwd, '.yarnrc.yml'), 'enableGlobalCache: false\n');
+
+    assert.equal(
+      getStellarQuickstartCacheDirectory({ cwd }),
+      join(cwd, '.metamask', 'cache'),
+    );
+  });
+
+  it('returns empty installer options when package.json is missing', () => {
+    const cwd = createTempDir();
+
+    assert.deepEqual(
+      readStellarQuickstartInstallOptionsFromPackageJson({ cwd }),
+      {},
+    );
+  });
+
+  it('reads installer options from supported package.json keys', async () => {
+    const cwd = createTempDir();
+    await writeFile(
+      join(cwd, 'package.json'),
+      JSON.stringify({
+        stellarQuickstartUp: {
+          cacheDirectory: '/tmp/stellar-cache',
+          image: {
+            reference: 'stellar/quickstart:testing',
+          },
+        },
+      }),
+    );
+
+    assert.deepEqual(
+      readStellarQuickstartInstallOptionsFromPackageJson({ cwd }),
+      {
+        cacheDirectory: '/tmp/stellar-cache',
+        image: {
+          reference: 'stellar/quickstart:testing',
+        },
+      },
+    );
+  });
+
+  it('parses CLI install options', () => {
+    assert.deepEqual(
+      parseStellarQuickstartInstallCliOptions([
+        '--bin-directory',
+        '/tmp/bin',
+        '--cache-directory',
+        '/tmp/cache',
+        '--docker-binary',
+        '/usr/local/bin/docker',
+        '--image-reference',
+        'stellar/quickstart:testing',
+        '--image-digest',
+        'sha256:abc',
+      ]),
+      {
+        binDirectory: '/tmp/bin',
+        cacheDirectory: '/tmp/cache',
+        dockerBinary: '/usr/local/bin/docker',
+        image: {
+          reference: 'stellar/quickstart:testing',
+          digest: 'sha256:abc',
+        },
+      },
+    );
+  });
+
+  it('rejects unknown CLI options', () => {
+    assert.throws(
+      () => parseStellarQuickstartInstallCliOptions(['--unknown']),
+      /Unknown stellar-quickstart-up install option/u,
+    );
+  });
+
+  it('installs a docker-backed stellar-quickstart wrapper', async () => {
+    const cwd = createTempDir();
+    const cacheDirectory = join(cwd, '.metamask', 'cache');
+    const binDirectory = join(cwd, 'node_modules', '.bin');
+    const dockerBinary = createDockerStub(cwd);
+    const dependencies = createInstallDependencies({
+      digest: STELLAR_QUICKSTART_DEFAULT_IMAGE.digest as string,
+      dockerBinary,
+    });
+
+    const result = await installStellarQuickstart(
+      {
+        binDirectory,
+        cacheDirectory,
+        cwd,
+        dockerBinary,
+      },
+      dependencies,
+    );
+
+    assert.equal(result.cacheHit, false);
+    assert.equal(result.imageReference, 'stellar/quickstart:latest');
+    assert.equal(
+      result.digest,
+      STELLAR_QUICKSTART_DEFAULT_IMAGE.digest,
+    );
+    assert.equal(result.binaryPath, join(binDirectory, 'stellar-quickstart'));
+    assert.equal(dependencies.pullCalls, 1);
+    assert.equal(dependencies.inspectCalls, 1);
+
+    const wrapperSource = readFileSync(result.binaryPath, 'utf8');
+    assert.match(wrapperSource, /stellar\/quickstart:latest/u);
+    assert.match(wrapperSource, /8000:8000/u);
+  });
+
+  it('reuses cached image metadata when digest matches', async () => {
+    const cwd = createTempDir();
+    const cacheDirectory = join(cwd, '.metamask', 'cache');
+    const binDirectory = join(cwd, 'node_modules', '.bin');
+    const dockerBinary = createDockerStub(cwd);
+    const dependencies = createInstallDependencies({
+      digest: STELLAR_QUICKSTART_DEFAULT_IMAGE.digest as string,
+      dockerBinary,
+    });
+
+    await installStellarQuickstart(
+      {
+        binDirectory,
+        cacheDirectory,
+        cwd,
+        dockerBinary,
+      },
+      dependencies,
+    );
+
+    const secondResult = await installStellarQuickstart(
+      {
+        binDirectory,
+        cacheDirectory,
+        cwd,
+        dockerBinary,
+      },
+      dependencies,
+    );
+
+    assert.equal(secondResult.cacheHit, true);
+    assert.equal(dependencies.pullCalls, 1);
+    assert.equal(dependencies.inspectCalls, 1);
+  });
+
+  it('rejects image digests that do not match the pinned default', async () => {
+    const cwd = createTempDir();
+    const cacheDirectory = join(cwd, '.metamask', 'cache');
+    const binDirectory = join(cwd, 'node_modules', '.bin');
+    const dockerBinary = createDockerStub(cwd);
+    const dependencies = createInstallDependencies({
+      digest: 'sha256:deadbeef',
+      dockerBinary,
+    });
+
+    await assert.rejects(
+      installStellarQuickstart(
+        {
+          binDirectory,
+          cacheDirectory,
+          cwd,
+          dockerBinary,
+        },
+        dependencies,
+      ),
+      /digest mismatch/u,
+    );
+  });
+
+  it('cleans only the stellar-quickstart-up cache namespace', async () => {
+    const cwd = createTempDir();
+    const cacheDirectory = join(cwd, '.metamask', 'cache');
+    const namespaceRoot = join(cacheDirectory, 'stellar-quickstart-up');
+    await mkdir(join(namespaceRoot, 'image', 'cache-key'), { recursive: true });
+    await mkdir(join(cacheDirectory, 'foundryup'), { recursive: true });
+
+    await cleanStellarQuickstartCache({ cacheDirectory, cwd });
+
+    assert.equal(existsSync(namespaceRoot), false);
+    assert.equal(existsSync(join(cacheDirectory, 'foundryup')), true);
+  });
+
+  it('forwards arguments through the installed wrapper', async () => {
+    const cwd = createTempDir();
+    const cacheDirectory = join(cwd, '.metamask', 'cache');
+    const binDirectory = join(cwd, 'node_modules', '.bin');
+    const dockerBinary = createDockerStub(cwd);
+    const dependencies = createInstallDependencies({
+      digest: STELLAR_QUICKSTART_DEFAULT_IMAGE.digest as string,
+      dockerBinary,
+    });
+
+    const result = await installStellarQuickstart(
+      {
+        binDirectory,
+        cacheDirectory,
+        cwd,
+        dockerBinary,
+      },
+      dependencies,
+    );
+
+    const output = execFileSync(result.binaryPath, ['--local'], {
+      encoding: 'utf8',
+    });
+
+    assert.match(output, /--local/u);
+    assert.match(output, /stellar\/quickstart:latest/u);
+  });
+
+  function createTempDir(): string {
+    const tempDir = mkdtempSync(join(tmpdir(), 'stellar-quickstart-up-'));
+    tempDirs.push(tempDir);
+    return tempDir;
+  }
+});
+
+function createDockerStub(cwd: string): string {
+  const dockerBinary = join(cwd, 'docker-stub');
+  writeFileSync(
+    dockerBinary,
+    `#!/usr/bin/env node
+const [,, command, ...args] = process.argv;
+if (command === 'version') {
+  process.exit(0);
+}
+if (command === 'pull') {
+  process.stdout.write('pulled ' + args.join(' '));
+  process.exit(0);
+}
+if (command === 'image') {
+  process.stdout.write('sha256:8ddf3ed87a5c07eab5202b0fd95f06fb5db3f48cacd7e69fdc0e22925f181168');
+  process.exit(0);
+}
+if (command === 'run') {
+  process.stdout.write(args.join(' '));
+  process.exit(0);
+}
+console.error('unexpected docker command', command, args.join(' '));
+process.exit(1);
+`,
+  );
+  chmodSync(dockerBinary, 0o755);
+  return dockerBinary;
+}
+
+function createInstallDependencies({
+  digest,
+  dockerBinary,
+}: {
+  digest: string;
+  dockerBinary: string;
+}): StellarQuickstartInstallDependencies & {
+  inspectCalls: number;
+  pullCalls: number;
+} {
+  const state = {
+    inspectCalls: 0,
+    pullCalls: 0,
+  };
+
+  return {
+    get inspectCalls(): number {
+      return state.inspectCalls;
+    },
+    get pullCalls(): number {
+      return state.pullCalls;
+    },
+    async inspectDockerImage(): Promise<string> {
+      state.inspectCalls += 1;
+      return digest;
+    },
+    async pullDockerImage(
+      binary: string,
+      imageReference: string,
+    ): Promise<void> {
+      state.pullCalls += 1;
+      assert.equal(binary, dockerBinary);
+      assert.equal(imageReference, 'stellar/quickstart:latest');
+    },
+    async runCommand(command: string, args: string[]): Promise<void> {
+      assert.equal(command, dockerBinary);
+      assert.deepEqual(args, ['version']);
+    },
+  };
+}

--- a/packages/stellar-quickstart-up/src/install.ts
+++ b/packages/stellar-quickstart-up/src/install.ts
@@ -1,0 +1,336 @@
+/* eslint-disable import-x/no-nodejs-modules, no-restricted-globals */
+import {
+  cleanInstallerCache,
+  getCacheKey,
+  getMetamaskCacheDirectory,
+  installExecutableWrapper,
+  readCliValue,
+  readPackageJsonToolConfig,
+  runCommand,
+} from '@metamask/local-node-utils';
+import { execFile } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+
+const STELLAR_QUICKSTART_CACHE_NAMESPACE = 'stellar-quickstart-up';
+const IMAGE_CACHE_NAMESPACE = 'image';
+
+export type StellarQuickstartImageConfig = {
+  digest?: string;
+  reference: string;
+  version: string;
+};
+
+export type StellarQuickstartInstallOptions = {
+  binDirectory?: string;
+  cacheDirectory?: string;
+  cwd?: string;
+  dockerBinary?: string;
+  image?: Partial<StellarQuickstartImageConfig>;
+  runArgs?: string[];
+};
+
+export type StellarQuickstartInstallResult = {
+  binaryPath: string;
+  cacheHit: boolean;
+  digest?: string;
+  imageReference: string;
+  version: string;
+};
+
+export type StellarQuickstartInstallDependencies = {
+  inspectDockerImage?: (
+    dockerBinary: string,
+    imageReference: string,
+  ) => Promise<string>;
+  pullDockerImage?: (
+    dockerBinary: string,
+    imageReference: string,
+  ) => Promise<void>;
+  runCommand?: typeof runCommand;
+};
+
+type StellarQuickstartPackageJsonConfig = Pick<
+  StellarQuickstartInstallOptions,
+  'binDirectory' | 'cacheDirectory' | 'image' | 'runArgs'
+>;
+
+export const STELLAR_QUICKSTART_DEFAULT_IMAGE: StellarQuickstartImageConfig = {
+  version: 'latest',
+  reference: 'stellar/quickstart:latest',
+  digest:
+    'sha256:8ddf3ed87a5c07eab5202b0fd95f06fb5db3f48cacd7e69fdc0e22925f181168',
+};
+
+export const STELLAR_QUICKSTART_DEFAULT_RUN_ARGS = [
+  'run',
+  '--rm',
+  '-i',
+  '-p',
+  '8000:8000',
+];
+
+export function getStellarQuickstartCacheDirectory({
+  cwd = process.cwd(),
+  homeDirectory,
+}: {
+  cwd?: string;
+  homeDirectory?: string;
+} = {}): string {
+  return getMetamaskCacheDirectory({
+    cwd,
+    homeDirectory,
+    toolName: STELLAR_QUICKSTART_CACHE_NAMESPACE,
+  });
+}
+
+export function readStellarQuickstartInstallOptionsFromPackageJson({
+  cwd = process.cwd(),
+  packageJsonPath = join(cwd, 'package.json'),
+}: {
+  cwd?: string;
+  packageJsonPath?: string;
+} = {}): StellarQuickstartInstallOptions {
+  const config = readPackageJsonToolConfig({
+    cwd,
+    packageJsonPath,
+    configKeys: [
+      'stellarQuickstartUp',
+      'stellarquickstartup',
+      'stellar-quickstart-up',
+    ],
+  }) as Partial<StellarQuickstartPackageJsonConfig>;
+  const options: StellarQuickstartInstallOptions = {};
+
+  if (config.binDirectory) {
+    options.binDirectory = config.binDirectory;
+  }
+  if (config.cacheDirectory) {
+    options.cacheDirectory = config.cacheDirectory;
+  }
+  if (config.image) {
+    options.image = config.image;
+  }
+  if (config.runArgs) {
+    options.runArgs = config.runArgs;
+  }
+
+  return options;
+}
+
+export function parseStellarQuickstartInstallCliOptions(
+  args: string[],
+): StellarQuickstartInstallOptions {
+  const options: StellarQuickstartInstallOptions = {};
+  const image: Partial<StellarQuickstartImageConfig> = {};
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    const value = args[index + 1];
+
+    switch (arg) {
+      case '--bin-directory':
+        options.binDirectory = readCliValue(arg, value);
+        index += 1;
+        break;
+      case '--cache-directory':
+        options.cacheDirectory = readCliValue(arg, value);
+        index += 1;
+        break;
+      case '--docker-binary':
+        options.dockerBinary = readCliValue(arg, value);
+        index += 1;
+        break;
+      case '--image-digest':
+        image.digest = readCliValue(arg, value);
+        index += 1;
+        break;
+      case '--image-reference':
+        image.reference = readCliValue(arg, value);
+        index += 1;
+        break;
+      default:
+        throw new Error(
+          `Unknown stellar-quickstart-up install option: ${arg}`,
+        );
+    }
+  }
+
+  if (image.reference || image.digest) {
+    options.image = image;
+  }
+
+  return options;
+}
+
+export async function installStellarQuickstart(
+  options: StellarQuickstartInstallOptions = {},
+  dependencies: StellarQuickstartInstallDependencies = {},
+): Promise<StellarQuickstartInstallResult> {
+  const cwd = options.cwd ?? process.cwd();
+  const cacheDirectory =
+    options.cacheDirectory ?? getStellarQuickstartCacheDirectory({ cwd });
+  const binDirectory =
+    options.binDirectory ?? join(cwd, 'node_modules', '.bin');
+  const dockerBinary = options.dockerBinary ?? 'docker';
+  const image = mergeImageConfig(
+    STELLAR_QUICKSTART_DEFAULT_IMAGE,
+    options.image,
+  );
+  const runArgs = options.runArgs ?? STELLAR_QUICKSTART_DEFAULT_RUN_ARGS;
+  const runCommandImpl = dependencies.runCommand ?? runCommand;
+  const pullDockerImage = dependencies.pullDockerImage ?? pullDockerImageDefault;
+  const inspectDockerImage =
+    dependencies.inspectDockerImage ?? inspectDockerImageDefault;
+
+  await runCommandImpl(dockerBinary, ['version']);
+
+  const imageResult = await installStellarQuickstartImage(
+    {
+      cacheDirectory,
+      dockerBinary,
+      image,
+    },
+    { inspectDockerImage, pullDockerImage },
+  );
+  const binaryPath = await installExecutableWrapper({
+    binDirectory,
+    commandName: 'stellar-quickstart',
+    executableArgs: [...runArgs, imageResult.imageReference],
+    executablePath: dockerBinary,
+    pathResolution: 'absolute',
+  });
+
+  return {
+    binaryPath,
+    cacheHit: imageResult.cacheHit,
+    digest: imageResult.digest,
+    imageReference: imageResult.imageReference,
+    version: image.version,
+  };
+}
+
+export async function cleanStellarQuickstartCache(
+  options: Pick<
+    StellarQuickstartInstallOptions,
+    'cacheDirectory' | 'cwd'
+  > = {},
+): Promise<void> {
+  const cwd = options.cwd ?? process.cwd();
+  const cacheDirectory =
+    options.cacheDirectory ?? getStellarQuickstartCacheDirectory({ cwd });
+
+  await cleanInstallerCache({
+    cacheDirectory,
+    namespace: STELLAR_QUICKSTART_CACHE_NAMESPACE,
+  });
+}
+
+function mergeImageConfig(
+  defaults: StellarQuickstartImageConfig,
+  override?: Partial<StellarQuickstartImageConfig>,
+): StellarQuickstartImageConfig {
+  return {
+    ...defaults,
+    ...override,
+  };
+}
+
+async function installStellarQuickstartImage(
+  {
+    cacheDirectory,
+    dockerBinary,
+    image,
+  }: {
+    cacheDirectory: string;
+    dockerBinary: string;
+    image: StellarQuickstartImageConfig;
+  },
+  dependencies: {
+    inspectDockerImage: (
+      dockerBinary: string,
+      imageReference: string,
+    ) => Promise<string>;
+    pullDockerImage: (
+      dockerBinary: string,
+      imageReference: string,
+    ) => Promise<void>;
+  },
+): Promise<{
+  cacheHit: boolean;
+  digest?: string;
+  imageReference: string;
+}> {
+  const cacheKey = getCacheKey({
+    checksum: image.digest ?? image.reference,
+    url: image.reference,
+  });
+  const cacheRoot = join(
+    cacheDirectory,
+    STELLAR_QUICKSTART_CACHE_NAMESPACE,
+    IMAGE_CACHE_NAMESPACE,
+    cacheKey,
+  );
+  const digestPath = join(cacheRoot, '.image-digest');
+  const referencePath = join(cacheRoot, '.image-reference');
+
+  if (
+    existsSync(digestPath) &&
+    existsSync(referencePath) &&
+    readFileSync(referencePath, 'utf8') === image.reference &&
+    (!image.digest || readFileSync(digestPath, 'utf8') === image.digest)
+  ) {
+    return {
+      cacheHit: true,
+      digest: readFileSync(digestPath, 'utf8'),
+      imageReference: image.reference,
+    };
+  }
+
+  await rm(cacheRoot, { force: true, recursive: true });
+  await mkdir(cacheRoot, { recursive: true });
+
+  await dependencies.pullDockerImage(dockerBinary, image.reference);
+  const digest = await dependencies.inspectDockerImage(
+    dockerBinary,
+    image.reference,
+  );
+
+  if (image.digest && digest !== image.digest) {
+    throw new Error(
+      `Stellar Quickstart image digest mismatch. Expected ${image.digest}, received ${digest}.`,
+    );
+  }
+
+  await writeFile(referencePath, image.reference);
+  await writeFile(digestPath, digest);
+
+  return {
+    cacheHit: false,
+    digest,
+    imageReference: image.reference,
+  };
+}
+
+async function pullDockerImageDefault(
+  dockerBinary: string,
+  imageReference: string,
+): Promise<void> {
+  await runCommand(dockerBinary, ['pull', imageReference]);
+}
+
+async function inspectDockerImageDefault(
+  dockerBinary: string,
+  imageReference: string,
+): Promise<string> {
+  const execFileAsync = promisify(execFile);
+  const { stdout } = await execFileAsync(
+    dockerBinary,
+    ['image', 'inspect', imageReference, '--format', '{{.Id}}'],
+    { encoding: 'utf8' },
+  );
+
+  return stdout.trim();
+}

--- a/packages/stellar-quickstart-up/tsconfig.build.json
+++ b/packages/stellar-quickstart-up/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.packages.build.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "references": [],
+  "include": ["../../types", "./src"]
+}

--- a/packages/stellar-quickstart-up/tsconfig.build.json
+++ b/packages/stellar-quickstart-up/tsconfig.build.json
@@ -5,6 +5,6 @@
     "outDir": "./dist",
     "rootDir": "./src"
   },
-  "references": [],
+  "references": [{ "path": "../local-node-utils/tsconfig.build.json" }],
   "include": ["../../types", "./src"]
 }

--- a/packages/stellar-quickstart-up/tsconfig.json
+++ b/packages/stellar-quickstart-up/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.packages.json",
+  "compilerOptions": {
+    "baseUrl": "./"
+  },
+  "references": [],
+  "include": ["../../types", "./src"]
+}

--- a/packages/stellar-quickstart-up/typedoc.json
+++ b/packages/stellar-quickstart-up/typedoc.json
@@ -1,0 +1,7 @@
+{
+  "entryPoints": ["./src/index.ts"],
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "out": "docs",
+  "tsconfig": "./tsconfig.build.json"
+}

--- a/teams.json
+++ b/teams.json
@@ -73,6 +73,7 @@
   "metamask/java-tron-up": "team-mobile-platform,team-extension-platform,team-networks",
   "metamask/local-node-utils": "team-mobile-platform,team-extension-platform,team-networks",
   "metamask/solana-test-validator-up": "team-mobile-platform,team-extension-platform,team-networks",
+  "metamask/stellar-quickstart-up": "team-mobile-platform,team-extension-platform,team-networks",
   "metamask/json-rpc-engine": "team-core-platform",
   "metamask/json-rpc-middleware-stream": "team-core-platform",
   "metamask/keyring-controller": "team-accounts-framework,team-core-platform",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -257,6 +257,9 @@
       "path": "./packages/solana-test-validator-up/tsconfig.build.json"
     },
     {
+      "path": "./packages/stellar-quickstart-up/tsconfig.build.json"
+    },
+    {
       "path": "./packages/storage-service/tsconfig.build.json"
     },
     {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -249,6 +249,9 @@
       "path": "./packages/solana-test-validator-up"
     },
     {
+      "path": "./packages/stellar-quickstart-up"
+    },
+    {
       "path": "./packages/subscription-controller"
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8637,6 +8637,7 @@ __metadata:
   resolution: "@metamask/stellar-quickstart-up@workspace:packages/stellar-quickstart-up"
   dependencies:
     "@metamask/auto-changelog": "npm:^6.1.0"
+    "@metamask/local-node-utils": "npm:^0.0.0"
     "@ts-bridge/cli": "npm:^0.6.4"
     "@types/jest": "npm:^29.5.14"
     deepmerge: "npm:^4.2.2"
@@ -8646,6 +8647,8 @@ __metadata:
     typedoc: "npm:^0.25.13"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:~5.3.3"
+  bin:
+    stellar-quickstart-up: ./dist/bin/stellar-quickstart-up.mjs
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8632,6 +8632,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/stellar-quickstart-up@workspace:packages/stellar-quickstart-up":
+  version: 0.0.0-use.local
+  resolution: "@metamask/stellar-quickstart-up@workspace:packages/stellar-quickstart-up"
+  dependencies:
+    "@metamask/auto-changelog": "npm:^6.1.0"
+    "@ts-bridge/cli": "npm:^0.6.4"
+    "@types/jest": "npm:^29.5.14"
+    deepmerge: "npm:^4.2.2"
+    jest: "npm:^29.7.0"
+    ts-jest: "npm:^29.2.5"
+    tsx: "npm:^4.20.5"
+    typedoc: "npm:^0.25.13"
+    typedoc-plugin-missing-exports: "npm:^2.0.0"
+    typescript: "npm:~5.3.3"
+  languageName: unknown
+  linkType: soft
+
 "@metamask/storage-service@npm:^1.0.1, @metamask/storage-service@npm:^1.0.2, @metamask/storage-service@workspace:packages/storage-service":
   version: 0.0.0-use.local
   resolution: "@metamask/storage-service@workspace:packages/storage-service"


### PR DESCRIPTION
## Explanation

Extension E2E tests need a local Stellar node bootstrap path comparable to the existing `java-tron-up`, `solana-test-validator-up`, and `bitcoin-regtest-up` packages. Stellar Quickstart runs as a Docker image (`stellar/quickstart`), so this adds a runtime-only installer that pulls a pinned image, caches metadata, and exposes a `stellar-quickstart` wrapper in `node_modules/.bin` for consuming harnesses to start and manage.

The PR includes both the `yarn create-package` scaffold (ownership wiring, monorepo references) and the implementation (`install.ts`, CLI `bin`, tests, README, changelog).

## References

* Jira Epic: [WPN-1509](https://consensyssoftware.atlassian.net/browse/WPN-1509) — [Extension] Expand Stellar's E2E test coverage
* Jira Task: [WPN-1510](https://consensyssoftware.atlassian.net/browse/WPN-1510) — Create Stellar Quickstart installer package "stellar-quickstart-up"
* Scaffold-only PR (stacked alternative): #9281

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

[WPN-1509]: https://consensyssoftware.atlassian.net/browse/WPN-1509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WPN-1510]: https://consensyssoftware.atlassian.net/browse/WPN-1510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ