### PR TITLE
ci: bump `peaceiris/actions-gh-pages` to `4.1.0`

### DIFF
--- a/.github/workflows/deploy-platform-api-docs.yml
+++ b/.github/workflows/deploy-platform-api-docs.yml
@@ -36,7 +36,7 @@ jobs:
             contents: write
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           personal_token: ${{ steps.get-token.outputs.token }}
           publish_dir: ./.platform-api-docs/build


### PR DESCRIPTION
## Explanation

This bumps `peaceiris/actions-gh-pages` to `4.1.0`, which runs on Node.js 24 instead of Node.js 20.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single dependency pin in CI with no application or auth logic changes; deploy behavior and inputs stay the same aside from the action runtime.
> 
> **Overview**
> Updates the **Deploy Platform API Docs** workflow to pin `peaceiris/actions-gh-pages` from **v4.0.0** to **v4.1.0** (commit `84c30a85…`). Deploy inputs (`personal_token`, `publish_dir`, `destination_dir`, `keep_files`) are unchanged.
> 
> **v4.1.0** runs the action on **Node.js 24** (replacing Node 20 in v4.0.0).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3e2809a72de455664f97d18ea036c85e17fd5be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->