### PR TITLE
feat(bridge-controller): expose metabridge discount type

### DIFF
--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `DiscountType` and expose `quote.feeData.metabridge.discountType` in quote validation ([#9305](https://github.com/MetaMask/core/pull/9305))
+
 ## [77.1.0]
 
 ### Added

--- a/packages/bridge-controller/src/index.ts
+++ b/packages/bridge-controller/src/index.ts
@@ -102,6 +102,7 @@ export {
 } from './types';
 
 export {
+  DiscountType,
   FeeType,
   ActionTypes,
   BridgeAssetSchema,

--- a/packages/bridge-controller/src/utils/validators.test.ts
+++ b/packages/bridge-controller/src/utils/validators.test.ts
@@ -516,9 +516,9 @@ describe('validators', () => {
     });
 
     it('rejects non-string discountType values', () => {
-      expect(
-        is({ ...metabridgeFee, discountType: 123 }, FeeDataSchema),
-      ).toBe(false);
+      expect(is({ ...metabridgeFee, discountType: 123 }, FeeDataSchema)).toBe(
+        false,
+      );
     });
   });
 
@@ -532,8 +532,7 @@ describe('validators', () => {
             feeData: {
               ...mockBridgeQuotesNativeErc20EthV1[0].quote.feeData,
               metabridge: {
-                ...mockBridgeQuotesNativeErc20EthV1[0].quote.feeData
-                  .metabridge,
+                ...mockBridgeQuotesNativeErc20EthV1[0].quote.feeData.metabridge,
                 discountType: DiscountType.PROMO,
               },
             },

--- a/packages/bridge-controller/src/utils/validators.test.ts
+++ b/packages/bridge-controller/src/utils/validators.test.ts
@@ -1,7 +1,11 @@
 import { is } from '@metamask/superstruct';
 
+import { mockBridgeQuotesNativeErc20EthV1 } from '../../tests/mock-quotes-native-erc20-eth';
 import {
+  DiscountType,
+  FeeDataSchema,
   validateFeatureFlagsResponse,
+  validateQuoteResponseV1,
   validateQuoteStreamComplete,
   QuoteStreamCompleteReason,
   IntentSchema,
@@ -485,6 +489,56 @@ describe('validators', () => {
           },
           IntentSchema,
         ),
+      ).toBe(true);
+    });
+  });
+
+  describe('FeeDataSchema', () => {
+    const metabridgeFee =
+      mockBridgeQuotesNativeErc20EthV1[0].quote.feeData.metabridge;
+
+    it.each([
+      ['absent', undefined],
+      ['null', null],
+      ['vip', DiscountType.VIP],
+      ['promo', DiscountType.PROMO],
+      ['dao', DiscountType.DAO],
+      ['future value', 'seasonal'],
+    ])('accepts %s discountType', (_label, discountType) => {
+      expect(
+        is(
+          discountType === undefined
+            ? metabridgeFee
+            : { ...metabridgeFee, discountType },
+          FeeDataSchema,
+        ),
+      ).toBe(true);
+    });
+
+    it('rejects non-string discountType values', () => {
+      expect(
+        is({ ...metabridgeFee, discountType: 123 }, FeeDataSchema),
+      ).toBe(false);
+    });
+  });
+
+  describe('validateQuoteResponseV1', () => {
+    it('accepts a quote with metabridge discountType', () => {
+      expect(
+        validateQuoteResponseV1({
+          ...mockBridgeQuotesNativeErc20EthV1[0],
+          quote: {
+            ...mockBridgeQuotesNativeErc20EthV1[0].quote,
+            feeData: {
+              ...mockBridgeQuotesNativeErc20EthV1[0].quote.feeData,
+              metabridge: {
+                ...mockBridgeQuotesNativeErc20EthV1[0].quote.feeData
+                  .metabridge,
+                discountType: DiscountType.PROMO,
+              },
+            },
+          },
+        }),
       ).toBe(true);
     });
   });

--- a/packages/bridge-controller/src/utils/validators.ts
+++ b/packages/bridge-controller/src/utils/validators.ts
@@ -31,6 +31,12 @@ export enum FeeType {
   TX_FEE = 'txFee',
 }
 
+export enum DiscountType {
+  VIP = 'vip',
+  PROMO = 'promo',
+  DAO = 'dao',
+}
+
 export enum ActionTypes {
   BRIDGE = 'bridge',
   SWAP = 'swap',
@@ -205,6 +211,7 @@ export const validateSwapsTokenObject = (
 export const FeeDataSchema = type({
   amount: TruthyDigitStringSchema,
   asset: BridgeAssetSchema,
+  discountType: optional(nullable(string())),
 });
 
 export const ProtocolSchema = type({


### PR DESCRIPTION
## Summary
- Expose known metabridge discount type values from the bridge-controller package.
- Allow `quote.feeData.metabridge.discountType` through quote validation as an optional nullable string so clients can handle future discount types without losing quotes.
- Add validator coverage for absent, null, known, future, and invalid discount type values plus full quote validation.

## Test plan
- `yarn workspace @metamask/bridge-controller test --runInBand --testPathPattern=src/utils/validators.test.ts --collectCoverage=false`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional schema field and public enum export; no changes to quote handling logic beyond accepting an extra fee field.
> 
> **Overview**
> Adds a **`DiscountType`** enum (`vip`, `promo`, `dao`) and exports it from `@metamask/bridge-controller` so clients can recognize known MetaBridge discount labels.
> 
> **`FeeDataSchema`** now accepts an optional, nullable **`discountType`** string on metabridge fee entries (`quote.feeData.metabridge.discountType`). Validation stays permissive—unknown future string values still pass—so quotes are not dropped when the API adds new discount types. **`FeeData`** types pick up the field via the existing schema inference.
> 
> Validator tests cover absent/null/known/future **`discountType`** values, rejection of non-strings, and full **`validateQuoteResponseV1`** with a promo discount. Changelog updated under Unreleased.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8373c0532a5acf039109342790348ac0b8122542. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->