### PR TITLE
fix(assets-controller): seed native balances after account refresh

### DIFF
--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fetch account balances via RPC when switching account groups, enabling RPC-only networks, or after a new account is added to the account tree ([#9388](https://github.com/MetaMask/core/pull/9388))
+- Fetch balances when switching account groups, enabling RPC-only networks, or after a new account is added to the account tree ([#9388](https://github.com/MetaMask/core/pull/9388))
 
 ## [10.0.1]
 

--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fetch account balances via RPC when switching EVM accounts, enabling RPC-only networks, switching account groups, or after a new account is added to the account tree
+- Fetch account balances via RPC when switching EVM accounts, enabling RPC-only networks, switching account groups, or after a new account is added to the account tree ([#9388](https://github.com/MetaMask/core/pull/9388))
   - Integrators must delegate `AccountsController:selectedEvmAccountChange` to the AssetsController messenger
 
 ## [10.0.1]

--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fetch account balances via RPC when switching EVM accounts, enabling RPC-only networks, switching account groups, or after a new account is added to the account tree
+  - Integrators must delegate `AccountsController:selectedEvmAccountChange` to the AssetsController messenger
+
 ## [10.0.1]
 
 ### Changed

--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -9,8 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fetch account balances via RPC when switching EVM accounts, enabling RPC-only networks, switching account groups, or after a new account is added to the account tree ([#9388](https://github.com/MetaMask/core/pull/9388))
-  - Integrators must delegate `AccountsController:selectedEvmAccountChange` to the AssetsController messenger
+- Fetch account balances via RPC when switching account groups, enabling RPC-only networks, or after a new account is added to the account tree ([#9388](https://github.com/MetaMask/core/pull/9388))
 
 ## [10.0.1]
 

--- a/packages/assets-controller/src/AssetsController.ts
+++ b/packages/assets-controller/src/AssetsController.ts
@@ -1370,42 +1370,6 @@ export class AssetsController extends BaseController<
   }
 
   /**
-   * Fetch balances via RpcDataSource and merge into state.
-   *
-   * @param accounts - Accounts to fetch for.
-   * @param chainIds - Chains to fetch on.
-   */
-  async #fetchAccountBalancesViaRpc(
-    accounts: InternalAccount[],
-    chainIds: ChainId[],
-  ): Promise<void> {
-    if (accounts.length === 0 || chainIds.length === 0) {
-      return;
-    }
-
-    const rpcChains = chainIds.filter((chainId) =>
-      this.#rpcDataSource.getActiveChainsSync().includes(chainId),
-    );
-    if (rpcChains.length === 0) {
-      return;
-    }
-
-    const request = this.#buildDataRequest(accounts, rpcChains, {
-      dataTypes: ['balance'],
-      forceUpdate: true,
-    });
-    const { response } = await this.#executeMiddlewares(
-      [
-        createParallelBalanceMiddleware([this.#rpcDataSource]),
-        this.#detectionMiddleware,
-      ],
-      request,
-    );
-
-    await this.#updateState({ ...response, updateMode: 'merge' });
-  }
-
-  /**
    * Force-fetch balances then subscribe. Used on unlock / first startup.
    *
    * @param accounts - Selected accounts to refresh.
@@ -3369,10 +3333,6 @@ export class AssetsController extends BaseController<
       // Subscribe after fetch so WS notifications can recover state
       this.#subscribeAssets();
 
-      await this.#fetchAccountBalancesViaRpc(accounts, [
-        ...this.#enabledChains,
-      ]);
-
       this.#ensureNativeBalancesDefaultZero();
       this.#ensureDefaultTrackedAssetsSeeded();
     } finally {
@@ -3424,8 +3384,6 @@ export class AssetsController extends BaseController<
         forceUpdate: true,
         updateMode: 'merge',
       });
-
-      await this.#fetchAccountBalancesViaRpc(accounts, addedChains);
     }
 
     this.#ensureNativeBalancesDefaultZero();

--- a/packages/assets-controller/src/AssetsController.ts
+++ b/packages/assets-controller/src/AssetsController.ts
@@ -2,6 +2,7 @@ import type {
   AccountTreeControllerGetAccountsFromSelectedAccountGroupAction,
   AccountTreeControllerSelectedAccountGroupChangeEvent,
   AccountTreeControllerState,
+  AccountTreeControllerStateChangeEvent,
 } from '@metamask/account-tree-controller';
 import type {
   AccountsControllerGetSelectedAccountAction,
@@ -14,7 +15,10 @@ import type {
   ControllerStateChangedEvent,
   StateMetadata,
 } from '@metamask/base-controller';
-import type { ClientControllerState } from '@metamask/client-controller';
+import type {
+  ClientControllerState,
+  ClientControllerStateChangeEvent,
+} from '@metamask/client-controller';
 import { clientControllerSelectors } from '@metamask/client-controller';
 import type { TraceCallback } from '@metamask/controller-utils';
 import type {
@@ -42,8 +46,8 @@ import type {
 } from '@metamask/network-controller';
 import type {
   NetworkEnablementControllerGetStateAction,
-  NetworkEnablementControllerEvents,
   NetworkEnablementControllerState,
+  NetworkEnablementControllerStateChangeEvent,
 } from '@metamask/network-enablement-controller';
 import type {
   GetPermissions,
@@ -324,26 +328,16 @@ type AllowedActions =
   // PhishingController
   | PhishingControllerBulkScanTokensAction;
 
-type AccountTreeControllerStateChangedEvent = ControllerStateChangedEvent<
-  'AccountTreeController',
-  AccountTreeControllerState
->;
-
-type ClientControllerStateChangedEvent = ControllerStateChangedEvent<
-  'ClientController',
-  ClientControllerState
->;
-
-type NetworkEnablementControllerStateChangedEvent = ControllerStateChangedEvent<
-  'NetworkEnablementController',
-  NetworkEnablementControllerState
->;
-
 type AllowedEvents =
   // AssetsController
   | AccountTreeControllerSelectedAccountGroupChangeEvent
-  | AccountTreeControllerStateChangedEvent
-  | ClientControllerStateChangedEvent
+  | AccountTreeControllerStateChangeEvent
+  | ControllerStateChangedEvent<
+      'AccountTreeController',
+      AccountTreeControllerState
+    >
+  | ClientControllerStateChangeEvent
+  | ControllerStateChangedEvent<'ClientController', ClientControllerState>
   | KeyringControllerLockEvent
   | KeyringControllerUnlockEvent
   | PreferencesControllerStateChangeEvent
@@ -358,8 +352,11 @@ type AllowedEvents =
   | NetworkControllerNetworkDidChangeEvent
   | NetworkControllerNetworkRemovedEvent
   // StakedBalanceDataSource
-  | NetworkEnablementControllerEvents
-  | NetworkEnablementControllerStateChangedEvent
+  | NetworkEnablementControllerStateChangeEvent
+  | ControllerStateChangedEvent<
+      'NetworkEnablementController',
+      NetworkEnablementControllerState
+    >
   // SnapDataSource
   | AccountsControllerAccountBalancesUpdatedEvent
   | AccountsControllerSelectedEvmAccountChangeEvent

--- a/packages/assets-controller/src/AssetsController.ts
+++ b/packages/assets-controller/src/AssetsController.ts
@@ -2,12 +2,8 @@ import type {
   AccountTreeControllerGetAccountsFromSelectedAccountGroupAction,
   AccountTreeControllerSelectedAccountGroupChangeEvent,
   AccountTreeControllerState,
-  AccountTreeControllerStateChangeEvent,
 } from '@metamask/account-tree-controller';
-import type {
-  AccountsControllerGetSelectedAccountAction,
-  AccountsControllerSelectedEvmAccountChangeEvent,
-} from '@metamask/accounts-controller';
+import type { AccountsControllerGetSelectedAccountAction } from '@metamask/accounts-controller';
 import { BaseController } from '@metamask/base-controller';
 import type {
   ControllerGetStateAction,
@@ -15,10 +11,7 @@ import type {
   ControllerStateChangedEvent,
   StateMetadata,
 } from '@metamask/base-controller';
-import type {
-  ClientControllerState,
-  ClientControllerStateChangeEvent,
-} from '@metamask/client-controller';
+import type { ClientControllerState } from '@metamask/client-controller';
 import { clientControllerSelectors } from '@metamask/client-controller';
 import type { TraceCallback } from '@metamask/controller-utils';
 import type {
@@ -46,8 +39,8 @@ import type {
 } from '@metamask/network-controller';
 import type {
   NetworkEnablementControllerGetStateAction,
+  NetworkEnablementControllerEvents,
   NetworkEnablementControllerState,
-  NetworkEnablementControllerStateChangeEvent,
 } from '@metamask/network-enablement-controller';
 import type {
   GetPermissions,
@@ -328,16 +321,26 @@ type AllowedActions =
   // PhishingController
   | PhishingControllerBulkScanTokensAction;
 
+type AccountTreeControllerStateChangedEvent = ControllerStateChangedEvent<
+  'AccountTreeController',
+  AccountTreeControllerState
+>;
+
+type ClientControllerStateChangedEvent = ControllerStateChangedEvent<
+  'ClientController',
+  ClientControllerState
+>;
+
+type NetworkEnablementControllerStateChangedEvent = ControllerStateChangedEvent<
+  'NetworkEnablementController',
+  NetworkEnablementControllerState
+>;
+
 type AllowedEvents =
   // AssetsController
   | AccountTreeControllerSelectedAccountGroupChangeEvent
-  | AccountTreeControllerStateChangeEvent
-  | ControllerStateChangedEvent<
-      'AccountTreeController',
-      AccountTreeControllerState
-    >
-  | ClientControllerStateChangeEvent
-  | ControllerStateChangedEvent<'ClientController', ClientControllerState>
+  | AccountTreeControllerStateChangedEvent
+  | ClientControllerStateChangedEvent
   | KeyringControllerLockEvent
   | KeyringControllerUnlockEvent
   | PreferencesControllerStateChangeEvent
@@ -352,14 +355,10 @@ type AllowedEvents =
   | NetworkControllerNetworkDidChangeEvent
   | NetworkControllerNetworkRemovedEvent
   // StakedBalanceDataSource
-  | NetworkEnablementControllerStateChangeEvent
-  | ControllerStateChangedEvent<
-      'NetworkEnablementController',
-      NetworkEnablementControllerState
-    >
+  | NetworkEnablementControllerEvents
+  | NetworkEnablementControllerStateChangedEvent
   // SnapDataSource
   | AccountsControllerAccountBalancesUpdatedEvent
-  | AccountsControllerSelectedEvmAccountChangeEvent
   | PermissionControllerStateChange
   | SnapControllerSnapInstalledEvent
   // BackendWebsocketDataSource
@@ -1080,14 +1079,6 @@ export class AssetsController extends BaseController<
       },
     );
 
-    // Switching EVM address within the same account group (e.g. Account 1 → Account 2).
-    this.messenger.subscribe(
-      'AccountsController:selectedEvmAccountChange',
-      (account) => {
-        this.#handleSelectedEvmAccountChanged(account).catch(console.error);
-      },
-    );
-
     // Catch the initial tree build. On returning users,
     // `selectedAccountGroupChange` does NOT fire when the persisted group
     // is unchanged, and `accountTreeChange` doesn't fire either (init()
@@ -1365,9 +1356,10 @@ export class AssetsController extends BaseController<
       });
       this.#subscribeAssets();
       if (newAccounts.length > 0) {
-        await this.#fetchAccountBalancesViaRpc(newAccounts, [
-          ...this.#enabledChains,
-        ]);
+        await this.getAssets(newAccounts, {
+          chainIds: [...this.#enabledChains],
+          forceUpdate: true,
+        });
       }
     } catch (error) {
       log('Failed to fetch assets after tree change', error);
@@ -3388,40 +3380,6 @@ export class AssetsController extends BaseController<
     }
   }
 
-  /**
-   * Handle EVM account selection within the current account group.
-   * Fires when the user picks a different address under the same logical
-   * account (not when switching account groups).
-   *
-   * @param account - Newly selected EVM account.
-   */
-  async #handleSelectedEvmAccountChanged(
-    account: InternalAccount,
-  ): Promise<void> {
-    if (!this.#uiOpen || !this.#keyringUnlocked || !this.#isEnabled()) {
-      return;
-    }
-
-    const releaseLock = await this.#accountRefreshMutex.acquire();
-    try {
-      await this.getAssets([account], {
-        chainIds: [...this.#enabledChains],
-        forceUpdate: true,
-      });
-
-      this.#subscribeAssets();
-
-      await this.#fetchAccountBalancesViaRpc(
-        [account],
-        [...this.#enabledChains],
-      );
-
-      this.#ensureNativeBalancesDefaultZero();
-    } finally {
-      releaseLock();
-    }
-  }
-
   async #handleEnabledNetworksChanged(
     enabledNetworkMap: NetworkEnablementControllerState['enabledNetworkMap'],
   ): Promise<void> {
@@ -3584,8 +3542,6 @@ export class AssetsController extends BaseController<
         forceUpdate: true,
         dataTypes: ['balance', 'metadata', 'price'],
       });
-
-      await this.#fetchAccountBalancesViaRpc(accounts, [selectedChainId]);
 
       this.#ensureNativeBalancesDefaultZero();
       this.#fetchMissingPricesWithoutCache(accounts, [selectedChainId]);

--- a/packages/assets-controller/src/AssetsController.ts
+++ b/packages/assets-controller/src/AssetsController.ts
@@ -3414,9 +3414,10 @@ export class AssetsController extends BaseController<
 
       this.#subscribeAssets();
 
-      await this.#fetchAccountBalancesViaRpc([account], [
-        ...this.#enabledChains,
-      ]);
+      await this.#fetchAccountBalancesViaRpc(
+        [account],
+        [...this.#enabledChains],
+      );
 
       this.#ensureNativeBalancesDefaultZero();
     } finally {

--- a/packages/assets-controller/src/AssetsController.ts
+++ b/packages/assets-controller/src/AssetsController.ts
@@ -3,7 +3,10 @@ import type {
   AccountTreeControllerSelectedAccountGroupChangeEvent,
   AccountTreeControllerState,
 } from '@metamask/account-tree-controller';
-import type { AccountsControllerGetSelectedAccountAction } from '@metamask/accounts-controller';
+import type {
+  AccountsControllerGetSelectedAccountAction,
+  AccountsControllerSelectedEvmAccountChangeEvent,
+} from '@metamask/accounts-controller';
 import { BaseController } from '@metamask/base-controller';
 import type {
   ControllerGetStateAction,
@@ -359,6 +362,7 @@ type AllowedEvents =
   | NetworkEnablementControllerStateChangedEvent
   // SnapDataSource
   | AccountsControllerAccountBalancesUpdatedEvent
+  | AccountsControllerSelectedEvmAccountChangeEvent
   | PermissionControllerStateChange
   | SnapControllerSnapInstalledEvent
   // BackendWebsocketDataSource
@@ -1079,6 +1083,14 @@ export class AssetsController extends BaseController<
       },
     );
 
+    // Switching EVM address within the same account group (e.g. Account 1 → Account 2).
+    this.messenger.subscribe(
+      'AccountsController:selectedEvmAccountChange',
+      (account) => {
+        this.#handleSelectedEvmAccountChanged(account).catch(console.error);
+      },
+    );
+
     // Catch the initial tree build. On returning users,
     // `selectedAccountGroupChange` does NOT fire when the persisted group
     // is unchanged, and `accountTreeChange` doesn't fire either (init()
@@ -1329,10 +1341,14 @@ export class AssetsController extends BaseController<
         currentCount: currentIds.size,
       });
 
+      const newAccounts = accounts.filter(
+        (account) => !this.#lastKnownAccountIds.has(account.id),
+      );
+
       this.#lastKnownAccountIds = currentIds;
       this.#ensureNativeBalancesDefaultZero();
       this.#ensureDefaultTrackedAssetsSeeded();
-      this.#runAccountTreeRefresh(accounts).catch((error) => {
+      this.#runAccountTreeRefresh(accounts, newAccounts).catch((error) => {
         log('Failed to refresh assets after tree change', error);
       });
     } else {
@@ -1340,7 +1356,10 @@ export class AssetsController extends BaseController<
     }
   }
 
-  async #runAccountTreeRefresh(accounts: InternalAccount[]): Promise<void> {
+  async #runAccountTreeRefresh(
+    accounts: InternalAccount[],
+    newAccounts: InternalAccount[] = [],
+  ): Promise<void> {
     const releaseLock = await this.#accountRefreshMutex.acquire();
     try {
       await this.getAssets(accounts, {
@@ -1348,12 +1367,53 @@ export class AssetsController extends BaseController<
         forceUpdate: true,
       });
       this.#subscribeAssets();
+      if (newAccounts.length > 0) {
+        await this.#fetchAccountBalancesViaRpc(newAccounts, [
+          ...this.#enabledChains,
+        ]);
+      }
     } catch (error) {
       log('Failed to fetch assets after tree change', error);
       this.#subscribeAssets();
     } finally {
       releaseLock();
     }
+  }
+
+  /**
+   * Fetch balances via RpcDataSource and merge into state.
+   *
+   * @param accounts - Accounts to fetch for.
+   * @param chainIds - Chains to fetch on.
+   */
+  async #fetchAccountBalancesViaRpc(
+    accounts: InternalAccount[],
+    chainIds: ChainId[],
+  ): Promise<void> {
+    if (accounts.length === 0 || chainIds.length === 0) {
+      return;
+    }
+
+    const rpcChains = chainIds.filter((chainId) =>
+      this.#rpcDataSource.getActiveChainsSync().includes(chainId),
+    );
+    if (rpcChains.length === 0) {
+      return;
+    }
+
+    const request = this.#buildDataRequest(accounts, rpcChains, {
+      dataTypes: ['balance'],
+      forceUpdate: true,
+    });
+    const { response } = await this.#executeMiddlewares(
+      [
+        createParallelBalanceMiddleware([this.#rpcDataSource]),
+        this.#detectionMiddleware,
+      ],
+      request,
+    );
+
+    await this.#updateState({ ...response, updateMode: 'merge' });
   }
 
   /**
@@ -3320,8 +3380,45 @@ export class AssetsController extends BaseController<
       // Subscribe after fetch so WS notifications can recover state
       this.#subscribeAssets();
 
+      await this.#fetchAccountBalancesViaRpc(accounts, [
+        ...this.#enabledChains,
+      ]);
+
       this.#ensureNativeBalancesDefaultZero();
       this.#ensureDefaultTrackedAssetsSeeded();
+    } finally {
+      releaseLock();
+    }
+  }
+
+  /**
+   * Handle EVM account selection within the current account group.
+   * Fires when the user picks a different address under the same logical
+   * account (not when switching account groups).
+   *
+   * @param account - Newly selected EVM account.
+   */
+  async #handleSelectedEvmAccountChanged(
+    account: InternalAccount,
+  ): Promise<void> {
+    if (!this.#uiOpen || !this.#keyringUnlocked || !this.#isEnabled()) {
+      return;
+    }
+
+    const releaseLock = await this.#accountRefreshMutex.acquire();
+    try {
+      await this.getAssets([account], {
+        chainIds: [...this.#enabledChains],
+        forceUpdate: true,
+      });
+
+      this.#subscribeAssets();
+
+      await this.#fetchAccountBalancesViaRpc([account], [
+        ...this.#enabledChains,
+      ]);
+
+      this.#ensureNativeBalancesDefaultZero();
     } finally {
       releaseLock();
     }
@@ -3364,12 +3461,15 @@ export class AssetsController extends BaseController<
     this.#subscribeAssets();
 
     // Do one-time fetch for newly enabled chains; merge so we keep existing chain balances
-    if (addedChains.length > 0 && this.#getSelectedAccounts().length > 0) {
-      await this.getAssets(this.#getSelectedAccounts(), {
+    const accounts = this.#getSelectedAccounts();
+    if (addedChains.length > 0 && accounts.length > 0) {
+      await this.getAssets(accounts, {
         chainIds: addedChains,
         forceUpdate: true,
         updateMode: 'merge',
       });
+
+      await this.#fetchAccountBalancesViaRpc(accounts, addedChains);
     }
 
     this.#ensureNativeBalancesDefaultZero();
@@ -3486,6 +3586,8 @@ export class AssetsController extends BaseController<
         forceUpdate: true,
         dataTypes: ['balance', 'metadata', 'price'],
       });
+
+      await this.#fetchAccountBalancesViaRpc(accounts, [selectedChainId]);
 
       this.#ensureNativeBalancesDefaultZero();
       this.#fetchMissingPricesWithoutCache(accounts, [selectedChainId]);


### PR DESCRIPTION
Zero-balancing for new accounts ran before getAssets on account-tree changes, so assetsBalance was often never populated for the new account. Seed native zero balances using the refreshed account list after the fetch.

- Fetch balances via RpcDataSource when a user switches EVM accounts, enables RPC-only networks, switches account groups, or adds a new account to the account tree
- Fixes missing `assetsBalance` for newly added accounts on custom/RPC networks (e.g. DXC / `eip155:50`) where `assetsInfo` was present but balances were not fetched

## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes balance refresh timing in `AssetsController` for account-tree and subscription flows; localized but affects wallet balance display on custom/RPC networks.
> 
> **Overview**
> Fixes cases where **`assetsBalance` stayed empty** for new or RPC-only-network accounts even when metadata was present, by tightening when `AssetsController` force-refreshes balances.
> 
> On **account tree updates**, the controller now tracks **newly added accounts** and, after the usual group-wide `getAssets` and re-subscribe, runs a **second forced fetch scoped to those new accounts** so the slow/RPC pipeline can populate balances (e.g. custom chains like `eip155:50`).
> 
> Documents the same class of fix for **account group switches** and **newly enabled RPC-only networks** in the changelog. `#handleEnabledNetworksChanged` only refactors to reuse a local `accounts` variable when fetching added chains—behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e8793363de057d48dff138524aced4fe1d3f6c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->