### PR TITLE
refactor(multichain-account-service): remove v1 `createAccount` entirely

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1226,11 +1226,6 @@
       "count": 2
     }
   },
-  "packages/multichain-account-service/src/providers/BtcAccountProvider.test.ts": {
-    "no-negated-condition": {
-      "count": 1
-    }
-  },
   "packages/multichain-account-service/src/providers/BtcAccountProvider.ts": {
     "@typescript-eslint/naming-convention": {
       "count": 2

--- a/packages/multichain-account-service/CHANGELOG.md
+++ b/packages/multichain-account-service/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Removed use of v1 `createAccount` entirely ([#9460](https://github.com/MetaMask/core/pull/9460))
+  - All BIP-44 Snaps are already implementing `createAccounts`.
+  - The old v1 `createAccount` flow had some undesired side-effetcs sometimes (e.g auto-selecting a non-EVM account after being created, which is not compatible with our new group model).
+
 ## [12.0.0]
 
 ### Added

--- a/packages/multichain-account-service/src/analytics/traces.ts
+++ b/packages/multichain-account-service/src/analytics/traces.ts
@@ -75,8 +75,7 @@ export function toCreateAccountsV2DataTraces(
 export enum TraceName {
   SnapDiscoverAccounts = 'Snap Discover Accounts',
   EvmDiscoverAccounts = 'EVM Discover Accounts',
-  ProviderCreateAccountV1 = 'Provider Create Account (v1)',
-  ProviderCreateAccounts = 'Provider Create Accounts (v2 - batched)',
+  ProviderCreateAccounts = 'Provider Create Accounts',
   WalletAlignment = 'Wallet Alignment',
   WalletCreateMultichainAccountGroup = 'Wallet Create Multichain Account Group',
   WalletCreateMultichainAccountGroups = 'Wallet Create Multichain Account Groups',

--- a/packages/multichain-account-service/src/analytics/traces.ts
+++ b/packages/multichain-account-service/src/analytics/traces.ts
@@ -75,7 +75,7 @@ export function toCreateAccountsV2DataTraces(
 export enum TraceName {
   SnapDiscoverAccounts = 'Snap Discover Accounts',
   EvmDiscoverAccounts = 'EVM Discover Accounts',
-  ProviderCreateAccounts = 'Provider Create Accounts',
+  ProviderCreateAccounts = 'Provider Create Accounts (v2 - batched)',
   WalletAlignment = 'Wallet Alignment',
   WalletCreateMultichainAccountGroup = 'Wallet Create Multichain Account Group',
   WalletCreateMultichainAccountGroups = 'Wallet Create Multichain Account Groups',

--- a/packages/multichain-account-service/src/providers/BtcAccountProvider.test.ts
+++ b/packages/multichain-account-service/src/providers/BtcAccountProvider.test.ts
@@ -1,9 +1,5 @@
 import { isBip44Account } from '@metamask/account-api';
-import {
-  AccountCreationType,
-  BtcAccountType,
-  BtcScope,
-} from '@metamask/keyring-api';
+import { AccountCreationType, BtcScope } from '@metamask/keyring-api';
 import type { KeyringCapabilities } from '@metamask/keyring-api/v2';
 import type { KeyringMetadata } from '@metamask/keyring-controller';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
@@ -29,10 +25,7 @@ import {
   BTC_ACCOUNT_PROVIDER_NAME,
   BtcAccountProvider,
 } from './BtcAccountProvider';
-import type {
-  RestrictedSnapKeyring,
-  SnapAccountProviderConfig,
-} from './SnapAccountProvider';
+import type { SnapAccountProviderConfig } from './SnapAccountProvider';
 
 function asConfig(
   partial: DeepPartial<SnapAccountProviderConfig>,
@@ -70,63 +63,6 @@ class MockBtcKeyring {
     this.accounts = accounts;
   }
 
-  #getIndexFromDerivationPath(derivationPath: string): number {
-    // eslint-disable-next-line prefer-regex-literals
-    const derivationPathIndexRegex = new RegExp(
-      "^m/44'/0'/0'/(?<index>[0-9]+)'$",
-      'u',
-    );
-
-    const matched = derivationPath.match(derivationPathIndexRegex);
-    if (matched?.groups?.index === undefined) {
-      throw new Error('Unable to extract index');
-    }
-
-    const { index } = matched.groups;
-    return Number(index);
-  }
-
-  createAccount = jest
-    .fn()
-    .mockImplementation(({ derivationPath, index, ...options }) => {
-      // Determine the group index to use - either from derivationPath parsing, explicit index, or fallback
-      let groupIndex: number;
-
-      if (derivationPath !== undefined) {
-        groupIndex = this.#getIndexFromDerivationPath(derivationPath);
-      } else if (index !== undefined) {
-        groupIndex = index;
-      } else {
-        groupIndex = this.accounts.length;
-      }
-
-      // Check if an account already exists for this group index AND account type (idempotent behavior)
-      const found = this.accounts.find(
-        (account) =>
-          isBip44Account(account) &&
-          account.options.entropy.groupIndex === groupIndex &&
-          account.type === options.addressType,
-      );
-
-      if (found) {
-        return found; // Idempotent.
-      }
-
-      // Create new account with the correct group index
-      const baseAccount =
-        options.addressType === BtcAccountType.P2wpkh
-          ? MOCK_BTC_P2WPKH_ACCOUNT_1
-          : MOCK_BTC_P2TR_ACCOUNT_1;
-      const account = MockAccountBuilder.from(baseAccount)
-        .withUuid()
-        .withAddressSuffix(`${this.accounts.length}`)
-        .withGroupIndex(groupIndex)
-        .get();
-      this.accounts.push(account);
-
-      return account;
-    });
-
   createAccounts = jest.fn().mockImplementation((options) => {
     const groupIndices =
       options.type === 'bip44:derive-index'
@@ -155,10 +91,6 @@ class MockBtcKeyring {
   });
 
   deleteAccount = jest.fn().mockResolvedValue(undefined);
-
-  get v1(): Required<RestrictedSnapKeyring['v1']> {
-    return { createAccount: this.createAccount };
-  }
 }
 
 class MockBtcAccountProvider extends BtcAccountProvider {
@@ -194,7 +126,6 @@ function setup({
   mocks: {
     handleRequest: jest.Mock;
     keyring: {
-      createAccount: jest.Mock;
       createAccounts: jest.Mock;
     };
     trace: jest.Mock;
@@ -270,7 +201,6 @@ function setup({
     mocks: {
       handleRequest: mockHandleRequest,
       keyring: {
-        createAccount: keyring.createAccount,
         createAccounts: keyring.createAccounts,
       },
       trace: mockTrace,
@@ -330,181 +260,22 @@ describe('BtcAccountProvider', () => {
     expect(provider.isAccountCompatible(account)).toBe(false);
   });
 
-  describe('v1', () => {
-    it('uses v1 by default when no config is provided', async () => {
-      const accounts = [MOCK_BTC_P2WPKH_ACCOUNT_1];
-      const { provider, mocks } = setup({
-        accounts,
-        // No capabilities provided → defaults to an empty capability set, so
-        // the provider falls back to the v1 (non-batched) flow.
-      });
+  it('discover accounts at a new group index creates an account (v1 discovery flow)', async () => {
+    const { provider, mocks } = setup({ accounts: [] });
 
-      await provider.createAccounts({
-        type: AccountCreationType.Bip44DeriveIndex,
-        entropySource: MOCK_HD_KEYRING_1.metadata.id,
-        groupIndex: accounts.length,
-      });
+    // Simulate one discovered account at the requested index via v1 client.discoverAccounts.
+    mocks.handleRequest.mockReturnValue([MOCK_BTC_P2TR_DISCOVERED_ACCOUNT_1]);
 
-      expect(mocks.keyring.createAccount).toHaveBeenCalled();
-      expect(mocks.keyring.createAccounts).not.toHaveBeenCalled();
+    const discovered = await provider.discoverAccounts({
+      entropySource: MOCK_HD_KEYRING_1.metadata.id,
+      groupIndex: 0,
     });
 
-    it('creates accounts', async () => {
-      const accounts = [MOCK_BTC_P2WPKH_ACCOUNT_1];
-      const { provider, mocks } = setup({ accounts });
-
-      const newGroupIndex = accounts.length; // Group-index are 0-based.
-      const newAccounts = await provider.createAccounts({
-        type: AccountCreationType.Bip44DeriveIndex,
-        entropySource: MOCK_HD_KEYRING_1.metadata.id,
-        groupIndex: newGroupIndex,
-      });
-      expect(newAccounts).toHaveLength(1);
-      expect(mocks.keyring.createAccount).toHaveBeenCalled();
-      expect(mocks.keyring.createAccounts).not.toHaveBeenCalled();
-    });
-
-    it('does not re-create accounts (idempotent)', async () => {
-      const accounts = [MOCK_BTC_P2WPKH_ACCOUNT_1];
-      const { provider } = setup({ accounts });
-
-      const newAccounts = await provider.createAccounts({
-        type: AccountCreationType.Bip44DeriveIndex,
-        entropySource: MOCK_HD_KEYRING_1.metadata.id,
-        groupIndex: 0,
-      });
-      expect(newAccounts).toHaveLength(1);
-      expect(newAccounts[0]).toStrictEqual(MOCK_BTC_P2WPKH_ACCOUNT_1);
-    });
-
-    it('creates multiple accounts using Bip44DeriveIndexRange', async () => {
-      const accounts = [MOCK_BTC_P2WPKH_ACCOUNT_1];
-      const { provider, mocks } = setup({ accounts });
-
-      const from = 1;
-      const newAccounts = await provider.createAccounts({
-        type: AccountCreationType.Bip44DeriveIndexRange,
-        entropySource: MOCK_HD_KEYRING_1.metadata.id,
-        range: { from, to: 3 },
-      });
-
-      expect(newAccounts).toHaveLength(3);
-      expect(mocks.keyring.createAccount).toHaveBeenCalledTimes(3);
-      expect(mocks.keyring.createAccounts).not.toHaveBeenCalled();
-
-      // Verify each account has the correct group index.
-      for (const [index, account] of newAccounts.entries()) {
-        expect(isBip44Account(account)).toBe(true);
-        expect(account.options.entropy.groupIndex).toBe(from + index);
-      }
-    });
-
-    it('creates accounts with range starting from 0', async () => {
-      const { provider, mocks } = setup({ accounts: [] });
-
-      const newAccounts = await provider.createAccounts({
-        type: AccountCreationType.Bip44DeriveIndexRange,
-        entropySource: MOCK_HD_KEYRING_1.metadata.id,
-        range: { from: 0, to: 2 },
-      });
-
-      expect(newAccounts).toHaveLength(3);
-      expect(mocks.keyring.createAccount).toHaveBeenCalledTimes(3);
-      expect(mocks.keyring.createAccounts).not.toHaveBeenCalled();
-    });
-
-    it('creates a single account when range from equals to', async () => {
-      const { provider, mocks } = setup({ accounts: [] });
-
-      const newAccounts = await provider.createAccounts({
-        type: AccountCreationType.Bip44DeriveIndexRange,
-        entropySource: MOCK_HD_KEYRING_1.metadata.id,
-        range: { from: 5, to: 5 },
-      });
-
-      expect(newAccounts).toHaveLength(1);
-      expect(mocks.keyring.createAccount).toHaveBeenCalledTimes(1);
-      expect(mocks.keyring.createAccounts).not.toHaveBeenCalled();
-      expect(
-        isBip44Account(newAccounts[0]) &&
-          newAccounts[0].options.entropy.groupIndex,
-      ).toBe(5);
-    });
-
-    it('throws if the account creation process takes too long', async () => {
-      const { provider, mocks } = setup({ accounts: [] });
-
-      mocks.keyring.createAccount.mockImplementation(() => {
-        return new Promise((resolve) => {
-          setTimeout(() => {
-            resolve(MOCK_BTC_P2TR_ACCOUNT_1);
-          }, 4000);
-        });
-      });
-
-      await expect(
-        provider.createAccounts({
-          type: AccountCreationType.Bip44DeriveIndex,
-          entropySource: MOCK_HD_KEYRING_1.metadata.id,
-          groupIndex: 0,
-        }),
-      ).rejects.toThrow('Timed out');
-    });
-
-    // Skip this test for now, since we manually inject those options upon
-    // account creation, so it cannot fails (until the Bitcoin Snap starts
-    // using the new typed options).
-    // eslint-disable-next-line jest/no-disabled-tests
-    it.skip('throws if the created account is not BIP-44 compatible', async () => {
-      const accounts = [MOCK_BTC_P2TR_ACCOUNT_1];
-      const { provider, mocks } = setup({
-        accounts,
-      });
-
-      mocks.keyring.createAccount.mockResolvedValue({
-        ...MOCK_BTC_P2TR_ACCOUNT_1,
-        options: {}, // No options, so it cannot be BIP-44 compatible.
-      });
-
-      await expect(
-        provider.createAccounts({
-          type: AccountCreationType.Bip44DeriveIndex,
-          entropySource: MOCK_HD_KEYRING_1.metadata.id,
-          groupIndex: 0,
-        }),
-      ).rejects.toThrow('Created account is not BIP-44 compatible');
-    });
-
-    it('discover accounts at a new group index creates an account', async () => {
-      const { provider, mocks } = setup({ accounts: [] });
-
-      // Simulate one discovered account at the requested index.
-      mocks.handleRequest.mockReturnValue([MOCK_BTC_P2TR_DISCOVERED_ACCOUNT_1]);
-
-      const discovered = await provider.discoverAccounts({
-        entropySource: MOCK_HD_KEYRING_1.metadata.id,
-        groupIndex: 0,
-      });
-
-      expect(discovered).toHaveLength(1);
-      // Ensure we did go through creation path
-      expect(mocks.keyring.createAccount).toHaveBeenCalled();
-      // Provider should now expose one account (newly created)
-      expect(provider.getAccounts()).toHaveLength(1);
-    });
-
-    it('throws when the Snap is v2-only and does not support v1 account creation', async () => {
-      const { provider, keyring } = setup({ accounts: [] });
-      jest.spyOn(keyring, 'v1', 'get').mockReturnValue(undefined);
-
-      await expect(
-        provider.createAccounts({
-          type: AccountCreationType.Bip44DeriveIndex,
-          entropySource: MOCK_HD_KEYRING_1.metadata.id,
-          groupIndex: 0,
-        }),
-      ).rejects.toThrow('is v2-only and does not support v1 account creation');
-    });
+    expect(discovered).toHaveLength(1);
+    // After v1 discovery, account creation goes through the v2 batched path.
+    expect(mocks.keyring.createAccounts).toHaveBeenCalled();
+    // Provider should now expose one account (newly created)
+    expect(provider.getAccounts()).toHaveLength(1);
   });
 
   describe('v2 - batched', () => {
@@ -528,7 +299,6 @@ describe('BtcAccountProvider', () => {
         entropySource: MOCK_HD_KEYRING_1.metadata.id,
         groupIndex: newGroupIndex,
       });
-      expect(mocks.keyring.createAccount).not.toHaveBeenCalled();
     });
 
     it('does not re-create accounts (idempotent)', async () => {
@@ -564,7 +334,6 @@ describe('BtcAccountProvider', () => {
       expect(newAccounts).toHaveLength(3);
       // Single batch call, NOT three individual calls.
       expect(mocks.keyring.createAccounts).toHaveBeenCalledTimes(1);
-      expect(mocks.keyring.createAccount).not.toHaveBeenCalled();
 
       // Verify each account has the correct group index.
       for (const [index, account] of newAccounts.entries()) {
@@ -587,7 +356,6 @@ describe('BtcAccountProvider', () => {
 
       expect(newAccounts).toHaveLength(3);
       expect(mocks.keyring.createAccounts).toHaveBeenCalledTimes(1);
-      expect(mocks.keyring.createAccount).not.toHaveBeenCalled();
     });
 
     it('creates a single account when range from equals to', async () => {
@@ -604,7 +372,6 @@ describe('BtcAccountProvider', () => {
 
       expect(newAccounts).toHaveLength(1);
       expect(mocks.keyring.createAccounts).toHaveBeenCalledTimes(1);
-      expect(mocks.keyring.createAccount).not.toHaveBeenCalled();
       expect(
         isBip44Account(newAccounts[0]) &&
           newAccounts[0].options.entropy.groupIndex,
@@ -696,7 +463,6 @@ describe('BtcAccountProvider', () => {
 
     expect(discovered).toStrictEqual([]);
     expect(mocks.keyring.createAccounts).not.toHaveBeenCalled();
-    expect(mocks.keyring.createAccount).not.toHaveBeenCalled();
   });
 
   it('does not run discovery if disabled', async () => {

--- a/packages/multichain-account-service/src/providers/BtcAccountProvider.ts
+++ b/packages/multichain-account-service/src/providers/BtcAccountProvider.ts
@@ -1,6 +1,5 @@
 import type { Bip44Account } from '@metamask/account-api';
 import type { TraceCallback } from '@metamask/controller-utils';
-import type { EntropySourceId, KeyringAccount } from '@metamask/keyring-api';
 import { BtcAccountType, BtcScope } from '@metamask/keyring-api';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 import type { SnapId } from '@metamask/snaps-sdk';
@@ -9,10 +8,7 @@ import type { CaipChainId } from '@metamask/utils';
 import { traceFallback } from '../analytics';
 import type { MultichainAccountServiceMessenger } from '../types';
 import { SnapAccountProvider } from './SnapAccountProvider';
-import type {
-  RestrictedSnapKeyring,
-  SnapAccountProviderConfig,
-} from './SnapAccountProvider';
+import type { SnapAccountProviderConfig } from './SnapAccountProvider';
 
 export type BtcAccountProviderConfig = SnapAccountProviderConfig;
 
@@ -60,25 +56,5 @@ export class BtcAccountProvider extends SnapAccountProvider {
       account.type === BtcAccountType.P2wpkh &&
       Object.values<string>(BtcAccountType).includes(account.type)
     );
-  }
-
-  protected override createAccountV1(
-    keyring: RestrictedSnapKeyring,
-    {
-      entropySource,
-      groupIndex,
-    }: { entropySource: EntropySourceId; groupIndex: number },
-  ): Promise<KeyringAccount> {
-    if (!keyring.v1) {
-      throw new Error(
-        `Snap "${BtcAccountProvider.BTC_SNAP_ID}" is v2-only and does not support v1 account creation`,
-      );
-    }
-    return keyring.v1.createAccount({
-      entropySource,
-      index: groupIndex,
-      addressType: BtcAccountType.P2wpkh,
-      scope: BtcScope.Mainnet,
-    });
   }
 }

--- a/packages/multichain-account-service/src/providers/SnapAccountProvider.test.ts
+++ b/packages/multichain-account-service/src/providers/SnapAccountProvider.test.ts
@@ -975,37 +975,6 @@ describe('SnapAccountProvider', () => {
     });
   });
 
-  describe('withKeyringV2 selector', () => {
-    const mockAccounts = [
-      MockAccountBuilder.from(MOCK_HD_ACCOUNT_1)
-        .withUuid()
-        .withSnapId(TEST_SNAP_ID)
-        .get(),
-    ].filter(isBip44Account);
-
-    it('rejects when the keyring type is not a Snap keyring', async () => {
-      const { provider } = setup({
-        accounts: mockAccounts,
-        keyring: { type: 'not-a-snap-keyring' },
-      });
-
-      await expect(provider.resyncAccounts(mockAccounts)).rejects.toThrow(
-        'No keyring matches the selector',
-      );
-    });
-
-    it('rejects when the Snap keyring is for a different Snap ID', async () => {
-      const { provider } = setup({
-        accounts: mockAccounts,
-        keyring: { snapId: 'npm:@metamask/other-snap' as SnapId },
-      });
-
-      await expect(provider.resyncAccounts(mockAccounts)).rejects.toThrow(
-        'No keyring matches the selector',
-      );
-    });
-  });
-
   describe('ensureReady', () => {
     it('delegates Snap platform readiness check to SnapAccountService:ensureReady', async () => {
       const { provider, mocks } = setup();

--- a/packages/multichain-account-service/src/providers/SnapAccountProvider.test.ts
+++ b/packages/multichain-account-service/src/providers/SnapAccountProvider.test.ts
@@ -33,10 +33,7 @@ import {
 } from '../tests';
 import type { MultichainAccountServiceMessenger } from '../types';
 import { BtcAccountProvider } from './BtcAccountProvider';
-import type {
-  RestrictedSnapKeyring,
-  SnapAccountProviderConfig,
-} from './SnapAccountProvider';
+import type { SnapAccountProviderConfig } from './SnapAccountProvider';
 import {
   isSnapAccountProvider,
   SnapAccountProvider,
@@ -107,20 +104,6 @@ class MockSnapAccountProvider extends SnapAccountProvider {
 
   async discoverAccounts(): Promise<Bip44Account<KeyringAccount>[]> {
     return [];
-  }
-
-  protected async createAccountV1(
-    keyring: RestrictedSnapKeyring,
-    options: { entropySource: EntropySourceId; groupIndex: number },
-  ): Promise<KeyringAccount> {
-    if (!keyring.v1) {
-      throw new Error(
-        'Snap is v2-only and does not support v1 account creation',
-      );
-    }
-    // Forward to the mocked keyring (no real purposes apart from implementing
-    // this abstract method).
-    return await keyring.v1.createAccount(options);
   }
 
   async createAccounts(
@@ -259,9 +242,6 @@ const setup = ({
   const keyring = {
     type: keyringOverrides.type ?? 'snap',
     snapId: keyringOverrides.snapId ?? TEST_SNAP_ID,
-    v1: {
-      createAccount: jest.fn(),
-    },
     createAccounts: jest.fn(),
     deleteAccount: jest.fn().mockResolvedValue(undefined),
     lookupByAddress: jest
@@ -593,7 +573,6 @@ describe('SnapAccountProvider', () => {
         },
         createAccounts: {
           timeoutMs: 3000,
-          batched: false,
         },
       };
       const testProvider = new MockSnapAccountProvider(
@@ -626,7 +605,6 @@ describe('SnapAccountProvider', () => {
         },
         createAccounts: {
           timeoutMs: 3000,
-          batched: false,
         },
       };
       const testProvider = new MockSnapAccountProvider(

--- a/packages/multichain-account-service/src/providers/SnapAccountProvider.ts
+++ b/packages/multichain-account-service/src/providers/SnapAccountProvider.ts
@@ -91,6 +91,15 @@ export abstract class SnapAccountProvider extends BaseBip44AccountProvider {
 
   readonly #trace: TraceCallback;
 
+  /**
+   * Scopes passed to the v1 `discoverAccounts` client method. Only used on the
+   * v1 discovery path.
+   *
+   * TODO: Remove once all Snaps are fully v2 — discovery is then driven by the
+   * Snap's own supported scopes via `createAccounts({ bip44:discover })`.
+   */
+  protected abstract readonly v1DiscoveryScopes: CaipChainId[];
+
   constructor(
     snapId: SnapId,
     messenger: MultichainAccountServiceMessenger,
@@ -324,12 +333,6 @@ export abstract class SnapAccountProvider extends BaseBip44AccountProvider {
     const client = await this.#resolveClient();
     return await operation({ client });
   }
-
-  /**
-   * Scopes passed to the v1 `discoverAccounts` client method. Only used on the
-   * v1 discovery path.
-   */
-  protected abstract readonly v1DiscoveryScopes: CaipChainId[];
 
   abstract isAccountCompatible(account: Bip44Account<InternalAccount>): boolean;
 

--- a/packages/multichain-account-service/src/providers/SnapAccountProvider.ts
+++ b/packages/multichain-account-service/src/providers/SnapAccountProvider.ts
@@ -124,6 +124,10 @@ export abstract class SnapAccountProvider extends BaseBip44AccountProvider {
   /**
    * Ensures that the Snap is ready to be used.
    *
+   * Once this resolves, a Snap keyring for {@link snapId} is guaranteed to
+   * exist in the `KeyringController`, so subsequent {@link #withSnapKeyring}
+   * calls will not fail with "No keyring matches the selector".
+   *
    * @returns A promise that resolves when the Snap is ready.
    * @throws An error if the Snap could not become ready.
    */
@@ -318,9 +322,6 @@ export abstract class SnapAccountProvider extends BaseBip44AccountProvider {
   ): Promise<CallbackResult> {
     await this.ensureReady();
     const client = await this.#resolveClient();
-    // Eagerly verify that a Snap keyring matching this Snap is accessible,
-    // preserving the fail-fast behaviour for selector mismatches.
-    await this.#withSnapKeyring(async () => {});
     return await operation({ client });
   }
 

--- a/packages/multichain-account-service/src/providers/SnapAccountProvider.ts
+++ b/packages/multichain-account-service/src/providers/SnapAccountProvider.ts
@@ -39,6 +39,17 @@ import { createSnapKeyringClient } from './SnapKeyringClient';
 import type { Sender, SnapKeyringClient } from './SnapKeyringClient';
 import { withRetry, withTimeout } from './utils';
 
+/**
+ * A proxy to the Snap's keyring operations that routes every call through the
+ * `KeyringController` mutex (via {@link SnapAccountProvider.#withSnapKeyring}).
+ * Callers receive this object from {@link SnapAccountProvider.withSnap} and
+ * never interact with the raw keyring or the mutex directly.
+ */
+export type SnapKeyringProxy = {
+  createAccounts: SnapKeyringV2['createAccounts'];
+  deleteAccount: SnapKeyringV2['deleteAccount'];
+};
+
 export type SnapAccountProviderConfig = {
   maxConcurrency?: number;
   discovery: {
@@ -221,7 +232,7 @@ export abstract class SnapAccountProvider extends BaseBip44AccountProvider {
   async resyncAccounts(
     accounts: Bip44Account<InternalAccount>[],
   ): Promise<void> {
-    await this.withSnap(async ({ client }) => {
+    await this.withSnap(async ({ client, keyring }) => {
       const localSnapAccounts = accounts.filter(
         (account) => account.metadata.snap?.id === this.snapId,
       );
@@ -286,9 +297,7 @@ export abstract class SnapAccountProvider extends BaseBip44AccountProvider {
                 // We still need to remove the accounts from the Snap keyring since we're
                 // about to create the same account again, which will use a new ID, but will
                 // keep using the same address, and the Snap keyring does not allow this.
-                await this.#withSnapKeyring(async ({ keyring }) => {
-                  await keyring.deleteAccount(account.id);
-                });
+                await keyring.deleteAccount(account.id);
                 // The Snap has no account in its state for this one, we re-create it.
                 await this.createAccounts({
                   type: AccountCreationType.Bip44DeriveIndex,
@@ -327,11 +336,20 @@ export abstract class SnapAccountProvider extends BaseBip44AccountProvider {
   }
 
   protected async withSnap<CallbackResult = void>(
-    operation: (snap: { client: SnapKeyringClient }) => Promise<CallbackResult>,
+    operation: (snap: {
+      client: SnapKeyringClient;
+      keyring: SnapKeyringProxy;
+    }) => Promise<CallbackResult>,
   ): Promise<CallbackResult> {
     await this.ensureReady();
     const client = await this.#resolveClient();
-    return await operation({ client });
+    const keyring: SnapKeyringProxy = {
+      createAccounts: (options) =>
+        this.#withSnapKeyring(({ keyring: k }) => k.createAccounts(options)),
+      deleteAccount: (id) =>
+        this.#withSnapKeyring(({ keyring: k }) => k.deleteAccount(id)),
+    };
+    return await operation({ client, keyring });
   }
 
   abstract isAccountCompatible(account: Bip44Account<InternalAccount>): boolean;
@@ -345,6 +363,7 @@ export abstract class SnapAccountProvider extends BaseBip44AccountProvider {
   }
 
   protected async createBip44Accounts(
+    keyring: SnapKeyringProxy,
     options:
       | CreateAccountBip44DeriveIndexOptions
       | CreateAccountBip44DeriveIndexRangeOptions
@@ -363,10 +382,7 @@ export abstract class SnapAccountProvider extends BaseBip44AccountProvider {
                 ...toCreateAccountsV2DataTraces(options),
               },
             },
-            () =>
-              this.#withSnapKeyring(async ({ keyring }) =>
-                keyring.createAccounts(options),
-              ),
+            () => keyring.createAccounts(options),
           ),
         this.config.createAccounts.timeoutMs,
       );
@@ -397,7 +413,9 @@ export abstract class SnapAccountProvider extends BaseBip44AccountProvider {
       `${AccountCreationType.Bip44DeriveIndexRange}`,
     ]);
 
-    return this.withSnap(async () => this.createBip44Accounts(options));
+    return this.withSnap(async ({ keyring }) =>
+      this.createBip44Accounts(keyring, options),
+    );
   }
 
   /**
@@ -443,7 +461,7 @@ export abstract class SnapAccountProvider extends BaseBip44AccountProvider {
     entropySource: EntropySourceId;
     groupIndex: number;
   }): Promise<Bip44Account<KeyringAccount>[]> {
-    return this.withSnap(async ({ client }) =>
+    return this.withSnap(async ({ client, keyring }) =>
       this.trace(
         {
           name: TraceName.SnapDiscoverAccounts,
@@ -467,7 +485,7 @@ export abstract class SnapAccountProvider extends BaseBip44AccountProvider {
             // v2: the Snap detects on-chain activity and creates the account in
             // a single `createAccounts({ bip44:discover })` call. An empty
             // result means discovery is exhausted at this group index.
-            return this.createBip44Accounts({
+            return this.createBip44Accounts(keyring, {
               type: AccountCreationType.Bip44Discover,
               entropySource,
               groupIndex,
@@ -497,7 +515,7 @@ export abstract class SnapAccountProvider extends BaseBip44AccountProvider {
             return [];
           }
 
-          return this.createBip44Accounts({
+          return this.createBip44Accounts(keyring, {
             type: AccountCreationType.Bip44DeriveIndex,
             entropySource,
             groupIndex,

--- a/packages/multichain-account-service/src/providers/SnapAccountProvider.ts
+++ b/packages/multichain-account-service/src/providers/SnapAccountProvider.ts
@@ -277,8 +277,8 @@ export abstract class SnapAccountProvider extends BaseBip44AccountProvider {
                 // We still need to remove the accounts from the Snap keyring since we're
                 // about to create the same account again, which will use a new ID, but will
                 // keep using the same address, and the Snap keyring does not allow this.
-                await this.#withSnapKeyring(async ({ keyring: k }) => {
-                  await k.deleteAccount(account.id);
+                await this.#withSnapKeyring(async ({ keyring }) => {
+                  await keyring.deleteAccount(account.id);
                 });
                 // The Snap has no account in its state for this one, we re-create it.
                 await this.createAccounts({

--- a/packages/multichain-account-service/src/providers/SnapAccountProvider.ts
+++ b/packages/multichain-account-service/src/providers/SnapAccountProvider.ts
@@ -39,11 +39,6 @@ import { createSnapKeyringClient } from './SnapKeyringClient';
 import type { Sender, SnapKeyringClient } from './SnapKeyringClient';
 import { withRetry, withTimeout } from './utils';
 
-export type RestrictedSnapKeyring = {
-  createAccounts: SnapKeyringV2['createAccounts'];
-  deleteAccount: SnapKeyringV2['deleteAccount'];
-};
-
 export type SnapAccountProviderConfig = {
   maxConcurrency?: number;
   discovery: {
@@ -160,25 +155,6 @@ export abstract class SnapAccountProvider extends BaseBip44AccountProvider {
     return this.#trace(request, fn);
   }
 
-  async #getRestrictedSnapKeyring(): Promise<RestrictedSnapKeyring> {
-    // Eagerly verify that a Snap keyring matching this Snap is accessible.
-    // This preserves the fail-fast behaviour that previously came from
-    // extracting the v1 createAccount binding.
-    await this.#withSnapKeyring(async () => {});
-
-    return {
-      // Every v2 operation must be done through the `#withSnapKeyring` transaction:
-      createAccounts: async (options) =>
-        await this.#withSnapKeyring(
-          async ({ keyring }) => await keyring.createAccounts(options),
-        ),
-      deleteAccount: async (id: string) =>
-        await this.#withSnapKeyring(async ({ keyring }) => {
-          await keyring.deleteAccount(id);
-        }),
-    };
-  }
-
   #createSender(snapId: string): Sender {
     return {
       send: async (request: JsonRpcRequest): Promise<Json> => {
@@ -232,7 +208,7 @@ export abstract class SnapAccountProvider extends BaseBip44AccountProvider {
   async resyncAccounts(
     accounts: Bip44Account<InternalAccount>[],
   ): Promise<void> {
-    await this.withSnap(async ({ client, keyring }) => {
+    await this.withSnap(async ({ client }) => {
       const localSnapAccounts = accounts.filter(
         (account) => account.metadata.snap?.id === this.snapId,
       );
@@ -297,7 +273,9 @@ export abstract class SnapAccountProvider extends BaseBip44AccountProvider {
                 // We still need to remove the accounts from the Snap keyring since we're
                 // about to create the same account again, which will use a new ID, but will
                 // keep using the same address, and the Snap keyring does not allow this.
-                await keyring.deleteAccount(account.id);
+                await this.#withSnapKeyring(async ({ keyring: k }) => {
+                  await k.deleteAccount(account.id);
+                });
                 // The Snap has no account in its state for this one, we re-create it.
                 await this.createAccounts({
                   type: AccountCreationType.Bip44DeriveIndex,
@@ -336,18 +314,14 @@ export abstract class SnapAccountProvider extends BaseBip44AccountProvider {
   }
 
   protected async withSnap<CallbackResult = void>(
-    operation: (snap: {
-      client: SnapKeyringClient;
-      keyring: RestrictedSnapKeyring;
-    }) => Promise<CallbackResult>,
+    operation: (snap: { client: SnapKeyringClient }) => Promise<CallbackResult>,
   ): Promise<CallbackResult> {
     await this.ensureReady();
     const client = await this.#resolveClient();
-
-    return await operation({
-      client,
-      keyring: await this.#getRestrictedSnapKeyring(),
-    });
+    // Eagerly verify that a Snap keyring matching this Snap is accessible,
+    // preserving the fail-fast behaviour for selector mismatches.
+    await this.#withSnapKeyring(async () => {});
+    return await operation({ client });
   }
 
   /**
@@ -367,7 +341,6 @@ export abstract class SnapAccountProvider extends BaseBip44AccountProvider {
   }
 
   protected async createBip44Accounts(
-    keyring: RestrictedSnapKeyring,
     options:
       | CreateAccountBip44DeriveIndexOptions
       | CreateAccountBip44DeriveIndexRangeOptions
@@ -386,7 +359,10 @@ export abstract class SnapAccountProvider extends BaseBip44AccountProvider {
                 ...toCreateAccountsV2DataTraces(options),
               },
             },
-            () => keyring.createAccounts(options),
+            () =>
+              this.#withSnapKeyring(async ({ keyring }) =>
+                keyring.createAccounts(options),
+              ),
           ),
         this.config.createAccounts.timeoutMs,
       );
@@ -417,9 +393,7 @@ export abstract class SnapAccountProvider extends BaseBip44AccountProvider {
       `${AccountCreationType.Bip44DeriveIndexRange}`,
     ]);
 
-    return this.withSnap(async ({ keyring }) =>
-      this.createBip44Accounts(keyring, options),
-    );
+    return this.withSnap(async () => this.createBip44Accounts(options));
   }
 
   /**
@@ -465,7 +439,7 @@ export abstract class SnapAccountProvider extends BaseBip44AccountProvider {
     entropySource: EntropySourceId;
     groupIndex: number;
   }): Promise<Bip44Account<KeyringAccount>[]> {
-    return this.withSnap(async ({ client, keyring }) =>
+    return this.withSnap(async ({ client }) =>
       this.trace(
         {
           name: TraceName.SnapDiscoverAccounts,
@@ -489,7 +463,7 @@ export abstract class SnapAccountProvider extends BaseBip44AccountProvider {
             // v2: the Snap detects on-chain activity and creates the account in
             // a single `createAccounts({ bip44:discover })` call. An empty
             // result means discovery is exhausted at this group index.
-            return this.createBip44Accounts(keyring, {
+            return this.createBip44Accounts({
               type: AccountCreationType.Bip44Discover,
               entropySource,
               groupIndex,
@@ -519,7 +493,7 @@ export abstract class SnapAccountProvider extends BaseBip44AccountProvider {
             return [];
           }
 
-          return this.createBip44Accounts(keyring, {
+          return this.createBip44Accounts({
             type: AccountCreationType.Bip44DeriveIndex,
             entropySource,
             groupIndex,

--- a/packages/multichain-account-service/src/providers/SnapAccountProvider.ts
+++ b/packages/multichain-account-service/src/providers/SnapAccountProvider.ts
@@ -345,9 +345,13 @@ export abstract class SnapAccountProvider extends BaseBip44AccountProvider {
     const client = await this.#resolveClient();
     const keyring: SnapKeyringProxy = {
       createAccounts: (options) =>
-        this.#withSnapKeyring(({ keyring: k }) => k.createAccounts(options)),
+        this.#withSnapKeyring(({ keyring: snapKeyring }) =>
+          snapKeyring.createAccounts(options),
+        ),
       deleteAccount: (id) =>
-        this.#withSnapKeyring(({ keyring: k }) => k.deleteAccount(id)),
+        this.#withSnapKeyring(({ keyring: snapKeyring }) =>
+          snapKeyring.deleteAccount(id),
+        ),
     };
     return await operation({ client, keyring });
   }

--- a/packages/multichain-account-service/src/providers/SnapAccountProvider.ts
+++ b/packages/multichain-account-service/src/providers/SnapAccountProvider.ts
@@ -1,7 +1,6 @@
 import { assertIsBip44Account } from '@metamask/account-api';
 import type { Bip44Account } from '@metamask/account-api';
 import type { TraceCallback, TraceRequest } from '@metamask/controller-utils';
-import type { SnapKeyringV1 } from '@metamask/eth-snap-keyring';
 import type { SnapKeyring as SnapKeyringV2 } from '@metamask/eth-snap-keyring/v2';
 import {
   EMPTY_CAPABILITIES,
@@ -41,15 +40,6 @@ import type { Sender, SnapKeyringClient } from './SnapKeyringClient';
 import { withRetry, withTimeout } from './utils';
 
 export type RestrictedSnapKeyring = {
-  /**
-   * V1 interface, present only when the Snap does not declare v2 capabilities.
-   * `undefined` for v2-only Snaps.
-   *
-   * Use this to make v1 calls explicit:
-   *   if (!keyring.v1) { throw new Error('Snap is v2-only'); }
-   *   keyring.v1.createAccount(options);
-   */
-  v1?: { createAccount: SnapKeyringV1['createAccount'] };
   createAccounts: SnapKeyringV2['createAccounts'];
   deleteAccount: SnapKeyringV2['deleteAccount'];
 };
@@ -105,15 +95,6 @@ export abstract class SnapAccountProvider extends BaseBip44AccountProvider {
   readonly #queue?: Semaphore;
 
   readonly #trace: TraceCallback;
-
-  /**
-   * Scopes passed to the v1 `discoverAccounts` client method. Only used on the
-   * v1 discovery path.
-   *
-   * TODO: Remove once all Snaps are fully v2 — discovery is then driven by the
-   * Snap's own supported scopes via `createAccounts({ bip44:discover })`.
-   */
-  protected abstract readonly v1DiscoveryScopes: CaipChainId[];
 
   constructor(
     snapId: SnapId,
@@ -180,25 +161,13 @@ export abstract class SnapAccountProvider extends BaseBip44AccountProvider {
   }
 
   async #getRestrictedSnapKeyring(): Promise<RestrictedSnapKeyring> {
-    // NOTE: We're not supposed to make the keyring instance escape `withKeyringV2` but
-    // we have to use the `SnapKeyringV2` instance to be able to create Solana account
-    // without triggering UI confirmation.
-    // Also, creating account that way won't invalidate the Snap keyring state. The
-    // account will get created and persisted properly with the Snap account creation
-    // flow "asynchronously" (with `notify:accountCreated`).
-    const createAccount = await this.#withSnapKeyring(async ({ keyring }) => {
-      if (keyring.v1) {
-        return keyring.v1.createAccount.bind(keyring.v1);
-      }
-
-      // This method does not exist in v2.
-      return undefined;
-    });
+    // Eagerly verify that a Snap keyring matching this Snap is accessible.
+    // This preserves the fail-fast behaviour that previously came from
+    // extracting the v1 createAccount binding.
+    await this.#withSnapKeyring(async () => {});
 
     return {
-      // V1 interface is only present for v1 Snaps, otherwise it's `undefined`.
-      v1: createAccount ? { createAccount } : undefined,
-      // Every v2 operations must be done through the `#withSnapKeyring` transaction:
+      // Every v2 operation must be done through the `#withSnapKeyring` transaction:
       createAccounts: async (options) =>
         await this.#withSnapKeyring(
           async ({ keyring }) => await keyring.createAccounts(options),
@@ -381,12 +350,13 @@ export abstract class SnapAccountProvider extends BaseBip44AccountProvider {
     });
   }
 
-  abstract isAccountCompatible(account: Bip44Account<InternalAccount>): boolean;
+  /**
+   * Scopes passed to the v1 `discoverAccounts` client method. Only used on the
+   * v1 discovery path.
+   */
+  protected abstract readonly v1DiscoveryScopes: CaipChainId[];
 
-  protected abstract createAccountV1(
-    keyring: RestrictedSnapKeyring,
-    options: { entropySource: EntropySourceId; groupIndex: number },
-  ): Promise<KeyringAccount>;
+  abstract isAccountCompatible(account: Bip44Account<InternalAccount>): boolean;
 
   protected toBip44Account(
     account: KeyringAccount,
@@ -404,92 +374,27 @@ export abstract class SnapAccountProvider extends BaseBip44AccountProvider {
       | CreateAccountBip44DiscoverOptions,
   ): Promise<Bip44Account<KeyringAccount>[]> {
     return this.withMaxConcurrency(async () => {
-      let groupIndexOffset = 0;
-      let snapAccounts: KeyringAccount[] = [];
-
-      // v2 Snaps expose `createAccounts` but no singular `createAccount`, so
-      // they must always go through the batched flow. v1 Snaps only have the
-      // singular `createAccount`.
-      const batched = this.isV2();
       const { entropySource } = options;
 
-      const createAccountV1 = async (
-        groupIndex: number,
-      ): Promise<KeyringAccount> =>
-        await withTimeout(
-          () =>
-            this.trace(
-              {
-                name: TraceName.ProviderCreateAccountV1,
-                data: {
-                  provider: this.getName(),
-                  groupIndex,
-                },
+      const snapAccounts = await withTimeout(
+        () =>
+          this.trace(
+            {
+              name: TraceName.ProviderCreateAccounts,
+              data: {
+                provider: this.getName(),
+                ...toCreateAccountsV2DataTraces(options),
               },
-              () =>
-                this.createAccountV1(keyring, { entropySource, groupIndex }),
-            ),
-          this.config.createAccounts.timeoutMs,
-        );
-      const createAccountsV2 = async (
-        optionsV2:
-          | CreateAccountBip44DeriveIndexOptions
-          | CreateAccountBip44DeriveIndexRangeOptions
-          | CreateAccountBip44DiscoverOptions,
-      ): Promise<KeyringAccount[]> =>
-        await withTimeout(
-          () =>
-            this.trace(
-              {
-                name: TraceName.ProviderCreateAccounts,
-                data: {
-                  provider: this.getName(),
-                  ...toCreateAccountsV2DataTraces(optionsV2),
-                },
-              },
-              () => keyring.createAccounts(optionsV2),
-            ),
-          this.config.createAccounts.timeoutMs,
-        );
+            },
+            () => keyring.createAccounts(options),
+          ),
+        this.config.createAccounts.timeoutMs,
+      );
 
-      if (options.type === `${AccountCreationType.Bip44DeriveIndexRange}`) {
-        if (batched) {
-          // Batch account creations.
-          snapAccounts = await createAccountsV2(options);
-        } else {
-          const { range } = options;
-
-          // Create accounts one by one.
-          for (
-            let groupIndex = range.from;
-            groupIndex <= range.to;
-            groupIndex++
-          ) {
-            const snapAccount = await createAccountV1(groupIndex);
-
-            snapAccounts.push(snapAccount);
-          }
-        }
-
-        // Group indices are sequential, so we just need the starting index.
-        groupIndexOffset = options.range.from;
-      } else {
-        if (batched) {
-          // Create account using new v2-like flow (no async flow + no Snap keyring events).
-          snapAccounts = await createAccountsV2(options);
-        } else {
-          const { groupIndex } = options;
-
-          // Create account using the existing v1 flow.
-          const snapAccount = await createAccountV1(groupIndex);
-
-          snapAccounts = [snapAccount];
-        }
-
-        // For single account, there will only be 1 account, so we can use the
-        // provided group index directly.
-        groupIndexOffset = options.groupIndex;
-      }
+      const groupIndexOffset =
+        options.type === `${AccountCreationType.Bip44DeriveIndexRange}`
+          ? options.range.from
+          : options.groupIndex;
 
       return snapAccounts.map((snapAccount, index) => {
         const groupIndex = groupIndexOffset + index;

--- a/packages/multichain-account-service/src/providers/SolAccountProvider.test.ts
+++ b/packages/multichain-account-service/src/providers/SolAccountProvider.test.ts
@@ -19,10 +19,7 @@ import {
 } from '../tests';
 import type { RootMessenger, DeepPartial } from '../tests';
 import { AccountProviderWrapper } from './AccountProviderWrapper';
-import type {
-  RestrictedSnapKeyring,
-  SnapAccountProviderConfig,
-} from './SnapAccountProvider';
+import type { SnapAccountProviderConfig } from './SnapAccountProvider';
 import {
   SOL_ACCOUNT_PROVIDER_DEFAULT_CONFIG,
   SOL_ACCOUNT_PROVIDER_NAME,
@@ -65,46 +62,6 @@ class MockSolanaKeyring {
     this.accounts = accounts;
   }
 
-  #getIndexFromDerivationPath(derivationPath: string): number {
-    // eslint-disable-next-line prefer-regex-literals
-    const derivationPathIndexRegex = new RegExp(
-      "^m/44'/501'/(?<index>[0-9]+)'/0'$",
-      'u',
-    );
-
-    const matched = derivationPath.match(derivationPathIndexRegex);
-    if (matched?.groups?.index === undefined) {
-      throw new Error('Unable to extract index');
-    }
-
-    const { index } = matched.groups;
-    return Number(index);
-  }
-
-  createAccount = jest.fn().mockImplementation(({ derivationPath }) => {
-    if (derivationPath !== undefined) {
-      const index = this.#getIndexFromDerivationPath(derivationPath);
-      const found = this.accounts.find(
-        (account) =>
-          isBip44Account(account) &&
-          account.options.entropy.groupIndex === index,
-      );
-
-      if (found) {
-        return found; // Idempotent.
-      }
-    }
-
-    const account = MockAccountBuilder.from(MOCK_SOL_ACCOUNT_1)
-      .withUuid()
-      .withAddressSuffix(`${this.accounts.length}`)
-      .withGroupIndex(this.accounts.length)
-      .get();
-    this.accounts.push(account);
-
-    return account;
-  });
-
   createAccounts = jest.fn().mockImplementation((options) => {
     const groupIndices =
       options.type === 'bip44:derive-index'
@@ -133,10 +90,6 @@ class MockSolanaKeyring {
   });
 
   deleteAccount = jest.fn().mockResolvedValue(undefined);
-
-  get v1(): Required<RestrictedSnapKeyring['v1']> {
-    return { createAccount: this.createAccount };
-  }
 }
 
 class MockSolAccountProvider extends SolAccountProvider {
@@ -172,7 +125,6 @@ function setup({
   mocks: {
     handleRequest: jest.Mock;
     keyring: {
-      createAccount: jest.Mock;
       createAccounts: jest.Mock;
     };
     trace: jest.Mock;
@@ -249,7 +201,6 @@ function setup({
     mocks: {
       handleRequest: mockHandleRequest,
       keyring: {
-        createAccount: keyring.createAccount,
         createAccounts: keyring.createAccounts,
       },
       trace: mockTrace,
@@ -309,178 +260,22 @@ describe('SolAccountProvider', () => {
     expect(provider.isAccountCompatible(account)).toBe(false);
   });
 
-  describe('v1', () => {
-    it('uses v1 by default when no config is provided', async () => {
-      const accounts = [MOCK_SOL_ACCOUNT_1];
-      const { provider, mocks } = setup({
-        accounts,
-        // No capabilities provided → defaults to an empty capability set, so
-        // the provider falls back to the v1 (non-batched) flow.
-      });
+  it('discover accounts at a new group index creates an account (v1 discovery flow)', async () => {
+    const { provider, mocks } = setup({ accounts: [] });
 
-      await provider.createAccounts({
-        type: AccountCreationType.Bip44DeriveIndex,
-        entropySource: MOCK_HD_KEYRING_1.metadata.id,
-        groupIndex: accounts.length,
-      });
+    // Simulate one discovered account at the requested index via v1 client.discoverAccounts.
+    mocks.handleRequest.mockReturnValue([MOCK_SOL_DISCOVERED_ACCOUNT_1]);
 
-      expect(mocks.keyring.createAccount).toHaveBeenCalled();
-      expect(mocks.keyring.createAccounts).not.toHaveBeenCalled();
+    const discovered = await provider.discoverAccounts({
+      entropySource: MOCK_HD_KEYRING_1.metadata.id,
+      groupIndex: 0,
     });
 
-    it('creates accounts', async () => {
-      const accounts = [MOCK_SOL_ACCOUNT_1];
-      const { provider, mocks } = setup({ accounts });
-
-      const newGroupIndex = accounts.length; // Group-index are 0-based.
-      const newAccounts = await provider.createAccounts({
-        type: AccountCreationType.Bip44DeriveIndex,
-        entropySource: MOCK_HD_KEYRING_1.metadata.id,
-        groupIndex: newGroupIndex,
-      });
-      expect(newAccounts).toHaveLength(1);
-      expect(mocks.keyring.createAccount).toHaveBeenCalled();
-      expect(mocks.keyring.createAccounts).not.toHaveBeenCalled();
-    });
-
-    it('does not re-create accounts (idempotent)', async () => {
-      const accounts = [MOCK_SOL_ACCOUNT_1];
-      const { provider } = setup({ accounts });
-
-      const newAccounts = await provider.createAccounts({
-        entropySource: MOCK_HD_KEYRING_1.metadata.id,
-        groupIndex: 0,
-        type: AccountCreationType.Bip44DeriveIndex,
-      });
-      expect(newAccounts).toHaveLength(1);
-      expect(newAccounts[0]).toStrictEqual(MOCK_SOL_ACCOUNT_1);
-    });
-
-    it('creates multiple accounts using Bip44DeriveIndexRange', async () => {
-      const accounts = [MOCK_SOL_ACCOUNT_1];
-      const { provider, mocks } = setup({ accounts });
-
-      const from = 1;
-      const newAccounts = await provider.createAccounts({
-        type: AccountCreationType.Bip44DeriveIndexRange,
-        entropySource: MOCK_HD_KEYRING_1.metadata.id,
-        range: { from, to: 3 },
-      });
-
-      expect(newAccounts).toHaveLength(3);
-      expect(mocks.keyring.createAccount).toHaveBeenCalledTimes(3);
-      expect(mocks.keyring.createAccounts).not.toHaveBeenCalled();
-
-      // Verify each account has the correct group index.
-      for (const [index, account] of newAccounts.entries()) {
-        expect(isBip44Account(account)).toBe(true);
-        expect(account.options.entropy.groupIndex).toBe(from + index);
-      }
-    });
-
-    it('creates accounts with range starting from 0', async () => {
-      const { provider, mocks } = setup({ accounts: [] });
-
-      const newAccounts = await provider.createAccounts({
-        type: AccountCreationType.Bip44DeriveIndexRange,
-        entropySource: MOCK_HD_KEYRING_1.metadata.id,
-        range: { from: 0, to: 2 },
-      });
-
-      expect(newAccounts).toHaveLength(3);
-      expect(mocks.keyring.createAccount).toHaveBeenCalledTimes(3);
-      expect(mocks.keyring.createAccounts).not.toHaveBeenCalled();
-    });
-
-    it('creates a single account when range from equals to', async () => {
-      const { provider, mocks } = setup({ accounts: [] });
-
-      const newAccounts = await provider.createAccounts({
-        type: AccountCreationType.Bip44DeriveIndexRange,
-        entropySource: MOCK_HD_KEYRING_1.metadata.id,
-        range: { from: 5, to: 5 },
-      });
-
-      expect(newAccounts).toHaveLength(1);
-      expect(mocks.keyring.createAccount).toHaveBeenCalledTimes(1);
-      expect(mocks.keyring.createAccounts).not.toHaveBeenCalled();
-      expect(
-        isBip44Account(newAccounts[0]) &&
-          newAccounts[0].options.entropy.groupIndex,
-      ).toBe(5);
-    });
-
-    it('throws if the account creation process takes too long', async () => {
-      const { provider, mocks } = setup({ accounts: [] });
-
-      mocks.keyring.createAccount.mockImplementation(
-        () =>
-          new Promise((resolve) => {
-            setTimeout(() => resolve(MOCK_SOL_ACCOUNT_1), 4000);
-          }),
-      );
-
-      await expect(
-        provider.createAccounts({
-          type: AccountCreationType.Bip44DeriveIndex,
-          entropySource: MOCK_HD_KEYRING_1.metadata.id,
-          groupIndex: 0,
-        }),
-      ).rejects.toThrow('Timed out');
-    });
-
-    // Skip this test for now, since we manually inject those options upon
-    // account creation, so it cannot fails (until the Solana Snap starts
-    // using the new typed options).
-    // eslint-disable-next-line jest/no-disabled-tests
-    it.skip('throws if the created account is not BIP-44 compatible', async () => {
-      const accounts = [MOCK_SOL_ACCOUNT_1];
-      const { provider, mocks } = setup({ accounts });
-
-      mocks.keyring.createAccount.mockResolvedValue({
-        ...MOCK_SOL_ACCOUNT_1,
-        options: {}, // No options, so it cannot be BIP-44 compatible.
-      });
-
-      await expect(
-        provider.createAccounts({
-          type: AccountCreationType.Bip44DeriveIndex,
-          entropySource: MOCK_HD_KEYRING_1.metadata.id,
-          groupIndex: 0,
-        }),
-      ).rejects.toThrow('Created account is not BIP-44 compatible');
-    });
-
-    it('discover accounts at a new group index creates an account', async () => {
-      const { provider, mocks } = setup({ accounts: [] });
-
-      // Simulate one discovered account at the requested index.
-      mocks.handleRequest.mockReturnValue([MOCK_SOL_DISCOVERED_ACCOUNT_1]);
-
-      const discovered = await provider.discoverAccounts({
-        entropySource: MOCK_HD_KEYRING_1.metadata.id,
-        groupIndex: 0,
-      });
-
-      expect(discovered).toHaveLength(1);
-      // Ensure we did go through creation path
-      expect(mocks.keyring.createAccount).toHaveBeenCalled();
-      // Provider should now expose one account (newly created)
-      expect(provider.getAccounts()).toHaveLength(1);
-    });
-
-    it('throws when the Snap is v2-only and does not support v1 account creation', async () => {
-      const { provider, keyring } = setup({ accounts: [] });
-      jest.spyOn(keyring, 'v1', 'get').mockReturnValue(undefined);
-
-      await expect(
-        provider.createAccounts({
-          type: AccountCreationType.Bip44DeriveIndex,
-          entropySource: MOCK_HD_KEYRING_1.metadata.id,
-          groupIndex: 0,
-        }),
-      ).rejects.toThrow('is v2-only and does not support v1 account creation');
-    });
+    expect(discovered).toHaveLength(1);
+    // After v1 discovery, account creation goes through the v2 batched path.
+    expect(mocks.keyring.createAccounts).toHaveBeenCalled();
+    // Provider should now expose one account (newly created)
+    expect(provider.getAccounts()).toHaveLength(1);
   });
 
   describe('v2 - batched', () => {
@@ -504,7 +299,6 @@ describe('SolAccountProvider', () => {
         entropySource: MOCK_HD_KEYRING_1.metadata.id,
         groupIndex: newGroupIndex,
       });
-      expect(mocks.keyring.createAccount).not.toHaveBeenCalled();
     });
 
     it('does not re-create accounts (idempotent)', async () => {
@@ -540,7 +334,6 @@ describe('SolAccountProvider', () => {
       expect(newAccounts).toHaveLength(3);
       // Single batch call, NOT three individual calls.
       expect(mocks.keyring.createAccounts).toHaveBeenCalledTimes(1);
-      expect(mocks.keyring.createAccount).not.toHaveBeenCalled();
 
       // Verify each account has the correct group index.
       for (const [index, account] of newAccounts.entries()) {
@@ -563,7 +356,6 @@ describe('SolAccountProvider', () => {
 
       expect(newAccounts).toHaveLength(3);
       expect(mocks.keyring.createAccounts).toHaveBeenCalledTimes(1);
-      expect(mocks.keyring.createAccount).not.toHaveBeenCalled();
     });
 
     it('creates a single account when range from equals to', async () => {
@@ -580,7 +372,6 @@ describe('SolAccountProvider', () => {
 
       expect(newAccounts).toHaveLength(1);
       expect(mocks.keyring.createAccounts).toHaveBeenCalledTimes(1);
-      expect(mocks.keyring.createAccount).not.toHaveBeenCalled();
       expect(
         isBip44Account(newAccounts[0]) &&
           newAccounts[0].options.entropy.groupIndex,
@@ -672,7 +463,6 @@ describe('SolAccountProvider', () => {
 
     expect(discovered).toStrictEqual([]);
     expect(mocks.keyring.createAccounts).not.toHaveBeenCalled();
-    expect(mocks.keyring.createAccount).not.toHaveBeenCalled();
   });
 
   it('does not run discovery if disabled', async () => {

--- a/packages/multichain-account-service/src/providers/SolAccountProvider.ts
+++ b/packages/multichain-account-service/src/providers/SolAccountProvider.ts
@@ -1,7 +1,6 @@
 import { assertIsBip44Account } from '@metamask/account-api';
 import type { Bip44Account } from '@metamask/account-api';
 import type { TraceCallback } from '@metamask/controller-utils';
-import type { EntropySourceId, KeyringAccount } from '@metamask/keyring-api';
 import {
   KeyringAccountEntropyTypeOption,
   SolAccountType,
@@ -15,10 +14,7 @@ import type { CaipChainId } from '@metamask/utils';
 import { traceFallback } from '../analytics';
 import type { MultichainAccountServiceMessenger } from '../types';
 import { SnapAccountProvider } from './SnapAccountProvider';
-import type {
-  RestrictedSnapKeyring,
-  SnapAccountProviderConfig,
-} from './SnapAccountProvider';
+import type { SnapAccountProviderConfig } from './SnapAccountProvider';
 
 export type SolAccountProviderConfig = SnapAccountProviderConfig;
 
@@ -70,24 +66,6 @@ export class SolAccountProvider extends SnapAccountProvider {
 
   #getDerivationPath(groupIndex: number): string {
     return `m/44'/501'/${groupIndex}'/0'`;
-  }
-
-  protected override async createAccountV1(
-    keyring: RestrictedSnapKeyring,
-    {
-      entropySource,
-      groupIndex,
-    }: { entropySource: EntropySourceId; groupIndex: number },
-  ): Promise<KeyringAccount> {
-    if (!keyring.v1) {
-      throw new Error(
-        `Snap "${SolAccountProvider.SOLANA_SNAP_ID}" is v2-only and does not support v1 account creation`,
-      );
-    }
-    return keyring.v1.createAccount({
-      entropySource,
-      derivationPath: this.#getDerivationPath(groupIndex),
-    });
   }
 
   protected override toBip44Account(

--- a/packages/multichain-account-service/src/providers/SolAccountProvider.ts
+++ b/packages/multichain-account-service/src/providers/SolAccountProvider.ts
@@ -6,6 +6,7 @@ import {
   SolAccountType,
   SolScope,
 } from '@metamask/keyring-api';
+import type { EntropySourceId, KeyringAccount } from '@metamask/keyring-api';
 import { KeyringTypes } from '@metamask/keyring-controller';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 import type { SnapId } from '@metamask/snaps-sdk';

--- a/packages/multichain-account-service/src/providers/TrxAccountProvider.test.ts
+++ b/packages/multichain-account-service/src/providers/TrxAccountProvider.test.ts
@@ -19,10 +19,7 @@ import {
 } from '../tests';
 import type { RootMessenger, DeepPartial } from '../tests';
 import { AccountProviderWrapper } from './AccountProviderWrapper';
-import type {
-  RestrictedSnapKeyring,
-  SnapAccountProviderConfig,
-} from './SnapAccountProvider';
+import type { SnapAccountProviderConfig } from './SnapAccountProvider';
 import {
   TRX_ACCOUNT_PROVIDER_DEFAULT_CONFIG,
   TRX_ACCOUNT_PROVIDER_NAME,
@@ -65,32 +62,6 @@ class MockTronKeyring {
     this.accounts = accounts;
   }
 
-  createAccount = jest.fn().mockImplementation(({ index }) => {
-    // Use the provided index or fallback to accounts length
-    const groupIndex = index ?? this.accounts.length;
-
-    // Check if an account already exists for this group index (idempotent behavior)
-    const found = this.accounts.find(
-      (account) =>
-        isBip44Account(account) &&
-        account.options.entropy.groupIndex === groupIndex,
-    );
-
-    if (found) {
-      return found; // Idempotent.
-    }
-
-    // Create new account with the correct group index
-    const account = MockAccountBuilder.from(MOCK_TRX_ACCOUNT_1)
-      .withUuid()
-      .withAddressSuffix(`${this.accounts.length}`)
-      .withGroupIndex(groupIndex)
-      .get();
-    this.accounts.push(account);
-
-    return account;
-  });
-
   createAccounts = jest.fn().mockImplementation((options) => {
     const groupIndices =
       options.type === 'bip44:derive-index'
@@ -122,10 +93,6 @@ class MockTronKeyring {
   discoverAccounts = jest.fn().mockResolvedValue([]);
 
   deleteAccount = jest.fn().mockResolvedValue(undefined);
-
-  get v1(): Required<RestrictedSnapKeyring['v1']> {
-    return { createAccount: this.createAccount };
-  }
 }
 
 class MockTrxAccountProvider extends TrxAccountProvider {
@@ -161,7 +128,6 @@ function setup({
   mocks: {
     handleRequest: jest.Mock;
     keyring: {
-      createAccount: jest.Mock;
       createAccounts: jest.Mock;
       discoverAccounts: jest.Mock;
     };
@@ -244,7 +210,6 @@ function setup({
     mocks: {
       handleRequest: mockHandleRequest,
       keyring: {
-        createAccount: keyring.createAccount,
         createAccounts: keyring.createAccounts,
         discoverAccounts: keyring.discoverAccounts,
       },
@@ -305,183 +270,24 @@ describe('TrxAccountProvider', () => {
     expect(provider.isAccountCompatible(account)).toBe(false);
   });
 
-  describe('v1', () => {
-    it('uses v1 by default when no config is provided', async () => {
-      const accounts = [MOCK_TRX_ACCOUNT_1];
-      const { provider, mocks } = setup({
-        accounts,
-        // No capabilities provided → defaults to an empty capability set, so
-        // the provider falls back to the v1 (non-batched) flow.
-      });
+  it('discover accounts at a new group index creates an account (v1 discovery flow)', async () => {
+    const { provider, mocks } = setup({ accounts: [] });
 
-      await provider.createAccounts({
-        type: AccountCreationType.Bip44DeriveIndex,
-        entropySource: MOCK_HD_KEYRING_1.metadata.id,
-        groupIndex: accounts.length,
-      });
+    // Simulate one discovered account at the requested index via v1 client.discoverAccounts.
+    mocks.keyring.discoverAccounts.mockResolvedValue([
+      MOCK_TRX_DISCOVERED_ACCOUNT_1,
+    ]);
 
-      expect(mocks.keyring.createAccount).toHaveBeenCalled();
-      expect(mocks.keyring.createAccounts).not.toHaveBeenCalled();
+    const discovered = await provider.discoverAccounts({
+      entropySource: MOCK_HD_KEYRING_1.metadata.id,
+      groupIndex: 0,
     });
 
-    it('creates accounts', async () => {
-      const accounts = [MOCK_TRX_ACCOUNT_1];
-      const { provider, mocks } = setup({ accounts });
-
-      const newGroupIndex = accounts.length; // Group-index are 0-based.
-      const newAccounts = await provider.createAccounts({
-        type: AccountCreationType.Bip44DeriveIndex,
-        entropySource: MOCK_HD_KEYRING_1.metadata.id,
-        groupIndex: newGroupIndex,
-      });
-      expect(newAccounts).toHaveLength(1);
-      expect(mocks.keyring.createAccount).toHaveBeenCalled();
-      expect(mocks.keyring.createAccounts).not.toHaveBeenCalled();
-    });
-
-    it('does not re-create accounts (idempotent)', async () => {
-      const accounts = [MOCK_TRX_ACCOUNT_1];
-      const { provider } = setup({ accounts });
-
-      const newAccounts = await provider.createAccounts({
-        entropySource: MOCK_HD_KEYRING_1.metadata.id,
-        groupIndex: 0,
-        type: AccountCreationType.Bip44DeriveIndex,
-      });
-      expect(newAccounts).toHaveLength(1);
-      expect(newAccounts[0]).toStrictEqual(MOCK_TRX_ACCOUNT_1);
-    });
-
-    it('creates multiple accounts using Bip44DeriveIndexRange', async () => {
-      const accounts = [MOCK_TRX_ACCOUNT_1];
-      const { provider, mocks } = setup({ accounts });
-
-      const from = 1;
-      const newAccounts = await provider.createAccounts({
-        type: AccountCreationType.Bip44DeriveIndexRange,
-        entropySource: MOCK_HD_KEYRING_1.metadata.id,
-        range: { from, to: 3 },
-      });
-
-      expect(newAccounts).toHaveLength(3);
-      expect(mocks.keyring.createAccount).toHaveBeenCalledTimes(3);
-      expect(mocks.keyring.createAccounts).not.toHaveBeenCalled();
-
-      // Verify each account has the correct group index.
-      for (const [index, account] of newAccounts.entries()) {
-        expect(isBip44Account(account)).toBe(true);
-        expect(account.options.entropy.groupIndex).toBe(from + index);
-      }
-    });
-
-    it('creates accounts with range starting from 0', async () => {
-      const { provider, mocks } = setup({ accounts: [] });
-
-      const newAccounts = await provider.createAccounts({
-        type: AccountCreationType.Bip44DeriveIndexRange,
-        entropySource: MOCK_HD_KEYRING_1.metadata.id,
-        range: { from: 0, to: 2 },
-      });
-
-      expect(newAccounts).toHaveLength(3);
-      expect(mocks.keyring.createAccount).toHaveBeenCalledTimes(3);
-      expect(mocks.keyring.createAccounts).not.toHaveBeenCalled();
-    });
-
-    it('creates a single account when range from equals to', async () => {
-      const { provider, mocks } = setup({ accounts: [] });
-
-      const newAccounts = await provider.createAccounts({
-        type: AccountCreationType.Bip44DeriveIndexRange,
-        entropySource: MOCK_HD_KEYRING_1.metadata.id,
-        range: { from: 5, to: 5 },
-      });
-
-      expect(newAccounts).toHaveLength(1);
-      expect(mocks.keyring.createAccount).toHaveBeenCalledTimes(1);
-      expect(mocks.keyring.createAccounts).not.toHaveBeenCalled();
-      expect(
-        isBip44Account(newAccounts[0]) &&
-          newAccounts[0].options.entropy.groupIndex,
-      ).toBe(5);
-    });
-
-    it('throws if the account creation process takes too long', async () => {
-      const { provider, mocks } = setup({ accounts: [] });
-
-      mocks.keyring.createAccount.mockImplementation(() => {
-        return new Promise((resolve) => {
-          setTimeout(() => {
-            resolve(MOCK_TRX_ACCOUNT_1);
-          }, 4000);
-        });
-      });
-
-      await expect(
-        provider.createAccounts({
-          type: AccountCreationType.Bip44DeriveIndex,
-          entropySource: MOCK_HD_KEYRING_1.metadata.id,
-          groupIndex: 0,
-        }),
-      ).rejects.toThrow('Timed out');
-    });
-
-    // Skip this test for now, since we manually inject those options upon
-    // account creation, so it cannot fails (until the Tron Snap starts
-    // using the new typed options).
-    // eslint-disable-next-line jest/no-disabled-tests
-    it.skip('throws if the created account is not BIP-44 compatible', async () => {
-      const accounts = [MOCK_TRX_ACCOUNT_1];
-      const { provider, mocks } = setup({
-        accounts,
-      });
-
-      mocks.keyring.createAccount.mockResolvedValue({
-        ...MOCK_TRX_ACCOUNT_1,
-        options: {}, // No options, so it cannot be BIP-44 compatible.
-      });
-
-      await expect(
-        provider.createAccounts({
-          type: AccountCreationType.Bip44DeriveIndex,
-          entropySource: MOCK_HD_KEYRING_1.metadata.id,
-          groupIndex: 0,
-        }),
-      ).rejects.toThrow('Created account is not BIP-44 compatible');
-    });
-
-    it('discover accounts at a new group index creates an account', async () => {
-      const { provider, mocks } = setup({ accounts: [] });
-
-      // Simulate one discovered account at the requested index.
-      mocks.keyring.discoverAccounts.mockResolvedValue([
-        MOCK_TRX_DISCOVERED_ACCOUNT_1,
-      ]);
-
-      const discovered = await provider.discoverAccounts({
-        entropySource: MOCK_HD_KEYRING_1.metadata.id,
-        groupIndex: 0,
-      });
-
-      expect(discovered).toHaveLength(1);
-      // Ensure we did go through creation path
-      expect(mocks.keyring.createAccount).toHaveBeenCalled();
-      // Provider should now expose one account (newly created)
-      expect(provider.getAccounts()).toHaveLength(1);
-    });
-
-    it('throws when the Snap is v2-only and does not support v1 account creation', async () => {
-      const { provider, keyring } = setup({ accounts: [] });
-      jest.spyOn(keyring, 'v1', 'get').mockReturnValue(undefined);
-
-      await expect(
-        provider.createAccounts({
-          type: AccountCreationType.Bip44DeriveIndex,
-          entropySource: MOCK_HD_KEYRING_1.metadata.id,
-          groupIndex: 0,
-        }),
-      ).rejects.toThrow('is v2-only and does not support v1 account creation');
-    });
+    expect(discovered).toHaveLength(1);
+    // After v1 discovery, account creation goes through the v2 batched path.
+    expect(mocks.keyring.createAccounts).toHaveBeenCalled();
+    // Provider should now expose one account (newly created)
+    expect(provider.getAccounts()).toHaveLength(1);
   });
 
   describe('v2 - batched', () => {
@@ -505,7 +311,6 @@ describe('TrxAccountProvider', () => {
         entropySource: MOCK_HD_KEYRING_1.metadata.id,
         groupIndex: newGroupIndex,
       });
-      expect(mocks.keyring.createAccount).not.toHaveBeenCalled();
     });
 
     it('does not re-create accounts (idempotent)', async () => {
@@ -541,7 +346,6 @@ describe('TrxAccountProvider', () => {
       expect(newAccounts).toHaveLength(3);
       // Single batch call, NOT three individual calls.
       expect(mocks.keyring.createAccounts).toHaveBeenCalledTimes(1);
-      expect(mocks.keyring.createAccount).not.toHaveBeenCalled();
 
       // Verify each account has the correct group index.
       for (const [index, account] of newAccounts.entries()) {
@@ -564,7 +368,6 @@ describe('TrxAccountProvider', () => {
 
       expect(newAccounts).toHaveLength(3);
       expect(mocks.keyring.createAccounts).toHaveBeenCalledTimes(1);
-      expect(mocks.keyring.createAccount).not.toHaveBeenCalled();
     });
 
     it('creates a single account when range from equals to', async () => {
@@ -581,7 +384,6 @@ describe('TrxAccountProvider', () => {
 
       expect(newAccounts).toHaveLength(1);
       expect(mocks.keyring.createAccounts).toHaveBeenCalledTimes(1);
-      expect(mocks.keyring.createAccount).not.toHaveBeenCalled();
       expect(
         isBip44Account(newAccounts[0]) &&
           newAccounts[0].options.entropy.groupIndex,
@@ -675,7 +477,6 @@ describe('TrxAccountProvider', () => {
 
     expect(discovered).toStrictEqual([]);
     expect(mocks.keyring.createAccounts).not.toHaveBeenCalled();
-    expect(mocks.keyring.createAccount).not.toHaveBeenCalled();
   });
 
   it('does not run discovery if disabled', async () => {

--- a/packages/multichain-account-service/src/providers/TrxAccountProvider.ts
+++ b/packages/multichain-account-service/src/providers/TrxAccountProvider.ts
@@ -1,6 +1,5 @@
 import type { Bip44Account } from '@metamask/account-api';
 import type { TraceCallback } from '@metamask/controller-utils';
-import type { EntropySourceId, KeyringAccount } from '@metamask/keyring-api';
 import { TrxAccountType, TrxScope } from '@metamask/keyring-api';
 import { KeyringTypes } from '@metamask/keyring-controller';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
@@ -10,10 +9,7 @@ import type { CaipChainId } from '@metamask/utils';
 import { traceFallback } from '../analytics';
 import type { MultichainAccountServiceMessenger } from '../types';
 import { SnapAccountProvider } from './SnapAccountProvider';
-import type {
-  RestrictedSnapKeyring,
-  SnapAccountProviderConfig,
-} from './SnapAccountProvider';
+import type { SnapAccountProviderConfig } from './SnapAccountProvider';
 
 export type TrxAccountProviderConfig = SnapAccountProviderConfig;
 
@@ -61,25 +57,5 @@ export class TrxAccountProvider extends SnapAccountProvider {
       account.type === TrxAccountType.Eoa &&
       account.metadata.keyring.type === (KeyringTypes.snap as string)
     );
-  }
-
-  protected override createAccountV1(
-    keyring: RestrictedSnapKeyring,
-    {
-      entropySource,
-      groupIndex,
-    }: { entropySource: EntropySourceId; groupIndex: number },
-  ): Promise<KeyringAccount> {
-    if (!keyring.v1) {
-      throw new Error(
-        `Snap "${TrxAccountProvider.TRX_SNAP_ID}" is v2-only and does not support v1 account creation`,
-      );
-    }
-    return keyring.v1.createAccount({
-      entropySource,
-      index: groupIndex,
-      addressType: TrxAccountType.Eoa,
-      scope: TrxScope.Mainnet,
-    });
   }
 }

--- a/packages/multichain-account-service/src/providers/XlmAccountProvider.test.ts
+++ b/packages/multichain-account-service/src/providers/XlmAccountProvider.test.ts
@@ -5,7 +5,6 @@ import type { KeyringCapabilities } from '@metamask/keyring-api/v2';
 import type { KeyringMetadata } from '@metamask/keyring-controller';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 import { SnapControllerState } from '@metamask/snaps-controllers';
-import type { Json } from '@metamask/utils';
 import deepmerge from 'deepmerge';
 
 import {
@@ -20,10 +19,7 @@ import {
 } from '../tests';
 import type { RootMessenger, DeepPartial } from '../tests';
 import { AccountProviderWrapper } from './AccountProviderWrapper';
-import type {
-  RestrictedSnapKeyring,
-  SnapAccountProviderConfig,
-} from './SnapAccountProvider';
+import type { SnapAccountProviderConfig } from './SnapAccountProvider';
 import {
   XLM_ACCOUNT_PROVIDER_DEFAULT_CONFIG,
   XLM_ACCOUNT_PROVIDER_NAME,
@@ -66,34 +62,6 @@ class MockStellarKeyring {
     this.accounts = accounts;
   }
 
-  createAccount = jest
-    .fn()
-    .mockImplementation((options: Record<string, Json>) => {
-      const { index } = options;
-      if (typeof index === 'number') {
-        const found = this.accounts.find(
-          (account) =>
-            isBip44Account(account) &&
-            account.options.entropy.groupIndex === index,
-        );
-
-        if (found) {
-          return found;
-        }
-      }
-
-      const account = MockAccountBuilder.from(MOCK_XLM_ACCOUNT_1)
-        .withUuid()
-        .withAddressSuffix(`${this.accounts.length}`)
-        .withGroupIndex(
-          typeof index === 'number' ? index : this.accounts.length,
-        )
-        .get();
-      this.accounts.push(account);
-
-      return account;
-    });
-
   createAccounts: SnapKeyring['createAccounts'] = jest
     .fn()
     .mockImplementation((options) => {
@@ -126,10 +94,6 @@ class MockStellarKeyring {
   discoverAccounts = jest.fn().mockResolvedValue([]);
 
   deleteAccount = jest.fn().mockResolvedValue(undefined);
-
-  get v1(): Required<RestrictedSnapKeyring['v1']> {
-    return { createAccount: this.createAccount };
-  }
 }
 
 class MockXlmAccountProvider extends XlmAccountProvider {
@@ -155,7 +119,6 @@ function setup({
   mocks: {
     handleRequest: jest.Mock;
     keyring: {
-      createAccount: jest.Mock;
       createAccounts: jest.Mock;
       discoverAccounts: jest.Mock;
     };
@@ -237,7 +200,6 @@ function setup({
     mocks: {
       handleRequest: mockHandleRequest,
       keyring: {
-        createAccount: keyring.createAccount,
         createAccounts: keyring.createAccounts as jest.Mock,
         discoverAccounts: keyring.discoverAccounts,
       },
@@ -323,7 +285,6 @@ describe('XlmAccountProvider', () => {
 
     expect(discovered).toStrictEqual([]);
     expect(mocks.keyring.createAccounts).not.toHaveBeenCalled();
-    expect(mocks.keyring.createAccount).not.toHaveBeenCalled();
   });
 
   it('does not run discovery if disabled', async () => {
@@ -342,42 +303,6 @@ describe('XlmAccountProvider', () => {
         groupIndex: 0,
       }),
     ).toStrictEqual([]);
-  });
-
-  describe('v1', () => {
-    it('uses createAccount when batching is disabled', async () => {
-      const accounts = [MOCK_XLM_ACCOUNT_1];
-      // No capabilities provided → empty capability set, so batching is
-      // disabled and the provider falls back to the v1 flow.
-      const { provider, mocks } = setup({
-        accounts,
-      });
-
-      await provider.createAccounts({
-        type: AccountCreationType.Bip44DeriveIndex,
-        entropySource: MOCK_HD_KEYRING_2.metadata.id,
-        groupIndex: accounts.length,
-      });
-
-      expect(mocks.keyring.createAccount).toHaveBeenCalled();
-      expect(mocks.keyring.createAccounts).not.toHaveBeenCalled();
-    });
-
-    it('throws when the Snap is v2-only and does not support v1 account creation', async () => {
-      const { provider, keyring } = setup({
-        accounts: [],
-        config: asConfig({ createAccounts: { batched: false } }),
-      });
-      jest.spyOn(keyring, 'v1', 'get').mockReturnValue(undefined);
-
-      await expect(
-        provider.createAccounts({
-          type: AccountCreationType.Bip44DeriveIndex,
-          entropySource: MOCK_HD_KEYRING_2.metadata.id,
-          groupIndex: 0,
-        }),
-      ).rejects.toThrow('is v2-only and does not support v1 account creation');
-    });
   });
 
   describe('v2 - batched', () => {
@@ -401,7 +326,6 @@ describe('XlmAccountProvider', () => {
         entropySource: MOCK_HD_KEYRING_2.metadata.id,
         groupIndex: newGroupIndex,
       });
-      expect(mocks.keyring.createAccount).not.toHaveBeenCalled();
     });
 
     it('creates multiple accounts using Bip44DeriveIndexRange', async () => {
@@ -420,7 +344,6 @@ describe('XlmAccountProvider', () => {
 
       expect(newAccounts).toHaveLength(3);
       expect(mocks.keyring.createAccounts).toHaveBeenCalledTimes(1);
-      expect(mocks.keyring.createAccount).not.toHaveBeenCalled();
 
       for (const [index, account] of newAccounts.entries()) {
         expect(isBip44Account(account)).toBe(true);

--- a/packages/multichain-account-service/src/providers/XlmAccountProvider.ts
+++ b/packages/multichain-account-service/src/providers/XlmAccountProvider.ts
@@ -1,6 +1,5 @@
 import type { Bip44Account } from '@metamask/account-api';
 import type { TraceCallback } from '@metamask/controller-utils';
-import type { EntropySourceId, KeyringAccount } from '@metamask/keyring-api';
 import { XlmAccountType, XlmScope } from '@metamask/keyring-api';
 import { KeyringTypes } from '@metamask/keyring-controller';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
@@ -10,10 +9,7 @@ import type { CaipChainId } from '@metamask/utils';
 import { traceFallback } from '../analytics';
 import type { MultichainAccountServiceMessenger } from '../types';
 import { SnapAccountProvider } from './SnapAccountProvider';
-import type {
-  RestrictedSnapKeyring,
-  SnapAccountProviderConfig,
-} from './SnapAccountProvider';
+import type { SnapAccountProviderConfig } from './SnapAccountProvider';
 
 export type XlmAccountProviderConfig = SnapAccountProviderConfig;
 
@@ -61,25 +57,5 @@ export class XlmAccountProvider extends SnapAccountProvider {
       account.type === XlmAccountType.Account &&
       account.metadata.keyring.type === (KeyringTypes.snap as string)
     );
-  }
-
-  protected override createAccountV1(
-    keyring: RestrictedSnapKeyring,
-    {
-      entropySource,
-      groupIndex,
-    }: { entropySource: EntropySourceId; groupIndex: number },
-  ): Promise<KeyringAccount> {
-    if (!keyring.v1) {
-      throw new Error(
-        `Snap "${XlmAccountProvider.XLM_SNAP_ID}" is v2-only and does not support v1 account creation`,
-      );
-    }
-    return keyring.v1.createAccount({
-      entropySource,
-      index: groupIndex,
-      addressType: XlmAccountType.Account,
-      scope: XlmScope.Pubnet,
-    });
   }
 }


### PR DESCRIPTION
## Explanation

All Snaps properly implements `createAccounts` (even if they are not truly v2-compatible yet).

So we can safely remove the old `createAccount` flow for those.

NOTE: The current `SnapKeyring` (v2) knows how to properly call `createAccounts` v1 or v2, see:
- https://github.com/MetaMask/accounts/blob/7ecc4248f8a80a06ca77f43e1f7345da2e478bbb/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts#L326-L334

## References

N/A

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Snap account creation behavior across chains; relies on all BIP-44 Snaps supporting `createAccounts`, though v1 discovery remains a separate path.
> 
> **Overview**
> Snap account providers no longer branch on capabilities to call singular **`createAccount`** (v1) versus batched **`createAccounts`**. **All** derive/discover/range creation now goes through **`SnapKeyringProxy.createAccounts`** under the **`Provider Create Accounts (v2 - batched)`** trace; the v1 create trace and **`RestrictedSnapKeyring` / `createAccountV1`** hooks are removed from **`SnapAccountProvider`** and chain providers (BTC, Solana, Tron, Stellar).
> 
> **`withSnap`** now builds a mutex-wrapped **`SnapKeyringProxy`** instead of exposing optional **`v1.createAccount`**. v1 **discovery** still uses the client’s **`discoverAccounts`**, but persisting discovered accounts uses the same **`createAccounts`** path as explicit creation. Tests and changelog document the removal and the prior v1 side effects (e.g. unwanted auto-selection).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae00c4c29c0947daa3f850b4556067c15cb28cc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->