### PR TITLE
refactor(assets-controller): memoize balance call encodings in Multic…

### DIFF
--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `MulticallClient` memoizes `balanceOf` and `getEthBalance` call encodings per account address when building multicall batches, reducing redundant ABI encoding for wallets with many tokens ([#9423](https://github.com/MetaMask/core/pull/9423))
 - Bump `@metamask/transaction-controller` from `^68.2.2` to `^68.3.0` ([#9421](https://github.com/MetaMask/core/pull/9421))
 
 ## [10.1.0]

--- a/packages/assets-controller/src/data-sources/evm-rpc-services/clients/MulticallClient.test.ts
+++ b/packages/assets-controller/src/data-sources/evm-rpc-services/clients/MulticallClient.test.ts
@@ -1,4 +1,5 @@
 import { defaultAbiCoder, Interface } from '@ethersproject/abi';
+import * as controllerUtils from '@metamask/controller-utils';
 import type { Hex } from '@metamask/utils';
 
 import type { Address, BalanceOfRequest, ChainId, Provider } from '../types';
@@ -210,6 +211,42 @@ describe('MulticallClient', () => {
         expect(result).toHaveLength(2);
         expect(result[0].balance).toBe('1000000000');
         expect(result[1].balance).toBe('2000000000');
+      });
+
+      it('encodes balance call data once per account address in a batch', async () => {
+        const encodeSpy = jest.spyOn(controllerUtils, 'encodeFunctionData');
+        const otherAccount: Address =
+          '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd' as Address;
+
+        const requests: BalanceOfRequest[] = [
+          { tokenAddress: TEST_TOKEN_1, accountAddress: TEST_ACCOUNT },
+          { tokenAddress: TEST_TOKEN_2, accountAddress: TEST_ACCOUNT },
+          { tokenAddress: TEST_TOKEN_1, accountAddress: otherAccount },
+          { tokenAddress: ZERO_ADDRESS, accountAddress: TEST_ACCOUNT },
+        ];
+
+        const mockResponse = buildMockAggregate3Response([
+          { success: true, balance: '1000000000' },
+          { success: true, balance: '2000000000' },
+          { success: true, balance: '3000000000' },
+          { success: true, balance: '1000000000000000000' },
+        ]);
+
+        mockProvider.call.mockResolvedValue(mockResponse);
+
+        await client.batchBalanceOf(MAINNET_CHAIN_ID, requests);
+
+        const balanceOfEncodings = encodeSpy.mock.calls.filter(
+          ([, method]) => method === 'balanceOf',
+        );
+        const getEthBalanceEncodings = encodeSpy.mock.calls.filter(
+          ([, method]) => method === 'getEthBalance',
+        );
+
+        expect(balanceOfEncodings).toHaveLength(2);
+        expect(getEthBalanceEncodings).toHaveLength(1);
+
+        encodeSpy.mockRestore();
       });
 
       it('should fetch native token balance using getEthBalance', async () => {

--- a/packages/assets-controller/src/data-sources/evm-rpc-services/clients/MulticallClient.ts
+++ b/packages/assets-controller/src/data-sources/evm-rpc-services/clients/MulticallClient.ts
@@ -402,6 +402,72 @@ function encodeGetEthBalance(accountAddress: Address): Hex {
   ]);
 }
 
+type BalanceCallDataCache = {
+  getErc20BalanceCallData: (accountAddress: Address) => Hex;
+  getNativeBalanceCallData: (accountAddress: Address) => Hex;
+};
+
+/**
+ * Cache balance call encodings per account address for a single batch request.
+ * ERC-20 `balanceOf` and native `getEthBalance` call data depend only on the
+ * account being queried, not the token contract (which is the multicall target).
+ *
+ * @returns A cache scoped to one `batchBalanceOf` invocation.
+ */
+function createBalanceCallDataCache(): BalanceCallDataCache {
+  const erc20ByAccount = new Map<string, Hex>();
+  const nativeByAccount = new Map<string, Hex>();
+
+  return {
+    getErc20BalanceCallData(accountAddress: Address): Hex {
+      const key = accountAddress.toLowerCase();
+      const existing = erc20ByAccount.get(key);
+      if (existing !== undefined) {
+        return existing;
+      }
+      const callData = encodeBalanceOf(accountAddress);
+      erc20ByAccount.set(key, callData);
+      return callData;
+    },
+    getNativeBalanceCallData(accountAddress: Address): Hex {
+      const key = accountAddress.toLowerCase();
+      const existing = nativeByAccount.get(key);
+      if (existing !== undefined) {
+        return existing;
+      }
+      const callData = encodeGetEthBalance(accountAddress);
+      nativeByAccount.set(key, callData);
+      return callData;
+    },
+  };
+}
+
+/**
+ * Build Multicall3 aggregate3 calls for a batch of balance requests.
+ *
+ * @param batch - Balance requests in the current batch.
+ * @param multicallAddress - Multicall3 contract address for native balance calls.
+ * @param callDataCache - Per-request cache for encoded balance call data.
+ * @returns Aggregate3 call descriptors.
+ */
+function buildAggregate3BalanceCalls(
+  batch: BalanceOfRequest[],
+  multicallAddress: Hex,
+  callDataCache: BalanceCallDataCache,
+): { target: Address; allowFailure: boolean; callData: Hex }[] {
+  return batch.map((req) => {
+    const isNative = req.tokenAddress === ZERO_ADDRESS;
+    const target = isNative ? multicallAddress : req.tokenAddress;
+    return {
+      target,
+      allowFailure: true,
+      callData: isNative
+        ? callDataCache.getNativeBalanceCallData(req.accountAddress)
+        : callDataCache.getErc20BalanceCallData(req.accountAddress),
+    };
+  });
+}
+
 /**
  * Encode a Multicall3 aggregate3 call.
  *
@@ -527,10 +593,11 @@ export class MulticallClient {
 
     const multicallAddress = MULTICALL3_ADDRESS_BY_CHAIN[chainId];
     const provider = this.#getProvider(chainId);
+    const callDataCache = createBalanceCallDataCache();
 
     if (!multicallAddress) {
       return options.fallbackToSingleCalls
-        ? this.#fallbackBatchBalanceOf(provider, requests)
+        ? this.#fallbackBatchBalanceOf(provider, requests, callDataCache)
         : this.#createFailedResponses(requests);
     }
 
@@ -540,6 +607,7 @@ export class MulticallClient {
       multicallAddress,
       requests,
       options.fallbackToSingleCalls,
+      callDataCache,
     );
   }
 
@@ -550,6 +618,7 @@ export class MulticallClient {
    * @param multicallAddress - The Multicall3 contract address.
    * @param requests - Array of balance requests.
    * @param fallbackToSingleCalls - Whether to fall back to individual RPC calls on batch failure.
+   * @param callDataCache - The cache for encoded balance call data.
    * @returns Array of balance responses.
    */
   async #multicallBatchBalanceOf(
@@ -557,6 +626,7 @@ export class MulticallClient {
     multicallAddress: Hex,
     requests: BalanceOfRequest[],
     fallbackToSingleCalls: boolean,
+    callDataCache: BalanceCallDataCache,
   ): Promise<BalanceOfResponse[]> {
     const batchSize = this.#config.maxCallsPerBatch;
 
@@ -568,23 +638,16 @@ export class MulticallClient {
       batchSize,
       initialResult: [],
       eachBatch: async (workingResult, batch) => {
+        const calls = buildAggregate3BalanceCalls(
+          batch,
+          multicallAddress,
+          callDataCache,
+        );
+
         try {
           await createServicePolicy({
             maxRetries: MULTICALL_MAX_RETRIES,
           }).execute(async () => {
-            // Build aggregate3 calls
-            const calls = batch.map((req) => {
-              const isNative = req.tokenAddress === ZERO_ADDRESS;
-              const target = isNative ? multicallAddress : req.tokenAddress;
-              return {
-                target,
-                allowFailure: true,
-                callData: isNative
-                  ? encodeGetEthBalance(req.accountAddress)
-                  : encodeBalanceOf(req.accountAddress),
-              };
-            });
-
             // Encode and send aggregate3 call
             const callData = encodeAggregate3(calls);
             const result = await provider.call({
@@ -625,7 +688,9 @@ export class MulticallClient {
             // #fetchSingleBalance never rejects - it catches all errors internally
             // and returns a failed response, so we use Promise.all here.
             const fallbackResults = await Promise.all(
-              batch.map((req) => this.#fetchSingleBalance(provider, req)),
+              batch.map((req) =>
+                this.#fetchSingleBalance(provider, req, callDataCache),
+              ),
             );
 
             for (const result of fallbackResults) {
@@ -649,10 +714,12 @@ export class MulticallClient {
    * @param provider - The RPC provider.
    * @param requests - Array of balance requests.
    * @returns Array of balance responses.
+   * @param callDataCache - The cache for encoded balance call data.
    */
   async #fallbackBatchBalanceOf(
     provider: Provider,
     requests: BalanceOfRequest[],
+    callDataCache: BalanceCallDataCache,
   ): Promise<BalanceOfResponse[]> {
     // Use smaller batch size for parallel individual calls to avoid overwhelming RPC
     const batchSize = Math.min(this.#config.maxCallsPerBatch, 50);
@@ -668,7 +735,9 @@ export class MulticallClient {
         // #fetchSingleBalance never rejects - it catches all errors internally
         // and returns a failed response, so we use Promise.all here.
         const batchResults = await Promise.all(
-          batch.map((req) => this.#fetchSingleBalance(provider, req)),
+          batch.map((req) =>
+            this.#fetchSingleBalance(provider, req, callDataCache),
+          ),
         );
 
         for (const result of batchResults) {
@@ -688,10 +757,12 @@ export class MulticallClient {
    * @param provider - The RPC provider.
    * @param request - The balance request.
    * @returns The balance response.
+   * @param callDataCache - The cache for encoded balance call data.
    */
   async #fetchSingleBalance(
     provider: Provider,
     request: BalanceOfRequest,
+    callDataCache: BalanceCallDataCache,
   ): Promise<BalanceOfResponse> {
     // Destructure inside try block to ensure any errors are caught
     // and don't cause promise rejections that bypass error handling
@@ -710,7 +781,7 @@ export class MulticallClient {
       }
 
       // ERC-20 token
-      const callData = encodeBalanceOf(accountAddress);
+      const callData = callDataCache.getErc20BalanceCallData(accountAddress);
       const result = await provider.call({
         to: tokenAddress,
         data: callData,


### PR DESCRIPTION
…allClient

Cache encodeBalanceOf and encodeGetEthBalance per account address to avoid redundant ABI encoding when batching many tokens for the same wallet.

## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal performance refactor with no API or balance semantics change; risk is limited to ensuring cached calldata stays identical to prior per-request encoding.
> 
> **Overview**
> **`MulticallClient.batchBalanceOf`** now builds ERC-20 `balanceOf` and native `getEthBalance` calldata once per account (case-insensitive) per invocation, instead of re-encoding for every token row in a batch.
> 
> A per-request **`createBalanceCallDataCache`** backs multicall **`aggregate3`** assembly via **`buildAggregate3BalanceCalls`**, and the same cache is passed through multicall fallback and unsupported-chain single-call paths so ERC-20 fallback reuses encoded calldata. Native balances on those fallback paths still use **`provider.getBalance`** (unchanged).
> 
> A unit test asserts encoding deduplication (e.g. two `balanceOf` and one `getEthBalance` encode for four mixed requests). Changelog updated under **Unreleased**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 655f6ec739933067a41007e0c7ee5483898fc158. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->