### PR TITLE
feat: add robinhood in popular networks list

### DIFF
--- a/packages/network-enablement-controller/CHANGELOG.md
+++ b/packages/network-enablement-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added Robinhood Chain (`0x1237`) to `POPULAR_NETWORKS` ([#9461](https://github.com/MetaMask/core/pull/9461))
+
 ### Changed
 
 - Restore Stellar to the Network Enablement Controller enabled network map by reverting the temporary rollback, as the corresponding Extension issue has already been resolved ([#9385](https://github.com/MetaMask/core/pull/9385))

--- a/packages/network-enablement-controller/src/constants.ts
+++ b/packages/network-enablement-controller/src/constants.ts
@@ -16,4 +16,5 @@ export const POPULAR_NETWORKS: readonly Hex[] = [
   '0x8f', // Monad (143)
   '0x10e6', // MegaETH (4326)
   '0x13b2', // Arc (5042)
+  '0x1237', // Robinhood (4663)
 ];


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

/!\ Not sure yet this is needed. Checking before merging.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single hex chain ID added to a constants array; behavior follows existing popular-network patterns with no auth or data-path changes.
> 
> **Overview**
> Adds **Robinhood Chain** (`0x1237`, chain ID 4663) to the `POPULAR_NETWORKS` list in `network-enablement-controller`, matching how other EVM chains (e.g. Arc) are registered.
> 
> That list drives popular-network discovery (`listPopularEvmNetworks` / `listPopularNetworks`) and bulk enablement (`enableAllPopularNetworks` / init paths that turn on configured popular networks). Robinhood is only surfaced or enabled when it also exists in `NetworkController` network configuration.
> 
> The unreleased changelog entry documents the addition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73b04be0f9f22da7ebc37e0cf66b11ae5c34726a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->