### PR TITLE
chore: restrict Dependabot GitHub Actions updates to major versions only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,5 +23,10 @@ updates:
     allow:
       - dependency-name: 'MetaMask/*'
       - dependency-name: 'actions/*'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-minor'
+          - 'version-update:semver-patch'
     target-branch: 'main'
     open-pull-requests-limit: 10


### PR DESCRIPTION
Dependabot was opening PRs for minor and patch updates to GitHub Actions (e.g., `MetaMask/action-is-release@v2.2.0`). Since we use floating major tags (e.g., `MetaMask/action-is-release@v2`), minor and patch bumps are automatically picked up and don't need separate PRs. This adds an `ignore` block to skip `semver-minor` and `semver-patch` updates, so Dependabot will only open PRs for major version bumps (e.g., `v2` → `v3`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only change to Dependabot; no runtime, auth, or workflow behavior is modified.
> 
> **Overview**
> **Dependabot** for the `github-actions` ecosystem now **ignores** `semver-minor` and `semver-patch` updates for all allowed dependencies (`dependency-name: '*'`).
> 
> Dependabot will only open PRs when a **major** version changes (e.g. `v2` → `v3`), which matches workflows that pin floating major tags like `MetaMask/action-is-release@v2` and `actions/checkout@v6` so minor/patch releases are already resolved without a separate bump PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7db8ee05c5cc454360478fc8dde312db7c38cd30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->