### PR TITLE
fix: unhide tokens with low occurrences for some chains

### DIFF
--- a/packages/assets-controller/src/data-sources/TokenDataSource.ts
+++ b/packages/assets-controller/src/data-sources/TokenDataSource.ts
@@ -6,7 +6,7 @@ import type {
 } from '@metamask/phishing-controller';
 import { TokenScanResultType } from '@metamask/phishing-controller';
 import { KnownCaipNamespace, parseCaipAssetType } from '@metamask/utils';
-import type { CaipAssetType } from '@metamask/utils';
+import type { CaipAssetType, CaipChainId } from '@metamask/utils';
 
 import type { AssetsControllerMessenger } from '../AssetsController';
 import { projectLogger, createModuleLogger } from '../logger';
@@ -43,6 +43,12 @@ const BULK_SCAN_BATCH_SIZE = 100;
  * pass the spam filter. Non-EVM tokens are filtered via Blockaid bulk scan instead.
  */
 const MIN_TOKEN_OCCURRENCES = 3;
+
+const MIN_TOKEN_OCCURRENCES_PER_CHAIN_OVERRIDE: { [key: CaipChainId]: number } =
+  {
+    // Arc: Chain not yet released so some important tokens (ex: EURC) have low occurrences.
+    'eip155:5042': 1,
+  };
 
 /** CAIP-19 `assetNamespace` segments used across filtering logic. */
 export enum CaipAssetNamespace {
@@ -415,7 +421,7 @@ export class TokenDataSource {
           metadataResponse.map((a) => [a.assetId, a.occurrences]),
         );
 
-        const evmErc20Ids: string[] = [];
+        const evmErc20Ids: Caip19AssetId[] = [];
         const nonEvmTokenIds: string[] = [];
 
         for (const assetData of metadataResponse) {
@@ -440,12 +446,18 @@ export class TokenDataSource {
         // can import whatever they want and we must keep their metadata even
         // if the API has fewer than `MIN_TOKEN_OCCURRENCES` aggregator hits.
         const allowedEvmIds = new Set(
-          evmErc20Ids.filter(
-            (id) =>
+          evmErc20Ids.filter((id) => {
+            // No exception handling herea as we already managed to parse it upstream.
+            const { chainId } = parseCaipAssetType(id);
+            const minOccurrences =
+              MIN_TOKEN_OCCURRENCES_PER_CHAIN_OVERRIDE[chainId] ??
+              MIN_TOKEN_OCCURRENCES;
+            return (
               customAssetIds.has(id.toLowerCase()) ||
-              (occurrencesByAssetId.get(id) ?? 0) >= MIN_TOKEN_OCCURRENCES ||
-              id.includes(`/erc20:${MUSD_ADDRESS_LOWERCASE}`),
-          ),
+              (occurrencesByAssetId.get(id) ?? 0) >= minOccurrences ||
+              id.includes(`/erc20:${MUSD_ADDRESS_LOWERCASE}`)
+            );
+          }),
         );
 
         // Non-EVM: Blockaid bulk scan.


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to token visibility on one chain’s spam heuristic; no auth, persistence, or API contract changes.
> 
> **Overview**
> **EVM ERC-20 spam filtering** in `TokenDataSource` now uses a **per-chain minimum aggregator occurrence** instead of a single global threshold of 3 for every chain.
> 
> A new `MIN_TOKEN_OCCURRENCES_PER_CHAIN_OVERRIDE` map sets **`eip155:5042` (Arc) to 1**, because the chain is not fully released yet and legitimate tokens (e.g. EURC) can report fewer aggregator hits. Other chains still use `MIN_TOKEN_OCCURRENCES` (3). Custom-import bypass and the MUSD allowlist are unchanged; only the comparison uses `minOccurrences` from the override or default.
> 
> `evmErc20Ids` is typed as `Caip19AssetId[]` for consistency with `parseCaipAssetType`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94a157a0cb1e498a2fab4815eb7fde3de6f917d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->