### PR TITLE
chore(perps-controller): remove TAT ticket refs from comments

### DIFF
--- a/packages/perps-controller/src/PerpsController-method-action-types.ts
+++ b/packages/perps-controller/src/PerpsController-method-action-types.ts
@@ -547,7 +547,7 @@ export type PerpsControllerGetWithdrawalRoutesAction = {
 };
 
 /**
- * Set the transient UTM / discovery attribution context (TAT-3133, TAT-3140).
+ * Set the transient UTM / discovery attribution context.
  * Replaces any previously set context. Held in-memory only — not persisted.
  *
  * @param context - The attribution context (UTM fields) to store.
@@ -558,7 +558,7 @@ export type PerpsControllerSetAttributionContextAction = {
 };
 
 /**
- * Get a copy of the current attribution context (TAT-3133, TAT-3140).
+ * Get a copy of the current attribution context.
  *
  * @returns A shallow copy of the stored attribution context.
  */
@@ -568,7 +568,7 @@ export type PerpsControllerGetAttributionContextAction = {
 };
 
 /**
- * Clear the stored attribution context (TAT-3133, TAT-3140).
+ * Clear the stored attribution context.
  */
 export type PerpsControllerClearAttributionContextAction = {
   type: `PerpsController:clearAttributionContext`;

--- a/packages/perps-controller/src/PerpsController.ts
+++ b/packages/perps-controller/src/PerpsController.ts
@@ -937,7 +937,7 @@ export class PerpsController extends BaseController<
   readonly #priceDeviationLimit?: number;
 
   /**
-   * Transient UTM / discovery attribution context (TAT-3133, TAT-3140).
+   * Transient UTM / discovery attribution context.
    * Held in-memory only (never persisted in PerpsControllerState) and merged
    * into analytics event properties via {@link mergeAttributionContext}.
    */
@@ -3926,7 +3926,7 @@ export class PerpsController extends BaseController<
   }
 
   /**
-   * Set the transient UTM / discovery attribution context (TAT-3133, TAT-3140).
+   * Set the transient UTM / discovery attribution context.
    * Replaces any previously set context. Held in-memory only — not persisted.
    *
    * @param context - The attribution context (UTM fields) to store.
@@ -3936,7 +3936,7 @@ export class PerpsController extends BaseController<
   }
 
   /**
-   * Get a copy of the current attribution context (TAT-3133, TAT-3140).
+   * Get a copy of the current attribution context.
    *
    * @returns A shallow copy of the stored attribution context.
    */
@@ -3945,7 +3945,7 @@ export class PerpsController extends BaseController<
   }
 
   /**
-   * Clear the stored attribution context (TAT-3133, TAT-3140).
+   * Clear the stored attribution context.
    */
   clearAttributionContext(): void {
     this.#attributionContext = {};
@@ -3953,7 +3953,7 @@ export class PerpsController extends BaseController<
 
   /**
    * Merge the stored UTM attribution context into a set of analytics event
-   * properties (TAT-3133, TAT-3140). Only defined UTM fields are added, mapped
+   * properties. Only defined UTM fields are added, mapped
    * to their canonical PERPS_EVENT_PROPERTY keys. Provided properties take
    * precedence and are never overwritten.
    *

--- a/packages/perps-controller/src/constants/eventNames.ts
+++ b/packages/perps-controller/src/constants/eventNames.ts
@@ -119,7 +119,7 @@ export const PERPS_EVENT_PROPERTY = {
 
   // A/B testing properties (flat per test for multiple concurrent tests)
   // Only include AB test properties when test is enabled (event not sent when disabled)
-  // Button color test (TAT-1937)
+  // Button color test
   AB_TEST_BUTTON_COLOR: 'ab_test_button_color',
   // Future tests: add as AB_TEST_{TEST_NAME} (no _ENABLED property needed)
 
@@ -182,31 +182,31 @@ export const PERPS_EVENT_PROPERTY = {
   ABSTRACTION_MODE: 'abstraction_mode',
   PREVIOUS_ABSTRACTION_MODE: 'previous_abstraction_mode',
 
-  // Entry point / discovery attribution (TAT-3080)
+  // Entry point / discovery attribution
   ENTRY_POINT: 'entry_point',
   DISCOVERY_SOURCE: 'discovery_source',
   PERP_DISCOVERY_SOURCE: 'perp_discovery_source',
 
-  // UTM attribution context (TAT-3133, TAT-3140)
+  // UTM attribution context
   UTM_SOURCE: 'utm_source',
   UTM_MEDIUM: 'utm_medium',
   UTM_CAMPAIGN: 'utm_campaign',
   UTM_CONTENT: 'utm_content',
   UTM_TERM: 'utm_term',
 
-  // Watchlist membership at event time (TAT-3148)
+  // Watchlist membership at event time
   WATCHLISTED: 'watchlisted',
 
-  // HyperLiquid protocol fee rate on trade + close (TAT-3149)
+  // HyperLiquid protocol fee rate on trade + close
   HL_FEE_RATE: 'hl_fee_rate',
 
-  // Bulk action correlation id for batch close/cancel (TAT-3150)
+  // Bulk action correlation id for batch close/cancel
   BULK_ACTION_ID: 'bulk_action_id',
 
-  // Client environment (Extension supplies value) (TAT-3335)
+  // Client environment (Extension supplies value)
   ENVIRONMENT_TYPE: 'environment_type',
 
-  // Order funnel / consideration + quote properties (TAT-3084)
+  // Order funnel / consideration + quote properties
   ORDER_CONTEXT: 'order_context',
   ORDER_SIZE_PERCENT: 'order_size_percent',
   LIMIT_PRICE_INPUT_TYPE: 'limit_price_input_type',
@@ -227,19 +227,19 @@ export const PERPS_EVENT_PROPERTY = {
   TO_TOKEN: 'to_token',
   TO_CHAIN: 'to_chain',
 
-  // Search / discovery query properties (TAT-3144, TAT-3202, TAT-3151)
+  // Search / discovery query properties
   SEARCH_QUERY: 'search_query',
   RESULTS_COUNT: 'results_count',
   RESULT_RANK: 'result_rank',
   MODE: 'mode',
   CURRENT_TOKEN: 'current_token',
 
-  // Sort / filter properties (TAT-3142)
+  // Sort / filter properties
   SORT_FIELD: 'sort_field',
   SORT_DIRECTION: 'sort_direction',
   FILTER_CATEGORY: 'filter_category',
 
-  // Time-on-screen for abandon tracking (TAT-3136)
+  // Time-on-screen for abandon tracking
   TIME_ON_SCREEN_MS: 'time_on_screen_ms',
 } as const;
 
@@ -468,14 +468,14 @@ export const PERPS_EVENT_VALUE = {
     TPSL_ROE_SIGN_TOGGLED: 'tpsl_roe_sign_toggled',
     // Discovery analytics
     MARKET_LIST_FILTER: 'market_list_filter',
-    // Sort / filter interactions (TAT-3142)
+    // Sort / filter interactions
     SORT_APPLIED: 'sort_applied',
     FILTER_APPLIED: 'filter_applied',
-    // Search interactions (TAT-3144, TAT-3202)
+    // Search interactions
     SEARCH_RESULT_TAPPED: 'search_result_tapped',
     SEARCH_CHIP_TAPPED: 'search_chip_tapped',
     SEARCH_SIGNAL_TILE_TAPPED: 'search_signal_tile_tapped',
-    // Pay-with token selector dismissed (TAT-3151)
+    // Pay-with token selector dismissed
     PAYMENT_TOKEN_SELECTOR_DISMISSED: 'payment_token_selector_dismissed',
   },
   MAX_SLIPPAGE_SOURCE: {
@@ -561,7 +561,7 @@ export const PERPS_EVENT_VALUE = {
     COMPLIANCE_BLOCK_NOTIF: 'compliance_block_notif',
     // Deposit + order (pay-with token) cancel toast
     CANCEL_TRADE_WITH_TOKEN_TOAST: 'cancel_trade_with_token_toast',
-    // Search result screen states (TAT-3144)
+    // Search result screen states
     SEARCH_RESULTS_SHOWN: 'search_results_shown',
     SEARCH_NO_RESULTS: 'search_no_results',
   },
@@ -596,7 +596,7 @@ export const PERPS_EVENT_VALUE = {
     // Flip position actions with direction specificity
     FLIP_LONG_TO_SHORT: 'flip_long_to_short',
     FLIP_SHORT_TO_LONG: 'flip_short_to_long',
-    // Order funnel abandonment (TAT-3136)
+    // Order funnel abandonment
     ABANDON_ORDER: 'abandon_order',
   },
   // Risk management sources
@@ -641,7 +641,7 @@ export const PERPS_EVENT_VALUE = {
     WATCHLIST: 'watchlist',
     TOP_MOVERS: 'top_movers',
     WHATS_HAPPENING: 'whats_happening',
-    // Order + position management CTAs (TAT-3135, TAT-3141)
+    // Order + position management CTAs
     PLACE_ORDER: 'place_order',
     CLOSE: 'close',
     REDUCE_EXPOSURE: 'reduce_exposure',

--- a/packages/perps-controller/src/services/TradingService.ts
+++ b/packages/perps-controller/src/services/TradingService.ts
@@ -46,7 +46,7 @@ export type TradingServiceControllerDeps = {
 
 /**
  * Subset of tracking data carrying discovery attribution + hl_fee_rate that is
- * shared across trade/close/cancel/risk events (TAT-3080, TAT-3149). Both
+ * shared across trade/close/cancel/risk events. Both
  * {@link TrackingData} and {@link TPSLTrackingData} satisfy this shape.
  */
 type AttributionTrackingData = Pick<
@@ -117,7 +117,7 @@ export class TradingService {
 
   /**
    * Build discovery/attribution properties shared across trade/close/cancel/risk
-   * events (TAT-3080, TAT-3149). Each property is only included when present so
+   * events. Each property is only included when present so
    * that, in particular, hl_fee_rate is omitted entirely when unavailable.
    *
    * @param trackingData - Optional tracking data carried on the operation params.
@@ -145,8 +145,8 @@ export class TradingService {
   }
 
   /**
-   * Emit a transaction event with status=submitted before the provider round-trip
-   * (TAT-3134). Fired for trade, close, cancel and risk-management operations.
+   * Emit a transaction event with status=submitted before the provider round-trip.
+   * Fired for trade, close, cancel and risk-management operations.
    *
    * @param event - The analytics event name to emit.
    * @param properties - Additional event properties (asset, attribution, etc.).
@@ -303,7 +303,7 @@ export class TradingService {
       properties[PERPS_EVENT_PROPERTY.AB_TESTS] = params.trackingData.abTests;
     }
 
-    // Propagate discovery attribution + hl_fee_rate (TAT-3080, TAT-3149)
+    // Propagate discovery attribution + hl_fee_rate
     Object.assign(
       properties,
       this.#buildAttributionProperties(params.trackingData),
@@ -561,7 +561,7 @@ export class TradingService {
         },
       );
 
-      // Emit submitted event before the provider round-trip (TAT-3134)
+      // Emit submitted event before the provider round-trip
       this.#trackSubmitted(PerpsAnalyticsEvent.TradeTransaction, {
         [PERPS_EVENT_PROPERTY.ASSET]: params.symbol,
         [PERPS_EVENT_PROPERTY.DIRECTION]: params.isBuy
@@ -901,7 +901,7 @@ export class TradingService {
       ...(effectiveLeverage !== undefined && {
         [PERPS_EVENT_PROPERTY.LEVERAGE]: effectiveLeverage,
       }),
-      // Discovery attribution + hl_fee_rate (TAT-3080, TAT-3149)
+      // Discovery attribution + hl_fee_rate
       ...this.#buildAttributionProperties(params.trackingData),
     };
 
@@ -945,7 +945,7 @@ export class TradingService {
    * @param options.params - The operation parameters.
    * @param options.context - The service context for dependencies.
    * @param options.duration - Optional time duration.
-   * @param options.bulkActionId - Optional batch correlation id (TAT-3150).
+   * @param options.bulkActionId - Optional batch correlation id.
    */
   #trackPositionCloseResult(options: {
     position: Position | undefined;
@@ -958,7 +958,7 @@ export class TradingService {
   }): void {
     const { position, result, error, params, duration, bulkActionId } = options;
 
-    // Bulk action correlation id for batch close events (TAT-3150)
+    // Bulk action correlation id for batch close events
     const bulkActionProps: PerpsAnalyticsProperties = bulkActionId
       ? { [PERPS_EVENT_PROPERTY.BULK_ACTION_ID]: bulkActionId }
       : {};
@@ -1309,7 +1309,7 @@ export class TradingService {
    * @param options.provider - The perps provider instance.
    * @param options.params - The operation parameters.
    * @param options.context - The service context for dependencies.
-   * @param options.bulkActionId - Optional batch correlation id (TAT-3150).
+   * @param options.bulkActionId - Optional batch correlation id.
    * @returns The result of the operation.
    */
   async cancelOrder(options: {
@@ -1325,7 +1325,7 @@ export class TradingService {
       | { success: boolean; error?: string; orderId?: string }
       | undefined;
 
-    // Shared attribution + bulk correlation props (TAT-3080, TAT-3150)
+    // Shared attribution + bulk correlation props
     const cancelExtraProps: PerpsAnalyticsProperties = {
       ...this.#buildAttributionProperties(params.trackingData),
       ...(bulkActionId && {
@@ -1349,7 +1349,7 @@ export class TradingService {
         },
       });
 
-      // Emit submitted event before the provider round-trip (TAT-3134)
+      // Emit submitted event before the provider round-trip
       this.#trackSubmitted(PerpsAnalyticsEvent.OrderCancelTransaction, {
         [PERPS_EVENT_PROPERTY.ASSET]: params.symbol,
         ...cancelExtraProps,
@@ -1463,7 +1463,7 @@ export class TradingService {
   }): Promise<CancelOrdersResult> {
     const { provider, params, context, withStreamPause } = options;
     const traceId = uuidv4();
-    // Correlation id linking every per-item event to the batch summary (TAT-3150)
+    // Correlation id linking every per-item event to the batch summary
     const bulkActionId = uuidv4();
     const startTime = this.#deps.performance.now();
     let operationResult: CancelOrdersResult | null = null;
@@ -1652,7 +1652,7 @@ export class TradingService {
    * @param options.params - The operation parameters.
    * @param options.context - The service context for dependencies.
    * @param options.reportOrderToDataLake - The report order to data lake value.
-   * @param options.bulkActionId - Optional batch correlation id (TAT-3150).
+   * @param options.bulkActionId - Optional batch correlation id.
    * @returns The result of the operation.
    */
   async closePosition(options: {
@@ -1694,7 +1694,7 @@ export class TradingService {
         context,
       });
 
-      // Emit submitted event before the provider round-trip (TAT-3134)
+      // Emit submitted event before the provider round-trip
       this.#trackSubmitted(PerpsAnalyticsEvent.PositionCloseTransaction, {
         [PERPS_EVENT_PROPERTY.ASSET]: params.symbol,
         [PERPS_EVENT_PROPERTY.ORDER_TYPE]:
@@ -1825,7 +1825,7 @@ export class TradingService {
   }): Promise<ClosePositionsResult> {
     const { provider, params, context } = options;
     const traceId = uuidv4();
-    // Correlation id linking every per-item event to the batch summary (TAT-3150)
+    // Correlation id linking every per-item event to the batch summary
     const bulkActionId = uuidv4();
     const startTime = this.#deps.performance.now();
     let operationResult: ClosePositionsResult | null = null;
@@ -2059,7 +2059,7 @@ export class TradingService {
         },
       });
 
-      // Emit submitted event before the provider round-trip (TAT-3134)
+      // Emit submitted event before the provider round-trip
       this.#trackSubmitted(PerpsAnalyticsEvent.RiskManagement, {
         [PERPS_EVENT_PROPERTY.ASSET]: params.symbol,
         [PERPS_EVENT_PROPERTY.SOURCE]: source,
@@ -2168,7 +2168,7 @@ export class TradingService {
         ...(errorMessage && {
           [PERPS_EVENT_PROPERTY.ERROR_MESSAGE]: errorMessage,
         }),
-        // Discovery attribution (TAT-3080)
+        // Discovery attribution
         ...this.#buildAttributionProperties(params.trackingData),
       };
 
@@ -2404,7 +2404,7 @@ export class TradingService {
             [PERPS_EVENT_PROPERTY.COMPLETION_DURATION]: completionDuration,
             [PERPS_EVENT_PROPERTY.ACTION]: flipAction,
             [PERPS_EVENT_PROPERTY.ORDER_VALUE]: positionSize * executedPrice,
-            // MetaMask fee on flip trades (TAT-3146)
+            // MetaMask fee on flip trades
             ...(trackingData?.metamaskFee !== undefined && {
               [PERPS_EVENT_PROPERTY.METAMASK_FEE]: trackingData.metamaskFee,
             }),

--- a/packages/perps-controller/src/types/index.ts
+++ b/packages/perps-controller/src/types/index.ts
@@ -179,13 +179,13 @@ export type TrackingData = {
   // Chart library active when the trade was initiated (e.g., lightweight, advanced)
   chartLibrary?: string;
 
-  // Entry point / discovery attribution (TAT-3080). Propagated onto trade/close/
+  // Entry point / discovery attribution. Propagated onto trade/close/
   // cancel/risk events as entry_point, discovery_source, perp_discovery_source.
   entryPoint?: string;
   discoverySource?: string;
   perpDiscoverySource?: string;
 
-  // HyperLiquid protocol fee rate (TAT-3149). Emitted as hl_fee_rate on trade +
+  // HyperLiquid protocol fee rate. Emitted as hl_fee_rate on trade +
   // close events when present; omitted entirely when unavailable.
   hlFeeRate?: number;
 
@@ -208,7 +208,7 @@ export type TPSLTrackingData = {
   /**
    * @deprecated Source of the TP/SL update (e.g., 'tp_sl_view', 'position_card').
    * Prefer `entryPoint` / `discoverySource` / `perpDiscoverySource` for risk-event
-   * attribution (TAT-3080); `source` is retained for backward compatibility.
+   * attribution; `source` is retained for backward compatibility.
    */
   source: string;
   positionSize: number; // Unsigned position size for metrics
@@ -217,7 +217,7 @@ export type TPSLTrackingData = {
   isEditingExistingPosition?: boolean; // true = editing existing position, false = creating for new order
   entryPrice?: number; // Entry price for percentage calculations
 
-  // Entry point / discovery attribution (TAT-3080), propagated onto risk events.
+  // Entry point / discovery attribution, propagated onto risk events.
   entryPoint?: string;
   discoverySource?: string;
   perpDiscoverySource?: string;
@@ -1522,7 +1522,7 @@ export enum PerpsAnalyticsEvent {
   RiskManagement = 'Perp Risk Management',
   PerpsError = 'Perp Error',
   AccountSetup = 'Perp Account Setup',
-  // New funnel + search events (TAT-3084, TAT-3202).
+  // New funnel + search events.
   // Names must match MetaMetrics/Mixpanel exactly; no other event names may be added.
   TransactionConsidered = 'Perp Transaction Considered',
   TradeQuoteReceived = 'Perp Trade Quote Received',
@@ -1532,7 +1532,7 @@ export enum PerpsAnalyticsEvent {
 }
 
 /**
- * UTM / discovery attribution context for Perps analytics (TAT-3133, TAT-3140).
+ * UTM / discovery attribution context for Perps analytics.
  *
  * Held transiently in-memory by PerpsController (never persisted in state) and
  * merged into analytics event properties so client-originated UTM attribution

--- a/packages/perps-controller/tests/src/PerpsController.state.test.ts
+++ b/packages/perps-controller/tests/src/PerpsController.state.test.ts
@@ -504,7 +504,7 @@ describe('PerpsController', () => {
     mockInfrastructure.logger.error.mockClear();
     mockInfrastructure.debugLogger.log.mockClear();
   });
-  describe('attribution context (TAT-3463)', () => {
+  describe('attribution context', () => {
     it('returns an empty context by default', () => {
       expect(controller.getAttributionContext()).toStrictEqual({});
     });

--- a/packages/perps-controller/tests/src/constants/eventNames.test.ts
+++ b/packages/perps-controller/tests/src/constants/eventNames.test.ts
@@ -21,8 +21,8 @@ describe('PERPS_EVENT_PROPERTY', () => {
     });
   });
 
-  describe('consolidated analytics contract property keys (TAT-3463)', () => {
-    it('exports entry point / discovery attribution keys (TAT-3080)', () => {
+  describe('consolidated analytics contract property keys', () => {
+    it('exports entry point / discovery attribution keys', () => {
       expect(PERPS_EVENT_PROPERTY.ENTRY_POINT).toBe('entry_point');
       expect(PERPS_EVENT_PROPERTY.DISCOVERY_SOURCE).toBe('discovery_source');
       expect(PERPS_EVENT_PROPERTY.PERP_DISCOVERY_SOURCE).toBe(
@@ -30,7 +30,7 @@ describe('PERPS_EVENT_PROPERTY', () => {
       );
     });
 
-    it('exports UTM attribution keys (TAT-3133, TAT-3140)', () => {
+    it('exports UTM attribution keys', () => {
       expect(PERPS_EVENT_PROPERTY.UTM_SOURCE).toBe('utm_source');
       expect(PERPS_EVENT_PROPERTY.UTM_MEDIUM).toBe('utm_medium');
       expect(PERPS_EVENT_PROPERTY.UTM_CAMPAIGN).toBe('utm_campaign');
@@ -45,7 +45,7 @@ describe('PERPS_EVENT_PROPERTY', () => {
       expect(PERPS_EVENT_PROPERTY.ENVIRONMENT_TYPE).toBe('environment_type');
     });
 
-    it('exports order funnel / quote keys (TAT-3084)', () => {
+    it('exports order funnel / quote keys', () => {
       expect(PERPS_EVENT_PROPERTY.ORDER_CONTEXT).toBe('order_context');
       expect(PERPS_EVENT_PROPERTY.ORDER_SIZE_PERCENT).toBe(
         'order_size_percent',
@@ -81,7 +81,7 @@ describe('PERPS_EVENT_PROPERTY', () => {
       expect(PERPS_EVENT_PROPERTY.TO_CHAIN).toBe('to_chain');
     });
 
-    it('exports search keys (TAT-3144, TAT-3202, TAT-3151)', () => {
+    it('exports search keys', () => {
       expect(PERPS_EVENT_PROPERTY.SEARCH_QUERY).toBe('search_query');
       expect(PERPS_EVENT_PROPERTY.RESULTS_COUNT).toBe('results_count');
       expect(PERPS_EVENT_PROPERTY.RESULT_RANK).toBe('result_rank');
@@ -89,7 +89,7 @@ describe('PERPS_EVENT_PROPERTY', () => {
       expect(PERPS_EVENT_PROPERTY.CURRENT_TOKEN).toBe('current_token');
     });
 
-    it('exports sort / filter and time-on-screen keys (TAT-3142, TAT-3136)', () => {
+    it('exports sort / filter and time-on-screen keys', () => {
       expect(PERPS_EVENT_PROPERTY.SORT_FIELD).toBe('sort_field');
       expect(PERPS_EVENT_PROPERTY.SORT_DIRECTION).toBe('sort_direction');
       expect(PERPS_EVENT_PROPERTY.FILTER_CATEGORY).toBe('filter_category');
@@ -334,8 +334,8 @@ describe('PERPS_EVENT_VALUE.BUTTON_LOCATION extensions', () => {
   });
 });
 
-describe('PERPS_EVENT_VALUE consolidated contract entries (TAT-3463)', () => {
-  it('exports new INTERACTION_TYPE values (TAT-3142, TAT-3144, TAT-3202, TAT-3151)', () => {
+describe('PERPS_EVENT_VALUE consolidated contract entries', () => {
+  it('exports new INTERACTION_TYPE values', () => {
     expect(PERPS_EVENT_VALUE.INTERACTION_TYPE.SORT_APPLIED).toBe(
       'sort_applied',
     );
@@ -359,11 +359,11 @@ describe('PERPS_EVENT_VALUE consolidated contract entries (TAT-3463)', () => {
     );
   });
 
-  it('exports ACTION.ABANDON_ORDER (TAT-3136)', () => {
+  it('exports ACTION.ABANDON_ORDER', () => {
     expect(PERPS_EVENT_VALUE.ACTION.ABANDON_ORDER).toBe('abandon_order');
   });
 
-  it('exports new BUTTON_CLICKED values (TAT-3135, TAT-3141)', () => {
+  it('exports new BUTTON_CLICKED values', () => {
     expect(PERPS_EVENT_VALUE.BUTTON_CLICKED.PLACE_ORDER).toBe('place_order');
     expect(PERPS_EVENT_VALUE.BUTTON_CLICKED.CLOSE).toBe('close');
     expect(PERPS_EVENT_VALUE.BUTTON_CLICKED.REDUCE_EXPOSURE).toBe(
@@ -371,24 +371,24 @@ describe('PERPS_EVENT_VALUE consolidated contract entries (TAT-3463)', () => {
     );
   });
 
-  it('exports new SCREEN_TYPE values and keeps add/remove margin (TAT-3144, TAT-3145)', () => {
+  it('exports new SCREEN_TYPE values and keeps add/remove margin', () => {
     expect(PERPS_EVENT_VALUE.SCREEN_TYPE.SEARCH_RESULTS_SHOWN).toBe(
       'search_results_shown',
     );
     expect(PERPS_EVENT_VALUE.SCREEN_TYPE.SEARCH_NO_RESULTS).toBe(
       'search_no_results',
     );
-    // add_margin / remove_margin already existed — verify still present (TAT-3145)
+    // add_margin / remove_margin already existed — verify still present
     expect(PERPS_EVENT_VALUE.SCREEN_TYPE.ADD_MARGIN).toBe('add_margin');
     expect(PERPS_EVENT_VALUE.SCREEN_TYPE.REMOVE_MARGIN).toBe('remove_margin');
   });
 
-  it('keeps STATUS.SUBMITTED for transaction pipeline events (TAT-3134)', () => {
+  it('keeps STATUS.SUBMITTED for transaction pipeline events', () => {
     expect(PERPS_EVENT_VALUE.STATUS.SUBMITTED).toBe('submitted');
   });
 });
 
-describe('PerpsAnalyticsEvent (TAT-3463)', () => {
+describe('PerpsAnalyticsEvent', () => {
   it('adds exactly the five new event names and keeps the nine existing', () => {
     expect(PerpsAnalyticsEvent.TransactionConsidered).toBe(
       'Perp Transaction Considered',

--- a/packages/perps-controller/tests/src/services/TradingService.test.ts
+++ b/packages/perps-controller/tests/src/services/TradingService.test.ts
@@ -2559,7 +2559,7 @@ describe('TradingService', () => {
     });
   });
 
-  describe('consolidated analytics pipeline (TAT-3463)', () => {
+  describe('consolidated analytics pipeline', () => {
     const mockClosePosition: Position = {
       symbol: 'BTC',
       size: '0.5',
@@ -2582,7 +2582,7 @@ describe('TradingService', () => {
           calledEvent === event && props.status === status,
       );
 
-    describe('status=submitted before provider round-trip (TAT-3134)', () => {
+    describe('status=submitted before provider round-trip', () => {
       it('emits a submitted trade event before placeOrder', async () => {
         mockProvider.placeOrder.mockResolvedValue({
           success: true,
@@ -2732,7 +2732,7 @@ describe('TradingService', () => {
       ).toEqual(expect.objectContaining({ asset: 'BTC', status: 'executed' }));
     });
 
-    it('populates metamask_fee on flip success from trackingData (TAT-3146)', async () => {
+    it('populates metamask_fee on flip success from trackingData', async () => {
       mockProvider.placeOrder.mockResolvedValue({
         success: true,
         orderId: 'flip-1',
@@ -2834,7 +2834,7 @@ describe('TradingService', () => {
       expect(closeProps?.leverage).toBeUndefined();
     });
 
-    describe('hl_fee_rate on trade + close (TAT-3149)', () => {
+    describe('hl_fee_rate on trade + close', () => {
       it('includes hl_fee_rate when present in trackingData', async () => {
         mockProvider.placeOrder.mockResolvedValue({
           success: true,
@@ -3237,7 +3237,7 @@ describe('TradingService', () => {
       });
     });
 
-    describe('bulk_action_id on batch close/cancel (TAT-3150)', () => {
+    describe('bulk_action_id on batch close/cancel', () => {
       it('attaches bulk_action_id to the batch close summary event', async () => {
         mockGetPositions.mockResolvedValue([mockClosePosition]);
         (mockProvider.closePositions as jest.Mock).mockResolvedValue({
@@ -3322,7 +3322,7 @@ describe('TradingService', () => {
       });
     });
 
-    it('propagates entry_point/discovery_source/perp_discovery_source on trade events (TAT-3080)', async () => {
+    it('propagates entry_point/discovery_source/perp_discovery_source on trade events', async () => {
       mockProvider.placeOrder.mockResolvedValue({
         success: true,
         orderId: 'order-1',


### PR DESCRIPTION
## Summary

- Removes internal Jira ticket IDs (`TAT-XXXX`) from perps-controller comments, JSDoc, and test names added in #9311
- Keeps the descriptive comment text unchanged; no runtime or API behavior changes

Follow-up to #9311 — the cleanup commit that was left off the merged branch.

## Test plan

- [x] `yarn eslint` on the 8 changed files — clean
- [x] Comment-only diff; no logic changes

Made with [Cursor](https://cursor.com)

