### PR TITLE
chore: add back stellar in network-enablement-controller

### DIFF
--- a/packages/network-enablement-controller/CHANGELOG.md
+++ b/packages/network-enablement-controller/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Revert Stellar from the Network Enablement Controller enabled network map to unblock release due to E2E failures in extension ([#9381](https://github.com/MetaMask/core/pull/9381))
-
 ## [5.4.1]
 
 ### Added

--- a/packages/network-enablement-controller/CHANGELOG.md
+++ b/packages/network-enablement-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Restore Stellar to the Network Enablement Controller enabled network map by reverting the temporary rollback, as the corresponding Extension issue has already been resolved.
+- Restore Stellar to the Network Enablement Controller enabled network map by reverting the temporary rollback, as the corresponding Extension issue has already been resolved ([#9385](https://github.com/MetaMask/core/pull/9385))
 
 ## [5.4.1]
 

--- a/packages/network-enablement-controller/CHANGELOG.md
+++ b/packages/network-enablement-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Restore Stellar to the Network Enablement Controller enabled network map by reverting the temporary rollback, as the corresponding Extension issue has already been resolved.
+
 ## [5.4.1]
 
 ### Added

--- a/packages/network-enablement-controller/src/NetworkEnablementController-method-action-types.ts
+++ b/packages/network-enablement-controller/src/NetworkEnablementController-method-action-types.ts
@@ -151,11 +151,11 @@ export type NetworkEnablementControllerListPopularEvmNetworksAction = {
 };
 
 /**
- * Returns popular multichain (Bitcoin, Solana, Tron) mainnet chain IDs in
+ * Returns popular multichain (Bitcoin, Solana, Tron, Stellar) mainnet chain IDs in
  * CAIP-2 form, restricted to networks that exist in MultichainNetworkController
  * (multichainNetworkConfigurationsByChainId).
  *
- * @returns CAIP-2 chain IDs for Bitcoin, Solana and Tron mainnets that are configured.
+ * @returns CAIP-2 chain IDs for Bitcoin, Solana, Tron, and Stellar mainnets that are configured.
  */
 export type NetworkEnablementControllerListPopularMultichainNetworksAction = {
   type: `NetworkEnablementController:listPopularMultichainNetworks`;
@@ -167,7 +167,7 @@ export type NetworkEnablementControllerListPopularMultichainNetworksAction = {
  * networks that exist in NetworkController (networkConfigurationsByChainId) and
  * MultichainNetworkController (multichainNetworkConfigurationsByChainId). EVM
  * popular networks come from POPULAR_NETWORKS; multichain popular are Bitcoin,
- * Solana and Tron mainnets.
+ * Solana, Tron, and Stellar mainnets.
  *
  * @returns CAIP-2 chain IDs for popular EVM networks and multichain mainnets that are configured.
  */

--- a/packages/network-enablement-controller/src/NetworkEnablementController.test.ts
+++ b/packages/network-enablement-controller/src/NetworkEnablementController.test.ts
@@ -1,6 +1,6 @@
 import { deriveStateFromMetadata } from '@metamask/base-controller';
 import { BuiltInNetworkName, ChainId } from '@metamask/controller-utils';
-import { BtcScope, SolScope, TrxScope } from '@metamask/keyring-api';
+import { BtcScope, SolScope, TrxScope, XlmScope } from '@metamask/keyring-api';
 import { Messenger, MOCK_ANY_NAMESPACE } from '@metamask/messenger';
 import type {
   MessengerActions,
@@ -83,6 +83,7 @@ const defaultMultichainGetState = (): MultichainGetStateReturn => ({
     [BtcScope.Mainnet]: { chainId: BtcScope.Mainnet, name: 'Bitcoin' },
     [SolScope.Mainnet]: { chainId: SolScope.Mainnet, name: 'Solana' },
     [TrxScope.Mainnet]: { chainId: TrxScope.Mainnet, name: 'Tron' },
+    [XlmScope.Pubnet]: { chainId: XlmScope.Pubnet, name: 'Stellar' },
   },
   selectedMultichainNetworkChainId: 'eip155:1',
   isEvmSelected: true,
@@ -212,6 +213,10 @@ describe('NetworkEnablementController', () => {
           [TrxScope.Nile]: false,
           [TrxScope.Shasta]: false,
         },
+        [KnownCaipNamespace.Stellar]: {
+          [XlmScope.Pubnet]: true,
+          [XlmScope.Testnet]: false,
+        },
       },
       nativeAssetIdentifiers: getDefaultNativeAssetIdentifiers(),
     });
@@ -268,6 +273,10 @@ describe('NetworkEnablementController', () => {
           [TrxScope.Mainnet]: true,
           [TrxScope.Nile]: false,
           [TrxScope.Shasta]: false,
+        },
+        [KnownCaipNamespace.Stellar]: {
+          [XlmScope.Pubnet]: true,
+          [XlmScope.Testnet]: false,
         },
       },
       nativeAssetIdentifiers: {
@@ -332,6 +341,10 @@ describe('NetworkEnablementController', () => {
           [TrxScope.Mainnet]: true,
           [TrxScope.Nile]: false,
           [TrxScope.Shasta]: false,
+        },
+        [KnownCaipNamespace.Stellar]: {
+          [XlmScope.Pubnet]: true,
+          [XlmScope.Testnet]: false,
         },
       },
       nativeAssetIdentifiers: expectedNativeAssetIdentifiers,
@@ -476,6 +489,10 @@ describe('NetworkEnablementController', () => {
           [TrxScope.Nile]: false,
           [TrxScope.Shasta]: false,
         },
+        [KnownCaipNamespace.Stellar]: {
+          [XlmScope.Pubnet]: true,
+          [XlmScope.Testnet]: false,
+        },
       },
       nativeAssetIdentifiers: expectedNativeAssetIdentifiersForFallback,
     });
@@ -576,6 +593,10 @@ describe('NetworkEnablementController', () => {
             [TrxScope.Mainnet]: true,
             [TrxScope.Nile]: false,
             [TrxScope.Shasta]: false,
+          },
+          [KnownCaipNamespace.Stellar]: {
+            [XlmScope.Pubnet]: true,
+            [XlmScope.Testnet]: false,
           },
         },
         // init() populates nativeAssetIdentifiers from NetworkController (EVM networks only)
@@ -1178,6 +1199,10 @@ describe('NetworkEnablementController', () => {
                   chainId: TrxScope.Mainnet,
                   name: 'Tron Mainnet',
                 },
+                [XlmScope.Pubnet]: {
+                  chainId: XlmScope.Pubnet,
+                  name: 'Stellar Mainnet',
+                },
               },
               selectedMultichainNetworkChainId:
                 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
@@ -1220,6 +1245,10 @@ describe('NetworkEnablementController', () => {
             [TrxScope.Nile]: false,
             [TrxScope.Shasta]: false,
           },
+          [KnownCaipNamespace.Stellar]: {
+            [XlmScope.Pubnet]: true,
+            [XlmScope.Testnet]: false,
+          },
         },
         nativeAssetIdentifiers: getDefaultNativeAssetIdentifiers(),
       });
@@ -1254,6 +1283,10 @@ describe('NetworkEnablementController', () => {
             [TrxScope.Mainnet]: true,
             [TrxScope.Nile]: false,
             [TrxScope.Shasta]: false,
+          },
+          [KnownCaipNamespace.Stellar]: {
+            [XlmScope.Pubnet]: true,
+            [XlmScope.Testnet]: false,
           },
         },
         nativeAssetIdentifiers: getDefaultNativeAssetIdentifiers(),
@@ -1336,6 +1369,10 @@ describe('NetworkEnablementController', () => {
             [TrxScope.Mainnet]: false,
             [TrxScope.Nile]: false,
             [TrxScope.Shasta]: false,
+          },
+          [KnownCaipNamespace.Stellar]: {
+            [XlmScope.Pubnet]: false,
+            [XlmScope.Testnet]: false,
           },
         },
         nativeAssetIdentifiers: getDefaultNativeAssetIdentifiers(),
@@ -1519,6 +1556,10 @@ describe('NetworkEnablementController', () => {
             [TrxScope.Nile]: false,
             [TrxScope.Shasta]: false,
           },
+          [KnownCaipNamespace.Stellar]: {
+            [XlmScope.Pubnet]: true,
+            [XlmScope.Testnet]: false,
+          },
         },
         nativeAssetIdentifiers: getDefaultNativeAssetIdentifiers(),
       });
@@ -1553,6 +1594,10 @@ describe('NetworkEnablementController', () => {
             [TrxScope.Mainnet]: false,
             [TrxScope.Nile]: false,
             [TrxScope.Shasta]: false,
+          },
+          [KnownCaipNamespace.Stellar]: {
+            [XlmScope.Pubnet]: false,
+            [XlmScope.Testnet]: false,
           },
         },
         nativeAssetIdentifiers: getDefaultNativeAssetIdentifiers(),
@@ -1609,6 +1654,10 @@ describe('NetworkEnablementController', () => {
             [TrxScope.Nile]: false,
             [TrxScope.Shasta]: false,
           },
+          [KnownCaipNamespace.Stellar]: {
+            [XlmScope.Pubnet]: false,
+            [XlmScope.Testnet]: false,
+          },
         },
         nativeAssetIdentifiers: {
           ...getDefaultNativeAssetIdentifiers(),
@@ -1648,6 +1697,10 @@ describe('NetworkEnablementController', () => {
             [TrxScope.Nile]: false,
             [TrxScope.Shasta]: false,
           },
+          [KnownCaipNamespace.Stellar]: {
+            [XlmScope.Pubnet]: false,
+            [XlmScope.Testnet]: false,
+          },
         },
         nativeAssetIdentifiers: {
           ...getDefaultNativeAssetIdentifiers(),
@@ -1686,6 +1739,10 @@ describe('NetworkEnablementController', () => {
             [TrxScope.Mainnet]: false,
             [TrxScope.Nile]: false,
             [TrxScope.Shasta]: false,
+          },
+          [KnownCaipNamespace.Stellar]: {
+            [XlmScope.Pubnet]: false,
+            [XlmScope.Testnet]: false,
           },
         },
         nativeAssetIdentifiers: {
@@ -1737,6 +1794,10 @@ describe('NetworkEnablementController', () => {
             [TrxScope.Nile]: false,
             [TrxScope.Shasta]: false,
           },
+          [KnownCaipNamespace.Stellar]: {
+            [XlmScope.Pubnet]: false,
+            [XlmScope.Testnet]: false,
+          },
         },
         nativeAssetIdentifiers: getDefaultNativeAssetIdentifiers(),
       });
@@ -1778,6 +1839,10 @@ describe('NetworkEnablementController', () => {
             [TrxScope.Mainnet]: false,
             [TrxScope.Nile]: false,
             [TrxScope.Shasta]: false,
+          },
+          [KnownCaipNamespace.Stellar]: {
+            [XlmScope.Pubnet]: false,
+            [XlmScope.Testnet]: false,
           },
         },
         nativeAssetIdentifiers: getDefaultNativeAssetIdentifiers(),
@@ -1834,6 +1899,10 @@ describe('NetworkEnablementController', () => {
             [TrxScope.Nile]: false,
             [TrxScope.Shasta]: false,
           },
+          [KnownCaipNamespace.Stellar]: {
+            [XlmScope.Pubnet]: false,
+            [XlmScope.Testnet]: false,
+          },
         },
         nativeAssetIdentifiers: {
           ...getDefaultNativeAssetIdentifiers(),
@@ -1880,6 +1949,10 @@ describe('NetworkEnablementController', () => {
             [TrxScope.Mainnet]: true,
             [TrxScope.Nile]: false,
             [TrxScope.Shasta]: false,
+          },
+          [KnownCaipNamespace.Stellar]: {
+            [XlmScope.Pubnet]: true,
+            [XlmScope.Testnet]: false,
           },
         },
         nativeAssetIdentifiers: getDefaultNativeAssetIdentifiers(),
@@ -1929,6 +2002,10 @@ describe('NetworkEnablementController', () => {
             [TrxScope.Mainnet]: true,
             [TrxScope.Nile]: false,
             [TrxScope.Shasta]: false,
+          },
+          [KnownCaipNamespace.Stellar]: {
+            [XlmScope.Pubnet]: true,
+            [XlmScope.Testnet]: false,
           },
         },
         nativeAssetIdentifiers: getDefaultNativeAssetIdentifiers(),
@@ -2166,14 +2243,15 @@ describe('NetworkEnablementController', () => {
       const { controller } = setupController();
       const result = controller.listPopularNetworks();
 
-      // Default setup: 3 EVM (0x1, 0xe708, 0x2105) + 4 multichain (Btc, Sol, Trx)
+      // Default setup: 3 EVM (0x1, 0xe708, 0x2105) + 4 multichain (Btc, Sol, Trx, Stellar)
       expect(result).toContain('eip155:1');
       expect(result).toContain('eip155:59144');
       expect(result).toContain('eip155:8453');
       expect(result).toContain(BtcScope.Mainnet);
       expect(result).toContain(SolScope.Mainnet);
       expect(result).toContain(TrxScope.Mainnet);
-      expect(result).toHaveLength(6);
+      expect(result).toContain(XlmScope.Pubnet);
+      expect(result).toHaveLength(7);
     });
 
     it('excludes multichain mainnets when not in MultichainNetworkController state', () => {
@@ -2193,6 +2271,7 @@ describe('NetworkEnablementController', () => {
       expect(result).not.toContain(BtcScope.Mainnet);
       expect(result).not.toContain(SolScope.Mainnet);
       expect(result).not.toContain(TrxScope.Mainnet);
+      expect(result).not.toContain(XlmScope.Pubnet);
       expect(result).toHaveLength(3);
     });
 
@@ -2240,14 +2319,15 @@ describe('NetworkEnablementController', () => {
   });
 
   describe('listPopularMultichainNetworks', () => {
-    it('returns only Bitcoin, Solana, Tron mainnets that exist in MultichainNetworkController state', () => {
+    it('returns only Bitcoin, Solana, Tron, Stellar mainnets that exist in MultichainNetworkController state', () => {
       const { controller } = setupController();
       const result = controller.listPopularMultichainNetworks();
 
       expect(result).toContain(BtcScope.Mainnet);
       expect(result).toContain(SolScope.Mainnet);
       expect(result).toContain(TrxScope.Mainnet);
-      expect(result).toHaveLength(3);
+      expect(result).toContain(XlmScope.Pubnet);
+      expect(result).toHaveLength(4);
     });
 
     it('returns empty when none of the multichain mainnets are configured', () => {

--- a/packages/network-enablement-controller/src/NetworkEnablementController.ts
+++ b/packages/network-enablement-controller/src/NetworkEnablementController.ts
@@ -4,7 +4,7 @@ import type {
   ControllerStateChangeEvent,
 } from '@metamask/base-controller';
 import { BuiltInNetworkName, ChainId } from '@metamask/controller-utils';
-import { BtcScope, SolScope, TrxScope } from '@metamask/keyring-api';
+import { BtcScope, SolScope, TrxScope, XlmScope } from '@metamask/keyring-api';
 import type { Messenger } from '@metamask/messenger';
 import type { MultichainNetworkControllerGetStateAction } from '@metamask/multichain-network-controller';
 import { toEvmCaipChainId } from '@metamask/multichain-network-controller';
@@ -183,6 +183,10 @@ const getDefaultNetworkEnablementControllerState =
         [TrxScope.Mainnet]: true,
         [TrxScope.Nile]: false,
         [TrxScope.Shasta]: false,
+      },
+      [KnownCaipNamespace.Stellar]: {
+        [XlmScope.Pubnet]: true,
+        [XlmScope.Testnet]: false,
       },
     },
     // nativeAssetIdentifiers is initialized as empty and should be populated
@@ -418,6 +422,18 @@ export class NetworkEnablementController extends BaseController<
         this.#ensureNamespaceBucket(state, tronKeys.namespace);
         // Enable Tron mainnet
         state.enabledNetworkMap[tronKeys.namespace][tronKeys.storageKey] = true;
+      }
+
+      // Enable Stellar mainnet if it exists in MultichainNetworkController configurations
+      const stellarKeys = deriveKeys(XlmScope.Pubnet as CaipChainId);
+      if (
+        multichainState.multichainNetworkConfigurationsByChainId[
+          XlmScope.Pubnet
+        ]
+      ) {
+        this.#ensureNamespaceBucket(state, stellarKeys.namespace);
+        state.enabledNetworkMap[stellarKeys.namespace][stellarKeys.storageKey] =
+          true;
       }
     });
   }
@@ -769,11 +785,11 @@ export class NetworkEnablementController extends BaseController<
   }
 
   /**
-   * Returns popular multichain (Bitcoin, Solana, Tron) mainnet chain IDs in
+   * Returns popular multichain (Bitcoin, Solana, Tron, Stellar) mainnet chain IDs in
    * CAIP-2 form, restricted to networks that exist in MultichainNetworkController
    * (multichainNetworkConfigurationsByChainId).
    *
-   * @returns CAIP-2 chain IDs for Bitcoin, Solana and Tron mainnets that are configured.
+   * @returns CAIP-2 chain IDs for Bitcoin, Solana, Tron, and Stellar mainnets that are configured.
    */
   listPopularMultichainNetworks(): CaipChainId[] {
     const multichainState = this.messenger.call(
@@ -783,6 +799,7 @@ export class NetworkEnablementController extends BaseController<
       BtcScope.Mainnet,
       SolScope.Mainnet,
       TrxScope.Mainnet,
+      XlmScope.Pubnet,
     ] as const;
     return multichainMainnets.filter(
       (chainId) =>
@@ -795,7 +812,7 @@ export class NetworkEnablementController extends BaseController<
    * networks that exist in NetworkController (networkConfigurationsByChainId) and
    * MultichainNetworkController (multichainNetworkConfigurationsByChainId). EVM
    * popular networks come from POPULAR_NETWORKS; multichain popular are Bitcoin,
-   * Solana and Tron mainnets.
+   * Solana, Tron, and Stellar mainnets.
    *
    * @returns CAIP-2 chain IDs for popular EVM networks and multichain mainnets that are configured.
    */


### PR DESCRIPTION
This reverts commit 22469493c868442c434451f1c579457faf7b5a23 (https://github.com/MetaMask/core/pull/9381) 

Reverts the previous rollback that removed Stellar from the Network Enablement Controller enabled network map.

The rollback was created in response to Extension E2E failures observed after enabling Stellar. Before the rollback was released or consumed downstream, the underlying Extension issue was resolved in https://github.com/MetaMask/metamask-extension/pull/44006.

Since the original issue has already been fixed in Extension, this PR restores Stellar to the enabled network map.

## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Restores prior Stellar enablement behavior with no new logic paths; main risk is downstream clients seeing Stellar enabled by default again when multichain config includes pubnet.
> 
> **Overview**
> **Re-enables Stellar** in `NetworkEnablementController` after the temporary rollback in [#9381](https://github.com/MetaMask/core/pull/9381). Extension E2E issues are addressed downstream, so this puts Stellar back on the same footing as Bitcoin, Solana, and Tron.
> 
> Default `enabledNetworkMap` again includes the Stellar namespace with **pubnet on** and **testnet off**. `enableAllPopularNetworks()` turns on Stellar pubnet when it exists in `MultichainNetworkController`, and `listPopularMultichainNetworks()` / `listPopularNetworks()` include `XlmScope.Pubnet` when configured. Messenger action JSDoc and tests are updated to match.
> 
> The unreleased changelog entry is switched from a revert note to documenting this restoration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 526fae3af9d1467fa0a1ba655986e20e74ebc188. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->