### PR TITLE
fix: gate Money Account payment override prepend to same-chain flows

### DIFF
--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix cross-chain Money Account deposits (e.g. Predict withdraw to a Money Account) reverting with `InvalidEOASignature()` (`0x3db6791c`) by only prepending the payment override onto the source Relay execute batch for same-chain flows ([#9439](https://github.com/MetaMask/core/pull/9439))
+
 ## [24.0.1]
 
 ### Changed

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/assets-controllers` from `^109.3.1` to `^109.4.0` ([#9450](https://github.com/MetaMask/core/pull/9450))
 - Bump `@metamask/transaction-controller` from `^68.3.0` to `^68.4.0` ([#9456](https://github.com/MetaMask/core/pull/9456))
 
+### Fixed
+
+- Fix cross-chain Money Account deposits (e.g. Predict withdraw to a Money Account) reverting with `InvalidEOASignature()` (`0x3db6791c`) by only prepending the payment override onto the source Relay execute batch for same-chain flows ([#9449](https://github.com/MetaMask/core/pull/9449))
+
 ## [24.0.0]
 
 ### Added

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-submit.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-submit.test.ts
@@ -966,6 +966,12 @@ describe('Relay Submit Utils', () => {
             [ORIGINAL_TRANSACTION_ID_MOCK]: TRANSACTION_DATA_MOCK,
           },
         });
+
+        // The payment override is only prepended onto the source execute batch
+        // for same-chain flows, so align the quote's source and destination
+        // chains for these override-prepend assertions.
+        request.quotes[0].original.details.currencyOut.currency.chainId =
+          request.quotes[0].original.details.currencyIn.currency.chainId;
       });
 
       it('prepends override tx params to submit batch', async () => {
@@ -994,6 +1000,20 @@ describe('Relay Submit Utils', () => {
       });
 
       it('does not call getPaymentOverrideData when paymentOverride is not defined', async () => {
+        await submitRelayQuotes(request);
+
+        expect(getPaymentOverrideDataMock).not.toHaveBeenCalled();
+      });
+
+      it('does not prepend override for cross-chain flows', async () => {
+        request.quotes[0].request.paymentOverride =
+          PaymentOverride.MoneyAccount;
+        request.quotes[0].original.details.currencyIn.currency.chainId = 137;
+        request.quotes[0].original.details.currencyOut.currency.chainId = 143;
+        getPaymentOverrideDataMock.mockResolvedValue({
+          calls: [PAYMENT_OVERRIDE_TX_MOCK],
+        });
+
         await submitRelayQuotes(request);
 
         expect(getPaymentOverrideDataMock).not.toHaveBeenCalled();

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-submit.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-submit.ts
@@ -430,9 +430,20 @@ async function submitTransactions(
     quote.request.from.toLowerCase() !==
     (transaction.txParams.from as Hex).toLowerCase();
 
+  // Only prepend the payment override onto the source execute batch for
+  // same-chain flows. For cross-chain flows (e.g. Predict withdraw on Polygon
+  // depositing to a Money Account on Monad) the deposit is carried in the relay
+  // quote's destination txs[] and runs on the destination chain; its delegation
+  // is signed for the destination chainId, so redeeming it inside the
+  // source-chain batch recovers a wrong signer and reverts. In that case we
+  // fall through and prepend the original (e.g. Predict withdraw) tx instead.
+  const isSameChainOverride =
+    quote.original.details.currencyIn.currency.chainId ===
+    quote.original.details.currencyOut.currency.chainId;
+
   let allParams = normalizedParams;
 
-  if (quote.request.paymentOverride) {
+  if (quote.request.paymentOverride && isSameChainOverride) {
     const { transactionData } = messenger.call(
       'TransactionPayController:getState',
     );


### PR DESCRIPTION
## Explanation

Cross-chain **Money Account deposits** — e.g. a Predict (Polymarket) withdrawal on Polygon that deposits into a Money Account on Monad — failed on the Relay `/execute` step with the custom error `InvalidEOASignature()` (selector `0x3db6791c`).

**Current state:** `submitTransactions` unconditionally prepends the Money Account payment override onto the **source-chain** execute batch whenever `quote.request.paymentOverride` is set. For a cross-chain deposit, the payment override is a Money Account deposit delegation that belongs on the **destination** chain — it is already carried in the Relay quote's destination `txs[]`, and its delegation is EIP-712 signed for the **destination** `chainId`. Prepending it onto the source-chain batch caused that destination-signed delegation to be redeemed on the source chain, so `redeemDelegations` → `executeFromExecutor` validated the signature with the source chain's domain, recovered a different signer, and the `EIP7702StatelessDeleGator` reverted with `InvalidEOASignature()`.

**Solution:** Only prepend the payment override onto the source execute batch for **same-chain** flows (`currencyIn.chainId === currencyOut.chainId`). For cross-chain flows we fall through to the existing post-quote path, which prepends the original transaction (e.g. the Predict withdrawal); the Money Account deposit continues to run on the destination side via the quote's `txs[]`.

The change is a one-line guard (`&& isSameChainOverride`) plus a comment explaining the invariant.

### Proof

Before the fix, the Relay `/execute` simulation returned (decoded revert trace):

```
Multicall3.aggregate3Value
└─ redeemDelegations                @ 0xdb9b1e94… (DelegationManager, source chain 137)
   └─ executeFromExecutor           @ 0x6d404afe… (7702 account)
      └─ redeemDelegations          @ 0xdb9b1e94…
         └─ revert 0x3db6791c = InvalidEOASignature()
```

The delegation being redeemed was signed for the **destination** chain (Monad, `chainId 143`) but executed on the **source** chain (Polygon, `chainId 137`) — confirmed via `signDelegation` logs showing `domain.chainId: 143` for the Money Account delegation while the execute body used `data.chainId: 137`.

After the fix, the cross-chain source batch no longer contains the destination-signed override, so the `InvalidEOASignature()` revert no longer occurs.

## References

- [CONF-1525](https://consensyssoftware.atlassian.net/browse/CONF-1525)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


[CONF-1525]: https://consensyssoftware.atlassian.net/browse/CONF-1525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Targets Relay submit batch assembly for payment overrides and cross-chain Money Account deposits; scope is narrow but touches delegation/signature-critical execute paths.
> 
> **Overview**
> Fixes cross-chain **Money Account deposits** (e.g. Predict withdraw on Polygon → Money Account on Monad) failing Relay `/execute` with **`InvalidEOASignature()`** (`0x3db6791c`).
> 
> **`submitTransactions`** in `relay-submit.ts` no longer always prepends the Money Account **payment override** on the source-chain batch when `paymentOverride` is set. It only does so when **`currencyIn.chainId === currencyOut.chainId`** (`isSameChainOverride`). On cross-chain quotes, the override delegation belongs on the **destination** (already in the quote’s destination `txs[]`) and is EIP-712 signed for the destination `chainId`; prepending it on the source batch caused wrong-domain signature recovery. Cross-chain flows **fall through** to the existing post-quote path (prepend the original tx, e.g. Predict withdraw).
> 
> Tests align quote chains for same-chain override cases and assert cross-chain flows **do not** call `getPaymentOverrideData`. Changelog updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb53dabb6523f8f08d5fd2f491371d4c47c0e3e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->