### PR TITLE
Release 1097.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "1096.0.0",
+  "version": "1097.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {

--- a/packages/chain-agnostic-permission/CHANGELOG.md
+++ b/packages/chain-agnostic-permission/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0]
+
 ### Added
 
 - Add `getSessionProperties` async function that hydrates the persisted session properties of a CAIP-25 caveat value with an `eip155Capabilities` record, mapping each permitted EVM account address to its per-chain capabilities resolved from the provided `getCapabilities` hook ([#9294](https://github.com/MetaMask/core/pull/9294))
@@ -228,7 +230,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/chain-agnostic-permission@1.6.2...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/chain-agnostic-permission@1.7.0...HEAD
+[1.7.0]: https://github.com/MetaMask/core/compare/@metamask/chain-agnostic-permission@1.6.2...@metamask/chain-agnostic-permission@1.7.0
 [1.6.2]: https://github.com/MetaMask/core/compare/@metamask/chain-agnostic-permission@1.6.1...@metamask/chain-agnostic-permission@1.6.2
 [1.6.1]: https://github.com/MetaMask/core/compare/@metamask/chain-agnostic-permission@1.6.0...@metamask/chain-agnostic-permission@1.6.1
 [1.6.0]: https://github.com/MetaMask/core/compare/@metamask/chain-agnostic-permission@1.5.0...@metamask/chain-agnostic-permission@1.6.0

--- a/packages/chain-agnostic-permission/package.json
+++ b/packages/chain-agnostic-permission/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/chain-agnostic-permission",
-  "version": "1.6.2",
+  "version": "1.7.0",
   "description": "Defines a CAIP-25 based endowment permission and helpers for interfacing with it",
   "keywords": [
     "Ethereum",

--- a/packages/eip1193-permission-middleware/CHANGELOG.md
+++ b/packages/eip1193-permission-middleware/CHANGELOG.md
@@ -11,8 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/utils` from `^11.9.0` to `^11.11.0` ([#9074](https://github.com/MetaMask/core/pull/9074))
 - Bump `@metamask/controller-utils` from `^12.0.0` to `^12.3.0` ([#8774](https://github.com/MetaMask/core/pull/8774), [#9058](https://github.com/MetaMask/core/pull/9058), [#9083](https://github.com/MetaMask/core/pull/9083), [#9218](https://github.com/MetaMask/core/pull/9218))
-- Bump `@metamask/chain-agnostic-permission` from `^1.6.1` to `^1.6.2` ([#9103](https://github.com/MetaMask/core/pull/9103)
-- Bump `@metamask/chain-agnostic-permission` from `^1.6.2` to `^1.7.0` ([#9399](https://github.com/MetaMask/core/pull/9399)
+- Bump `@metamask/chain-agnostic-permission` from `^1.6.1` to `^1.6.2` ([#9103](https://github.com/MetaMask/core/pull/9103))
+- Bump `@metamask/chain-agnostic-permission` from `^1.6.2` to `^1.7.0` ([#9399](https://github.com/MetaMask/core/pull/9399))
 
 ## [2.0.1]
 

--- a/packages/eip1193-permission-middleware/CHANGELOG.md
+++ b/packages/eip1193-permission-middleware/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/utils` from `^11.9.0` to `^11.11.0` ([#9074](https://github.com/MetaMask/core/pull/9074))
 - Bump `@metamask/controller-utils` from `^12.0.0` to `^12.3.0` ([#8774](https://github.com/MetaMask/core/pull/8774), [#9058](https://github.com/MetaMask/core/pull/9058), [#9083](https://github.com/MetaMask/core/pull/9083), [#9218](https://github.com/MetaMask/core/pull/9218))
-- Bump `@metamask/chain-agnostic-permission` from `^1.6.1` to `^1.6.2` ([#9103](https://github.com/MetaMask/core/pull/9103))
+- Bump `@metamask/chain-agnostic-permission` from `^1.6.1` to `^1.6.2` ([#9103](https://github.com/MetaMask/core/pull/9103)
+- Bump `@metamask/chain-agnostic-permission` from `^1.6.2` to `^1.7.0` ([#9399](https://github.com/MetaMask/core/pull/9399)
 
 ## [2.0.1]
 

--- a/packages/eip1193-permission-middleware/package.json
+++ b/packages/eip1193-permission-middleware/package.json
@@ -51,7 +51,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/chain-agnostic-permission": "^1.6.2",
+    "@metamask/chain-agnostic-permission": "^1.7.0",
     "@metamask/controller-utils": "^12.3.0",
     "@metamask/json-rpc-engine": "^10.5.0",
     "@metamask/permission-controller": "^13.1.1",

--- a/packages/multichain-api-middleware/CHANGELOG.md
+++ b/packages/multichain-api-middleware/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.0.1]
 
+### Changed
+
+- Bump `@metamask/chain-agnostic-permission` from `^1.6.2` to `^1.7.0` ([#9399](https://github.com/MetaMask/core/pull/9399))
+  - This aligns the declared dependency range with the version that provides `getSessionProperties`, which this package requires.
+
 ## [4.0.0]
 
 ### Added

--- a/packages/multichain-api-middleware/CHANGELOG.md
+++ b/packages/multichain-api-middleware/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/chain-agnostic-permission` from `^1.6.2` to `^1.7.0` ([#9399](https://github.com/MetaMask/core/pull/9399))
   - This aligns the declared dependency range with the version that provides `getSessionProperties`, which this package requires.
+  - This change should have been included in 4.0.0.
 
 ## [4.0.0] [DEPRECATED]
 

--- a/packages/multichain-api-middleware/CHANGELOG.md
+++ b/packages/multichain-api-middleware/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/chain-agnostic-permission` from `^1.6.2` to `^1.7.0` ([#9399](https://github.com/MetaMask/core/pull/9399))
   - This aligns the declared dependency range with the version that provides `getSessionProperties`, which this package requires.
 
-## [4.0.0]
+## [4.0.0] [DEPRECATED]
 
 ### Added
 

--- a/packages/multichain-api-middleware/CHANGELOG.md
+++ b/packages/multichain-api-middleware/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.1]
+
 ## [4.0.0]
 
 ### Added
@@ -268,7 +270,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/multichain-api-middleware@4.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/multichain-api-middleware@4.0.1...HEAD
+[4.0.1]: https://github.com/MetaMask/core/compare/@metamask/multichain-api-middleware@4.0.0...@metamask/multichain-api-middleware@4.0.1
 [4.0.0]: https://github.com/MetaMask/core/compare/@metamask/multichain-api-middleware@3.1.5...@metamask/multichain-api-middleware@4.0.0
 [3.1.5]: https://github.com/MetaMask/core/compare/@metamask/multichain-api-middleware@3.1.4...@metamask/multichain-api-middleware@3.1.5
 [3.1.4]: https://github.com/MetaMask/core/compare/@metamask/multichain-api-middleware@3.1.3...@metamask/multichain-api-middleware@3.1.4

--- a/packages/multichain-api-middleware/package.json
+++ b/packages/multichain-api-middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/multichain-api-middleware",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "JSON-RPC methods and middleware to support the MetaMask Multichain API",
   "keywords": [
     "Ethereum",
@@ -53,7 +53,7 @@
   "dependencies": {
     "@metamask/accounts-controller": "^39.0.4",
     "@metamask/api-specs": "^0.15.0",
-    "@metamask/chain-agnostic-permission": "^1.6.2",
+    "@metamask/chain-agnostic-permission": "^1.7.0",
     "@metamask/controller-utils": "^12.3.0",
     "@metamask/json-rpc-engine": "^10.5.0",
     "@metamask/network-controller": "^34.0.0",

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [9.2.1]
+
 ### Changed
 
 - Bump `@metamask/messenger` from `^1.2.0` to `^2.0.0` ([#9392](https://github.com/MetaMask/core/pull/9392))
@@ -487,7 +489,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/controller-utils` from `^11.18.0` to `^11.19.0` ([#7995](https://github.com/MetaMask/core/pull/7995))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/perps-controller@9.2.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/perps-controller@9.2.1...HEAD
+[9.2.1]: https://github.com/MetaMask/core/compare/@metamask/perps-controller@9.2.0...@metamask/perps-controller@9.2.1
 [9.2.0]: https://github.com/MetaMask/core/compare/@metamask/perps-controller@9.1.0...@metamask/perps-controller@9.2.0
 [9.1.0]: https://github.com/MetaMask/core/compare/@metamask/perps-controller@9.0.0...@metamask/perps-controller@9.1.0
 [9.0.0]: https://github.com/MetaMask/core/compare/@metamask/perps-controller@8.3.0...@metamask/perps-controller@9.0.0

--- a/packages/perps-controller/package.json
+++ b/packages/perps-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/perps-controller",
-  "version": "9.2.0",
+  "version": "9.2.1",
   "description": "Controller for perpetual trading functionality in MetaMask",
   "keywords": [
     "Ethereum",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6036,7 +6036,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/chain-agnostic-permission@npm:^1.6.2, @metamask/chain-agnostic-permission@workspace:packages/chain-agnostic-permission":
+"@metamask/chain-agnostic-permission@npm:^1.7.0, @metamask/chain-agnostic-permission@workspace:packages/chain-agnostic-permission":
   version: 0.0.0-use.local
   resolution: "@metamask/chain-agnostic-permission@workspace:packages/chain-agnostic-permission"
   dependencies:
@@ -6535,7 +6535,7 @@ __metadata:
   resolution: "@metamask/eip1193-permission-middleware@workspace:packages/eip1193-permission-middleware"
   dependencies:
     "@metamask/auto-changelog": "npm:^6.1.0"
-    "@metamask/chain-agnostic-permission": "npm:^1.6.2"
+    "@metamask/chain-agnostic-permission": "npm:^1.7.0"
     "@metamask/controller-utils": "npm:^12.3.0"
     "@metamask/json-rpc-engine": "npm:^10.5.0"
     "@metamask/permission-controller": "npm:^13.1.1"
@@ -7595,7 +7595,7 @@ __metadata:
     "@metamask/accounts-controller": "npm:^39.0.4"
     "@metamask/api-specs": "npm:^0.15.0"
     "@metamask/auto-changelog": "npm:^6.1.0"
-    "@metamask/chain-agnostic-permission": "npm:^1.6.2"
+    "@metamask/chain-agnostic-permission": "npm:^1.7.0"
     "@metamask/controller-utils": "npm:^12.3.0"
     "@metamask/eth-json-rpc-filters": "npm:^9.0.0"
     "@metamask/json-rpc-engine": "npm:^10.5.0"


### PR DESCRIPTION
## Explanation

Releases the following packages:

- **`@metamask/chain-agnostic-permission`**: `1.6.2` → `1.7.0` (minor)
  - Adds the `getSessionProperties` async function (from [#9294](https://github.com/MetaMask/core/pull/9294)).
- **`@metamask/multichain-api-middleware`**: `4.0.0` → `4.0.1` (patch)
  - Bumps its `@metamask/chain-agnostic-permission` dependency from `^1.6.2` to `^1.7.0`. `4.0.0` already consumes `getSessionProperties` (introduced in [#9294](https://github.com/MetaMask/core/pull/9294)), which is only available from `chain-agnostic-permission@1.7.0`, so this aligns the declared dependency range with what the package actually requires.
 - **`@metamask/perps-controller`**: `9.2.0` → `9.2.1` (patch)
  - Bumps `@metamask/messenger` from `^1.2.0` to `^2.0.0`. 
  - Fix `adaptOrderFromSDK` dropping `takeProfitPrice`/`stopLossPrice` for child TP/SL orders whose `triggerPx` is an empty string

## References

- Follow-up to [#9294](https://github.com/MetaMask/core/pull/9294)
- Mobile: https://github.com/MetaMask/metamask-mobile/pull/32660

## Checklist

- [x] Versions bumped following SemVer
- [x] Changelog entries migrated to new version sections
- [x] All changelogs pass validation
- [x] `yarn constraints` passes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version, changelog, and dependency-range-only changes with no new runtime code; fixes a packaging mismatch for an API already used in 4.0.0.
> 
> **Overview**
> **Monorepo release 1097.0.0** cuts new package versions and updates lockfile entries; there is no application logic change in this diff.
> 
> **`@metamask/chain-agnostic-permission` 1.7.0** moves the existing Unreleased changelog (including **`getSessionProperties`**) into the **1.7.0** section and bumps the package version.
> 
> **`@metamask/multichain-api-middleware` 4.0.1** raises its declared **`@metamask/chain-agnostic-permission`** range from **`^1.6.2`** to **`^1.7.0`**, because **4.0.0** already calls **`getSessionProperties`** but did not declare that minimum version. The **4.0.0** changelog section is marked **[DEPRECATED]**.
> 
> **`@metamask/eip1193-permission-middleware`** gets the same **`chain-agnostic-permission`** dependency bump and changelog note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a02bb3e2830bd9a22cc4b1b26debf9f851d93733. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->