### PR TITLE
fix: trigger price fallback

### DIFF
--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/messenger` from `^1.2.0` to `^2.0.0` ([#9392](https://github.com/MetaMask/core/pull/9392))
 
+### Fixed
+
+- Fix `adaptOrderFromSDK` dropping `takeProfitPrice`/`stopLossPrice` for child TP/SL orders whose `triggerPx` is an empty string (HyperLiquid's representation of "no trigger price" when the price is instead carried in `limitPx`)
+  - `??` only falls back on `null`/`undefined`, so an empty-string `triggerPx` was never replaced by `limitPx`, leaving `takeProfitPrice`/`stopLossPrice` (and their order IDs) `undefined` on the resulting `Order`. Switched back to `||`, which correctly treats `''` as falsy.
+
 ## [9.2.0]
 
 ### Added

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix `adaptOrderFromSDK` dropping `takeProfitPrice`/`stopLossPrice` for child TP/SL orders whose `triggerPx` is an empty string (HyperLiquid's representation of "no trigger price" when the price is instead carried in `limitPx`)
+- Fix `adaptOrderFromSDK` dropping `takeProfitPrice`/`stopLossPrice` for child TP/SL orders whose `triggerPx` is an empty string (HyperLiquid's representation of "no trigger price" when the price is instead carried in `limitPx`) ([#9398](https://github.com/MetaMask/core/pull/9398))
   - `??` only falls back on `null`/`undefined`, so an empty-string `triggerPx` was never replaced by `limitPx`, leaving `takeProfitPrice`/`stopLossPrice` (and their order IDs) `undefined` on the resulting `Order`. Switched back to `||`, which correctly treats `''` as falsy.
 
 ## [9.2.0]

--- a/packages/perps-controller/src/utils/hyperLiquidAdapter.ts
+++ b/packages/perps-controller/src/utils/hyperLiquidAdapter.ts
@@ -187,10 +187,13 @@ export function adaptOrderFromSDK(
     rawOrder.children.forEach((child) => {
       if (child.isTrigger && child.orderType) {
         if (child.orderType.includes('Take Profit')) {
-          takeProfitPrice = child.triggerPx ?? child.limitPx;
+          // HyperLiquid represents "no trigger price" as an empty string, not
+          // null/undefined, so `||` (not `??`) is required to fall back to
+          // limitPx when triggerPx is ''.
+          takeProfitPrice = child.triggerPx || child.limitPx;
           takeProfitOrderId = child.oid.toString();
         } else if (child.orderType.includes('Stop')) {
-          stopLossPrice = child.triggerPx ?? child.limitPx;
+          stopLossPrice = child.triggerPx || child.limitPx;
           stopLossOrderId = child.oid.toString();
         }
       }

--- a/packages/perps-controller/tests/src/utils/hyperLiquidAdapter.test.ts
+++ b/packages/perps-controller/tests/src/utils/hyperLiquidAdapter.test.ts
@@ -1,0 +1,105 @@
+import { adaptOrderFromSDK } from '../../../src/utils/hyperLiquidAdapter';
+import type { FrontendOrder } from '../../../src/types/hyperliquid-types';
+
+/**
+ * Builds a minimal valid `FrontendOrder` fixture, overridable per test.
+ *
+ * @param overrides - Fields to override on the base fixture.
+ * @returns A `FrontendOrder` fixture.
+ */
+function buildFrontendOrder(
+  overrides: Partial<FrontendOrder> = {},
+): FrontendOrder {
+  return {
+    coin: 'BTC',
+    side: 'B',
+    limitPx: '50000',
+    sz: '0.1',
+    oid: 12345,
+    timestamp: Date.now(),
+    origSz: '0.1',
+    triggerCondition: 'N/A',
+    isTrigger: false,
+    triggerPx: '',
+    children: [],
+    isPositionTpsl: false,
+    reduceOnly: false,
+    orderType: 'Limit',
+    ...overrides,
+  } as FrontendOrder;
+}
+
+describe('adaptOrderFromSDK', () => {
+  it('converts a child take-profit order with limitPx instead of triggerPx', () => {
+    const frontendOrder = buildFrontendOrder({
+      coin: 'ADA',
+      oid: 66666,
+      children: [
+        buildFrontendOrder({
+          oid: 66667,
+          orderType: 'Take Profit Limit',
+          isTrigger: true,
+          // HyperLiquid represents "no trigger price" as an empty string,
+          // with the actual price carried in limitPx instead.
+          triggerPx: '',
+          limitPx: '0.6',
+        }),
+      ],
+    });
+
+    const result = adaptOrderFromSDK(frontendOrder);
+
+    expect(result.takeProfitPrice).toBe('0.6');
+    expect(result.takeProfitOrderId).toBe('66667');
+  });
+
+  it('converts a child stop-loss order with limitPx instead of triggerPx', () => {
+    const frontendOrder = buildFrontendOrder({
+      coin: 'ADA',
+      oid: 66666,
+      children: [
+        buildFrontendOrder({
+          oid: 66668,
+          orderType: 'Stop Limit',
+          isTrigger: true,
+          triggerPx: '',
+          limitPx: '0.4',
+        }),
+      ],
+    });
+
+    const result = adaptOrderFromSDK(frontendOrder);
+
+    expect(result.stopLossPrice).toBe('0.4');
+    expect(result.stopLossOrderId).toBe('66668');
+  });
+
+  it('prefers triggerPx over limitPx when triggerPx is a non-empty value', () => {
+    const frontendOrder = buildFrontendOrder({
+      coin: 'ADA',
+      oid: 66666,
+      children: [
+        buildFrontendOrder({
+          oid: 66667,
+          orderType: 'Take Profit Limit',
+          isTrigger: true,
+          triggerPx: '0.75',
+          limitPx: '0.6',
+        }),
+      ],
+    });
+
+    const result = adaptOrderFromSDK(frontendOrder);
+
+    expect(result.takeProfitPrice).toBe('0.75');
+  });
+
+  it('does not set take-profit/stop-loss fields when there are no children', () => {
+    const frontendOrder = buildFrontendOrder({ children: [] });
+
+    const result = adaptOrderFromSDK(frontendOrder);
+
+    expect(result.takeProfitPrice).toBeUndefined();
+    expect(result.stopLossPrice).toBeUndefined();
+  });
+});

--- a/packages/perps-controller/tests/src/utils/hyperLiquidAdapter.test.ts
+++ b/packages/perps-controller/tests/src/utils/hyperLiquidAdapter.test.ts
@@ -1,5 +1,5 @@
-import { adaptOrderFromSDK } from '../../../src/utils/hyperLiquidAdapter';
 import type { FrontendOrder } from '../../../src/types/hyperliquid-types';
+import { adaptOrderFromSDK } from '../../../src/utils/hyperLiquidAdapter';
 
 /**
  * Builds a minimal valid `FrontendOrder` fixture, overridable per test.


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Fixes regression where a empty string is not falsy, and therefore `triggerPx` fallback were not being processed as expected.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small adapter fix with targeted tests; no auth, persistence, or trading submission path changes beyond correct TP/SL display/metadata.
> 
> **Overview**
> Fixes **`adaptOrderFromSDK`** so child take-profit and stop-loss prices are populated when HyperLiquid sends **`triggerPx` as `''`** and the real price is in **`limitPx`**.
> 
> Child TP/SL mapping now uses **`||`** instead of **`??`**, so empty-string triggers fall back to **`limitPx`** while non-empty **`triggerPx`** still wins. Parent-level TP/SL fallback logic is unchanged.
> 
> Adds unit tests for TP/SL limit fallback, **`triggerPx`** preference, and orders without children; changelog documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c13f28a58fbd2266e99730766d7742fbf67011b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->