### PR TITLE
fix(transaction-pay-controller): allow payment token selection without fiat rate for post-quote flows

### DIFF
--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow payment token selection without a local fiat rate for post-quote transactions ([#9366](https://github.com/MetaMask/core/pull/9366))
+  - `updatePaymentToken` threw `Payment token not found` when the selected token had no market price or native-currency rate in wallet state, which blocked selecting a withdraw destination token on a chain the wallet does not actively track. For post-quote (withdraw) flows the token now resolves with zeroed fiat rates instead; standard (deposit) flows keep the strict behavior.
+
 ## [23.17.3]
 
 ### Changed

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Allow payment token selection without a local fiat rate for post-quote transactions ([#9366](https://github.com/MetaMask/core/pull/9366))
+- Allow payment token selection without a local fiat rate for post-quote transactions ([#9361](https://github.com/MetaMask/core/pull/9361))
   - `updatePaymentToken` threw `Payment token not found` when the selected token had no market price or native-currency rate in wallet state, which blocked selecting a withdraw destination token on a chain the wallet does not actively track. For post-quote (withdraw) flows the token now resolves with zeroed fiat rates instead; standard (deposit) flows keep the strict behavior.
 
 ## [23.17.3]

--- a/packages/transaction-pay-controller/src/actions/update-payment-token.test.ts
+++ b/packages/transaction-pay-controller/src/actions/update-payment-token.test.ts
@@ -177,6 +177,87 @@ describe('Update Payment Token Action', () => {
     ).toThrow('Payment token not found');
   });
 
+  it('resolves with zeroed fiat when rate not found and transaction is post-quote', () => {
+    getTokenFiatRateMock.mockReturnValue(undefined);
+
+    const updateTransactionDataMock = jest.fn();
+    const messenger = createMessengerMock({
+      [TRANSACTION_ID_MOCK]: { isPostQuote: true },
+    });
+
+    updatePaymentToken(
+      {
+        chainId: CHAIN_ID_MOCK,
+        tokenAddress: TOKEN_ADDRESS_MOCK,
+        transactionId: TRANSACTION_ID_MOCK,
+      },
+      {
+        messenger,
+        updateTransactionData: updateTransactionDataMock,
+      },
+    );
+
+    expect(updateTransactionDataMock).toHaveBeenCalledTimes(1);
+
+    const transactionDataMock = {} as TransactionData;
+    updateTransactionDataMock.mock.calls[0][1](transactionDataMock);
+
+    expect(transactionDataMock.paymentToken).toStrictEqual({
+      address: TOKEN_ADDRESS_MOCK,
+      balanceFiat: '0',
+      balanceHuman: '1.23',
+      balanceRaw: '1230000',
+      balanceUsd: '0',
+      chainId: CHAIN_ID_MOCK,
+      decimals: 6,
+      symbol: 'TST',
+    });
+  });
+
+  it('uses actual fiat rate when available and transaction is post-quote', () => {
+    const updateTransactionDataMock = jest.fn();
+    const messenger = createMessengerMock({
+      [TRANSACTION_ID_MOCK]: { isPostQuote: true },
+    });
+
+    updatePaymentToken(
+      {
+        chainId: CHAIN_ID_MOCK,
+        tokenAddress: TOKEN_ADDRESS_MOCK,
+        transactionId: TRANSACTION_ID_MOCK,
+      },
+      {
+        messenger,
+        updateTransactionData: updateTransactionDataMock,
+      },
+    );
+
+    const transactionDataMock = {} as TransactionData;
+    updateTransactionDataMock.mock.calls[0][1](transactionDataMock);
+
+    expect(transactionDataMock.paymentToken).toStrictEqual(PAYMENT_TOKEN_MOCK);
+  });
+
+  it('throws if token info not found even when transaction is post-quote', () => {
+    getTokenInfoMock.mockReturnValue(undefined);
+
+    expect(() =>
+      updatePaymentToken(
+        {
+          chainId: CHAIN_ID_MOCK,
+          tokenAddress: TOKEN_ADDRESS_MOCK,
+          transactionId: TRANSACTION_ID_MOCK,
+        },
+        {
+          messenger: createMessengerMock({
+            [TRANSACTION_ID_MOCK]: { isPostQuote: true },
+          }),
+          updateTransactionData: noop,
+        },
+      ),
+    ).toThrow('Payment token not found');
+  });
+
   it('throws if transaction not found', () => {
     getTransactionMock.mockReturnValue(undefined);
 

--- a/packages/transaction-pay-controller/src/actions/update-payment-token.ts
+++ b/packages/transaction-pay-controller/src/actions/update-payment-token.ts
@@ -43,13 +43,20 @@ export function updatePaymentToken(
   }
 
   const state = messenger.call('TransactionPayController:getState');
-  const accountOverride = state.transactionData[transactionId]?.accountOverride;
+  const transactionPayData = state.transactionData[transactionId];
+  const accountOverride = transactionPayData?.accountOverride;
 
   const paymentToken = getPaymentToken({
     chainId,
     from: accountOverride ?? (transaction.txParams.from as Hex),
     messenger,
     tokenAddress,
+    // For post-quote (withdraw) flows the selected token is the receive
+    // destination, which may live on a chain the wallet does not actively
+    // track, so no local market price or native-currency rate exists.
+    // Allow resolution without a fiat rate so selection is not blocked; the
+    // received amount is determined by the quote, not local rates.
+    allowMissingFiatRate: Boolean(transactionPayData?.isPostQuote),
   });
 
   if (!paymentToken) {
@@ -72,6 +79,8 @@ export function updatePaymentToken(
  * @param request.from - The address to get the token balance for.
  * @param request.messenger - The transaction pay controller messenger.
  * @param request.tokenAddress - The token address.
+ * @param request.allowMissingFiatRate - Whether to resolve the token with
+ * zeroed fiat rates when no local rate is available.
  * @returns The payment token or undefined if the token data could not be retrieved.
  */
 function getPaymentToken({
@@ -79,11 +88,13 @@ function getPaymentToken({
   from,
   messenger,
   tokenAddress,
+  allowMissingFiatRate,
 }: {
   chainId: Hex;
   from: Hex;
   messenger: TransactionPayControllerMessenger;
   tokenAddress: Hex;
+  allowMissingFiatRate?: boolean;
 }): TransactionPaymentToken | undefined {
   const { decimals, symbol } =
     getTokenInfo(messenger, tokenAddress, chainId) ?? {};
@@ -92,10 +103,17 @@ function getPaymentToken({
     return undefined;
   }
 
-  const tokenFiatRate = getTokenFiatRate(messenger, tokenAddress, chainId);
+  let tokenFiatRate = getTokenFiatRate(messenger, tokenAddress, chainId);
 
   if (tokenFiatRate === undefined) {
-    return undefined;
+    if (!allowMissingFiatRate) {
+      return undefined;
+    }
+
+    // No local fiat rate for this chain and token, such as a withdraw
+    // destination on a chain the wallet does not track. Resolve with zeroed
+    // fiat rates so the token can be selected; fiat display is best-effort.
+    tokenFiatRate = { usdRate: '0', fiatRate: '0' };
   }
 
   const balance = getTokenBalance(messenger, from, chainId, tokenAddress);


### PR DESCRIPTION
## Explanation

`updatePaymentToken` resolves the selected payment token only when it has both token metadata AND a locally-cached fiat rate (`getTokenFiatRate`, which requires a market price for the token plus a native-currency conversion rate for the chain). That data only exists for chains the wallet actively tracks.

For post-quote (withdraw) flows — e.g. Predict/Perps "withdraw to any token" — the selected token is the *receive destination*, which is frequently on a chain the user holds nothing on (Base/Arbitrum/BNB USDC, etc.). In that case no local rate exists, `getPaymentToken` returns `undefined`, and `updatePaymentToken` throws `Payment token not found`, blocking the token selection entirely. Verified end-to-end on MetaMask Mobile: token metadata resolves fine, and the fiat-rate check is the only failing condition.

This PR relaxes only that case: when the transaction's `TransactionData.isPostQuote` is true and no fiat rate is available, the token resolves with zeroed fiat rates (`usdRate: '0'`, `fiatRate: '0'`) so it can be selected. The fiat balance display for the destination token is best-effort — the received amount is determined by the quote, not local rates. Standard (deposit / non-post-quote) flows keep the strict behavior and still throw.

Once released, MetaMask Mobile will adopt this via a `@metamask/transaction-pay-controller` version bump (no mobile-side changes required; an interim mobile patch-package hotfix PR was superseded by this fix).

## References

- Supersedes the mobile patch-package hotfix: https://github.com/MetaMask/metamask-mobile/pull/32641
- Repro: on a wallet in production flag state, Predict → Withdraw → Receive → "Other assets" → select a token the user does not hold (e.g. USDT on BNB) → selection silently fails with `Payment token not found`.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow, flag-gated behavior change in payment token resolution only; deposit flows unchanged and token metadata is still required.
> 
> **Overview**
> **Post-quote withdraw flows** can now pick a receive-destination token even when the wallet has no local fiat/market rate for that chain and token (e.g. USDT on BNB). **`updatePaymentToken`** sets **`allowMissingFiatRate`** from **`TransactionData.isPostQuote`**; **`getPaymentToken`** then uses zero **`usdRate`/`fiatRate`** instead of failing, so selection no longer throws **`Payment token not found`**. Deposit and other non–post-quote paths still require a real fiat rate; missing token metadata still fails.
> 
> Tests cover zeroed fiat when the rate is absent, normal rates when present, and unchanged strict behavior for non–post-quote and missing token info.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01c57148b1d2b35d29b39b4be6aa6e1fdd04db4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->