### PR TITLE
ci: fail if release PR commit format is undetected by `action-is-release`

### DIFF
--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -87,7 +87,7 @@ runs:
         skip-checkout: true
 
     - name: Fail if root package is bumped but not detected as release
-      if: steps.is-release.outputs.IS_RELEASE != 'true' && steps.check-root-package.outputs.root-package-bumped == 'true'
+      if: github.event_name == 'pull_request' && steps.is-release.outputs.IS_RELEASE != 'true' && steps.check-root-package.outputs.root-package-bumped == 'true'
       shell: bash
       env:
         COMMIT_STARTS_WITH: ${{ inputs.commit-starts-with }}

--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -37,6 +37,7 @@ runs:
 
     - name: Check that root package.json is bumped for release PRs
       shell: bash
+      id: check-root-package
       env:
         MERGE_BASE: ${{ steps.merge-base.outputs.MERGE_BASE }}
       run: |
@@ -70,6 +71,7 @@ runs:
             exit 1
           else
             echo "✅ Root package.json is bumped (\`$CURRENT_ROOT_VERSION\` -> \`$NEW_ROOT_VERSION\`)"
+            echo "root-package-bumped=true" >> "$GITHUB_OUTPUT"
           fi
         else
           echo "✅ No package version bumps detected; skipping root package.json check."
@@ -83,6 +85,15 @@ runs:
         commit-message: ${{ github.event.pull_request.title }}
         before: ${{ steps.merge-base.outputs.MERGE_BASE }}
         skip-checkout: true
+
+    - name: Fail if root package is bumped but not detected as release
+      if: steps.is-release.outputs.IS_RELEASE != 'true' && steps.check-root-package.outputs.root-package-bumped == 'true'
+      shell: bash
+      env:
+        COMMIT_STARTS_WITH: ${{ inputs.commit-starts-with }}
+      run: |
+        echo "::error::This pull request is a release, but the release check did not detect it as such. Please ensure that the commit message starts with one of the following prefixes: $COMMIT_STARTS_WITH."
+        exit 1
 
     - name: Get pull request number
       id: pr-number


### PR DESCRIPTION
## Explanation

The `check-release` action already validates that the root `package.json` is bumped whenever any package version is bumped. However, there was no corresponding check in the other direction: if the root `package.json` is bumped (indicating a release PR) but `action-is-release` does not detect it as a release (e.g., because the commit message uses the wrong prefix), the action would silently succeed.

This PR adds a new step that cross-checks those two signals and fails with a clear error message if they disagree, pointing the author to the required commit message prefixes.

## References

<!--
Are there any issues that this pull request is tied to?
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow logic only; no runtime application, auth, or data-path changes.
> 
> **Overview**
> Closes a gap in the **check-release** composite action: it already required a root `package.json` bump when any workspace package version changes, but did not fail when the root version was bumped yet **`action-is-release`** did not treat the PR as a release (for example, wrong commit/PR title prefix).
> 
> The root-bump step now has **`id: check-root-package`** and sets **`root-package-bumped=true`** when the root version increases. A new step runs on **`pull_request`** only when that output is true and **`IS_RELEASE`** is not, and fails with an error that lists the required **`commit-starts-with`** prefixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e36b4e03d5d50604fcbfe71ac69b0a37a56d688. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->