### PR TITLE
feat(perps-controller): add TP/SL RoE sign analytics constants (TAT-3429)

### DIFF
--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add Auto Close TP/SL RoE sign toggle analytics constants to `PERPS_EVENT_PROPERTY` and `PERPS_EVENT_VALUE` so mobile and extension can import them from `@metamask/perps-controller` instead of local mirrors ([TAT-3429](https://consensyssoftware.atlassian.net/browse/TAT-3429))
+  - New `PERPS_EVENT_PROPERTY` key: `ROE_SIGN` (`roe_sign`)
+  - New `PERPS_EVENT_VALUE.INTERACTION_TYPE` entry: `TPSL_ROE_SIGN_TOGGLED` (`tpsl_roe_sign_toggled`)
 - Consolidate the Perps analytics contract so clients import a single source of truth from `@metamask/perps-controller` ([#9311](https://github.com/MetaMask/core/pull/9311))
   - Add five new `PerpsAnalyticsEvent` members: `TransactionConsidered` (`Perp Transaction Considered`), `TradeQuoteReceived` (`Perp Trade Quote Received`), `SearchQuery` (`Perp Search Query`), `SearchResultTapped` (`Perp Search Result Tapped`), `SearchAbandoned` (`Perp Search Abandoned`)
   - Add new `PERPS_EVENT_PROPERTY` keys: `entry_point`, `discovery_source`, `perp_discovery_source`, `utm_source`, `utm_medium`, `utm_campaign`, `utm_content`, `utm_term`, `watchlisted`, `hl_fee_rate`, `bulk_action_id`, `environment_type`, `order_context`, `order_size_percent`, `limit_price_input_type`, `limit_price_input_preset`, `order_has_tp`, `order_has_sl`, `quote_latency_ms`, `error_reason`, `saved_order`, `default_payment_token`, `default_size_amount`, `default_leverage`, `default_auto_close`, `order_execution_latency_ms`, `screen_context`, `from_token`, `from_chain`, `to_token`, `to_chain`, `search_query`, `results_count`, `result_rank`, `mode`, `current_token`, `sort_field`, `sort_direction`, `filter_category`, `time_on_screen_ms`

--- a/packages/perps-controller/src/constants/eventNames.ts
+++ b/packages/perps-controller/src/constants/eventNames.ts
@@ -140,6 +140,8 @@ export const PERPS_EVENT_PROPERTY = {
   HAS_STOP_LOSS: 'has_stop_loss',
   TAKE_PROFIT_PERCENTAGE: 'take_profit_percentage',
   STOP_LOSS_PERCENTAGE: 'stop_loss_percentage',
+  // Auto Close TP/SL RoE sign toggle (`'+'` | `'-'`)
+  ROE_SIGN: 'roe_sign',
   // Watchlist/Favorites properties
   FAVORITES_COUNT: 'favorites_count',
 
@@ -454,6 +456,8 @@ export const PERPS_EVENT_VALUE = {
     SLIPPAGE_CONFIG_OPENED: 'slippage_config_opened',
     SLIPPAGE_CONFIG_CHANGED: 'slippage_config_changed',
     SLIPPAGE_LIMIT_BLOCKED_ORDER: 'slippage_limit_blocked_order',
+    // Auto Close TP/SL RoE sign toggle
+    TPSL_ROE_SIGN_TOGGLED: 'tpsl_roe_sign_toggled',
     // Discovery analytics
     MARKET_LIST_FILTER: 'market_list_filter',
     // Sort / filter interactions (TAT-3142)

--- a/packages/perps-controller/tests/src/constants/eventNames.test.ts
+++ b/packages/perps-controller/tests/src/constants/eventNames.test.ts
@@ -15,6 +15,12 @@ describe('PERPS_EVENT_PROPERTY', () => {
     });
   });
 
+  describe('Auto Close TP/SL RoE sign analytics keys', () => {
+    it('exports ROE_SIGN property key', () => {
+      expect(PERPS_EVENT_PROPERTY.ROE_SIGN).toBe('roe_sign');
+    });
+  });
+
   describe('consolidated analytics contract property keys (TAT-3463)', () => {
     it('exports entry point / discovery attribution keys (TAT-3080)', () => {
       expect(PERPS_EVENT_PROPERTY.ENTRY_POINT).toBe('entry_point');
@@ -348,6 +354,9 @@ describe('PERPS_EVENT_VALUE consolidated contract entries (TAT-3463)', () => {
     expect(
       PERPS_EVENT_VALUE.INTERACTION_TYPE.PAYMENT_TOKEN_SELECTOR_DISMISSED,
     ).toBe('payment_token_selector_dismissed');
+    expect(PERPS_EVENT_VALUE.INTERACTION_TYPE.TPSL_ROE_SIGN_TOGGLED).toBe(
+      'tpsl_roe_sign_toggled',
+    );
   });
 
   it('exports ACTION.ABANDON_ORDER (TAT-3136)', () => {


### PR DESCRIPTION
## Summary

Adds the [TAT-3429](https://consensyssoftware.atlassian.net/browse/TAT-3429) analytics constants to `@metamask/perps-controller` so mobile/extension can replace interim local mirrors (`perpsEventsLocal.ts`) after release:

- `PERPS_EVENT_PROPERTY.ROE_SIGN` → `roe_sign`
- `PERPS_EVENT_VALUE.INTERACTION_TYPE.TPSL_ROE_SIGN_TOGGLED` → `tpsl_roe_sign_toggled`

No runtime behavior changes — contract/constants only. Event emission remains client-side (`Perp UI Interaction`).

## Follow-up

- [TAT-3430](https://consensyssoftware.atlassian.net/browse/TAT-3430): Mobile + Extension bump dep and replace local constants

## Test plan

- [x] `yarn workspace @metamask/perps-controller jest tests/src/constants/eventNames.test.ts --no-coverage`


Made with [Cursor](https://cursor.com)

[TAT-3429]: https://consensyssoftware.atlassian.net/browse/TAT-3429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TAT-3430]: https://consensyssoftware.atlassian.net/browse/TAT-3430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ