### PR TITLE
fix: swap tx fails when smart account upgrade is required

### DIFF
--- a/packages/bridge-status-controller/CHANGELOG.md
+++ b/packages/bridge-status-controller/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/transaction-controller` from `^68.2.2` to `^68.3.0` ([#9421](https://github.com/MetaMask/core/pull/9421))
 
+### Fixed
+
+- Remove `gasFeeToken`, `skipInitialGasEstimate`, and `excludeNativeTokenForFee` from batch-strategy `addTransactionBatch` params
+
 ## [74.1.0]
 
 ### Added

--- a/packages/bridge-status-controller/CHANGELOG.md
+++ b/packages/bridge-status-controller/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Remove `gasFeeToken`, `skipInitialGasEstimate`, and `excludeNativeTokenForFee` from batch-strategy `addTransactionBatch` params
+- Remove `gasFeeToken`, `skipInitialGasEstimate`, and `excludeNativeTokenForFee` from batch-strategy `addTransactionBatch` params ([#9431](https://github.com/MetaMask/core/pull/9431))
 
 ## [74.1.0]
 

--- a/packages/bridge-status-controller/src/__snapshots__/bridge-status-controller.test.ts.snap
+++ b/packages/bridge-status-controller/src/__snapshots__/bridge-status-controller.test.ts.snap
@@ -1240,16 +1240,13 @@ exports[`BridgeStatusController submitTx: EVM bridge should handle smart transac
     {
       "atomic": true,
       "disable7702": true,
-      "excludeNativeTokenForFee": true,
       "from": "0xaccount1",
-      "gasFeeToken": undefined,
       "isGasFeeIncluded": false,
       "isGasFeeSponsored": false,
       "isInternal": true,
       "networkClientId": "arbitrum",
       "origin": "metamask",
       "requireApproval": false,
-      "skipInitialGasEstimate": false,
       "transactions": [
         {
           "assetsFiatValues": {
@@ -3953,16 +3950,13 @@ exports[`BridgeStatusController submitTx: EVM swap should handle smart transacti
     {
       "atomic": true,
       "disable7702": true,
-      "excludeNativeTokenForFee": true,
       "from": "0xaccount1",
-      "gasFeeToken": undefined,
       "isGasFeeIncluded": false,
       "isGasFeeSponsored": false,
       "isInternal": true,
       "networkClientId": "arbitrum",
       "origin": "metamask",
       "requireApproval": false,
-      "skipInitialGasEstimate": false,
       "transactions": [
         {
           "assetsFiatValues": undefined,

--- a/packages/bridge-status-controller/src/bridge-status-controller.test.ts
+++ b/packages/bridge-status-controller/src/bridge-status-controller.test.ts
@@ -4168,13 +4168,10 @@ describe('BridgeStatusController', () => {
         {
           "atomic": true,
           "disable7702": true,
-          "excludeNativeTokenForFee": true,
-          "gasFeeToken": undefined,
           "isDelegatedAccount": false,
           "isGasFeeIncluded": false,
           "isGasFeeSponsored": false,
           "requireApproval": false,
-          "skipInitialGasEstimate": false,
         }
       `);
     });
@@ -4251,13 +4248,10 @@ describe('BridgeStatusController', () => {
         {
           "atomic": true,
           "disable7702": true,
-          "excludeNativeTokenForFee": false,
-          "gasFeeToken": "0x0000000000000000000000000000000000000032",
           "isDelegatedAccount": false,
           "isGasFeeIncluded": false,
           "isGasFeeSponsored": false,
           "requireApproval": false,
-          "skipInitialGasEstimate": true,
         }
       `);
     });
@@ -4584,13 +4578,10 @@ describe('BridgeStatusController', () => {
         {
           "atomic": true,
           "disable7702": false,
-          "excludeNativeTokenForFee": true,
-          "gasFeeToken": undefined,
           "isDelegatedAccount": true,
           "isGasFeeIncluded": false,
           "isGasFeeSponsored": false,
           "requireApproval": false,
-          "skipInitialGasEstimate": false,
         }
       `);
     });
@@ -4710,13 +4701,10 @@ describe('BridgeStatusController', () => {
         {
           "atomic": true,
           "disable7702": false,
-          "excludeNativeTokenForFee": true,
-          "gasFeeToken": undefined,
           "isDelegatedAccount": false,
           "isGasFeeIncluded": true,
           "isGasFeeSponsored": false,
           "requireApproval": false,
-          "skipInitialGasEstimate": false,
         }
       `);
     });
@@ -4768,13 +4756,10 @@ describe('BridgeStatusController', () => {
         {
           "atomic": true,
           "disable7702": true,
-          "excludeNativeTokenForFee": true,
-          "gasFeeToken": undefined,
           "isDelegatedAccount": false,
           "isGasFeeIncluded": false,
           "isGasFeeSponsored": false,
           "requireApproval": false,
-          "skipInitialGasEstimate": false,
         }
       `);
     });

--- a/packages/bridge-status-controller/src/strategy/batch-strategy.ts
+++ b/packages/bridge-status-controller/src/strategy/batch-strategy.ts
@@ -1,6 +1,4 @@
-import { FeeType, isNativeAddress } from '@metamask/bridge-controller';
 import type { TxData } from '@metamask/bridge-controller';
-import type { Hex } from '@metamask/utils';
 
 import {
   findAllTransactionsInBatch,
@@ -36,12 +34,6 @@ export async function* submitBatchHandler(
     isBridgeTx,
   });
 
-  const gasFeeToken =
-    quoteResponse.quote.feeData[FeeType.TX_FEE]?.asset?.address &&
-    isNativeAddress(quoteResponse.quote.feeData[FeeType.TX_FEE].asset.address)
-      ? undefined
-      : (quoteResponse.quote.feeData[FeeType.TX_FEE]?.asset?.address as Hex);
-
   const transactionParams = await getAddTransactionBatchParams({
     tradeData,
     requireApproval,
@@ -55,11 +47,6 @@ export async function* submitBatchHandler(
     ),
     isGasFeeSponsored: Boolean(quoteResponse.quote.gasSponsored),
     isGasFeeIncluded: Boolean(quoteResponse.quote.gasIncluded7702),
-    gasFeeToken,
-    skipInitialGasEstimate: quoteResponse.quote.gasIncluded7702
-      ? isDelegatedAccount
-      : Boolean(gasFeeToken),
-    excludeNativeTokenForFee: !gasFeeToken,
   });
 
   const { batchId } = await addTransactionBatchFn(transactionParams);


### PR DESCRIPTION
## Explanation

#### Problem
There has been a spike in swap tx failures with this error: `Gas fee token not found and insufficient native balance`

#### Cause

The error happens when STX is enabled, account has not been upgraded, and the user receives a `gasIncluded=7702` quote. During the submission flow, passing `gasFeeToken`, `skipInitialGasEstimate`, and `excludeNativeTokenForFee` as addTransactionBatch params causes `checkGasFeeTokenBeforePublish` to throw the error. 

#### Solution

Remove the parameters from the batch-strategy so `checkGasFeeTokenBeforePublish` returns early

#### Repro steps (extension, Base network)
1. if running extension locally, set the BRIDGE_API_BASE_URL to the prod bridge-api
2. enable smart transactions
3. disable smart account for Base
4. not sure if this matters but I have < $.02 of ETH in the account
5. try to get a swap gasIncluded7702 quote for which the txFee is an ERC20 token (i.e, base:USDC to base:USDT)
6. submit the trade and the error appears in the console
7. no transactions are published on-chain, account does not get upgraded

#### Expected behavior
The TransactionController should upgrade the account to a smart account and submit the swap transactions in a single contract interaction

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References
N/A
<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:


* Fixes #12345
* Related to #67890
-->

Related to
- https://github.com/MetaMask/metamask-mobile/issues/32980
- https://github.com/MetaMask/metamask-extension/issues/44274

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live swap/bridge batch submission and reverses gas-fee batch options added in 72.0.1 for this path only; batch-sell behavior is unchanged but ERC20-fee batch swaps may behave differently.
> 
> **Overview**
> Fixes swap submission failures (`Gas fee token not found and insufficient native balance`) when **smart transactions** are on, the account is **not yet upgraded**, and the quote is **`gasIncluded7702`**.
> 
> The **batch strategy** (`batch-strategy.ts`) no longer derives or forwards `gasFeeToken`, `skipInitialGasEstimate`, or `excludeNativeTokenForFee` into `getAddTransactionBatchParams` / `addTransactionBatch`, so TransactionController’s `checkGasFeeTokenBeforePublish` can bail out instead of rejecting the batch. Related **FeeType** / **isNativeAddress** logic is removed from that path. Tests and snapshots are updated to match the slimmer batch params; **batch-sell** still sets those options separately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e407fb9b539118ebe4ece73073c041850969e772. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->