### PR TITLE
fix: merge account balances preserve fields

### DIFF
--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserve existing per-asset balance fields when applying merge-mode balance updates, so amount-only updates do not drop extra fields already present on the prior balance ([#9453](https://github.com/MetaMask/core/pull/9453))
+
 ## [10.2.0]
 
 ### Added

--- a/packages/assets-controller/src/AssetsController.test.ts
+++ b/packages/assets-controller/src/AssetsController.test.ts
@@ -1807,6 +1807,40 @@ describe('AssetsController', () => {
       });
     });
 
+    it('preserves extra balance fields when merge update changes amount', async () => {
+      const initialState: Partial<AssetsControllerState> = {
+        assetsBalance: {
+          [MOCK_ACCOUNT_ID]: {
+            [MOCK_ASSET_ID]: {
+              amount: '1',
+              metadata: { limit: '1000', authorized: true },
+            },
+          },
+        },
+      };
+
+      await withController({ state: initialState }, async ({ controller }) => {
+        await controller.handleAssetsUpdate(
+          {
+            updateMode: 'merge',
+            assetsBalance: {
+              [MOCK_ACCOUNT_ID]: {
+                [MOCK_ASSET_ID]: { amount: '2' },
+              },
+            },
+          },
+          'TestSource',
+        );
+
+        expect(
+          controller.state.assetsBalance[MOCK_ACCOUNT_ID]?.[MOCK_ASSET_ID],
+        ).toStrictEqual({
+          amount: '2',
+          metadata: { limit: '1000', authorized: true },
+        });
+      });
+    });
+
     it('preserves existing balances when merge update adds new chain data', async () => {
       const polygonNative = 'eip155:137/slip44:966' as Caip19AssetId;
       const initialState: Partial<AssetsControllerState> = {

--- a/packages/assets-controller/src/AssetsController.ts
+++ b/packages/assets-controller/src/AssetsController.ts
@@ -582,7 +582,16 @@ function mergeAccountBalances(
   replaceCoveredChains: boolean,
 ): Record<string, AssetBalance> {
   if (!replaceCoveredChains) {
-    return { ...previousBalances, ...accountBalances };
+    // Per-asset shallow merge so amount updates do not drop extra fields
+    // already on the prior balance (e.g. enrichment metadata).
+    const next: Record<string, AssetBalance> = { ...previousBalances };
+    for (const [assetId, balance] of Object.entries(accountBalances)) {
+      next[assetId] = {
+        ...(previousBalances[assetId] ?? { amount: '0' }),
+        ...balance,
+      };
+    }
+    return next;
   }
 
   const coveredChains = new Set(


### PR DESCRIPTION
## Explanation

Fix merge-mode balance updates to shallow-merge per asset instead of replacing the whole balance object.
Amount-only updates no longer drop existing fields (e.g. enrichment metadata).

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them
