### PR TITLE
feat: added tracing for money-account-balance-service network requests

### DIFF
--- a/packages/money-account-balance-service/CHANGELOG.md
+++ b/packages/money-account-balance-service/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add optional `trace` constructor option to `MoneyAccountBalanceService` for tracing network requests (RPC calls and the Veda APY API fetch). Tracing is best-effort and does not affect query results if it fails. ([#9434](https://github.com/MetaMask/core/pull/9434))
+
 ### Changed
 
 - Bump `@metamask/messenger` from `^1.2.0` to `^2.0.0` ([#9392](https://github.com/MetaMask/core/pull/9392))

--- a/packages/money-account-balance-service/src/index.ts
+++ b/packages/money-account-balance-service/src/index.ts
@@ -3,6 +3,9 @@ export type {
   MoneyAccountBalanceServiceActions,
   MoneyAccountBalanceServiceEvents,
   MoneyAccountBalanceServiceMessenger,
+  MoneyAccountBalanceServiceOptions,
+  MoneyAccountBalanceServiceTraceCallback,
+  MoneyAccountBalanceServiceTraceRequest,
 } from './money-account-balance-service';
 export type {
   MoneyAccountBalanceServiceGetMoneyAccountBalanceAction,

--- a/packages/money-account-balance-service/src/money-account-balance-service.test.ts
+++ b/packages/money-account-balance-service/src/money-account-balance-service.test.ts
@@ -422,11 +422,13 @@ function expectTraceRequest(
     name,
     operation,
     success = true,
+    tokenAddress,
   }: {
     errorName?: string;
     name: string;
     operation: string;
     success?: boolean;
+    tokenAddress?: string;
   },
 ): void {
   const traceRequest = traceCallback.mock.calls.find(
@@ -441,6 +443,7 @@ function expectTraceRequest(
       ...(errorName ? { errorName } : {}),
       operation,
       success,
+      ...(tokenAddress ? { tokenAddress } : {}),
     },
   });
 }
@@ -775,6 +778,7 @@ describe('MoneyAccountBalanceService', () => {
       expectTraceRequest(trace, {
         name: 'Get Money Account ERC20 Balance RPC',
         operation: 'balanceOf',
+        tokenAddress: MOCK_UNDERLYING_TOKEN_ADDRESS,
       });
     });
 
@@ -812,6 +816,7 @@ describe('MoneyAccountBalanceService', () => {
       expectTraceRequest(trace, {
         name: 'Get Money Account ERC20 Balance RPC',
         operation: 'balanceOf',
+        tokenAddress: MOCK_VAULT_ADDRESS,
       });
     });
 
@@ -875,6 +880,7 @@ describe('MoneyAccountBalanceService', () => {
       expectTraceRequest(trace, {
         name: 'Get Money Account ERC20 Balance RPC',
         operation: 'balanceOf',
+        tokenAddress: MOCK_UNDERLYING_TOKEN_ADDRESS,
       });
     });
 

--- a/packages/money-account-balance-service/src/money-account-balance-service.test.ts
+++ b/packages/money-account-balance-service/src/money-account-balance-service.test.ts
@@ -1,6 +1,11 @@
 import { Contract } from '@ethersproject/contracts';
 import { Web3Provider } from '@ethersproject/providers';
 import { DEFAULT_MAX_RETRIES, HttpError } from '@metamask/controller-utils';
+import type {
+  TraceCallback,
+  TraceContext,
+  TraceRequest,
+} from '@metamask/controller-utils';
 import { Messenger, MOCK_ANY_NAMESPACE } from '@metamask/messenger';
 import type {
   MockAnyNamespace,
@@ -57,6 +62,11 @@ const MOCK_VAULT_CONFIG = {
   tellerAddress: MOCK_TELLER_ADDRESS,
   lensAddress: MOCK_LENS_ADDRESS,
   chainId: '0xa4b1' as const,
+};
+
+const MOCK_VAULT_CONFIG_WITH_UNDERLYING_TOKEN = {
+  ...MOCK_VAULT_CONFIG,
+  underlyingToken: MOCK_UNDERLYING_TOKEN_ADDRESS,
 };
 
 const MOCK_NETWORK_CONFIG = {
@@ -389,6 +399,52 @@ function mockMoneyAccountBalanceMulticall({
   return aggregate3Mock;
 }
 
+function createTraceCallback(): jest.MockedFunction<TraceCallback> {
+  return jest
+    .fn()
+    .mockImplementation(
+      async <ReturnType>(
+        _request: TraceRequest,
+        fn?: (context?: TraceContext) => ReturnType,
+      ): Promise<ReturnType> => {
+        if (!fn) {
+          return undefined as ReturnType;
+        }
+        return await Promise.resolve(fn());
+      },
+    ) as jest.MockedFunction<TraceCallback>;
+}
+
+function expectTraceRequest(
+  traceCallback: jest.MockedFunction<TraceCallback>,
+  {
+    errorName,
+    name,
+    operation,
+    success = true,
+  }: {
+    errorName?: string;
+    name: string;
+    operation: string;
+    success?: boolean;
+  },
+): void {
+  const traceRequest = traceCallback.mock.calls.find(
+    ([request]) => request.name === name,
+  )?.[0];
+
+  expect(traceRequest).toStrictEqual({
+    name,
+    startTime: expect.any(Number),
+    data: {
+      chainId: MOCK_VAULT_CONFIG.chainId,
+      ...(errorName ? { errorName } : {}),
+      operation,
+      success,
+    },
+  });
+}
+
 // ============================================================
 // Tests
 // ============================================================
@@ -694,6 +750,280 @@ describe('MoneyAccountBalanceService', () => {
       await expect(service.getVaultApy()).rejects.toThrow(
         VaultConfigNotAvailableError,
       );
+    });
+  });
+
+  // ----------------------------------------------------------
+  // tracing
+  // ----------------------------------------------------------
+
+  describe('tracing', () => {
+    it('traces getMusdBalance ERC-20 balance RPC on cache miss', async () => {
+      mockErc20BalanceOf('5000000');
+      const trace = createTraceCallback();
+      const { service } = createService({
+        rffcFlags: {
+          [VAULT_CONFIG_FEATURE_FLAG_KEY]:
+            MOCK_VAULT_CONFIG_WITH_UNDERLYING_TOKEN,
+        },
+        options: { trace },
+      });
+
+      await service.getMusdBalance(MOCK_ACCOUNT_ADDRESS);
+
+      expect(trace).toHaveBeenCalledTimes(1);
+      expectTraceRequest(trace, {
+        name: 'Get Money Account ERC20 Balance RPC',
+        operation: 'balanceOf',
+      });
+    });
+
+    it('traces getMoneyAccountBalance Multicall3 RPC on cache miss', async () => {
+      mockMoneyAccountBalanceMulticall({
+        musdBalance: '5000000',
+        vmusdValueInMusd: '2200000',
+      });
+      const trace = createTraceCallback();
+      const { service } = createService({
+        rffcFlags: {
+          [VAULT_CONFIG_FEATURE_FLAG_KEY]:
+            MOCK_VAULT_CONFIG_WITH_UNDERLYING_TOKEN,
+        },
+        options: { trace },
+      });
+
+      await service.getMoneyAccountBalance(MOCK_ACCOUNT_ADDRESS);
+
+      expect(trace).toHaveBeenCalledTimes(1);
+      expectTraceRequest(trace, {
+        name: 'Get Money Account Balance RPC',
+        operation: 'aggregate3',
+      });
+    });
+
+    it('traces getVmusdBalance ERC-20 balance RPC on cache miss', async () => {
+      mockErc20BalanceOf('3000000');
+      const trace = createTraceCallback();
+      const { service } = createService({ options: { trace } });
+
+      await service.getVmusdBalance(MOCK_ACCOUNT_ADDRESS);
+
+      expect(trace).toHaveBeenCalledTimes(1);
+      expectTraceRequest(trace, {
+        name: 'Get Money Account ERC20 Balance RPC',
+        operation: 'balanceOf',
+      });
+    });
+
+    it('traces getExchangeRate Accountant RPC on cache miss', async () => {
+      mockAccountantGetRate('1050000');
+      const trace = createTraceCallback();
+      const { service } = createService({ options: { trace } });
+
+      await service.getExchangeRate();
+
+      expect(trace).toHaveBeenCalledTimes(1);
+      expectTraceRequest(trace, {
+        name: 'Get Money Account Exchange Rate RPC',
+        operation: 'getRate',
+      });
+    });
+
+    it('traces getMusdEquivalentValue Lens RPC on cache miss', async () => {
+      mockLensBalanceOfInAssets('1000000');
+      const trace = createTraceCallback();
+      const { service } = createService({ options: { trace } });
+
+      await service.getMusdEquivalentValue(MOCK_ACCOUNT_ADDRESS);
+
+      expect(trace).toHaveBeenCalledTimes(1);
+      expectTraceRequest(trace, {
+        name: 'Get Money Account mUSD Equivalent Value RPC',
+        operation: 'balanceOfInAssets',
+      });
+    });
+
+    it('traces getVaultApy Veda API fetch on cache miss', async () => {
+      nock('https://api.sevenseas.capital')
+        .get(`/performance/arbitrum/${MOCK_VAULT_ADDRESS}`)
+        .reply(200, MOCK_VAULT_APY_RAW_RESPONSE);
+      const trace = createTraceCallback();
+      const { service } = createService({ options: { trace } });
+
+      await service.getVaultApy();
+
+      expect(trace).toHaveBeenCalledTimes(1);
+      expectTraceRequest(trace, {
+        name: 'Get Money Account Vault APY API',
+        operation: 'fetchVaultApy',
+      });
+    });
+
+    it('traces fallback underlying token RPC when configured token is absent', async () => {
+      mockAccountantBase();
+      mockErc20BalanceOf('5000000');
+      const trace = createTraceCallback();
+      const { service } = createService({ options: { trace } });
+
+      await service.getMusdBalance(MOCK_ACCOUNT_ADDRESS);
+
+      expect(trace).toHaveBeenCalledTimes(2);
+      expectTraceRequest(trace, {
+        name: 'Get Money Account Underlying Token RPC',
+        operation: 'base',
+      });
+      expectTraceRequest(trace, {
+        name: 'Get Money Account ERC20 Balance RPC',
+        operation: 'balanceOf',
+      });
+    });
+
+    it('does not trace a cached query result', async () => {
+      mockAccountantGetRate('1050000');
+      const trace = createTraceCallback();
+      const { service } = createService({ options: { trace } });
+
+      await service.getExchangeRate();
+      await service.getExchangeRate();
+
+      expect(trace).toHaveBeenCalledTimes(1);
+      expectTraceRequest(trace, {
+        name: 'Get Money Account Exchange Rate RPC',
+        operation: 'getRate',
+      });
+    });
+
+    it('does not fail or refetch when the trace callback rejects', async () => {
+      const mockGetRate = jest
+        .fn()
+        .mockResolvedValue({ toString: () => '1050000' });
+      MockContract.mockImplementation(
+        () => ({ getRate: mockGetRate }) as unknown as Contract,
+      );
+      const trace = jest
+        .fn()
+        .mockRejectedValue(new Error('trace boom')) as jest.MockedFunction<
+        TraceCallback
+      >;
+      const { service } = createService({ options: { trace } });
+
+      expect(await service.getExchangeRate()).toStrictEqual({
+        rate: '1050000',
+      });
+      expect(await service.getExchangeRate()).toStrictEqual({
+        rate: '1050000',
+      });
+
+      expect(mockGetRate).toHaveBeenCalledTimes(1);
+      expect(trace).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not fail when the trace callback returns undefined', async () => {
+      mockAccountantGetRate('1050000');
+      const trace = jest.fn().mockReturnValue(undefined) as jest.MockedFunction<
+        TraceCallback
+      >;
+      const { service } = createService({ options: { trace } });
+
+      expect(await service.getExchangeRate()).toStrictEqual({
+        rate: '1050000',
+      });
+
+      expect(trace).toHaveBeenCalledTimes(1);
+      expectTraceRequest(trace, {
+        name: 'Get Money Account Exchange Rate RPC',
+        operation: 'getRate',
+      });
+    });
+
+    it('does not fail when the trace callback throws synchronously', async () => {
+      const mockGetRate = jest
+        .fn()
+        .mockResolvedValue({ toString: () => '1050000' });
+      MockContract.mockImplementation(
+        () => ({ getRate: mockGetRate }) as unknown as Contract,
+      );
+      const trace = jest.fn().mockImplementation(() => {
+        throw new Error('trace boom');
+      }) as jest.MockedFunction<TraceCallback>;
+      const { service } = createService({ options: { trace } });
+
+      expect(await service.getExchangeRate()).toStrictEqual({
+        rate: '1050000',
+      });
+      expect(await service.getExchangeRate()).toStrictEqual({
+        rate: '1050000',
+      });
+
+      expect(mockGetRate).toHaveBeenCalledTimes(1);
+      expect(trace).toHaveBeenCalledTimes(1);
+    });
+
+    it('propagates aggregate3 rejections after emitting a failed trace', async () => {
+      const aggregate3 = jest
+        .fn()
+        .mockRejectedValue(new Error('execution reverted'));
+      mockMoneyAccountBalanceMulticall({ aggregate3 });
+      const trace = createTraceCallback();
+      const { service } = createService({
+        rffcFlags: {
+          [VAULT_CONFIG_FEATURE_FLAG_KEY]:
+            MOCK_VAULT_CONFIG_WITH_UNDERLYING_TOKEN,
+        },
+        options: { trace },
+      });
+
+      await expect(
+        service.getMoneyAccountBalance(MOCK_ACCOUNT_ADDRESS),
+      ).rejects.toThrow('execution reverted');
+      expectTraceRequest(trace, {
+        errorName: 'Error',
+        name: 'Get Money Account Balance RPC',
+        operation: 'aggregate3',
+        success: false,
+      });
+    });
+
+    it('traces non-Error aggregate3 rejections with the thrown value type', async () => {
+      const aggregate3 = jest.fn().mockRejectedValue('execution reverted');
+      mockMoneyAccountBalanceMulticall({ aggregate3 });
+      const trace = createTraceCallback();
+      const { service } = createService({
+        rffcFlags: {
+          [VAULT_CONFIG_FEATURE_FLAG_KEY]:
+            MOCK_VAULT_CONFIG_WITH_UNDERLYING_TOKEN,
+        },
+        options: { trace },
+      });
+
+      await expect(
+        service.getMoneyAccountBalance(MOCK_ACCOUNT_ADDRESS),
+      ).rejects.toBe('execution reverted');
+      expectTraceRequest(trace, {
+        errorName: 'string',
+        name: 'Get Money Account Balance RPC',
+        operation: 'aggregate3',
+        success: false,
+      });
+    });
+
+    it('propagates Veda API errors after emitting a failed trace', async () => {
+      nock('https://api.sevenseas.capital')
+        .get(`/performance/arbitrum/${MOCK_VAULT_ADDRESS}`)
+        .times(DEFAULT_MAX_RETRIES + 1)
+        .reply(500);
+      const trace = createTraceCallback();
+      const { service } = createService({ options: { trace } });
+
+      await expect(service.getVaultApy()).rejects.toThrow(
+        new HttpError(500, "Veda performance API failed with status '500'"),
+      );
+      expectTraceRequest(trace, {
+        errorName: 'Error',
+        name: 'Get Money Account Vault APY API',
+        operation: 'fetchVaultApy',
+        success: false,
+      });
     });
   });
 
@@ -1062,15 +1392,6 @@ describe('MoneyAccountBalanceService', () => {
   // ----------------------------------------------------------
 
   describe('getMoneyAccountBalance', () => {
-    /**
-     * Vault config including `underlyingToken`, so balance resolution skips the
-     * on-chain `base()` read.
-     */
-    const VAULT_CONFIG_WITH_UNDERLYING_TOKEN = {
-      ...MOCK_VAULT_CONFIG,
-      underlyingToken: MOCK_UNDERLYING_TOKEN_ADDRESS,
-    };
-
     it('returns musdBalance, vmusdValueInMusd, and totalBalance from a single aggregate3 call', async () => {
       const aggregate3 = mockMoneyAccountBalanceMulticall({
         musdBalance: '5000000',
@@ -1078,7 +1399,8 @@ describe('MoneyAccountBalanceService', () => {
       });
       const { service } = createService({
         rffcFlags: {
-          [VAULT_CONFIG_FEATURE_FLAG_KEY]: VAULT_CONFIG_WITH_UNDERLYING_TOKEN,
+          [VAULT_CONFIG_FEATURE_FLAG_KEY]:
+            MOCK_VAULT_CONFIG_WITH_UNDERLYING_TOKEN,
         },
       });
 
@@ -1127,7 +1449,8 @@ describe('MoneyAccountBalanceService', () => {
 
       const { service } = createService({
         rffcFlags: {
-          [VAULT_CONFIG_FEATURE_FLAG_KEY]: VAULT_CONFIG_WITH_UNDERLYING_TOKEN,
+          [VAULT_CONFIG_FEATURE_FLAG_KEY]:
+            MOCK_VAULT_CONFIG_WITH_UNDERLYING_TOKEN,
         },
       });
 
@@ -1157,7 +1480,8 @@ describe('MoneyAccountBalanceService', () => {
       const aggregate3 = mockMoneyAccountBalanceMulticall();
       const { service } = createService({
         rffcFlags: {
-          [VAULT_CONFIG_FEATURE_FLAG_KEY]: VAULT_CONFIG_WITH_UNDERLYING_TOKEN,
+          [VAULT_CONFIG_FEATURE_FLAG_KEY]:
+            MOCK_VAULT_CONFIG_WITH_UNDERLYING_TOKEN,
         },
       });
 
@@ -1224,7 +1548,8 @@ describe('MoneyAccountBalanceService', () => {
       });
       const { rootMessenger } = createService({
         rffcFlags: {
-          [VAULT_CONFIG_FEATURE_FLAG_KEY]: VAULT_CONFIG_WITH_UNDERLYING_TOKEN,
+          [VAULT_CONFIG_FEATURE_FLAG_KEY]:
+            MOCK_VAULT_CONFIG_WITH_UNDERLYING_TOKEN,
         },
       });
 
@@ -1247,7 +1572,8 @@ describe('MoneyAccountBalanceService', () => {
       mockMoneyAccountBalanceMulticall({ aggregate3 });
       const { service } = createService({
         rffcFlags: {
-          [VAULT_CONFIG_FEATURE_FLAG_KEY]: VAULT_CONFIG_WITH_UNDERLYING_TOKEN,
+          [VAULT_CONFIG_FEATURE_FLAG_KEY]:
+            MOCK_VAULT_CONFIG_WITH_UNDERLYING_TOKEN,
         },
       });
 
@@ -1261,7 +1587,7 @@ describe('MoneyAccountBalanceService', () => {
       const { service } = createService({
         rffcFlags: {
           [VAULT_CONFIG_FEATURE_FLAG_KEY]: {
-            ...VAULT_CONFIG_WITH_UNDERLYING_TOKEN,
+            ...MOCK_VAULT_CONFIG_WITH_UNDERLYING_TOKEN,
             chainId: '0x1',
           },
         },

--- a/packages/money-account-balance-service/src/money-account-balance-service.test.ts
+++ b/packages/money-account-balance-service/src/money-account-balance-service.test.ts
@@ -902,9 +902,9 @@ describe('MoneyAccountBalanceService', () => {
       );
       const trace = jest
         .fn()
-        .mockRejectedValue(new Error('trace boom')) as jest.MockedFunction<
-        TraceCallback
-      >;
+        .mockRejectedValue(
+          new Error('trace boom'),
+        ) as jest.MockedFunction<TraceCallback>;
       const { service } = createService({ options: { trace } });
 
       expect(await service.getExchangeRate()).toStrictEqual({
@@ -920,9 +920,9 @@ describe('MoneyAccountBalanceService', () => {
 
     it('does not fail when the trace callback returns undefined', async () => {
       mockAccountantGetRate('1050000');
-      const trace = jest.fn().mockReturnValue(undefined) as jest.MockedFunction<
-        TraceCallback
-      >;
+      const trace = jest
+        .fn()
+        .mockReturnValue(undefined) as jest.MockedFunction<TraceCallback>;
       const { service } = createService({ options: { trace } });
 
       expect(await service.getExchangeRate()).toStrictEqual({

--- a/packages/money-account-balance-service/src/money-account-balance-service.ts
+++ b/packages/money-account-balance-service/src/money-account-balance-service.ts
@@ -6,7 +6,11 @@ import type {
   DataServiceInvalidateQueriesAction,
 } from '@metamask/base-data-service';
 import { BaseDataService } from '@metamask/base-data-service';
-import type { CreateServicePolicyOptions } from '@metamask/controller-utils';
+import type {
+  CreateServicePolicyOptions,
+  TraceContext,
+  TraceRequest,
+} from '@metamask/controller-utils';
 import { handleWhen, HttpError } from '@metamask/controller-utils';
 import type { Messenger } from '@metamask/messenger';
 import { abiERC20 } from '@metamask/metamask-eth-abis';
@@ -74,7 +78,33 @@ const PENDING_READ_OVERRIDES = { blockTag: 'pending' } as const;
  */
 export const serviceName = 'MoneyAccountBalanceService';
 
+export const TRACES = {
+  ERC20_BALANCE_RPC: 'Get Money Account ERC20 Balance RPC',
+  UNDERLYING_TOKEN_RPC: 'Get Money Account Underlying Token RPC',
+  MONEY_ACCOUNT_BALANCE_RPC: 'Get Money Account Balance RPC',
+  EXCHANGE_RATE_RPC: 'Get Money Account Exchange Rate RPC',
+  MUSD_EQUIVALENT_VALUE_RPC: 'Get Money Account mUSD Equivalent Value RPC',
+  VAULT_APY_API: 'Get Money Account Vault APY API',
+} as const;
+
+export type MoneyAccountBalanceServiceTraceName =
+  (typeof TRACES)[keyof typeof TRACES];
+
+export type MoneyAccountBalanceServiceTraceRequest = Omit<
+  TraceRequest,
+  'name'
+> & {
+  name: MoneyAccountBalanceServiceTraceName;
+  startTime?: number;
+};
+
+export type MoneyAccountBalanceServiceTraceCallback = <ReturnType>(
+  request: MoneyAccountBalanceServiceTraceRequest,
+  fn?: (context?: TraceContext) => ReturnType,
+) => Promise<ReturnType>;
+
 const configLogger = createModuleLogger(projectLogger, 'config');
+const traceLogger = createModuleLogger(projectLogger, 'trace');
 
 // === MESSENGER ===
 
@@ -171,9 +201,10 @@ export type MoneyAccountBalanceServiceMessenger = Messenger<
  * ```
  */
 
-type MoneyAccountBalanceServiceOptions = {
+export type MoneyAccountBalanceServiceOptions = {
   messenger: MoneyAccountBalanceServiceMessenger;
   policyOptions?: CreateServicePolicyOptions;
+  trace?: MoneyAccountBalanceServiceTraceCallback;
 };
 
 export class MoneyAccountBalanceService extends BaseDataService<
@@ -185,14 +216,18 @@ export class MoneyAccountBalanceService extends BaseDataService<
   /** Cache stale time (ms) for on-chain balance reads. Overridable via remote feature flag. */
   #balanceStaleTime: number = DEFAULT_BALANCE_STALE_TIME;
 
+  readonly #trace: MoneyAccountBalanceServiceTraceCallback;
+
   /**
    * @param options - Constructor options.
    * @param options.messenger - The messenger for this service.
    * @param options.policyOptions - Options passed to `createServicePolicy`.
+   * @param options.trace - Optional callback to trace network requests.
    */
   constructor({
     messenger,
     policyOptions = {},
+    trace,
   }: MoneyAccountBalanceServiceOptions) {
     super({
       name: serviceName,
@@ -207,6 +242,15 @@ export class MoneyAccountBalanceService extends BaseDataService<
       },
     });
 
+    this.#trace =
+      trace ??
+      (async <ReturnType>(
+        _request: MoneyAccountBalanceServiceTraceRequest,
+        fn?: (context?: TraceContext) => ReturnType,
+      ): Promise<ReturnType> => {
+        return await Promise.resolve(fn?.() as ReturnType);
+      });
+
     this.messenger.subscribe(
       // eslint-disable-next-line no-restricted-syntax
       'RemoteFeatureFlagController:stateChange',
@@ -217,6 +261,55 @@ export class MoneyAccountBalanceService extends BaseDataService<
       this,
       MESSENGER_EXPOSED_METHODS,
     );
+  }
+
+  /**
+   * Runs a network request and emits a best-effort backdated trace.
+   *
+   * @param request - Trace metadata for the network request.
+   * @param fn - Network request to execute.
+   * @returns The network request result.
+   */
+  async #traceNetworkRequest<ReturnType>(
+    request: MoneyAccountBalanceServiceTraceRequest,
+    fn: () => Promise<ReturnType>,
+  ): Promise<ReturnType> {
+    const startTime = Date.now();
+    let success = false;
+    let errorName: string | undefined;
+
+    try {
+      const result = await fn();
+      success = true;
+      return result;
+    } catch (error) {
+      errorName = error instanceof Error ? error.name : typeof error;
+      throw error;
+    } finally {
+      const traceRequest = {
+        ...request,
+        startTime,
+        data: {
+          ...request.data,
+          success,
+          ...(errorName ? { errorName } : {}),
+        },
+      };
+      const onTraceError = (traceError: unknown): void => {
+        traceLogger('Failed to emit trace', {
+          traceName: request.name,
+          traceError,
+        });
+      };
+
+      try {
+        Promise.resolve(this.#trace(traceRequest, () => undefined)).catch(
+          onTraceError,
+        );
+      } catch (traceError) {
+        onTraceError(traceError);
+      }
+    }
   }
 
   /**
@@ -445,9 +538,17 @@ export class MoneyAccountBalanceService extends BaseDataService<
   ): Promise<string> {
     const provider = this.#getProvider(chainId);
     const contract = new Contract(contractAddress, abiERC20, provider);
-    const balance = await contract.balanceOf(
-      accountAddress,
-      PENDING_READ_OVERRIDES,
+    const balance = await this.#traceNetworkRequest(
+      {
+        name: TRACES.ERC20_BALANCE_RPC,
+        data: {
+          chainId,
+          tokenAddress: contractAddress,
+          operation: 'balanceOf',
+        },
+      },
+      async () =>
+        await contract.balanceOf(accountAddress, PENDING_READ_OVERRIDES),
     );
     return balance.toString();
   }
@@ -462,7 +563,13 @@ export class MoneyAccountBalanceService extends BaseDataService<
     const { accountantAddress } = this.#requireConfig();
     const provider = this.#getProvider(chainId);
     const contract = new Contract(accountantAddress, ACCOUNTANT_ABI, provider);
-    const underlyingTokenAddress = await contract.base();
+    const underlyingTokenAddress = await this.#traceNetworkRequest(
+      {
+        name: TRACES.UNDERLYING_TOKEN_RPC,
+        data: { chainId, operation: 'base' },
+      },
+      async () => await contract.base(),
+    );
     return underlyingTokenAddress;
   }
 
@@ -578,11 +685,17 @@ export class MoneyAccountBalanceService extends BaseDataService<
           MULTICALL3_ABI,
           provider,
         );
-        const [musdResult, vmusdResult] =
-          (await multicall3.callStatic.aggregate3(
-            calls,
-            PENDING_READ_OVERRIDES,
-          )) as [Multicall3Result, Multicall3Result];
+        const [musdResult, vmusdResult] = (await this.#traceNetworkRequest(
+          {
+            name: TRACES.MONEY_ACCOUNT_BALANCE_RPC,
+            data: { chainId, operation: 'aggregate3' },
+          },
+          async () =>
+            await multicall3.callStatic.aggregate3(
+              calls,
+              PENDING_READ_OVERRIDES,
+            ),
+        )) as [Multicall3Result, Multicall3Result];
 
         const musdBalanceBN = erc20.interface.decodeFunctionResult(
           'balanceOf',
@@ -650,7 +763,13 @@ export class MoneyAccountBalanceService extends BaseDataService<
           ACCOUNTANT_ABI,
           provider,
         );
-        const rate = await contract.getRate();
+        const rate = await this.#traceNetworkRequest(
+          {
+            name: TRACES.EXCHANGE_RATE_RPC,
+            data: { chainId, operation: 'getRate' },
+          },
+          async () => await contract.getRate(),
+        );
         return { rate: rate.toString() };
       },
       staleTime: staleTime ?? this.#balanceStaleTime,
@@ -675,11 +794,18 @@ export class MoneyAccountBalanceService extends BaseDataService<
           this.#requireConfig();
         const provider = this.#getProvider(chainId);
         const contract = new Contract(lensAddress, LENS_ABI, provider);
-        const balanceOfInAssets = await contract.balanceOfInAssets(
-          accountAddress,
-          boringVault,
-          accountantAddress,
-          PENDING_READ_OVERRIDES,
+        const balanceOfInAssets = await this.#traceNetworkRequest(
+          {
+            name: TRACES.MUSD_EQUIVALENT_VALUE_RPC,
+            data: { chainId, operation: 'balanceOfInAssets' },
+          },
+          async () =>
+            await contract.balanceOfInAssets(
+              accountAddress,
+              boringVault,
+              accountantAddress,
+              PENDING_READ_OVERRIDES,
+            ),
         );
 
         return { balanceOfInAssets: balanceOfInAssets.toString() };
@@ -712,16 +838,24 @@ export class MoneyAccountBalanceService extends BaseDataService<
           VEDA_PERFORMANCE_API_BASE_URL,
         );
 
-        const response = await fetch(url);
+        const rawResponse = await this.#traceNetworkRequest(
+          {
+            name: TRACES.VAULT_APY_API,
+            data: { chainId, operation: 'fetchVaultApy' },
+          },
+          async () => {
+            const response = await fetch(url);
 
-        if (!response.ok) {
-          throw new HttpError(
-            response.status,
-            `Veda performance API failed with status '${response.status}'`,
-          );
-        }
+            if (!response.ok) {
+              throw new HttpError(
+                response.status,
+                `Veda performance API failed with status '${response.status}'`,
+              );
+            }
 
-        const rawResponse = await response.json();
+            return await response.json();
+          },
+        );
 
         // Validate raw response inside queryFn to avoid poisoned cache.
         if (!is(rawResponse, VaultApyRawResponseStruct)) {


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Added optional tracing for network requests in money-account-balance-service.

### Changes
- Added optional `trace` arg to money-account-balance-service constructor.
- Added `traceNetworkRequest` which runs a network request and emits a best-effort backdated trace. Tracing failure does not impact our queries.
- Wrapped all RPC and HTTP calls with `traceNetworkRequest`

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->
Fixes: [MUSD-1140: Add Sentry tracing for money-account-balance-service network requests](https://consensyssoftware.atlassian.net/browse/MUSD-1140)
## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional API with no-op default; tracing is isolated from fetch/retry logic and covered by tests, so balance and APY behavior should be unchanged when trace is not provided or fails.
> 
> **Overview**
> Adds **optional observability** for `MoneyAccountBalanceService` via a new constructor `trace` callback, aimed at wiring Sentry (or similar) without changing balance/APY behavior when tracing is omitted or fails.
> 
> A private `#traceNetworkRequest` helper runs each real network call, then emits a **backdated** trace with `startTime`, `chainId`, `operation`, `success`, and optional `errorName` / `tokenAddress`. Trace emission is **best-effort** (async, errors logged only); query failures still propagate, and **cached hits do not trace**.
> 
> **RPC and HTTP paths** are wrapped: ERC-20 `balanceOf`, Accountant `base` / `getRate`, Multicall3 `aggregate3`, Lens `balanceOfInAssets`, and the Veda vault APY `fetch`. Named trace constants (`TRACES`) and exported types (`MoneyAccountBalanceServiceOptions`, trace callback/request) support consumers. Changelog and a broad `tracing` test suite cover success, cache skip, trace callback failures, and failed requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 975339c60300236acd955a54f6e9a130c3ea4bb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->