### PR TITLE
feat(client-utils): map Stellar trustline keyring transactions

### DIFF
--- a/packages/client-utils/CHANGELOG.md
+++ b/packages/client-utils/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `mapKeyringTransaction` for mapping keyring transactions to activity items
   - `mapLocalTransaction` for mapping local transaction groups to activity items
   - Shared activity types (`ActivityItem`, `ActivityKind`, `Status`, etc.)
+- Add `assetActivation`/`assetDeactivation` activity kinds and map Stellar trustline `TokenApprove`/`TokenDisapprove` keyring transactions to them in `mapKeyringTransaction`
 
 ### Changed
 

--- a/packages/client-utils/CHANGELOG.md
+++ b/packages/client-utils/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Map `assetActivation` and `assetDeactivation` activity types in transaction activity mappers ([#9440](https://github.com/MetaMask/core/pull/9440))
+
 ## [1.0.0]
 
 ### Added
@@ -17,7 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `mapKeyringTransaction` for mapping keyring transactions to activity items
   - `mapLocalTransaction` for mapping local transaction groups to activity items
   - Shared activity types (`ActivityItem`, `ActivityKind`, `Status`, etc.)
-- Add `assetActivation`/`assetDeactivation` activity kinds and map Stellar trustline `TokenApprove`/`TokenDisapprove` keyring transactions to them in `mapKeyringTransaction` ([#9440](https://github.com/MetaMask/core/pull/9440))
 
 ### Changed
 

--- a/packages/client-utils/CHANGELOG.md
+++ b/packages/client-utils/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `mapKeyringTransaction` for mapping keyring transactions to activity items
   - `mapLocalTransaction` for mapping local transaction groups to activity items
   - Shared activity types (`ActivityItem`, `ActivityKind`, `Status`, etc.)
-- Add `assetActivation`/`assetDeactivation` activity kinds and map Stellar trustline `TokenApprove`/`TokenDisapprove` keyring transactions to them in `mapKeyringTransaction`
+- Add `assetActivation`/`assetDeactivation` activity kinds and map Stellar trustline `TokenApprove`/`TokenDisapprove` keyring transactions to them in `mapKeyringTransaction` ([#9440](https://github.com/MetaMask/core/pull/9440))
 
 ### Changed
 

--- a/packages/client-utils/src/mappers/keyring-transaction-mapper.test.ts
+++ b/packages/client-utils/src/mappers/keyring-transaction-mapper.test.ts
@@ -214,4 +214,85 @@ describe('mapKeyringTransaction', () => {
       },
     });
   });
+
+  it('maps trustline approve TokenApprove to assetActivation', () => {
+    const item = mapKeyringTransaction(
+      keyringTransactionFixtures.mapArgs.trustlineApprove,
+    );
+
+    expect(item).toMatchObject({
+      type: 'assetActivation',
+      chainId: 'stellar:pubnet',
+      status: 'success',
+      timestamp: 1716367781000,
+      hash: 'trustline-approve-id',
+      data: {
+        from: 'owner-address',
+        token: {
+          amount: undefined,
+          symbol: 'USDC',
+          direction: 'out',
+        },
+      },
+    });
+  });
+
+  it('returns the trustline activation token unchanged when no amount is present', () => {
+    const item = mapKeyringTransaction(
+      keyringTransactionFixtures.mapArgs.trustlineApproveNoAmount,
+    );
+
+    expect(item).toMatchObject({
+      type: 'assetActivation',
+      data: { from: 'owner-address', token: undefined },
+    });
+  });
+
+  it('maps trustline disapprove TokenDisapprove to assetDeactivation', () => {
+    const item = mapKeyringTransaction(
+      keyringTransactionFixtures.mapArgs.trustlineDisapprove,
+    );
+
+    expect(item).toMatchObject({
+      type: 'assetDeactivation',
+      chainId: 'stellar:pubnet',
+      status: 'success',
+      timestamp: 1716367781000,
+      hash: 'trustline-disapprove-id',
+      data: {
+        from: 'owner-address',
+        token: {
+          amount: undefined,
+          symbol: 'USDC',
+          direction: 'out',
+        },
+      },
+    });
+  });
+
+  it('returns the trustline deactivation token unchanged when no amount is present', () => {
+    const item = mapKeyringTransaction(
+      keyringTransactionFixtures.mapArgs.trustlineDisapproveNoAmount,
+    );
+
+    expect(item).toMatchObject({
+      type: 'assetDeactivation',
+      data: { from: 'owner-address', token: undefined },
+    });
+  });
+
+  it('maps a non-trustline TokenDisapprove to a contract interaction', () => {
+    const item = mapKeyringTransaction(
+      keyringTransactionFixtures.mapArgs.disapproveNonTrustline,
+    );
+
+    expect(item).toMatchObject({
+      type: 'contractInteraction',
+      chainId: SolScope.Mainnet,
+      data: {
+        from: 'owner-address',
+        to: 'spender-address',
+      },
+    });
+  });
 });

--- a/packages/client-utils/src/mappers/keyring-transaction-mapper.ts
+++ b/packages/client-utils/src/mappers/keyring-transaction-mapper.ts
@@ -13,6 +13,30 @@ type FungibleAsset = Extract<
   { fungible: true }
 >;
 
+/**
+ * Custom labels for non-EVM transactions.
+ *
+ * The labels are used to map the transaction type to the title in the activity list and dialog.
+ * The labels are defined in the `transaction.details.typeLabel` property.
+ * For details: {@link https://github.com/MetaMask/metamask-extension/pull/38040}
+ */
+export enum CustomTransactionTypeLabel {
+  // Token requires one off approve to receive
+  TrustlineApprove = 'trustline-approve',
+  // Token requires revoke the approve to stop receiving
+  TrustlineDisapprove = 'trustline-disapprove',
+}
+
+function hasTrustlineTypeLabel(
+  details: KeyringTransaction['details'],
+): boolean {
+  // A flag to indicate if the transaction is a trustline type.
+  return [
+    String(CustomTransactionTypeLabel.TrustlineApprove),
+    String(CustomTransactionTypeLabel.TrustlineDisapprove),
+  ].includes(details?.typeLabel ?? '');
+}
+
 function mapStatus(status: KeyringTransaction['status']): Status {
   switch (status) {
     case TransactionStatus.Confirmed:
@@ -158,6 +182,19 @@ export function mapKeyringTransaction({
 
     case KeyringTransactionType.TokenApprove: {
       const rawToken = getToken(transaction.from, 'out');
+
+      if (hasTrustlineTypeLabel(transaction.details)) {
+        return {
+          type: 'assetActivation',
+          ...common,
+          data: {
+            from,
+            token: rawToken ? { ...rawToken, amount: undefined } : rawToken,
+            fees,
+          },
+        };
+      }
+
       const isUnlimited =
         rawToken?.amount !== undefined &&
         rawToken.amount.split('.')[0].length > approveAmountMaxIntegerDigits;
@@ -170,6 +207,32 @@ export function mapKeyringTransaction({
           token: rawToken
             ? { ...rawToken, amount: isUnlimited ? undefined : rawToken.amount }
             : rawToken,
+          fees,
+        },
+      };
+    }
+
+    case KeyringTransactionType.TokenDisapprove: {
+      if (!hasTrustlineTypeLabel(transaction.details)) {
+        return {
+          type: 'contractInteraction',
+          ...common,
+          data: {
+            from,
+            to,
+            fees,
+          },
+        };
+      }
+
+      const rawToken = getToken(transaction.from, 'out');
+
+      return {
+        type: 'assetDeactivation',
+        ...common,
+        data: {
+          from,
+          token: rawToken ? { ...rawToken, amount: undefined } : rawToken,
           fees,
         },
       };

--- a/packages/client-utils/src/types.ts
+++ b/packages/client-utils/src/types.ts
@@ -46,7 +46,9 @@ export type ActivityKind =
   | 'perpsCloseLongTakeProfit'
   | 'marketShort'
   | 'stopMarketCloseShort'
-  | 'marketCloseShort';
+  | 'marketCloseShort'
+  | 'assetActivation'
+  | 'assetDeactivation';
 
 export type Status = 'pending' | 'success' | 'failed' | 'cancelled';
 
@@ -83,6 +85,14 @@ type ActivityData<Type extends ActivityKind, Data> = {
 export type ActivityItem =
   | ActivityData<
       'approveSpendingCap' | 'revokeSpendingCap' | 'increaseSpendingCap',
+      {
+        from?: string;
+        token?: TokenAmount;
+        fees?: Fee[];
+      }
+    >
+  | ActivityData<
+      'assetActivation' | 'assetDeactivation',
       {
         from?: string;
         token?: TokenAmount;

--- a/packages/client-utils/test/fixtures/keyring-transactions.ts
+++ b/packages/client-utils/test/fixtures/keyring-transactions.ts
@@ -5,7 +5,10 @@ import {
   TransactionType,
 } from '@metamask/keyring-api';
 
+import { CustomTransactionTypeLabel } from '../../src/mappers/keyring-transaction-mapper';
+
 const accountId = '00000000-0000-4000-8000-000000000000';
+const stellarUsdcAsset = `stellar:pubnet/asset:USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN`;
 
 export const keyringTransactionFixtures = {
   addresses: {
@@ -285,6 +288,108 @@ export const keyringTransactionFixtures = {
             },
           },
         ],
+        fees: [],
+        events: [],
+      } as never,
+    },
+    trustlineApprove: {
+      transaction: {
+        id: 'trustline-approve-id',
+        chain: 'stellar:pubnet',
+        account: accountId,
+        status: TransactionStatus.Confirmed,
+        timestamp: 1716367781,
+        type: TransactionType.TokenApprove,
+        details: {
+          typeLabel: CustomTransactionTypeLabel.TrustlineApprove,
+        },
+        from: [
+          {
+            address: 'owner-address',
+            asset: {
+              fungible: true,
+              type: stellarUsdcAsset,
+              unit: 'USDC',
+              amount: '0',
+            },
+          },
+        ],
+        to: [{ address: 'issuer-address', asset: null }],
+        fees: [],
+        events: [],
+      } as never,
+    },
+    trustlineApproveNoAmount: {
+      transaction: {
+        id: 'trustline-approve-no-amount-id',
+        chain: 'stellar:pubnet',
+        account: accountId,
+        status: TransactionStatus.Confirmed,
+        timestamp: 1716367781,
+        type: TransactionType.TokenApprove,
+        details: {
+          typeLabel: CustomTransactionTypeLabel.TrustlineApprove,
+        },
+        from: [{ address: 'owner-address', asset: null }],
+        to: [{ address: 'issuer-address', asset: null }],
+        fees: [],
+        events: [],
+      } as never,
+    },
+    trustlineDisapprove: {
+      transaction: {
+        id: 'trustline-disapprove-id',
+        chain: 'stellar:pubnet',
+        account: accountId,
+        status: TransactionStatus.Confirmed,
+        timestamp: 1716367781,
+        type: TransactionType.TokenDisapprove,
+        details: {
+          typeLabel: CustomTransactionTypeLabel.TrustlineDisapprove,
+        },
+        from: [
+          {
+            address: 'owner-address',
+            asset: {
+              fungible: true,
+              type: stellarUsdcAsset,
+              unit: 'USDC',
+              amount: '0',
+            },
+          },
+        ],
+        to: [{ address: 'issuer-address', asset: null }],
+        fees: [],
+        events: [],
+      } as never,
+    },
+    trustlineDisapproveNoAmount: {
+      transaction: {
+        id: 'trustline-disapprove-no-amount-id',
+        chain: 'stellar:pubnet',
+        account: accountId,
+        status: TransactionStatus.Confirmed,
+        timestamp: 1716367781,
+        type: TransactionType.TokenDisapprove,
+        details: {
+          typeLabel: CustomTransactionTypeLabel.TrustlineDisapprove,
+        },
+        from: [{ address: 'owner-address', asset: null }],
+        to: [{ address: 'issuer-address', asset: null }],
+        fees: [],
+        events: [],
+      } as never,
+    },
+    disapproveNonTrustline: {
+      transaction: {
+        id: 'plain-disapprove-id',
+        chain: SolScope.Mainnet,
+        account: accountId,
+        status: TransactionStatus.Confirmed,
+        timestamp: 1716367781,
+        type: TransactionType.TokenDisapprove,
+        from: [{ address: 'owner-address', asset: null }],
+        to: [{ address: 'spender-address', asset: null }],
         fees: [],
         events: [],
       } as never,


### PR DESCRIPTION
## Explanation

`@metamask/client-utils`'s `mapKeyringTransaction` (#9376) doesn't yet handle Stellar trustline `TokenApprove`/`TokenDisapprove` transactions — they fall through to `approveSpendingCap`/`contractInteraction` like any other token approval, which shows a spending-cap UI for what's actually a trustline activation/deactivation (not a token transfer).

metamask-extension#44200 added this mapping locally in its own adapter ahead of Core support, keyed off a `details.typeLabel` of `trustline-approve`/`trustline-disapprove`. This PR ports that mapping into the canonical `keyring-transaction-mapper` so Extension can switch over to it, per review discussion on that PR.

Changes:
   - Add `assetActivation`/`assetDeactivation` to `ActivityKind` and a matching
     `ActivityItem` data shape (`{ from?, token?, fees? }`).
   - Port `CustomTransactionTypeLabel` and `hasTrustlineTypeLabel` from the extension adapter.
   - `TokenApprove` now branches to `assetActivation` for trustline ops before falling into the existing `approveSpendingCap` logic.
   - Add a `TokenDisapprove` case (previously unhandled — fell through to `contractInteraction` via `default`): branches to `assetDeactivation` for trustline
     ops, otherwise keeps the existing `contractInteraction` fallback.
   - Trustline items clear the token `amount` (matching the spending-cap "unlimited" pattern) since a trustline change isn't a token transfer and shouldn't show a total.

   ## References

   - Follow-up to #9376, which added `mapKeyringTransaction`.
   - Ports the mapping from metamask-extension#44200.
   - Requested here: metamask-extension#44200 (review thread)

   ## Checklist

   - [x] I've updated the test suite for new or updated code as appropriate
   - [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
   - [x] I've communicated my changes to consumers by updating changelogs for packages I've changed
   - [ ] I've introduced breaking changes in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped mapper and type additions with tests; non-trustline approve/disapprove behavior is unchanged aside from an explicit `TokenDisapprove` path that still falls back to `contractInteraction`.
> 
> **Overview**
> **`mapKeyringTransaction`** now recognizes Stellar trustline operations via `details.typeLabel` (`trustline-approve` / `trustline-disapprove`) instead of treating them like generic token approvals.
> 
> **`TokenApprove`** with a trustline label maps to **`assetActivation`** (token amount cleared so the UI does not show a transfer total). **`TokenDisapprove`** gets an explicit branch: trustline → **`assetDeactivation`**, otherwise **`contractInteraction`** as before.
> 
> Shared types add **`assetActivation`** and **`assetDeactivation`** to `ActivityKind` and `ActivityItem`. **`CustomTransactionTypeLabel`** and **`hasTrustlineTypeLabel`** are exported from the keyring mapper (ported from extension). Tests and changelog updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc50e538e45ccd45d7c3402ac8e181f170cee52b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->