### PR TITLE
Fix check-release to ignore reversions to 0.0.0

### DIFF
--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -55,7 +55,7 @@ runs:
           CURRENT_VERSION=$(echo "$PACKAGE_JSON_AT_BASE" | jq -r .version)
           NEW_VERSION=$(jq -r .version "$package")
 
-          if [ "$NEW_VERSION" != "0.0.0" && "$NEW_VERSION" != "$CURRENT_VERSION" ]; then
+          if [[ "$NEW_VERSION" != "0.0.0" && "$NEW_VERSION" != "$CURRENT_VERSION" ]]; then
             ANY_PACKAGE_BUMPED=true
             package_name=$(jq -r ".name" "$package")
             echo "📦 Package \`$package_name\` has a version bump (\`$CURRENT_VERSION\` -> \`$NEW_VERSION\`)"

--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -55,7 +55,7 @@ runs:
           CURRENT_VERSION=$(echo "$PACKAGE_JSON_AT_BASE" | jq -r .version)
           NEW_VERSION=$(jq -r .version "$package")
 
-          if [ "$NEW_VERSION" != "$CURRENT_VERSION" ]; then
+          if [ "$NEW_VERSION" != "0.0.0" && "$NEW_VERSION" != "$CURRENT_VERSION" ]; then
             ANY_PACKAGE_BUMPED=true
             package_name=$(jq -r ".name" "$package")
             echo "📦 Package \`$package_name\` has a version bump (\`$CURRENT_VERSION\` -> \`$NEW_VERSION\`)"


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Sometimes we set the version of a package prematurely and need to revert it to 0.0.0. Currently, the `check-release` action would flag this as a problem: it would think that the package was being staged for release and and would require the `package.json` to also be bumped. In reality, however, this step should not be necessary, as packages with a version of 0.0.0 will not be released anyway.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line CI guard change with no runtime impact; only nuance is mixed PRs with real bumps still require root bump as before.
> 
> **Overview**
> Updates the **check-release** composite action so reverting a workspace package to **`0.0.0`** no longer counts as a version bump for the root `package.json` gate.
> 
> The workspace scan now treats a change as a bump only when the new version differs from the merge-base version **and** the new version is not **`0.0.0`**, so PRs that undo a premature version without shipping a release are not forced to bump the root `package.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ff9b0f72753552f1837e9e5b422122685756f52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->