### PR TITLE
chore(assets-controllers): add isDeprecated to TokenDetectionController

### DIFF
--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `isDeprecated` option to `TokenDetectionController` constructor
+  - When `isDeprecated()` returns `true`, no token detection requests are sent and polling is stopped at construction and at every entry point (`detectTokens`, `addDetectedTokensViaWs`, `addDetectedTokensViaPolling`, `start`, `_executePoll`, and event-driven restarts), so the controller is fully inactive.
+  - The function is re-evaluated on each entry point so it can be toggled at runtime without reconstructing the controller.
+
 ## [109.3.0]
 
 ### Added

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `isDeprecated` option to `TokenDetectionController` constructor
+- Add `isDeprecated` option to `TokenDetectionController` constructor ([#9363](https://github.com/MetaMask/core/pull/9363))
   - When `isDeprecated()` returns `true`, no token detection requests are sent and polling is stopped at construction and at every entry point (`detectTokens`, `addDetectedTokensViaWs`, `addDetectedTokensViaPolling`, `start`, `_executePoll`, and event-driven restarts), so the controller is fully inactive.
   - The function is re-evaluated on each entry point so it can be toggled at runtime without reconstructing the controller.
 

--- a/packages/assets-controllers/src/TokenDetectionController.test.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.test.ts
@@ -4236,7 +4236,11 @@ describe('TokenDetectionController', () => {
             },
           },
         },
-        async ({ controller, callActionSpy, mockFindNetworkClientIdByChainId }) => {
+        async ({
+          controller,
+          callActionSpy,
+          mockFindNetworkClientIdByChainId,
+        }) => {
           mockFindNetworkClientIdByChainId(() => 'mainnet');
 
           deprecated = true;
@@ -4275,7 +4279,11 @@ describe('TokenDetectionController', () => {
             },
           },
         },
-        async ({ controller, callActionSpy, mockFindNetworkClientIdByChainId }) => {
+        async ({
+          controller,
+          callActionSpy,
+          mockFindNetworkClientIdByChainId,
+        }) => {
           mockFindNetworkClientIdByChainId(() => 'mainnet');
 
           deprecated = true;

--- a/packages/assets-controllers/src/TokenDetectionController.test.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.test.ts
@@ -4061,6 +4061,276 @@ describe('TokenDetectionController', () => {
       );
     });
   });
+
+  describe('isDeprecated', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('stops polling at construction when isDeprecated() returns true', async () => {
+      await withController(
+        {
+          isKeyringUnlocked: true,
+          options: { disabled: false, isDeprecated: () => true },
+        },
+        async ({ controller }) => {
+          const mockDetectTokens = jest
+            .spyOn(controller, 'detectTokens')
+            .mockImplementation();
+
+          await controller.start();
+          await jestAdvanceTime({ duration: DEFAULT_INTERVAL * 2 });
+
+          expect(mockDetectTokens).not.toHaveBeenCalled();
+          expect(controller.isActive).toBe(false);
+        },
+      );
+    });
+
+    it('does not throw at construction when isDeprecated() returns true', async () => {
+      await withController(
+        {
+          options: { isDeprecated: () => true },
+        },
+        ({ controller }) => {
+          expect(controller.state).toStrictEqual({});
+        },
+      );
+    });
+
+    it('does not make any detection requests when isDeprecated() returns true from construction', async () => {
+      const mockGetBalancesInSingleCall = jest.fn();
+      await withController(
+        {
+          isKeyringUnlocked: true,
+          options: {
+            disabled: false,
+            isDeprecated: () => true,
+            getBalancesInSingleCall: mockGetBalancesInSingleCall,
+          },
+        },
+        async ({ controller }) => {
+          await controller.detectTokens({ chainIds: ['0xa86a'] });
+
+          expect(mockGetBalancesInSingleCall).not.toHaveBeenCalled();
+        },
+      );
+    });
+
+    it('does not detect tokens and stops polling when isDeprecated toggles to true at runtime via detectTokens', async () => {
+      let deprecated = false;
+      const mockGetBalancesInSingleCall = jest.fn().mockResolvedValue({});
+      const selectedAccount = createMockInternalAccount({
+        address: '0x0000000000000000000000000000000000000001',
+      });
+      await withController(
+        {
+          isKeyringUnlocked: true,
+          options: {
+            disabled: false,
+            isDeprecated: () => deprecated,
+            getBalancesInSingleCall: mockGetBalancesInSingleCall,
+          },
+          mocks: {
+            getSelectedAccount: selectedAccount,
+            getAccount: selectedAccount,
+          },
+        },
+        async ({ controller, mockTokenListGetState, mockNetworkState }) => {
+          const defaultState = getDefaultNetworkControllerState();
+          mockNetworkState({
+            ...defaultState,
+            networkConfigurationsByChainId: {
+              ...defaultState.networkConfigurationsByChainId,
+              ...mockNetworkConfigurationsByChainId,
+            },
+          });
+          mockTokenListGetState({
+            ...getDefaultTokenListState(),
+            tokensChainsCache: {
+              '0xa86a': {
+                timestamp: 0,
+                data: {
+                  [sampleTokenA.address]: {
+                    name: sampleTokenA.name,
+                    symbol: sampleTokenA.symbol,
+                    decimals: sampleTokenA.decimals,
+                    address: sampleTokenA.address,
+                    occurrences: 1,
+                    aggregators: sampleTokenA.aggregators,
+                    iconUrl: sampleTokenA.image,
+                  },
+                },
+              },
+            },
+          });
+
+          await controller.detectTokens({
+            chainIds: ['0xa86a'],
+            selectedAddress: selectedAccount.address,
+          });
+          expect(mockGetBalancesInSingleCall).toHaveBeenCalled();
+
+          mockGetBalancesInSingleCall.mockClear();
+          deprecated = true;
+
+          await controller.detectTokens({
+            chainIds: ['0xa86a'],
+            selectedAddress: selectedAccount.address,
+          });
+
+          expect(mockGetBalancesInSingleCall).not.toHaveBeenCalled();
+          expect(controller.isActive).toBe(false);
+        },
+      );
+    });
+
+    it('does not poll when isDeprecated toggles to true at runtime via start', async () => {
+      let deprecated = false;
+      await withController(
+        {
+          isKeyringUnlocked: true,
+          options: { disabled: false, isDeprecated: () => deprecated },
+        },
+        async ({ controller }) => {
+          const mockDetectTokens = jest
+            .spyOn(controller, 'detectTokens')
+            .mockImplementation();
+
+          await controller.start();
+          expect(mockDetectTokens).toHaveBeenCalledTimes(1);
+
+          deprecated = true;
+          mockDetectTokens.mockClear();
+
+          await controller.start();
+          await jestAdvanceTime({ duration: DEFAULT_INTERVAL * 2 });
+
+          expect(mockDetectTokens).not.toHaveBeenCalled();
+          expect(controller.isActive).toBe(false);
+        },
+      );
+    });
+
+    it('does not add tokens when isDeprecated toggles to true at runtime via addDetectedTokensViaWs', async () => {
+      let deprecated = false;
+      await withController(
+        {
+          options: { isDeprecated: () => deprecated },
+          mockTokenListState: {
+            tokensChainsCache: {
+              [ChainId.mainnet]: {
+                timestamp: Date.now(),
+                data: {
+                  [tokenAFromList.address.toLowerCase()]: {
+                    ...tokenAFromList,
+                    aggregators: formattedSampleAggregators,
+                    iconUrl: '',
+                  },
+                },
+              },
+            },
+          },
+        },
+        async ({ controller, callActionSpy, mockFindNetworkClientIdByChainId }) => {
+          mockFindNetworkClientIdByChainId(() => 'mainnet');
+
+          deprecated = true;
+
+          await controller.addDetectedTokensViaWs({
+            tokensSlice: [tokenAFromList.address],
+            chainId: ChainId.mainnet,
+          });
+
+          expect(callActionSpy).not.toHaveBeenCalledWith(
+            'TokensController:addTokens',
+            expect.anything(),
+            expect.anything(),
+          );
+        },
+      );
+    });
+
+    it('does not add tokens when isDeprecated toggles to true at runtime via addDetectedTokensViaPolling', async () => {
+      let deprecated = false;
+      await withController(
+        {
+          options: { isDeprecated: () => deprecated },
+          mockTokenListState: {
+            tokensChainsCache: {
+              [ChainId.mainnet]: {
+                timestamp: Date.now(),
+                data: {
+                  [tokenAFromList.address.toLowerCase()]: {
+                    ...tokenAFromList,
+                    aggregators: formattedSampleAggregators,
+                    iconUrl: '',
+                  },
+                },
+              },
+            },
+          },
+        },
+        async ({ controller, callActionSpy, mockFindNetworkClientIdByChainId }) => {
+          mockFindNetworkClientIdByChainId(() => 'mainnet');
+
+          deprecated = true;
+
+          await controller.addDetectedTokensViaPolling({
+            tokensSlice: [tokenAFromList.address],
+            chainId: ChainId.mainnet,
+          });
+
+          expect(callActionSpy).not.toHaveBeenCalledWith(
+            'TokensController:addTokens',
+            expect.anything(),
+            expect.anything(),
+          );
+        },
+      );
+    });
+
+    it('does not detect tokens on KeyringController:unlock when deprecated', async () => {
+      await withController(
+        {
+          isKeyringUnlocked: false,
+          options: { disabled: false, isDeprecated: () => true },
+        },
+        async ({ controller, triggerKeyringUnlock }) => {
+          const mockDetectTokens = jest
+            .spyOn(controller, 'detectTokens')
+            .mockImplementation();
+
+          triggerKeyringUnlock();
+
+          expect(mockDetectTokens).not.toHaveBeenCalled();
+        },
+      );
+    });
+
+    it('does not detect tokens on TransactionController:transactionConfirmed when deprecated', async () => {
+      const mockGetBalancesInSingleCall = jest.fn().mockResolvedValue({});
+      await withController(
+        {
+          isKeyringUnlocked: true,
+          options: {
+            disabled: false,
+            isDeprecated: () => true,
+            getBalancesInSingleCall: mockGetBalancesInSingleCall,
+          },
+        },
+        async ({ triggerTransactionConfirmed }) => {
+          triggerTransactionConfirmed({ chainId: ChainId.mainnet });
+
+          expect(mockGetBalancesInSingleCall).not.toHaveBeenCalled();
+        },
+      );
+    });
+  });
 });
 
 /**

--- a/packages/assets-controllers/src/TokenDetectionController.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.ts
@@ -204,6 +204,8 @@ export class TokenDetectionController extends StaticIntervalPollingController<To
 
   readonly #useExternalServices: () => boolean;
 
+  readonly #isDeprecated: () => boolean;
+
   readonly #getBalancesInSingleCall: AssetsContractController['getBalancesInSingleCall'];
 
   readonly #trackMetaMetricsEvent: (options: {
@@ -230,6 +232,12 @@ export class TokenDetectionController extends StaticIntervalPollingController<To
    * @param options.trackMetaMetricsEvent - Sets options for MetaMetrics event tracking.
    * @param options.useTokenDetection - Feature Switch for using token detection (default: true)
    * @param options.useExternalServices - Feature Switch for using external services (default: false)
+   * @param options.isDeprecated - Optional function that returns true to completely
+   * disable this controller (no requests, no polling). When it returns `true`,
+   * polling is stopped at construction and at every entry point. The function is
+   * evaluated dynamically on each entry point so it can be toggled at runtime.
+   * Intended for use when a higher-level controller (e.g. AssetsController)
+   * supersedes this one.
    */
   constructor({
     interval = DEFAULT_INTERVAL,
@@ -240,6 +248,7 @@ export class TokenDetectionController extends StaticIntervalPollingController<To
     tokenListService,
     useTokenDetection = (): boolean => true,
     useExternalServices = (): boolean => true,
+    isDeprecated = (): boolean => false,
   }: {
     interval?: number;
     disabled?: boolean;
@@ -259,6 +268,7 @@ export class TokenDetectionController extends StaticIntervalPollingController<To
     tokenListService: TokenListService;
     useTokenDetection?: () => boolean;
     useExternalServices?: () => boolean;
+    isDeprecated?: () => boolean;
   }) {
     super({
       name: controllerName,
@@ -290,8 +300,25 @@ export class TokenDetectionController extends StaticIntervalPollingController<To
 
     this.#useTokenDetection = useTokenDetection;
     this.#useExternalServices = useExternalServices;
+    this.#isDeprecated = isDeprecated;
+
+    if (this.#isDeprecated()) {
+      this.#enforceDisabledState();
+    }
 
     this.#registerEventListeners();
+  }
+
+  /**
+   * Stops polling and blocks network activity so the controller is fully inactive.
+   *
+   * Called from every entry point when `isDeprecated()` is true so that a
+   * runtime toggle propagates immediately, even if the controller was originally
+   * constructed while it was enabled.
+   */
+  #enforceDisabledState(): void {
+    this.#stopPolling();
+    this.#disabled = true;
   }
 
   /**
@@ -390,6 +417,10 @@ export class TokenDetectionController extends StaticIntervalPollingController<To
    * Start polling for detected tokens.
    */
   async start(): Promise<void> {
+    if (this.#isDeprecated()) {
+      this.#enforceDisabledState();
+      return;
+    }
     this.enable();
     await this.#startPolling();
   }
@@ -412,6 +443,10 @@ export class TokenDetectionController extends StaticIntervalPollingController<To
    * Starts a new polling interval.
    */
   async #startPolling(): Promise<void> {
+    if (this.#isDeprecated()) {
+      this.#enforceDisabledState();
+      return;
+    }
     if (!this.isActive) {
       return;
     }
@@ -459,6 +494,10 @@ export class TokenDetectionController extends StaticIntervalPollingController<To
     chainIds,
     address,
   }: TokenDetectionPollingInput): Promise<void> {
+    if (this.#isDeprecated()) {
+      this.#enforceDisabledState();
+      return;
+    }
     if (!this.isActive) {
       return;
     }
@@ -483,6 +522,10 @@ export class TokenDetectionController extends StaticIntervalPollingController<To
     selectedAddress?: string;
     chainIds?: Hex[];
   } = {}): Promise<void> {
+    if (this.#isDeprecated()) {
+      this.#enforceDisabledState();
+      return;
+    }
     await this.detectTokens({
       chainIds,
       selectedAddress,
@@ -574,6 +617,10 @@ export class TokenDetectionController extends StaticIntervalPollingController<To
     selectedAddress?: string;
     forceRpc?: boolean;
   } = {}): Promise<void> {
+    if (this.#isDeprecated()) {
+      this.#enforceDisabledState();
+      return;
+    }
     if (!this.isActive) {
       return;
     }
@@ -886,6 +933,11 @@ export class TokenDetectionController extends StaticIntervalPollingController<To
     tokensSlice: string[];
     chainId: Hex;
   }): Promise<void> {
+    if (this.#isDeprecated()) {
+      this.#enforceDisabledState();
+      return;
+    }
+
     // Check if token detection is enabled via preferences
     if (!this.#useTokenDetection()) {
       return;
@@ -992,6 +1044,11 @@ export class TokenDetectionController extends StaticIntervalPollingController<To
     tokensSlice: string[];
     chainId: Hex;
   }): Promise<void> {
+    if (this.#isDeprecated()) {
+      this.#enforceDisabledState();
+      return;
+    }
+
     // Check if token detection is enabled via preferences
     if (!this.#useTokenDetection()) {
       return;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Explanation

As part of the `assets-unify-state` rollout, legacy asset controllers need an opt-in deprecation path so hosts can disable them when `AssetsController` supersedes their behavior — without removing the controllers yet.

This PR adds an optional `isDeprecated` constructor callback to `TokenDetectionController`, following the same pattern already used by `TokensController`, `CurrencyRateController`, `TokenListController`, and the multichain controllers. When `isDeprecated()` returns `true`:

- Polling is stopped immediately
- All detection entry points become no-ops (`detectTokens`, `addDetectedTokensViaWs`, `addDetectedTokensViaPolling`, `start`, `_executePoll`, and event-driven restarts)
- The callback is re-evaluated on every entry point so it can be toggled at runtime

This is behavior-preserving when the callback is omitted or returns `false` (the default).

## References

- [ASSETS-3337](https://consensyssoftware.atlassian.net/browse/ASSETS-3337)
- Extension reference: https://github.com/MetaMask/metamask-extension/pull/43108
- Core reference pattern: https://github.com/MetaMask/core/pull/8945

## Manual testing steps

N/A — behavior-preserving when `isDeprecated` is not provided.

## Screenshots/Recordings

N/A

## Changed files

| File | Change | Verification |
|------|--------|--------------|
| `packages/assets-controllers/src/TokenDetectionController.ts` | Added `isDeprecated` option and guards at all entry points | ESLint pass |
| `packages/assets-controllers/src/TokenDetectionController.test.ts` | Added `isDeprecated` test suite (9 tests) | `yarn workspace @metamask/assets-controllers run jest --no-coverage packages/assets-controllers/src/TokenDetectionController.test.ts -t "isDeprecated"` — all pass |
| `packages/assets-controllers/CHANGELOG.md` | Added Unreleased entry | Reviewed against Keep a Changelog format |

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ea21278-2b3f-4934-b8d9-4adc16405cde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ea21278-2b3f-4934-b8d9-4adc16405cde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[ASSETS-3337]: https://consensyssoftware.atlassian.net/browse/ASSETS-3337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ