### PR TITLE
feat(perps-controller): add TP/SL RoE sign analytics constants

### DIFF
--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add Auto Close TP/SL RoE sign toggle analytics constants to `PERPS_EVENT_PROPERTY` and `PERPS_EVENT_VALUE` so mobile and extension can import them from `@metamask/perps-controller` instead of local mirrors ([TAT-3429](https://consensyssoftware.atlassian.net/browse/TAT-3429), [#9322](https://github.com/MetaMask/core/pull/9322))
+- Add Auto Close TP/SL RoE sign toggle analytics constants to `PERPS_EVENT_PROPERTY` and `PERPS_EVENT_VALUE` so mobile and extension can import them from `@metamask/perps-controller` instead of local mirrors ([#9322](https://github.com/MetaMask/core/pull/9322))
   - New `PERPS_EVENT_PROPERTY` key: `ROE_SIGN` (`roe_sign`)
   - New `PERPS_EVENT_VALUE.INTERACTION_TYPE` entry: `TPSL_ROE_SIGN_TOGGLED` (`tpsl_roe_sign_toggled`)
 - Add `listedAt` (epoch ms) to `PerpsMarketData` and `TerminalAssetMetadata`, sourced from the Terminal API and normalized from either a numeric epoch value or an ISO 8601 string. Clients can use this field to surface recently added markets (e.g. markets listed within the last 30 days). ([#9308](https://github.com/MetaMask/core/pull/9308))

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add Auto Close TP/SL RoE sign toggle analytics constants to `PERPS_EVENT_PROPERTY` and `PERPS_EVENT_VALUE` so mobile and extension can import them from `@metamask/perps-controller` instead of local mirrors ([TAT-3429](https://consensyssoftware.atlassian.net/browse/TAT-3429), [#9322](https://github.com/MetaMask/core/pull/9322))
+  - New `PERPS_EVENT_PROPERTY` key: `ROE_SIGN` (`roe_sign`)
+  - New `PERPS_EVENT_VALUE.INTERACTION_TYPE` entry: `TPSL_ROE_SIGN_TOGGLED` (`tpsl_roe_sign_toggled`)
 - Add `listedAt` (epoch ms) to `PerpsMarketData` and `TerminalAssetMetadata`, sourced from the Terminal API and normalized from either a numeric epoch value or an ISO 8601 string. Clients can use this field to surface recently added markets (e.g. markets listed within the last 30 days). ([#9308](https://github.com/MetaMask/core/pull/9308))
 - Add recently viewed markets tracking to `PerpsController`: ([#9308](https://github.com/MetaMask/core/pull/9308))
   - New `recentlyViewedMarkets` persisted state (per-network: `testnet`/`mainnet`), containing `{ symbol, viewedAt }` entries ordered newest-first and capped at 10.

--- a/packages/perps-controller/src/constants/eventNames.ts
+++ b/packages/perps-controller/src/constants/eventNames.ts
@@ -140,6 +140,8 @@ export const PERPS_EVENT_PROPERTY = {
   HAS_STOP_LOSS: 'has_stop_loss',
   TAKE_PROFIT_PERCENTAGE: 'take_profit_percentage',
   STOP_LOSS_PERCENTAGE: 'stop_loss_percentage',
+  // Auto Close TP/SL RoE sign toggle (`'+'` | `'-'`)
+  ROE_SIGN: 'roe_sign',
   // Watchlist/Favorites properties
   FAVORITES_COUNT: 'favorites_count',
 
@@ -454,6 +456,8 @@ export const PERPS_EVENT_VALUE = {
     SLIPPAGE_CONFIG_OPENED: 'slippage_config_opened',
     SLIPPAGE_CONFIG_CHANGED: 'slippage_config_changed',
     SLIPPAGE_LIMIT_BLOCKED_ORDER: 'slippage_limit_blocked_order',
+    // Auto Close TP/SL RoE sign toggle
+    TPSL_ROE_SIGN_TOGGLED: 'tpsl_roe_sign_toggled',
     // Discovery analytics
     MARKET_LIST_FILTER: 'market_list_filter',
     // Sort / filter interactions (TAT-3142)

--- a/packages/perps-controller/tests/src/constants/eventNames.test.ts
+++ b/packages/perps-controller/tests/src/constants/eventNames.test.ts
@@ -15,6 +15,12 @@ describe('PERPS_EVENT_PROPERTY', () => {
     });
   });
 
+  describe('Auto Close TP/SL RoE sign analytics keys', () => {
+    it('exports ROE_SIGN property key', () => {
+      expect(PERPS_EVENT_PROPERTY.ROE_SIGN).toBe('roe_sign');
+    });
+  });
+
   describe('consolidated analytics contract property keys (TAT-3463)', () => {
     it('exports entry point / discovery attribution keys (TAT-3080)', () => {
       expect(PERPS_EVENT_PROPERTY.ENTRY_POINT).toBe('entry_point');
@@ -348,6 +354,9 @@ describe('PERPS_EVENT_VALUE consolidated contract entries (TAT-3463)', () => {
     expect(
       PERPS_EVENT_VALUE.INTERACTION_TYPE.PAYMENT_TOKEN_SELECTOR_DISMISSED,
     ).toBe('payment_token_selector_dismissed');
+    expect(PERPS_EVENT_VALUE.INTERACTION_TYPE.TPSL_ROE_SIGN_TOGGLED).toBe(
+      'tpsl_roe_sign_toggled',
+    );
   });
 
   it('exports ACTION.ABANDON_ORDER (TAT-3136)', () => {


### PR DESCRIPTION
## Explanation

Mobile ships Auto Close TP/SL RoE sign toggle analytics using interim local constants in `perpsEventsLocal.ts` (`tpsl_roe_sign_toggled`, `roe_sign`) because these keys were not yet in the published `@metamask/perps-controller` contract. After #9311 consolidated the analytics contract in core, this small gap remained for the RoE sign toggle interaction.

This PR adds the missing shared constants to `@metamask/perps-controller` so clients can import typed values instead of maintaining local mirrors:

- `PERPS_EVENT_PROPERTY.ROE_SIGN` → `roe_sign` (the toggled sign: `'+'` | `'-'`)
- `PERPS_EVENT_VALUE.INTERACTION_TYPE.TPSL_ROE_SIGN_TOGGLED` → `tpsl_roe_sign_toggled`

No controller or runtime behavior changes — event emission stays client-side (`Perp UI Interaction`). Only the contract/constants surface is extended.

## References

- https://consensyssoftware.atlassian.net/browse/TAT-3429
- Follow-up client wiring: https://consensyssoftware.atlassian.net/browse/TAT-3430 (Mobile + Extension replace `perpsEventsLocal.ts` after package release)
- Builds on analytics consolidation: #9311

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them — N/A: additive constants only

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive analytics constants only; no runtime, auth, or trading behavior changes.
> 
> **Overview**
> Extends the shared Perps analytics contract in `@metamask/perps-controller` with constants for **Auto Close TP/SL RoE sign toggle** events, so mobile and extension can drop local mirrors (`perpsEventsLocal.ts`) and import typed keys from core.
> 
> Adds **`PERPS_EVENT_PROPERTY.ROE_SIGN`** (`roe_sign`) for the toggled sign (`'+'` | `'-'`) and **`PERPS_EVENT_VALUE.INTERACTION_TYPE.TPSL_ROE_SIGN_TOGGLED`** (`tpsl_roe_sign_toggled`). Changelog and `eventNames` tests assert the new exports; **no controller or emission logic** changes in this package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f933d8821646ab3814497a4073ad6aad12778e3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->