### PR TITLE
fix(geolocation-controller): point to API Platform geolocation-api instead of legacy Ramps endpoint

### DIFF
--- a/packages/geolocation-controller/CHANGELOG.md
+++ b/packages/geolocation-controller/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Point `GeolocationApiService` at API Platform's `geolocation-api` service instead of the legacy Ramps-owned `on-ramp` geolocation endpoint, which is slated for deprecation ([#TBD](https://github.com/MetaMask/core/pull/TBD))
+  - UAT temporarily resolves to the production URL since API Platform has not yet provisioned a dedicated UAT deployment for this service
 - Bump `@metamask/controller-utils` from `^12.0.0` to `^12.3.0` ([#8774](https://github.com/MetaMask/core/pull/8774), [#9058](https://github.com/MetaMask/core/pull/9058), [#9083](https://github.com/MetaMask/core/pull/9083), [#9218](https://github.com/MetaMask/core/pull/9218))
 - Bump `@metamask/messenger` from `^1.2.0` to `^2.0.0` ([#9392](https://github.com/MetaMask/core/pull/9392))
 

--- a/packages/geolocation-controller/CHANGELOG.md
+++ b/packages/geolocation-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Point `GeolocationApiService` at API Platform's `geolocation-api` service instead of the legacy Ramps-owned `on-ramp` geolocation endpoint, which is slated for deprecation ([#TBD](https://github.com/MetaMask/core/pull/TBD))
+- Point `GeolocationApiService` at API Platform's `geolocation-api` service instead of the legacy Ramps-owned `on-ramp` geolocation endpoint, which is slated for deprecation ([#9415](https://github.com/MetaMask/core/pull/9415))
   - UAT temporarily resolves to the production URL since API Platform has not yet provisioned a dedicated UAT deployment for this service
 - Bump `@metamask/controller-utils` from `^12.0.0` to `^12.3.0` ([#8774](https://github.com/MetaMask/core/pull/8774), [#9058](https://github.com/MetaMask/core/pull/9058), [#9083](https://github.com/MetaMask/core/pull/9083), [#9218](https://github.com/MetaMask/core/pull/9218))
 - Bump `@metamask/messenger` from `^1.2.0` to `^2.0.0` ([#9392](https://github.com/MetaMask/core/pull/9392))

--- a/packages/geolocation-controller/CHANGELOG.md
+++ b/packages/geolocation-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Point `GeolocationApiService` at API Platform's `geolocation-api` service instead of the legacy Ramps-owned `on-ramp` geolocation endpoint, which is slated for deprecation ([#9415](https://github.com/MetaMask/core/pull/9415))
+- Point `GeolocationApiService` at API Platform's `geolocation-api` service instead of the legacy Ramps-owned `on-ramp` geolocation endpoint, which is slated for deprecation ([#9417](https://github.com/MetaMask/core/pull/9417))
   - UAT temporarily resolves to the production URL since API Platform has not yet provisioned a dedicated UAT deployment for this service
 - Bump `@metamask/controller-utils` from `^12.0.0` to `^12.3.0` ([#8774](https://github.com/MetaMask/core/pull/8774), [#9058](https://github.com/MetaMask/core/pull/9058), [#9083](https://github.com/MetaMask/core/pull/9083), [#9218](https://github.com/MetaMask/core/pull/9218))
 - Bump `@metamask/messenger` from `^1.2.0` to `^2.0.0` ([#9392](https://github.com/MetaMask/core/pull/9392))

--- a/packages/geolocation-controller/src/geolocation-api-service/geolocation-api-service.test.ts
+++ b/packages/geolocation-controller/src/geolocation-api-service/geolocation-api-service.test.ts
@@ -44,11 +44,11 @@ describe('GeolocationApiService', () => {
       await rootMessenger.call('GeolocationApiService:fetchGeolocation');
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://on-ramp.api.cx.metamask.io/geolocation',
+        'https://geolocation.api.cx.metamask.io/v1/geolocation',
       );
     });
 
-    it('fetches from the UAT URL when env is UAT', async () => {
+    it('fetches from the production URL when env is UAT, since API Platform has not provisioned a dedicated UAT deployment', async () => {
       const mockFetch = createMockFetch('FR');
       const { rootMessenger } = getService({
         options: { fetch: mockFetch, env: Env.UAT },
@@ -57,7 +57,7 @@ describe('GeolocationApiService', () => {
       await rootMessenger.call('GeolocationApiService:fetchGeolocation');
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://on-ramp.uat-api.cx.metamask.io/geolocation',
+        'https://geolocation.api.cx.metamask.io/v1/geolocation',
       );
     });
 
@@ -70,7 +70,7 @@ describe('GeolocationApiService', () => {
       await rootMessenger.call('GeolocationApiService:fetchGeolocation');
 
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://on-ramp.dev-api.cx.metamask.io/geolocation',
+        'https://geolocation.dev-api.cx.metamask.io/v1/geolocation',
       );
     });
   });

--- a/packages/geolocation-controller/src/geolocation-api-service/geolocation-api-service.ts
+++ b/packages/geolocation-controller/src/geolocation-api-service/geolocation-api-service.ts
@@ -11,7 +11,7 @@ import type { GeolocationApiServiceMethodActions } from './geolocation-api-servi
 
 const DEFAULT_TTL_MS = 5 * 60 * 1000;
 
-const ENDPOINT_PATH = '/geolocation';
+const ENDPOINT_PATH = '/v1/geolocation';
 
 // === GENERAL ===
 
@@ -68,12 +68,17 @@ export type GeolocationApiServiceMessenger = Messenger<
 /**
  * Returns the base URL for the geolocation API for the given environment.
  *
+ * Served by API Platform's `geolocation-api` service, not the legacy
+ * Ramps-owned `on-ramp` endpoint this previously pointed to. API Platform has
+ * not yet provisioned a dedicated UAT deployment for this service, so UAT
+ * temporarily resolves to the production URL until one exists.
+ *
  * @param env - The environment to get the URL for.
  * @returns The full URL for the geolocation endpoint.
  */
 function getGeolocationUrl(env: Env): string {
-  const envPrefix = env === Env.PRD ? '' : `${env}-`;
-  return `https://on-ramp.${envPrefix}api.cx.metamask.io${ENDPOINT_PATH}`;
+  const envPrefix = env === Env.DEV ? 'dev-' : '';
+  return `https://geolocation.${envPrefix}api.cx.metamask.io${ENDPOINT_PATH}`;
 }
 
 /**


### PR DESCRIPTION
## Explanation

`GeolocationApiService` (used by Ramp, Perps, Rewards, Card, mUSD, and Money Account across extension and mobile) still fetches from the legacy Ramps-owned `on-ramp.{env}api.cx.metamask.io/geolocation` endpoint.

That endpoint is slated for deprecation now that geolocation is a platform-owned service. API Platform's replacement, `geolocation.{env}api.cx.metamask.io/v1/geolocation`, has been live since March and returns the same plain-text ISO 3166-2 response format, so this is a same-contract URL swap with no consumer-facing changes.

## Open item before merge

API Platform has **not yet provisioned a dedicated UAT deployment** for `geolocation-api` (confirmed: `geolocation.uat-api.cx.metamask.io` does not resolve, and the UAT workload config in `va-mmcx-geolocation-api-workload` is empty). This PR temporarily maps `Env.UAT` to the production URL so UAT testing isn't broken by this change. That mapping should be revisited once a real UAT deployment exists.

Opening as **draft** pending confirmation from API Platform (`@api-platform-devs`) that:
- the PROD/DEV URLs are correct and stable
- the UAT-points-at-PROD interim approach is acceptable on their end

## References

- `packages/geolocation-controller` is owned by `@metamask-mobile-platform` per CODEOWNERS
- API Platform docs: https://docs.cx.metamask.io/api/geolocation/

Supersedes #9415 (opened from a fork by mistake, which broke the changelog-diff CI check).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide downstream use (Ramp, Perps, Rewards, etc.) makes any geolocation outage impactful, though the API contract is unchanged; UAT hitting production is an interim operational caveat.
> 
> **Overview**
> **`GeolocationApiService`** now calls API Platform’s **`geolocation-api`** host and **`/v1/geolocation`** path instead of the legacy Ramps **`on-ramp.*`** **`/geolocation`** URLs that are being deprecated. The response contract is unchanged (plain-text ISO 3166-2).
> 
> **`getGeolocationUrl`** builds **`https://geolocation.api.cx.metamask.io`** for production and UAT, and **`https://geolocation.dev-api.cx.metamask.io`** for DEV. **UAT** no longer uses a separate **`uat-`** host and temporarily shares the production URL until API Platform provisions a UAT deployment. Tests and the changelog reflect the new URLs and UAT behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 411259b25db2c234a296e15faf46ee41269758cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->