### PR TITLE
chore: make `react-dom` and `react-native` optional peer dependencies

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -22,10 +22,6 @@ const config: KnipConfig = {
       // relative path that doesn't resolve inside this monorepo.
       ignoreUnresolved: [/^\.\.\/\.\.\/\.\.\/core\/Engine$/u],
     },
-    'packages/react-data-query': {
-      // Flagged due to knip bug, see https://github.com/webpro-nl/knip/issues/1823
-      ignoreDependencies: ['react-dom', 'react-native'],
-    },
 
     // -- Per-workspace `ignoreDependencies` snapshots --
     //

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -22,6 +22,10 @@ const config: KnipConfig = {
       // relative path that doesn't resolve inside this monorepo.
       ignoreUnresolved: [/^\.\.\/\.\.\/\.\.\/core\/Engine$/u],
     },
+    'packages/react-data-query': {
+      // Flagged due to knip bug, see https://github.com/webpro-nl/knip/issues/1823
+      ignoreDependencies: ['react-dom', 'react-native'],
+    },
 
     // -- Per-workspace `ignoreDependencies` snapshots --
     //

--- a/packages/react-data-query/CHANGELOG.md
+++ b/packages/react-data-query/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `@metamask/utils` from `^11.9.0` to `^11.11.0` ([#9074](https://github.com/MetaMask/core/pull/9074))
+- Make `react-dom` and `react-native` peer dependencies optional ([#9295](https://github.com/MetaMask/core/pull/9295))
 
 ## [0.2.1]
 

--- a/packages/react-data-query/package.json
+++ b/packages/react-data-query/package.json
@@ -73,6 +73,14 @@
     "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "react-native": "*"
   },
+  "peerDependenciesMeta": {
+    "react-dom": {
+      "optional": true
+    },
+    "react-native": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": "^18.18 || >=20"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8200,6 +8200,11 @@ __metadata:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     react-native: "*"
+  peerDependenciesMeta:
+    react-dom:
+      optional: true
+    react-native:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Explanation

The package `@metamask/react-data-query` has `react-dom` and `react-native` as `peerDependencies` because they are peer dependencies of a dependency this package uses, `@tanstack/react-query`. This "forwarding" of peer dependencies is something we started doing in our own packages because it better highlights the legitimate requirements of the package (transitive peer dependencies tend to not get surfaced by package managers when they're not met, you have to dig for it).

However, `@tanstack/react-query` has these two peer dependencies as _optional_, as they should be. We forgot to document them as optional.

This resolves an unnecessary peer dependency warning in `metamask-extension`.

## References

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only metadata change with no runtime or API changes.
> 
> **Overview**
> **`@metamask/react-data-query`** now declares **`react-dom`** and **`react-native`** as **optional** peer dependencies via `peerDependenciesMeta`, matching how **`@tanstack/react-query`** treats them while still forwarding those peers for consumers who need them.
> 
> The **Unreleased** changelog notes the change; **`yarn.lock`** reflects the updated workspace package metadata. **`react`** remains a required peer dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bca409ead931a7ffd07550d6e68ead21206c3f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->