### PR TITLE
fix: revert unpublished "release/1087.0.0 (#9342)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "1087.0.0",
+  "version": "1086.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {

--- a/packages/authenticated-user-storage/CHANGELOG.md
+++ b/packages/authenticated-user-storage/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.0.0]
-
 ### Added
 
 - Add `PriceAlertPreference` type, required `priceAlerts` field on `NotificationPreferences`, and `DEFAULT_PRICE_ALERT_PREFERENCES` constant ([#9316](https://github.com/MetaMask/core/pull/9316))
@@ -63,8 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **BREAKING**: Rename `SocialAIPreference.traderProfileIds` to `mutedTraderProfileIds` in types and notification-preferences validation to match the API payload. ([#8536](https://github.com/MetaMask/core/pull/8536))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/authenticated-user-storage@3.0.0...HEAD
-[3.0.0]: https://github.com/MetaMask/core/compare/@metamask/authenticated-user-storage@2.1.0...@metamask/authenticated-user-storage@3.0.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/authenticated-user-storage@2.1.0...HEAD
 [2.1.0]: https://github.com/MetaMask/core/compare/@metamask/authenticated-user-storage@2.0.0...@metamask/authenticated-user-storage@2.1.0
 [2.0.0]: https://github.com/MetaMask/core/compare/@metamask/authenticated-user-storage@1.0.1...@metamask/authenticated-user-storage@2.0.0
 [1.0.1]: https://github.com/MetaMask/core/compare/@metamask/authenticated-user-storage@1.0.0...@metamask/authenticated-user-storage@1.0.1

--- a/packages/authenticated-user-storage/package.json
+++ b/packages/authenticated-user-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/authenticated-user-storage",
-  "version": "3.0.0",
+  "version": "2.1.0",
   "description": "SDK for authenticated (non-encrypted) user storage endpoints",
   "keywords": [
     "Ethereum",

--- a/packages/money-account-upgrade-controller/CHANGELOG.md
+++ b/packages/money-account-upgrade-controller/CHANGELOG.md
@@ -7,11 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.2.0]
-
 ### Changed
 
-- Bump `@metamask/authenticated-user-storage` from `^2.0.0` to `^3.0.0` ([#9220](https://github.com/MetaMask/core/pull/9220), [#9342](https://github.com/MetaMask/core/pull/9342))
+- Bump `@metamask/authenticated-user-storage` from `^2.0.0` to `^2.1.0` ([#9220](https://github.com/MetaMask/core/pull/9220))
 
 ## [2.1.0]
 
@@ -134,8 +132,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `MoneyAccountUpgradeController` with `upgradeAccount` method ([#8426](https://github.com/MetaMask/core/pull/8426))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/money-account-upgrade-controller@2.2.0...HEAD
-[2.2.0]: https://github.com/MetaMask/core/compare/@metamask/money-account-upgrade-controller@2.1.0...@metamask/money-account-upgrade-controller@2.2.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/money-account-upgrade-controller@2.1.0...HEAD
 [2.1.0]: https://github.com/MetaMask/core/compare/@metamask/money-account-upgrade-controller@2.0.5...@metamask/money-account-upgrade-controller@2.1.0
 [2.0.5]: https://github.com/MetaMask/core/compare/@metamask/money-account-upgrade-controller@2.0.4...@metamask/money-account-upgrade-controller@2.0.5
 [2.0.4]: https://github.com/MetaMask/core/compare/@metamask/money-account-upgrade-controller@2.0.3...@metamask/money-account-upgrade-controller@2.0.4

--- a/packages/money-account-upgrade-controller/package.json
+++ b/packages/money-account-upgrade-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/money-account-upgrade-controller",
-  "version": "2.2.0",
+  "version": "2.1.0",
   "description": "MetaMask Money account upgrade controller",
   "keywords": [
     "Ethereum",
@@ -53,7 +53,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/authenticated-user-storage": "^3.0.0",
+    "@metamask/authenticated-user-storage": "^2.1.0",
     "@metamask/base-controller": "^9.1.0",
     "@metamask/chomp-api-service": "^3.1.0",
     "@metamask/delegation-controller": "^3.0.2",

--- a/packages/notification-services-controller/CHANGELOG.md
+++ b/packages/notification-services-controller/CHANGELOG.md
@@ -7,16 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [24.3.0]
-
 ### Added
 
 - Add `DEFAULT_PRICE_ALERT_PREFERENCES` and initialize `priceAlerts` when building fresh notification preferences via `NotificationServicesController` ([#9316](https://github.com/MetaMask/core/pull/9316))
   - Re-export `DEFAULT_PRICE_ALERT_PREFERENCES` from `@metamask/authenticated-user-storage`.
-
-### Changed
-
-- Bump `@metamask/authenticated-user-storage` from `^2.1.0` to `^3.0.0` ([#9342](https://github.com/MetaMask/core/pull/9342))
 
 ## [24.2.0]
 
@@ -797,8 +791,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/notification-services-controller@24.3.0...HEAD
-[24.3.0]: https://github.com/MetaMask/core/compare/@metamask/notification-services-controller@24.2.0...@metamask/notification-services-controller@24.3.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/notification-services-controller@24.2.0...HEAD
 [24.2.0]: https://github.com/MetaMask/core/compare/@metamask/notification-services-controller@24.1.3...@metamask/notification-services-controller@24.2.0
 [24.1.3]: https://github.com/MetaMask/core/compare/@metamask/notification-services-controller@24.1.2...@metamask/notification-services-controller@24.1.3
 [24.1.2]: https://github.com/MetaMask/core/compare/@metamask/notification-services-controller@24.1.1...@metamask/notification-services-controller@24.1.2

--- a/packages/notification-services-controller/package.json
+++ b/packages/notification-services-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/notification-services-controller",
-  "version": "24.3.0",
+  "version": "24.2.0",
   "description": "Manages New MetaMask decentralized Notification system",
   "keywords": [
     "Ethereum",
@@ -106,7 +106,7 @@
   },
   "dependencies": {
     "@contentful/rich-text-html-renderer": "^16.5.2",
-    "@metamask/authenticated-user-storage": "^3.0.0",
+    "@metamask/authenticated-user-storage": "^2.1.0",
     "@metamask/base-controller": "^9.1.0",
     "@metamask/controller-utils": "^12.3.0",
     "@metamask/keyring-controller": "^27.1.0",

--- a/packages/perps-controller/package.json
+++ b/packages/perps-controller/package.json
@@ -109,7 +109,7 @@
   },
   "devDependencies": {
     "@metamask/account-tree-controller": "^7.5.3",
-    "@metamask/authenticated-user-storage": "^3.0.0",
+    "@metamask/authenticated-user-storage": "^2.1.0",
     "@metamask/auto-changelog": "^6.1.0",
     "@metamask/geolocation-controller": "^0.1.3",
     "@metamask/keyring-controller": "^27.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5818,7 +5818,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/authenticated-user-storage@npm:^3.0.0, @metamask/authenticated-user-storage@workspace:packages/authenticated-user-storage":
+"@metamask/authenticated-user-storage@npm:^2.1.0, @metamask/authenticated-user-storage@workspace:packages/authenticated-user-storage":
   version: 0.0.0-use.local
   resolution: "@metamask/authenticated-user-storage@workspace:packages/authenticated-user-storage"
   dependencies:
@@ -7485,7 +7485,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@metamask/money-account-upgrade-controller@workspace:packages/money-account-upgrade-controller"
   dependencies:
-    "@metamask/authenticated-user-storage": "npm:^3.0.0"
+    "@metamask/authenticated-user-storage": "npm:^2.1.0"
     "@metamask/auto-changelog": "npm:^6.1.0"
     "@metamask/base-controller": "npm:^9.1.0"
     "@metamask/chomp-api-service": "npm:^3.1.0"
@@ -7770,7 +7770,7 @@ __metadata:
     "@contentful/rich-text-html-renderer": "npm:^16.5.2"
     "@lavamoat/allow-scripts": "npm:^3.0.4"
     "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
-    "@metamask/authenticated-user-storage": "npm:^3.0.0"
+    "@metamask/authenticated-user-storage": "npm:^2.1.0"
     "@metamask/auto-changelog": "npm:^6.1.0"
     "@metamask/base-controller": "npm:^9.1.0"
     "@metamask/controller-utils": "npm:^12.3.0"
@@ -7923,7 +7923,7 @@ __metadata:
   dependencies:
     "@metamask/abi-utils": "npm:^2.0.3"
     "@metamask/account-tree-controller": "npm:^7.5.3"
-    "@metamask/authenticated-user-storage": "npm:^3.0.0"
+    "@metamask/authenticated-user-storage": "npm:^2.1.0"
     "@metamask/auto-changelog": "npm:^6.1.0"
     "@metamask/base-controller": "npm:^9.1.0"
     "@metamask/controller-utils": "npm:^12.3.0"


### PR DESCRIPTION
## Explanation
This reverts commit e96907cc93eddca1d642fc188d8a035a4b6f177d.

The release PR had an invalid title for the CI (lower case r instead of uppercase) so this needs to be reverted and then re-created to be picked up by CI
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to version numbers, changelogs, and lockfile entries; no runtime or API code is modified in this diff.
> 
> **Overview**
> Reverts the **release/1087.0.0** merge (#9342) because that release was not published. The monorepo root version goes from `1087.0.0` back to **`1086.0.0`**.
> 
> Published package versions and changelogs are rolled back: **`@metamask/authenticated-user-storage`** `3.0.0` → **`2.1.0`** (the `[3.0.0]` release notes are removed; those entries stay under **`[Unreleased]`**). **`@metamask/money-account-upgrade-controller`** `2.2.0` → **`2.1.0`**, **`@metamask/notification-services-controller`** `24.3.0` → **`24.2.0`**, with matching changelog link fixes.
> 
> Dependents that had been bumped to **`@metamask/authenticated-user-storage@^3.0.0`** (**money-account-upgrade-controller**, **notification-services-controller**, **perps-controller** devDeps) are pinned again to **`^2.1.0`**, and **`yarn.lock`** is updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53fcfa4bdf37c2157fbab2108490d9e194a0405d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->