### PR TITLE
feat: create money account utils package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -54,6 +54,7 @@
 /packages/money-account-api-data-service      @MetaMask/earn
 /packages/chomp-api-service                   @MetaMask/earn @MetaMask/delegation
 /packages/money-account-upgrade-controller    @MetaMask/earn @MetaMask/delegation
+/packages/money-account-utils                 @MetaMask/earn
 
 ## Social AI Team
 /packages/ai-controllers        @MetaMask/social-ai
@@ -285,5 +286,7 @@
 /packages/chomp-api-service/CHANGELOG.md                       @MetaMask/earn @MetaMask/delegation @MetaMask/core-platform
 /packages/money-account-upgrade-controller/package.json        @MetaMask/earn @MetaMask/delegation @MetaMask/core-platform
 /packages/money-account-upgrade-controller/CHANGELOG.md        @MetaMask/earn @MetaMask/delegation @MetaMask/core-platform
+/packages/money-account-utils/package.json                     @MetaMask/earn @MetaMask/core-platform
+/packages/money-account-utils/CHANGELOG.md                     @MetaMask/earn @MetaMask/core-platform
 /packages/snap-account-service/package.json                    @MetaMask/accounts-engineers @MetaMask/core-platform
 /packages/snap-account-service/CHANGELOG.md                    @MetaMask/accounts-engineers @MetaMask/core-platform

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ yarn skills --reset                 # clear saved local selection
 - [`@metamask/money-account-balance-service`](packages/money-account-balance-service)
 - [`@metamask/money-account-controller`](packages/money-account-controller)
 - [`@metamask/money-account-upgrade-controller`](packages/money-account-upgrade-controller)
+- [`@metamask/money-account-utils`](packages/money-account-utils)
 - [`@metamask/multichain-account-service`](packages/multichain-account-service)
 - [`@metamask/multichain-api-middleware`](packages/multichain-api-middleware)
 - [`@metamask/multichain-network-controller`](packages/multichain-network-controller)
@@ -200,6 +201,7 @@ linkStyle default opacity:0.5
   money_account_balance_service(["@metamask/money-account-balance-service"]);
   money_account_controller(["@metamask/money-account-controller"]);
   money_account_upgrade_controller(["@metamask/money-account-upgrade-controller"]);
+  money_account_utils(["@metamask/money-account-utils"]);
   multichain_account_service(["@metamask/multichain-account-service"]);
   multichain_api_middleware(["@metamask/multichain-api-middleware"]);
   multichain_network_controller(["@metamask/multichain-network-controller"]);
@@ -444,6 +446,7 @@ linkStyle default opacity:0.5
   money_account_upgrade_controller --> keyring_controller;
   money_account_upgrade_controller --> messenger;
   money_account_upgrade_controller --> network_controller;
+  money_account_utils --> transaction_controller;
   multichain_account_service --> accounts_controller;
   multichain_account_service --> base_controller;
   multichain_account_service --> keyring_controller;

--- a/codeowners.ts
+++ b/codeowners.ts
@@ -216,6 +216,9 @@ const PACKAGES: Record<string, PackageInfo> = {
   'money-account-upgrade-controller': {
     teams: ['@MetaMask/earn', '@MetaMask/delegation'],
   },
+  'money-account-utils': {
+    teams: ['@MetaMask/earn'],
+  },
   'multichain-account-service': {
     teams: ['@MetaMask/accounts-engineers'],
   },
@@ -460,6 +463,7 @@ function buildTeamSections(): CodeownersSection[] {
         buildRuleForPackage('money-account-api-data-service'),
         buildRuleForPackage('chomp-api-service'),
         buildRuleForPackage('money-account-upgrade-controller'),
+        buildRuleForPackage('money-account-utils'),
       ],
     },
     {
@@ -689,6 +693,7 @@ function buildPackageReleaseSection(): CodeownersSection {
     'money-account-controller',
     'chomp-api-service',
     'money-account-upgrade-controller',
+    'money-account-utils',
     'snap-account-service',
   ] as const satisfies (keyof typeof PACKAGES)[];
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lint": "yarn lint:tsc && yarn lint:eslint && echo && yarn lint:misc --check && yarn constraints && yarn lint:dependencies && yarn lint:teams && yarn messenger-action-types:check && yarn readme-content:check && yarn lint:tsconfigs:all && yarn codeowners:check",
     "lint:dependencies": "knip --config knip.config.mts --dependencies && yarn dedupe --check",
     "lint:dependencies:fix": "knip --config knip.config.mts --dependencies && yarn dedupe",
-    "lint:eslint": "yarn build:only-clean && NODE_OPTIONS='--max-old-space-size=8192' yarn eslint",
+    "lint:eslint": "yarn build:only-clean && NODE_OPTIONS='--max-old-space-size=10240' yarn eslint",
     "lint:fix": "yarn lint:eslint --fix --prune-suppressions && echo && yarn lint:misc --write && yarn constraints --fix && yarn lint:dependencies:fix && yarn messenger-action-types:generate && yarn readme-content:update && yarn codeowners:generate",
     "lint:misc": "oxfmt --ignore-path .gitignore",
     "lint:misc:check": "yarn lint:misc --check",

--- a/packages/money-account-utils/CHANGELOG.md
+++ b/packages/money-account-utils/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Add mUSD token constants and guards, ported from MetaMask Mobile ([#9397](https://github.com/MetaMask/core/pull/9397))
+  - Constants: `MUSD_TOKEN` (without client icon assets), `MUSD_DECIMALS`, `MUSD_TOKEN_ADDRESS`, `MUSD_TOKEN_ADDRESS_BY_CHAIN`, `MUSD_TOKEN_ASSET_ID_BY_CHAIN`, `MUSD_CURRENCY`, `MUSD_MONEY_ACCOUNT_CHAIN_IDS`
+  - Guards: `isMusdToken`, `isMusdTokenOnChain`, `isMusdOnMoneyAccountChain`
+- Add `getTokenDisplaySymbol`, ported from MetaMask Mobile, which canonicalises the registry symbol of the mUSD token to its branded casing (`MUSD` → `mUSD`) and passes all other symbols through unchanged ([#9397](https://github.com/MetaMask/core/pull/9397))
+
+[Unreleased]: https://github.com/MetaMask/core/

--- a/packages/money-account-utils/LICENSE
+++ b/packages/money-account-utils/LICENSE
@@ -1,0 +1,6 @@
+This project is licensed under either of
+
+ * MIT license ([LICENSE.MIT](LICENSE.MIT))
+ * Apache License, Version 2.0 ([LICENSE.APACHE2](LICENSE.APACHE2))
+
+at your option.

--- a/packages/money-account-utils/LICENSE.APACHE2
+++ b/packages/money-account-utils/LICENSE.APACHE2
@@ -1,0 +1,201 @@
+ Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/money-account-utils/LICENSE.MIT
+++ b/packages/money-account-utils/LICENSE.MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 MetaMask
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/money-account-utils/README.md
+++ b/packages/money-account-utils/README.md
@@ -1,0 +1,15 @@
+# `@metamask/money-account-utils`
+
+Shared money account utilities: activity parsing, classification, and mUSD constants.
+
+## Installation
+
+`yarn add @metamask/money-account-utils`
+
+or
+
+`npm install @metamask/money-account-utils`
+
+## Contributing
+
+This package is part of a monorepo. Instructions for contributing can be found in the [monorepo README](https://github.com/MetaMask/core#readme).

--- a/packages/money-account-utils/jest.config.js
+++ b/packages/money-account-utils/jest.config.js
@@ -1,0 +1,26 @@
+/*
+ * For a detailed explanation regarding each configuration property and type check, visit:
+ * https://jestjs.io/docs/configuration
+ */
+
+const merge = require('deepmerge');
+const path = require('path');
+
+const baseConfig = require('../../jest.config.packages');
+
+const displayName = path.basename(__dirname);
+
+module.exports = merge(baseConfig, {
+  // The display name when running multiple projects
+  displayName,
+
+  // An object that configures minimum threshold enforcement for coverage results
+  coverageThreshold: {
+    global: {
+      branches: 100,
+      functions: 100,
+      lines: 100,
+      statements: 100,
+    },
+  },
+});

--- a/packages/money-account-utils/package.json
+++ b/packages/money-account-utils/package.json
@@ -1,0 +1,76 @@
+{
+  "name": "@metamask/money-account-utils",
+  "version": "0.0.0",
+  "description": "Shared money account utilities: activity parsing, classification, and mUSD constants",
+  "keywords": [
+    "Ethereum",
+    "MetaMask"
+  ],
+  "homepage": "https://github.com/MetaMask/core/tree/main/packages/money-account-utils#readme",
+  "bugs": {
+    "url": "https://github.com/MetaMask/core/issues"
+  },
+  "license": "(MIT OR Apache-2.0)",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MetaMask/core.git"
+  },
+  "files": [
+    "dist/"
+  ],
+  "sideEffects": false,
+  "main": "./dist/index.cjs",
+  "types": "./dist/index.d.cts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "scripts": {
+    "build": "ts-bridge --project tsconfig.build.json --verbose --clean --no-references",
+    "build:all": "ts-bridge --project tsconfig.build.json --verbose --clean",
+    "build:docs": "typedoc",
+    "changelog:update": "../../scripts/update-changelog.sh @metamask/money-account-utils",
+    "changelog:validate": "../../scripts/validate-changelog.sh @metamask/money-account-utils",
+    "lint:tsconfigs": "tsx ../../scripts/lint-tsconfigs/lint-tsconfigs.mts",
+    "lint:tsconfigs:fix": "tsx ../../scripts/lint-tsconfigs/lint-tsconfigs.mts --fix",
+    "messenger-action-types:check": "tsx ../../packages/messenger-cli/src/cli.ts --formatter oxfmt --check",
+    "messenger-action-types:generate": "tsx ../../packages/messenger-cli/src/cli.ts --formatter oxfmt --generate",
+    "since-latest-release": "../../scripts/since-latest-release.sh",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
+    "test:clean": "NODE_OPTIONS=--experimental-vm-modules jest --clearCache",
+    "test:verbose": "NODE_OPTIONS=--experimental-vm-modules jest --verbose",
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
+  },
+  "dependencies": {
+    "@metamask/transaction-controller": "^69.2.1",
+    "@metamask/utils": "^11.11.0"
+  },
+  "devDependencies": {
+    "@metamask/auto-changelog": "^6.1.0",
+    "@ts-bridge/cli": "^0.6.4",
+    "@types/jest": "^30.0.0",
+    "deepmerge": "^4.2.2",
+    "jest": "^30.4.2",
+    "ts-jest": "^29.4.11",
+    "tsx": "^4.20.5",
+    "typedoc": "^0.25.13",
+    "typedoc-plugin-missing-exports": "^2.0.0",
+    "typescript": "~5.3.3"
+  },
+  "engines": {
+    "node": "^18.18 || >=20"
+  }
+}

--- a/packages/money-account-utils/package.json
+++ b/packages/money-account-utils/package.json
@@ -55,7 +55,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/transaction-controller": "^69.2.1",
+    "@metamask/transaction-controller": "^69.3.0",
     "@metamask/utils": "^11.11.0"
   },
   "devDependencies": {

--- a/packages/money-account-utils/src/index.ts
+++ b/packages/money-account-utils/src/index.ts
@@ -1,0 +1,13 @@
+export {
+  MUSD_TOKEN,
+  MUSD_DECIMALS,
+  MUSD_TOKEN_ADDRESS,
+  MUSD_TOKEN_ADDRESS_BY_CHAIN,
+  MUSD_TOKEN_ASSET_ID_BY_CHAIN,
+  MUSD_CURRENCY,
+  MUSD_MONEY_ACCOUNT_CHAIN_IDS,
+  getTokenDisplaySymbol,
+  isMusdToken,
+  isMusdTokenOnChain,
+  isMusdOnMoneyAccountChain,
+} from './musd.js';

--- a/packages/money-account-utils/src/musd.test.ts
+++ b/packages/money-account-utils/src/musd.test.ts
@@ -1,0 +1,170 @@
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+
+import {
+  getTokenDisplaySymbol,
+  isMusdOnMoneyAccountChain,
+  isMusdToken,
+  isMusdTokenOnChain,
+  MUSD_DECIMALS,
+  MUSD_MONEY_ACCOUNT_CHAIN_IDS,
+  MUSD_TOKEN,
+  MUSD_TOKEN_ADDRESS,
+  MUSD_TOKEN_ADDRESS_BY_CHAIN,
+  MUSD_TOKEN_ASSET_ID_BY_CHAIN,
+} from './musd.js';
+
+const MUSD_ADDRESS = MUSD_TOKEN_ADDRESS_BY_CHAIN[CHAIN_IDS.MAINNET];
+
+describe('mUSD constants', () => {
+  it('derives MUSD_DECIMALS from MUSD_TOKEN', () => {
+    expect(MUSD_DECIMALS).toBe(MUSD_TOKEN.decimals);
+  });
+
+  it('uses the same address on every supported chain', () => {
+    for (const address of Object.values(MUSD_TOKEN_ADDRESS_BY_CHAIN)) {
+      expect(address).toBe(MUSD_TOKEN_ADDRESS);
+    }
+  });
+
+  it('defines a CAIP asset id for every chain mUSD is deployed on', () => {
+    expect(Object.keys(MUSD_TOKEN_ASSET_ID_BY_CHAIN).sort()).toStrictEqual(
+      Object.keys(MUSD_TOKEN_ADDRESS_BY_CHAIN).sort(),
+    );
+    for (const assetId of Object.values(MUSD_TOKEN_ASSET_ID_BY_CHAIN)) {
+      expect(assetId.toLowerCase()).toContain(
+        `erc20:${MUSD_TOKEN_ADDRESS.toLowerCase()}`,
+      );
+    }
+  });
+
+  it('only tracks Money Account activity on a subset of deployed chains', () => {
+    for (const chainId of MUSD_MONEY_ACCOUNT_CHAIN_IDS) {
+      expect(MUSD_TOKEN_ADDRESS_BY_CHAIN[chainId]).toBeDefined();
+    }
+  });
+});
+
+describe('isMusdToken', () => {
+  it('returns true for the mUSD token address in lowercase', () => {
+    expect(isMusdToken(MUSD_ADDRESS)).toBe(true);
+  });
+
+  it('returns true for the mUSD token address in uppercase', () => {
+    expect(isMusdToken(MUSD_ADDRESS.toUpperCase())).toBe(true);
+  });
+
+  it('returns true for the mUSD token address with mixed case', () => {
+    expect(isMusdToken('0xAcA92E438df0B2401fF60dA7E4337B687a2435DA')).toBe(
+      true,
+    );
+  });
+
+  it('returns false for a non-mUSD token address', () => {
+    expect(isMusdToken('0x1234567890123456789012345678901234567890')).toBe(
+      false,
+    );
+  });
+
+  it('returns false for an undefined address', () => {
+    expect(isMusdToken(undefined)).toBe(false);
+  });
+
+  it('returns false for an empty string address', () => {
+    expect(isMusdToken('')).toBe(false);
+  });
+});
+
+describe('getTokenDisplaySymbol', () => {
+  it('canonicalises the registry symbol to the branded casing for the mUSD address', () => {
+    expect(getTokenDisplaySymbol(MUSD_ADDRESS, 'MUSD')).toBe(MUSD_TOKEN.symbol);
+  });
+
+  it('canonicalises regardless of address casing', () => {
+    expect(
+      getTokenDisplaySymbol(
+        '0xAcA92E438df0B2401fF60dA7E4337B687a2435DA',
+        'MUSD',
+      ),
+    ).toBe(MUSD_TOKEN.symbol);
+  });
+
+  it('passes non-mUSD symbols through untouched', () => {
+    expect(
+      getTokenDisplaySymbol(
+        '0x1234567890123456789012345678901234567890',
+        'USDC',
+      ),
+    ).toBe('USDC');
+  });
+
+  it('passes the symbol through when the address is undefined', () => {
+    expect(getTokenDisplaySymbol(undefined, 'USDC')).toBe('USDC');
+  });
+
+  it('returns undefined when a non-mUSD address has no symbol', () => {
+    expect(
+      getTokenDisplaySymbol(
+        '0x1234567890123456789012345678901234567890',
+        undefined,
+      ),
+    ).toBeUndefined();
+  });
+});
+
+describe('isMusdTokenOnChain', () => {
+  it('returns true for the mUSD address on a supported chain', () => {
+    expect(isMusdTokenOnChain(MUSD_ADDRESS, CHAIN_IDS.MAINNET)).toBe(true);
+    expect(isMusdTokenOnChain(MUSD_ADDRESS, CHAIN_IDS.LINEA_MAINNET)).toBe(
+      true,
+    );
+    expect(isMusdTokenOnChain(MUSD_ADDRESS, CHAIN_IDS.BSC)).toBe(true);
+    expect(isMusdTokenOnChain(MUSD_ADDRESS, CHAIN_IDS.MONAD)).toBe(true);
+  });
+
+  it('returns false for the mUSD address on an unsupported chain', () => {
+    expect(isMusdTokenOnChain(MUSD_ADDRESS, CHAIN_IDS.POLYGON)).toBe(false);
+    expect(isMusdTokenOnChain(MUSD_ADDRESS, CHAIN_IDS.ARBITRUM)).toBe(false);
+    expect(isMusdTokenOnChain(MUSD_ADDRESS, CHAIN_IDS.OPTIMISM)).toBe(false);
+  });
+
+  it('is case-insensitive', () => {
+    expect(
+      isMusdTokenOnChain(MUSD_ADDRESS.toUpperCase(), CHAIN_IDS.MAINNET),
+    ).toBe(true);
+  });
+
+  it('returns false for a missing address or chainId', () => {
+    expect(isMusdTokenOnChain(undefined, CHAIN_IDS.MAINNET)).toBe(false);
+    expect(isMusdTokenOnChain(MUSD_ADDRESS, undefined)).toBe(false);
+  });
+});
+
+describe('isMusdOnMoneyAccountChain', () => {
+  it('returns true only for mUSD on Monad', () => {
+    expect(isMusdOnMoneyAccountChain(MUSD_ADDRESS, CHAIN_IDS.MONAD)).toBe(true);
+  });
+
+  it('returns false for mUSD on chains where mUSD is deployed but the Money Account is not active', () => {
+    expect(isMusdOnMoneyAccountChain(MUSD_ADDRESS, CHAIN_IDS.MAINNET)).toBe(
+      false,
+    );
+    expect(
+      isMusdOnMoneyAccountChain(MUSD_ADDRESS, CHAIN_IDS.LINEA_MAINNET),
+    ).toBe(false);
+    expect(isMusdOnMoneyAccountChain(MUSD_ADDRESS, CHAIN_IDS.BSC)).toBe(false);
+  });
+
+  it('returns false for missing arguments', () => {
+    expect(isMusdOnMoneyAccountChain(undefined, CHAIN_IDS.MONAD)).toBe(false);
+    expect(isMusdOnMoneyAccountChain(MUSD_ADDRESS, undefined)).toBe(false);
+  });
+
+  it('returns false for a non-mUSD address on Monad', () => {
+    expect(
+      isMusdOnMoneyAccountChain(
+        '0x1234567890123456789012345678901234567890',
+        CHAIN_IDS.MONAD,
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/money-account-utils/src/musd.ts
+++ b/packages/money-account-utils/src/musd.ts
@@ -1,0 +1,138 @@
+import { CHAIN_IDS } from '@metamask/transaction-controller';
+import type { Hex } from '@metamask/utils';
+
+/**
+ * The mUSD (MetaMask USD) token, minus any client-specific presentation
+ * (icon assets stay in each client).
+ */
+export const MUSD_TOKEN = {
+  symbol: 'mUSD',
+  name: 'MetaMask USD',
+  decimals: 6,
+  /**
+   * Remote image URL used when the token is not yet in the user's wallet
+   * token list and a URI-based image source is needed (e.g. for token avatars
+   * in confirmation screens). The address casing in the path matches the
+   * token address on all supported chains.
+   */
+  image:
+    'https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/0xaca92e438df0b2401ff60da7e4337b687a2435da.png',
+} as const;
+
+/**
+ * mUSD token decimals (derived from {@link MUSD_TOKEN} for a single source of
+ * truth).
+ */
+export const MUSD_DECIMALS = MUSD_TOKEN.decimals;
+
+/**
+ * mUSD token address (same on all supported chains).
+ */
+export const MUSD_TOKEN_ADDRESS: Hex =
+  '0xaca92e438df0b2401ff60da7e4337b687a2435da';
+
+/**
+ * The mUSD token address on each chain where it is deployed.
+ */
+export const MUSD_TOKEN_ADDRESS_BY_CHAIN: Record<Hex, Hex> = {
+  [CHAIN_IDS.MAINNET]: MUSD_TOKEN_ADDRESS,
+  [CHAIN_IDS.LINEA_MAINNET]: MUSD_TOKEN_ADDRESS,
+  [CHAIN_IDS.BSC]: MUSD_TOKEN_ADDRESS,
+  [CHAIN_IDS.MONAD]: MUSD_TOKEN_ADDRESS,
+};
+
+/**
+ * The CAIP-19 asset id of the mUSD token on each chain where it is deployed.
+ */
+export const MUSD_TOKEN_ASSET_ID_BY_CHAIN: Record<Hex, string> = {
+  [CHAIN_IDS.MAINNET]:
+    'eip155:1/erc20:0xacA92E438df0B2401fF60dA7E4337B687a2435DA',
+  [CHAIN_IDS.LINEA_MAINNET]:
+    'eip155:59144/erc20:0xacA92E438df0B2401fF60dA7E4337B687a2435DA',
+  [CHAIN_IDS.BSC]: 'eip155:56/erc20:0xacA92E438df0B2401fF60dA7E4337B687a2435DA',
+  [CHAIN_IDS.MONAD]:
+    'eip155:143/erc20:0xacA92E438df0B2401fF60dA7E4337B687a2435DA',
+};
+
+/**
+ * The ticker used for mUSD when treated as a currency.
+ */
+export const MUSD_CURRENCY = 'MUSD';
+
+/**
+ * Chains where the Money Account surfaces mUSD activity. mUSD exists on
+ * several chains for buy/convert flows, but the Money Account currently only
+ * tracks Monad — inbound mUSD on Mainnet/Linea/BSC is unrelated to it and
+ * must not appear in Money activity.
+ */
+export const MUSD_MONEY_ACCOUNT_CHAIN_IDS: Hex[] = [CHAIN_IDS.MONAD];
+
+/**
+ * Check whether the given token address is mUSD. mUSD has the same address on
+ * all supported chains.
+ *
+ * @param address - The token address to check.
+ * @returns Whether the address is the mUSD token address.
+ */
+export function isMusdToken(address?: string): boolean {
+  if (!address) {
+    return false;
+  }
+  return address.toLowerCase() === MUSD_TOKEN_ADDRESS.toLowerCase();
+}
+
+/**
+ * Resolves the display symbol for a token, special-casing tokens whose
+ * registry symbol differs from the branded casing. mUSD may be registered
+ * with the uppercase symbol "MUSD" (e.g. via token detection); canonicalise
+ * it to the branded "mUSD" so UI never leaks the registry casing.
+ *
+ * @param address - The token address the symbol belongs to.
+ * @param symbol - The registry symbol for the token.
+ * @returns The branded mUSD symbol for the mUSD address, otherwise the given
+ * symbol unchanged.
+ */
+export function getTokenDisplaySymbol(
+  address?: string,
+  symbol?: string,
+): string | undefined {
+  return isMusdToken(address) ? MUSD_TOKEN.symbol : symbol;
+}
+
+/**
+ * Like {@link isMusdToken} but also requires `chainId` to be a chain where
+ * mUSD is actually deployed. Prevents a same-address token on an unsupported
+ * chain from being misclassified as mUSD.
+ *
+ * @param address - The token address to check.
+ * @param chainId - The chain the token lives on.
+ * @returns Whether the address is mUSD on a chain where mUSD is deployed.
+ */
+export function isMusdTokenOnChain(address?: string, chainId?: Hex): boolean {
+  if (!address || !chainId) {
+    return false;
+  }
+  const expected = MUSD_TOKEN_ADDRESS_BY_CHAIN[chainId];
+  if (!expected) {
+    return false;
+  }
+  return address.toLowerCase() === expected.toLowerCase();
+}
+
+/**
+ * Like {@link isMusdTokenOnChain} but restricted to chains where the Money
+ * Account is active (currently Monad only).
+ *
+ * @param address - The token address to check.
+ * @param chainId - The chain the token lives on.
+ * @returns Whether the address is mUSD on a Money Account chain.
+ */
+export function isMusdOnMoneyAccountChain(
+  address?: string,
+  chainId?: Hex,
+): boolean {
+  if (!chainId || !MUSD_MONEY_ACCOUNT_CHAIN_IDS.includes(chainId)) {
+    return false;
+  }
+  return isMusdTokenOnChain(address, chainId);
+}

--- a/packages/money-account-utils/tsconfig.build.json
+++ b/packages/money-account-utils/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.packages.build.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "references": [
+    {
+      "path": "../transaction-controller/tsconfig.build.json"
+    }
+  ],
+  "include": ["../../types", "./src"]
+}

--- a/packages/money-account-utils/tsconfig.json
+++ b/packages/money-account-utils/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.packages.json",
+  "compilerOptions": {
+    "baseUrl": "./"
+  },
+  "references": [
+    {
+      "path": "../transaction-controller"
+    }
+  ],
+  "include": ["../../types", "./src"]
+}

--- a/packages/money-account-utils/typedoc.json
+++ b/packages/money-account-utils/typedoc.json
@@ -1,0 +1,7 @@
+{
+  "entryPoints": ["./src/index.ts"],
+  "excludePrivate": true,
+  "hideGenerator": true,
+  "out": "docs",
+  "tsconfig": "./tsconfig.build.json"
+}

--- a/teams.json
+++ b/teams.json
@@ -27,6 +27,7 @@
   "metamask/eip-7702-internal-rpc-middleware": "team-delegation",
   "metamask/earn-controller": "team-earn",
   "metamask/money-account-balance-service": "team-earn",
+  "metamask/money-account-utils": "team-earn",
   "metamask/money-account-api-data-service": "team-earn",
   "metamask/notification-services-controller": "team-assets",
   "metamask/compliance-controller": "team-perps",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -176,6 +176,9 @@
       "path": "./packages/money-account-upgrade-controller/tsconfig.build.json"
     },
     {
+      "path": "./packages/money-account-utils/tsconfig.build.json"
+    },
+    {
       "path": "./packages/multichain-account-service/tsconfig.build.json"
     },
     {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -168,6 +168,9 @@
       "path": "./packages/money-account-upgrade-controller"
     },
     {
+      "path": "./packages/money-account-utils"
+    },
+    {
       "path": "./packages/multichain-account-service"
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9283,7 +9283,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@npm:^69.3.0, @metamask/transaction-controller@workspace:packages/transaction-controller":
+"@metamask/transaction-controller@npm:^69.2.1, @metamask/transaction-controller@npm:^69.3.0, @metamask/transaction-controller@workspace:packages/transaction-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/transaction-controller@workspace:packages/transaction-controller"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -7928,6 +7928,25 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@metamask/money-account-utils@workspace:packages/money-account-utils":
+  version: 0.0.0-use.local
+  resolution: "@metamask/money-account-utils@workspace:packages/money-account-utils"
+  dependencies:
+    "@metamask/auto-changelog": "npm:^6.1.0"
+    "@metamask/transaction-controller": "npm:^69.2.1"
+    "@metamask/utils": "npm:^11.11.0"
+    "@ts-bridge/cli": "npm:^0.6.4"
+    "@types/jest": "npm:^30.0.0"
+    deepmerge: "npm:^4.2.2"
+    jest: "npm:^30.4.2"
+    ts-jest: "npm:^29.4.11"
+    tsx: "npm:^4.20.5"
+    typedoc: "npm:^0.25.13"
+    typedoc-plugin-missing-exports: "npm:^2.0.0"
+    typescript: "npm:~5.3.3"
+  languageName: unknown
+  linkType: soft
+
 "@metamask/multichain-account-service@npm:^13.0.0, @metamask/multichain-account-service@workspace:packages/multichain-account-service":
   version: 0.0.0-use.local
   resolution: "@metamask/multichain-account-service@workspace:packages/multichain-account-service"
@@ -14909,9 +14928,9 @@ __metadata:
   linkType: hard
 
 "cjs-module-lexer@npm:^1.3.1":
-  version: 1.4.0
-  resolution: "cjs-module-lexer@npm:1.4.0"
-  checksum: 10/b041096749792526120d8b8756929f8ef5dd4596502a0e1013f857e3027acd6091915fea77037921d70ee1a99988a100d994d3d3c2e323b04dd4c5ffd516cf13
+  version: 1.4.3
+  resolution: "cjs-module-lexer@npm:1.4.3"
+  checksum: 10/d2b92f919a2dedbfd61d016964fce8da0035f827182ed6839c97cac56e8a8077cfa6a59388adfe2bc588a19cef9bbe830d683a76a6e93c51f65852062cfe2591
   languageName: node
   linkType: hard
 
@@ -15906,14 +15925,14 @@ __metadata:
   linkType: hard
 
 "dedent@npm:^1.6.0":
-  version: 1.7.1
-  resolution: "dedent@npm:1.7.1"
+  version: 1.7.2
+  resolution: "dedent@npm:1.7.2"
   peerDependencies:
     babel-plugin-macros: ^3.1.0
   peerDependenciesMeta:
     babel-plugin-macros:
       optional: true
-  checksum: 10/78785ef592e37e0b1ca7a7a5964c8f3dee1abdff46c5bb49864168579c122328f6bb55c769bc7e005046a7381c3372d3859f0f78ab083950fa146e1c24873f4f
+  checksum: 10/30b9062290dca72b0f5a6cd3667633448cef8cd0dec602eab61015741269ad49df90cabf0521f9a32d134ceab4e21aa7f097258c55cc3baadef94874686d6480
   languageName: node
   linkType: hard
 
@@ -28133,7 +28152,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:17.7.2, yargs@npm:^17.0.1, yargs@npm:^17.7.1, yargs@npm:^17.7.2":
+"yargs@npm:17.7.2":
   version: 17.7.2
   resolution: "yargs@npm:17.7.2"
   dependencies:
@@ -28145,6 +28164,21 @@ __metadata:
     y18n: "npm:^5.0.5"
     yargs-parser: "npm:^21.1.1"
   checksum: 10/abb3e37678d6e38ea85485ed86ebe0d1e3464c640d7d9069805ea0da12f69d5a32df8e5625e370f9c96dd1c2dc088ab2d0a4dd32af18222ef3c4224a19471576
+  languageName: node
+  linkType: hard
+
+"yargs@npm:^17.0.1, yargs@npm:^17.7.1, yargs@npm:^17.7.2":
+  version: 17.7.3
+  resolution: "yargs@npm:17.7.3"
+  dependencies:
+    cliui: "npm:^8.0.1"
+    escalade: "npm:^3.1.1"
+    get-caller-file: "npm:^2.0.5"
+    require-directory: "npm:^2.1.1"
+    string-width: "npm:^4.2.3"
+    y18n: "npm:^5.0.5"
+    yargs-parser: "npm:^21.1.1"
+  checksum: 10/a3826798c03b159e139d0580a3b2733953889a9a1bac8e4e1ca7a1a249b55315b213c323a6a1dbdb305f6e59496a9eaa810742c87e34abcf1a0584d8f59212a1
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7933,7 +7933,7 @@ __metadata:
   resolution: "@metamask/money-account-utils@workspace:packages/money-account-utils"
   dependencies:
     "@metamask/auto-changelog": "npm:^6.1.0"
-    "@metamask/transaction-controller": "npm:^69.2.1"
+    "@metamask/transaction-controller": "npm:^69.3.0"
     "@metamask/utils": "npm:^11.11.0"
     "@ts-bridge/cli": "npm:^0.6.4"
     "@types/jest": "npm:^30.0.0"
@@ -9283,7 +9283,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-controller@npm:^69.2.1, @metamask/transaction-controller@npm:^69.3.0, @metamask/transaction-controller@workspace:packages/transaction-controller":
+"@metamask/transaction-controller@npm:^69.3.0, @metamask/transaction-controller@workspace:packages/transaction-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/transaction-controller@workspace:packages/transaction-controller"
   dependencies:
@@ -14928,9 +14928,9 @@ __metadata:
   linkType: hard
 
 "cjs-module-lexer@npm:^1.3.1":
-  version: 1.4.3
-  resolution: "cjs-module-lexer@npm:1.4.3"
-  checksum: 10/d2b92f919a2dedbfd61d016964fce8da0035f827182ed6839c97cac56e8a8077cfa6a59388adfe2bc588a19cef9bbe830d683a76a6e93c51f65852062cfe2591
+  version: 1.4.0
+  resolution: "cjs-module-lexer@npm:1.4.0"
+  checksum: 10/b041096749792526120d8b8756929f8ef5dd4596502a0e1013f857e3027acd6091915fea77037921d70ee1a99988a100d994d3d3c2e323b04dd4c5ffd516cf13
   languageName: node
   linkType: hard
 
@@ -15925,14 +15925,14 @@ __metadata:
   linkType: hard
 
 "dedent@npm:^1.6.0":
-  version: 1.7.2
-  resolution: "dedent@npm:1.7.2"
+  version: 1.7.1
+  resolution: "dedent@npm:1.7.1"
   peerDependencies:
     babel-plugin-macros: ^3.1.0
   peerDependenciesMeta:
     babel-plugin-macros:
       optional: true
-  checksum: 10/30b9062290dca72b0f5a6cd3667633448cef8cd0dec602eab61015741269ad49df90cabf0521f9a32d134ceab4e21aa7f097258c55cc3baadef94874686d6480
+  checksum: 10/78785ef592e37e0b1ca7a7a5964c8f3dee1abdff46c5bb49864168579c122328f6bb55c769bc7e005046a7381c3372d3859f0f78ab083950fa146e1c24873f4f
   languageName: node
   linkType: hard
 
@@ -28152,7 +28152,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:17.7.2":
+"yargs@npm:17.7.2, yargs@npm:^17.0.1, yargs@npm:^17.7.1, yargs@npm:^17.7.2":
   version: 17.7.2
   resolution: "yargs@npm:17.7.2"
   dependencies:
@@ -28164,21 +28164,6 @@ __metadata:
     y18n: "npm:^5.0.5"
     yargs-parser: "npm:^21.1.1"
   checksum: 10/abb3e37678d6e38ea85485ed86ebe0d1e3464c640d7d9069805ea0da12f69d5a32df8e5625e370f9c96dd1c2dc088ab2d0a4dd32af18222ef3c4224a19471576
-  languageName: node
-  linkType: hard
-
-"yargs@npm:^17.0.1, yargs@npm:^17.7.1, yargs@npm:^17.7.2":
-  version: 17.7.3
-  resolution: "yargs@npm:17.7.3"
-  dependencies:
-    cliui: "npm:^8.0.1"
-    escalade: "npm:^3.1.1"
-    get-caller-file: "npm:^2.0.5"
-    require-directory: "npm:^2.1.1"
-    string-width: "npm:^4.2.3"
-    y18n: "npm:^5.0.5"
-    yargs-parser: "npm:^21.1.1"
-  checksum: 10/a3826798c03b159e139d0580a3b2733953889a9a1bac8e4e1ca7a1a249b55315b213c323a6a1dbdb305f6e59496a9eaa810742c87e34abcf1a0584d8f59212a1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation
Create a new package to extract various pieces of code related to the money account.

The intention of this is to capture as much of non-platform specific code as possible, such that we can more easily share code between mobile and extension.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New additive package with no in-repo consumers yet; behavior is covered by tests and only affects clients once they adopt the dependency.
> 
> **Overview**
> Introduces **`@metamask/money-account-utils`** as a new Earn-owned workspace package so money-account logic can be shared across Extension and Mobile instead of living only in clients.
> 
> The initial export is **mUSD support ported from MetaMask Mobile**: token metadata and per-chain address/CAIP asset maps, **`getTokenDisplaySymbol`** (registry `MUSD` → branded `mUSD`), and guards **`isMusdToken`**, **`isMusdTokenOnChain`**, and **`isMusdOnMoneyAccountChain`** (Money Account activity limited to Monad while mUSD is also on Mainnet/Linea/BSC). Unit tests target full coverage.
> 
> Monorepo wiring adds the package to **CODEOWNERS**, **`teams.json`**, root **`tsconfig`**, README package list/dependency graph, and **`yarn.lock`**. Root **`lint:eslint`** Node heap is raised from 8192MB to 10240MB.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c82229a377c4e3826366b51a4418e6b74ce5c16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->