### PR TITLE
fix: rename ARC native to USDC from USDC-native

### DIFF
--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix Arc native token symbol from `USDC-native` to `USDC` ([#9364](https://github.com/MetaMask/core/pull/9364))
+
 ## [77.3.1]
 
 ### Changed

--- a/packages/bridge-controller/src/constants/tokens.ts
+++ b/packages/bridge-controller/src/constants/tokens.ts
@@ -201,8 +201,8 @@ const MEGAETH_SWAPS_TOKEN_OBJECT = {
 
 // Leaving for code consistency but we won't display it in the asset picker
 const ARC_SWAPS_TOKEN_OBJECT = {
-  symbol: 'USDC-native',
-  name: 'USDC-native',
+  symbol: 'USDC',
+  name: 'USDC',
   address: '0x0000000000000000000000000000000000000000',
   decimals: 18,
   iconUrl: '',
@@ -259,5 +259,5 @@ export const SYMBOL_TO_SLIP44_MAP: Record<
   MON: 'slip44:268435779',
   HYPE: 'slip44:2457',
   // It won't be displayed - hidden on UI client side
-  'USDC-native': 'erc20:0x0000000000000000000000000000000000000000',
+  USDC: 'erc20:0x0000000000000000000000000000000000000000',
 };


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small constant rename in token metadata; low risk unless downstream code still expects the old `USDC-native` symbol string.
> 
> **Overview**
> Renames the **Arc** chain native token metadata in `tokens.ts` from `USDC-native` to **`USDC`** for both `symbol` and `name` on `ARC_SWAPS_TOKEN_OBJECT`, and updates the matching key in `SYMBOL_TO_SLIP44_MAP` so CAIP/asset lookups use `USDC` instead of `USDC-native`.
> 
> Documents the fix under **Unreleased** in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 552ea4bd3c1e4738a6b7f15fc6af3193ca59100c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->