### PR TITLE
chore: mark cancelled-STX failure change as breaking

### DIFF
--- a/packages/smart-transactions-controller/CHANGELOG.md
+++ b/packages/smart-transactions-controller/CHANGELOG.md
@@ -9,13 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bump `@metamask/messenger` from `^1.2.0` to `^2.0.0` ([#9392](https://github.com/MetaMask/core/pull/9392))
-
-### Fixed
-
-- Fail the associated regular transaction via the new `TransactionController:failTransaction` action instead of `TransactionController:updateTransaction` when a smart transaction is cancelled ([#9400](https://github.com/MetaMask/core/pull/9400))
+- **BREAKING:** Fail the associated regular transaction via the new `TransactionController:failTransaction` action instead of `TransactionController:updateTransaction` when a smart transaction is cancelled ([#9400](https://github.com/MetaMask/core/pull/9400))
+  - Consumers must now grant the smart transactions controller messenger access to the `TransactionController:failTransaction` action (previously `TransactionController:updateTransaction`).
   - `updateTransaction` only patches state and does not emit transaction lifecycle events, so consumers that react to `transactionFailed`/`transactionStatusUpdated` (e.g. the bridge status controller and metrics) were never notified, leaving cancelled smart transactions — such as bridges — stuck as pending indefinitely.
-  - This requires consumers to grant the smart transactions controller messenger access to the `TransactionController:failTransaction` action (previously `TransactionController:updateTransaction`).
+- Bump `@metamask/messenger` from `^1.2.0` to `^2.0.0` ([#9392](https://github.com/MetaMask/core/pull/9392))
 
 ## [24.2.4]
 


### PR DESCRIPTION
## Explanation

Follow-up to #9400 (already merged). That PR changed the `smart-transactions-controller` messenger requirement from `TransactionController:updateTransaction` to `TransactionController:failTransaction`. Adding/removing a required allowed action is a **breaking change** for consumers — they must delegate the new action to the controller messenger on the client side (extension/mobile) or they get a type error.

The changelog entry was filed under `### Fixed`, which would have the package cut as a patch release and silently break consumers on upgrade. This recategorizes it under `### Changed` with a `**BREAKING:**` marker so the next release is correctly a **major** version bump (`24.2.4` → `25.0.0`), consistent with how allowed-action changes are documented elsewhere in the monorepo (e.g. `AssetsControllerMessenger now requires ...` in assets-controller, `NftController allowed actions` in assets-controllers).

No code changes — changelog only.

## References

- Follow-up to #9400
- Raised in review by @cryptodev-2s

## Changelog

### `@metamask/smart-transactions-controller`

- Recategorized the #9400 entry from `Fixed` to `Changed` and marked it `BREAKING`; no functional change.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate (N/A — changelog only)
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate (changelog)
- [x] I've highlighted breaking changes using the 'BREAKING' category above as appropriate

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog edit with no code, tests, or runtime behavior changes.
> 
> **Overview**
> Updates `@metamask/smart-transactions-controller` **Unreleased** changelog only: the #9400 note about using `TransactionController:failTransaction` instead of `TransactionController:updateTransaction` when a smart transaction is cancelled moves from `### Fixed` to `### Changed` and is labeled **`BREAKING:`**, with explicit guidance that consumers must delegate the new allowed action.
> 
> The separate `### Fixed` section is removed and the `@metamask/messenger` bump stays under `### Changed`. **No runtime or API code changes** in this PR—only semver/documentation so the next release is treated as major for the messenger requirement change from #9400.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bdac953b6982dc60de511537f5157a292590045. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->