### PR TITLE
feat(messenger): Add `buildChild` utility

### DIFF
--- a/packages/messenger/CHANGELOG.md
+++ b/packages/messenger/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `Messenger.getRegisteredActionTypes` method, which returns the action types the messenger can call directly ([#9271](https://github.com/MetaMask/core/pull/9271))
+- Add a `buildChild` utility method to `Messenger` ([#9338](https://github.com/MetaMask/core/pull/9338))
 
 ### Changed
 

--- a/packages/messenger/src/Messenger.test.ts
+++ b/packages/messenger/src/Messenger.test.ts
@@ -409,6 +409,42 @@ describe('Messenger', () => {
     });
   });
 
+  describe('buildChild', () => {
+    it('delegates actions to children', () => {
+      type PingAction = { type: 'Fixture:ping'; handler: () => string };
+      const messenger = new Messenger<MockAnyNamespace, PingAction, never>({
+        namespace: MOCK_ANY_NAMESPACE,
+      });
+
+      messenger.registerActionHandler('Fixture:ping', () => 'pong');
+
+      const childMessenger = messenger.buildChild({
+        namespace: 'ChildMessenger',
+        actions: ['Fixture:ping'],
+      });
+
+      expect(childMessenger.call('Fixture:ping')).toBe('pong');
+    });
+
+    it('delegates events to children', () => {
+      type MessageEvent = { type: 'Fixture:message'; payload: [string] };
+      const messenger = new Messenger<MockAnyNamespace, never, MessageEvent>({
+        namespace: MOCK_ANY_NAMESPACE,
+      });
+
+      const childMessenger = messenger.buildChild({
+        namespace: 'ChildMessenger',
+        events: ['Fixture:message'],
+      });
+
+      const handler = jest.fn();
+      childMessenger.subscribe('Fixture:message', handler);
+      messenger.publish('Fixture:message', 'hello');
+
+      expect(handler).toHaveBeenCalledWith('hello');
+    });
+  });
+
   describe('publish and subscribe', () => {
     it('publishes event to subscriber', () => {
       type MessageEvent = { type: 'Fixture:message'; payload: [string] };

--- a/packages/messenger/src/Messenger.ts
+++ b/packages/messenger/src/Messenger.ts
@@ -432,6 +432,47 @@ export class Messenger<
   }
 
   /**
+   * Create a new child messenger that automatically is delegated the specified actions/events from this messenger.
+   *
+   * @param args - Arguments.
+   * @param args.namespace - The child messenger namespace.
+   * @param args.actions - A list of action types to delegate to the child messenger.
+   * @param args.events - A list of event types to delegate to the child messenger.
+   * @returns The child messenger.
+   */
+  buildChild<
+    ChildNamespace extends string,
+    ChildAction extends Action,
+    ChildEvent extends Event,
+  >({
+    namespace,
+    actions,
+    events,
+  }: {
+    namespace: ChildNamespace;
+    actions?: ChildAction['type'][];
+    events?: ChildEvent['type'][];
+  }): Messenger<ChildNamespace, ChildAction, ChildEvent> {
+    const childMessenger = new Messenger<
+      ChildNamespace,
+      ChildAction,
+      ChildEvent,
+      typeof this
+    >({
+      namespace,
+      parent: this,
+    });
+
+    this.delegate({
+      messenger: childMessenger,
+      actions,
+      events,
+    });
+
+    return childMessenger;
+  }
+
+  /**
    * Call an action.
    *
    * This function will call the action handler corresponding to the given action type, passing

--- a/packages/messenger/src/Messenger.ts
+++ b/packages/messenger/src/Messenger.ts
@@ -432,7 +432,8 @@ export class Messenger<
   }
 
   /**
-   * Create a new child messenger that automatically is delegated the specified actions/events from this messenger.
+   * Create a new messenger as a child of this messenger (the "parent").
+   * All actions/events are delegated from the child to the parent, and the specified actions/events are delegated from the parent to the child.
    *
    * @param args - Arguments.
    * @param args.namespace - The child messenger namespace.

--- a/packages/messenger/src/Messenger.ts
+++ b/packages/messenger/src/Messenger.ts
@@ -460,6 +460,8 @@ export class Messenger<
       typeof this
     >({
       namespace,
+      // @ts-expect-error TypeScript cannot correctly infer this, but should be safe
+      // given `ChildAction extends Action` and `ChildEvent extends Event`.
       parent: this,
     });
 


### PR DESCRIPTION
## Explanation

Add `buildChild` utility method to `Messenger`, simplifying the creation of child messengers with automatic delegation.

## References

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API wrapping existing parent/delegate behavior with no changes to core messenger logic.
> 
> **Overview**
> Adds **`Messenger.buildChild`**, a helper that creates a child messenger wired to the current instance as parent and immediately **`delegate`s** the optional `actions` and `events` lists to that child.
> 
> Callers no longer need to manually construct a child with `parent: this` and call `delegate` separately. Child-to-parent delegation still comes from the existing constructor behavior; tests cover delegated **`call`** and **`subscribe`** / **`publish`** for actions and events. The messenger package changelog records the addition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70d4502928cf23847869d64e5b3d1d295c2225e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->