### PR TITLE
fix: fix assets watchlist url

### DIFF
--- a/packages/authenticated-user-storage/CHANGELOG.md
+++ b/packages/authenticated-user-storage/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `getAssetsWatchlist` and `setAssetsWatchlist` to use the correct API path `/preferences/assets-watchlist` instead of `/assets-watchlist` ([#9441](https://github.com/MetaMask/core/pull/9441))
+
 ### Changed
 
 - Bump `@metamask/messenger` from `^1.2.0` to `^2.0.0` ([#9392](https://github.com/MetaMask/core/pull/9392))

--- a/packages/authenticated-user-storage/CHANGELOG.md
+++ b/packages/authenticated-user-storage/CHANGELOG.md
@@ -7,13 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Fix `getAssetsWatchlist` and `setAssetsWatchlist` to use the correct API path `/preferences/assets-watchlist` instead of `/assets-watchlist` ([#9441](https://github.com/MetaMask/core/pull/9441))
-
 ### Changed
 
 - Bump `@metamask/messenger` from `^1.2.0` to `^2.0.0` ([#9392](https://github.com/MetaMask/core/pull/9392))
+
+### Fixed
+
+- Fix `getAssetsWatchlist` and `setAssetsWatchlist` to use the correct API path `/preferences/assets-watchlist` instead of `/assets-watchlist` ([#9441](https://github.com/MetaMask/core/pull/9441))
 
 ## [3.0.0]
 

--- a/packages/authenticated-user-storage/src/authenticated-user-storage.ts
+++ b/packages/authenticated-user-storage/src/authenticated-user-storage.ts
@@ -354,7 +354,7 @@ export class AuthenticatedUserStorageService extends BaseDataService<
    * @returns The assets-watchlist blob, or `null` if none has been set (404).
    */
   async getAssetsWatchlist(): Promise<AssetsWatchlistBlob | null> {
-    const url = `${getAuthenticatedStorageUrl(this.#environment)}/assets-watchlist`;
+    const url = `${getAuthenticatedStorageUrl(this.#environment)}/preferences/assets-watchlist`;
 
     const data = await this.fetchQuery({
       queryKey: [`${this.name}:getAssetsWatchlist`],
@@ -403,7 +403,7 @@ export class AuthenticatedUserStorageService extends BaseDataService<
   ): Promise<void> {
     assertAssetsWatchlistBlobForWrite(blob);
 
-    const url = `${getAuthenticatedStorageUrl(this.#environment)}/assets-watchlist`;
+    const url = `${getAuthenticatedStorageUrl(this.#environment)}/preferences/assets-watchlist`;
 
     await this.fetchQuery({
       queryKey: [`${this.name}:setAssetsWatchlist`, blob as unknown as Json],

--- a/packages/authenticated-user-storage/tests/mocks/authenticated-userstorage.ts
+++ b/packages/authenticated-user-storage/tests/mocks/authenticated-userstorage.ts
@@ -9,7 +9,7 @@ import { DEFAULT_PRICE_ALERT_PREFERENCES } from '../../src/validators';
 
 export const MOCK_DELEGATIONS_URL = `${getAuthenticatedStorageUrl('prod')}/delegations`;
 export const MOCK_NOTIFICATION_PREFERENCES_URL = `${getAuthenticatedStorageUrl('prod')}/preferences/notifications`;
-export const MOCK_ASSETS_WATCHLIST_URL = `${getAuthenticatedStorageUrl('prod')}/assets-watchlist`;
+export const MOCK_ASSETS_WATCHLIST_URL = `${getAuthenticatedStorageUrl('prod')}/preferences/assets-watchlist`;
 
 export const MOCK_DELEGATION_SUBMISSION: DelegationSubmission = {
   signedDelegation: {


### PR DESCRIPTION
## Explanation

The `AuthenticatedUserStorageService` was calling `/api/v1/assets-watchlist` for the `getAssetsWatchlist` and `setAssetsWatchlist` methods. The correct API path is `/api/v1/preferences/assets-watchlist`, consistent with other preference endpoints (e.g. `/preferences/notifications`).
This fix updates both the GET and PUT URLs to use the `/preferences/assets-watchlist` path, along with the corresponding test mock URL.

https://docs.cx.metamask.io/api/user-storage/#tag/Authenticated-User-Storage/operation/getAssetsWatchlist


## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wrong endpoints likely broke watchlist read/write in production; the fix is a path-only change with no request/validation logic altered.
> 
> **Overview**
> **Fixes assets watchlist HTTP calls** so `getAssetsWatchlist` and `setAssetsWatchlist` hit `/preferences/assets-watchlist` instead of `/assets-watchlist`, matching the authenticated user storage API and the same `/preferences/...` pattern as notification preferences.
> 
> The test mock `MOCK_ASSETS_WATCHLIST_URL` and the package changelog are updated to reflect the path correction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6686e7bf028c3fa95b2e93e81783f20095258aaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->