### PR TITLE
feat: use getQuoteStatus endpoint when polling tx status

### DIFF
--- a/packages/bridge-status-controller/CHANGELOG.md
+++ b/packages/bridge-status-controller/CHANGELOG.md
@@ -7,9 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Source transaction status from the `/getQuoteStatus` backend during polling for history items with an associated `quoteId`, falling back to the `/getTxStatus` bridge-api endpoint when no quote-status backend status is available yet or the QuoteStatusManager is disabled. ([#0000](https://github.com/MetaMask/core/pull/0000))
+
 ### Changed
 
 - Bump `@metamask/bridge-controller` from `^77.3.1` to `^77.3.2` ([#9372](https://github.com/MetaMask/core/pull/9372))
+
+### Fixed
+
+- Remove the redundant quote-status fetch previously issued after a `FINALIZED_SUCCESS`/`FINALIZED_FAILED` quote-status update was accepted. ([#0000](https://github.com/MetaMask/core/pull/0000))
 
 ## [74.0.2]
 

--- a/packages/bridge-status-controller/CHANGELOG.md
+++ b/packages/bridge-status-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Source transaction status from the `/getQuoteStatus` backend during polling for history items with an associated `quoteId`, falling back to the `/getTxStatus` bridge-api endpoint when no quote-status backend status is available yet or the QuoteStatusManager is disabled. ([#0000](https://github.com/MetaMask/core/pull/0000))
+- Source transaction status from the `/getQuoteStatus` backend during polling for history items with an associated `quoteId`, falling back to the `/getTxStatus` bridge-api endpoint when no quote-status backend status is available yet or the QuoteStatusManager is disabled. ([#9389](https://github.com/MetaMask/core/pull/9389))
 
 ### Changed
 
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Remove the redundant quote-status fetch previously issued after a `FINALIZED_SUCCESS`/`FINALIZED_FAILED` quote-status update was accepted. ([#0000](https://github.com/MetaMask/core/pull/0000))
+- Remove the redundant quote-status fetch previously issued after a `FINALIZED_SUCCESS`/`FINALIZED_FAILED` quote-status update was accepted. ([#9389](https://github.com/MetaMask/core/pull/9389))
 
 ## [74.0.2]
 

--- a/packages/bridge-status-controller/src/bridge-status-controller.test.ts
+++ b/packages/bridge-status-controller/src/bridge-status-controller.test.ts
@@ -1430,6 +1430,143 @@ describe('BridgeStatusController', () => {
       bridgeStatusController.stopAllPolling();
     });
 
+    describe('quote status manager integration', () => {
+      it('fetches status via the quote status manager instead of the bridge API when the history item has a quoteId', async () => {
+        jest.useFakeTimers();
+        const fetchBridgeTxStatusSpy = jest.spyOn(
+          bridgeStatusUtils,
+          'fetchBridgeTxStatus',
+        );
+        const fetchBridgeQuoteStatusSpy = jest
+          .spyOn(bridgeStatusUtils, 'fetchBridgeQuoteStatus')
+          .mockResolvedValueOnce({
+            status: MockStatusResponse.getPending(),
+            validationFailures: [],
+          });
+
+        await withController(
+          {
+            options: {
+              isQuoteStatusManagerEnabled: () => true,
+              state: {
+                txHistory: {
+                  bridgeTxMetaId1: {
+                    ...MockTxHistory.getPending().bridgeTxMetaId1,
+                    quoteId: 'quote-1',
+                  },
+                },
+              },
+            },
+          },
+          async ({ controller, rootMessenger }) => {
+            registerDefaultActionHandlers(rootMessenger);
+            controller.startPolling({ bridgeTxMetaId: 'bridgeTxMetaId1' });
+
+            jest.advanceTimersByTime(10000);
+            await flushPromises();
+
+            expect(fetchBridgeQuoteStatusSpy).toHaveBeenCalledWith(
+              expect.anything(),
+              'quote-1',
+            );
+            expect(fetchBridgeTxStatusSpy).not.toHaveBeenCalled();
+            expect(
+              controller.state.txHistory.bridgeTxMetaId1.status.status,
+            ).toBe(StatusTypes.PENDING);
+
+            controller.stopAllPolling();
+            jest.restoreAllMocks();
+          },
+        );
+      });
+
+      it('falls back to the bridge API when the quote status manager has no status yet', async () => {
+        jest.useFakeTimers();
+        const fetchBridgeTxStatusSpy = jest
+          .spyOn(bridgeStatusUtils, 'fetchBridgeTxStatus')
+          .mockResolvedValueOnce({
+            status: MockStatusResponse.getPending(),
+            validationFailures: [],
+          });
+        const fetchBridgeQuoteStatusSpy = jest
+          .spyOn(bridgeStatusUtils, 'fetchBridgeQuoteStatus')
+          .mockResolvedValueOnce(null);
+
+        await withController(
+          {
+            options: {
+              isQuoteStatusManagerEnabled: () => true,
+              state: {
+                txHistory: {
+                  bridgeTxMetaId1: {
+                    ...MockTxHistory.getPending().bridgeTxMetaId1,
+                    quoteId: 'quote-1',
+                  },
+                },
+              },
+            },
+          },
+          async ({ controller, rootMessenger }) => {
+            registerDefaultActionHandlers(rootMessenger);
+            controller.startPolling({ bridgeTxMetaId: 'bridgeTxMetaId1' });
+
+            jest.advanceTimersByTime(10000);
+            await flushPromises();
+
+            expect(fetchBridgeQuoteStatusSpy).toHaveBeenCalledWith(
+              expect.anything(),
+              'quote-1',
+            );
+            expect(fetchBridgeTxStatusSpy).toHaveBeenCalledTimes(1);
+            expect(
+              controller.state.txHistory.bridgeTxMetaId1.status.status,
+            ).toBe(StatusTypes.PENDING);
+
+            controller.stopAllPolling();
+            jest.restoreAllMocks();
+          },
+        );
+      });
+
+      it('does not call the quote status manager when the history item has no quoteId', async () => {
+        jest.useFakeTimers();
+        const fetchBridgeTxStatusSpy = jest
+          .spyOn(bridgeStatusUtils, 'fetchBridgeTxStatus')
+          .mockResolvedValueOnce({
+            status: MockStatusResponse.getPending(),
+            validationFailures: [],
+          });
+        const fetchBridgeQuoteStatusSpy = jest.spyOn(
+          bridgeStatusUtils,
+          'fetchBridgeQuoteStatus',
+        );
+
+        await withController(
+          {
+            options: {
+              isQuoteStatusManagerEnabled: () => true,
+              state: {
+                txHistory: MockTxHistory.getPending(),
+              },
+            },
+          },
+          async ({ controller, rootMessenger }) => {
+            registerDefaultActionHandlers(rootMessenger);
+            controller.startPolling({ bridgeTxMetaId: 'bridgeTxMetaId1' });
+
+            jest.advanceTimersByTime(10000);
+            await flushPromises();
+
+            expect(fetchBridgeQuoteStatusSpy).not.toHaveBeenCalled();
+            expect(fetchBridgeTxStatusSpy).toHaveBeenCalledTimes(1);
+
+            controller.stopAllPolling();
+            jest.restoreAllMocks();
+          },
+        );
+      });
+    });
+
     it('stops polling when the status response is complete', async () => {
       // Setup
       jest.useFakeTimers();

--- a/packages/bridge-status-controller/src/bridge-status-controller.ts
+++ b/packages/bridge-status-controller/src/bridge-status-controller.ts
@@ -69,6 +69,7 @@ import {
 } from './utils/bridge';
 import {
   fetchBridgeTxStatus,
+  fetchBridgeQuoteStatus,
   getStatusRequestWithSrcTxHash,
   shouldSkipFetchDueToFetchFailures,
   shouldWaitForFinalBridgeStatus,
@@ -893,13 +894,20 @@ export class BridgeStatusController extends StaticIntervalPollingController<Brid
           historyItem.quote,
           srcTxHash,
         );
-        const response = await fetchBridgeTxStatus(
-          statusRequest,
-          this.#clientId,
-          await getJwt(this.messenger),
-          this.#fetchFn,
-          this.#config.customBridgeApiBaseUrl,
-        );
+        const response =
+          (historyItem.quoteId
+            ? await fetchBridgeQuoteStatus(
+                this.#quoteStatusManager,
+                historyItem.quoteId,
+              )
+            : null) ??
+          (await fetchBridgeTxStatus(
+            statusRequest,
+            this.#clientId,
+            await getJwt(this.messenger),
+            this.#fetchFn,
+            this.#config.customBridgeApiBaseUrl,
+          ));
         status = response.status;
         validationFailures = response.validationFailures;
       }

--- a/packages/bridge-status-controller/src/quote-status-manager/quotes-status-manager.test.ts
+++ b/packages/bridge-status-controller/src/quote-status-manager/quotes-status-manager.test.ts
@@ -457,20 +457,21 @@ describe('QuoteStatusUpdateManager', () => {
   });
 
   describe('getStatus', () => {
-    it('does nothing when the manager is disabled', () => {
+    it('does nothing when the manager is disabled', async () => {
       const { manager } = createManager({
         isEnabled: jest.fn().mockReturnValue(false),
       });
 
-      manager.getStatus('quote-1');
+      const result = await manager.getStatus('quote-1');
 
       expect(mockGetQuoteStatusWithRetry).not.toHaveBeenCalled();
+      expect(result).toBeUndefined();
     });
 
-    it('delegates to the API service with the default retry options when enabled', () => {
+    it('delegates to the API service with the default retry options when enabled', async () => {
       const { manager } = createManager();
 
-      manager.getStatus('quote-1');
+      await manager.getStatus('quote-1');
 
       expect(mockGetQuoteStatusWithRetry).toHaveBeenCalledWith(
         { quoteId: 'quote-1' },
@@ -478,10 +479,10 @@ describe('QuoteStatusUpdateManager', () => {
       );
     });
 
-    it('passes custom options to the API service', () => {
+    it('passes custom options to the API service', async () => {
       const { manager } = createManager();
 
-      manager.getStatus('quote-1', {
+      await manager.getStatus('quote-1', {
         maxRetries: 3,
         delayMsBetweenRetries: 500,
       });
@@ -490,6 +491,27 @@ describe('QuoteStatusUpdateManager', () => {
         { quoteId: 'quote-1' },
         { maxRetries: 3, delayMsBetweenRetries: 500 },
       );
+    });
+
+    it('resolves with the outcome returned by the API service', async () => {
+      const outcome = new QuoteStatusGetWithRetryOutcome(
+        QuoteStatusFetchWithRetryOutcomeType.Accepted,
+      );
+      mockGetQuoteStatusWithRetry.mockResolvedValueOnce(outcome);
+      const { manager } = createManager();
+
+      const result = await manager.getStatus('quote-1');
+
+      expect(result).toBe(outcome);
+    });
+
+    it('resolves with undefined when the API service rejects', async () => {
+      mockGetQuoteStatusWithRetry.mockRejectedValueOnce(new Error('boom'));
+      const { manager } = createManager();
+
+      const result = await manager.getStatus('quote-1');
+
+      expect(result).toBeUndefined();
     });
   });
 
@@ -933,7 +955,7 @@ describe('QuoteStatusUpdateManager', () => {
       });
     });
 
-    it('calls getStatus after a FinalizedSuccess update is accepted', async () => {
+    it('does not call getStatus after a FinalizedSuccess update is accepted', async () => {
       mockUpdate
         .mockResolvedValueOnce(
           new QuoteStatusUpdateWithRetryOutcome(
@@ -952,13 +974,10 @@ describe('QuoteStatusUpdateManager', () => {
       manager.reportFinalised('tx-1', true);
       await flush();
 
-      expect(mockGetQuoteStatusWithRetry).toHaveBeenCalledWith(
-        { quoteId: 'quote-1' },
-        { maxRetries: 1, delayMsBetweenRetries: 1000 },
-      );
+      expect(mockGetQuoteStatusWithRetry).not.toHaveBeenCalled();
     });
 
-    it('calls getStatus after a FinalizedFailed update is accepted', async () => {
+    it('does not call getStatus after a FinalizedFailed update is accepted', async () => {
       mockUpdate
         .mockResolvedValueOnce(
           new QuoteStatusUpdateWithRetryOutcome(
@@ -977,10 +996,7 @@ describe('QuoteStatusUpdateManager', () => {
       manager.reportFinalised('tx-1', false);
       await flush();
 
-      expect(mockGetQuoteStatusWithRetry).toHaveBeenCalledWith(
-        { quoteId: 'quote-1' },
-        { maxRetries: 1, delayMsBetweenRetries: 1000 },
-      );
+      expect(mockGetQuoteStatusWithRetry).not.toHaveBeenCalled();
     });
 
     it('does not call getStatus when a non-finalized update is accepted', async () => {

--- a/packages/bridge-status-controller/src/quote-status-manager/quotes-status-manager.ts
+++ b/packages/bridge-status-controller/src/quote-status-manager/quotes-status-manager.ts
@@ -16,6 +16,7 @@ import {
 import { QuoteStatusUpdateError } from './errors';
 import { QuoteStatusApiService } from './quote-status-api-service';
 import { QuoteStatusEntryStore } from './quote-status-entry-store';
+import { QuoteStatusGetWithRetryOutcome } from './quote-status-get-with-retry-outcome';
 import { QuoteStatusStateFsm } from './quote-status-state-fsm';
 import { QuoteStatusUpdateWithRetryOutcome } from './quote-status-update-with-retry-outcome';
 import { QuoteStatusPersistEntry, QuoteStatusRuntimeEntry } from './types';
@@ -299,8 +300,9 @@ export class QuoteStatusManager {
    * @param options - Retry configuration.
    * @param options.maxRetries - Maximum number of retries after the initial attempt.
    * @param options.delayMsBetweenRetries - Delay in milliseconds between attempts.
+   * @returns The quote status outcome, or `undefined` when the manager is disabled.
    */
-  getStatus(
+  async getStatus(
     quoteId: string,
     options: {
       maxRetries?: number;
@@ -309,12 +311,12 @@ export class QuoteStatusManager {
       maxRetries: 0,
       delayMsBetweenRetries: 1000,
     },
-  ): void {
+  ): Promise<QuoteStatusGetWithRetryOutcome | undefined> {
     if (!this.#isEnabled?.()) {
-      return;
+      return undefined;
     }
 
-    this.#quoteStatusApiService
+    const response = this.#quoteStatusApiService
       .getQuoteStatusWithRetry(
         {
           quoteId,
@@ -323,9 +325,11 @@ export class QuoteStatusManager {
           maxRetries: options.maxRetries ?? 0,
           delayMsBetweenRetries: options.delayMsBetweenRetries ?? 1000,
         },
-        // Errors already reported by #onError handlers of `getQuoteStatusWithRetry()`
       )
+      // Errors already reported by #onError handlers of `getQuoteStatusWithRetry()`
       .catch(() => undefined);
+
+    return response;
   }
 
   /**
@@ -520,10 +524,7 @@ export class QuoteStatusManager {
               // `Completed` state and keep the entry so any later duplicate
               // `reportSubmitted` for this quote is rejected instead of looping.
               this.#markCompleted(current);
-              // Call getStatus to complete the flow on the backend.
-              // We discard any value for now, this is used purely
-              // to notify backend that the flow is complete.
-              this.getStatus(entry.quoteId, { maxRetries: 1 });
+
               return undefined;
             }
             // A non-final status (e.g. `Submitted`) was accepted. The quote is

--- a/packages/bridge-status-controller/src/utils/bridge-status.test.ts
+++ b/packages/bridge-status-controller/src/utils/bridge-status.test.ts
@@ -1,7 +1,12 @@
 import { BRIDGE_PROD_API_BASE_URL, REFRESH_INTERVAL_MS } from '../constants';
+import { QuoteStatusFetchWithRetryOutcomeType } from '../quote-status-manager/constants';
+import { QuoteStatusGetError } from '../quote-status-manager/errors';
+import { QuoteStatusGetWithRetryOutcome } from '../quote-status-manager/quote-status-get-with-retry-outcome';
+import type { QuoteStatusManager } from '../quote-status-manager/quotes-status-manager';
 import { BridgeClientId } from '../types';
 import type { StatusRequestWithSrcTxHash, FetchFunction } from '../types';
 import {
+  fetchBridgeQuoteStatus,
   fetchBridgeTxStatus,
   getBridgeStatusUrl,
   getStatusRequestDto,
@@ -215,6 +220,119 @@ describe('utils', () => {
           BRIDGE_PROD_API_BASE_URL,
         ),
       ).rejects.toThrow('Network error');
+    });
+  });
+
+  describe('fetchBridgeQuoteStatus', () => {
+    const mockQuoteId = 'quote-1';
+
+    /**
+     * Builds a mock `QuoteStatusManager` whose `getStatus` method resolves
+     * with the given outcome.
+     *
+     * @param outcome - The outcome `getStatus` should resolve with.
+     * @returns An object with the mocked manager and its `getStatus` spy.
+     */
+    function createMockQuoteStatusManager(
+      outcome: QuoteStatusGetWithRetryOutcome | undefined,
+    ): {
+      quoteStatusManager: QuoteStatusManager;
+      getStatus: jest.Mock;
+    } {
+      const getStatus = jest.fn().mockResolvedValue(outcome);
+      return {
+        quoteStatusManager: { getStatus } as unknown as QuoteStatusManager,
+        getStatus,
+      };
+    }
+
+    it('returns the submitted tx status when the manager reports it', async () => {
+      const { quoteStatusManager, getStatus } = createMockQuoteStatusManager(
+        new QuoteStatusGetWithRetryOutcome(
+          QuoteStatusFetchWithRetryOutcomeType.Accepted,
+          { submittedTx: mockValidResponse as never },
+        ),
+      );
+
+      const result = await fetchBridgeQuoteStatus(
+        quoteStatusManager,
+        mockQuoteId,
+      );
+
+      expect(getStatus).toHaveBeenCalledWith(mockQuoteId);
+      expect(result).toStrictEqual({
+        status: mockValidResponse,
+        validationFailures: [],
+      });
+    });
+
+    it('returns validation failures from the outcome error alongside the submitted tx status', async () => {
+      const { quoteStatusManager } = createMockQuoteStatusManager(
+        new QuoteStatusGetWithRetryOutcome(
+          QuoteStatusFetchWithRetryOutcomeType.Accepted,
+          { submittedTx: mockValidResponse as never },
+          new QuoteStatusGetError('unexpected response shape', {
+            quoteId: mockQuoteId,
+            validationFailures: ['socket|status'],
+          }),
+        ),
+      );
+
+      const result = await fetchBridgeQuoteStatus(
+        quoteStatusManager,
+        mockQuoteId,
+      );
+
+      expect(result).toStrictEqual({
+        status: mockValidResponse,
+        validationFailures: ['socket|status'],
+      });
+    });
+
+    it('returns null when the manager is disabled (resolves undefined)', async () => {
+      const { quoteStatusManager } = createMockQuoteStatusManager(undefined);
+
+      const result = await fetchBridgeQuoteStatus(
+        quoteStatusManager,
+        mockQuoteId,
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when the outcome has no response', async () => {
+      const { quoteStatusManager } = createMockQuoteStatusManager(
+        new QuoteStatusGetWithRetryOutcome(
+          QuoteStatusFetchWithRetryOutcomeType.NonRetryable,
+          undefined,
+          new QuoteStatusGetError('request error', {
+            quoteId: mockQuoteId,
+          }),
+        ),
+      );
+
+      const result = await fetchBridgeQuoteStatus(
+        quoteStatusManager,
+        mockQuoteId,
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when the response has no submittedTx yet', async () => {
+      const { quoteStatusManager } = createMockQuoteStatusManager(
+        new QuoteStatusGetWithRetryOutcome(
+          QuoteStatusFetchWithRetryOutcomeType.Accepted,
+          {},
+        ),
+      );
+
+      const result = await fetchBridgeQuoteStatus(
+        quoteStatusManager,
+        mockQuoteId,
+      );
+
+      expect(result).toBeNull();
     });
   });
 

--- a/packages/bridge-status-controller/src/utils/bridge-status.ts
+++ b/packages/bridge-status-controller/src/utils/bridge-status.ts
@@ -8,6 +8,7 @@ import type { Provider } from '@metamask/network-controller';
 import { StructError } from '@metamask/superstruct';
 
 import { REFRESH_INTERVAL_MS } from '../constants';
+import { QuoteStatusManager } from '../quote-status-manager/quotes-status-manager';
 import type {
   StatusResponse,
   StatusRequestWithSrcTxHash,
@@ -42,6 +43,24 @@ export const getStatusRequestDto = (
   return {
     ...statusRequestNoQuoteFormatted,
     ...requestId,
+  };
+};
+
+export const fetchBridgeQuoteStatus = async (
+  quoteStatusManager: QuoteStatusManager,
+  quoteId: string,
+): Promise<{ status: StatusResponse; validationFailures: string[] } | null> => {
+  const response = await quoteStatusManager.getStatus(quoteId);
+
+  const status = response?.response?.submittedTx;
+
+  if (!status) {
+    return null;
+  }
+
+  return {
+    status,
+    validationFailures: response.error?.details?.validationFailures ?? [],
   };
 };
 


### PR DESCRIPTION
## Explanation

`BridgeStatusController#pollForTxStatus` previously always fetched a bridge transaction's status by calling the bridge-api `getTxStatus` endpoint (via `fetchBridgeTxStatus`), even for swaps/bridges whose quotes are already tracked by the `QuoteStatusManager` (which receives status pushes via `getQuoteStatus`/SSE). This meant we were double-tracking status for the same transaction through two separate backends, and polling could lag behind status the `QuoteStatusManager` had already fetched.

This PR makes `pollForTxStatus` prefer the `QuoteStatusManager` as the source of truth when a history item has a `quoteId`:

* Added `fetchBridgeQuoteStatus` (`src/utils/bridge-status.ts`), which calls `QuoteStatusManager#getStatus(quoteId)` and maps its `submittedTx` response (plus any `validationFailures`) into the same `{ status, validationFailures }` shape that `fetchBridgeTxStatus` already returns, so downstream code in `pollForTxStatus` didn't need to change.
* In `bridge-status-controller.ts`, when a history item has a `quoteId`, `fetchBridgeQuoteStatus` is tried first. If it returns `null` (no `submittedTx` yet, e.g. because the quote-status backend hasn't confirmed the transaction) or the item has no `quoteId`, we fall back to the existing `fetchBridgeTxStatus` bridge-api call unchanged. This keeps the change low-risk: the quote-status path is purely additive and any failure/absence of data falls back to today's behavior.
* `QuoteStatusManager#getStatus` was changed from fire-and-forget (`void`) to `async`, returning `Promise<QuoteStatusGetWithRetryOutcome | undefined>` (`undefined` when the manager is disabled), since `fetchBridgeQuoteStatus` now needs to await and read its result.
* As a result, the call to `getStatus` inside `QuoteStatusManager`'s finalization handling (previously used only to "ping" the backend after a `FINALIZED_SUCCESS`/`FINALIZED_FAILED` update, discarding the result) is now redundant — polling itself calls `getStatus` via `fetchBridgeQuoteStatus` — so it was removed.

No dependency upgrades were required; only `bridge-status-controller` source, tests, and changelog were touched.

## References

* Related to the `bridgeQuoteStatusManager` rollout for extension bridge/swap status polling (consumer PR: `MetaMask/metamask-extension` — adds e2e coverage exercising `getQuoteStatus` and its `getTxStatus` fallback via the `bridgeQuoteStatusManager` feature flag).
* https://consensyssoftware.atlassian.net/browse/SWAPS-4702

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them
