### PR TITLE
fix: correct initial version of @metamask/network-connection-banner-controller

### DIFF
--- a/packages/network-connection-banner-controller/package.json
+++ b/packages/network-connection-banner-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/network-connection-banner-controller",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "description": "Decides when and how to surface the network connection banner based on RPC endpoint health",
   "keywords": [
     "Ethereum",


### PR DESCRIPTION
## Explanation

The package was merged in #9041 with an initial version of `0.1.0`. New packages should start at `0.0.0` (that's what the `create-package` template sets). This bumps it back down so the first release goes out correctly.

## References

Follow up to #9041

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for cross repository changes as appropriate

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only `package.json` version metadata changes; no runtime or API behavior is affected.
> 
> **Overview**
> Aligns `@metamask/network-connection-banner-controller` with the monorepo convention for new packages by changing **`version`** in `package.json` from **`0.1.0`** to **`0.0.0`**, matching the `create-package` template and other unreleased packages.
> 
> This is a metadata-only fix so the first automated release can version the package correctly after it was introduced with the wrong starting version in #9041.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08e6c203293679854a8712253ea6d88752e5fc71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->