### PR TITLE
Copy createServicePolicy to base-data-service

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,6 @@ linkStyle default opacity:0.5
   authenticated_user_storage --> controller_utils;
   authenticated_user_storage --> messenger;
   base_controller --> messenger;
-  base_data_service --> controller_utils;
   base_data_service --> messenger;
   bitcoin_regtest_up --> local_node_utils;
   bridge_controller --> accounts_controller;

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -626,6 +626,11 @@
       "count": 3
     }
   },
+  "packages/base-data-service/src/createServicePolicy.ts": {
+    "no-restricted-syntax": {
+      "count": 1
+    }
+  },
   "packages/bridge-controller/src/utils/assets.ts": {
     "@typescript-eslint/explicit-function-return-type": {
       "count": 2

--- a/packages/base-data-service/CHANGELOG.md
+++ b/packages/base-data-service/CHANGELOG.md
@@ -7,11 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `createServicePolicy` and related symbols, copied from `@metamask/controller-utils` ([#9418](https://github.com/MetaMask/core/pull/9418))
+  - Added functions:
+    `createServicePolicy`
+  - Added constants:
+    - `DEFAULT_CIRCUIT_BREAK_DURATION`
+    - `DEFAULT_DEGRADED_THRESHOLD`
+    - `DEFAULT_MAX_CONSECUTIVE_FAILURES`
+    - `DEFAULT_MAX_RETRIES`
+  - Added types:
+    - `CreateServicePolicyOptions`
+    - `ServicePolicy`
+  - Added re-exports from `cockatiel`:
+    - `BrokenCircuitError`
+    - `CircuitState`
+    - `CockatielEventEmitter`
+    - `CockatielEvent`
+    - `CockatielFailureReason`
+    - `ConstantBackoff`
+    - `ExponentialBackoff`
+    - `handleAll`
+    - `handleWhen`
+
 ### Changed
 
 - Bump `@metamask/utils` from `^11.9.0` to `^11.11.0` ([#9074](https://github.com/MetaMask/core/pull/9074))
 - Bump `@metamask/controller-utils` from `^12.1.0` to `^12.3.0` ([#9058](https://github.com/MetaMask/core/pull/9058), [#9083](https://github.com/MetaMask/core/pull/9083), [#9218](https://github.com/MetaMask/core/pull/9218))
 - Bump `@metamask/messenger` from `^1.2.0` to `^2.0.0` ([#9392](https://github.com/MetaMask/core/pull/9392))
+- Add dependency `cockatiel` (`^3.1.2`) ([#9418](https://github.com/MetaMask/core/pull/9418))
 
 ## [0.1.3]
 

--- a/packages/base-data-service/package.json
+++ b/packages/base-data-service/package.json
@@ -54,10 +54,10 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/controller-utils": "^12.3.0",
     "@metamask/messenger": "^2.0.0",
     "@metamask/utils": "^11.11.0",
     "@tanstack/query-core": "^4.43.0",
+    "cockatiel": "^3.1.2",
     "fast-deep-equal": "^3.1.3"
   },
   "devDependencies": {

--- a/packages/base-data-service/src/BaseDataService.test.ts
+++ b/packages/base-data-service/src/BaseDataService.test.ts
@@ -1,6 +1,6 @@
-import { BrokenCircuitError } from '@metamask/controller-utils';
 import { Messenger } from '@metamask/messenger';
 import { hashQueryKey } from '@tanstack/query-core';
+import { BrokenCircuitError } from 'cockatiel';
 import { cleanAll } from 'nock';
 
 import { ExampleDataService, serviceName } from '../tests/ExampleDataService';

--- a/packages/base-data-service/src/BaseDataService.ts
+++ b/packages/base-data-service/src/BaseDataService.ts
@@ -1,9 +1,4 @@
 import {
-  createServicePolicy,
-  CreateServicePolicyOptions,
-  ServicePolicy,
-} from '@metamask/controller-utils';
-import {
   Messenger,
   ActionConstraint,
   EventConstraint,
@@ -25,6 +20,12 @@ import {
   dehydrate,
 } from '@tanstack/query-core';
 import deepEqual from 'fast-deep-equal';
+
+import {
+  createServicePolicy,
+  CreateServicePolicyOptions,
+  ServicePolicy,
+} from './createServicePolicy';
 
 // Data service queries use the following format: ['ServiceActionName', ...params]
 export type QueryKey = [string, ...Json[]];

--- a/packages/base-data-service/src/createServicePolicy.test.ts
+++ b/packages/base-data-service/src/createServicePolicy.test.ts
@@ -1,0 +1,964 @@
+import { CircuitState, ConstantBackoff, handleWhen } from 'cockatiel';
+
+import {
+  createServicePolicy,
+  DEFAULT_CIRCUIT_BREAK_DURATION,
+  DEFAULT_DEGRADED_THRESHOLD,
+  DEFAULT_MAX_CONSECUTIVE_FAILURES,
+  DEFAULT_MAX_RETRIES,
+  ServicePolicy,
+} from './createServicePolicy';
+
+describe('createServicePolicy', () => {
+  beforeEach(() => {
+    jest.useFakeTimers({ doNotFake: ['nextTick', 'queueMicrotask'] });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('execute', () => {
+    describe('when the service succeeds at least on the first attempt', () => {
+      it('returns what the service returns', async () => {
+        const policy = createServicePolicy();
+        const result = await policy.execute(() => ({ some: 'data' }));
+        expect(result).toStrictEqual({ some: 'data' });
+      });
+
+      it('fires onAvailable on the first successful execution and not again on subsequent successful executions', async () => {
+        const mockService = jest.fn();
+        const onAvailableListener = jest.fn();
+        const policy = createServicePolicy();
+        policy.onAvailable(onAvailableListener);
+
+        await policy.execute(mockService);
+        await policy.execute(mockService);
+        await policy.execute(mockService);
+
+        expect(onAvailableListener).toHaveBeenCalledTimes(1);
+      });
+
+      it('does not fire onDegraded when the service responds within the degraded threshold', async () => {
+        const onDegradedListener = jest.fn();
+        const policy = createServicePolicy();
+        policy.onDegraded(onDegradedListener);
+
+        await policy.execute(jest.fn());
+
+        expect(onDegradedListener).not.toHaveBeenCalled();
+      });
+
+      it('fires onDegraded when the service takes longer than the degraded threshold', async () => {
+        const degradedThreshold = 2_000;
+        const delay = degradedThreshold + 1;
+        const mockService = jest.fn(
+          () =>
+            new Promise<void>((resolve) => setTimeout(() => resolve(), delay)),
+        );
+        const onDegradedListener = jest.fn();
+        const policy = createServicePolicy({
+          degradedThreshold,
+        });
+        policy.onDegraded(onDegradedListener);
+
+        const promise = policy.execute(mockService);
+        jest.advanceTimersByTime(delay);
+        await promise;
+
+        expect(onDegradedListener).toHaveBeenCalledTimes(1);
+      });
+
+      it('does not fire onAvailable when the service takes longer than the degraded threshold', async () => {
+        const degradedThreshold = 2_000;
+        const delay = degradedThreshold + 1;
+        const mockService = jest.fn(
+          () =>
+            new Promise<void>((resolve) => setTimeout(() => resolve(), delay)),
+        );
+        const onAvailableListener = jest.fn();
+        const policy = createServicePolicy({
+          degradedThreshold,
+        });
+        policy.onAvailable(onAvailableListener);
+
+        const promise = policy.execute(mockService);
+        jest.advanceTimersByTime(delay);
+        await promise;
+
+        expect(onAvailableListener).not.toHaveBeenCalled();
+      });
+
+      it('uses the default degraded threshold when none is provided', async () => {
+        const delay = DEFAULT_DEGRADED_THRESHOLD + 1;
+        const mockService = jest.fn(
+          () =>
+            new Promise<void>((resolve) => setTimeout(() => resolve(), delay)),
+        );
+        const onDegradedListener = jest.fn();
+        const policy = createServicePolicy();
+        policy.onDegraded(onDegradedListener);
+
+        const promise = policy.execute(mockService);
+        jest.advanceTimersByTime(delay);
+        await promise;
+
+        expect(onDegradedListener).toHaveBeenCalledTimes(1);
+      });
+
+      it('does not fire onBreak', async () => {
+        const onBreakListener = jest.fn();
+        const policy = createServicePolicy();
+        policy.onBreak(onBreakListener);
+
+        await policy.execute(jest.fn());
+
+        expect(onBreakListener).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when the service throws an error which has an httpStatus property', () => {
+      it('treats errors with httpStatus >= 500 as service failures, making them circuit-breakable', async () => {
+        const error = Object.assign(new Error('server error'), {
+          httpStatus: 500,
+        });
+        const mockService = createErroringService({ error });
+        const onBreakListener = jest.fn();
+        const policy = createServicePolicyForTestingRetries({
+          breakAfterFirstExecution: true,
+        });
+        policy.onBreak(onBreakListener);
+
+        await ignoreRejection(policy.execute(mockService));
+
+        expect(onBreakListener).toHaveBeenCalledTimes(1);
+      });
+
+      it('treats errors with httpStatus < 500 as non-service failures, making them non-circuit-breakable', async () => {
+        const error = Object.assign(new Error('client error'), {
+          httpStatus: 404,
+        });
+        const mockService = createErroringService({ error });
+        const onBreakListener = jest.fn();
+        const policy = createServicePolicyForTestingRetries({
+          breakAfterFirstExecution: true,
+        });
+        policy.onBreak(onBreakListener);
+
+        await ignoreRejection(policy.execute(mockService));
+
+        expect(onBreakListener).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when the service always throws', () => {
+      describe.each([
+        {
+          desc: `using a default maxRetries (of ${DEFAULT_MAX_RETRIES})`,
+          maxRetries: DEFAULT_MAX_RETRIES,
+          options: {},
+        },
+        {
+          desc: 'using a custom maxRetries',
+          maxRetries: 5,
+          options: { maxRetries: 5 },
+        },
+      ])('using $desc', ({ maxRetries, options }) => {
+        it(`calls the service maxRetries + 1 times`, async () => {
+          const mockService = createErroringService();
+          const policy = createServicePolicyForTestingRetries({ options });
+
+          await ignoreRejection(policy.execute(mockService));
+
+          expect(mockService).toHaveBeenCalledTimes(maxRetries + 1);
+        });
+
+        it('fires onRetry once per retry', async () => {
+          const mockService = createErroringService();
+          const onRetryListener = jest.fn().mockImplementation(() => {
+            jest.advanceTimersToNextTimer();
+          });
+          const policy = createServicePolicyForTestingRetries({
+            options,
+            onRetryListener,
+          });
+
+          await ignoreRejection(policy.execute(mockService));
+
+          expect(onRetryListener).toHaveBeenCalledTimes(maxRetries);
+        });
+      });
+
+      describe('when a single retry round does not break the circuit', () => {
+        // Setting the number of attempts (maxRetries + 1) less than the
+        // maximum number of consecutive failures causes the circuit to stay
+        // closed even after calling `.execute` once
+        const maxRetries = 2;
+        const maxConsecutiveFailures = 4;
+
+        it('throws the original error', async () => {
+          const error = new Error('failure');
+          const mockService = createErroringService({ error });
+          const policy = createServicePolicyForTestingRetries({
+            options: {
+              maxRetries,
+              maxConsecutiveFailures,
+            },
+          });
+
+          await expect(policy.execute(mockService)).rejects.toThrow(error);
+        });
+
+        it('does not fire onAvailable', async () => {
+          const mockService = createErroringService();
+          const onAvailableListener = jest.fn();
+          const policy = createServicePolicyForTestingRetries({
+            options: {
+              maxRetries,
+              maxConsecutiveFailures,
+            },
+          });
+          policy.onAvailable(onAvailableListener);
+
+          await ignoreRejection(policy.execute(mockService));
+
+          expect(onAvailableListener).not.toHaveBeenCalled();
+        });
+
+        it('fires onDegraded with the error', async () => {
+          const error = new Error('failure');
+          const mockService = createErroringService({ error });
+          const onDegradedListener = jest.fn();
+          const policy = createServicePolicyForTestingRetries({
+            options: {
+              maxRetries,
+              maxConsecutiveFailures,
+            },
+          });
+          policy.onDegraded(onDegradedListener);
+
+          await ignoreRejection(policy.execute(mockService));
+
+          expect(onDegradedListener).toHaveBeenCalledTimes(1);
+          expect(onDegradedListener).toHaveBeenCalledWith({ error });
+        });
+
+        it('does not fire onBreak', async () => {
+          const mockService = createErroringService();
+          const onBreakListener = jest.fn();
+          const policy = createServicePolicyForTestingRetries({
+            options: {
+              maxRetries,
+              maxConsecutiveFailures,
+            },
+          });
+          policy.onBreak(onBreakListener);
+
+          await ignoreRejection(policy.execute(mockService));
+
+          expect(onBreakListener).not.toHaveBeenCalled();
+        });
+      });
+
+      describe('when a single retry round breaks the circuit after the last attempt', () => {
+        // Setting maxConsecutiveFailures equal to maxRetries + 1 causes the
+        // circuit to open after calling `.execute` only once
+        const maxRetries = 2;
+        const maxConsecutiveFailures = 3;
+
+        it('throws the original error', async () => {
+          const error = new Error('failure');
+          const mockService = createErroringService({ error });
+          const policy = createServicePolicyForTestingRetries({
+            options: {
+              maxRetries,
+              maxConsecutiveFailures,
+            },
+          });
+
+          await expect(policy.execute(mockService)).rejects.toThrow(error);
+        });
+
+        it('does not fire onAvailable', async () => {
+          const mockService = createErroringService();
+          const onAvailableListener = jest.fn();
+          const policy = createServicePolicyForTestingRetries({
+            options: {
+              maxRetries,
+              maxConsecutiveFailures,
+            },
+          });
+          policy.onAvailable(onAvailableListener);
+
+          await ignoreRejection(policy.execute(mockService));
+
+          expect(onAvailableListener).not.toHaveBeenCalled();
+        });
+
+        it('does not fire onDegraded', async () => {
+          const mockService = createErroringService();
+          const onDegradedListener = jest.fn();
+          const policy = createServicePolicyForTestingRetries({
+            options: {
+              maxRetries,
+              maxConsecutiveFailures,
+            },
+          });
+          policy.onDegraded(onDegradedListener);
+
+          await ignoreRejection(policy.execute(mockService));
+
+          expect(onDegradedListener).not.toHaveBeenCalled();
+        });
+
+        it('fires onBreak', async () => {
+          const mockService = createErroringService();
+          const onBreakListener = jest.fn();
+          const policy = createServicePolicyForTestingRetries({
+            options: {
+              maxRetries,
+              maxConsecutiveFailures,
+            },
+          });
+          policy.onBreak(onBreakListener);
+
+          await ignoreRejection(policy.execute(mockService));
+
+          expect(onBreakListener).toHaveBeenCalledTimes(1);
+        });
+
+        it('throws BrokenCircuitError on the next service execution', async () => {
+          const mockService = createErroringService();
+          const policy = createServicePolicyForTestingRetries({
+            options: {
+              maxRetries,
+              maxConsecutiveFailures,
+            },
+          });
+
+          await ignoreRejection(policy.execute(mockService));
+
+          await expect(policy.execute(mockService)).rejects.toThrow(
+            'Execution prevented because the circuit breaker is open',
+          );
+        });
+      });
+
+      describe('when a single retry round breaks the circuit before reaching the max number of retries', () => {
+        // Setting the number of attempts (maxRetries + 1) greater than the
+        // maximum number of consecutive failures causes the circuit to break
+        // before the last attempt is reached
+        const maxRetries = 3;
+        const maxConsecutiveFailures = 3;
+
+        it('throws BrokenCircuitError', async () => {
+          const mockService = createErroringService();
+          const policy = createServicePolicyForTestingRetries({
+            options: {
+              maxRetries,
+              maxConsecutiveFailures,
+            },
+          });
+
+          await expect(policy.execute(mockService)).rejects.toThrow(
+            'Execution prevented because the circuit breaker is open',
+          );
+        });
+
+        it('does not fire onAvailable', async () => {
+          const mockService = createErroringService();
+          const onAvailableListener = jest.fn();
+          const policy = createServicePolicyForTestingRetries({
+            options: {
+              maxRetries,
+              maxConsecutiveFailures,
+            },
+          });
+          policy.onAvailable(onAvailableListener);
+
+          await ignoreRejection(policy.execute(mockService));
+
+          expect(onAvailableListener).not.toHaveBeenCalled();
+        });
+
+        it('does not fire onDegraded', async () => {
+          const mockService = createErroringService();
+          const onDegradedListener = jest.fn();
+          const policy = createServicePolicyForTestingRetries({
+            options: {
+              maxRetries,
+              maxConsecutiveFailures,
+            },
+          });
+          policy.onDegraded(onDegradedListener);
+
+          await ignoreRejection(policy.execute(mockService));
+
+          expect(onDegradedListener).not.toHaveBeenCalled();
+        });
+
+        it('fires onBreak', async () => {
+          const mockService = createErroringService();
+          const onBreakListener = jest.fn();
+          const policy = createServicePolicyForTestingRetries({
+            options: {
+              maxRetries,
+              maxConsecutiveFailures,
+            },
+          });
+          policy.onBreak(onBreakListener);
+
+          await ignoreRejection(policy.execute(mockService));
+
+          expect(onBreakListener).toHaveBeenCalledTimes(1);
+        });
+      });
+    });
+
+    describe('when the service throws at first but succeeds on the final attempt', () => {
+      it('returns the eventual successful result from the service', async () => {
+        const mockService = createErroringService({
+          failUntilNthAttempt: DEFAULT_MAX_RETRIES + 1,
+        });
+        const policy = createServicePolicyForTestingRetries();
+
+        const result = await policy.execute(mockService);
+
+        expect(result).toStrictEqual({ some: 'data' });
+      });
+
+      it('fires onAvailable on the first successful (fast) execution and not again on subsequent successful (fast) executions', async () => {
+        const mockService = createErroringService({
+          failUntilNthAttempt: DEFAULT_MAX_RETRIES + 1,
+        });
+        const onAvailableListener = jest.fn();
+        const policy = createServicePolicyForTestingRetries();
+        policy.onAvailable(onAvailableListener);
+
+        await policy.execute(mockService);
+        await policy.execute(() => {
+          // dummy function
+        });
+
+        expect(onAvailableListener).toHaveBeenCalledTimes(1);
+      });
+
+      it('does not fire onDegraded if the final attempt takes less time than the degraded threshold', async () => {
+        const mockService = createErroringService({
+          failUntilNthAttempt: DEFAULT_MAX_RETRIES + 1,
+        });
+        const onDegradedListener = jest.fn();
+        const policy = createServicePolicyForTestingRetries();
+        policy.onDegraded(onDegradedListener);
+
+        await policy.execute(mockService);
+
+        expect(onDegradedListener).not.toHaveBeenCalled();
+      });
+
+      it('fires onDegraded when the final attempt takes longer than the degraded threshold', async () => {
+        const degradedThreshold = 2_000;
+        const delay = degradedThreshold + 1;
+        let attempts = 0;
+        const mockService = jest.fn(
+          () =>
+            new Promise<{ some: string }>((resolve, reject) => {
+              attempts += 1;
+              if (attempts === 1 + DEFAULT_MAX_RETRIES) {
+                setTimeout(() => resolve({ some: 'data' }), delay);
+              } else {
+                reject(new Error('failure'));
+              }
+            }),
+        );
+        const onDegradedListener = jest.fn();
+        const policy = createServicePolicyForTestingRetries({
+          options: {
+            degradedThreshold,
+          },
+        });
+        policy.onDegraded(onDegradedListener);
+
+        const promise = policy.execute(mockService);
+        await jest.runAllTimersAsync();
+        await promise;
+
+        expect(onDegradedListener).toHaveBeenCalledTimes(1);
+      });
+
+      it('does not fire onAvailable when the final attempt takes longer than the degraded threshold', async () => {
+        const degradedThreshold = 2_000;
+        const delay = degradedThreshold + 1;
+        let attempts = 0;
+        const mockService = jest.fn(
+          () =>
+            new Promise<{ some: string }>((resolve, reject) => {
+              attempts += 1;
+              if (attempts === 1 + DEFAULT_MAX_RETRIES) {
+                setTimeout(() => resolve({ some: 'data' }), delay);
+              } else {
+                reject(new Error('failure'));
+              }
+            }),
+        );
+        const onAvailableListener = jest.fn();
+        const policy = createServicePolicyForTestingRetries({
+          options: {
+            degradedThreshold,
+          },
+        });
+        policy.onAvailable(onAvailableListener);
+
+        const promise = policy.execute(mockService);
+        await jest.runAllTimersAsync();
+        await promise;
+
+        expect(onAvailableListener).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when the service fails enough times to break the circuit, then the circuit break duration elapses', () => {
+      it('returns what the service returns if it then succeeds', async () => {
+        // Setup
+        const circuitBreakDuration = 5_000;
+        let attempts = 0;
+        const mockService = jest.fn(() => {
+          attempts += 1;
+          if (attempts > DEFAULT_MAX_CONSECUTIVE_FAILURES) {
+            return { some: 'data' };
+          }
+          throw new Error('failure');
+        });
+        const policy = createServicePolicyForTestingRetries({
+          options: {
+            circuitBreakDuration,
+          },
+        });
+
+        // Drive the circuit open, then advance past the circuit break duration
+        await ignoreRejection(policy.execute(mockService));
+        await ignoreRejection(policy.execute(mockService));
+        await ignoreRejection(policy.execute(mockService));
+        jest.advanceTimersByTime(circuitBreakDuration);
+
+        const result = await policy.execute(mockService);
+        expect(result).toStrictEqual({ some: 'data' });
+      });
+
+      it('uses the default circuit break duration when none is provided', async () => {
+        // Setup
+        let attempts = 0;
+        const mockService = jest.fn(() => {
+          attempts += 1;
+          if (attempts > DEFAULT_MAX_CONSECUTIVE_FAILURES) {
+            return { some: 'data' };
+          }
+          throw new Error('failure');
+        });
+        const policy = createServicePolicyForTestingRetries();
+
+        // Drive the circuit open, then advance past the circuit break duration
+        await ignoreRejection(policy.execute(mockService));
+        await ignoreRejection(policy.execute(mockService));
+        await ignoreRejection(policy.execute(mockService));
+        jest.advanceTimersByTime(DEFAULT_CIRCUIT_BREAK_DURATION);
+
+        const result = await policy.execute(mockService);
+        expect(result).toStrictEqual({ some: 'data' });
+      });
+
+      it('fires onAvailable again after the circuit recovers', async () => {
+        // Setup
+        const circuitBreakDuration = 5_000;
+        let attempts = 0;
+        const mockService = jest.fn(() => {
+          attempts += 1;
+          if (
+            attempts === 1 ||
+            attempts > DEFAULT_MAX_CONSECUTIVE_FAILURES + 1
+          ) {
+            return { some: 'data' };
+          }
+          throw new Error('failure');
+        });
+        const onAvailableListener = jest.fn();
+        const policy = createServicePolicyForTestingRetries({
+          options: {
+            circuitBreakDuration,
+          },
+        });
+        policy.onAvailable(onAvailableListener);
+
+        // Check that onAvailable fires at first for completeness
+        await policy.execute(mockService);
+        expect(onAvailableListener).toHaveBeenCalledTimes(1);
+
+        // Drive the circuit open
+        await ignoreRejection(policy.execute(mockService));
+        await ignoreRejection(policy.execute(mockService));
+        await ignoreRejection(policy.execute(mockService));
+
+        // Recover
+        jest.advanceTimersByTime(circuitBreakDuration);
+        await policy.execute(mockService);
+        expect(onAvailableListener).toHaveBeenCalledTimes(2);
+      });
+
+      it('does not fire onAvailable again if the circuit recovers but then the service fails', async () => {
+        // Setup
+        const circuitBreakDuration = 5_000;
+        let attempts = 0;
+        const mockService = jest.fn(() => {
+          attempts += 1;
+          if (attempts === 1) {
+            return { some: 'data' };
+          }
+          throw new Error('failure');
+        });
+        const onAvailableListener = jest.fn();
+        const policy = createServicePolicyForTestingRetries({
+          options: {
+            circuitBreakDuration,
+          },
+        });
+        policy.onAvailable(onAvailableListener);
+
+        // Establish baseline
+        await policy.execute(mockService);
+        expect(onAvailableListener).toHaveBeenCalledTimes(1);
+
+        // Drive the circuit open
+        await ignoreRejection(policy.execute(mockService));
+        await ignoreRejection(policy.execute(mockService));
+        await ignoreRejection(policy.execute(mockService));
+
+        // Recover
+        jest.advanceTimersByTime(circuitBreakDuration);
+        await ignoreRejection(policy.execute(mockService));
+        expect(onAvailableListener).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('using a custom retryFilterPolicy', () => {
+      it('throws the error immediately without retrying if retryFilterPolicy filters the error out', async () => {
+        const error = new Error('failure');
+        const mockService = jest.fn(() => {
+          throw error;
+        });
+        const policy = createServicePolicyForTestingRetries({
+          options: {
+            retryFilterPolicy: handleWhen(
+              (caughtError) => caughtError.message !== 'failure',
+            ),
+          },
+        });
+
+        await expect(policy.execute(mockService)).rejects.toThrow(error);
+        expect(mockService).toHaveBeenCalledTimes(1);
+      });
+
+      it('does not fire onRetry, onBreak, onDegraded, or onAvailable if retryFilterPolicy filters the error out', async () => {
+        const error = new Error('failure');
+        const mockService = jest.fn(() => {
+          throw error;
+        });
+        const onRetryListener = jest.fn();
+        const onBreakListener = jest.fn();
+        const onDegradedListener = jest.fn();
+        const onAvailableListener = jest.fn();
+        const policy = createServicePolicyForTestingRetries({
+          options: {
+            retryFilterPolicy: handleWhen(
+              (caughtError) => caughtError.message !== 'failure',
+            ),
+          },
+        });
+        policy.onRetry(onRetryListener);
+        policy.onBreak(onBreakListener);
+        policy.onDegraded(onDegradedListener);
+        policy.onAvailable(onAvailableListener);
+
+        await ignoreRejection(policy.execute(mockService));
+
+        expect(onRetryListener).not.toHaveBeenCalled();
+        expect(onBreakListener).not.toHaveBeenCalled();
+        expect(onDegradedListener).not.toHaveBeenCalled();
+        expect(onAvailableListener).not.toHaveBeenCalled();
+      });
+
+      it('throws the error after retrying if retryFilterPolicy filters the error in', async () => {
+        const error = new Error('failure');
+        const mockService = jest.fn(() => {
+          throw error;
+        });
+        const policy = createServicePolicyForTestingRetries({
+          options: {
+            retryFilterPolicy: handleWhen(
+              (caughtError) => caughtError.message === 'failure',
+            ),
+          },
+        });
+
+        await expect(policy.execute(mockService)).rejects.toThrow(error);
+        expect(mockService).toHaveBeenCalledTimes(DEFAULT_MAX_RETRIES + 1);
+      });
+
+      it('fires onRetry if retryFilterPolicy filters the error in', async () => {
+        const error = new Error('failure');
+        const mockService = jest.fn(() => {
+          throw error;
+        });
+        const onRetryListener = jest.fn();
+        const policy = createServicePolicyForTestingRetries({
+          options: {
+            retryFilterPolicy: handleWhen(
+              (caughtError) => caughtError.message === 'failure',
+            ),
+          },
+        });
+        policy.onRetry(onRetryListener);
+
+        await ignoreRejection(policy.execute(mockService));
+        expect(onRetryListener).toHaveBeenCalled();
+      });
+    });
+
+    describe('using a custom isServiceFailure predicate', () => {
+      it('opens the circuit when the predicate treats the error as a service failure', async () => {
+        const error = new Error('failure');
+        const mockService = createErroringService({ error });
+        const onBreakListener = jest.fn();
+        const policy = createServicePolicyForTestingRetries({
+          options: {
+            isServiceFailure: () => true,
+          },
+          breakAfterFirstExecution: true,
+        });
+        policy.onBreak(onBreakListener);
+
+        await ignoreRejection(policy.execute(mockService));
+
+        expect(onBreakListener).toHaveBeenCalledTimes(1);
+        expect(onBreakListener).toHaveBeenCalledWith({ error });
+      });
+
+      it('never opens the circuit when the predicate does not treat the error as a service failure', async () => {
+        const error = new Error('failure');
+        const mockService = createErroringService({ error });
+        const onBreakListener = jest.fn();
+        const policy = createServicePolicyForTestingRetries({
+          options: {
+            isServiceFailure: () => false,
+          },
+          breakAfterFirstExecution: true,
+        });
+        policy.onBreak(onBreakListener);
+
+        await ignoreRejection(policy.execute(mockService));
+
+        expect(onBreakListener).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('getRemainingCircuitOpenDuration', () => {
+    it('returns null when the circuit is closed', () => {
+      const policy = createServicePolicyForTestingRetries();
+      expect(policy.getRemainingCircuitOpenDuration()).toBeNull();
+    });
+
+    it('returns the milliseconds remaining before the circuit transitions to half-open', async () => {
+      const policy = createServicePolicyForTestingRetries();
+
+      // Drive the circuit open
+      await ignoreRejection(policy.execute(createErroringService()));
+      await ignoreRejection(policy.execute(createErroringService()));
+      await ignoreRejection(policy.execute(createErroringService()));
+      jest.advanceTimersByTime(1_000);
+
+      expect(policy.getRemainingCircuitOpenDuration()).toBe(
+        DEFAULT_CIRCUIT_BREAK_DURATION - 1_000,
+      );
+    });
+  });
+
+  describe('getCircuitState', () => {
+    it('tracks circuit state transitions: Closed → Open → HalfOpen → Open', async () => {
+      // Establish initial state
+      const policy = createServicePolicyForTestingRetries();
+      expect(policy.getCircuitState()).toBe(CircuitState.Closed);
+
+      // Drive the circuit open
+      await ignoreRejection(policy.execute(createErroringService()));
+      await ignoreRejection(policy.execute(createErroringService()));
+      await ignoreRejection(policy.execute(createErroringService()));
+      expect(policy.getCircuitState()).toBe(CircuitState.Open);
+
+      // Advance to half-open
+      jest.advanceTimersByTime(DEFAULT_CIRCUIT_BREAK_DURATION);
+      const promise = ignoreRejection(policy.execute(createErroringService()));
+      expect(policy.getCircuitState()).toBe(CircuitState.HalfOpen);
+      await promise;
+      expect(policy.getCircuitState()).toBe(CircuitState.Open);
+    });
+  });
+
+  describe('reset', () => {
+    it('transitions the circuit from Open to Closed', async () => {
+      const policy = createServicePolicyForTestingRetries();
+      // Drive the circuit open
+      await ignoreRejection(policy.execute(createErroringService()));
+      await ignoreRejection(policy.execute(createErroringService()));
+      await ignoreRejection(policy.execute(createErroringService()));
+      expect(policy.getCircuitState()).toBe(CircuitState.Open);
+
+      policy.reset();
+
+      expect(policy.getCircuitState()).toBe(CircuitState.Closed);
+    });
+
+    it('allows the service to succeed after the circuit was open', async () => {
+      let attempts = 0;
+      const mockService = jest.fn(() => {
+        attempts += 1;
+        if (attempts > DEFAULT_MAX_CONSECUTIVE_FAILURES) {
+          return { some: 'data' };
+        }
+        throw new Error('failure');
+      });
+      const policy = createServicePolicyForTestingRetries();
+      // Drive the circuit open
+      await ignoreRejection(policy.execute(mockService));
+      await ignoreRejection(policy.execute(mockService));
+      await ignoreRejection(policy.execute(mockService));
+
+      policy.reset();
+
+      expect(await policy.execute(mockService)).toStrictEqual({ some: 'data' });
+    });
+
+    it('allows the service to fail again without throwing BrokenCircuitError', async () => {
+      const service = createErroringService();
+      const policy = createServicePolicyForTestingRetries();
+      // Drive the circuit open
+      await ignoreRejection(policy.execute(service));
+      await ignoreRejection(policy.execute(service));
+      await ignoreRejection(policy.execute(service));
+
+      policy.reset();
+
+      await expect(policy.execute(service)).rejects.toThrow('failure');
+    });
+
+    it('fires onAvailable again after reset when the service succeeds', async () => {
+      // Setup
+      let attempts = 0;
+      const mockService = jest.fn(() => {
+        attempts += 1;
+        if (attempts === 1 || attempts > DEFAULT_MAX_CONSECUTIVE_FAILURES + 1) {
+          return { some: 'data' };
+        }
+        throw new Error('failure');
+      });
+      const onAvailableListener = jest.fn();
+      const policy = createServicePolicyForTestingRetries();
+      policy.onAvailable(onAvailableListener);
+
+      // Establish baseline
+      await policy.execute(mockService);
+      expect(onAvailableListener).toHaveBeenCalledTimes(1);
+
+      // Drive the circuit open
+      await ignoreRejection(policy.execute(mockService));
+      await ignoreRejection(policy.execute(mockService));
+      await ignoreRejection(policy.execute(mockService));
+
+      // Reset
+      policy.reset();
+      await policy.execute(mockService);
+      expect(onAvailableListener).toHaveBeenCalledTimes(2);
+    });
+  });
+});
+
+/**
+ * Some tests involve a rejected promise that is not necessarily the focus of
+ * the test. In these cases we don't want to ignore the error in case the
+ * promise _isn't_ rejected, but we don't want to highlight the assertion,
+ * either.
+ *
+ * @param promise - A promise that rejects.
+ */
+async function ignoreRejection<Type>(promise: Promise<Type>): Promise<void> {
+  await expect(promise).rejects.toThrow(expect.any(Error));
+}
+
+/**
+ * Builds a service policy that takes care of some boilerplate when testing
+ * retries by:
+ *
+ * - using a zero-delay constant backoff so tests do not need to account for
+ *   jitter when advancing timers
+ * - advancing timers automatically whenever retries occur
+ * - allowing for the service to break on first execution
+ *
+ * @param args - The arguments.
+ * @param args.options - Any additional options to pass to `createServicePolicy`.
+ * @param args.onRetryListener - The onRetry callback to register.
+ * @returns The service policy.
+ * @param args.breakAfterFirstExecution - Assuming that the service always
+ * error, causes the policy's circuit to break the first time the service is
+ * executed.
+ */
+function createServicePolicyForTestingRetries({
+  options,
+  onRetryListener = (): ReturnType<Parameters<ServicePolicy['onRetry']>[0]> =>
+    jest.advanceTimersToNextTimer(),
+  breakAfterFirstExecution = false,
+}: {
+  options?: Parameters<typeof createServicePolicy>[0];
+  onRetryListener?: Parameters<ServicePolicy['onRetry']>[0];
+  breakAfterFirstExecution?: boolean;
+} = {}): ReturnType<typeof createServicePolicy> {
+  const policy = createServicePolicy({
+    backoff: new ConstantBackoff(0),
+    ...(breakAfterFirstExecution
+      ? { maxRetries: 0, maxConsecutiveFailures: 1 }
+      : {}),
+    ...options,
+  });
+  policy.onRetry(onRetryListener);
+  return policy;
+}
+
+/**
+ * Builds a mock service that throws `error` on every call before some number of
+ * attempts, then returns `result`.
+ *
+ * @param options - Options.
+ * @param options.failUntilNthAttempt - The 1-based attempt number at which the
+ * service should start succeeding (default: Infinity — never succeeds).
+ * @param options.error - The error to throw on failure (default: `new
+ * Error('failure')`).
+ * @param options.result - The value to return on success (default: `{ some:
+ * 'data' }`).
+ * @returns A Jest mock function.
+ */
+function createErroringService({
+  failUntilNthAttempt = Infinity,
+  error = new Error('failure'),
+  result = { some: 'data' },
+}: {
+  failUntilNthAttempt?: number;
+  error?: Error;
+  result?: unknown;
+} = {}): jest.Mock {
+  let attempts = 0;
+  return jest.fn(() => {
+    attempts += 1;
+    if (attempts >= failUntilNthAttempt) {
+      return result;
+    }
+    throw error;
+  });
+}

--- a/packages/base-data-service/src/createServicePolicy.ts
+++ b/packages/base-data-service/src/createServicePolicy.ts
@@ -1,10 +1,8 @@
 import {
-  BrokenCircuitError,
   CircuitState,
   EventEmitter as CockatielEventEmitter,
   ConsecutiveBreaker,
   ExponentialBackoff,
-  ConstantBackoff,
   circuitBreaker,
   handleAll,
   handleWhen,
@@ -21,64 +19,8 @@ import type {
   RetryPolicy,
 } from 'cockatiel';
 
-export {
-  /**
-   * @deprecated This is deprecated and will be removed in a future major
-   * version. Please use the equivalent type from `@metamask/base-data-service`.
-   */
-  BrokenCircuitError,
-  /**
-   * @deprecated This is deprecated and will be removed in a future major
-   * version. Please use the equivalent type from `@metamask/base-data-service`.
-   */
-  CockatielEventEmitter,
-  /**
-   * @deprecated This is deprecated and will be removed in a future major
-   * version. Please use the equivalent type from `@metamask/base-data-service`.
-   */
-  CircuitState,
-  /**
-   * @deprecated This is deprecated and will be removed in a future major
-   * version. Please use the equivalent type from `@metamask/base-data-service`.
-   */
-  ConstantBackoff,
-  /**
-   * @deprecated This is deprecated and will be removed in a future major
-   * version. Please use the equivalent type from `@metamask/base-data-service`.
-   */
-  ExponentialBackoff,
-  /**
-   * @deprecated This is deprecated and will be removed in a future major
-   * version. Please use the equivalent function from
-   * `@metamask/base-data-service`.
-   */
-  handleAll,
-  /**
-   * @deprecated This is deprecated and will be removed in a future major
-   * version. Please use the equivalent function from
-   * `@metamask/base-data-service`.
-   */
-  handleWhen,
-};
-
-export type {
-  /**
-   * @deprecated This is deprecated and will be removed in a future major
-   * version. Please use the equivalent type from `@metamask/base-data-service`.
-   */
-  CockatielEvent,
-  /**
-   * @deprecated This is deprecated and will be removed in a future major
-   * version. Please use the equivalent type from `@metamask/base-data-service`.
-   */
-  FailureReason as CockatielFailureReason,
-};
-
 /**
  * The options for `createServicePolicy`.
- *
- * @deprecated This is deprecated and will be removed in a future major version.
- * Please use the equivalent type from `@metamask/base-data-service`.
  */
 export type CreateServicePolicyOptions = {
   /**
@@ -122,9 +64,6 @@ export type CreateServicePolicyOptions = {
 
 /**
  * The service policy object.
- *
- * @deprecated This is deprecated and will be removed in a future major
- * version. Please use the equivalent type from `@metamask/base-data-service`.
  */
 export type ServicePolicy = IPolicy & {
   /**
@@ -217,9 +156,6 @@ type AvailabilityStatus =
 /**
  * The maximum number of times that a failing service should be re-run before
  * giving up.
- *
- * @deprecated This is deprecated and will be removed in a future major version.
- * Please use the equivalent variable from `@metamask/base-data-service`.
  */
 export const DEFAULT_MAX_RETRIES = 3;
 
@@ -228,27 +164,18 @@ export const DEFAULT_MAX_RETRIES = 3;
  * pausing further retries. This is set to a value such that if given a
  * service that continually fails, the policy needs to be executed 3 times
  * before further retries are paused.
- *
- * @deprecated This is deprecated and will be removed in a future major version.
- * Please use the equivalent variable from `@metamask/base-data-service`.
  */
 export const DEFAULT_MAX_CONSECUTIVE_FAILURES = (1 + DEFAULT_MAX_RETRIES) * 3;
 
 /**
  * The default length of time (in milliseconds) to temporarily pause retries of
  * the service after enough consecutive failures.
- *
- * @deprecated This is deprecated and will be removed in a future major version.
- * Please use the equivalent variable from `@metamask/base-data-service`.
  */
 export const DEFAULT_CIRCUIT_BREAK_DURATION = 30 * 60 * 1000;
 
 /**
  * The default length of time (in milliseconds) that governs when the service is
  * regarded as degraded (affecting when `onDegraded` is called).
- *
- * @deprecated This is deprecated and will be removed in a future major version.
- * Please use the equivalent variable from `@metamask/base-data-service`.
  */
 export const DEFAULT_DEGRADED_THRESHOLD = 5_000;
 
@@ -336,9 +263,6 @@ function getInternalCircuitState(state: CircuitState): InternalCircuitState {
  *   }
  * }
  * ```
- *
- * @deprecated This is deprecated and will be removed in a future major version.
- * Please use the equivalent function from `@metamask/base-data-service`.
  */
 export function createServicePolicy(
   options: CreateServicePolicyOptions = {},

--- a/packages/base-data-service/src/index.ts
+++ b/packages/base-data-service/src/index.ts
@@ -1,4 +1,19 @@
 export type {
+  Event as CockatielEvent,
+  FailureReason as CockatielFailureReason,
+} from 'cockatiel';
+
+export {
+  BrokenCircuitError,
+  EventEmitter as CockatielEventEmitter,
+  CircuitState,
+  ConstantBackoff,
+  ExponentialBackoff,
+  handleAll,
+  handleWhen,
+} from 'cockatiel';
+
+export type {
   DataServiceCacheUpdatedPayload,
   DataServiceGranularCacheUpdatedPayload,
   DataServiceInvalidateQueriesAction,
@@ -7,3 +22,15 @@ export type {
   QueryKey,
 } from './BaseDataService';
 export { BaseDataService } from './BaseDataService';
+
+export {
+  DEFAULT_CIRCUIT_BREAK_DURATION,
+  DEFAULT_DEGRADED_THRESHOLD,
+  DEFAULT_MAX_CONSECUTIVE_FAILURES,
+  DEFAULT_MAX_RETRIES,
+  createServicePolicy,
+} from './createServicePolicy';
+export type {
+  CreateServicePolicyOptions,
+  ServicePolicy,
+} from './createServicePolicy';

--- a/packages/base-data-service/tests/ExampleDataService.ts
+++ b/packages/base-data-service/tests/ExampleDataService.ts
@@ -1,6 +1,6 @@
-import { ConstantBackoff } from '@metamask/controller-utils';
 import { Messenger } from '@metamask/messenger';
 import { CaipAssetId, Duration, inMilliseconds, Json } from '@metamask/utils';
+import { ConstantBackoff } from 'cockatiel';
 
 import {
   BaseDataService,

--- a/packages/controller-utils/CHANGELOG.md
+++ b/packages/controller-utils/CHANGELOG.md
@@ -11,6 +11,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add optional `startTime` to `TraceRequest` to allow backdating a span's start time ([#9315](https://github.com/MetaMask/core/pull/9315))
 
+### Deprecated
+
+- Deprecate `createServicePolicy` and related symbols ([#9418](https://github.com/MetaMask/core/pull/9418))
+  - Deprecated functions:
+    `createServicePolicy`
+  - Deprecated constants:
+    - `DEFAULT_CIRCUIT_BREAK_DURATION`
+    - `DEFAULT_DEGRADED_THRESHOLD`
+    - `DEFAULT_MAX_CONSECUTIVE_FAILURES`
+    - `DEFAULT_MAX_RETRIES`
+  - Deprecated types:
+    - `CreateServicePolicyOptions`
+    - `ServicePolicy`
+  - Deprecated re-exports from `cockatiel`:
+    - `BrokenCircuitError`
+    - `CircuitState`
+    - `CockatielEventEmitter`
+    - `CockatielEvent`
+    - `CockatielFailureReason`
+    - `ConstantBackoff`
+    - `ExponentialBackoff`
+    - `handleAll`
+    - `handleWhen`
+  - These symbols will be removed in a future major version. Please use equivalent implementations from `@metamask/base-data-service` going forward.
+
 ## [12.3.0]
 
 ### Added

--- a/yarn.lock
+++ b/yarn.lock
@@ -5888,12 +5888,12 @@ __metadata:
   resolution: "@metamask/base-data-service@workspace:packages/base-data-service"
   dependencies:
     "@metamask/auto-changelog": "npm:^6.1.0"
-    "@metamask/controller-utils": "npm:^12.3.0"
     "@metamask/messenger": "npm:^2.0.0"
     "@metamask/utils": "npm:^11.11.0"
     "@tanstack/query-core": "npm:^4.43.0"
     "@ts-bridge/cli": "npm:^0.6.4"
     "@types/jest": "npm:^29.5.14"
+    cockatiel: "npm:^3.1.2"
     deepmerge: "npm:^4.2.2"
     fast-deep-equal: "npm:^3.1.3"
     jest: "npm:^29.7.0"


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Currently `createServicePolicy` lives in `controller-utils`, as originally we wrote it as an abstract utility that could theoretically be used for any kind of data access. However, there are a few reasons why this is suboptimal now:

1. `controller-utils` is too large and serves as a dependent of almost every package in the monorepo, so extreme care must be taken when changing this package to avoid breaking changes.
2. `createServicePolicy` was added before we formalized data services. Now we have a `BaseDataService` class, and this class sets up `createServicePolicy` by default, so it's highly unlikely that `createServicePolicy` will be used independently going forward.
3. Also, we only use `createServicePolicy` for HTTP requests, so making it abstract is kind of unnecessary.

This commit deprecates the existing exports in `controller-utils`, copies them to `base-data-service`, and changes `BaseDataService` to use the copied version instead.

In the future we will remove the symbols from `controller-utils` and modify `createServicePolicy` further so it works better for HTTP requests.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

https://consensyssoftware.atlassian.net/browse/WPC-1130

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared HTTP retry/circuit-breaker behavior for data services; behavior is intended to be a straight copy, but any drift would affect outage handling. Deprecations are non-breaking for now.
> 
> **Overview**
> Moves **`createServicePolicy`** (retry/circuit-breaker wiring around Cockatiel) from `@metamask/controller-utils` into `@metamask/base-data-service`, so data-layer resilience lives next to `BaseDataService` instead of a widely depended-on utils package.
> 
> **`@metamask/base-data-service`** adds `createServicePolicy.ts`, exports the same API (including Cockatiel re-exports), drops the **`@metamask/controller-utils`** dependency in favor of direct **`cockatiel`**, and points **`BaseDataService`** at the local module. Tests for the policy are added under base-data-service; example/tests import `BrokenCircuitError` / `ConstantBackoff` from `cockatiel` where appropriate.
> 
> **`@metamask/controller-utils`** keeps the old implementations but marks **`createServicePolicy`** and related types, constants, and Cockatiel re-exports as **deprecated**, with changelogs directing callers to **`@metamask/base-data-service`**. The README dependency graph no longer shows `base-data-service` → `controller-utils` for this path.
> 
> No in-repo consumer migrations beyond `BaseDataService` in this PR; other packages can keep importing from controller-utils until a follow-up removes the deprecated surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2e3704584971984aa9cb00c2404d9e7464def76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->