### PR TITLE
fix: update push onchain notif detection

### DIFF
--- a/packages/notification-services-controller/CHANGELOG.md
+++ b/packages/notification-services-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Update `isOnChainRawNotification` to detect on-chain notifications using the v4 `notification_type` discriminator instead of legacy payload field checks, fixing web push notification handling after the v4 API migration
+- Update `isOnChainRawNotification` to detect on-chain notifications using the v4 `notification_type` discriminator instead of legacy payload field checks, fixing web push notification handling after the v4 API migration ([#9407](https://github.com/MetaMask/core/pull/9407))
 
 ## [25.0.0]
 

--- a/packages/notification-services-controller/CHANGELOG.md
+++ b/packages/notification-services-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Update `isOnChainRawNotification` to detect on-chain notifications using the v4 `notification_type` discriminator instead of legacy payload field checks, fixing web push notification handling after the v4 API migration
+
 ## [25.0.0]
 
 ### Added

--- a/packages/notification-services-controller/src/shared/is-onchain-notification.ts
+++ b/packages/notification-services-controller/src/shared/is-onchain-notification.ts
@@ -1,21 +1,17 @@
-import type { OnChainRawNotification } from '../NotificationServicesController';
+import type {
+  UnprocessedRawNotification,
+  OnChainNotification,
+} from '../NotificationServicesController/types/notification-api';
+import { isOnChainNotification } from './notification-api-type-guards';
 
 /**
- * Checks if the given value is an OnChainRawNotification object.
+ * Checks if the given value is an on-chain notification using the v4 `notification_type` discriminator.
  *
  * @param notification - The value to check.
- * @returns True if the value is an OnChainRawNotification object, false otherwise.
+ * @returns True if the value is an on-chain notification, false otherwise.
  */
 export function isOnChainRawNotification(
   notification: unknown,
-): notification is OnChainRawNotification {
-  const assumed = notification as OnChainRawNotification;
-
-  // We don't have a validation/parsing library to check all possible types of an on chain notification
-  // It is safe enough just to check "some" fields, and catch any errors down the line if the shape is bad.
-  const isValidEnoughToBeOnChainNotification = [
-    assumed?.id,
-    assumed?.payload?.data,
-  ].every((field) => field !== undefined);
-  return isValidEnoughToBeOnChainNotification;
+): notification is OnChainNotification {
+  return isOnChainNotification(notification as UnprocessedRawNotification);
 }


### PR DESCRIPTION
## Explanation

After the v4 Notification API migration ([#9384](https://github.com/MetaMask/core/pull/9384)), `isOnChainRawNotification` still used legacy heuristics (`id` and `payload.data` must be defined). v4 on-chain push payloads are discriminated by `notification_type === 'wallet_activity'`, so the old check could reject valid notifications and web push handling in `push-utils.ts` would bail out early.

This PR updates `isOnChainRawNotification` to delegate to the existing `isOnChainNotification` type guard, which uses the v4 `notification_type` discriminator. The function now narrows to `OnChainNotification` (the unprocessed v4 shape) instead of `OnChainRawNotification` (the normalised shape with a `type` field added by `toRawAPINotification`). That matches the push flow: discriminate first, then normalise via `toRawAPINotification`.

No other packages were changed. No dependency upgrades.

**Changelog entry:**

> ### Fixed
>
> - Update `isOnChainRawNotification` to detect on-chain notifications using the v4 `notification_type` discriminator instead of legacy payload field checks, fixing web push notification handling after the v4 API migration ([#9407](https://github.com/MetaMask/core/pull/9407))

## References

* Fixes [GE-343](https://consensyssoftware.atlassian.net/browse/GE-343)
* Follow-up to the v4 API migration in [#9384](https://github.com/MetaMask/core/pull/9384)
* Affects web push handling in `NotificationServicesPushController/web/push-utils.ts`

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

[GE-343]: https://consensyssoftware.atlassian.net/browse/GE-343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-function detection fix in notification-services-controller with no auth or data-model changes; main caveat is the type guard now narrows to `OnChainNotification` instead of `OnChainRawNotification`.
> 
> **Overview**
> Fixes **web push** dropping valid on-chain payloads after the v4 Notification API migration by updating **`isOnChainRawNotification`** to use the v4 discriminator instead of legacy shape checks.
> 
> The guard no longer requires `id` and `payload.data` to be defined; it delegates to **`isOnChainNotification`** (`notification_type === 'wallet_activity'`). The narrowed type is now **`OnChainNotification`** (unprocessed v4 API shape), matching the push path in **`push-utils.ts`**: discriminate first, then **`toRawAPINotification`**.
> 
> Changelog updated under **Fixed** for this package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77c4b5b0fa599e113bcfc51021f2d229a34c7057. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->