### PR TITLE
feat(ai-controllers): add fetchFrontPageItem to fetch a market overview front page by id

### DIFF
--- a/packages/ai-controllers/CHANGELOG.md
+++ b/packages/ai-controllers/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `AiDigestController.fetchFrontPageItem(id)` (and the underlying `AiDigestService.fetchFrontPageItem`) which fetches a single market overview "front page" by id from `GET /market-overview/front-page/:id`, exposed via the `AiDigestController:fetchFrontPageItem` messenger action ([#0000](https://github.com/MetaMask/core/pull/0000))
+- Add `MarketOverviewFrontPage` and `MarketOverviewItem` types ([#0000](https://github.com/MetaMask/core/pull/0000))
+
 ### Changed
 
 - Bump `@metamask/utils` from `^11.9.0` to `^11.11.0` ([#9074](https://github.com/MetaMask/core/pull/9074))

--- a/packages/ai-controllers/CHANGELOG.md
+++ b/packages/ai-controllers/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `AiDigestController.fetchFrontPageItem(id)` (and the underlying `AiDigestService.fetchFrontPageItem`) which fetches a single market overview "front page" by id from `GET /market-overview/front-page/:id`, exposed via the `AiDigestController:fetchFrontPageItem` messenger action ([#0000](https://github.com/MetaMask/core/pull/0000))
-- Add `MarketOverviewFrontPage` and `MarketOverviewItem` types ([#0000](https://github.com/MetaMask/core/pull/0000))
+- Add `AiDigestController.fetchFrontPageItem(id)` (and the underlying `AiDigestService.fetchFrontPageItem`) which fetches a single market overview "front page" by id from `GET /market-overview/front-page/:id`, exposed via the `AiDigestController:fetchFrontPageItem` messenger action ([#9394](https://github.com/MetaMask/core/pull/9394))
+- Add `MarketOverviewFrontPage` and `MarketOverviewItem` types ([#9394](https://github.com/MetaMask/core/pull/9394))
 
 ### Changed
 

--- a/packages/ai-controllers/src/AiDigestController-method-action-types.ts
+++ b/packages/ai-controllers/src/AiDigestController-method-action-types.ts
@@ -33,8 +33,24 @@ export type AiDigestControllerFetchMarketOverviewAction = {
 };
 
 /**
+ * Fetches a single market overview front page by id.
+ *
+ * Unlike the market overview report (which only returns the latest items),
+ * this resolves an older item that has since dropped out of the report, so
+ * clients can render it directly (e.g. from a deep link).
+ *
+ * @param id - The front-page identifier (UUID).
+ * @returns The market overview front page, or `null` if none exists.
+ */
+export type AiDigestControllerFetchFrontPageItemAction = {
+  type: `AiDigestController:fetchFrontPageItem`;
+  handler: AiDigestController['fetchFrontPageItem'];
+};
+
+/**
  * Union of all AiDigestController action types.
  */
 export type AiDigestControllerMethodActions =
   | AiDigestControllerFetchMarketInsightsAction
-  | AiDigestControllerFetchMarketOverviewAction;
+  | AiDigestControllerFetchMarketOverviewAction
+  | AiDigestControllerFetchFrontPageItemAction;

--- a/packages/ai-controllers/src/AiDigestController.test.ts
+++ b/packages/ai-controllers/src/AiDigestController.test.ts
@@ -12,6 +12,7 @@ import type {
   DigestService,
   MarketInsightsReport,
   MarketOverview,
+  MarketOverviewFrontPage,
 } from '.';
 
 const mockReport: MarketInsightsReport = {
@@ -30,6 +31,21 @@ const mockOverview: MarketOverview = {
   trends: [],
 };
 
+const mockFrontPage: MarketOverviewFrontPage = {
+  id: 'a3f1c2d4-5e6f-4a7b-8c9d-0e1f2a3b4c5d',
+  item: {
+    title: 'Institutional adoption',
+    description: 'Institutional players continue accumulating.',
+    category: 'macro',
+    impact: 'positive',
+    articles: [],
+    relatedAssets: [],
+  },
+  ctaTitle: 'Majors steady as volatility cools',
+  ctaDescription: 'Bitcoin and Ethereum held firm as funding rates normalized.',
+  createdAt: '2026-02-11T10:32:52.403Z',
+};
+
 const createMessenger = (): AiDigestControllerMessenger =>
   new Messenger({
     namespace: 'AiDigestController',
@@ -38,6 +54,7 @@ const createMessenger = (): AiDigestControllerMessenger =>
 const createService = (overrides?: Partial<DigestService>): DigestService => ({
   searchDigest: jest.fn().mockResolvedValue(mockReport),
   fetchMarketOverview: jest.fn().mockResolvedValue(mockOverview),
+  fetchFrontPageItem: jest.fn().mockResolvedValue(mockFrontPage),
   ...overrides,
 });
 
@@ -260,5 +277,67 @@ describe('AiDigestController (market overview)', () => {
 
     expect(result).toBeNull();
     expect(controller.state.marketOverview).toBeNull();
+  });
+});
+
+describe('AiDigestController (front page)', () => {
+  it('registers fetchFrontPageItem action on messenger', async () => {
+    const digestService = createService();
+    const messenger = createMessenger();
+    const controller = new AiDigestController({ messenger, digestService });
+
+    const result = await messenger.call(
+      'AiDigestController:fetchFrontPageItem',
+      mockFrontPage.id,
+    );
+
+    expect(result).toStrictEqual(mockFrontPage);
+    expect(digestService.fetchFrontPageItem).toHaveBeenCalledWith(
+      mockFrontPage.id,
+    );
+    // The front page is not cached, so controller state is left untouched.
+    expect(controller.state).toStrictEqual({
+      marketInsights: {},
+      marketOverview: null,
+    });
+  });
+
+  it('delegates to the service and returns the front page', async () => {
+    const digestService = createService();
+    const controller = new AiDigestController({
+      messenger: createMessenger(),
+      digestService,
+    });
+
+    const result = await controller.fetchFrontPageItem(mockFrontPage.id);
+
+    expect(result).toStrictEqual(mockFrontPage);
+  });
+
+  it('returns null when the service returns null', async () => {
+    const digestService = createService({
+      fetchFrontPageItem: jest.fn().mockResolvedValue(null),
+    });
+    const controller = new AiDigestController({
+      messenger: createMessenger(),
+      digestService,
+    });
+
+    const result = await controller.fetchFrontPageItem(mockFrontPage.id);
+
+    expect(result).toBeNull();
+  });
+
+  it('throws for an empty id without calling the service', async () => {
+    const digestService = createService();
+    const controller = new AiDigestController({
+      messenger: createMessenger(),
+      digestService,
+    });
+
+    await expect(controller.fetchFrontPageItem('')).rejects.toThrow(
+      AiDigestControllerErrorMessage.INVALID_FRONT_PAGE_ID,
+    );
+    expect(digestService.fetchFrontPageItem).not.toHaveBeenCalled();
   });
 });

--- a/packages/ai-controllers/src/AiDigestController.ts
+++ b/packages/ai-controllers/src/AiDigestController.ts
@@ -19,6 +19,7 @@ import type {
   MarketInsightsEntry,
   MarketOverview,
   MarketOverviewEntry,
+  MarketOverviewFrontPage,
 } from './ai-digest-types';
 import type { AiDigestControllerMethodActions } from './AiDigestController-method-action-types';
 
@@ -75,6 +76,7 @@ const aiDigestControllerMetadata: StateMetadata<AiDigestControllerState> = {
 const MESSENGER_EXPOSED_METHODS = [
   'fetchMarketInsights',
   'fetchMarketOverview',
+  'fetchFrontPageItem',
 ] as const;
 
 export class AiDigestController extends BaseController<
@@ -186,6 +188,26 @@ export class AiDigestController extends BaseController<
     });
 
     return data;
+  }
+
+  /**
+   * Fetches a single market overview front page by id.
+   *
+   * Unlike the market overview report (which only returns the latest items),
+   * this resolves an older item that has since dropped out of the report, so
+   * clients can render it directly (e.g. from a deep link).
+   *
+   * @param id - The front-page identifier (UUID).
+   * @returns The market overview front page, or `null` if none exists.
+   */
+  async fetchFrontPageItem(
+    id: string,
+  ): Promise<MarketOverviewFrontPage | null> {
+    if (!id) {
+      throw new Error(AiDigestControllerErrorMessage.INVALID_FRONT_PAGE_ID);
+    }
+
+    return this.#digestService.fetchFrontPageItem(id);
   }
 
   /**

--- a/packages/ai-controllers/src/AiDigestService.test.ts
+++ b/packages/ai-controllers/src/AiDigestService.test.ts
@@ -895,4 +895,156 @@ describe('AiDigestService', () => {
       expect(result).toStrictEqual(withExtras);
     });
   });
+
+  describe('fetchFrontPageItem', () => {
+    const mockRelatedAsset = {
+      name: 'Bitcoin',
+      symbol: 'BTC',
+      caip19: ['bip122:000000000019d6689c085ae165831e93/slip44:0'],
+      sourceAssetId: 'bitcoin',
+      hlPerpsMarket: ['BTC'],
+    };
+
+    const mockFrontPage = {
+      id: 'a3f1c2d4-5e6f-4a7b-8c9d-0e1f2a3b4c5d',
+      item: {
+        title: 'Institutional adoption',
+        description: 'Institutional players continue accumulating.',
+        category: 'macro',
+        impact: 'positive',
+        articles: [
+          {
+            title: 'Crypto adoption rises',
+            url: 'https://example.com/crypto-adoption',
+            source: 'example.com',
+            date: '2026-02-16',
+          },
+        ],
+        relatedAssets: [mockRelatedAsset],
+      },
+      ctaTitle: 'Majors steady as volatility cools',
+      ctaDescription:
+        'Bitcoin and Ethereum held firm as funding rates normalized.',
+      createdAt: '2026-02-16T10:00:00.000Z',
+    };
+
+    it('fetches a front page item from the correct endpoint', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(mockFrontPage),
+      });
+
+      const service = new AiDigestService({
+        baseUrl: 'http://test.com/api/v1',
+      });
+      const result = await service.fetchFrontPageItem(mockFrontPage.id);
+
+      expect(result).toStrictEqual(mockFrontPage);
+      expect(mockFetch).toHaveBeenCalledWith(
+        `http://test.com/api/v1/market-overview/front-page/${mockFrontPage.id}`,
+      );
+    });
+
+    it('url-encodes the id in the request path', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(mockFrontPage),
+      });
+
+      const service = new AiDigestService({
+        baseUrl: 'http://test.com/api/v1',
+      });
+      await service.fetchFrontPageItem('a b/c');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://test.com/api/v1/market-overview/front-page/a%20b%2Fc',
+      );
+    });
+
+    it('returns null when API returns 404', async () => {
+      mockFetch.mockResolvedValue({ ok: false, status: 404 });
+
+      const service = new AiDigestService({
+        baseUrl: 'http://test.com/api/v1',
+      });
+      const result = await service.fetchFrontPageItem(mockFrontPage.id);
+
+      expect(result).toBeNull();
+    });
+
+    it('throws on non-404 non-ok response', async () => {
+      mockFetch.mockResolvedValue({ ok: false, status: 500 });
+
+      const service = new AiDigestService({
+        baseUrl: 'http://test.com/api/v1',
+      });
+
+      await expect(
+        service.fetchFrontPageItem(mockFrontPage.id),
+      ).rejects.toThrow('API request failed: 500');
+    });
+
+    it('throws when the item schema is invalid', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({ ...mockFrontPage, item: 'not-an-object' }),
+      });
+
+      const service = new AiDigestService({
+        baseUrl: 'http://test.com/api/v1',
+      });
+
+      await expect(
+        service.fetchFrontPageItem(mockFrontPage.id),
+      ).rejects.toThrow(AiDigestControllerErrorMessage.API_INVALID_RESPONSE);
+    });
+
+    it('throws when ctaTitle is missing', async () => {
+      const { ctaTitle: _ctaTitle, ...withoutCtaTitle } = mockFrontPage;
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(withoutCtaTitle),
+      });
+
+      const service = new AiDigestService({
+        baseUrl: 'http://test.com/api/v1',
+      });
+
+      await expect(
+        service.fetchFrontPageItem(mockFrontPage.id),
+      ).rejects.toThrow(AiDigestControllerErrorMessage.API_INVALID_RESPONSE);
+    });
+
+    it('normalises missing caip19 on the item to []', async () => {
+      const perpsOnlyAsset = {
+        name: 'ETHFI',
+        symbol: 'ETHFI',
+        sourceAssetId: '',
+        hlPerpsMarket: ['ETHFI'],
+      };
+
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            ...mockFrontPage,
+            item: { ...mockFrontPage.item, relatedAssets: [perpsOnlyAsset] },
+          }),
+      });
+
+      const service = new AiDigestService({
+        baseUrl: 'http://test.com/api/v1',
+      });
+      const result = await service.fetchFrontPageItem(mockFrontPage.id);
+
+      expect(result?.item.relatedAssets[0].caip19).toStrictEqual([]);
+    });
+  });
 });

--- a/packages/ai-controllers/src/AiDigestService.ts
+++ b/packages/ai-controllers/src/AiDigestService.ts
@@ -12,6 +12,8 @@ import type {
   DigestService,
   MarketInsightsReport,
   MarketOverview,
+  MarketOverviewFrontPage,
+  MarketOverviewTrend,
 } from './ai-digest-types';
 
 export type AiDigestServiceConfig = {
@@ -113,15 +115,30 @@ const MarketOverviewReportEnvelopeStruct = structType({
   report: MarketOverviewStruct,
 });
 
+// A single front-page row. `item` shares the exact same schema as an
+// individual market overview trend; `ctaTitle`/`ctaDescription` are the
+// AI-authored call-to-action copy layered on top.
+const MarketOverviewFrontPageStruct = structType({
+  id: string(),
+  item: MarketOverviewTrendStruct,
+  ctaTitle: string(),
+  ctaDescription: string(),
+  createdAt: string(),
+});
+
+const normalizeItemRelatedAssets = (
+  item: MarketOverviewTrend,
+): MarketOverviewTrend => ({
+  ...item,
+  relatedAssets: item.relatedAssets.map((asset) => ({
+    ...asset,
+    caip19: asset.caip19 ?? [],
+  })),
+});
+
 const normalizeRelatedAssets = (raw: MarketOverview): MarketOverview => ({
   ...raw,
-  trends: raw.trends.map((trend) => ({
-    ...trend,
-    relatedAssets: trend.relatedAssets.map((asset) => ({
-      ...asset,
-      caip19: asset.caip19 ?? [],
-    })),
-  })),
+  trends: raw.trends.map(normalizeItemRelatedAssets),
 });
 
 const getNormalizedMarketOverview = (value: unknown): MarketOverview | null => {
@@ -134,6 +151,16 @@ const getNormalizedMarketOverview = (value: unknown): MarketOverview | null => {
   }
 
   return null;
+};
+
+const getNormalizedFrontPage = (
+  value: unknown,
+): MarketOverviewFrontPage | null => {
+  if (!is(value, MarketOverviewFrontPageStruct)) {
+    return null;
+  }
+
+  return { ...value, item: normalizeItemRelatedAssets(value.item) };
 };
 
 const getNormalizedMarketInsightsReport = (
@@ -180,6 +207,40 @@ export class AiDigestService implements DigestService {
     }
 
     return overview;
+  }
+
+  /**
+   * Fetch a single market overview front page by id.
+   *
+   * Calls `GET ${this.#baseUrl}/market-overview/front-page/:id`.
+   *
+   * @param id - The front-page identifier (UUID).
+   * @returns The market overview front page, or `null` if none exists (404).
+   */
+  async fetchFrontPageItem(
+    id: string,
+  ): Promise<MarketOverviewFrontPage | null> {
+    const response = await fetch(
+      `${this.#baseUrl}/market-overview/front-page/${encodeURIComponent(id)}`,
+    );
+
+    if (response.status === 404) {
+      return null;
+    }
+
+    if (!response.ok) {
+      throw new Error(
+        `${AiDigestControllerErrorMessage.API_REQUEST_FAILED}: ${response.status}`,
+      );
+    }
+
+    const frontPage = getNormalizedFrontPage(await response.json());
+
+    if (!frontPage) {
+      throw new Error(AiDigestControllerErrorMessage.API_INVALID_RESPONSE);
+    }
+
+    return frontPage;
   }
 
   /**

--- a/packages/ai-controllers/src/ai-digest-constants.ts
+++ b/packages/ai-controllers/src/ai-digest-constants.ts
@@ -8,4 +8,5 @@ export const AiDigestControllerErrorMessage = {
   API_REQUEST_FAILED: 'API request failed',
   API_INVALID_RESPONSE: 'API returned invalid response',
   INVALID_ASSET_IDENTIFIER: 'Invalid asset identifier',
+  INVALID_FRONT_PAGE_ID: 'Invalid front page id',
 } as const;

--- a/packages/ai-controllers/src/ai-digest-types.ts
+++ b/packages/ai-controllers/src/ai-digest-types.ts
@@ -188,6 +188,33 @@ export type MarketOverview = {
   metadata?: AIResponseMetadata[];
 };
 
+/**
+ * A single market overview item. Shares the exact same schema as a
+ * {@link MarketOverviewTrend} — i.e. one entry of `MarketOverview.trends`.
+ */
+export type MarketOverviewItem = MarketOverviewTrend;
+
+/**
+ * A market overview "front page": a single AI-selected item (mirroring the
+ * front page of a newspaper) plus its call-to-action copy, addressable by id.
+ *
+ * Returned by `GET /market-overview/front-page/:id` (and `.../latest`). Unlike
+ * `/market-overview`, which only ever returns the latest report, this lets
+ * clients fetch an older item that has since dropped out of the report.
+ */
+export type MarketOverviewFrontPage = {
+  /** Unique identifier of the front-page row (UUID). */
+  id: string;
+  /** The selected item — same schema as an individual market overview item. */
+  item: MarketOverviewItem;
+  /** Call-to-action title for the front-page item. */
+  ctaTitle: string;
+  /** Call-to-action description for the front-page item. */
+  ctaDescription: string;
+  /** ISO date string when the front-page row was created. */
+  createdAt: string;
+};
+
 // ---------------------------------------------------------------------------
 // Controller state
 // ---------------------------------------------------------------------------
@@ -223,4 +250,13 @@ export type DigestService = {
    * @returns The market overview report, or `null` if none exists (404).
    */
   fetchMarketOverview(): Promise<MarketOverview | null>;
+
+  /**
+   * Fetch a single market overview front page by id.
+   * Calls `GET /market-overview/front-page/:id`.
+   *
+   * @param id - The front-page identifier (UUID).
+   * @returns The market overview front page, or `null` if none exists (404).
+   */
+  fetchFrontPageItem(id: string): Promise<MarketOverviewFrontPage | null>;
 };

--- a/packages/ai-controllers/src/index.ts
+++ b/packages/ai-controllers/src/index.ts
@@ -13,6 +13,7 @@ export {
 export type {
   AiDigestControllerFetchMarketInsightsAction,
   AiDigestControllerFetchMarketOverviewAction,
+  AiDigestControllerFetchFrontPageItemAction,
 } from './AiDigestController-method-action-types';
 
 export type { AiDigestServiceConfig } from './AiDigestService';
@@ -31,6 +32,8 @@ export type {
   MarketInsightsTweet,
   MarketOverview,
   MarketOverviewEntry,
+  MarketOverviewFrontPage,
+  MarketOverviewItem,
   MarketOverviewTrend,
   RelatedAsset,
   Source,


### PR DESCRIPTION
## Explanation

The What's Happening / market overview feature (`AiDigestController.fetchMarketOverview()`) only ever returns the **latest** items from `GET /market-overview`. Older items drop out of that report, so there is currently no way for a client to render a specific older item.

The digest API added a new endpoint:

```
GET /market-overview/front-page/:id      # :id is a UUID
```

It returns a single "front page" row whose `item` shares the **exact same schema** as an individual market overview item (a trend entry), plus call-to-action copy. This PR adds first-class support for it in `@metamask/ai-controllers`.

## References

- Consumed by an upcoming metamask-mobile deep-link feature that renders an older ("outdated") What's Happening item in the carousel.

## Changelog

### `@metamask/ai-controllers`

- **ADDED**: `AiDigestController.fetchFrontPageItem(id)` and `AiDigestService.fetchFrontPageItem(id)`, which fetch a single market overview front page by id from `GET /market-overview/front-page/:id`, exposed via the `AiDigestController:fetchFrontPageItem` messenger action.
- **ADDED**: `MarketOverviewFrontPage` and `MarketOverviewItem` types.

## Details

- `AiDigestService.fetchFrontPageItem` mirrors `fetchMarketOverview`: it validates the response with superstruct (reusing `MarketOverviewTrendStruct` for `item`), normalizes missing `caip19` to `[]`, returns `null` on `404`, and throws on other non-OK responses or an invalid schema.
- `AiDigestController.fetchFrontPageItem` is a thin pass-through (no caching — a single item by id does not need the report cache) that throws on an empty id.
- The messenger action type file was regenerated via `messenger-action-types:generate`.

## Checklist

- [x] Tests added/updated (100% coverage for the package)
- [x] Changelog updated
- [x] `yarn lint`, build, and `yarn validate:changelog` pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive read-only API client and controller method following existing `fetchMarketOverview` patterns; no auth, persistence, or caching behavior changes beyond new exports.
> 
> **Overview**
> Adds support for loading a **single** What's Happening / market overview **front page** by UUID when it is no longer in the latest `fetchMarketOverview` report (e.g. deep links).
> 
> **`AiDigestService.fetchFrontPageItem(id)`** calls `GET /market-overview/front-page/:id` (URL-encoded id), validates with superstruct (reusing the market-overview trend schema for `item`), normalizes missing `caip19` on related assets to `[]`, returns `null` on 404, and throws on other errors or invalid payloads. **`AiDigestController.fetchFrontPageItem`** delegates to the service with **no controller cache**, rejects empty ids, and is exposed as **`AiDigestController:fetchFrontPageItem`**.
> 
> New public types **`MarketOverviewFrontPage`** and **`MarketOverviewItem`** are exported; **`DigestService`** and package changelog are updated. Market overview normalization is refactored to share **`normalizeItemRelatedAssets`** between report and front-page responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8980fa57f1f496ae92f3bed4b824faf4ec594182. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->