### PR TITLE
fix: don't treat a 0.0.0 target version as a release in check-release

### DIFF
--- a/.github/actions/check-release/action.yml
+++ b/.github/actions/check-release/action.yml
@@ -55,6 +55,13 @@ runs:
           CURRENT_VERSION=$(echo "$PACKAGE_JSON_AT_BASE" | jq -r .version)
           NEW_VERSION=$(jq -r .version "$package")
 
+          if [ "$NEW_VERSION" = "0.0.0" ]; then
+            # A target version of 0.0.0 is the unreleased initial state, not a
+            # release. Skip it so correcting a version back to 0.0.0 doesn't
+            # require a root package.json bump.
+            continue
+          fi
+
           if [ "$NEW_VERSION" != "$CURRENT_VERSION" ]; then
             ANY_PACKAGE_BUMPED=true
             package_name=$(jq -r ".name" "$package")
@@ -151,6 +158,12 @@ runs:
         for package in "${PACKAGES[@]}"; do
           MAIN_VERSION=$(git show "$MERGE_BASE:$package" | jq -r .version)
           HEAD_VERSION=$(jq -r .version "$package")
+
+          if [ "$HEAD_VERSION" = "0.0.0" ]; then
+            # A target version of 0.0.0 is the unreleased initial state, not a
+            # release.
+            continue
+          fi
 
           if [ "$HEAD_VERSION" != "$MAIN_VERSION" ]; then
             package_name=$(jq -r ".name" "$package")


### PR DESCRIPTION
## Explanation

The `check-release` action flags any package whose version changed as a release, and then requires the root `package.json` to be bumped too. That breaks when you correct a package's version back down to `0.0.0`, which is the unreleased initial state, not a real release.

This makes both loops in the action skip a package when its target version is `0.0.0`, so resetting a version to `0.0.0` no longer trips the release check.

This should merge first, then #9436 (which resets `@metamask/network-connection-banner-controller` from `0.1.0` back to `0.0.0`) will pass CI.

## References

Unblocks #9436, follow up to #9041

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for cross repository changes as appropriate

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to release validation logic; no runtime application or security paths affected.
> 
> **Overview**
> The **`check-release`** composite action no longer treats a workspace package whose **target version is `0.0.0`** as a version bump or a release.
> 
> Both package-scan loops now **`continue`** when the head/new version is **`0.0.0`**, so resetting a package from a published version back to the unreleased placeholder does not force a root **`package.json`** bump or include that package in release-conflict detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b2482458bc66ad8cf24fef102817660a016ba99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->