### PR TITLE
chore: rename @MetaMask/notifications to /engagement in CODEOWNERS [GE-232]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -60,8 +60,8 @@
 ## Networks Team
 /packages/config-registry-controller        @MetaMask/networks
 
-## Notifications Team
-/packages/notification-services-controller     @MetaMask/notifications
+## Engagement Team
+/packages/notification-services-controller     @MetaMask/engagement
 
 ## Perps Team
 /packages/compliance-controller             @MetaMask/perps
@@ -193,8 +193,8 @@
 /packages/multichain-account-service/CHANGELOG.md @MetaMask/accounts-engineers @MetaMask/core-platform
 /packages/name-controller/package.json            @MetaMask/confirmations @MetaMask/core-platform
 /packages/name-controller/CHANGELOG.md            @MetaMask/confirmations @MetaMask/core-platform
-/packages/notification-services-controller/package.json @MetaMask/notifications @MetaMask/core-platform
-/packages/notification-services-controller/CHANGELOG.md @MetaMask/notifications @MetaMask/core-platform
+/packages/notification-services-controller/package.json @MetaMask/engagement @MetaMask/core-platform
+/packages/notification-services-controller/CHANGELOG.md @MetaMask/engagement @MetaMask/core-platform
 /packages/compliance-controller/package.json   @MetaMask/perps @MetaMask/core-platform
 /packages/compliance-controller/CHANGELOG.md   @MetaMask/perps @MetaMask/core-platform
 /packages/perps-controller/package.json       @MetaMask/perps @MetaMask/core-platform


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->
This PR renames @MetaMask/notifications to @MetaMask/engagement in CODEOWNERS, as /notifications is being gradually removed from all repos

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->
Fixed https://consensyssoftware.atlassian.net/browse/GE-232

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> GitHub ownership metadata only; no runtime, API, or dependency changes.
> 
> **Overview**
> Updates **CODEOWNERS** so `notification-services-controller` is owned by **@MetaMask/engagement** instead of **@MetaMask/notifications**, matching the org’s move away from the notifications team name.
> 
> The section header changes from “Notifications Team” to **Engagement Team**, and the same owner swap applies to that package’s **`package.json`** and **`CHANGELOG.md`** release-review lines. No application code or package behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a07b2fe121310f6aa0cf6e7e7dd96d7f2d5fa6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->