### PR TITLE
ci: fix dependency caching for Platform API docs build

### DIFF
--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -232,7 +232,7 @@ jobs:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v3
         with:
-          is-high-risk-environment: true
+          is-high-risk-environment: false
           persist-credentials: false
 
       - name: Generate and build Platform API docs

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -235,6 +235,7 @@ jobs:
         with:
           is-high-risk-environment: false
           persist-credentials: false
+          node-version: 24.x
 
       - name: Generate and build Platform API docs
         run: yarn docs:platform-api:build

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -226,6 +226,7 @@ jobs:
   build-platform-api-docs:
     name: Build Platform API docs
     runs-on: ubuntu-latest
+    needs: prepare
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Explanation

The `build-platform-api-docs` job used `is-high-risk-environment: true`, which disables dependency caching as a precaution against cache poisoning attacks. This was unnecessarily restrictive for this job — setting it to `false`, and setting a Node.js version re-enables caching and brings it in line with all other jobs in this workflow.

## References

N/A

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to checkout flags and job ordering; no application or security logic changes.
> 
> **Overview**
> Aligns the **Build Platform API docs** job with the rest of `lint-build-test.yml` so installs can use the shared dependency cache from **prepare**.
> 
> The job now **`needs: prepare`**, sets **`is-high-risk-environment: false`** (was `true`, which disabled node_modules caching), and pins **`node-version: 24.x`** on checkout/setup like lint, build, and test jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8349f96b401b71c9ed49bfad762f4e92bcb13bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->