### PR TITLE
feat: improve chomp upgrade process

### DIFF
--- a/packages/chomp-api-service/CHANGELOG.md
+++ b/packages/chomp-api-service/CHANGELOG.md
@@ -7,8 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `getAssociatedAddresses` method, exposed as the `ChompApiService:getAssociatedAddresses` messenger action, which fetches the active address associations of the authenticated profile via `GET /v1/auth/address` ([#9387](https://github.com/MetaMask/core/pull/9387))
+  - Also adds the `ProfileAddressEntry` type describing each returned entry and the `ChompApiServiceGetAssociatedAddressesAction` type
+  - Returned addresses are parsed into canonical lowercase form, entries are guaranteed to have `status: 'active'`, and results are never served from cache
+  - The query cache key is scoped to the authenticated profile via a SHA-256 digest of the bearer token, so concurrent calls only share an in-flight request when they are for the same profile and one profile's associations are never cached under another's key
+
 ### Changed
 
+- **BREAKING:** `associateAddress` now throws an `HttpError` on a 409 response instead of returning the parsed body ([#9387](https://github.com/MetaMask/core/pull/9387))
+  - A 409 from `POST /v1/auth/address` indicates the address is associated with a _different_ profile; the previous handling attempted to parse the error body as an association result and failed with a confusing validation error. An address already associated with the authenticated profile is reported via a 201 response with `status: 'active'`, which is unchanged.
 - Bump `@metamask/utils` from `^11.9.0` to `^11.11.0` ([#9074](https://github.com/MetaMask/core/pull/9074))
 - Bump `@metamask/controller-utils` from `^12.0.0` to `^12.3.0` ([#8774](https://github.com/MetaMask/core/pull/8774), [#9058](https://github.com/MetaMask/core/pull/9058), [#9083](https://github.com/MetaMask/core/pull/9083), [#9218](https://github.com/MetaMask/core/pull/9218))
 - Bump `@metamask/base-data-service` from `^0.1.2` to `^0.1.3` ([#8799](https://github.com/MetaMask/core/pull/8799))

--- a/packages/chomp-api-service/src/chomp-api-service-method-action-types.ts
+++ b/packages/chomp-api-service/src/chomp-api-service-method-action-types.ts
@@ -12,11 +12,33 @@ import type { ChompApiService } from './chomp-api-service';
  *
  * @param params - The association params containing signature, timestamp,
  * and address.
- * @returns The profile association result. Returns on both 201 and 409.
+ * @returns The profile association result: `status: 'created'` for a new
+ * association, `status: 'active'` when the address was already associated
+ * with the authenticated profile. Throws on 409, which indicates the
+ * address is associated with a different profile.
  */
 export type ChompApiServiceAssociateAddressAction = {
   type: `ChompApiService:associateAddress`;
   handler: ChompApiService['associateAddress'];
+};
+
+/**
+ * Fetches the addresses associated with the authenticated profile.
+ *
+ * GET /v1/auth/address
+ *
+ * The result is scoped to the authenticated profile and consumers use it to
+ * decide whether an association already exists, so it is always fetched
+ * fresh (`staleTime: 0`, `cacheTime: 0`) and the query key is scoped to the
+ * profile via a digest of the bearer token — concurrent calls only share a
+ * request when they are for the same profile.
+ *
+ * @returns The active address associations; empty array if none exist.
+ * Addresses are lowercased.
+ */
+export type ChompApiServiceGetAssociatedAddressesAction = {
+  type: `ChompApiService:getAssociatedAddresses`;
+  handler: ChompApiService['getAssociatedAddresses'];
 };
 
 /**
@@ -120,6 +142,7 @@ export type ChompApiServiceGetServiceDetailsAction = {
  */
 export type ChompApiServiceMethodActions =
   | ChompApiServiceAssociateAddressAction
+  | ChompApiServiceGetAssociatedAddressesAction
   | ChompApiServiceCreateUpgradeAction
   | ChompApiServiceGetUpgradesAction
   | ChompApiServiceVerifyDelegationAction

--- a/packages/chomp-api-service/src/chomp-api-service.test.ts
+++ b/packages/chomp-api-service/src/chomp-api-service.test.ts
@@ -45,8 +45,8 @@ describe('ChompApiService', () => {
       });
     });
 
-    it('returns the response on 409 without throwing', async () => {
-      nock(BASE_URL).post('/v1/auth/address').reply(409, {
+    it('returns the response when the address is already associated with the profile', async () => {
+      nock(BASE_URL).post('/v1/auth/address').reply(201, {
         address: '0xabc',
         status: 'active',
       });
@@ -60,7 +60,19 @@ describe('ChompApiService', () => {
       });
     });
 
-    it('throws on non-201/409 status', async () => {
+    it('throws when the address is associated with another profile (409)', async () => {
+      nock(BASE_URL).post('/v1/auth/address').reply(409, {
+        statusCode: 409,
+        message: 'Address is already associated with another profile',
+      });
+      const { service } = createService();
+
+      await expect(service.associateAddress(associateParams)).rejects.toThrow(
+        "POST /v1/auth/address failed with status '409'",
+      );
+    });
+
+    it('throws on non-OK status', async () => {
       nock(BASE_URL)
         .post('/v1/auth/address')
         .times(DEFAULT_MAX_RETRIES + 1)
@@ -80,6 +92,177 @@ describe('ChompApiService', () => {
 
       await expect(service.associateAddress(associateParams)).rejects.toThrow(
         'At path: address',
+      );
+    });
+  });
+
+  describe('getAssociatedAddresses', () => {
+    const addressEntry = {
+      profileId: 'p1',
+      address: '0xabc',
+      status: 'active',
+    };
+
+    it('sends a GET with auth headers and returns the address entries', async () => {
+      nock(BASE_URL)
+        .get('/v1/auth/address')
+        .matchHeader('Authorization', `Bearer ${MOCK_TOKEN}`)
+        .reply(200, [addressEntry]);
+      const { rootMessenger } = createService();
+
+      const result = await rootMessenger.call(
+        'ChompApiService:getAssociatedAddresses',
+      );
+
+      expect(result).toStrictEqual([addressEntry]);
+    });
+
+    it('returns an empty array when no addresses are associated', async () => {
+      nock(BASE_URL).get('/v1/auth/address').reply(200, []);
+      const { service } = createService();
+
+      const result = await service.getAssociatedAddresses();
+
+      expect(result).toStrictEqual([]);
+    });
+
+    it('lowercases returned addresses', async () => {
+      nock(BASE_URL)
+        .get('/v1/auth/address')
+        .reply(200, [
+          {
+            profileId: 'p1',
+            address: '0xABCdef1234567890ABCdef1234567890ABCdef12',
+            status: 'active',
+          },
+        ]);
+      const { service } = createService();
+
+      const result = await service.getAssociatedAddresses();
+
+      expect(result).toStrictEqual([
+        {
+          profileId: 'p1',
+          address: '0xabcdef1234567890abcdef1234567890abcdef12',
+          status: 'active',
+        },
+      ]);
+    });
+
+    it('rejects entries with a non-active status', async () => {
+      nock(BASE_URL)
+        .get('/v1/auth/address')
+        .reply(200, [{ profileId: 'p1', address: '0xabc', status: 'deleted' }]);
+      const { service } = createService();
+
+      await expect(service.getAssociatedAddresses()).rejects.toThrow(
+        'At path: 0.status',
+      );
+    });
+
+    it('does not serve results from cache', async () => {
+      nock(BASE_URL).get('/v1/auth/address').reply(200, []);
+      nock(BASE_URL).get('/v1/auth/address').reply(200, [addressEntry]);
+      const { service } = createService();
+
+      const first = await service.getAssociatedAddresses();
+      const second = await service.getAssociatedAddresses();
+
+      expect(first).toStrictEqual([]);
+      expect(second).toStrictEqual([addressEntry]);
+    });
+
+    it('does not share an in-flight request across different bearer tokens', async () => {
+      const tokens = ['profile-a-token', 'profile-b-token'];
+      const { service } = createService({
+        getBearerToken: async () => tokens.shift() ?? 'exhausted',
+      });
+      // The first profile's request is still in flight when the second
+      // profile's request is issued; the second must not be deduplicated
+      // onto the first, or it would receive the first profile's addresses.
+      nock(BASE_URL)
+        .get('/v1/auth/address')
+        .matchHeader('Authorization', 'Bearer profile-a-token')
+        .delay(100)
+        .reply(200, []);
+      nock(BASE_URL)
+        .get('/v1/auth/address')
+        .matchHeader('Authorization', 'Bearer profile-b-token')
+        .reply(200, [addressEntry]);
+
+      const [first, second] = await Promise.all([
+        service.getAssociatedAddresses(),
+        service.getAssociatedAddresses(),
+      ]);
+
+      expect(first).toStrictEqual([]);
+      expect(second).toStrictEqual([addressEntry]);
+    });
+
+    it('shares an in-flight request across calls with the same bearer token', async () => {
+      // A single interceptor: both concurrent same-profile calls must be
+      // served by one HTTP request.
+      nock(BASE_URL)
+        .get('/v1/auth/address')
+        .delay(100)
+        .reply(200, [addressEntry]);
+      const { service } = createService();
+
+      const [first, second] = await Promise.all([
+        service.getAssociatedAddresses(),
+        service.getAssociatedAddresses(),
+      ]);
+
+      expect(first).toStrictEqual([addressEntry]);
+      expect(second).toStrictEqual([addressEntry]);
+    });
+
+    it('does not leak the bearer token through cache update events', async () => {
+      nock(BASE_URL).get('/v1/auth/address').reply(200, [addressEntry]);
+      const { service, messenger } = createService();
+      const publishSpy = jest.spyOn(messenger, 'publish');
+
+      await service.getAssociatedAddresses();
+
+      expect(publishSpy).toHaveBeenCalled();
+      expect(JSON.stringify(publishSpy.mock.calls)).not.toContain(MOCK_TOKEN);
+    });
+
+    it('evicts the result from the cache once the call settles', async () => {
+      nock(BASE_URL).get('/v1/auth/address').reply(200, [addressEntry]);
+      const { service, messenger } = createService();
+      const publishSpy = jest.spyOn(messenger, 'publish');
+
+      await service.getAssociatedAddresses();
+      // Eviction (`cacheTime: 0`) is scheduled on a macrotask; let it run.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(publishSpy).toHaveBeenCalledWith(
+        'ChompApiService:cacheUpdated',
+        expect.objectContaining({ type: 'removed' }),
+      );
+    });
+
+    it('throws on non-OK status', async () => {
+      nock(BASE_URL)
+        .get('/v1/auth/address')
+        .times(DEFAULT_MAX_RETRIES + 1)
+        .reply(500);
+      const { service } = createService();
+
+      await expect(service.getAssociatedAddresses()).rejects.toThrow(
+        "GET /v1/auth/address failed with status '500'",
+      );
+    });
+
+    it('throws on malformed response', async () => {
+      nock(BASE_URL)
+        .get('/v1/auth/address')
+        .reply(200, JSON.stringify([{ bad: 'data' }]));
+      const { service } = createService();
+
+      await expect(service.getAssociatedAddresses()).rejects.toThrow(
+        'At path: 0.profileId',
       );
     });
   });
@@ -663,12 +846,17 @@ function createServiceMessenger(
  * @param args.options - The options that the service constructor takes. All are
  * optional and will be filled in with defaults as needed (including
  * `messenger`).
+ * @param args.getBearerToken - The handler for the
+ * `AuthenticationController:getBearerToken` action. Defaults to returning
+ * `MOCK_TOKEN`.
  * @returns The new service, root messenger, and service messenger.
  */
 function createService({
   options = {},
+  getBearerToken = async (): Promise<string> => MOCK_TOKEN,
 }: {
   options?: Partial<ConstructorParameters<typeof ChompApiService>[0]>;
+  getBearerToken?: () => Promise<string>;
 } = {}): {
   service: ChompApiService;
   rootMessenger: RootMessenger;
@@ -677,7 +865,7 @@ function createService({
   const rootMessenger = createRootMessenger();
   rootMessenger.registerActionHandler(
     'AuthenticationController:getBearerToken',
-    async () => MOCK_TOKEN,
+    getBearerToken,
   );
   const messenger = createServiceMessenger(rootMessenger);
   rootMessenger.delegate({

--- a/packages/chomp-api-service/src/chomp-api-service.ts
+++ b/packages/chomp-api-service/src/chomp-api-service.ts
@@ -10,6 +10,7 @@ import type { Messenger } from '@metamask/messenger';
 import {
   array,
   boolean,
+  coerce,
   create,
   enums,
   literal,
@@ -20,13 +21,19 @@ import {
   type,
 } from '@metamask/superstruct';
 import type { Hex } from '@metamask/utils';
-import { StrictHexStruct } from '@metamask/utils';
+import {
+  bytesToHex,
+  sha256,
+  stringToBytes,
+  StrictHexStruct,
+} from '@metamask/utils';
 import type { QueryClientConfig } from '@tanstack/query-core';
 
 import type { ChompApiServiceMethodActions } from './chomp-api-service-method-action-types';
 import type {
   AssociateAddressParams,
   AssociateAddressResponse,
+  ProfileAddressEntry,
   CreateUpgradeParams,
   CreateUpgradeResponse,
   UpgradeEntry,
@@ -56,6 +63,7 @@ export const serviceName = 'ChompApiService';
  */
 const MESSENGER_EXPOSED_METHODS = [
   'associateAddress',
+  'getAssociatedAddresses',
   'createUpgrade',
   'getUpgrades',
   'verifyDelegation',
@@ -128,6 +136,24 @@ const AssociateAddressResponseStruct = type({
   address: StrictHexStruct,
   status: enums(['active', 'created']),
 });
+
+/**
+ * Parses addresses into canonical lowercase form. CHOMP stores and returns
+ * addresses lowercased, but `StrictHexStruct` alone accepts any casing, so
+ * this makes the canonical form a guarantee of the parsed data rather than a
+ * convention consumers must each remember.
+ */
+const LowercaseHexAddressStruct = coerce(StrictHexStruct, string(), (value) =>
+  value.toLowerCase(),
+);
+
+const ProfileAddressEntryArrayStruct = array(
+  type({
+    profileId: string(),
+    address: LowercaseHexAddressStruct,
+    status: enums(['active']),
+  }),
+);
 
 const AccountUpgradeStatusStruct = enums(['pending', 'upgraded']);
 
@@ -302,6 +328,20 @@ export class ChompApiService extends BaseDataService<
   }
 
   /**
+   * Builds the standard headers for a CHOMP API request authenticated with
+   * the given bearer token.
+   *
+   * @param token - The bearer token to authenticate with.
+   * @returns Headers including Authorization and Content-Type.
+   */
+  #headersForToken(token: string): Record<string, string> {
+    return {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    };
+  }
+
+  /**
    * Builds the standard headers for an authenticated CHOMP API request.
    *
    * @returns Headers including Authorization and Content-Type.
@@ -310,10 +350,7 @@ export class ChompApiService extends BaseDataService<
     const token = await this.messenger.call(
       'AuthenticationController:getBearerToken',
     );
-    return {
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-    };
+    return this.#headersForToken(token);
   }
 
   /**
@@ -323,7 +360,10 @@ export class ChompApiService extends BaseDataService<
    *
    * @param params - The association params containing signature, timestamp,
    * and address.
-   * @returns The profile association result. Returns on both 201 and 409.
+   * @returns The profile association result: `status: 'created'` for a new
+   * association, `status: 'active'` when the address was already associated
+   * with the authenticated profile. Throws on 409, which indicates the
+   * address is associated with a different profile.
    */
   async associateAddress(
     params: AssociateAddressParams,
@@ -342,7 +382,7 @@ export class ChompApiService extends BaseDataService<
           },
         );
 
-        if (!response.ok && response.status !== 409) {
+        if (!response.ok) {
           throw new HttpError(
             response.status,
             `POST /v1/auth/address failed with status '${response.status}'`,
@@ -354,6 +394,53 @@ export class ChompApiService extends BaseDataService<
     });
 
     return create(jsonResponse, AssociateAddressResponseStruct);
+  }
+
+  /**
+   * Fetches the addresses associated with the authenticated profile.
+   *
+   * GET /v1/auth/address
+   *
+   * The result is scoped to the authenticated profile and consumers use it
+   * to decide whether an association already exists, so it is always fetched
+   * fresh (`staleTime: 0`) and evicted as soon as the call settles
+   * (`cacheTime: 0`). The query key carries a SHA-256 digest of the bearer
+   * token — the same token the request is made with — so concurrent calls
+   * only share an in-flight request when they are for the same profile. The
+   * digest, not the token, is used because query keys leave the service via
+   * the `cacheUpdated` messenger events.
+   *
+   * @returns The active address associations; empty array if none exist.
+   * Addresses are lowercased.
+   */
+  async getAssociatedAddresses(): Promise<ProfileAddressEntry[]> {
+    const token = await this.messenger.call(
+      'AuthenticationController:getBearerToken',
+    );
+    const profileKey = bytesToHex(await sha256(stringToBytes(token)));
+
+    const jsonResponse = await this.fetchQuery({
+      queryKey: [`${this.name}:getAssociatedAddresses`, profileKey],
+      staleTime: 0,
+      cacheTime: 0,
+      queryFn: async () => {
+        const response = await fetch(
+          new URL('/v1/auth/address', this.#baseUrl),
+          { headers: this.#headersForToken(token) },
+        );
+
+        if (!response.ok) {
+          throw new HttpError(
+            response.status,
+            `GET /v1/auth/address failed with status '${response.status}'`,
+          );
+        }
+
+        return response.json();
+      },
+    });
+
+    return create(jsonResponse, ProfileAddressEntryArrayStruct);
   }
 
   /**

--- a/packages/chomp-api-service/src/index.ts
+++ b/packages/chomp-api-service/src/index.ts
@@ -9,6 +9,7 @@ export type {
 } from './chomp-api-service';
 export type {
   ChompApiServiceAssociateAddressAction,
+  ChompApiServiceGetAssociatedAddressesAction,
   ChompApiServiceCreateUpgradeAction,
   ChompApiServiceGetUpgradesAction,
   ChompApiServiceVerifyDelegationAction,
@@ -31,6 +32,7 @@ export type {
   IntentEntry,
   IntentMetadataParams,
   IntentMetadataResponse,
+  ProfileAddressEntry,
   SendIntentParams,
   SendIntentResponse,
   ServiceDetailsChain,

--- a/packages/chomp-api-service/src/types.ts
+++ b/packages/chomp-api-service/src/types.ts
@@ -69,11 +69,25 @@ export type CreateWithdrawalParams = {
  * `profileId` is only included when the address was newly associated
  * (`status: 'created'`). When the address was already associated with the
  * authenticated profile (`status: 'active'`), only `address` is returned.
+ * Both cases respond with 201; an address associated with a different
+ * profile responds with 409, which is surfaced as an error.
  */
 export type AssociateAddressResponse = {
   profileId?: string;
   address: Hex;
   status: 'active' | 'created';
+};
+
+/**
+ * One entry returned by GET /v1/auth/address. The endpoint returns an array
+ * of these — the active address associations of the authenticated profile
+ * (the API filters out soft-deleted associations, so `status` is always
+ * `'active'`). Addresses are lowercased.
+ */
+export type ProfileAddressEntry = {
+  profileId: string;
+  address: Hex;
+  status: 'active';
 };
 
 export type AccountUpgradeStatus = 'pending' | 'upgraded';

--- a/packages/money-account-upgrade-controller/CHANGELOG.md
+++ b/packages/money-account-upgrade-controller/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING:** The `associate-address` upgrade step now checks the profile's existing address associations via `ChompApiService:getAssociatedAddresses` before signing, and reports `already-done` without signing or submitting anything when the address is already associated ([#9387](https://github.com/MetaMask/core/pull/9387))
+  - `MoneyAccountUpgradeControllerMessenger` consumers must grant the `ChompApiService:getAssociatedAddresses` action alongside the previously required actions, and must provide a `@metamask/chomp-api-service` version that registers it (`>=4.0.0`).
+  - The lookup is an optimization: if it fails, the step falls through to the previous sign-and-submit behavior.
+  - A 409 conflict from the association request is disambiguated by re-fetching the associations, so a same-profile create race reports `already-done` instead of failing the upgrade; a genuine conflict (address associated with a different profile) still fails the step.
 - Bump `@metamask/messenger` from `^1.2.0` to `^2.0.0` ([#9392](https://github.com/MetaMask/core/pull/9392))
 - Bump `@metamask/authenticated-user-storage` from `^3.0.0` to `^3.0.1` ([#9458](https://github.com/MetaMask/core/pull/9458))
 

--- a/packages/money-account-upgrade-controller/src/MoneyAccountUpgradeController.test.ts
+++ b/packages/money-account-upgrade-controller/src/MoneyAccountUpgradeController.test.ts
@@ -70,6 +70,7 @@ type Mocks = {
   getServiceDetails: jest.Mock;
   signPersonalMessage: jest.Mock;
   associateAddress: jest.Mock;
+  getAssociatedAddresses: jest.Mock;
   createUpgrade: jest.Mock;
   signEip7702Authorization: jest.Mock;
   findNetworkClientIdByChainId: jest.Mock;
@@ -115,6 +116,7 @@ function setup(): {
       address: MOCK_ACCOUNT_ADDRESS,
       status: 'created',
     }),
+    getAssociatedAddresses: jest.fn().mockResolvedValue([]),
     createUpgrade: jest.fn().mockResolvedValue({
       signerAddress: MOCK_ACCOUNT_ADDRESS,
       address: MAINNET_CONTRACTS.EIP7702StatelessDeleGatorImpl,
@@ -154,6 +156,10 @@ function setup(): {
   rootMessenger.registerActionHandler(
     'ChompApiService:associateAddress',
     mocks.associateAddress,
+  );
+  rootMessenger.registerActionHandler(
+    'ChompApiService:getAssociatedAddresses',
+    mocks.getAssociatedAddresses,
   );
   rootMessenger.registerActionHandler(
     'ChompApiService:createUpgrade',
@@ -206,6 +212,7 @@ function setup(): {
       'ChompApiService:getServiceDetails',
       'KeyringController:signPersonalMessage',
       'ChompApiService:associateAddress',
+      'ChompApiService:getAssociatedAddresses',
       'ChompApiService:createUpgrade',
       'KeyringController:signEip7702Authorization',
       'NetworkController:findNetworkClientIdByChainId',

--- a/packages/money-account-upgrade-controller/src/MoneyAccountUpgradeController.ts
+++ b/packages/money-account-upgrade-controller/src/MoneyAccountUpgradeController.ts
@@ -12,6 +12,7 @@ import type {
   ChompApiServiceAssociateAddressAction,
   ChompApiServiceCreateIntentsAction,
   ChompApiServiceCreateUpgradeAction,
+  ChompApiServiceGetAssociatedAddressesAction,
   ChompApiServiceGetIntentsByAddressAction,
   ChompApiServiceGetServiceDetailsAction,
   ChompApiServiceVerifyDelegationAction,
@@ -70,6 +71,7 @@ type AllowedActions =
   | ChompApiServiceAssociateAddressAction
   | ChompApiServiceCreateIntentsAction
   | ChompApiServiceCreateUpgradeAction
+  | ChompApiServiceGetAssociatedAddressesAction
   | ChompApiServiceGetIntentsByAddressAction
   | ChompApiServiceGetServiceDetailsAction
   | ChompApiServiceVerifyDelegationAction

--- a/packages/money-account-upgrade-controller/src/steps/associate-address.test.ts
+++ b/packages/money-account-upgrade-controller/src/steps/associate-address.test.ts
@@ -9,7 +9,8 @@ import type { Hex } from '@metamask/utils';
 import type { MoneyAccountUpgradeControllerMessenger } from '../MoneyAccountUpgradeController';
 import { associateAddressStep } from './associate-address';
 
-const MOCK_ADDRESS = '0xabcdef1234567890abcdef1234567890abcdef12' as Hex;
+const MOCK_ADDRESS = '0xAbCdEf1234567890AbCdEf1234567890AbCdEf12' as Hex;
+const MOCK_ADDRESS_LOWERCASE = MOCK_ADDRESS.toLowerCase() as Hex;
 const MOCK_CHAIN_ID = '0x1' as Hex;
 const MOCK_DELEGATE = '0x1111111111111111111111111111111111111111' as Hex;
 const MOCK_DELEGATOR_IMPL = '0x2222222222222222222222222222222222222222' as Hex;
@@ -23,12 +24,26 @@ const MOCK_VALUE_LTE_ENFORCER =
 const MOCK_SIGNATURE = '0xdeadbeefcafebabe';
 const MOCK_NOW = new Date('2026-04-17T12:00:00.000Z').getTime();
 
+/**
+ * Builds the error `ChompApiService.associateAddress` throws on a 409.
+ *
+ * @returns An `Error` carrying `httpStatus: 409`, matching `HttpError` from
+ * `@metamask/controller-utils`.
+ */
+function conflictError(): Error {
+  return Object.assign(
+    new Error("POST /v1/auth/address failed with status '409'"),
+    { httpStatus: 409 },
+  );
+}
+
 type AllActions = MessengerActions<MoneyAccountUpgradeControllerMessenger>;
 type AllEvents = MessengerEvents<MoneyAccountUpgradeControllerMessenger>;
 
 type Mocks = {
   signPersonalMessage: jest.Mock;
   associateAddress: jest.Mock;
+  getAssociatedAddresses: jest.Mock;
 };
 
 function setup(): {
@@ -39,9 +54,10 @@ function setup(): {
     signPersonalMessage: jest.fn().mockResolvedValue(MOCK_SIGNATURE),
     associateAddress: jest.fn().mockResolvedValue({
       profileId: 'profile-1',
-      address: MOCK_ADDRESS,
+      address: MOCK_ADDRESS_LOWERCASE,
       status: 'created',
     }),
+    getAssociatedAddresses: jest.fn().mockResolvedValue([]),
   };
 
   const rootMessenger = new Messenger<MockAnyNamespace, AllActions, AllEvents>({
@@ -55,6 +71,10 @@ function setup(): {
     'ChompApiService:associateAddress',
     mocks.associateAddress,
   );
+  rootMessenger.registerActionHandler(
+    'ChompApiService:getAssociatedAddresses',
+    mocks.getAssociatedAddresses,
+  );
 
   const messenger: MoneyAccountUpgradeControllerMessenger = new Messenger({
     namespace: 'MoneyAccountUpgradeController',
@@ -64,6 +84,7 @@ function setup(): {
     actions: [
       'KeyringController:signPersonalMessage',
       'ChompApiService:associateAddress',
+      'ChompApiService:getAssociatedAddresses',
     ],
     events: [],
     messenger,
@@ -104,6 +125,52 @@ describe('associateAddressStep', () => {
     expect(associateAddressStep.name).toBe('associate-address');
   });
 
+  it('checks the associated addresses before signing anything', async () => {
+    const { messenger, mocks } = setup();
+
+    await run(messenger);
+
+    expect(mocks.getAssociatedAddresses).toHaveBeenCalledTimes(1);
+    expect(
+      mocks.getAssociatedAddresses.mock.invocationCallOrder[0],
+    ).toBeLessThan(mocks.signPersonalMessage.mock.invocationCallOrder[0]);
+  });
+
+  it('returns "already-done" without signing or submitting when the address is already associated', async () => {
+    const { messenger, mocks } = setup();
+    // CHOMP lowercases stored addresses; the step receives a checksummed one,
+    // so this also covers the case-insensitive match.
+    mocks.getAssociatedAddresses.mockResolvedValue([
+      {
+        profileId: 'profile-1',
+        address: MOCK_ADDRESS_LOWERCASE,
+        status: 'active',
+      },
+    ]);
+
+    const result = await run(messenger);
+
+    expect(result).toBe('already-done');
+    expect(mocks.signPersonalMessage).not.toHaveBeenCalled();
+    expect(mocks.associateAddress).not.toHaveBeenCalled();
+  });
+
+  it('proceeds with association when only other addresses are associated', async () => {
+    const { messenger, mocks } = setup();
+    mocks.getAssociatedAddresses.mockResolvedValue([
+      {
+        profileId: 'profile-1',
+        address: '0x9999999999999999999999999999999999999999',
+        status: 'active',
+      },
+    ]);
+
+    const result = await run(messenger);
+
+    expect(result).toBe('completed');
+    expect(mocks.associateAddress).toHaveBeenCalled();
+  });
+
   it('signs the CHOMP Authentication message with the given address', async () => {
     const { messenger, mocks } = setup();
 
@@ -135,16 +202,68 @@ describe('associateAddressStep', () => {
     expect(result).toBe('completed');
   });
 
-  it('returns "already-done" when CHOMP responds with active (409)', async () => {
+  it('returns "already-done" when the association was created concurrently', async () => {
     const { messenger, mocks } = setup();
     mocks.associateAddress.mockResolvedValue({
-      address: MOCK_ADDRESS,
+      address: MOCK_ADDRESS_LOWERCASE,
       status: 'active',
     });
 
     const result = await run(messenger);
 
     expect(result).toBe('already-done');
+  });
+
+  it('falls through to sign-and-submit when the lookup fails', async () => {
+    const { messenger, mocks } = setup();
+    mocks.getAssociatedAddresses.mockRejectedValue(new Error('lookup failed'));
+
+    const result = await run(messenger);
+
+    expect(result).toBe('completed');
+    expect(mocks.signPersonalMessage).toHaveBeenCalled();
+    expect(mocks.associateAddress).toHaveBeenCalled();
+  });
+
+  it('returns "already-done" when a conflict turns out to be a same-profile race', async () => {
+    const { messenger, mocks } = setup();
+    mocks.associateAddress.mockRejectedValue(conflictError());
+    // First lookup (pre-check) misses; second (disambiguation) finds it.
+    mocks.getAssociatedAddresses
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          profileId: 'profile-1',
+          address: MOCK_ADDRESS_LOWERCASE,
+          status: 'active',
+        },
+      ]);
+
+    const result = await run(messenger);
+
+    expect(result).toBe('already-done');
+  });
+
+  it('rethrows a conflict when the address belongs to another profile', async () => {
+    const { messenger, mocks } = setup();
+    mocks.associateAddress.mockRejectedValue(conflictError());
+    mocks.getAssociatedAddresses.mockResolvedValue([]);
+
+    await expect(run(messenger)).rejects.toThrow(
+      "POST /v1/auth/address failed with status '409'",
+    );
+  });
+
+  it('rethrows a conflict when the disambiguating lookup also fails', async () => {
+    const { messenger, mocks } = setup();
+    mocks.associateAddress.mockRejectedValue(conflictError());
+    mocks.getAssociatedAddresses
+      .mockResolvedValueOnce([])
+      .mockRejectedValueOnce(new Error('lookup failed'));
+
+    await expect(run(messenger)).rejects.toThrow(
+      "POST /v1/auth/address failed with status '409'",
+    );
   });
 
   it('propagates errors from signing and does not submit to the API', async () => {

--- a/packages/money-account-upgrade-controller/src/steps/associate-address.ts
+++ b/packages/money-account-upgrade-controller/src/steps/associate-address.ts
@@ -1,23 +1,63 @@
 import type { Hex } from '@metamask/utils';
+import { hasProperty } from '@metamask/utils';
 
+import { equalsIgnoreCase } from './delegation-matchers';
 import type { Step } from './step';
+
+/**
+ * Determines whether an error is a CHOMP conflict (HTTP 409) response.
+ *
+ * @param error - The error to inspect.
+ * @returns `true` when the error carries a 409 HTTP status.
+ */
+function isConflictError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    hasProperty(error, 'httpStatus') &&
+    error.httpStatus === 409
+  );
+}
 
 /**
  * Associates the Money Account address with the user's CHOMP profile.
  *
- * Signs `CHOMP Authentication {timestamp}` (EIP-191) with the account's key
- * and submits the signature to CHOMP, which verifies the timestamp is fresh,
- * recovers the signer, and records the profile–address mapping.
+ * First checks the profile's existing associations via
+ * `GET /v1/auth/address`; if the address is already associated the step
+ * reports `'already-done'` without signing anything. The lookup is an
+ * optimization: if it fails, the step falls through to the POST path below,
+ * which is authoritative and matches the behavior before the lookup existed.
  *
- * CHOMP responds with 201 and `status: 'created'` when a new association is
- * made, and 409 with `status: 'active'` when the address is already
- * associated with the authenticated profile. The service surfaces both
- * responses, so this step reports `'already-done'` for the 409 case and
- * `'completed'` otherwise.
+ * Otherwise, signs `CHOMP Authentication {timestamp}` (EIP-191) with the
+ * account's key and submits the signature to CHOMP, which verifies the
+ * timestamp is fresh, recovers the signer, and records the profile–address
+ * mapping. CHOMP responds with `status: 'created'` for a new association and
+ * `status: 'active'` when the address was already associated with this
+ * profile, so the latter also reports `'already-done'`.
+ *
+ * A 409 usually means the address belongs to a different profile, but CHOMP
+ * also returns it when two same-profile requests race on the initial create
+ * (the loser's conditional write fails). The step disambiguates by re-fetching
+ * the associations: if the address is now present the race was benign and the
+ * step reports `'already-done'`; otherwise the conflict propagates.
  */
 export const associateAddressStep: Step = {
   name: 'associate-address',
   async run({ messenger, address }) {
+    const isAssociated = async (): Promise<boolean> => {
+      const entries = await messenger.call(
+        'ChompApiService:getAssociatedAddresses',
+      );
+      return entries.some((entry) => equalsIgnoreCase(entry.address, address));
+    };
+
+    try {
+      if (await isAssociated()) {
+        return 'already-done';
+      }
+    } catch {
+      // The lookup is an optimization — the POST path below is authoritative.
+    }
+
     const timestamp = Date.now();
     const message = `CHOMP Authentication ${timestamp}`;
 
@@ -26,16 +66,23 @@ export const associateAddressStep: Step = {
       { data: message, from: address },
     )) as Hex;
 
-    const response = await messenger.call('ChompApiService:associateAddress', {
-      signature,
-      timestamp,
-      address,
-    });
-
-    if (response.status === 'active') {
-      return 'already-done';
+    try {
+      const response = await messenger.call(
+        'ChompApiService:associateAddress',
+        { signature, timestamp, address },
+      );
+      return response.status === 'active' ? 'already-done' : 'completed';
+    } catch (error) {
+      if (isConflictError(error)) {
+        try {
+          if (await isAssociated()) {
+            return 'already-done';
+          }
+        } catch {
+          // Could not disambiguate — surface the original conflict.
+        }
+      }
+      throw error;
     }
-
-    return 'completed';
   },
 };


### PR DESCRIPTION
# PR: GET-first address association for the Money Account upgrade flow

**Repos:** MetaMask/core → metamask-mobile (adoption to follow)
**Packages:** `@metamask/chomp-api-service` (breaking → 4.0.0), `@metamask/money-account-upgrade-controller` (breaking → 3.0.0)

## Explanation

The `associate-address` step of the Money Account upgrade flow currently signs a
`CHOMP Authentication` message and POSTs it to `/v1/auth/address` on every run,
relying on the response to discover that the address was already associated. That
means a keyring signing operation happens even when there is nothing to do.

This PR makes the step check first and sign only when needed:

- **`@metamask/chomp-api-service`**: adds `getAssociatedAddresses()`
  (`GET /v1/auth/address`), which returns the authenticated profile's active
  address associations. Results are parsed into canonical form (lowercased
  addresses, `status` guaranteed `'active'`) and are never served from cache,
  since the response is scoped to the authenticated profile and consumers use it
  to decide whether to sign.
- **`@metamask/money-account-upgrade-controller`**: the `associate-address` step
  now calls the new action first and reports `already-done` — without touching
  the keyring — when the address is already associated. The lookup is an
  optimization: if it fails, the step falls through to the previous
  sign-and-submit behaviour.

While verifying the endpoint's semantics against the CHOMP API source, I found
that the existing 409 handling was wrong. CHOMP returns
**201 + `status: 'active'`** when the address is already associated with the
authenticated profile; a **409** means the address is associated with a
*different* profile (or, rarely, that two same-profile requests raced on the
initial create). The old code treated 409 as a success case and tried to parse
its error body as an association result, which would have failed with a
confusing validation error. Now:

- `associateAddress` throws an `HttpError` on any non-OK response (**breaking**).
- The step disambiguates a 409 by re-fetching the associations: a same-profile
  race resolves to `already-done`; a genuine cross-profile conflict fails the
  step with a clear error.

The controller change is **breaking** because `MoneyAccountUpgradeControllerMessenger`
consumers must now grant `ChompApiService:getAssociatedAddresses` and pair it
with `@metamask/chomp-api-service` >= 4.0.0.

## References

<!-- Add issue/consumer-PR links here — mobile adoption PR to follow -->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking API and messenger contract changes affect all Chomp `associateAddress` callers and upgrade-controller integrators; behavior touches authenticated profile–address binding and upgrade flow failure modes.
> 
> **Overview**
> Adds **`getAssociatedAddresses`** (`GET /v1/auth/address`) to `@metamask/chomp-api-service`, with messenger action `ChompApiService:getAssociatedAddresses`, **`ProfileAddressEntry`** typing, lowercase address parsing, and **no durable cache** (profile-scoped query key via SHA-256 of the bearer token so tokens are not exposed in cache events).
> 
> **Breaking:** **`associateAddress`** now **throws `HttpError` on 409** instead of treating it as success; same-profile “already associated” remains **201 + `status: 'active'`**.
> 
> The **`associate-address`** upgrade step calls the GET first and returns **`already-done` without keyring signing** when the address is already linked; lookup failures still fall through to sign-and-submit. On POST **409**, it **re-fetches associations** to distinguish a benign same-profile race from a real cross-profile conflict.
> 
> **Breaking for consumers:** `MoneyAccountUpgradeController` must delegate **`ChompApiService:getAssociatedAddresses`** and use **`@metamask/chomp-api-service` >= 4.0.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cba10e003b096439576e23b724815eade299bddb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->