### PR TITLE
Add mixins for using polling in data services

### DIFF
--- a/packages/polling-controller/CHANGELOG.md
+++ b/packages/polling-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `BlockTrackerPollingDataService` and `StaticIntervalPollingDataService` mixins for integrating the polling pattern in data services ([#9352](https://github.com/MetaMask/core/pull/9352))
+
 ## [16.0.8]
 
 ### Changed

--- a/packages/polling-controller/package.json
+++ b/packages/polling-controller/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "@metamask/base-controller": "^9.1.0",
+    "@metamask/base-data-service": "^0.1.3",
     "@metamask/network-controller": "^34.0.0",
     "@metamask/utils": "^11.11.0",
     "@types/uuid": "^8.3.0",

--- a/packages/polling-controller/src/BlockTrackerPollingController.ts
+++ b/packages/polling-controller/src/BlockTrackerPollingController.ts
@@ -1,4 +1,5 @@
 import { BaseController } from '@metamask/base-controller';
+import { BaseDataService } from '@metamask/base-data-service';
 import type {
   NetworkClientId,
   NetworkClient,
@@ -102,4 +103,14 @@ export const BlockTrackerPollingController = <
 >() =>
   BlockTrackerPollingControllerMixin<typeof BaseController, PollingInput>(
     BaseController,
+  );
+
+export const BlockTrackerPollingDataService = <
+  PollingInput extends BlockTrackerPollingInput,
+  // The return type is inferred from the class defined inside the function
+  // scope, so this can't be easily typed.
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+>() =>
+  BlockTrackerPollingControllerMixin<typeof BaseDataService, PollingInput>(
+    BaseDataService,
   );

--- a/packages/polling-controller/src/StaticIntervalPollingController.ts
+++ b/packages/polling-controller/src/StaticIntervalPollingController.ts
@@ -1,4 +1,5 @@
 import { BaseController } from '@metamask/base-controller';
+import { BaseDataService } from '@metamask/base-data-service';
 import type { Json } from '@metamask/utils';
 
 import {
@@ -95,4 +96,12 @@ export const StaticIntervalPollingControllerOnly = <
 export const StaticIntervalPollingController = <PollingInput extends Json>() =>
   StaticIntervalPollingControllerMixin<typeof BaseController, PollingInput>(
     BaseController,
+  );
+
+// The return type is inferred from the class defined inside the function
+// scope, so this can't be easily typed.
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const StaticIntervalPollingDataService = <PollingInput extends Json>() =>
+  StaticIntervalPollingControllerMixin<typeof BaseDataService, PollingInput>(
+    BaseDataService,
   );

--- a/packages/polling-controller/src/index.ts
+++ b/packages/polling-controller/src/index.ts
@@ -1,11 +1,13 @@
 export {
   BlockTrackerPollingControllerOnly,
   BlockTrackerPollingController,
+  BlockTrackerPollingDataService,
 } from './BlockTrackerPollingController';
 
 export {
   StaticIntervalPollingControllerOnly,
   StaticIntervalPollingController,
+  StaticIntervalPollingDataService,
 } from './StaticIntervalPollingController';
 
 export type { IPollingController } from './types';

--- a/packages/polling-controller/tsconfig.build.json
+++ b/packages/polling-controller/tsconfig.build.json
@@ -7,6 +7,7 @@
   },
   "references": [
     { "path": "../base-controller/tsconfig.build.json" },
+    { "path": "../base-data-service/tsconfig.build.json" },
     { "path": "../controller-utils/tsconfig.build.json" },
     { "path": "../network-controller/tsconfig.build.json" },
     { "path": "../messenger/tsconfig.build.json" }

--- a/packages/polling-controller/tsconfig.json
+++ b/packages/polling-controller/tsconfig.json
@@ -6,6 +6,7 @@
   },
   "references": [
     { "path": "../base-controller" },
+    { "path": "../base-data-service" },
     { "path": "../controller-utils" },
     { "path": "../network-controller" },
     { "path": "../messenger" }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8029,6 +8029,7 @@ __metadata:
   dependencies:
     "@metamask/auto-changelog": "npm:^6.1.0"
     "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/base-data-service": "npm:^0.1.3"
     "@metamask/messenger": "npm:^1.2.0"
     "@metamask/network-controller": "npm:^34.0.0"
     "@metamask/utils": "npm:^11.11.0"


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

The `polling-controller` package contains mixins for integrating the polling pattern into a class. Using these mixins on their own is somewhat cumbersome, so the package also contains utility functions which can be used in place of a superclass.

Currently, there are two styles of polling supported — one that subscribes to the block tracker, the other that runs on a cadence — and then past this, there are variants of these utility functions for controllers and non-controllers.

However, there is no variant for data services. That means if engineers want to integrate polling into data services, they are out of luck. This commit corrects that by adding two new mixins: `BlockTrackerPollingDataService` and `StaticIntervalPollingDataService`.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Closes https://consensyssoftware.atlassian.net/browse/WPC-1038.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them
