### PR TITLE
feat(transaction-controller)!: adopt @metamask/sentinel-api-service for simulation

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** Add required `sentinelApiService` constructor option, an instance of `SentinelApiService` from `@metamask/sentinel-api-service`, used to perform all Sentinel simulation requests ([#0](https://github.com/MetaMask/core/pull/0))
   - Consumers must construct a `SentinelApiService` (with its own `fetch` and messenger) and pass it to the `TransactionController`.
   - Adds a dependency on `@metamask/sentinel-api-service`.
+- Add optional `getSimulationConfig` constructor option and `GetSimulationConfig` type, allowing consumers to rewrite the simulation request URL (for example to route through the MetaMask Shield proxy) ([#0](https://github.com/MetaMask/core/pull/0))
+  - The callback receives the default URL and returns `{ newUrl?: string }`; when `newUrl` is provided it replaces the resolved Sentinel URL for that request, routed through the service's `getUrl` option.
+  - This is a reduced version of the previously-removed option: the old `authorization` return field is dropped, as authentication headers are now handled by `SentinelApiService`.
 - Export `generateEIP7702BatchTransaction` utility for building an ERC-7821 `execute(mode, calls)` batch transaction from a list of nested transactions ([#9298](https://github.com/MetaMask/core/pull/9298))
 
 ### Changed
@@ -21,8 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- **BREAKING:** Remove the `getSimulationConfig` constructor option and the `GetSimulationConfig` type ([#0](https://github.com/MetaMask/core/pull/0))
-  - The simulation request URL override and `Authorization` header hook are no longer honoured by the controller. Configure request behaviour on the injected `SentinelApiService` instead.
+- **BREAKING:** Drop the `authorization` field from the `getSimulationConfig` return value ([#0](https://github.com/MetaMask/core/pull/0))
+  - The `GetSimulationConfig` type now returns only `{ newUrl?: string }`; authentication headers are handled by the injected `SentinelApiService` instead.
 
 ## [68.3.0]
 

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -9,23 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **BREAKING:** Add required `sentinelApiService` constructor option, an instance of `SentinelApiService` from `@metamask/sentinel-api-service`, used to perform all Sentinel simulation requests ([#0](https://github.com/MetaMask/core/pull/0))
-  - Consumers must construct a `SentinelApiService` (with its own `fetch` and messenger) and pass it to the `TransactionController`.
-  - Adds a dependency on `@metamask/sentinel-api-service`.
-- Add optional `getSimulationConfig` constructor option and `GetSimulationConfig` type, allowing consumers to rewrite the simulation request URL (for example to route through the MetaMask Shield proxy) ([#0](https://github.com/MetaMask/core/pull/0))
-  - The callback receives the default URL and returns `{ newUrl?: string }`; when `newUrl` is provided it replaces the resolved Sentinel URL for that request, routed through the service's `getUrl` option.
-  - This is a reduced version of the previously-removed option: the old `authorization` return field is dropped, as authentication headers are now handled by `SentinelApiService`.
 - Export `generateEIP7702BatchTransaction` utility for building an ERC-7821 `execute(mode, calls)` batch transaction from a list of nested transactions ([#9298](https://github.com/MetaMask/core/pull/9298))
 
 ### Changed
 
-- Delegate all Sentinel simulation requests (`infura_simulateTransactions`), the supported-network registry (`/networks`) lookup, and subdomain URL resolution to the shared `@metamask/sentinel-api-service` data service ([#0](https://github.com/MetaMask/core/pull/0))
-  - Removes the controller's own simulation client, `/networks` client, and per-request refetch of the registry (the service caches it).
-
-### Removed
-
-- **BREAKING:** Drop the `authorization` field from the `getSimulationConfig` return value ([#0](https://github.com/MetaMask/core/pull/0))
-  - The `GetSimulationConfig` type now returns only `{ newUrl?: string }`; authentication headers are handled by the injected `SentinelApiService` instead.
+- **BREAKING:** Delegate all Sentinel simulation requests to the shared `@metamask/sentinel-api-service` data service via the new `SentinelApiService:simulateTransactions` messenger action ([#9476](https://github.com/MetaMask/core/pull/9476))
+  - Consumers must construct a `SentinelApiService` and expose the `SentinelApiService:simulateTransactions` action on the `TransactionController` messenger. The optional `getSimulationConfig` constructor option now returns `{ newUrl?: string }` only (the old `authorization` field is dropped, as authentication headers are handled by the service).
 
 ## [68.3.0]
 

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -9,14 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **BREAKING:** Add required `sentinelApiService` constructor option, an instance of `SentinelApiService` from `@metamask/sentinel-api-service`, used to perform all Sentinel simulation requests ([#0](https://github.com/MetaMask/core/pull/0))
+  - Consumers must construct a `SentinelApiService` (with its own `fetch` and messenger) and pass it to the `TransactionController`.
+  - Adds a dependency on `@metamask/sentinel-api-service`.
 - Export `generateEIP7702BatchTransaction` utility for building an ERC-7821 `execute(mode, calls)` batch transaction from a list of nested transactions ([#9298](https://github.com/MetaMask/core/pull/9298))
 
 ### Changed
 
-- Delegate the Sentinel simulation supported-network registry (`/networks`) lookup and subdomain URL resolution to the shared `@metamask/sentinel-api-service` data service ([#0](https://github.com/MetaMask/core/pull/0))
-  - Removes the controller's duplicate `/networks` client and its per-request refetch of the registry (the service caches it).
-  - Behaviour is preserved: the controller still performs the `infura_simulateTransactions` request itself to honour the `getSimulationConfig` URL override and `Authorization` header hook.
-  - Adds a dependency on `@metamask/sentinel-api-service`.
+- Delegate all Sentinel simulation requests (`infura_simulateTransactions`), the supported-network registry (`/networks`) lookup, and subdomain URL resolution to the shared `@metamask/sentinel-api-service` data service ([#0](https://github.com/MetaMask/core/pull/0))
+  - Removes the controller's own simulation client, `/networks` client, and per-request refetch of the registry (the service caches it).
+
+### Removed
+
+- **BREAKING:** Remove the `getSimulationConfig` constructor option and the `GetSimulationConfig` type ([#0](https://github.com/MetaMask/core/pull/0))
+  - The simulation request URL override and `Authorization` header hook are no longer honoured by the controller. Configure request behaviour on the injected `SentinelApiService` instead.
 
 ## [68.3.0]
 

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Export `generateEIP7702BatchTransaction` utility for building an ERC-7821 `execute(mode, calls)` batch transaction from a list of nested transactions ([#9298](https://github.com/MetaMask/core/pull/9298))
 
+### Changed
+
+- Delegate the Sentinel simulation supported-network registry (`/networks`) lookup and subdomain URL resolution to the shared `@metamask/sentinel-api-service` data service ([#0](https://github.com/MetaMask/core/pull/0))
+  - Removes the controller's duplicate `/networks` client and its per-request refetch of the registry (the service caches it).
+  - Behaviour is preserved: the controller still performs the `infura_simulateTransactions` request itself to honour the `getSimulationConfig` URL override and `Authorization` header hook.
+  - Adds a dependency on `@metamask/sentinel-api-service`.
+
 ## [68.3.0]
 
 ### Added

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -72,6 +72,7 @@
     "@metamask/nonce-tracker": "^6.0.0",
     "@metamask/remote-feature-flag-controller": "^4.2.2",
     "@metamask/rpc-errors": "^7.0.2",
+    "@metamask/sentinel-api-service": "^0.0.0",
     "@metamask/utils": "^11.11.0",
     "async-mutex": "^0.5.0",
     "bignumber.js": "^9.1.2",

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -1408,6 +1408,7 @@ describe('TransactionController', () => {
       expect(estimateGasMock).toHaveBeenCalledTimes(1);
       expect(estimateGasMock).toHaveBeenCalledWith({
         isSimulationEnabled: true,
+        getSimulationConfig: expect.any(Function),
         sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         messenger: expect.anything(),
         networkClientId: NETWORK_CLIENT_ID_MOCK,
@@ -1423,6 +1424,33 @@ describe('TransactionController', () => {
 
       expect(gas).toBe(expectedEstimatedGas);
       expect(simulationFails).toBe(simulationFailsMock);
+    });
+
+    it('threads the getSimulationConfig constructor option to estimateGas', async () => {
+      const getSimulationConfig = jest.fn().mockResolvedValue({});
+
+      const { controller } = setupController({
+        options: { getSimulationConfig },
+      });
+
+      estimateGasMock.mockResolvedValue({
+        estimatedGas: '0x123',
+        blockGasLimit: '0x1234',
+        simulationFails: undefined,
+        isUpgradeWithData: false,
+      });
+
+      addGasBufferMock.mockReturnValue('0x12345');
+
+      await controller.estimateGasBuffered(
+        { from: ACCOUNT_MOCK, to: ACCOUNT_MOCK },
+        1,
+        NETWORK_CLIENT_ID_MOCK,
+      );
+
+      expect(estimateGasMock).toHaveBeenCalledWith(
+        expect.objectContaining({ getSimulationConfig }),
+      );
     });
   });
 
@@ -1999,6 +2027,7 @@ describe('TransactionController', () => {
       expect(updateGasMock).toHaveBeenCalledWith({
         isCustomNetwork: false,
         isSimulationEnabled: true,
+        getSimulationConfig: expect.any(Function),
         sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         messenger: expect.any(Object),
         txMeta: expect.any(Object),
@@ -2276,6 +2305,7 @@ describe('TransactionController', () => {
         expect(getBalanceChangesMock).toHaveBeenCalledWith({
           blockTime: undefined,
           chainId: MOCK_NETWORK.chainId,
+          getSimulationConfig: expect.any(Function),
           sentinelApiService: SENTINEL_API_SERVICE_MOCK,
           messenger: expect.any(Object),
           nestedTransactions: undefined,
@@ -7472,6 +7502,7 @@ describe('TransactionController', () => {
       expect(getBalanceChangesMock).toHaveBeenCalledWith({
         blockTime: 123,
         chainId: ChainId.sepolia,
+        getSimulationConfig: expect.any(Function),
         sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         messenger: expect.any(Object),
         nestedTransactions: undefined,
@@ -7514,6 +7545,7 @@ describe('TransactionController', () => {
       expect(getBalanceChangesMock).toHaveBeenCalledWith({
         blockTime: 123,
         chainId: ChainId.sepolia,
+        getSimulationConfig: expect.any(Function),
         sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         messenger: expect.any(Object),
         nestedTransactions: undefined,
@@ -8463,6 +8495,7 @@ describe('TransactionController', () => {
         expect(estimateGasBatchMock).toHaveBeenCalledTimes(1);
         expect(estimateGasBatchMock).toHaveBeenCalledWith({
           from: ACCOUNT_MOCK,
+          getSimulationConfig: expect.any(Function),
           sentinelApiService: SENTINEL_API_SERVICE_MOCK,
           isAtomicBatchSupported: expect.any(Function),
           messenger: expect.anything(),

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -18,7 +18,6 @@ import {
 import type { InternalProvider } from '@metamask/eth-json-rpc-provider';
 import HttpProvider from '@metamask/ethjs-provider-http';
 import { Messenger, MOCK_ANY_NAMESPACE } from '@metamask/messenger';
-import type { SentinelApiService } from '@metamask/sentinel-api-service';
 import type {
   MockAnyNamespace,
   MessengerActions,
@@ -331,7 +330,6 @@ const ACCOUNT_2_MOCK = '0x08f137f335ea1b8f193b8f6ea92561a60d23a211';
 const NONCE_MOCK = 12;
 const ACTION_ID_MOCK = '123456';
 const CHAIN_ID_MOCK = MOCK_NETWORK.chainId;
-const SENTINEL_API_SERVICE_MOCK = {} as unknown as SentinelApiService;
 const NETWORK_CLIENT_ID_MOCK = 'networkClientIdMock';
 const BATCH_ID_MOCK = '0xabcd12';
 const ERROR_MESSAGE_MOCK = 'Test Error';
@@ -603,7 +601,6 @@ describe('TransactionController', () => {
       hooks: {},
       isEIP7702GasFeeTokensEnabled: isEIP7702GasFeeTokensEnabledMock,
       publicKeyEIP7702: '0x1234',
-      sentinelApiService: SENTINEL_API_SERVICE_MOCK,
       ...givenOptions,
     };
 
@@ -627,6 +624,7 @@ describe('TransactionController', () => {
         'NetworkController:getNetworkClientRegistry',
         'NetworkController:getState',
         'RemoteFeatureFlagController:getState',
+      'SentinelApiService:simulateTransactions',
       ],
     });
 
@@ -1409,7 +1407,6 @@ describe('TransactionController', () => {
       expect(estimateGasMock).toHaveBeenCalledWith({
         isSimulationEnabled: true,
         getSimulationConfig: expect.any(Function),
-        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         messenger: expect.anything(),
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         txParams: transactionParamsMock,
@@ -2028,7 +2025,6 @@ describe('TransactionController', () => {
         isCustomNetwork: false,
         isSimulationEnabled: true,
         getSimulationConfig: expect.any(Function),
-        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         messenger: expect.any(Object),
         txMeta: expect.any(Object),
       });
@@ -2306,7 +2302,6 @@ describe('TransactionController', () => {
           blockTime: undefined,
           chainId: MOCK_NETWORK.chainId,
           getSimulationConfig: expect.any(Function),
-          sentinelApiService: SENTINEL_API_SERVICE_MOCK,
           messenger: expect.any(Object),
           nestedTransactions: undefined,
           networkClientId: NETWORK_CLIENT_ID_MOCK,
@@ -2370,7 +2365,6 @@ describe('TransactionController', () => {
         expect(getBalanceChangesMock).toHaveBeenCalledTimes(1);
         expect(getBalanceChangesMock).toHaveBeenCalledWith(
           expect.objectContaining({
-            sentinelApiService: SENTINEL_API_SERVICE_MOCK,
           }),
         );
 
@@ -2477,7 +2471,6 @@ describe('TransactionController', () => {
         expect(getGasFeeTokensMock).toHaveBeenCalledTimes(1);
         expect(getGasFeeTokensMock).toHaveBeenCalledWith(
           expect.objectContaining({
-            sentinelApiService: SENTINEL_API_SERVICE_MOCK,
           }),
         );
 
@@ -7503,7 +7496,6 @@ describe('TransactionController', () => {
         blockTime: 123,
         chainId: ChainId.sepolia,
         getSimulationConfig: expect.any(Function),
-        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         messenger: expect.any(Object),
         nestedTransactions: undefined,
         networkClientId: InfuraNetworkType.sepolia,
@@ -7546,7 +7538,6 @@ describe('TransactionController', () => {
         blockTime: 123,
         chainId: ChainId.sepolia,
         getSimulationConfig: expect.any(Function),
-        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         messenger: expect.any(Object),
         nestedTransactions: undefined,
         networkClientId: InfuraNetworkType.sepolia,
@@ -8496,7 +8487,6 @@ describe('TransactionController', () => {
         expect(estimateGasBatchMock).toHaveBeenCalledWith({
           from: ACCOUNT_MOCK,
           getSimulationConfig: expect.any(Function),
-          sentinelApiService: SENTINEL_API_SERVICE_MOCK,
           isAtomicBatchSupported: expect.any(Function),
           messenger: expect.anything(),
           networkClientId: InfuraNetworkType.sepolia,

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -18,6 +18,7 @@ import {
 import type { InternalProvider } from '@metamask/eth-json-rpc-provider';
 import HttpProvider from '@metamask/ethjs-provider-http';
 import { Messenger, MOCK_ANY_NAMESPACE } from '@metamask/messenger';
+import type { SentinelApiService } from '@metamask/sentinel-api-service';
 import type {
   MockAnyNamespace,
   MessengerActions,
@@ -83,7 +84,6 @@ import type {
   GasFeeToken,
   GasFeeEstimates,
   SimulationData,
-  GetSimulationConfig,
 } from './types';
 import {
   GasFeeEstimateLevel,
@@ -331,6 +331,7 @@ const ACCOUNT_2_MOCK = '0x08f137f335ea1b8f193b8f6ea92561a60d23a211';
 const NONCE_MOCK = 12;
 const ACTION_ID_MOCK = '123456';
 const CHAIN_ID_MOCK = MOCK_NETWORK.chainId;
+const SENTINEL_API_SERVICE_MOCK = {} as unknown as SentinelApiService;
 const NETWORK_CLIENT_ID_MOCK = 'networkClientIdMock';
 const BATCH_ID_MOCK = '0xabcd12';
 const ERROR_MESSAGE_MOCK = 'Test Error';
@@ -602,6 +603,7 @@ describe('TransactionController', () => {
       hooks: {},
       isEIP7702GasFeeTokensEnabled: isEIP7702GasFeeTokensEnabledMock,
       publicKeyEIP7702: '0x1234',
+      sentinelApiService: SENTINEL_API_SERVICE_MOCK,
       ...givenOptions,
     };
 
@@ -1406,7 +1408,7 @@ describe('TransactionController', () => {
       expect(estimateGasMock).toHaveBeenCalledTimes(1);
       expect(estimateGasMock).toHaveBeenCalledWith({
         isSimulationEnabled: true,
-        getSimulationConfig: expect.any(Function),
+        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         messenger: expect.anything(),
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         txParams: transactionParamsMock,
@@ -1997,7 +1999,7 @@ describe('TransactionController', () => {
       expect(updateGasMock).toHaveBeenCalledWith({
         isCustomNetwork: false,
         isSimulationEnabled: true,
-        getSimulationConfig: expect.any(Function),
+        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         messenger: expect.any(Object),
         txMeta: expect.any(Object),
       });
@@ -2252,11 +2254,8 @@ describe('TransactionController', () => {
 
     describe('updates simulation data', () => {
       it('by default', async () => {
-        getBalanceChangesMock.mockImplementationOnce(async (request) => {
-          await request.getSimulationConfig('https://testurl.com');
-          return {
-            simulationData: SIMULATION_DATA_RESULT_MOCK,
-          };
+        getBalanceChangesMock.mockResolvedValueOnce({
+          simulationData: SIMULATION_DATA_RESULT_MOCK,
         });
 
         const { controller } = setupController();
@@ -2277,7 +2276,7 @@ describe('TransactionController', () => {
         expect(getBalanceChangesMock).toHaveBeenCalledWith({
           blockTime: undefined,
           chainId: MOCK_NETWORK.chainId,
-          getSimulationConfig: expect.any(Function),
+          sentinelApiService: SENTINEL_API_SERVICE_MOCK,
           messenger: expect.any(Object),
           nestedTransactions: undefined,
           networkClientId: NETWORK_CLIENT_ID_MOCK,
@@ -2319,23 +2318,12 @@ describe('TransactionController', () => {
         expect(controller.state.transactions[0].gasUsed).toBe(testGasUsed);
       });
 
-      it('with getSimulationConfig', async () => {
-        getBalanceChangesMock.mockImplementationOnce(async (request) => {
-          await request.getSimulationConfig('https://testurl.com');
-          return {
-            simulationData: SIMULATION_DATA_RESULT_MOCK,
-          };
+      it('forwards the Sentinel API service', async () => {
+        getBalanceChangesMock.mockResolvedValueOnce({
+          simulationData: SIMULATION_DATA_RESULT_MOCK,
         });
 
-        const getSimulationConfigMock: GetSimulationConfig = jest
-          .fn()
-          .mockResolvedValue({});
-
-        const { controller } = setupController({
-          options: {
-            getSimulationConfig: getSimulationConfigMock,
-          },
-        });
+        const { controller } = setupController();
 
         await controller.addTransaction(
           {
@@ -2352,21 +2340,8 @@ describe('TransactionController', () => {
         expect(getBalanceChangesMock).toHaveBeenCalledTimes(1);
         expect(getBalanceChangesMock).toHaveBeenCalledWith(
           expect.objectContaining({
-            getSimulationConfig: expect.any(Function),
+            sentinelApiService: SENTINEL_API_SERVICE_MOCK,
           }),
-        );
-
-        expect(getSimulationConfigMock).toHaveBeenCalledTimes(1);
-        expect(getSimulationConfigMock).toHaveBeenCalledWith(
-          'https://testurl.com',
-          {
-            txMeta: expect.objectContaining({
-              txParams: expect.objectContaining({
-                from: ACCOUNT_MOCK,
-                to: ACCOUNT_MOCK,
-              }),
-            }),
-          },
         );
 
         expect(controller.state.transactions[0].simulationData).toStrictEqual(
@@ -2449,21 +2424,13 @@ describe('TransactionController', () => {
         ]);
       });
 
-      it('with getSimulationConfig', async () => {
+      it('forwards the Sentinel API service', async () => {
         getGasFeeTokensMock.mockResolvedValueOnce({
           gasFeeTokens: [GAS_FEE_TOKEN_MOCK],
           isGasFeeSponsored: false,
         });
 
-        const getSimulationConfigMock: GetSimulationConfig = jest
-          .fn()
-          .mockResolvedValue({});
-
-        const { controller } = setupController({
-          options: {
-            getSimulationConfig: getSimulationConfigMock,
-          },
-        });
+        const { controller } = setupController();
 
         await controller.addTransaction(
           {
@@ -2480,7 +2447,7 @@ describe('TransactionController', () => {
         expect(getGasFeeTokensMock).toHaveBeenCalledTimes(1);
         expect(getGasFeeTokensMock).toHaveBeenCalledWith(
           expect.objectContaining({
-            getSimulationConfig: getSimulationConfigMock,
+            sentinelApiService: SENTINEL_API_SERVICE_MOCK,
           }),
         );
 
@@ -7505,7 +7472,7 @@ describe('TransactionController', () => {
       expect(getBalanceChangesMock).toHaveBeenCalledWith({
         blockTime: 123,
         chainId: ChainId.sepolia,
-        getSimulationConfig: expect.any(Function),
+        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         messenger: expect.any(Object),
         nestedTransactions: undefined,
         networkClientId: InfuraNetworkType.sepolia,
@@ -7547,7 +7514,7 @@ describe('TransactionController', () => {
       expect(getBalanceChangesMock).toHaveBeenCalledWith({
         blockTime: 123,
         chainId: ChainId.sepolia,
-        getSimulationConfig: expect.any(Function),
+        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         messenger: expect.any(Object),
         nestedTransactions: undefined,
         networkClientId: InfuraNetworkType.sepolia,
@@ -8496,7 +8463,7 @@ describe('TransactionController', () => {
         expect(estimateGasBatchMock).toHaveBeenCalledTimes(1);
         expect(estimateGasBatchMock).toHaveBeenCalledWith({
           from: ACCOUNT_MOCK,
-          getSimulationConfig: expect.any(Function),
+          sentinelApiService: SENTINEL_API_SERVICE_MOCK,
           isAtomicBatchSupported: expect.any(Function),
           messenger: expect.anything(),
           networkClientId: InfuraNetworkType.sepolia,

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -58,6 +58,7 @@ import {
   providerErrors,
   JsonRpcError,
 } from '@metamask/rpc-errors';
+import type { SentinelApiService } from '@metamask/sentinel-api-service';
 import type { Hex, Json } from '@metamask/utils';
 import { add0x } from '@metamask/utils';
 // This package purposefully relies on Node's EventEmitter module.
@@ -120,7 +121,6 @@ import type {
   GasFeeEstimateLevel as GasFeeEstimateLevelType,
   TransactionBatchMeta,
   BeforeSignHook,
-  GetSimulationConfig,
   AddTransactionOptions,
   PublishHookResult,
   GetGasFeeTokensRequest,
@@ -325,11 +325,6 @@ export type TransactionControllerOptions = {
   getSavedGasFees?: (chainId: Hex) => SavedGasFees | undefined;
 
   /**
-   * Gets the transaction simulation configuration.
-   */
-  getSimulationConfig?: GetSimulationConfig;
-
-  /**
    * Callback to determine whether gas fee updates should be enabled for a given transaction.
    * Returns true to enable updates, false to disable them.
    */
@@ -356,6 +351,9 @@ export type TransactionControllerOptions = {
 
   /** Public key used to validate EIP-7702 contract signatures in feature flags. */
   publicKeyEIP7702?: Hex;
+
+  /** The Sentinel API service used to simulate transactions. */
+  sentinelApiService: SentinelApiService;
 
   /** Initial state to set on this controller. */
   state?: Partial<TransactionControllerState>;
@@ -702,8 +700,6 @@ export class TransactionController extends BaseController<
 
   readonly #getSavedGasFees: (chainId: Hex) => SavedGasFees | undefined;
 
-  readonly #getSimulationConfig: GetSimulationConfig;
-
   readonly #internalEvents = new EventEmitter();
 
   readonly #isAutomaticGasFeeUpdateEnabled: (
@@ -737,6 +733,8 @@ export class TransactionController extends BaseController<
 
   readonly #publishBatchHook?: PublishBatchHook;
 
+  readonly #sentinelApiService: SentinelApiService;
+
   readonly #signAbortCallbacks: Map<string, () => void> = new Map();
 
   readonly #skipSimulationTransactionIds: Set<string> = new Set();
@@ -755,7 +753,6 @@ export class TransactionController extends BaseController<
       disableSwaps,
       getPermittedAccounts,
       getSavedGasFees,
-      getSimulationConfig,
       hooks,
       isAutomaticGasFeeUpdateEnabled,
       isEIP7702GasFeeTokensEnabled,
@@ -764,6 +761,7 @@ export class TransactionController extends BaseController<
       isTimeoutEnabled,
       messenger,
       publicKeyEIP7702,
+      sentinelApiService,
       state,
       testGasFeeFlows,
       trace,
@@ -795,9 +793,7 @@ export class TransactionController extends BaseController<
     this.#getPermittedAccounts = getPermittedAccounts;
     this.#getSavedGasFees =
       getSavedGasFees ?? ((_chainId): SavedGasFees | undefined => undefined);
-    this.#getSimulationConfig =
-      getSimulationConfig ??
-      ((): ReturnType<GetSimulationConfig> => Promise.resolve({}));
+    this.#sentinelApiService = sentinelApiService;
     this.#isAutomaticGasFeeUpdateEnabled =
       isAutomaticGasFeeUpdateEnabled ??
       ((_txMeta: TransactionMeta): boolean => false);
@@ -962,7 +958,6 @@ export class TransactionController extends BaseController<
       getGasFeeEstimates: (options) =>
         this.messenger.call('GasFeeController:fetchGasFeeEstimates', options),
       getInternalAccounts: this.#getInternalAccounts.bind(this),
-      getSimulationConfig: this.#getSimulationConfig.bind(this),
       getPendingTransactionTracker: (networkClientId: NetworkClientId) =>
         this.#createPendingTransactionTracker({
           blockTracker,
@@ -977,6 +972,7 @@ export class TransactionController extends BaseController<
       publishTransaction: (transactionMeta: TransactionMeta) =>
         this.#publishTransaction(transactionMeta) as Promise<Hex>,
       request,
+      sentinelApiService: this.#sentinelApiService,
       signTransaction: this.#signTransaction.bind(this),
       update: this.update.bind(this),
       updateTransaction: this.#updateTransactionInternal.bind(this),
@@ -1486,9 +1482,9 @@ export class TransactionController extends BaseController<
     const { estimatedGas, simulationFails } = await estimateGas({
       ignoreDelegationSignatures,
       isSimulationEnabled: this.#isSimulationEnabled(),
-      getSimulationConfig: this.#getSimulationConfig,
       messenger: this.messenger,
       networkClientId,
+      sentinelApiService: this.#sentinelApiService,
       txParams: transaction,
     });
 
@@ -1515,13 +1511,13 @@ export class TransactionController extends BaseController<
   }): Promise<EstimateGasBatchResult> {
     return estimateGasBatch({
       from,
-      getSimulationConfig: this.#getSimulationConfig,
       isAtomicBatchSupported: this.isAtomicBatchSupported.bind(this),
       messenger: this.messenger,
       networkClientId: getNetworkClientId({
         messenger: this.messenger,
         chainId,
       }),
+      sentinelApiService: this.#sentinelApiService,
       transactions,
     });
   }
@@ -1544,9 +1540,9 @@ export class TransactionController extends BaseController<
   }> {
     const { blockGasLimit, estimatedGas, simulationFails } = await estimateGas({
       isSimulationEnabled: this.#isSimulationEnabled(),
-      getSimulationConfig: this.#getSimulationConfig,
       messenger: this.messenger,
       networkClientId,
+      sentinelApiService: this.#sentinelApiService,
       txParams: transaction,
     });
 
@@ -4033,13 +4029,8 @@ export class TransactionController extends BaseController<
             chainId,
             messenger: this.messenger,
             networkClientId,
-            getSimulationConfig: (url, opts) => {
-              return this.#getSimulationConfig(url, {
-                txMeta: transactionMeta,
-                ...opts,
-              });
-            },
             nestedTransactions,
+            sentinelApiService: this.#sentinelApiService,
             txParams,
           }),
       );
@@ -4221,8 +4212,8 @@ export class TransactionController extends BaseController<
     await updateGas({
       isCustomNetwork,
       isSimulationEnabled: this.#isSimulationEnabled(),
-      getSimulationConfig: this.#getSimulationConfig,
       messenger: this.messenger,
+      sentinelApiService: this.#sentinelApiService,
       txMeta: transactionMeta,
     });
   }
@@ -4382,10 +4373,10 @@ export class TransactionController extends BaseController<
 
     return await getGasFeeTokens({
       chainId,
-      getSimulationConfig: this.#getSimulationConfig,
       isEIP7702GasFeeTokensEnabled: this.#isEIP7702GasFeeTokensEnabled,
       messenger: this.messenger,
       publicKeyEIP7702: this.#publicKeyEIP7702,
+      sentinelApiService: this.#sentinelApiService,
       transactionMeta: transaction,
     });
   }

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -58,7 +58,7 @@ import {
   providerErrors,
   JsonRpcError,
 } from '@metamask/rpc-errors';
-import type { SentinelApiService } from '@metamask/sentinel-api-service';
+import type { SentinelApiServiceSimulateTransactionsAction } from '@metamask/sentinel-api-service';
 import type { Hex, Json } from '@metamask/utils';
 import { add0x } from '@metamask/utils';
 // This package purposefully relies on Node's EventEmitter module.
@@ -360,9 +360,6 @@ export type TransactionControllerOptions = {
   /** Public key used to validate EIP-7702 contract signatures in feature flags. */
   publicKeyEIP7702?: Hex;
 
-  /** The Sentinel API service used to simulate transactions. */
-  sentinelApiService: SentinelApiService;
-
   /** Initial state to set on this controller. */
   state?: Partial<TransactionControllerState>;
 
@@ -422,7 +419,8 @@ export type AllowedActions =
   | NetworkControllerGetNetworkClientByIdAction
   | NetworkControllerGetNetworkClientRegistryAction
   | NetworkControllerGetStateAction
-  | RemoteFeatureFlagControllerGetStateAction;
+  | RemoteFeatureFlagControllerGetStateAction
+  | SentinelApiServiceSimulateTransactionsAction;
 
 /**
  * The external events available to the {@link TransactionController}.
@@ -743,8 +741,6 @@ export class TransactionController extends BaseController<
 
   readonly #publishBatchHook?: PublishBatchHook;
 
-  readonly #sentinelApiService: SentinelApiService;
-
   readonly #signAbortCallbacks: Map<string, () => void> = new Map();
 
   readonly #skipSimulationTransactionIds: Set<string> = new Set();
@@ -772,7 +768,6 @@ export class TransactionController extends BaseController<
       isTimeoutEnabled,
       messenger,
       publicKeyEIP7702,
-      sentinelApiService,
       state,
       testGasFeeFlows,
       trace,
@@ -807,7 +802,6 @@ export class TransactionController extends BaseController<
     this.#getSimulationConfig =
       getSimulationConfig ??
       ((): ReturnType<GetSimulationConfig> => Promise.resolve({}));
-    this.#sentinelApiService = sentinelApiService;
     this.#isAutomaticGasFeeUpdateEnabled =
       isAutomaticGasFeeUpdateEnabled ??
       ((_txMeta: TransactionMeta): boolean => false);
@@ -987,7 +981,6 @@ export class TransactionController extends BaseController<
       publishTransaction: (transactionMeta: TransactionMeta) =>
         this.#publishTransaction(transactionMeta) as Promise<Hex>,
       request,
-      sentinelApiService: this.#sentinelApiService,
       signTransaction: this.#signTransaction.bind(this),
       update: this.update.bind(this),
       updateTransaction: this.#updateTransactionInternal.bind(this),
@@ -1500,7 +1493,6 @@ export class TransactionController extends BaseController<
       getSimulationConfig: this.#getSimulationConfig,
       messenger: this.messenger,
       networkClientId,
-      sentinelApiService: this.#sentinelApiService,
       txParams: transaction,
     });
 
@@ -1534,7 +1526,6 @@ export class TransactionController extends BaseController<
         messenger: this.messenger,
         chainId,
       }),
-      sentinelApiService: this.#sentinelApiService,
       transactions,
     });
   }
@@ -1560,7 +1551,6 @@ export class TransactionController extends BaseController<
       getSimulationConfig: this.#getSimulationConfig,
       messenger: this.messenger,
       networkClientId,
-      sentinelApiService: this.#sentinelApiService,
       txParams: transaction,
     });
 
@@ -4054,7 +4044,6 @@ export class TransactionController extends BaseController<
             messenger: this.messenger,
             networkClientId,
             nestedTransactions,
-            sentinelApiService: this.#sentinelApiService,
             txParams,
           }),
       );
@@ -4238,7 +4227,6 @@ export class TransactionController extends BaseController<
       isSimulationEnabled: this.#isSimulationEnabled(),
       getSimulationConfig: this.#getSimulationConfig,
       messenger: this.messenger,
-      sentinelApiService: this.#sentinelApiService,
       txMeta: transactionMeta,
     });
   }
@@ -4402,7 +4390,6 @@ export class TransactionController extends BaseController<
       isEIP7702GasFeeTokensEnabled: this.#isEIP7702GasFeeTokensEnabled,
       messenger: this.messenger,
       publicKeyEIP7702: this.#publicKeyEIP7702,
-      sentinelApiService: this.#sentinelApiService,
       transactionMeta: transaction,
     });
   }

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -121,6 +121,7 @@ import type {
   GasFeeEstimateLevel as GasFeeEstimateLevelType,
   TransactionBatchMeta,
   BeforeSignHook,
+  GetSimulationConfig,
   AddTransactionOptions,
   PublishHookResult,
   GetGasFeeTokensRequest,
@@ -323,6 +324,13 @@ export type TransactionControllerOptions = {
 
   /** Gets the saved gas fee config. */
   getSavedGasFees?: (chainId: Hex) => SavedGasFees | undefined;
+
+  /**
+   * Gets the transaction simulation configuration, allowing the simulation
+   * request URL to be rewritten (for example to route through the MetaMask
+   * Shield proxy).
+   */
+  getSimulationConfig?: GetSimulationConfig;
 
   /**
    * Callback to determine whether gas fee updates should be enabled for a given transaction.
@@ -700,6 +708,8 @@ export class TransactionController extends BaseController<
 
   readonly #getSavedGasFees: (chainId: Hex) => SavedGasFees | undefined;
 
+  readonly #getSimulationConfig: GetSimulationConfig;
+
   readonly #internalEvents = new EventEmitter();
 
   readonly #isAutomaticGasFeeUpdateEnabled: (
@@ -753,6 +763,7 @@ export class TransactionController extends BaseController<
       disableSwaps,
       getPermittedAccounts,
       getSavedGasFees,
+      getSimulationConfig,
       hooks,
       isAutomaticGasFeeUpdateEnabled,
       isEIP7702GasFeeTokensEnabled,
@@ -793,6 +804,9 @@ export class TransactionController extends BaseController<
     this.#getPermittedAccounts = getPermittedAccounts;
     this.#getSavedGasFees =
       getSavedGasFees ?? ((_chainId): SavedGasFees | undefined => undefined);
+    this.#getSimulationConfig =
+      getSimulationConfig ??
+      ((): ReturnType<GetSimulationConfig> => Promise.resolve({}));
     this.#sentinelApiService = sentinelApiService;
     this.#isAutomaticGasFeeUpdateEnabled =
       isAutomaticGasFeeUpdateEnabled ??
@@ -958,6 +972,7 @@ export class TransactionController extends BaseController<
       getGasFeeEstimates: (options) =>
         this.messenger.call('GasFeeController:fetchGasFeeEstimates', options),
       getInternalAccounts: this.#getInternalAccounts.bind(this),
+      getSimulationConfig: this.#getSimulationConfig.bind(this),
       getPendingTransactionTracker: (networkClientId: NetworkClientId) =>
         this.#createPendingTransactionTracker({
           blockTracker,
@@ -1482,6 +1497,7 @@ export class TransactionController extends BaseController<
     const { estimatedGas, simulationFails } = await estimateGas({
       ignoreDelegationSignatures,
       isSimulationEnabled: this.#isSimulationEnabled(),
+      getSimulationConfig: this.#getSimulationConfig,
       messenger: this.messenger,
       networkClientId,
       sentinelApiService: this.#sentinelApiService,
@@ -1511,6 +1527,7 @@ export class TransactionController extends BaseController<
   }): Promise<EstimateGasBatchResult> {
     return estimateGasBatch({
       from,
+      getSimulationConfig: this.#getSimulationConfig,
       isAtomicBatchSupported: this.isAtomicBatchSupported.bind(this),
       messenger: this.messenger,
       networkClientId: getNetworkClientId({
@@ -1540,6 +1557,7 @@ export class TransactionController extends BaseController<
   }> {
     const { blockGasLimit, estimatedGas, simulationFails } = await estimateGas({
       isSimulationEnabled: this.#isSimulationEnabled(),
+      getSimulationConfig: this.#getSimulationConfig,
       messenger: this.messenger,
       networkClientId,
       sentinelApiService: this.#sentinelApiService,
@@ -4027,6 +4045,12 @@ export class TransactionController extends BaseController<
           getBalanceChanges({
             blockTime,
             chainId,
+            getSimulationConfig: (url, opts) => {
+              return this.#getSimulationConfig(url, {
+                txMeta: transactionMeta,
+                ...opts,
+              });
+            },
             messenger: this.messenger,
             networkClientId,
             nestedTransactions,
@@ -4212,6 +4236,7 @@ export class TransactionController extends BaseController<
     await updateGas({
       isCustomNetwork,
       isSimulationEnabled: this.#isSimulationEnabled(),
+      getSimulationConfig: this.#getSimulationConfig,
       messenger: this.messenger,
       sentinelApiService: this.#sentinelApiService,
       txMeta: transactionMeta,
@@ -4373,6 +4398,7 @@ export class TransactionController extends BaseController<
 
     return await getGasFeeTokens({
       chainId,
+      getSimulationConfig: this.#getSimulationConfig,
       isEIP7702GasFeeTokensEnabled: this.#isEIP7702GasFeeTokensEnabled,
       messenger: this.messenger,
       publicKeyEIP7702: this.#publicKeyEIP7702,

--- a/packages/transaction-controller/src/api/simulation-api.test.ts
+++ b/packages/transaction-controller/src/api/simulation-api.test.ts
@@ -104,7 +104,91 @@ describe('Simulation API Utils', () => {
       expect(sentinelApiServiceMock.simulateTransactions).toHaveBeenCalledWith(
         CHAIN_ID_MOCK,
         REQUEST_MOCK,
+        {},
       );
+    });
+
+    it('does not forward getSimulationConfig to the Sentinel API service', async () => {
+      const getSimulationConfig = jest.fn().mockResolvedValue({});
+
+      await simulateTransactions(
+        sentinelApiServiceMock as unknown as SentinelApiService,
+        CHAIN_ID_MOCK,
+        { ...REQUEST_MOCK, getSimulationConfig },
+      );
+
+      const forwardedRequest = sentinelApiServiceMock.simulateTransactions.mock
+        .calls[0][1] as unknown as SimulationRequest;
+
+      expect(forwardedRequest).not.toHaveProperty('getSimulationConfig');
+      expect(forwardedRequest).toStrictEqual(REQUEST_MOCK);
+    });
+
+    it('passes a getUrl option that resolves to newUrl when getSimulationConfig returns one', async () => {
+      const newUrl = 'https://shield.example.com/simulate';
+      const getSimulationConfig = jest.fn().mockResolvedValue({ newUrl });
+
+      await simulateTransactions(
+        sentinelApiServiceMock as unknown as SentinelApiService,
+        CHAIN_ID_MOCK,
+        { ...REQUEST_MOCK, getSimulationConfig },
+      );
+
+      const options = sentinelApiServiceMock.simulateTransactions.mock
+        .calls[0][2] as { getUrl?: (defaultUrl: string) => Promise<string> };
+
+      expect(options.getUrl).toBeDefined();
+      expect(await options.getUrl?.('https://default.example.com')).toBe(
+        newUrl,
+      );
+      expect(getSimulationConfig).toHaveBeenCalledWith(
+        'https://default.example.com',
+      );
+    });
+
+    it('passes a getUrl option that falls back to the default URL when getSimulationConfig returns no newUrl', async () => {
+      const getSimulationConfig = jest.fn().mockResolvedValue({});
+      const defaultUrl = 'https://default.example.com';
+
+      await simulateTransactions(
+        sentinelApiServiceMock as unknown as SentinelApiService,
+        CHAIN_ID_MOCK,
+        { ...REQUEST_MOCK, getSimulationConfig },
+      );
+
+      const options = sentinelApiServiceMock.simulateTransactions.mock
+        .calls[0][2] as { getUrl?: (defaultUrl: string) => Promise<string> };
+
+      expect(await options.getUrl?.(defaultUrl)).toBe(defaultUrl);
+    });
+
+    it('falls back to the default URL when getSimulationConfig resolves to undefined', async () => {
+      const getSimulationConfig = jest.fn().mockResolvedValue(undefined);
+      const defaultUrl = 'https://default.example.com';
+
+      await simulateTransactions(
+        sentinelApiServiceMock as unknown as SentinelApiService,
+        CHAIN_ID_MOCK,
+        { ...REQUEST_MOCK, getSimulationConfig },
+      );
+
+      const options = sentinelApiServiceMock.simulateTransactions.mock
+        .calls[0][2] as { getUrl?: (defaultUrl: string) => Promise<string> };
+
+      expect(await options.getUrl?.(defaultUrl)).toBe(defaultUrl);
+    });
+
+    it('does not pass a getUrl option when getSimulationConfig is absent', async () => {
+      await simulateTransactions(
+        sentinelApiServiceMock as unknown as SentinelApiService,
+        CHAIN_ID_MOCK,
+        REQUEST_MOCK,
+      );
+
+      const options =
+        sentinelApiServiceMock.simulateTransactions.mock.calls[0][2];
+
+      expect(options).toStrictEqual({});
     });
 
     it('does not mutate the original request', async () => {

--- a/packages/transaction-controller/src/api/simulation-api.test.ts
+++ b/packages/transaction-controller/src/api/simulation-api.test.ts
@@ -4,7 +4,7 @@ import type { GetSimulationConfig } from 'src';
 
 import { CHAIN_IDS, DELEGATION_MANAGER_ADDRESSES } from '../constants';
 import type { SimulationRequest, SimulationResponse } from './simulation-api';
-import { simulateTransactions } from './simulation-api';
+import { resetSentinelApiService, simulateTransactions } from './simulation-api';
 
 const CHAIN_ID_MOCK = '0x1';
 const CHAIN_ID_MOCK_DECIMAL = 1;
@@ -73,11 +73,18 @@ describe('Simulation API Utils', () => {
    */
   function mockFetchResponse(jsonResponse: unknown): void {
     fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
       json: jest.fn().mockResolvedValue(jsonResponse),
     } as unknown as Response);
   }
 
   beforeEach(() => {
+    // The Sentinel network registry is cached for the lifetime of the shared
+    // service singleton; reset it so each test performs a fresh `/networks`
+    // fetch against the mock.
+    resetSentinelApiService();
+
     fetchMock = jest.spyOn(global, 'fetch') as jest.MockedFunction<
       typeof fetch
     >;
@@ -155,6 +162,18 @@ describe('Simulation API Utils', () => {
           }),
         }),
       );
+    });
+
+    it('reuses the shared Sentinel service across calls', async () => {
+      // Second call's simulate response (the first is queued in beforeEach).
+      mockFetchResponse({ result: RESPONSE_MOCK });
+
+      await simulateTransactions(CHAIN_ID_MOCK, REQUEST_MOCK);
+      await simulateTransactions(CHAIN_ID_MOCK, REQUEST_MOCK);
+
+      // The registry is fetched once and cached: 1 networks fetch + 2
+      // simulate POSTs = 3 total, not 4.
+      expect(fetchMock).toHaveBeenCalledTimes(3);
     });
 
     it('throws if response has error', async () => {

--- a/packages/transaction-controller/src/api/simulation-api.test.ts
+++ b/packages/transaction-controller/src/api/simulation-api.test.ts
@@ -1,21 +1,17 @@
+import type { SentinelApiService } from '@metamask/sentinel-api-service';
 import type { Hex } from '@metamask/utils';
 import { cloneDeep } from 'lodash';
-import type { GetSimulationConfig } from 'src';
 
-import { CHAIN_IDS, DELEGATION_MANAGER_ADDRESSES } from '../constants';
+import {
+  CODE_DELEGATION_MANAGER_NO_SIGNATURE_ERRORS,
+  DELEGATION_MANAGER_ADDRESSES,
+} from '../constants';
 import type { SimulationRequest, SimulationResponse } from './simulation-api';
-import { resetSentinelApiService, simulateTransactions } from './simulation-api';
+import { simulateTransactions } from './simulation-api';
 
 const CHAIN_ID_MOCK = '0x1';
-const CHAIN_ID_MOCK_DECIMAL = 1;
-const ERROR_CODE_MOCK = 123;
-const ERROR_MESSAGE_MOCK = 'Test Error Message';
-const GET_SIMULATION_CONFIG_MOCK: GetSimulationConfig = jest
-  .fn()
-  .mockResolvedValue({});
 
 const REQUEST_MOCK: SimulationRequest = {
-  getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
   transactions: [{ from: '0x1', to: '0x2', value: '0x1' }],
   overrides: {
     '0x1': {
@@ -56,159 +52,143 @@ const RESPONSE_MOCK: SimulationResponse = {
   },
 };
 
-const RESPONSE_MOCK_NETWORKS = {
-  [CHAIN_ID_MOCK_DECIMAL]: {
-    network: 'test-subdomain',
-    confirmations: true,
-  },
-};
+/**
+ * Create a mock {@link SentinelApiService} exposing jest-mocked
+ * `simulateTransactions` and `getNetworks` methods.
+ *
+ * @returns The mocked service.
+ */
+function createSentinelApiServiceMock(): jest.Mocked<
+  Pick<SentinelApiService, 'simulateTransactions' | 'getNetworks'>
+> {
+  return {
+    simulateTransactions: jest.fn(),
+    getNetworks: jest.fn(),
+  } as unknown as jest.Mocked<
+    Pick<SentinelApiService, 'simulateTransactions' | 'getNetworks'>
+  >;
+}
 
 describe('Simulation API Utils', () => {
-  let fetchMock: jest.MockedFunction<typeof fetch>;
-
-  /**
-   * Mock a JSON response from fetch.
-   *
-   * @param jsonResponse - The response body to return.
-   */
-  function mockFetchResponse(jsonResponse: unknown): void {
-    fetchMock.mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      json: jest.fn().mockResolvedValue(jsonResponse),
-    } as unknown as Response);
-  }
+  let sentinelApiServiceMock: ReturnType<typeof createSentinelApiServiceMock>;
 
   beforeEach(() => {
-    // The Sentinel network registry is cached for the lifetime of the shared
-    // service singleton; reset it so each test performs a fresh `/networks`
-    // fetch against the mock.
-    resetSentinelApiService();
+    sentinelApiServiceMock = createSentinelApiServiceMock();
 
-    fetchMock = jest.spyOn(global, 'fetch') as jest.MockedFunction<
-      typeof fetch
-    >;
-
-    mockFetchResponse(RESPONSE_MOCK_NETWORKS);
-    mockFetchResponse({ result: RESPONSE_MOCK });
+    sentinelApiServiceMock.simulateTransactions.mockResolvedValue(
+      RESPONSE_MOCK as never,
+    );
   });
 
   describe('simulateTransactions', () => {
-    it('returns response from RPC provider', async () => {
-      expect(await simulateTransactions('0x1', REQUEST_MOCK)).toStrictEqual(
-        RESPONSE_MOCK,
+    it('returns response from the Sentinel API service', async () => {
+      expect(
+        await simulateTransactions(
+          sentinelApiServiceMock as unknown as SentinelApiService,
+          CHAIN_ID_MOCK,
+          REQUEST_MOCK,
+        ),
+      ).toStrictEqual(RESPONSE_MOCK);
+    });
+
+    it('delegates to the Sentinel API service with the chain ID and finalized request', async () => {
+      await simulateTransactions(
+        sentinelApiServiceMock as unknown as SentinelApiService,
+        CHAIN_ID_MOCK,
+        REQUEST_MOCK,
+      );
+
+      expect(
+        sentinelApiServiceMock.simulateTransactions,
+      ).toHaveBeenCalledTimes(1);
+      expect(sentinelApiServiceMock.simulateTransactions).toHaveBeenCalledWith(
+        CHAIN_ID_MOCK,
+        REQUEST_MOCK,
       );
     });
 
-    it('sends simulation request', async () => {
-      await simulateTransactions(CHAIN_ID_MOCK, REQUEST_MOCK);
+    it('does not mutate the original request', async () => {
+      const request = cloneDeep(REQUEST_MOCK);
 
-      expect(fetchMock).toHaveBeenCalledTimes(2);
+      await simulateTransactions(
+        sentinelApiServiceMock as unknown as SentinelApiService,
+        CHAIN_ID_MOCK,
+        request,
+      );
 
-      const request = fetchMock.mock.calls[1][1] as RequestInit;
-
-      // eslint-disable-next-line @typescript-eslint/no-base-to-string
-      const requestBodyRaw = (request.body as BodyInit).toString();
-      const requestBody = JSON.parse(requestBodyRaw);
-
-      // JSON.stringify strips functions, so we apply it here.
-      const expectedRequest = JSON.parse(JSON.stringify(REQUEST_MOCK));
-      expect(requestBody.params[0]).toStrictEqual(expectedRequest);
+      expect(request).toStrictEqual(REQUEST_MOCK);
     });
 
-    it('throws if chain ID not supported', async () => {
-      const unsupportedChainId = '0x123';
+    it('propagates errors thrown by the Sentinel API service', async () => {
+      const error = new Error('Test Error Message');
+      sentinelApiServiceMock.simulateTransactions.mockRejectedValueOnce(error);
 
       await expect(
-        simulateTransactions(unsupportedChainId, REQUEST_MOCK),
-      ).rejects.toThrow(`Chain is not supported: ${unsupportedChainId}`);
+        simulateTransactions(
+          sentinelApiServiceMock as unknown as SentinelApiService,
+          CHAIN_ID_MOCK,
+          REQUEST_MOCK,
+        ),
+      ).rejects.toThrow(error);
     });
 
-    it('uses URL specific to chain ID', async () => {
-      await simulateTransactions(CHAIN_IDS.MAINNET, REQUEST_MOCK);
-
-      expect(fetchMock).toHaveBeenCalledWith(
-        'https://tx-sentinel-test-subdomain.api.cx.metamask.io/',
-        expect.any(Object),
-      );
-    });
-
-    it('uses simulation config', async () => {
-      const getSimulationConfigMock: GetSimulationConfig = jest
-        .fn()
-        .mockResolvedValue({
-          authorization: 'Bearer test',
-          newUrl: 'https://tx-sentinel-new-test-subdomain.api.cx.metamask.io/',
-        });
-
-      const request = {
-        ...REQUEST_MOCK,
-        getSimulationConfig: getSimulationConfigMock,
-      };
-
-      await simulateTransactions(CHAIN_ID_MOCK, request);
-
-      expect(getSimulationConfigMock).toHaveBeenCalledTimes(1);
-      expect(getSimulationConfigMock).toHaveBeenCalledWith(
-        'https://tx-sentinel-test-subdomain.api.cx.metamask.io/',
-      );
-
-      expect(fetchMock).toHaveBeenCalledWith(
-        'https://tx-sentinel-new-test-subdomain.api.cx.metamask.io/',
-        expect.objectContaining({
-          headers: expect.objectContaining({
-            'Content-Type': 'application/json',
-            Authorization: 'Bearer test',
-          }),
-        }),
-      );
-    });
-
-    it('reuses the shared Sentinel service across calls', async () => {
-      // Second call's simulate response (the first is queued in beforeEach).
-      mockFetchResponse({ result: RESPONSE_MOCK });
-
-      await simulateTransactions(CHAIN_ID_MOCK, REQUEST_MOCK);
-      await simulateTransactions(CHAIN_ID_MOCK, REQUEST_MOCK);
-
-      // The registry is fetched once and cached: 1 networks fetch + 2
-      // simulate POSTs = 3 total, not 4.
-      expect(fetchMock).toHaveBeenCalledTimes(3);
-    });
-
-    it('throws if response has error', async () => {
-      fetchMock.mockReset();
-      mockFetchResponse(RESPONSE_MOCK_NETWORKS);
-      mockFetchResponse({
-        error: { code: ERROR_CODE_MOCK, message: ERROR_MESSAGE_MOCK },
-      });
-
-      await expect(
-        simulateTransactions(CHAIN_ID_MOCK, REQUEST_MOCK),
-      ).rejects.toThrow({
-        code: ERROR_CODE_MOCK,
-        message: ERROR_MESSAGE_MOCK,
-      } as unknown as Error);
-    });
-
-    it('overrides DelegationManager code', async () => {
+    it('overrides DelegationManager code before delegating', async () => {
       const request = cloneDeep(REQUEST_MOCK);
       request.transactions[0].to =
         DELEGATION_MANAGER_ADDRESSES[0].toUpperCase() as Hex;
 
-      await simulateTransactions(CHAIN_ID_MOCK, request);
-
-      expect(fetchMock).toHaveBeenCalledTimes(2);
-
-      const requestBody = JSON.parse(
-        fetchMock.mock.calls[1][1]?.body as string,
+      await simulateTransactions(
+        sentinelApiServiceMock as unknown as SentinelApiService,
+        CHAIN_ID_MOCK,
+        request,
       );
 
+      const finalizedRequest =
+        sentinelApiServiceMock.simulateTransactions.mock.calls[0][1];
+
       expect(
-        requestBody.params[0].overrides[DELEGATION_MANAGER_ADDRESSES[0]],
+        (finalizedRequest as unknown as SimulationRequest).overrides?.[
+          DELEGATION_MANAGER_ADDRESSES[0]
+        ],
       ).toStrictEqual({
-        code: expect.any(String),
+        code: CODE_DELEGATION_MANAGER_NO_SIGNATURE_ERRORS,
       });
+    });
+
+    it('initializes overrides when overriding DelegationManager code with no existing overrides', async () => {
+      const request: SimulationRequest = {
+        transactions: [
+          { from: '0x1', to: DELEGATION_MANAGER_ADDRESSES[0], value: '0x1' },
+        ],
+      };
+
+      await simulateTransactions(
+        sentinelApiServiceMock as unknown as SentinelApiService,
+        CHAIN_ID_MOCK,
+        request,
+      );
+
+      const finalizedRequest = sentinelApiServiceMock.simulateTransactions.mock
+        .calls[0][1] as unknown as SimulationRequest;
+
+      expect(finalizedRequest.overrides).toStrictEqual({
+        [DELEGATION_MANAGER_ADDRESSES[0]]: {
+          code: CODE_DELEGATION_MANAGER_NO_SIGNATURE_ERRORS,
+        },
+      });
+    });
+
+    it('does not apply DelegationManager override for other recipients', async () => {
+      await simulateTransactions(
+        sentinelApiServiceMock as unknown as SentinelApiService,
+        CHAIN_ID_MOCK,
+        REQUEST_MOCK,
+      );
+
+      const finalizedRequest = sentinelApiServiceMock.simulateTransactions.mock
+        .calls[0][1] as unknown as SimulationRequest;
+
+      expect(finalizedRequest.overrides).toStrictEqual(REQUEST_MOCK.overrides);
     });
   });
 });

--- a/packages/transaction-controller/src/api/simulation-api.test.ts
+++ b/packages/transaction-controller/src/api/simulation-api.test.ts
@@ -1,4 +1,4 @@
-import type { SentinelApiService } from '@metamask/sentinel-api-service';
+import type { SentinelSimulationResponse } from '@metamask/sentinel-api-service';
 import type { Hex } from '@metamask/utils';
 import { cloneDeep } from 'lodash';
 
@@ -6,7 +6,8 @@ import {
   CODE_DELEGATION_MANAGER_NO_SIGNATURE_ERRORS,
   DELEGATION_MANAGER_ADDRESSES,
 } from '../constants';
-import type { SimulationRequest, SimulationResponse } from './simulation-api';
+import type { TransactionControllerMessenger } from '../TransactionController';
+import type { SimulationRequest } from './simulation-api';
 import { simulateTransactions } from './simulation-api';
 
 const CHAIN_ID_MOCK = '0x1';
@@ -24,7 +25,7 @@ const REQUEST_MOCK: SimulationRequest = {
   withLogs: false,
 };
 
-const RESPONSE_MOCK: SimulationResponse = {
+const RESPONSE_MOCK: SentinelSimulationResponse = {
   transactions: [
     {
       return: '0x1',
@@ -53,72 +54,57 @@ const RESPONSE_MOCK: SimulationResponse = {
 };
 
 /**
- * Create a mock {@link SentinelApiService} exposing jest-mocked
- * `simulateTransactions` and `getNetworks` methods.
+ * Create a mock {@link TransactionControllerMessenger} whose `call` method is
+ * a jest mock that resolves the `SentinelApiService:simulateTransactions`
+ * action with {@link RESPONSE_MOCK}.
  *
- * @returns The mocked service.
+ * @returns The messenger mock and its underlying `call` jest mock.
  */
-function createSentinelApiServiceMock(): jest.Mocked<
-  Pick<SentinelApiService, 'simulateTransactions' | 'getNetworks'>
-> {
-  return {
-    simulateTransactions: jest.fn(),
-    getNetworks: jest.fn(),
-  } as unknown as jest.Mocked<
-    Pick<SentinelApiService, 'simulateTransactions' | 'getNetworks'>
-  >;
+function createMessengerMock(): {
+  messenger: TransactionControllerMessenger;
+  callMock: jest.Mock;
+} {
+  const callMock = jest.fn().mockResolvedValue(RESPONSE_MOCK);
+  const messenger = { call: callMock } as unknown as TransactionControllerMessenger;
+  return { messenger, callMock };
 }
 
 describe('Simulation API Utils', () => {
-  let sentinelApiServiceMock: ReturnType<typeof createSentinelApiServiceMock>;
+  let messenger: TransactionControllerMessenger;
+  let callMock: jest.Mock;
 
   beforeEach(() => {
-    sentinelApiServiceMock = createSentinelApiServiceMock();
-
-    sentinelApiServiceMock.simulateTransactions.mockResolvedValue(
-      RESPONSE_MOCK as never,
-    );
+    ({ messenger, callMock } = createMessengerMock());
   });
 
   describe('simulateTransactions', () => {
-    it('returns response from the Sentinel API service', async () => {
+    it('returns response from the Sentinel simulation action', async () => {
       expect(
-        await simulateTransactions(
-          sentinelApiServiceMock as unknown as SentinelApiService,
-          CHAIN_ID_MOCK,
-          REQUEST_MOCK,
-        ),
+        await simulateTransactions(messenger, CHAIN_ID_MOCK, REQUEST_MOCK),
       ).toStrictEqual(RESPONSE_MOCK);
     });
 
-    it('delegates to the Sentinel API service with the chain ID and finalized request', async () => {
-      await simulateTransactions(
-        sentinelApiServiceMock as unknown as SentinelApiService,
-        CHAIN_ID_MOCK,
-        REQUEST_MOCK,
-      );
+    it('invokes the Sentinel simulation action with the chain ID and finalized request', async () => {
+      await simulateTransactions(messenger, CHAIN_ID_MOCK, REQUEST_MOCK);
 
-      expect(
-        sentinelApiServiceMock.simulateTransactions,
-      ).toHaveBeenCalledTimes(1);
-      expect(sentinelApiServiceMock.simulateTransactions).toHaveBeenCalledWith(
+      expect(callMock).toHaveBeenCalledTimes(1);
+      expect(callMock).toHaveBeenCalledWith(
+        'SentinelApiService:simulateTransactions',
         CHAIN_ID_MOCK,
         REQUEST_MOCK,
         {},
       );
     });
 
-    it('does not forward getSimulationConfig to the Sentinel API service', async () => {
+    it('does not forward getSimulationConfig to the Sentinel simulation action', async () => {
       const getSimulationConfig = jest.fn().mockResolvedValue({});
 
-      await simulateTransactions(
-        sentinelApiServiceMock as unknown as SentinelApiService,
-        CHAIN_ID_MOCK,
-        { ...REQUEST_MOCK, getSimulationConfig },
-      );
+      await simulateTransactions(messenger, CHAIN_ID_MOCK, {
+        ...REQUEST_MOCK,
+        getSimulationConfig,
+      });
 
-      const forwardedRequest = sentinelApiServiceMock.simulateTransactions.mock
-        .calls[0][1] as unknown as SimulationRequest;
+      const forwardedRequest = callMock.mock.calls[0][2] as SimulationRequest;
 
       expect(forwardedRequest).not.toHaveProperty('getSimulationConfig');
       expect(forwardedRequest).toStrictEqual(REQUEST_MOCK);
@@ -128,14 +114,14 @@ describe('Simulation API Utils', () => {
       const newUrl = 'https://shield.example.com/simulate';
       const getSimulationConfig = jest.fn().mockResolvedValue({ newUrl });
 
-      await simulateTransactions(
-        sentinelApiServiceMock as unknown as SentinelApiService,
-        CHAIN_ID_MOCK,
-        { ...REQUEST_MOCK, getSimulationConfig },
-      );
+      await simulateTransactions(messenger, CHAIN_ID_MOCK, {
+        ...REQUEST_MOCK,
+        getSimulationConfig,
+      });
 
-      const options = sentinelApiServiceMock.simulateTransactions.mock
-        .calls[0][2] as { getUrl?: (defaultUrl: string) => Promise<string> };
+      const options = callMock.mock.calls[0][3] as {
+        getUrl?: (defaultUrl: string) => Promise<string>;
+      };
 
       expect(options.getUrl).toBeDefined();
       expect(await options.getUrl?.('https://default.example.com')).toBe(
@@ -150,14 +136,14 @@ describe('Simulation API Utils', () => {
       const getSimulationConfig = jest.fn().mockResolvedValue({});
       const defaultUrl = 'https://default.example.com';
 
-      await simulateTransactions(
-        sentinelApiServiceMock as unknown as SentinelApiService,
-        CHAIN_ID_MOCK,
-        { ...REQUEST_MOCK, getSimulationConfig },
-      );
+      await simulateTransactions(messenger, CHAIN_ID_MOCK, {
+        ...REQUEST_MOCK,
+        getSimulationConfig,
+      });
 
-      const options = sentinelApiServiceMock.simulateTransactions.mock
-        .calls[0][2] as { getUrl?: (defaultUrl: string) => Promise<string> };
+      const options = callMock.mock.calls[0][3] as {
+        getUrl?: (defaultUrl: string) => Promise<string>;
+      };
 
       expect(await options.getUrl?.(defaultUrl)).toBe(defaultUrl);
     });
@@ -166,27 +152,22 @@ describe('Simulation API Utils', () => {
       const getSimulationConfig = jest.fn().mockResolvedValue(undefined);
       const defaultUrl = 'https://default.example.com';
 
-      await simulateTransactions(
-        sentinelApiServiceMock as unknown as SentinelApiService,
-        CHAIN_ID_MOCK,
-        { ...REQUEST_MOCK, getSimulationConfig },
-      );
+      await simulateTransactions(messenger, CHAIN_ID_MOCK, {
+        ...REQUEST_MOCK,
+        getSimulationConfig,
+      });
 
-      const options = sentinelApiServiceMock.simulateTransactions.mock
-        .calls[0][2] as { getUrl?: (defaultUrl: string) => Promise<string> };
+      const options = callMock.mock.calls[0][3] as {
+        getUrl?: (defaultUrl: string) => Promise<string>;
+      };
 
       expect(await options.getUrl?.(defaultUrl)).toBe(defaultUrl);
     });
 
     it('does not pass a getUrl option when getSimulationConfig is absent', async () => {
-      await simulateTransactions(
-        sentinelApiServiceMock as unknown as SentinelApiService,
-        CHAIN_ID_MOCK,
-        REQUEST_MOCK,
-      );
+      await simulateTransactions(messenger, CHAIN_ID_MOCK, REQUEST_MOCK);
 
-      const options =
-        sentinelApiServiceMock.simulateTransactions.mock.calls[0][2];
+      const options = callMock.mock.calls[0][3];
 
       expect(options).toStrictEqual({});
     });
@@ -194,25 +175,17 @@ describe('Simulation API Utils', () => {
     it('does not mutate the original request', async () => {
       const request = cloneDeep(REQUEST_MOCK);
 
-      await simulateTransactions(
-        sentinelApiServiceMock as unknown as SentinelApiService,
-        CHAIN_ID_MOCK,
-        request,
-      );
+      await simulateTransactions(messenger, CHAIN_ID_MOCK, request);
 
       expect(request).toStrictEqual(REQUEST_MOCK);
     });
 
-    it('propagates errors thrown by the Sentinel API service', async () => {
+    it('propagates errors thrown by the Sentinel simulation action', async () => {
       const error = new Error('Test Error Message');
-      sentinelApiServiceMock.simulateTransactions.mockRejectedValueOnce(error);
+      callMock.mockRejectedValueOnce(error);
 
       await expect(
-        simulateTransactions(
-          sentinelApiServiceMock as unknown as SentinelApiService,
-          CHAIN_ID_MOCK,
-          REQUEST_MOCK,
-        ),
+        simulateTransactions(messenger, CHAIN_ID_MOCK, REQUEST_MOCK),
       ).rejects.toThrow(error);
     });
 
@@ -221,19 +194,12 @@ describe('Simulation API Utils', () => {
       request.transactions[0].to =
         DELEGATION_MANAGER_ADDRESSES[0].toUpperCase() as Hex;
 
-      await simulateTransactions(
-        sentinelApiServiceMock as unknown as SentinelApiService,
-        CHAIN_ID_MOCK,
-        request,
-      );
+      await simulateTransactions(messenger, CHAIN_ID_MOCK, request);
 
-      const finalizedRequest =
-        sentinelApiServiceMock.simulateTransactions.mock.calls[0][1];
+      const finalizedRequest = callMock.mock.calls[0][2] as SimulationRequest;
 
       expect(
-        (finalizedRequest as unknown as SimulationRequest).overrides?.[
-          DELEGATION_MANAGER_ADDRESSES[0]
-        ],
+        finalizedRequest.overrides?.[DELEGATION_MANAGER_ADDRESSES[0] as Hex],
       ).toStrictEqual({
         code: CODE_DELEGATION_MANAGER_NO_SIGNATURE_ERRORS,
       });
@@ -242,18 +208,17 @@ describe('Simulation API Utils', () => {
     it('initializes overrides when overriding DelegationManager code with no existing overrides', async () => {
       const request: SimulationRequest = {
         transactions: [
-          { from: '0x1', to: DELEGATION_MANAGER_ADDRESSES[0], value: '0x1' },
+          {
+            from: '0x1',
+            to: DELEGATION_MANAGER_ADDRESSES[0] as Hex,
+            value: '0x1',
+          },
         ],
       };
 
-      await simulateTransactions(
-        sentinelApiServiceMock as unknown as SentinelApiService,
-        CHAIN_ID_MOCK,
-        request,
-      );
+      await simulateTransactions(messenger, CHAIN_ID_MOCK, request);
 
-      const finalizedRequest = sentinelApiServiceMock.simulateTransactions.mock
-        .calls[0][1] as unknown as SimulationRequest;
+      const finalizedRequest = callMock.mock.calls[0][2] as SimulationRequest;
 
       expect(finalizedRequest.overrides).toStrictEqual({
         [DELEGATION_MANAGER_ADDRESSES[0]]: {
@@ -263,14 +228,9 @@ describe('Simulation API Utils', () => {
     });
 
     it('does not apply DelegationManager override for other recipients', async () => {
-      await simulateTransactions(
-        sentinelApiServiceMock as unknown as SentinelApiService,
-        CHAIN_ID_MOCK,
-        REQUEST_MOCK,
-      );
+      await simulateTransactions(messenger, CHAIN_ID_MOCK, REQUEST_MOCK);
 
-      const finalizedRequest = sentinelApiServiceMock.simulateTransactions.mock
-        .calls[0][1] as unknown as SimulationRequest;
+      const finalizedRequest = callMock.mock.calls[0][2] as SimulationRequest;
 
       expect(finalizedRequest.overrides).toStrictEqual(REQUEST_MOCK.overrides);
     });

--- a/packages/transaction-controller/src/api/simulation-api.ts
+++ b/packages/transaction-controller/src/api/simulation-api.ts
@@ -11,6 +11,7 @@ import {
   DELEGATION_MANAGER_ADDRESSES,
 } from '../constants';
 import { projectLogger } from '../logger';
+import type { GetSimulationConfig } from '../types';
 
 const log = createModuleLogger(projectLogger, 'simulation-api');
 
@@ -51,6 +52,12 @@ export type SimulationRequest = {
   blockOverrides?: {
     time?: Hex;
   };
+
+  /**
+   * Optional callback to rewrite the simulation request URL.
+   * Transaction-controller-only field; not forwarded to the Sentinel API.
+   */
+  getSimulationConfig?: GetSimulationConfig;
 
   /**
    * Overrides to the state of the blockchain, keyed by address.
@@ -272,11 +279,24 @@ export async function simulateTransactions(
 ): Promise<SimulationResponse> {
   const finalizedRequest = finalizeRequest(request);
 
-  log('Sending request', chainId, finalizedRequest);
+  // `getSimulationConfig` is a transaction-controller-only field and must not
+  // be forwarded to the Sentinel API. It is routed through the service's
+  // `getUrl` callback instead.
+  const { getSimulationConfig, ...sentinelRequest } = finalizedRequest;
+
+  const getUrl = getSimulationConfig
+    ? async (defaultUrl: string): Promise<string> => {
+        const { newUrl } = (await getSimulationConfig(defaultUrl)) ?? {};
+        return newUrl ?? defaultUrl;
+      }
+    : undefined;
+
+  log('Sending request', chainId, sentinelRequest);
 
   const response = await sentinelApiService.simulateTransactions(
     chainId,
-    finalizedRequest as unknown as SentinelSimulationRequest,
+    sentinelRequest as unknown as SentinelSimulationRequest,
+    getUrl ? { getUrl } : {},
   );
 
   log('Received response', response);

--- a/packages/transaction-controller/src/api/simulation-api.ts
+++ b/packages/transaction-controller/src/api/simulation-api.ts
@@ -1,10 +1,7 @@
-import { convertHexToDecimal } from '@metamask/controller-utils';
-import { Messenger } from '@metamask/messenger';
 import type {
-  SentinelApiServiceMessenger,
-  SentinelNetworkRegistry,
+  SentinelApiService,
+  SentinelSimulationRequest,
 } from '@metamask/sentinel-api-service';
-import { SentinelApiService } from '@metamask/sentinel-api-service';
 import { createModuleLogger } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
 import { cloneDeep } from 'lodash';
@@ -13,54 +10,9 @@ import {
   CODE_DELEGATION_MANAGER_NO_SIGNATURE_ERRORS,
   DELEGATION_MANAGER_ADDRESSES,
 } from '../constants';
-import { SimulationChainNotSupportedError, SimulationError } from '../errors';
 import { projectLogger } from '../logger';
-import type { GetSimulationConfig } from '../types';
 
 const log = createModuleLogger(projectLogger, 'simulation-api');
-
-const RPC_METHOD = 'infura_simulateTransactions';
-const BASE_URL = 'https://tx-sentinel-{0}.api.cx.metamask.io/';
-
-/**
- * Lazily-constructed singleton {@link SentinelApiService}, used to centralise
- * the Sentinel supported-network registry (`/networks`) lookup and the
- * subdomain-based URL derivation. The controller still performs the actual
- * `infura_simulateTransactions` HTTP request itself because it needs to honour
- * the per-request `getSimulationConfig` hook (URL override + `Authorization`
- * header) which the shared service does not expose.
- */
-let sentinelApiService: SentinelApiService | undefined;
-
-/**
- * Returns the shared {@link SentinelApiService}, constructing it on first use.
- *
- * @returns The Sentinel API service.
- */
-function getSentinelApiService(): SentinelApiService {
-  if (!sentinelApiService) {
-    const rootMessenger = new Messenger<'SimulationApi', never, never>({
-      namespace: 'SimulationApi',
-    });
-    const messenger = new Messenger({
-      namespace: 'SentinelApiService',
-      parent: rootMessenger,
-    }) as unknown as SentinelApiServiceMessenger;
-
-    sentinelApiService = new SentinelApiService({ messenger });
-  }
-
-  return sentinelApiService;
-}
-
-/**
- * Reset the shared {@link SentinelApiService} singleton. Intended for use in
- * tests so that the cached network registry does not leak between cases.
- */
-export function resetSentinelApiService(): void {
-  sentinelApiService?.destroy();
-  sentinelApiService = undefined;
-}
 
 /** Single transaction to simulate in a simulation API request.  */
 export type SimulationRequestTransaction = {
@@ -99,11 +51,6 @@ export type SimulationRequest = {
   blockOverrides?: {
     time?: Hex;
   };
-
-  /**
-   * Function to get the simulation configuration.
-   */
-  getSimulationConfig: GetSimulationConfig;
 
   /**
    * Overrides to the state of the blockchain, keyed by address.
@@ -305,97 +252,36 @@ export type SimulationResponse = {
   };
 };
 
-let requestIdCounter = 0;
-
 /**
- * Simulate transactions using the transaction simulation API.
+ * Simulate transactions using the injected {@link SentinelApiService}.
  *
+ * The DelegationManager code override is still applied locally via
+ * {@link finalizeRequest} before delegating the actual
+ * `infura_simulateTransactions` request (URL derivation, JSON-RPC transport,
+ * validation, and error handling) to the shared service.
+ *
+ * @param sentinelApiService - The Sentinel API service to delegate to.
  * @param chainId - The chain ID to simulate transactions on.
  * @param request - The request to simulate transactions.
  * @returns The response from the simulation API.
  */
 export async function simulateTransactions(
+  sentinelApiService: SentinelApiService,
   chainId: Hex,
   request: SimulationRequest,
 ): Promise<SimulationResponse> {
-  let url = await getSimulationUrl(chainId);
+  const finalizedRequest = finalizeRequest(request);
 
-  const { newUrl, authorization } =
-    (await request.getSimulationConfig(url)) || {};
-  if (newUrl) {
-    url = newUrl;
-  }
+  log('Sending request', chainId, finalizedRequest);
 
-  const requestId = requestIdCounter;
-  requestIdCounter += 1;
+  const response = await sentinelApiService.simulateTransactions(
+    chainId,
+    finalizedRequest as unknown as SentinelSimulationRequest,
+  );
 
-  const finalRequest = finalizeRequest(request);
+  log('Received response', response);
 
-  log('Sending request', url, request);
-
-  const headers: Record<string, string> = {
-    'Content-Type': 'application/json',
-  };
-
-  // Add optional authorization header, if provided.
-  if (authorization) {
-    headers.Authorization = authorization;
-  }
-
-  const response = await fetch(url, {
-    method: 'POST',
-    headers,
-    body: JSON.stringify({
-      id: String(requestId),
-      jsonrpc: '2.0',
-      method: RPC_METHOD,
-      params: [finalRequest],
-    }),
-  });
-
-  const responseJson = await response.json();
-
-  log('Received response', responseJson);
-
-  if (responseJson.error) {
-    const { code, message } = responseJson.error;
-    throw new SimulationError(message, code);
-  }
-
-  return responseJson?.result;
-}
-
-/**
- * Get the URL for the transaction simulation API.
- *
- * Uses the shared {@link SentinelApiService} to fetch and cache the
- * supported-network registry, then derives the network subdomain URL.
- *
- * @param chainId - The chain ID to get the URL for.
- * @returns The URL for the transaction simulation API.
- */
-async function getSimulationUrl(chainId: Hex): Promise<string> {
-  const networkData: SentinelNetworkRegistry =
-    await getSentinelApiService().getNetworks();
-  const chainIdDecimal = convertHexToDecimal(chainId);
-  const network = networkData[chainIdDecimal];
-
-  if (!network?.confirmations) {
-    log('Chain is not supported', chainId);
-    throw new SimulationChainNotSupportedError(chainId);
-  }
-
-  return getUrl(network.network);
-}
-
-/**
- * Generate the URL for the specified subdomain in the simulation API.
- *
- * @param subdomain - The subdomain to generate the URL for.
- * @returns The URL for the transaction simulation API.
- */
-function getUrl(subdomain: string): string {
-  return BASE_URL.replace('{0}', subdomain);
+  return response as unknown as SimulationResponse;
 }
 
 /**

--- a/packages/transaction-controller/src/api/simulation-api.ts
+++ b/packages/transaction-controller/src/api/simulation-api.ts
@@ -1,6 +1,6 @@
 import type {
-  SentinelApiService,
   SentinelSimulationRequest,
+  SentinelSimulationResponse,
 } from '@metamask/sentinel-api-service';
 import { createModuleLogger } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
@@ -11,277 +11,45 @@ import {
   DELEGATION_MANAGER_ADDRESSES,
 } from '../constants';
 import { projectLogger } from '../logger';
+import type { TransactionControllerMessenger } from '../TransactionController';
 import type { GetSimulationConfig } from '../types';
 
 const log = createModuleLogger(projectLogger, 'simulation-api');
 
-/** Single transaction to simulate in a simulation API request.  */
-export type SimulationRequestTransaction = {
-  authorizationList?: {
-    /** Address of a smart contract that contains the code to be set. */
-    address: Hex;
-
-    /** Address of the account being upgraded. */
-    from: Hex;
-  }[];
-
-  /** Data to send with the transaction. */
-  data?: Hex;
-
-  /** Sender of the transaction. */
-  from: Hex;
-
-  /** Gas limit for the transaction. */
-  gas?: Hex;
-
-  /** Maximum fee per gas for the transaction. */
-  maxFeePerGas?: Hex;
-
-  /** Maximum priority fee per gas for the transaction. */
-  maxPriorityFeePerGas?: Hex;
-
-  /** Recipient of the transaction. */
-  to?: Hex;
-
-  /** Value to send with the transaction. */
-  value?: Hex;
-};
-
-/** Request to the simulation API to simulate transactions. */
-export type SimulationRequest = {
-  blockOverrides?: {
-    time?: Hex;
-  };
-
+/**
+ * Request to simulate transactions, extended with the transaction-controller-only
+ * `getSimulationConfig` hook for URL rewriting.
+ */
+export type SimulationRequest = SentinelSimulationRequest & {
   /**
    * Optional callback to rewrite the simulation request URL.
    * Transaction-controller-only field; not forwarded to the Sentinel API.
    */
   getSimulationConfig?: GetSimulationConfig;
-
-  /**
-   * Overrides to the state of the blockchain, keyed by address.
-   */
-  overrides?: {
-    [address: Hex]: {
-      /** Override the code for an address. */
-      code?: Hex;
-
-      /** Overrides to the storage slots for an address. */
-      stateDiff?: {
-        [slot: Hex]: Hex;
-      };
-    };
-  };
-
-  /**
-   * Whether to include available token fees.
-   */
-  suggestFees?: {
-    /* Whether to estimate gas for the transaction being submitted via a delegation. */
-    with7702?: boolean;
-
-    /* Whether to include the gas fee of the token transfer. */
-    withFeeTransfer?: boolean;
-
-    /* Whether to include the native transfer if available. */
-    withTransfer?: boolean;
-  };
-
-  /**
-   * Transactions to be sequentially simulated.
-   * State changes impact subsequent transactions in the list.
-   */
-  transactions: SimulationRequestTransaction[];
-
-  /**
-   * Whether to include call traces in the response.
-   * Defaults to false.
-   */
-  withCallTrace?: boolean;
-
-  /**
-   * Whether to include the default block data in the simulation.
-   * Defaults to false.
-   */
-  withDefaultBlockOverrides?: boolean;
-
-  /**
-   * Whether to use the gas fees in the simulation.
-   * Defaults to false.
-   */
-  withGas?: boolean;
-
-  /**
-   * Whether to include event logs in the response.
-   * Defaults to false.
-   */
-  withLogs?: boolean;
-};
-
-/** Raw event log emitted by a simulated transaction. */
-export type SimulationResponseLog = {
-  /** Address of the account that created the event. */
-  address: Hex;
-
-  /** Raw data in the event that is not indexed. */
-  data: Hex;
-
-  /** Raw indexed data from the event. */
-  topics: Hex[];
-};
-
-/** Call trace of a single simulated transaction. */
-export type SimulationResponseCallTrace = {
-  /** Nested calls. */
-  calls?: SimulationResponseCallTrace[] | null;
-
-  /** Error message for the call, if any. */
-  error?: string;
-
-  /** Raw event logs created by the call. */
-  logs?: SimulationResponseLog[] | null;
-
-  /** Raw return data from the call (revert hex when reverted). */
-  output?: Hex;
 };
 
 /**
- * Changes to the blockchain state.
- * Keyed by account address.
- */
-export type SimulationResponseStateDiff = {
-  [address: Hex]: {
-    /** Native balance of the account. */
-    balance?: Hex;
-
-    /** Nonce of the account. */
-    nonce?: Hex;
-
-    /** Storage values per slot. */
-    storage?: {
-      [slot: Hex]: Hex;
-    };
-  };
-};
-
-export type SimulationResponseTokenFee = {
-  /** Token data independent of current transaction. */
-  token: {
-    /** Address of the token contract. */
-    address: Hex;
-
-    /** Decimals of the token. */
-    decimals: number;
-
-    /** Symbol of the token. */
-    symbol: string;
-  };
-
-  /** Amount of tokens needed to pay for gas. */
-  balanceNeededToken: Hex;
-
-  /** Current token balance of sender. */
-  currentBalanceToken: Hex;
-
-  /** Account address that token should be transferred to. */
-  feeRecipient: Hex;
-
-  /** Conversation rate of 1 token to native WEI. */
-  rateWei: Hex;
-
-  /** Portion of `balanceNeededToken` that is the fee paid to MetaMask. */
-  serviceFee?: Hex;
-
-  /** Estimated gas limit required for fee transfer. */
-  transferEstimate: Hex;
-};
-
-/** Response from the simulation API for a single transaction. */
-export type SimulationResponseTransaction = {
-  /** Hierarchy of call data including nested calls and logs. */
-  callTrace?: SimulationResponseCallTrace;
-
-  /** An error message indicating the transaction could not be simulated. */
-  error?: string;
-
-  /** Recommended gas fees for the transaction. */
-  fees?: {
-    /** Gas limit for the fee level. */
-    gas: Hex;
-
-    /** Maximum fee per gas for the fee level. */
-    maxFeePerGas: Hex;
-
-    /** Maximum priority fee per gas for the fee level. */
-    maxPriorityFeePerGas: Hex;
-
-    /** Token fee data for the fee level. */
-    tokenFees: SimulationResponseTokenFee[];
-  }[];
-
-  /**
-   * Estimated total gas cost of the transaction.
-   * Included in the stateDiff if `withGas` is true.
-   */
-  gasCost?: number;
-
-  /** Required `gasLimit` for the transaction. */
-  gasLimit?: Hex;
-
-  /** Total gas used by the transaction. */
-  gasUsed?: Hex;
-
-  /** Return value of the transaction, such as the balance if calling balanceOf. */
-  return: Hex;
-
-  /** Changes to the blockchain state. */
-  stateDiff?: {
-    /** Initial blockchain state before the transaction. */
-    pre?: SimulationResponseStateDiff;
-
-    /** Updated blockchain state after the transaction. */
-    post?: SimulationResponseStateDiff;
-  };
-};
-
-/** Response from the simulation API. */
-export type SimulationResponse = {
-  /** Simulation data for each transaction in the request. */
-  transactions: SimulationResponseTransaction[];
-
-  sponsorship: {
-    /** Whether the gas costs are sponsored meaning a transfer is not required. */
-    isSponsored: boolean;
-
-    /** Error message for the determination of sponsorship. */
-    error: string | null;
-  };
-};
-
-/**
- * Simulate transactions using the injected {@link SentinelApiService}.
+ * Simulate transactions via the `SentinelApiService:simulateTransactions`
+ * messenger action.
  *
  * The DelegationManager code override is still applied locally via
  * {@link finalizeRequest} before delegating the actual
  * `infura_simulateTransactions` request (URL derivation, JSON-RPC transport,
  * validation, and error handling) to the shared service.
  *
- * @param sentinelApiService - The Sentinel API service to delegate to.
+ * @param messenger - The transaction-controller messenger, used to invoke
+ * `SentinelApiService:simulateTransactions`.
  * @param chainId - The chain ID to simulate transactions on.
  * @param request - The request to simulate transactions.
  * @returns The response from the simulation API.
  */
 export async function simulateTransactions(
-  sentinelApiService: SentinelApiService,
+  messenger: TransactionControllerMessenger,
   chainId: Hex,
   request: SimulationRequest,
-): Promise<SimulationResponse> {
+): Promise<SentinelSimulationResponse> {
   const finalizedRequest = finalizeRequest(request);
 
-  // `getSimulationConfig` is a transaction-controller-only field and must not
-  // be forwarded to the Sentinel API. It is routed through the service's
-  // `getUrl` callback instead.
   const { getSimulationConfig, ...sentinelRequest } = finalizedRequest;
 
   const getUrl = getSimulationConfig
@@ -293,15 +61,16 @@ export async function simulateTransactions(
 
   log('Sending request', chainId, sentinelRequest);
 
-  const response = await sentinelApiService.simulateTransactions(
+  const response = await messenger.call(
+    'SentinelApiService:simulateTransactions',
     chainId,
-    sentinelRequest as unknown as SentinelSimulationRequest,
+    sentinelRequest,
     getUrl ? { getUrl } : {},
   );
 
   log('Received response', response);
 
-  return response as unknown as SimulationResponse;
+  return response;
 }
 
 /**

--- a/packages/transaction-controller/src/api/simulation-api.ts
+++ b/packages/transaction-controller/src/api/simulation-api.ts
@@ -1,4 +1,10 @@
 import { convertHexToDecimal } from '@metamask/controller-utils';
+import { Messenger } from '@metamask/messenger';
+import type {
+  SentinelApiServiceMessenger,
+  SentinelNetworkRegistry,
+} from '@metamask/sentinel-api-service';
+import { SentinelApiService } from '@metamask/sentinel-api-service';
 import { createModuleLogger } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
 import { cloneDeep } from 'lodash';
@@ -15,7 +21,46 @@ const log = createModuleLogger(projectLogger, 'simulation-api');
 
 const RPC_METHOD = 'infura_simulateTransactions';
 const BASE_URL = 'https://tx-sentinel-{0}.api.cx.metamask.io/';
-const ENDPOINT_NETWORKS = 'networks';
+
+/**
+ * Lazily-constructed singleton {@link SentinelApiService}, used to centralise
+ * the Sentinel supported-network registry (`/networks`) lookup and the
+ * subdomain-based URL derivation. The controller still performs the actual
+ * `infura_simulateTransactions` HTTP request itself because it needs to honour
+ * the per-request `getSimulationConfig` hook (URL override + `Authorization`
+ * header) which the shared service does not expose.
+ */
+let sentinelApiService: SentinelApiService | undefined;
+
+/**
+ * Returns the shared {@link SentinelApiService}, constructing it on first use.
+ *
+ * @returns The Sentinel API service.
+ */
+function getSentinelApiService(): SentinelApiService {
+  if (!sentinelApiService) {
+    const rootMessenger = new Messenger<'SimulationApi', never, never>({
+      namespace: 'SimulationApi',
+    });
+    const messenger = new Messenger({
+      namespace: 'SentinelApiService',
+      parent: rootMessenger,
+    }) as unknown as SentinelApiServiceMessenger;
+
+    sentinelApiService = new SentinelApiService({ messenger });
+  }
+
+  return sentinelApiService;
+}
+
+/**
+ * Reset the shared {@link SentinelApiService} singleton. Intended for use in
+ * tests so that the cached network registry does not leak between cases.
+ */
+export function resetSentinelApiService(): void {
+  sentinelApiService?.destroy();
+  sentinelApiService = undefined;
+}
 
 /** Single transaction to simulate in a simulation API request.  */
 export type SimulationRequestTransaction = {
@@ -260,20 +305,6 @@ export type SimulationResponse = {
   };
 };
 
-/** Data for a network supported by the Simulation API. */
-type SimulationNetwork = {
-  /** Subdomain of the API for the network.  */
-  network: string;
-
-  /** Whether the network supports confirmation simulations. */
-  confirmations: boolean;
-};
-
-/** Response from the simulation API containing supported networks. */
-type SimulationNetworkResponse = {
-  [chainIdDecimal: string]: SimulationNetwork;
-};
-
 let requestIdCounter = 0;
 
 /**
@@ -337,11 +368,15 @@ export async function simulateTransactions(
 /**
  * Get the URL for the transaction simulation API.
  *
+ * Uses the shared {@link SentinelApiService} to fetch and cache the
+ * supported-network registry, then derives the network subdomain URL.
+ *
  * @param chainId - The chain ID to get the URL for.
  * @returns The URL for the transaction simulation API.
  */
 async function getSimulationUrl(chainId: Hex): Promise<string> {
-  const networkData = await getNetworkData();
+  const networkData: SentinelNetworkRegistry =
+    await getSentinelApiService().getNetworks();
   const chainIdDecimal = convertHexToDecimal(chainId);
   const network = networkData[chainIdDecimal];
 
@@ -351,17 +386,6 @@ async function getSimulationUrl(chainId: Hex): Promise<string> {
   }
 
   return getUrl(network.network);
-}
-
-/**
- * Retrieve the supported network data from the simulation API.
- *
- * @returns The network data response from the simulation API.
- */
-async function getNetworkData(): Promise<SimulationNetworkResponse> {
-  const url = `${getUrl('ethereum-mainnet')}${ENDPOINT_NETWORKS}`;
-  const response = await fetch(url);
-  return response.json();
 }
 
 /**

--- a/packages/transaction-controller/src/index.ts
+++ b/packages/transaction-controller/src/index.ts
@@ -80,6 +80,7 @@ export type {
   GasPriceGasFeeEstimates,
   GasPriceValue,
   GetGasFeeTokensRequest,
+  GetSimulationConfig,
   InferTransactionTypeResult,
   IsAtomicBatchSupportedRequest,
   IsAtomicBatchSupportedResult,

--- a/packages/transaction-controller/src/index.ts
+++ b/packages/transaction-controller/src/index.ts
@@ -80,7 +80,6 @@ export type {
   GasPriceGasFeeEstimates,
   GasPriceValue,
   GetGasFeeTokensRequest,
-  GetSimulationConfig,
   InferTransactionTypeResult,
   IsAtomicBatchSupportedRequest,
   IsAtomicBatchSupportedResult,

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -2185,19 +2185,6 @@ export type MetamaskPayMetadata = {
 };
 
 /**
- * Parameters for the transaction simulation API.
- */
-export type GetSimulationConfig = (
-  url: string,
-  opts?: {
-    txMeta?: TransactionMeta;
-  },
-) => Promise<{
-  newUrl?: string;
-  authorization?: string;
-}>;
-
-/**
  * Options for adding a transaction.
  */
 export type AddTransactionOptions = {

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -2185,6 +2185,21 @@ export type MetamaskPayMetadata = {
 };
 
 /**
+ * Parameters for the transaction simulation API.
+ *
+ * Lets consumers rewrite the simulation request URL (for example to route
+ * through the MetaMask Shield proxy) via the returned `newUrl`.
+ */
+export type GetSimulationConfig = (
+  url: string,
+  opts?: {
+    txMeta?: TransactionMeta;
+  },
+) => Promise<{
+  newUrl?: string;
+}>;
+
+/**
  * Options for adding a transaction.
  */
 export type AddTransactionOptions = {

--- a/packages/transaction-controller/src/utils/balance-changes.test.ts
+++ b/packages/transaction-controller/src/utils/balance-changes.test.ts
@@ -1,6 +1,7 @@
 import type { LogDescription } from '@ethersproject/abi';
 import { Interface } from '@ethersproject/abi';
 import type { NetworkClientId } from '@metamask/network-controller';
+import type { SentinelApiService } from '@metamask/sentinel-api-service';
 import type { Hex } from '@metamask/utils';
 
 import { simulateTransactions } from '../api/simulation-api';
@@ -14,7 +15,6 @@ import {
   SimulationRevertedError,
 } from '../errors';
 import type { TransactionControllerMessenger } from '../TransactionController';
-import type { GetSimulationConfig } from '../types';
 import { SimulationErrorCode, SimulationTokenStandard } from '../types';
 import type { GetBalanceChangesRequest } from './balance-changes';
 import { getBalanceChanges, SupportedToken } from './balance-changes';
@@ -59,12 +59,13 @@ const USER_ADDRESS_WITH_LEADING_ZERO =
 
 const MESSENGER_MOCK = {} as unknown as TransactionControllerMessenger;
 const NETWORK_CLIENT_ID_MOCK = 'testNetworkClientId' as NetworkClientId;
+const SENTINEL_API_SERVICE_MOCK = {} as unknown as SentinelApiService;
 
 const REQUEST_MOCK: GetBalanceChangesRequest = {
   chainId: '0x1',
   messenger: MESSENGER_MOCK,
   networkClientId: NETWORK_CLIENT_ID_MOCK,
-  getSimulationConfig: jest.fn(),
+  sentinelApiService: SENTINEL_API_SERVICE_MOCK,
   txParams: {
     data: '0x123',
     from: USER_ADDRESS_MOCK,
@@ -705,9 +706,9 @@ describe('Balance Change Utils', () => {
         // The ERC-721 token balance is only checked after the transaction since it is minted.
         expect(simulateTransactionsMock).toHaveBeenNthCalledWith(
           2,
+          SENTINEL_API_SERVICE_MOCK,
           REQUEST_MOCK.chainId,
           {
-            getSimulationConfig: REQUEST_MOCK.getSimulationConfig,
             transactions: [
               // ERC-20 balance before minting.
               {
@@ -1304,6 +1305,7 @@ describe('Balance Change Utils', () => {
 
       expect(simulateTransactionsMock).toHaveBeenCalledTimes(1);
       expect(simulateTransactionsMock).toHaveBeenCalledWith(
+        SENTINEL_API_SERVICE_MOCK,
         expect.any(String),
         expect.objectContaining({
           transactions: [
@@ -1334,6 +1336,7 @@ describe('Balance Change Utils', () => {
 
         expect(simulateTransactionsMock).toHaveBeenCalledTimes(1);
         expect(simulateTransactionsMock).toHaveBeenCalledWith(
+          SENTINEL_API_SERVICE_MOCK,
           expect.any(String),
           expect.objectContaining({
             overrides: {
@@ -1361,6 +1364,7 @@ describe('Balance Change Utils', () => {
 
         expect(simulateTransactionsMock).toHaveBeenCalledTimes(1);
         expect(simulateTransactionsMock).toHaveBeenCalledWith(
+          SENTINEL_API_SERVICE_MOCK,
           expect.any(String),
           expect.objectContaining({
             overrides: {
@@ -1386,6 +1390,7 @@ describe('Balance Change Utils', () => {
 
         expect(simulateTransactionsMock).toHaveBeenCalledTimes(1);
         expect(simulateTransactionsMock).toHaveBeenCalledWith(
+          SENTINEL_API_SERVICE_MOCK,
           expect.any(String),
           expect.objectContaining({
             overrides: {
@@ -1419,6 +1424,7 @@ describe('Balance Change Utils', () => {
 
         expect(simulateTransactionsMock).toHaveBeenCalledTimes(1);
         expect(simulateTransactionsMock).toHaveBeenCalledWith(
+          SENTINEL_API_SERVICE_MOCK,
           expect.any(String),
           expect.objectContaining({
             overrides: {
@@ -1431,22 +1437,21 @@ describe('Balance Change Utils', () => {
       });
     });
 
-    it('forwards simulation config', async () => {
-      const getSimulationConfigMock: GetSimulationConfig = jest.fn();
+    it('forwards the Sentinel API service', async () => {
+      const sentinelApiServiceMock = {} as unknown as SentinelApiService;
 
       const request = {
         ...REQUEST_MOCK,
-        getSimulationConfig: getSimulationConfigMock,
+        sentinelApiService: sentinelApiServiceMock,
       };
 
       await getBalanceChanges(request);
 
       expect(simulateTransactionsMock).toHaveBeenCalledTimes(1);
       expect(simulateTransactionsMock).toHaveBeenCalledWith(
+        sentinelApiServiceMock,
         expect.any(String),
-        expect.objectContaining({
-          getSimulationConfig: getSimulationConfigMock,
-        }),
+        expect.any(Object),
       );
     });
   });

--- a/packages/transaction-controller/src/utils/balance-changes.test.ts
+++ b/packages/transaction-controller/src/utils/balance-changes.test.ts
@@ -1,15 +1,14 @@
 import type { LogDescription } from '@ethersproject/abi';
 import { Interface } from '@ethersproject/abi';
 import type { NetworkClientId } from '@metamask/network-controller';
-import type { SentinelApiService } from '@metamask/sentinel-api-service';
 import type { Hex } from '@metamask/utils';
 
 import { simulateTransactions } from '../api/simulation-api';
 import type {
-  SimulationResponseLog,
-  SimulationResponseTransaction,
-} from '../api/simulation-api';
-import type { SimulationResponse } from '../api/simulation-api';
+  SentinelSimulationLog,
+  SentinelSimulationResponse,
+  SentinelSimulationResponseTransaction,
+} from '@metamask/sentinel-api-service';
 import {
   SimulationInvalidResponseError,
   SimulationRevertedError,
@@ -59,13 +58,11 @@ const USER_ADDRESS_WITH_LEADING_ZERO =
 
 const MESSENGER_MOCK = {} as unknown as TransactionControllerMessenger;
 const NETWORK_CLIENT_ID_MOCK = 'testNetworkClientId' as NetworkClientId;
-const SENTINEL_API_SERVICE_MOCK = {} as unknown as SentinelApiService;
 
 const REQUEST_MOCK: GetBalanceChangesRequest = {
   chainId: '0x1',
   messenger: MESSENGER_MOCK,
   networkClientId: NETWORK_CLIENT_ID_MOCK,
-  sentinelApiService: SENTINEL_API_SERVICE_MOCK,
   txParams: {
     data: '0x123',
     from: USER_ADDRESS_MOCK,
@@ -126,13 +123,13 @@ const PARSED_WRAPPED_ERC20_DEPOSIT_EVENT_MOCK = {
   args: [USER_ADDRESS_MOCK, { toHexString: (): Hex => VALUE_MOCK }],
 } as unknown as LogDescription;
 
-const defaultResponseTx: SimulationResponseTransaction = {
+const defaultResponseTx: SentinelSimulationResponseTransaction = {
   return: encodeTo32ByteHex('0x0'),
   callTrace: { calls: [], logs: [] },
   stateDiff: { pre: {}, post: {} },
 };
 
-const RESPONSE_NESTED_LOGS_MOCK: SimulationResponse = {
+const RESPONSE_NESTED_LOGS_MOCK: SentinelSimulationResponse = {
   transactions: [
     {
       ...defaultResponseTx,
@@ -164,10 +161,10 @@ const RESPONSE_NESTED_LOGS_MOCK: SimulationResponse = {
  * @param contractAddress - The contract address.
  * @returns The raw log mock.
  */
-function createLogMock(contractAddress: string): SimulationResponseLog {
+function createLogMock(contractAddress: string): SentinelSimulationLog {
   return {
     address: contractAddress,
-  } as unknown as SimulationResponseLog;
+  } as unknown as SentinelSimulationLog;
 }
 
 /**
@@ -177,8 +174,8 @@ function createLogMock(contractAddress: string): SimulationResponseLog {
  * @returns Mock API response.
  */
 function createEventResponseMock(
-  logs: SimulationResponseLog[],
-): SimulationResponse {
+  logs: SentinelSimulationLog[],
+): SentinelSimulationResponse {
   return {
     transactions: [{ ...defaultResponseTx, callTrace: { calls: [], logs } }],
     sponsorship: {
@@ -200,7 +197,7 @@ function createNativeBalanceResponse(
   previousBalance: string,
   newBalance: string,
   gasCost: number = 0,
-): SimulationResponse {
+): SentinelSimulationResponse {
   return {
     transactions: [
       {
@@ -217,7 +214,7 @@ function createNativeBalanceResponse(
         },
       },
     ],
-  } as unknown as SimulationResponse;
+  } as unknown as SentinelSimulationResponse;
 }
 
 /**
@@ -230,7 +227,7 @@ function createNativeBalanceResponse(
 function createBalanceOfResponse(
   previousBalances: string[],
   newBalances: string[],
-): SimulationResponse {
+): SentinelSimulationResponse {
   return {
     transactions: [
       ...previousBalances.map((previousBalance) => ({
@@ -243,7 +240,7 @@ function createBalanceOfResponse(
         return: encodeTo32ByteHex(newBalance),
       })),
     ],
-  } as unknown as SimulationResponse;
+  } as unknown as SentinelSimulationResponse;
 }
 
 /**
@@ -706,7 +703,7 @@ describe('Balance Change Utils', () => {
         // The ERC-721 token balance is only checked after the transaction since it is minted.
         expect(simulateTransactionsMock).toHaveBeenNthCalledWith(
           2,
-          SENTINEL_API_SERVICE_MOCK,
+          MESSENGER_MOCK,
           REQUEST_MOCK.chainId,
           {
             transactions: [
@@ -1305,7 +1302,7 @@ describe('Balance Change Utils', () => {
 
       expect(simulateTransactionsMock).toHaveBeenCalledTimes(1);
       expect(simulateTransactionsMock).toHaveBeenCalledWith(
-        SENTINEL_API_SERVICE_MOCK,
+        MESSENGER_MOCK,
         expect.any(String),
         expect.objectContaining({
           transactions: [
@@ -1336,7 +1333,7 @@ describe('Balance Change Utils', () => {
 
         expect(simulateTransactionsMock).toHaveBeenCalledTimes(1);
         expect(simulateTransactionsMock).toHaveBeenCalledWith(
-          SENTINEL_API_SERVICE_MOCK,
+          MESSENGER_MOCK,
           expect.any(String),
           expect.objectContaining({
             overrides: {
@@ -1364,7 +1361,7 @@ describe('Balance Change Utils', () => {
 
         expect(simulateTransactionsMock).toHaveBeenCalledTimes(1);
         expect(simulateTransactionsMock).toHaveBeenCalledWith(
-          SENTINEL_API_SERVICE_MOCK,
+          MESSENGER_MOCK,
           expect.any(String),
           expect.objectContaining({
             overrides: {
@@ -1390,7 +1387,7 @@ describe('Balance Change Utils', () => {
 
         expect(simulateTransactionsMock).toHaveBeenCalledTimes(1);
         expect(simulateTransactionsMock).toHaveBeenCalledWith(
-          SENTINEL_API_SERVICE_MOCK,
+          MESSENGER_MOCK,
           expect.any(String),
           expect.objectContaining({
             overrides: {
@@ -1424,7 +1421,7 @@ describe('Balance Change Utils', () => {
 
         expect(simulateTransactionsMock).toHaveBeenCalledTimes(1);
         expect(simulateTransactionsMock).toHaveBeenCalledWith(
-          SENTINEL_API_SERVICE_MOCK,
+          MESSENGER_MOCK,
           expect.any(String),
           expect.objectContaining({
             overrides: {
@@ -1437,19 +1434,12 @@ describe('Balance Change Utils', () => {
       });
     });
 
-    it('forwards the Sentinel API service', async () => {
-      const sentinelApiServiceMock = {} as unknown as SentinelApiService;
-
-      const request = {
-        ...REQUEST_MOCK,
-        sentinelApiService: sentinelApiServiceMock,
-      };
-
-      await getBalanceChanges(request);
+    it('forwards the messenger to simulateTransactions', async () => {
+      await getBalanceChanges(REQUEST_MOCK);
 
       expect(simulateTransactionsMock).toHaveBeenCalledTimes(1);
       expect(simulateTransactionsMock).toHaveBeenCalledWith(
-        sentinelApiServiceMock,
+        MESSENGER_MOCK,
         expect.any(String),
         expect.any(Object),
       );

--- a/packages/transaction-controller/src/utils/balance-changes.ts
+++ b/packages/transaction-controller/src/utils/balance-changes.ts
@@ -36,6 +36,7 @@ import type {
   SimulationToken,
   TransactionParams,
   NestedTransactionMetadata,
+  GetSimulationConfig,
 } from '../types';
 import { SimulationTokenStandard } from '../types';
 import { getNativeBalance } from './balance';
@@ -56,6 +57,7 @@ type ABI = Fragment[];
 export type GetBalanceChangesRequest = {
   blockTime?: number;
   chainId: Hex;
+  getSimulationConfig?: GetSimulationConfig;
   messenger: TransactionControllerMessenger;
   networkClientId: NetworkClientId;
   nestedTransactions?: NestedTransactionMetadata[];
@@ -117,6 +119,7 @@ type BalanceTransactionMap = Map<SimulationToken, SimulationRequestTransaction>;
  * @param request.to - The recipient of the transaction.
  * @param request.value - The value of the transaction.
  * @param request.data - The data of the transaction.
+ * @param request.getSimulationConfig - Optional callback to rewrite the simulation request URL.
  * @param request.sentinelApiService - The Sentinel API service used to simulate transactions.
  * @returns The simulation data.
  */
@@ -761,6 +764,7 @@ async function baseRequest({
   const {
     blockTime,
     chainId,
+    getSimulationConfig,
     messenger,
     networkClientId,
     sentinelApiService,
@@ -806,6 +810,7 @@ async function baseRequest({
 
   return await simulateTransactions(sentinelApiService, chainId, {
     ...params,
+    getSimulationConfig,
     transactions,
     withGas: true,
     withDefaultBlockOverrides: true,

--- a/packages/transaction-controller/src/utils/balance-changes.ts
+++ b/packages/transaction-controller/src/utils/balance-changes.ts
@@ -3,6 +3,7 @@ import { Interface } from '@ethersproject/abi';
 import { hexToBN, toHex } from '@metamask/controller-utils';
 import { abiERC20, abiERC721, abiERC1155 } from '@metamask/metamask-eth-abis';
 import type { NetworkClientId } from '@metamask/network-controller';
+import type { SentinelApiService } from '@metamask/sentinel-api-service';
 import { createModuleLogger } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
 import BN from 'bn.js';
@@ -35,7 +36,6 @@ import type {
   SimulationToken,
   TransactionParams,
   NestedTransactionMetadata,
-  GetSimulationConfig,
 } from '../types';
 import { SimulationTokenStandard } from '../types';
 import { getNativeBalance } from './balance';
@@ -58,8 +58,8 @@ export type GetBalanceChangesRequest = {
   chainId: Hex;
   messenger: TransactionControllerMessenger;
   networkClientId: NetworkClientId;
-  getSimulationConfig: GetSimulationConfig;
   nestedTransactions?: NestedTransactionMetadata[];
+  sentinelApiService: SentinelApiService;
   txParams: TransactionParams;
 };
 
@@ -117,7 +117,7 @@ type BalanceTransactionMap = Map<SimulationToken, SimulationRequestTransaction>;
  * @param request.to - The recipient of the transaction.
  * @param request.value - The value of the transaction.
  * @param request.data - The data of the transaction.
- * @param request.getSimulationConfig - Optional transaction simulation parameters.
+ * @param request.sentinelApiService - The Sentinel API service used to simulate transactions.
  * @returns The simulation data.
  */
 export async function getBalanceChanges(
@@ -763,7 +763,7 @@ async function baseRequest({
     chainId,
     messenger,
     networkClientId,
-    getSimulationConfig,
+    sentinelApiService,
     txParams,
   } = request;
   const { authorizationList } = txParams;
@@ -804,9 +804,8 @@ async function baseRequest({
 
   const isInsufficientBalance = currentBalanceBN.lt(requiredBalanceBN);
 
-  return await simulateTransactions(chainId, {
+  return await simulateTransactions(sentinelApiService, chainId, {
     ...params,
-    getSimulationConfig,
     transactions,
     withGas: true,
     withDefaultBlockOverrides: true,

--- a/packages/transaction-controller/src/utils/balance-changes.ts
+++ b/packages/transaction-controller/src/utils/balance-changes.ts
@@ -3,20 +3,19 @@ import { Interface } from '@ethersproject/abi';
 import { hexToBN, toHex } from '@metamask/controller-utils';
 import { abiERC20, abiERC721, abiERC1155 } from '@metamask/metamask-eth-abis';
 import type { NetworkClientId } from '@metamask/network-controller';
-import type { SentinelApiService } from '@metamask/sentinel-api-service';
+import type {
+  SentinelSimulationCallTrace,
+  SentinelSimulationLog,
+  SentinelSimulationResponse,
+  SentinelSimulationResponseTransaction,
+  SentinelSimulationTransaction,
+} from '@metamask/sentinel-api-service';
 import { createModuleLogger } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
 import BN from 'bn.js';
 
 import { simulateTransactions } from '../api/simulation-api';
-import type {
-  SimulationResponseLog,
-  SimulationRequestTransaction,
-  SimulationResponse,
-  SimulationResponseCallTrace,
-  SimulationResponseTransaction,
-  SimulationRequest,
-} from '../api/simulation-api';
+import type { SimulationRequest } from '../api/simulation-api';
 import {
   ABI_SIMULATION_ERC20_WRAPPED,
   ABI_SIMULATION_ERC721_LEGACY,
@@ -61,7 +60,6 @@ export type GetBalanceChangesRequest = {
   messenger: TransactionControllerMessenger;
   networkClientId: NetworkClientId;
   nestedTransactions?: NestedTransactionMetadata[];
-  sentinelApiService: SentinelApiService;
   txParams: TransactionParams;
 };
 
@@ -108,7 +106,7 @@ const SUPPORTED_TOKEN_ABIS = {
 
 const REVERTED_ERRORS = ['execution reverted', 'insufficient funds for gas'];
 
-type BalanceTransactionMap = Map<SimulationToken, SimulationRequestTransaction>;
+type BalanceTransactionMap = Map<SimulationToken, SentinelSimulationTransaction>;
 
 /**
  * Generate simulation data for a transaction.
@@ -120,7 +118,6 @@ type BalanceTransactionMap = Map<SimulationToken, SimulationRequestTransaction>;
  * @param request.value - The value of the transaction.
  * @param request.data - The data of the transaction.
  * @param request.getSimulationConfig - Optional callback to rewrite the simulation request URL.
- * @param request.sentinelApiService - The Sentinel API service used to simulate transactions.
  * @returns The simulation data.
  */
 export async function getBalanceChanges(
@@ -207,7 +204,7 @@ export async function getBalanceChanges(
  */
 function getNativeBalanceChange(
   request: GetBalanceChangesRequest,
-  response: SimulationResponse,
+  response: SentinelSimulationResponse,
 ): SimulationBalanceChange | undefined {
   const transactionResponse = response.transactions[0];
 
@@ -239,10 +236,10 @@ function getNativeBalanceChange(
  * @param response - The simulation response.
  * @returns The parsed events.
  */
-function getEvents(response: SimulationResponse): ParsedEvent[] {
+function getEvents(response: SentinelSimulationResponse): ParsedEvent[] {
   /* istanbul ignore next */
   const logs = extractLogs(
-    response.transactions[0]?.callTrace ?? ({} as SimulationResponseCallTrace),
+    response.transactions[0]?.callTrace ?? ({} as SentinelSimulationCallTrace),
   );
 
   log('Extracted logs', logs);
@@ -456,7 +453,7 @@ function getTokenBalanceTransactions(
         tokenId,
       );
 
-      const transaction: SimulationRequestTransaction = {
+      const transaction: SentinelSimulationTransaction = {
         from,
         to: event.contractAddress,
         data,
@@ -549,7 +546,7 @@ function getContractInterface(
 function getAmountFromBalanceTransactionResult(
   from: Hex,
   token: SimulationToken,
-  response: SimulationResponseTransaction,
+  response: SentinelSimulationResponseTransaction,
 ): Hex {
   const contract = getContractInterface(token.standard);
 
@@ -606,7 +603,7 @@ function getBalanceTransactionData(
  * @returns The parsed event log or undefined if it could not be parsed.
  */
 function parseLog(
-  eventLog: SimulationResponseLog,
+  eventLog: SentinelSimulationLog,
   interfaces: Map<SupportedToken, Interface>,
 ):
   | (LogDescription & { abi: ABI; standard: SimulationTokenStandard })
@@ -638,8 +635,8 @@ function parseLog(
  * @returns An array of logs.
  */
 function extractLogs(
-  call: SimulationResponseCallTrace,
-): SimulationResponseLog[] {
+  call: SentinelSimulationCallTrace,
+): SentinelSimulationLog[] {
   /* istanbul ignore next */
   const logs = call.logs ?? [];
 
@@ -658,7 +655,7 @@ function extractLogs(
  * @param call - The root call trace.
  * @returns An array of error messages.
  */
-function extractCallTraceErrors(call?: SimulationResponseCallTrace): string[] {
+function extractCallTraceErrors(call?: SentinelSimulationCallTrace): string[] {
   if (!call) {
     return [];
   }
@@ -683,7 +680,7 @@ function extractCallTraceErrors(call?: SimulationResponseCallTrace): string[] {
  * otherwise `undefined`.
  */
 function extractRootRevert(
-  call?: SimulationResponseCallTrace,
+  call?: SentinelSimulationCallTrace,
 ): Revert | undefined {
   if (!call?.error) {
     return undefined;
@@ -758,16 +755,15 @@ async function baseRequest({
 }: {
   request: GetBalanceChangesRequest;
   params?: Partial<SimulationRequest>;
-  before?: SimulationRequestTransaction[];
-  after?: SimulationRequestTransaction[];
-}): Promise<SimulationResponse> {
+  before?: SentinelSimulationTransaction[];
+  after?: SentinelSimulationTransaction[];
+}): Promise<SentinelSimulationResponse> {
   const {
     blockTime,
     chainId,
     getSimulationConfig,
     messenger,
     networkClientId,
-    sentinelApiService,
     txParams,
   } = request;
   const { authorizationList } = txParams;
@@ -778,7 +774,7 @@ async function baseRequest({
     from,
   }));
 
-  const userTransaction: SimulationRequestTransaction = {
+  const userTransaction: SentinelSimulationTransaction = {
     authorizationList: authorizationListFinal,
     data: txParams.data as Hex,
     from: txParams.from as Hex,
@@ -808,7 +804,7 @@ async function baseRequest({
 
   const isInsufficientBalance = currentBalanceBN.lt(requiredBalanceBN);
 
-  return await simulateTransactions(sentinelApiService, chainId, {
+  return await simulateTransactions(messenger, chainId, {
     ...params,
     getSimulationConfig,
     transactions,

--- a/packages/transaction-controller/src/utils/batch.test.ts
+++ b/packages/transaction-controller/src/utils/batch.test.ts
@@ -2,7 +2,6 @@ import { ORIGIN_METAMASK } from '@metamask/approval-controller';
 import type { AddResult } from '@metamask/approval-controller';
 import { ApprovalType } from '@metamask/controller-utils';
 import { rpcErrors, errorCodes } from '@metamask/rpc-errors';
-import type { SentinelApiService } from '@metamask/sentinel-api-service';
 import { cloneDeep } from 'lodash';
 
 import {
@@ -100,7 +99,6 @@ const MESSENGER_MOCK = {
 
 const NETWORK_CLIENT_ID_MOCK = 'testNetworkClientId';
 const PUBLIC_KEY_MOCK = '0x112233';
-const SENTINEL_API_SERVICE_MOCK = {} as unknown as SentinelApiService;
 const BATCH_ID_MOCK = '0x654321';
 const BATCH_ID_CUSTOM_MOCK = '0x123456';
 const GET_INTERNAL_ACCOUNTS_MOCK = jest.fn().mockReturnValue([]);
@@ -173,7 +171,8 @@ const PUBLISH_BATCH_HOOK_PARAMS = {
 };
 
 function mockMessengerNetworkCalls(): void {
-  const messengerCallMock = jest.mocked(MESSENGER_MOCK.call);
+  // eslint-disable-next-line jest/unbound-method
+  const messengerCallMock = MESSENGER_MOCK.call as unknown as jest.Mock;
 
   messengerCallMock.mockImplementation((...args: unknown[]) => {
     const [action] = args as [string];
@@ -472,7 +471,6 @@ describe('Batch Utils', () => {
           disableHook: false,
           disableSequential: false,
         },
-        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         signTransaction: signTransactionMock,
         update: updateMock,
         updateTransaction: updateTransactionMock,
@@ -2361,7 +2359,7 @@ describe('Batch Utils', () => {
         expect(simulateGasBatchMock).toHaveBeenCalledWith({
           chainId: CHAIN_ID_MOCK,
           from: FROM_MOCK,
-          sentinelApiService: SENTINEL_API_SERVICE_MOCK,
+          messenger: MESSENGER_MOCK,
           transactions: TRANSACTIONS_BATCH_MOCK,
         });
         expect(getGasFeesMock).toHaveBeenCalledTimes(1);

--- a/packages/transaction-controller/src/utils/batch.test.ts
+++ b/packages/transaction-controller/src/utils/batch.test.ts
@@ -2,6 +2,7 @@ import { ORIGIN_METAMASK } from '@metamask/approval-controller';
 import type { AddResult } from '@metamask/approval-controller';
 import { ApprovalType } from '@metamask/controller-utils';
 import { rpcErrors, errorCodes } from '@metamask/rpc-errors';
+import type { SentinelApiService } from '@metamask/sentinel-api-service';
 import { cloneDeep } from 'lodash';
 
 import {
@@ -99,6 +100,7 @@ const MESSENGER_MOCK = {
 
 const NETWORK_CLIENT_ID_MOCK = 'testNetworkClientId';
 const PUBLIC_KEY_MOCK = '0x112233';
+const SENTINEL_API_SERVICE_MOCK = {} as unknown as SentinelApiService;
 const BATCH_ID_MOCK = '0x654321';
 const BATCH_ID_CUSTOM_MOCK = '0x123456';
 const GET_INTERNAL_ACCOUNTS_MOCK = jest.fn().mockReturnValue([]);
@@ -455,7 +457,6 @@ describe('Batch Utils', () => {
         getGasFeeEstimates: getGasFeeEstimatesMock,
         getInternalAccounts: GET_INTERNAL_ACCOUNTS_MOCK,
         getPendingTransactionTracker: getPendingTransactionTrackerMock,
-        getSimulationConfig: jest.fn(),
         getTransaction: getTransactionMock,
         isSimulationEnabled: jest.fn().mockReturnValue(true),
         messenger: MESSENGER_MOCK,
@@ -471,6 +472,7 @@ describe('Batch Utils', () => {
           disableHook: false,
           disableSequential: false,
         },
+        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         signTransaction: signTransactionMock,
         update: updateMock,
         updateTransaction: updateTransactionMock,
@@ -2359,7 +2361,7 @@ describe('Batch Utils', () => {
         expect(simulateGasBatchMock).toHaveBeenCalledWith({
           chainId: CHAIN_ID_MOCK,
           from: FROM_MOCK,
-          getSimulationConfig: request.getSimulationConfig,
+          sentinelApiService: SENTINEL_API_SERVICE_MOCK,
           transactions: TRANSACTIONS_BATCH_MOCK,
         });
         expect(getGasFeesMock).toHaveBeenCalledTimes(1);

--- a/packages/transaction-controller/src/utils/batch.ts
+++ b/packages/transaction-controller/src/utils/batch.ts
@@ -13,6 +13,7 @@ import type {
 } from '@metamask/gas-fee-controller';
 import type { NetworkClientId } from '@metamask/network-controller';
 import { JsonRpcError, rpcErrors } from '@metamask/rpc-errors';
+import type { SentinelApiService } from '@metamask/sentinel-api-service';
 import type { Hex } from '@metamask/utils';
 import { bytesToHex, createModuleLogger } from '@metamask/utils';
 import type { WritableDraft } from 'immer/dist/internal.js';
@@ -21,7 +22,6 @@ import { parse, v4 } from 'uuid';
 import { GasFeeEstimateLevel, TransactionStatus } from '..';
 import type {
   BatchTransactionParams,
-  GetSimulationConfig,
   PublishBatchHookRequest,
   TransactionController,
   TransactionControllerMessenger,
@@ -82,7 +82,6 @@ type AddTransactionBatchRequest = {
   getPendingTransactionTracker: (
     networkClientId: string,
   ) => PendingTransactionTracker;
-  getSimulationConfig: GetSimulationConfig;
   getTransaction: (id: string) => TransactionMeta;
   isSimulationEnabled: () => boolean;
   messenger: TransactionControllerMessenger;
@@ -91,6 +90,7 @@ type AddTransactionBatchRequest = {
   publicKeyEIP7702?: Hex;
   request: TransactionBatchRequest;
   requestId?: string;
+  sentinelApiService: SentinelApiService;
   signTransaction: (
     transactionMeta: TransactionMeta,
   ) => Promise<string | undefined>;
@@ -947,7 +947,7 @@ async function prepareApprovalData({
     request: userRequest,
     isSimulationEnabled,
     getGasFeeEstimates,
-    getSimulationConfig,
+    sentinelApiService,
     update,
   } = request;
 
@@ -970,7 +970,7 @@ async function prepareApprovalData({
   const { totalGasLimit: gasLimit } = await simulateGasBatch({
     chainId,
     from,
-    getSimulationConfig,
+    sentinelApiService,
     transactions: nestedTransactions,
   });
 

--- a/packages/transaction-controller/src/utils/batch.ts
+++ b/packages/transaction-controller/src/utils/batch.ts
@@ -47,6 +47,7 @@ import type {
   IsAtomicBatchSupportedResult,
   IsAtomicBatchSupportedResultEntry,
   TransactionBatchMeta,
+  GetSimulationConfig,
 } from '../types';
 import type { TransactionBatchResult, TransactionParams } from '../types';
 import {
@@ -82,6 +83,7 @@ type AddTransactionBatchRequest = {
   getPendingTransactionTracker: (
     networkClientId: string,
   ) => PendingTransactionTracker;
+  getSimulationConfig?: GetSimulationConfig;
   getTransaction: (id: string) => TransactionMeta;
   isSimulationEnabled: () => boolean;
   messenger: TransactionControllerMessenger;
@@ -947,6 +949,7 @@ async function prepareApprovalData({
     request: userRequest,
     isSimulationEnabled,
     getGasFeeEstimates,
+    getSimulationConfig,
     sentinelApiService,
     update,
   } = request;
@@ -970,6 +973,7 @@ async function prepareApprovalData({
   const { totalGasLimit: gasLimit } = await simulateGasBatch({
     chainId,
     from,
+    getSimulationConfig,
     sentinelApiService,
     transactions: nestedTransactions,
   });

--- a/packages/transaction-controller/src/utils/batch.ts
+++ b/packages/transaction-controller/src/utils/batch.ts
@@ -13,7 +13,6 @@ import type {
 } from '@metamask/gas-fee-controller';
 import type { NetworkClientId } from '@metamask/network-controller';
 import { JsonRpcError, rpcErrors } from '@metamask/rpc-errors';
-import type { SentinelApiService } from '@metamask/sentinel-api-service';
 import type { Hex } from '@metamask/utils';
 import { bytesToHex, createModuleLogger } from '@metamask/utils';
 import type { WritableDraft } from 'immer/dist/internal.js';
@@ -92,7 +91,6 @@ type AddTransactionBatchRequest = {
   publicKeyEIP7702?: Hex;
   request: TransactionBatchRequest;
   requestId?: string;
-  sentinelApiService: SentinelApiService;
   signTransaction: (
     transactionMeta: TransactionMeta,
   ) => Promise<string | undefined>;
@@ -950,7 +948,6 @@ async function prepareApprovalData({
     isSimulationEnabled,
     getGasFeeEstimates,
     getSimulationConfig,
-    sentinelApiService,
     update,
   } = request;
 
@@ -974,7 +971,7 @@ async function prepareApprovalData({
     chainId,
     from,
     getSimulationConfig,
-    sentinelApiService,
+    messenger,
     transactions: nestedTransactions,
   });
 

--- a/packages/transaction-controller/src/utils/gas-fee-tokens.test.ts
+++ b/packages/transaction-controller/src/utils/gas-fee-tokens.test.ts
@@ -1,4 +1,3 @@
-import type { SentinelApiService } from '@metamask/sentinel-api-service';
 import type { Hex } from '@metamask/utils';
 import { cloneDeep } from 'lodash';
 
@@ -28,7 +27,6 @@ const TOKEN_ADDRESS_1_MOCK =
 const TOKEN_ADDRESS_2_MOCK = '0xabcdef1234567890abcdef1234567890abcdef12';
 const UPGRADE_CONTRACT_ADDRESS_MOCK =
   '0xabcdefabcdefabcdefabcdefabcdefabcdefabcdef';
-const SENTINEL_API_SERVICE_MOCK = {} as unknown as SentinelApiService;
 
 const TRANSACTION_META_MOCK = {
   txParams: {
@@ -39,12 +37,13 @@ const TRANSACTION_META_MOCK = {
   },
 } as TransactionMeta;
 
+const MESSENGER_MOCK = {} as TransactionControllerMessenger;
+
 const REQUEST_MOCK: GetGasFeeTokensRequest = {
   chainId: CHAIN_ID_MOCK,
   isEIP7702GasFeeTokensEnabled: jest.fn().mockResolvedValue(true),
-  messenger: {} as TransactionControllerMessenger,
+  messenger: MESSENGER_MOCK,
   publicKeyEIP7702: '0x123',
-  sentinelApiService: SENTINEL_API_SERVICE_MOCK,
   transactionMeta: TRANSACTION_META_MOCK,
 };
 
@@ -265,7 +264,7 @@ describe('Gas Fee Tokens Utils', () => {
       await getGasFeeTokens(REQUEST_MOCK);
 
       expect(simulateTransactionsMock).toHaveBeenCalledWith(
-        SENTINEL_API_SERVICE_MOCK,
+        MESSENGER_MOCK,
         CHAIN_ID_MOCK,
         expect.objectContaining({
           suggestFees: expect.objectContaining({
@@ -293,7 +292,7 @@ describe('Gas Fee Tokens Utils', () => {
       await getGasFeeTokens(REQUEST_MOCK);
 
       expect(simulateTransactionsMock).toHaveBeenCalledWith(
-        SENTINEL_API_SERVICE_MOCK,
+        MESSENGER_MOCK,
         CHAIN_ID_MOCK,
         expect.objectContaining({
           suggestFees: expect.objectContaining({
@@ -321,7 +320,7 @@ describe('Gas Fee Tokens Utils', () => {
       await getGasFeeTokens(REQUEST_MOCK);
 
       expect(simulateTransactionsMock).toHaveBeenCalledWith(
-        SENTINEL_API_SERVICE_MOCK,
+        MESSENGER_MOCK,
         CHAIN_ID_MOCK,
         expect.objectContaining({
           transactions: [
@@ -362,7 +361,7 @@ describe('Gas Fee Tokens Utils', () => {
       await getGasFeeTokens(request);
 
       expect(simulateTransactionsMock).toHaveBeenCalledWith(
-        SENTINEL_API_SERVICE_MOCK,
+        MESSENGER_MOCK,
         CHAIN_ID_MOCK,
         expect.objectContaining({
           transactions: [
@@ -379,19 +378,12 @@ describe('Gas Fee Tokens Utils', () => {
       );
     });
 
-    it('forwards the Sentinel API service', async () => {
-      const sentinelApiServiceMock = {} as unknown as SentinelApiService;
-
-      const request = {
-        ...REQUEST_MOCK,
-        sentinelApiService: sentinelApiServiceMock,
-      };
-
-      await getGasFeeTokens(request);
+    it('forwards the messenger to simulateTransactions', async () => {
+      await getGasFeeTokens(REQUEST_MOCK);
 
       expect(simulateTransactionsMock).toHaveBeenCalledTimes(1);
       expect(simulateTransactionsMock).toHaveBeenCalledWith(
-        sentinelApiServiceMock,
+        MESSENGER_MOCK,
         expect.any(String),
         expect.any(Object),
       );

--- a/packages/transaction-controller/src/utils/gas-fee-tokens.test.ts
+++ b/packages/transaction-controller/src/utils/gas-fee-tokens.test.ts
@@ -1,9 +1,9 @@
+import type { SentinelApiService } from '@metamask/sentinel-api-service';
 import type { Hex } from '@metamask/utils';
 import { cloneDeep } from 'lodash';
 
 import type {
   GasFeeToken,
-  GetSimulationConfig,
   TransactionControllerMessenger,
   TransactionMeta,
 } from '..';
@@ -28,6 +28,7 @@ const TOKEN_ADDRESS_1_MOCK =
 const TOKEN_ADDRESS_2_MOCK = '0xabcdef1234567890abcdef1234567890abcdef12';
 const UPGRADE_CONTRACT_ADDRESS_MOCK =
   '0xabcdefabcdefabcdefabcdefabcdefabcdefabcdef';
+const SENTINEL_API_SERVICE_MOCK = {} as unknown as SentinelApiService;
 
 const TRANSACTION_META_MOCK = {
   txParams: {
@@ -41,9 +42,9 @@ const TRANSACTION_META_MOCK = {
 const REQUEST_MOCK: GetGasFeeTokensRequest = {
   chainId: CHAIN_ID_MOCK,
   isEIP7702GasFeeTokensEnabled: jest.fn().mockResolvedValue(true),
-  getSimulationConfig: jest.fn(),
   messenger: {} as TransactionControllerMessenger,
   publicKeyEIP7702: '0x123',
+  sentinelApiService: SENTINEL_API_SERVICE_MOCK,
   transactionMeta: TRANSACTION_META_MOCK,
 };
 
@@ -264,6 +265,7 @@ describe('Gas Fee Tokens Utils', () => {
       await getGasFeeTokens(REQUEST_MOCK);
 
       expect(simulateTransactionsMock).toHaveBeenCalledWith(
+        SENTINEL_API_SERVICE_MOCK,
         CHAIN_ID_MOCK,
         expect.objectContaining({
           suggestFees: expect.objectContaining({
@@ -291,6 +293,7 @@ describe('Gas Fee Tokens Utils', () => {
       await getGasFeeTokens(REQUEST_MOCK);
 
       expect(simulateTransactionsMock).toHaveBeenCalledWith(
+        SENTINEL_API_SERVICE_MOCK,
         CHAIN_ID_MOCK,
         expect.objectContaining({
           suggestFees: expect.objectContaining({
@@ -318,6 +321,7 @@ describe('Gas Fee Tokens Utils', () => {
       await getGasFeeTokens(REQUEST_MOCK);
 
       expect(simulateTransactionsMock).toHaveBeenCalledWith(
+        SENTINEL_API_SERVICE_MOCK,
         CHAIN_ID_MOCK,
         expect.objectContaining({
           transactions: [
@@ -358,6 +362,7 @@ describe('Gas Fee Tokens Utils', () => {
       await getGasFeeTokens(request);
 
       expect(simulateTransactionsMock).toHaveBeenCalledWith(
+        SENTINEL_API_SERVICE_MOCK,
         CHAIN_ID_MOCK,
         expect.objectContaining({
           transactions: [
@@ -374,22 +379,21 @@ describe('Gas Fee Tokens Utils', () => {
       );
     });
 
-    it('forwards simulation config', async () => {
-      const getSimulationConfigMock: GetSimulationConfig = jest.fn();
+    it('forwards the Sentinel API service', async () => {
+      const sentinelApiServiceMock = {} as unknown as SentinelApiService;
 
       const request = {
         ...REQUEST_MOCK,
-        getSimulationConfig: getSimulationConfigMock,
+        sentinelApiService: sentinelApiServiceMock,
       };
 
       await getGasFeeTokens(request);
 
       expect(simulateTransactionsMock).toHaveBeenCalledTimes(1);
       expect(simulateTransactionsMock).toHaveBeenCalledWith(
+        sentinelApiServiceMock,
         expect.any(String),
-        expect.objectContaining({
-          getSimulationConfig: getSimulationConfigMock,
-        }),
+        expect.any(Object),
       );
     });
   });

--- a/packages/transaction-controller/src/utils/gas-fee-tokens.ts
+++ b/packages/transaction-controller/src/utils/gas-fee-tokens.ts
@@ -1,6 +1,10 @@
 import type { NetworkClientId } from '@metamask/network-controller';
 import { rpcErrors } from '@metamask/rpc-errors';
-import type { SentinelApiService } from '@metamask/sentinel-api-service';
+import type {
+  SentinelSimulationResponse,
+  SentinelSimulationResponseTransaction,
+  SentinelSimulationTransaction,
+} from '@metamask/sentinel-api-service';
 import type { Hex } from '@metamask/utils';
 import { createModuleLogger } from '@metamask/utils';
 
@@ -10,11 +14,6 @@ import type {
   TransactionMeta,
 } from '..';
 import { simulateTransactions } from '../api/simulation-api';
-import type { SimulationRequestTransaction } from '../api/simulation-api';
-import type {
-  SimulationResponse,
-  SimulationResponseTransaction,
-} from '../api/simulation-api';
 import { projectLogger } from '../logger';
 import type { GetSimulationConfig } from '../types';
 import { isNativeBalanceSufficientForGas } from './balance';
@@ -32,7 +31,6 @@ export type GetGasFeeTokensRequest = {
   getSimulationConfig?: GetSimulationConfig;
   messenger: TransactionControllerMessenger;
   publicKeyEIP7702?: Hex;
-  sentinelApiService: SentinelApiService;
   transactionMeta: TransactionMeta;
 };
 
@@ -45,7 +43,6 @@ export type GetGasFeeTokensRequest = {
  * @param request.getSimulationConfig - Optional callback to rewrite the simulation request URL.
  * @param request.messenger - The messenger instance.
  * @param request.publicKeyEIP7702 - Public key to validate EIP-7702 contract signatures.
- * @param request.sentinelApiService - The Sentinel API service used to simulate transactions.
  * @param request.transactionMeta - The transaction metadata.
  * @returns An array of gas fee tokens.
  */
@@ -55,7 +52,6 @@ export async function getGasFeeTokens({
   getSimulationConfig,
   messenger,
   publicKeyEIP7702,
-  sentinelApiService,
   transactionMeta,
 }: GetGasFeeTokensRequest): Promise<{
   gasFeeTokens: GasFeeToken[];
@@ -77,7 +73,7 @@ export async function getGasFeeTokens({
     is7702GasFeeTokensEnabled && doesChainSupportEIP7702(chainId, messenger);
 
   let authorizationList:
-    | SimulationRequestTransaction['authorizationList']
+    | SentinelSimulationTransaction['authorizationList']
     | undefined = authorizationListRequest?.map((authorization) => ({
     address: authorization.address,
     from,
@@ -93,7 +89,7 @@ export async function getGasFeeTokens({
   }
 
   try {
-    const response = await simulateTransactions(sentinelApiService, chainId, {
+    const response = await simulateTransactions(messenger, chainId, {
       getSimulationConfig,
       transactions: [
         {
@@ -217,12 +213,12 @@ export async function checkGasFeeTokenBeforePublish({
  * @param response - The simulation response.
  * @returns gasFeeTokens: An array of gas fee tokens. isGasFeeSponsored: Whether the transaction is sponsored
  */
-function parseGasFeeTokens(response: SimulationResponse): {
+function parseGasFeeTokens(response: SentinelSimulationResponse): {
   gasFeeTokens: GasFeeToken[];
   isGasFeeSponsored: boolean;
 } {
   const feeLevel = response.transactions?.[0]
-    ?.fees?.[0] as Required<SimulationResponseTransaction>['fees'][0];
+    ?.fees?.[0] as Required<SentinelSimulationResponseTransaction>['fees'][0];
 
   const isGasFeeSponsored = response.sponsorship?.isSponsored ?? false;
 
@@ -267,7 +263,7 @@ function buildAuthorizationList({
   from: Hex;
   messenger: TransactionControllerMessenger;
   publicKeyEIP7702?: Hex;
-}): SimulationRequestTransaction['authorizationList'] | undefined {
+}): SentinelSimulationTransaction['authorizationList'] | undefined {
   if (!publicKeyEIP7702) {
     throw rpcErrors.internal(ERROR_MESSGE_PUBLIC_KEY);
   }

--- a/packages/transaction-controller/src/utils/gas-fee-tokens.ts
+++ b/packages/transaction-controller/src/utils/gas-fee-tokens.ts
@@ -16,6 +16,7 @@ import type {
   SimulationResponseTransaction,
 } from '../api/simulation-api';
 import { projectLogger } from '../logger';
+import type { GetSimulationConfig } from '../types';
 import { isNativeBalanceSufficientForGas } from './balance';
 import { ERROR_MESSAGE_NO_UPGRADE_CONTRACT } from './batch';
 import { ERROR_MESSGE_PUBLIC_KEY, doesChainSupportEIP7702 } from './eip7702';
@@ -28,6 +29,7 @@ export type GetGasFeeTokensRequest = {
   isEIP7702GasFeeTokensEnabled: (
     transactionMeta: TransactionMeta,
   ) => Promise<boolean>;
+  getSimulationConfig?: GetSimulationConfig;
   messenger: TransactionControllerMessenger;
   publicKeyEIP7702?: Hex;
   sentinelApiService: SentinelApiService;
@@ -40,6 +42,7 @@ export type GetGasFeeTokensRequest = {
  * @param request - The request object.
  * @param request.chainId - The chain ID of the transaction.
  * @param request.isEIP7702GasFeeTokensEnabled - Callback to check if EIP-7702 gas fee tokens are enabled.
+ * @param request.getSimulationConfig - Optional callback to rewrite the simulation request URL.
  * @param request.messenger - The messenger instance.
  * @param request.publicKeyEIP7702 - Public key to validate EIP-7702 contract signatures.
  * @param request.sentinelApiService - The Sentinel API service used to simulate transactions.
@@ -49,6 +52,7 @@ export type GetGasFeeTokensRequest = {
 export async function getGasFeeTokens({
   chainId,
   isEIP7702GasFeeTokensEnabled,
+  getSimulationConfig,
   messenger,
   publicKeyEIP7702,
   sentinelApiService,
@@ -90,6 +94,7 @@ export async function getGasFeeTokens({
 
   try {
     const response = await simulateTransactions(sentinelApiService, chainId, {
+      getSimulationConfig,
       transactions: [
         {
           authorizationList,

--- a/packages/transaction-controller/src/utils/gas-fee-tokens.ts
+++ b/packages/transaction-controller/src/utils/gas-fee-tokens.ts
@@ -1,5 +1,6 @@
 import type { NetworkClientId } from '@metamask/network-controller';
 import { rpcErrors } from '@metamask/rpc-errors';
+import type { SentinelApiService } from '@metamask/sentinel-api-service';
 import type { Hex } from '@metamask/utils';
 import { createModuleLogger } from '@metamask/utils';
 
@@ -15,7 +16,6 @@ import type {
   SimulationResponseTransaction,
 } from '../api/simulation-api';
 import { projectLogger } from '../logger';
-import type { GetSimulationConfig } from '../types';
 import { isNativeBalanceSufficientForGas } from './balance';
 import { ERROR_MESSAGE_NO_UPGRADE_CONTRACT } from './batch';
 import { ERROR_MESSGE_PUBLIC_KEY, doesChainSupportEIP7702 } from './eip7702';
@@ -28,9 +28,9 @@ export type GetGasFeeTokensRequest = {
   isEIP7702GasFeeTokensEnabled: (
     transactionMeta: TransactionMeta,
   ) => Promise<boolean>;
-  getSimulationConfig: GetSimulationConfig;
   messenger: TransactionControllerMessenger;
   publicKeyEIP7702?: Hex;
+  sentinelApiService: SentinelApiService;
   transactionMeta: TransactionMeta;
 };
 
@@ -42,8 +42,8 @@ export type GetGasFeeTokensRequest = {
  * @param request.isEIP7702GasFeeTokensEnabled - Callback to check if EIP-7702 gas fee tokens are enabled.
  * @param request.messenger - The messenger instance.
  * @param request.publicKeyEIP7702 - Public key to validate EIP-7702 contract signatures.
+ * @param request.sentinelApiService - The Sentinel API service used to simulate transactions.
  * @param request.transactionMeta - The transaction metadata.
- * @param request.getSimulationConfig - Optional transaction simulation parameters.
  * @returns An array of gas fee tokens.
  */
 export async function getGasFeeTokens({
@@ -51,8 +51,8 @@ export async function getGasFeeTokens({
   isEIP7702GasFeeTokensEnabled,
   messenger,
   publicKeyEIP7702,
+  sentinelApiService,
   transactionMeta,
-  getSimulationConfig,
 }: GetGasFeeTokensRequest): Promise<{
   gasFeeTokens: GasFeeToken[];
   isGasFeeSponsored: boolean;
@@ -89,8 +89,7 @@ export async function getGasFeeTokens({
   }
 
   try {
-    const response = await simulateTransactions(chainId, {
-      getSimulationConfig,
+    const response = await simulateTransactions(sentinelApiService, chainId, {
       transactions: [
         {
           authorizationList,

--- a/packages/transaction-controller/src/utils/gas.test.ts
+++ b/packages/transaction-controller/src/utils/gas.test.ts
@@ -54,7 +54,8 @@ const BLOCK_GAS_LIMIT_MOCK = 123456789;
 const BLOCK_NUMBER_MOCK = '0x5678';
 const NETWORK_CLIENT_ID_MOCK = 'testNetworkClientId' as NetworkClientId;
 const FALLBACK_MULTIPLIER_35_PERCENT = 0.35;
-const GET_SIMULATION_CONFIG_MOCK = jest.fn();
+const SENTINEL_API_SERVICE_MOCK =
+  {} as unknown as import('@metamask/sentinel-api-service').SentinelApiService;
 const MAX_GAS_MULTIPLIER = MAX_GAS_BLOCK_PERCENT / 100;
 const CHAIN_ID_MOCK = '0x123';
 const GAS_2_MOCK = 12345;
@@ -202,7 +203,7 @@ const UPDATE_GAS_REQUEST_MOCK = {
   txMeta: TRANSACTION_META_MOCK,
   isCustomNetwork: false,
   isSimulationEnabled: false,
-  getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
+  sentinelApiService: SENTINEL_API_SERVICE_MOCK,
   messenger: MESSENGER_MOCK,
 } as UpdateGasRequest;
 
@@ -573,7 +574,7 @@ describe('gas', () => {
       const result = await estimateGas({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         isSimulationEnabled: false,
-        getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
+        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         messenger: MESSENGER_MOCK,
         txParams: TRANSACTION_META_MOCK.txParams,
       });
@@ -599,7 +600,7 @@ describe('gas', () => {
       const result = await estimateGas({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         isSimulationEnabled: false,
-        getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
+        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         messenger: MESSENGER_MOCK,
         txParams: TRANSACTION_META_MOCK.txParams,
       });
@@ -635,7 +636,7 @@ describe('gas', () => {
       const result = await estimateGas({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         isSimulationEnabled: false,
-        getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
+        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         messenger: MESSENGER_MOCK,
         txParams: TRANSACTION_META_MOCK.txParams,
       });
@@ -661,7 +662,7 @@ describe('gas', () => {
       const result = await estimateGas({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         isSimulationEnabled: false,
-        getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
+        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         messenger: MESSENGER_MOCK,
         txParams: TRANSACTION_META_MOCK.txParams,
       });
@@ -684,7 +685,7 @@ describe('gas', () => {
       const result = await estimateGas({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         isSimulationEnabled: false,
-        getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
+        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         messenger: MESSENGER_MOCK,
         txParams: TRANSACTION_META_MOCK.txParams,
       });
@@ -710,7 +711,7 @@ describe('gas', () => {
       const result = await estimateGas({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         isSimulationEnabled: false,
-        getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
+        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         messenger: MESSENGER_MOCK,
         txParams: TRANSACTION_META_MOCK.txParams,
       });
@@ -742,7 +743,7 @@ describe('gas', () => {
       const result = await estimateGas({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         isSimulationEnabled: false,
-        getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
+        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         messenger: MESSENGER_MOCK,
         txParams: TRANSACTION_META_MOCK.txParams,
       });
@@ -769,7 +770,7 @@ describe('gas', () => {
       const result = await estimateGas({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         isSimulationEnabled: false,
-        getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
+        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         messenger: MESSENGER_MOCK,
         txParams: TRANSACTION_META_MOCK.txParams,
       });
@@ -794,7 +795,7 @@ describe('gas', () => {
       const result = await estimateGas({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         isSimulationEnabled: false,
-        getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
+        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         messenger: MESSENGER_MOCK,
         txParams: TRANSACTION_META_MOCK.txParams,
       });
@@ -811,7 +812,7 @@ describe('gas', () => {
       await estimateGas({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         isSimulationEnabled: false,
-        getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
+        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         messenger: MESSENGER_MOCK,
         txParams: {
           ...TRANSACTION_META_MOCK.txParams,
@@ -843,7 +844,7 @@ describe('gas', () => {
       await estimateGas({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         isSimulationEnabled: false,
-        getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
+        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         messenger: MESSENGER_MOCK,
         txParams: {
           ...TRANSACTION_META_MOCK.txParams,
@@ -873,7 +874,7 @@ describe('gas', () => {
       await estimateGas({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         isSimulationEnabled: false,
-        getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
+        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         messenger: MESSENGER_MOCK,
         txParams: {
           ...TRANSACTION_META_MOCK.txParams,
@@ -903,7 +904,7 @@ describe('gas', () => {
       await estimateGas({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         isSimulationEnabled: false,
-        getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
+        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         messenger: MESSENGER_MOCK,
         txParams: {
           ...TRANSACTION_META_MOCK.txParams,
@@ -954,7 +955,7 @@ describe('gas', () => {
           networkClientId: NETWORK_CLIENT_ID_MOCK,
           ignoreDelegationSignatures: true,
           isSimulationEnabled: true,
-          getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
+          sentinelApiService: SENTINEL_API_SERVICE_MOCK,
           messenger: MESSENGER_MOCK,
           txParams: TRANSACTION_META_MOCK.txParams,
         });
@@ -974,7 +975,7 @@ describe('gas', () => {
             networkClientId: NETWORK_CLIENT_ID_MOCK,
             ignoreDelegationSignatures: true,
             isSimulationEnabled: false,
-            getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
+            sentinelApiService: SENTINEL_API_SERVICE_MOCK,
             messenger: MESSENGER_MOCK,
             txParams: TRANSACTION_META_MOCK.txParams,
           }),
@@ -1002,7 +1003,7 @@ describe('gas', () => {
         const result = await estimateGas({
           networkClientId: NETWORK_CLIENT_ID_MOCK,
           isSimulationEnabled: true,
-          getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
+          sentinelApiService: SENTINEL_API_SERVICE_MOCK,
           messenger: MESSENGER_MOCK,
           txParams: {
             ...TRANSACTION_META_MOCK.txParams,
@@ -1038,7 +1039,7 @@ describe('gas', () => {
         await estimateGas({
           networkClientId: NETWORK_CLIENT_ID_MOCK,
           isSimulationEnabled: true,
-          getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
+          sentinelApiService: SENTINEL_API_SERVICE_MOCK,
           messenger: MESSENGER_MOCK,
           txParams: {
             ...TRANSACTION_META_MOCK.txParams,
@@ -1099,7 +1100,7 @@ describe('gas', () => {
         await estimateGas({
           networkClientId: NETWORK_CLIENT_ID_MOCK,
           isSimulationEnabled: true,
-          getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
+          sentinelApiService: SENTINEL_API_SERVICE_MOCK,
           messenger: MESSENGER_MOCK,
           txParams: {
             ...TRANSACTION_META_MOCK.txParams,
@@ -1109,22 +1110,25 @@ describe('gas', () => {
           },
         });
 
-        expect(simulateTransactionsMock).toHaveBeenCalledWith(CHAIN_ID_MOCK, {
-          getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
-          transactions: [
-            {
-              ...TRANSACTION_META_MOCK.txParams,
-              to: TRANSACTION_META_MOCK.txParams.from,
-            },
-          ],
-          overrides: {
-            [TRANSACTION_META_MOCK.txParams.from]: {
-              code:
-                DELEGATION_PREFIX +
-                remove0x(AUTHORIZATION_LIST_MOCK[0].address),
+        expect(simulateTransactionsMock).toHaveBeenCalledWith(
+          SENTINEL_API_SERVICE_MOCK,
+          CHAIN_ID_MOCK,
+          {
+            transactions: [
+              {
+                ...TRANSACTION_META_MOCK.txParams,
+                to: TRANSACTION_META_MOCK.txParams.from,
+              },
+            ],
+            overrides: {
+              [TRANSACTION_META_MOCK.txParams.from]: {
+                code:
+                  DELEGATION_PREFIX +
+                  remove0x(AUTHORIZATION_LIST_MOCK[0].address),
+              },
             },
           },
-        });
+        );
       });
 
       it('does provider estimation if simulation is disabled', async () => {
@@ -1136,7 +1140,7 @@ describe('gas', () => {
         const result = await estimateGas({
           networkClientId: NETWORK_CLIENT_ID_MOCK,
           isSimulationEnabled: false,
-          getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
+          sentinelApiService: SENTINEL_API_SERVICE_MOCK,
           messenger: MESSENGER_MOCK,
           txParams: {
             ...TRANSACTION_META_MOCK.txParams,
@@ -1173,7 +1177,7 @@ describe('gas', () => {
         const result = await estimateGas({
           networkClientId: NETWORK_CLIENT_ID_MOCK,
           isSimulationEnabled: true,
-          getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
+          sentinelApiService: SENTINEL_API_SERVICE_MOCK,
           messenger: MESSENGER_MOCK,
           txParams: {
             ...TRANSACTION_META_MOCK.txParams,
@@ -1210,7 +1214,7 @@ describe('gas', () => {
         const result = await estimateGas({
           networkClientId: NETWORK_CLIENT_ID_MOCK,
           isSimulationEnabled: true,
-          getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
+          sentinelApiService: SENTINEL_API_SERVICE_MOCK,
           messenger: MESSENGER_MOCK,
           txParams: {
             ...TRANSACTION_META_MOCK.txParams,
@@ -1317,7 +1321,7 @@ describe('gas', () => {
       const result = await estimateGasBatch({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         from: FROM_MOCK,
-        getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
+        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         isAtomicBatchSupported: isAtomicBatchSupportedMock,
         messenger: MESSENGER_MOCK,
         transactions: BATCH_TX_PARAMS_MOCK,
@@ -1377,7 +1381,7 @@ describe('gas', () => {
       const result = await estimateGasBatch({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         from: FROM_MOCK,
-        getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
+        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         isAtomicBatchSupported: isAtomicBatchSupportedMock,
         messenger: MESSENGER_MOCK,
         transactions: BATCH_TX_PARAMS_MOCK,
@@ -1429,7 +1433,7 @@ describe('gas', () => {
       const result = await estimateGasBatch({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         from: FROM_MOCK,
-        getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
+        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         isAtomicBatchSupported: isAtomicBatchSupportedMock,
         messenger: MESSENGER_MOCK,
         transactions: BATCH_TX_PARAMS_WITH_GAS_MOCK,
@@ -1467,7 +1471,7 @@ describe('gas', () => {
       const result = await estimateGasBatch({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         from: FROM_MOCK,
-        getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
+        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         isAtomicBatchSupported: isAtomicBatchSupportedMock,
         messenger: MESSENGER_MOCK,
         transactions: BATCH_TX_PARAMS_WITH_GAS_MOCK,
@@ -1501,7 +1505,7 @@ describe('gas', () => {
       const result = await estimateGasBatch({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         from: FROM_MOCK,
-        getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
+        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         isAtomicBatchSupported: isAtomicBatchSupportedMock,
         messenger: MESSENGER_MOCK,
         transactions: BATCH_TX_PARAMS_WITH_GAS_MOCK,
@@ -1527,7 +1531,7 @@ describe('gas', () => {
         estimateGasBatch({
           networkClientId: NETWORK_CLIENT_ID_MOCK,
           from: FROM_MOCK,
-          getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
+          sentinelApiService: SENTINEL_API_SERVICE_MOCK,
           isAtomicBatchSupported: isAtomicBatchSupportedMock,
           messenger: MESSENGER_MOCK,
           transactions: BATCH_TX_PARAMS_MOCK,
@@ -1541,7 +1545,7 @@ describe('gas', () => {
       const result = await estimateGasBatch({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         from: FROM_MOCK,
-        getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
+        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         isAtomicBatchSupported: isAtomicBatchSupportedMock,
         messenger: MESSENGER_MOCK,
         transactions: BATCH_TX_PARAMS_WITH_GAS_MOCK,
@@ -1565,7 +1569,7 @@ describe('gas', () => {
       const result = await estimateGasBatch({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         from: FROM_MOCK,
-        getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
+        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         isAtomicBatchSupported: isAtomicBatchSupportedMock,
         messenger: MESSENGER_MOCK,
         transactions: BATCH_TX_PARAMS_MOCK,
@@ -1576,19 +1580,22 @@ describe('gas', () => {
         gasLimits: [21000, 500000],
       });
 
-      expect(simulateTransactionsMock).toHaveBeenCalledWith(CHAIN_ID_MOCK, {
-        getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
-        transactions: [
-          {
-            ...BATCH_TX_PARAMS_MOCK[0],
-            from: FROM_MOCK,
-          },
-          {
-            ...BATCH_TX_PARAMS_MOCK[1],
-            from: FROM_MOCK,
-          },
-        ],
-      });
+      expect(simulateTransactionsMock).toHaveBeenCalledWith(
+        SENTINEL_API_SERVICE_MOCK,
+        CHAIN_ID_MOCK,
+        {
+          transactions: [
+            {
+              ...BATCH_TX_PARAMS_MOCK[0],
+              from: FROM_MOCK,
+            },
+            {
+              ...BATCH_TX_PARAMS_MOCK[1],
+              from: FROM_MOCK,
+            },
+          ],
+        },
+      );
     });
 
     it('prefers provided gas over simulated gas when both available', async () => {
@@ -1617,7 +1624,7 @@ describe('gas', () => {
       const result = await estimateGasBatch({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         from: FROM_MOCK,
-        getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
+        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         isAtomicBatchSupported: isAtomicBatchSupportedMock,
         messenger: MESSENGER_MOCK,
         transactions: mixedBatchParams,
@@ -1668,7 +1675,7 @@ describe('gas', () => {
       const result = await estimateGasBatch({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         from: FROM_MOCK,
-        getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
+        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         isAtomicBatchSupported: isAtomicBatchSupportedMock,
         messenger: MESSENGER_MOCK,
         transactions: BATCH_TX_PARAMS_MOCK,
@@ -1730,7 +1737,7 @@ describe('gas', () => {
       const result = await simulateGasBatch({
         chainId: CHAIN_ID_MOCK,
         from: FROM_MOCK,
-        getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
+        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         transactions: TRANSACTION_BATCH_REQUEST_MOCK,
       });
 
@@ -1740,19 +1747,22 @@ describe('gas', () => {
       });
 
       expect(simulateTransactionsMock).toHaveBeenCalledTimes(1);
-      expect(simulateTransactionsMock).toHaveBeenCalledWith(CHAIN_ID_MOCK, {
-        getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
-        transactions: [
-          {
-            ...TRANSACTION_BATCH_REQUEST_MOCK[0].params,
-            from: FROM_MOCK,
-          },
-          {
-            ...TRANSACTION_BATCH_REQUEST_MOCK[1].params,
-            from: FROM_MOCK,
-          },
-        ],
-      });
+      expect(simulateTransactionsMock).toHaveBeenCalledWith(
+        SENTINEL_API_SERVICE_MOCK,
+        CHAIN_ID_MOCK,
+        {
+          transactions: [
+            {
+              ...TRANSACTION_BATCH_REQUEST_MOCK[0].params,
+              from: FROM_MOCK,
+            },
+            {
+              ...TRANSACTION_BATCH_REQUEST_MOCK[1].params,
+              from: FROM_MOCK,
+            },
+          ],
+        },
+      );
     });
 
     it('throws an error if the simulated response does not match the number of transactions', async () => {
@@ -1770,7 +1780,7 @@ describe('gas', () => {
         simulateGasBatch({
           chainId: CHAIN_ID_MOCK,
           from: FROM_MOCK,
-          getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
+          sentinelApiService: SENTINEL_API_SERVICE_MOCK,
           transactions: TRANSACTION_BATCH_REQUEST_MOCK,
         }),
       ).rejects.toThrow(
@@ -1796,7 +1806,7 @@ describe('gas', () => {
         simulateGasBatch({
           chainId: CHAIN_ID_MOCK,
           from: FROM_MOCK,
-          getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
+          sentinelApiService: SENTINEL_API_SERVICE_MOCK,
           transactions: TRANSACTION_BATCH_REQUEST_MOCK,
         }),
       ).rejects.toThrow(
@@ -1818,7 +1828,7 @@ describe('gas', () => {
       const result = await simulateGasBatch({
         chainId: CHAIN_ID_MOCK,
         from: FROM_MOCK,
-        getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
+        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         transactions: [],
       });
 
@@ -1828,10 +1838,13 @@ describe('gas', () => {
       });
 
       expect(simulateTransactionsMock).toHaveBeenCalledTimes(1);
-      expect(simulateTransactionsMock).toHaveBeenCalledWith(CHAIN_ID_MOCK, {
-        getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
-        transactions: [],
-      });
+      expect(simulateTransactionsMock).toHaveBeenCalledWith(
+        SENTINEL_API_SERVICE_MOCK,
+        CHAIN_ID_MOCK,
+        {
+          transactions: [],
+        },
+      );
     });
 
     it('throws an error if the simulation fails', async () => {
@@ -1843,7 +1856,7 @@ describe('gas', () => {
         simulateGasBatch({
           chainId: CHAIN_ID_MOCK,
           from: FROM_MOCK,
-          getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
+          sentinelApiService: SENTINEL_API_SERVICE_MOCK,
           transactions: TRANSACTION_BATCH_REQUEST_MOCK,
         }),
       ).rejects.toThrow(

--- a/packages/transaction-controller/src/utils/gas.test.ts
+++ b/packages/transaction-controller/src/utils/gas.test.ts
@@ -4,9 +4,9 @@ import type { Hex } from '@metamask/utils';
 import { cloneDeep } from 'lodash';
 
 import type {
-  SimulationResponse,
-  SimulationResponseTransaction,
-} from '../api/simulation-api';
+  SentinelSimulationResponse,
+  SentinelSimulationResponseTransaction,
+} from '@metamask/sentinel-api-service';
 import { simulateTransactions } from '../api/simulation-api';
 import type { TransactionControllerMessenger } from '../TransactionController';
 import { TransactionEnvelopeType } from '../types';
@@ -54,8 +54,6 @@ const BLOCK_GAS_LIMIT_MOCK = 123456789;
 const BLOCK_NUMBER_MOCK = '0x5678';
 const NETWORK_CLIENT_ID_MOCK = 'testNetworkClientId' as NetworkClientId;
 const FALLBACK_MULTIPLIER_35_PERCENT = 0.35;
-const SENTINEL_API_SERVICE_MOCK =
-  {} as unknown as import('@metamask/sentinel-api-service').SentinelApiService;
 const MAX_GAS_MULTIPLIER = MAX_GAS_BLOCK_PERCENT / 100;
 const CHAIN_ID_MOCK = '0x123';
 const GAS_2_MOCK = 12345;
@@ -97,7 +95,8 @@ const MESSENGER_MOCK = {
 } as unknown as jest.Mocked<TransactionControllerMessenger>;
 
 function mockMessengerCall(): void {
-  const messengerCallMock = jest.mocked(MESSENGER_MOCK.call);
+  // eslint-disable-next-line jest/unbound-method
+  const messengerCallMock = MESSENGER_MOCK.call as unknown as jest.Mock;
 
   messengerCallMock.mockImplementation((action: string) => {
     if (action === 'NetworkController:getNetworkClientById') {
@@ -179,9 +178,9 @@ const TRANSACTION_BATCH_REQUEST_MOCK: TransactionBatchSingleRequest[] = [
   },
 ];
 
-const SIMULATED_TRANSACTIONS_RESPONSE_MOCK: SimulationResponse = {
+const SIMULATED_TRANSACTIONS_RESPONSE_MOCK: SentinelSimulationResponse = {
   transactions: [{ gasLimit: GAS_MOCK_1 }, { gasLimit: GAS_MOCK_2 }],
-} as unknown as SimulationResponse;
+} as unknown as SentinelSimulationResponse;
 
 const AUTHORIZATION_LIST_MOCK: AuthorizationList = [
   {
@@ -203,7 +202,6 @@ const UPDATE_GAS_REQUEST_MOCK = {
   txMeta: TRANSACTION_META_MOCK,
   isCustomNetwork: false,
   isSimulationEnabled: false,
-  sentinelApiService: SENTINEL_API_SERVICE_MOCK,
   messenger: MESSENGER_MOCK,
 } as UpdateGasRequest;
 
@@ -574,7 +572,6 @@ describe('gas', () => {
       const result = await estimateGas({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         isSimulationEnabled: false,
-        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         messenger: MESSENGER_MOCK,
         txParams: TRANSACTION_META_MOCK.txParams,
       });
@@ -600,7 +597,6 @@ describe('gas', () => {
       const result = await estimateGas({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         isSimulationEnabled: false,
-        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         messenger: MESSENGER_MOCK,
         txParams: TRANSACTION_META_MOCK.txParams,
       });
@@ -636,7 +632,6 @@ describe('gas', () => {
       const result = await estimateGas({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         isSimulationEnabled: false,
-        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         messenger: MESSENGER_MOCK,
         txParams: TRANSACTION_META_MOCK.txParams,
       });
@@ -662,7 +657,6 @@ describe('gas', () => {
       const result = await estimateGas({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         isSimulationEnabled: false,
-        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         messenger: MESSENGER_MOCK,
         txParams: TRANSACTION_META_MOCK.txParams,
       });
@@ -685,7 +679,6 @@ describe('gas', () => {
       const result = await estimateGas({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         isSimulationEnabled: false,
-        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         messenger: MESSENGER_MOCK,
         txParams: TRANSACTION_META_MOCK.txParams,
       });
@@ -711,7 +704,6 @@ describe('gas', () => {
       const result = await estimateGas({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         isSimulationEnabled: false,
-        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         messenger: MESSENGER_MOCK,
         txParams: TRANSACTION_META_MOCK.txParams,
       });
@@ -743,7 +735,6 @@ describe('gas', () => {
       const result = await estimateGas({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         isSimulationEnabled: false,
-        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         messenger: MESSENGER_MOCK,
         txParams: TRANSACTION_META_MOCK.txParams,
       });
@@ -770,7 +761,6 @@ describe('gas', () => {
       const result = await estimateGas({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         isSimulationEnabled: false,
-        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         messenger: MESSENGER_MOCK,
         txParams: TRANSACTION_META_MOCK.txParams,
       });
@@ -795,7 +785,6 @@ describe('gas', () => {
       const result = await estimateGas({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         isSimulationEnabled: false,
-        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         messenger: MESSENGER_MOCK,
         txParams: TRANSACTION_META_MOCK.txParams,
       });
@@ -812,7 +801,6 @@ describe('gas', () => {
       await estimateGas({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         isSimulationEnabled: false,
-        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         messenger: MESSENGER_MOCK,
         txParams: {
           ...TRANSACTION_META_MOCK.txParams,
@@ -844,7 +832,6 @@ describe('gas', () => {
       await estimateGas({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         isSimulationEnabled: false,
-        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         messenger: MESSENGER_MOCK,
         txParams: {
           ...TRANSACTION_META_MOCK.txParams,
@@ -874,7 +861,6 @@ describe('gas', () => {
       await estimateGas({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         isSimulationEnabled: false,
-        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         messenger: MESSENGER_MOCK,
         txParams: {
           ...TRANSACTION_META_MOCK.txParams,
@@ -904,7 +890,6 @@ describe('gas', () => {
       await estimateGas({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         isSimulationEnabled: false,
-        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         messenger: MESSENGER_MOCK,
         txParams: {
           ...TRANSACTION_META_MOCK.txParams,
@@ -944,7 +929,7 @@ describe('gas', () => {
               gasLimit: toHex(SIMULATE_GAS_MOCK),
             },
           ],
-        } as SimulationResponse);
+        } as SentinelSimulationResponse);
 
         mockQuery({
           getBlockByNumberResponse: { gasLimit: toHex(BLOCK_GAS_LIMIT_MOCK) },
@@ -955,7 +940,6 @@ describe('gas', () => {
           networkClientId: NETWORK_CLIENT_ID_MOCK,
           ignoreDelegationSignatures: true,
           isSimulationEnabled: true,
-          sentinelApiService: SENTINEL_API_SERVICE_MOCK,
           messenger: MESSENGER_MOCK,
           txParams: TRANSACTION_META_MOCK.txParams,
         });
@@ -975,7 +959,6 @@ describe('gas', () => {
             networkClientId: NETWORK_CLIENT_ID_MOCK,
             ignoreDelegationSignatures: true,
             isSimulationEnabled: false,
-            sentinelApiService: SENTINEL_API_SERVICE_MOCK,
             messenger: MESSENGER_MOCK,
             txParams: TRANSACTION_META_MOCK.txParams,
           }),
@@ -998,12 +981,11 @@ describe('gas', () => {
               gasLimit: toHex(SIMULATE_GAS_MOCK),
             },
           ],
-        } as SimulationResponse);
+        } as SentinelSimulationResponse);
 
         const result = await estimateGas({
           networkClientId: NETWORK_CLIENT_ID_MOCK,
           isSimulationEnabled: true,
-          sentinelApiService: SENTINEL_API_SERVICE_MOCK,
           messenger: MESSENGER_MOCK,
           txParams: {
             ...TRANSACTION_META_MOCK.txParams,
@@ -1034,12 +1016,11 @@ describe('gas', () => {
               gasUsed: toHex(SIMULATE_GAS_MOCK),
             },
           ],
-        } as SimulationResponse);
+        } as SentinelSimulationResponse);
 
         await estimateGas({
           networkClientId: NETWORK_CLIENT_ID_MOCK,
           isSimulationEnabled: true,
-          sentinelApiService: SENTINEL_API_SERVICE_MOCK,
           messenger: MESSENGER_MOCK,
           txParams: {
             ...TRANSACTION_META_MOCK.txParams,
@@ -1095,12 +1076,11 @@ describe('gas', () => {
               gasUsed: toHex(SIMULATE_GAS_MOCK),
             },
           ],
-        } as SimulationResponse);
+        } as SentinelSimulationResponse);
 
         await estimateGas({
           networkClientId: NETWORK_CLIENT_ID_MOCK,
           isSimulationEnabled: true,
-          sentinelApiService: SENTINEL_API_SERVICE_MOCK,
           messenger: MESSENGER_MOCK,
           txParams: {
             ...TRANSACTION_META_MOCK.txParams,
@@ -1111,7 +1091,7 @@ describe('gas', () => {
         });
 
         expect(simulateTransactionsMock).toHaveBeenCalledWith(
-          SENTINEL_API_SERVICE_MOCK,
+          MESSENGER_MOCK,
           CHAIN_ID_MOCK,
           {
             transactions: [
@@ -1140,7 +1120,6 @@ describe('gas', () => {
         const result = await estimateGas({
           networkClientId: NETWORK_CLIENT_ID_MOCK,
           isSimulationEnabled: false,
-          sentinelApiService: SENTINEL_API_SERVICE_MOCK,
           messenger: MESSENGER_MOCK,
           txParams: {
             ...TRANSACTION_META_MOCK.txParams,
@@ -1172,12 +1151,11 @@ describe('gas', () => {
               gasUsed: undefined,
             },
           ],
-        } as SimulationResponse);
+        } as SentinelSimulationResponse);
 
         const result = await estimateGas({
           networkClientId: NETWORK_CLIENT_ID_MOCK,
           isSimulationEnabled: true,
-          sentinelApiService: SENTINEL_API_SERVICE_MOCK,
           messenger: MESSENGER_MOCK,
           txParams: {
             ...TRANSACTION_META_MOCK.txParams,
@@ -1209,12 +1187,11 @@ describe('gas', () => {
               gasUsed: undefined,
             },
           ],
-        } as SimulationResponse);
+        } as SentinelSimulationResponse);
 
         const result = await estimateGas({
           networkClientId: NETWORK_CLIENT_ID_MOCK,
           isSimulationEnabled: true,
-          sentinelApiService: SENTINEL_API_SERVICE_MOCK,
           messenger: MESSENGER_MOCK,
           txParams: {
             ...TRANSACTION_META_MOCK.txParams,
@@ -1316,12 +1293,11 @@ describe('gas', () => {
             gasLimit: toHex(INTRINSIC_GAS),
           },
         ],
-      } as SimulationResponse);
+      } as SentinelSimulationResponse);
 
       const result = await estimateGasBatch({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         from: FROM_MOCK,
-        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         isAtomicBatchSupported: isAtomicBatchSupportedMock,
         messenger: MESSENGER_MOCK,
         transactions: BATCH_TX_PARAMS_MOCK,
@@ -1381,7 +1357,6 @@ describe('gas', () => {
       const result = await estimateGasBatch({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         from: FROM_MOCK,
-        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         isAtomicBatchSupported: isAtomicBatchSupportedMock,
         messenger: MESSENGER_MOCK,
         transactions: BATCH_TX_PARAMS_MOCK,
@@ -1433,7 +1408,6 @@ describe('gas', () => {
       const result = await estimateGasBatch({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         from: FROM_MOCK,
-        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         isAtomicBatchSupported: isAtomicBatchSupportedMock,
         messenger: MESSENGER_MOCK,
         transactions: BATCH_TX_PARAMS_WITH_GAS_MOCK,
@@ -1471,7 +1445,6 @@ describe('gas', () => {
       const result = await estimateGasBatch({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         from: FROM_MOCK,
-        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         isAtomicBatchSupported: isAtomicBatchSupportedMock,
         messenger: MESSENGER_MOCK,
         transactions: BATCH_TX_PARAMS_WITH_GAS_MOCK,
@@ -1505,7 +1478,6 @@ describe('gas', () => {
       const result = await estimateGasBatch({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         from: FROM_MOCK,
-        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         isAtomicBatchSupported: isAtomicBatchSupportedMock,
         messenger: MESSENGER_MOCK,
         transactions: BATCH_TX_PARAMS_WITH_GAS_MOCK,
@@ -1531,7 +1503,6 @@ describe('gas', () => {
         estimateGasBatch({
           networkClientId: NETWORK_CLIENT_ID_MOCK,
           from: FROM_MOCK,
-          sentinelApiService: SENTINEL_API_SERVICE_MOCK,
           isAtomicBatchSupported: isAtomicBatchSupportedMock,
           messenger: MESSENGER_MOCK,
           transactions: BATCH_TX_PARAMS_MOCK,
@@ -1545,7 +1516,6 @@ describe('gas', () => {
       const result = await estimateGasBatch({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         from: FROM_MOCK,
-        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         isAtomicBatchSupported: isAtomicBatchSupportedMock,
         messenger: MESSENGER_MOCK,
         transactions: BATCH_TX_PARAMS_WITH_GAS_MOCK,
@@ -1569,7 +1539,6 @@ describe('gas', () => {
       const result = await estimateGasBatch({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         from: FROM_MOCK,
-        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         isAtomicBatchSupported: isAtomicBatchSupportedMock,
         messenger: MESSENGER_MOCK,
         transactions: BATCH_TX_PARAMS_MOCK,
@@ -1581,7 +1550,7 @@ describe('gas', () => {
       });
 
       expect(simulateTransactionsMock).toHaveBeenCalledWith(
-        SENTINEL_API_SERVICE_MOCK,
+        MESSENGER_MOCK,
         CHAIN_ID_MOCK,
         {
           transactions: [
@@ -1624,7 +1593,6 @@ describe('gas', () => {
       const result = await estimateGasBatch({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         from: FROM_MOCK,
-        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         isAtomicBatchSupported: isAtomicBatchSupportedMock,
         messenger: MESSENGER_MOCK,
         transactions: mixedBatchParams,
@@ -1644,7 +1612,7 @@ describe('gas', () => {
         },
       ]);
 
-      jest.mocked(MESSENGER_MOCK.call).mockImplementation((action: string) => {
+      (MESSENGER_MOCK.call as unknown as jest.Mock).mockImplementation((action: string) => {
         if (action === 'NetworkController:getNetworkClientById') {
           return {
             configuration: { chainId: CHAIN_ID_MOCK },
@@ -1675,7 +1643,6 @@ describe('gas', () => {
       const result = await estimateGasBatch({
         networkClientId: NETWORK_CLIENT_ID_MOCK,
         from: FROM_MOCK,
-        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
         isAtomicBatchSupported: isAtomicBatchSupportedMock,
         messenger: MESSENGER_MOCK,
         transactions: BATCH_TX_PARAMS_MOCK,
@@ -1737,7 +1704,7 @@ describe('gas', () => {
       const result = await simulateGasBatch({
         chainId: CHAIN_ID_MOCK,
         from: FROM_MOCK,
-        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
+        messenger: MESSENGER_MOCK,
         transactions: TRANSACTION_BATCH_REQUEST_MOCK,
       });
 
@@ -1748,7 +1715,7 @@ describe('gas', () => {
 
       expect(simulateTransactionsMock).toHaveBeenCalledTimes(1);
       expect(simulateTransactionsMock).toHaveBeenCalledWith(
-        SENTINEL_API_SERVICE_MOCK,
+        MESSENGER_MOCK,
         CHAIN_ID_MOCK,
         {
           transactions: [
@@ -1768,7 +1735,7 @@ describe('gas', () => {
     it('throws an error if the simulated response does not match the number of transactions', async () => {
       simulateTransactionsMock.mockResolvedValueOnce({
         transactions: [
-          { gasLimit: GAS_MOCK_1 } as unknown as SimulationResponseTransaction,
+          { gasLimit: GAS_MOCK_1 } as unknown as SentinelSimulationResponseTransaction,
         ], // Only one transaction returned
         sponsorship: {
           isSponsored: false,
@@ -1780,7 +1747,7 @@ describe('gas', () => {
         simulateGasBatch({
           chainId: CHAIN_ID_MOCK,
           from: FROM_MOCK,
-          sentinelApiService: SENTINEL_API_SERVICE_MOCK,
+          messenger: MESSENGER_MOCK,
           transactions: TRANSACTION_BATCH_REQUEST_MOCK,
         }),
       ).rejects.toThrow(
@@ -1795,7 +1762,7 @@ describe('gas', () => {
         transactions: [
           { gasLimit: undefined },
           { gasLimit: GAS_MOCK_2 },
-        ] as unknown as SimulationResponseTransaction[],
+        ] as unknown as SentinelSimulationResponseTransaction[],
         sponsorship: {
           isSponsored: false,
           error: null,
@@ -1806,7 +1773,7 @@ describe('gas', () => {
         simulateGasBatch({
           chainId: CHAIN_ID_MOCK,
           from: FROM_MOCK,
-          sentinelApiService: SENTINEL_API_SERVICE_MOCK,
+          messenger: MESSENGER_MOCK,
           transactions: TRANSACTION_BATCH_REQUEST_MOCK,
         }),
       ).rejects.toThrow(
@@ -1828,7 +1795,7 @@ describe('gas', () => {
       const result = await simulateGasBatch({
         chainId: CHAIN_ID_MOCK,
         from: FROM_MOCK,
-        sentinelApiService: SENTINEL_API_SERVICE_MOCK,
+        messenger: MESSENGER_MOCK,
         transactions: [],
       });
 
@@ -1839,7 +1806,7 @@ describe('gas', () => {
 
       expect(simulateTransactionsMock).toHaveBeenCalledTimes(1);
       expect(simulateTransactionsMock).toHaveBeenCalledWith(
-        SENTINEL_API_SERVICE_MOCK,
+        MESSENGER_MOCK,
         CHAIN_ID_MOCK,
         {
           transactions: [],
@@ -1856,7 +1823,7 @@ describe('gas', () => {
         simulateGasBatch({
           chainId: CHAIN_ID_MOCK,
           from: FROM_MOCK,
-          sentinelApiService: SENTINEL_API_SERVICE_MOCK,
+          messenger: MESSENGER_MOCK,
           transactions: TRANSACTION_BATCH_REQUEST_MOCK,
         }),
       ).rejects.toThrow(

--- a/packages/transaction-controller/src/utils/gas.ts
+++ b/packages/transaction-controller/src/utils/gas.ts
@@ -17,6 +17,7 @@ import { TransactionEnvelopeType } from '../types';
 import type {
   AuthorizationList,
   BatchTransactionParams,
+  GetSimulationConfig,
   IsAtomicBatchSupportedRequest,
   IsAtomicBatchSupportedResult,
   Revert,
@@ -36,6 +37,7 @@ import { decodeRevert } from './revert-reason';
 export type UpdateGasRequest = {
   isCustomNetwork: boolean;
   isSimulationEnabled: boolean;
+  getSimulationConfig?: GetSimulationConfig;
   messenger: TransactionControllerMessenger;
   sentinelApiService: SentinelApiService;
   txMeta: TransactionMeta;
@@ -92,6 +94,7 @@ export async function updateGas(request: UpdateGasRequest): Promise<void> {
  * @param options - The options object.
  * @param options.ignoreDelegationSignatures - Ignore signature errors if submitting delegations to the DelegationManager.
  * @param options.isSimulationEnabled - Whether the simulation is enabled.
+ * @param options.getSimulationConfig - Optional callback to rewrite the simulation request URL.
  * @param options.messenger - The messenger instance for communication.
  * @param options.networkClientId - The network client ID.
  * @param options.sentinelApiService - The Sentinel API service used to simulate transactions.
@@ -101,6 +104,7 @@ export async function updateGas(request: UpdateGasRequest): Promise<void> {
 export async function estimateGas({
   ignoreDelegationSignatures,
   isSimulationEnabled,
+  getSimulationConfig,
   messenger,
   networkClientId,
   sentinelApiService,
@@ -108,6 +112,7 @@ export async function estimateGas({
 }: {
   ignoreDelegationSignatures?: boolean;
   isSimulationEnabled: boolean;
+  getSimulationConfig?: GetSimulationConfig;
   messenger: TransactionControllerMessenger;
   networkClientId: NetworkClientId;
   sentinelApiService: SentinelApiService;
@@ -187,10 +192,12 @@ export async function estimateGas({
         networkClientId,
         chainId,
         sentinelApiService,
+        getSimulationConfig,
       );
     } else if (ignoreDelegationSignatures && isSimulationEnabled) {
       estimatedGas = await simulateGas({
         chainId,
+        getSimulationConfig,
         sentinelApiService,
         transaction: request,
       });
@@ -257,6 +264,7 @@ export function getProvidedBatchGasLimits(
 
 export async function estimateGasBatch({
   from,
+  getSimulationConfig,
   isAtomicBatchSupported,
   messenger,
   networkClientId,
@@ -264,6 +272,7 @@ export async function estimateGasBatch({
   transactions,
 }: {
   from: Hex;
+  getSimulationConfig?: GetSimulationConfig;
   isAtomicBatchSupported: (
     request: IsAtomicBatchSupportedRequest,
   ) => Promise<IsAtomicBatchSupportedResult>;
@@ -316,6 +325,7 @@ export async function estimateGasBatch({
     // first sub-call provides source-token balance to subsequent sub-calls).
     const { estimatedGas: gasLimitHex, simulationFails } = await estimateGas({
       isSimulationEnabled: true,
+      getSimulationConfig,
       messenger,
       networkClientId,
       sentinelApiService,
@@ -355,6 +365,7 @@ export async function estimateGasBatch({
   const { gasLimits: gasLimitsHex } = await simulateGasBatch({
     chainId,
     from,
+    getSimulationConfig,
     sentinelApiService,
     transactions: transactions.map((transaction) => ({
       params: transaction,
@@ -421,6 +432,7 @@ export function addGasBuffer(
  * @param options - The options object.
  * @param options.chainId - The chain ID of the transactions.
  * @param options.from - The address of the sender.
+ * @param options.getSimulationConfig - Optional callback to rewrite the simulation request URL.
  * @param options.sentinelApiService - The Sentinel API service used to simulate transactions.
  * @param options.transactions - The array of transactions within a batch request.
  * @returns An object containing the transactions with their gas limits and the total gas limit.
@@ -428,16 +440,19 @@ export function addGasBuffer(
 export async function simulateGasBatch({
   chainId,
   from,
+  getSimulationConfig,
   sentinelApiService,
   transactions,
 }: {
   chainId: Hex;
   from: Hex;
+  getSimulationConfig?: GetSimulationConfig;
   sentinelApiService: SentinelApiService;
   transactions: TransactionBatchSingleRequest[];
 }): Promise<{ totalGasLimit: Hex; gasLimits: Hex[] }> {
   try {
     const response = await simulateTransactions(sentinelApiService, chainId, {
+      getSimulationConfig,
       transactions: transactions.map((transaction) => ({
         ...transaction.params,
         from,
@@ -494,6 +509,7 @@ async function getGas(
   const {
     isCustomNetwork,
     isSimulationEnabled,
+    getSimulationConfig,
     messenger,
     sentinelApiService,
     txMeta,
@@ -520,6 +536,7 @@ async function getGas(
     simulationFails,
   } = await estimateGas({
     isSimulationEnabled,
+    getSimulationConfig,
     messenger,
     networkClientId,
     sentinelApiService,
@@ -641,6 +658,7 @@ async function getLatestBlock(
  * @param networkClientId - The network client ID.
  * @param chainId - The chain ID of the transaction.
  * @param sentinelApiService - The Sentinel API service used to simulate transactions.
+ * @param getSimulationConfig - Optional callback to rewrite the simulation request URL.
  * @returns The estimated gas.
  */
 async function estimateGasUpgradeWithDataToSelf(
@@ -649,6 +667,7 @@ async function estimateGasUpgradeWithDataToSelf(
   networkClientId: NetworkClientId,
   chainId: Hex,
   sentinelApiService: SentinelApiService,
+  getSimulationConfig?: GetSimulationConfig,
 ): Promise<Hex> {
   const upgradeGas = (await rpcRequest({
     messenger,
@@ -673,6 +692,7 @@ async function estimateGasUpgradeWithDataToSelf(
     executeGas = await simulateGas({
       chainId,
       delegationAddress,
+      getSimulationConfig,
       sentinelApiService,
       transaction: txParams,
     });
@@ -713,6 +733,7 @@ async function estimateGasUpgradeWithDataToSelf(
  * @param options - The options object.
  * @param options.chainId - The chain ID of the transaction.
  * @param options.delegationAddress - The delegation address of the sender to mock.
+ * @param options.getSimulationConfig - Optional callback to rewrite the simulation request URL.
  * @param options.sentinelApiService - The Sentinel API service used to simulate transactions.
  * @param options.transaction - The transaction parameters.
  * @returns The simulated gas.
@@ -720,15 +741,18 @@ async function estimateGasUpgradeWithDataToSelf(
 async function simulateGas({
   chainId,
   delegationAddress,
+  getSimulationConfig,
   sentinelApiService,
   transaction,
 }: {
   chainId: Hex;
   delegationAddress?: Hex;
+  getSimulationConfig?: GetSimulationConfig;
   sentinelApiService: SentinelApiService;
   transaction: TransactionParams;
 }): Promise<Hex> {
   const response = await simulateTransactions(sentinelApiService, chainId, {
+    getSimulationConfig,
     transactions: [
       {
         to: transaction.to as Hex,

--- a/packages/transaction-controller/src/utils/gas.ts
+++ b/packages/transaction-controller/src/utils/gas.ts
@@ -5,7 +5,6 @@ import {
   toHex,
 } from '@metamask/controller-utils';
 import type { NetworkClientId } from '@metamask/network-controller';
-import type { SentinelApiService } from '@metamask/sentinel-api-service';
 import type { Hex, Json } from '@metamask/utils';
 import { add0x, createModuleLogger, remove0x } from '@metamask/utils';
 import { BigNumber } from 'bignumber.js';
@@ -39,7 +38,6 @@ export type UpdateGasRequest = {
   isSimulationEnabled: boolean;
   getSimulationConfig?: GetSimulationConfig;
   messenger: TransactionControllerMessenger;
-  sentinelApiService: SentinelApiService;
   txMeta: TransactionMeta;
 };
 
@@ -97,7 +95,6 @@ export async function updateGas(request: UpdateGasRequest): Promise<void> {
  * @param options.getSimulationConfig - Optional callback to rewrite the simulation request URL.
  * @param options.messenger - The messenger instance for communication.
  * @param options.networkClientId - The network client ID.
- * @param options.sentinelApiService - The Sentinel API service used to simulate transactions.
  * @param options.txParams - The transaction parameters.
  * @returns The estimated gas and related info.
  */
@@ -107,7 +104,6 @@ export async function estimateGas({
   getSimulationConfig,
   messenger,
   networkClientId,
-  sentinelApiService,
   txParams,
 }: {
   ignoreDelegationSignatures?: boolean;
@@ -115,7 +111,6 @@ export async function estimateGas({
   getSimulationConfig?: GetSimulationConfig;
   messenger: TransactionControllerMessenger;
   networkClientId: NetworkClientId;
-  sentinelApiService: SentinelApiService;
   txParams: TransactionParams;
 }): Promise<{
   blockGasLimit: string;
@@ -191,14 +186,13 @@ export async function estimateGas({
         messenger,
         networkClientId,
         chainId,
-        sentinelApiService,
         getSimulationConfig,
       );
     } else if (ignoreDelegationSignatures && isSimulationEnabled) {
       estimatedGas = await simulateGas({
         chainId,
         getSimulationConfig,
-        sentinelApiService,
+        messenger,
         transaction: request,
       });
     } else {
@@ -268,7 +262,6 @@ export async function estimateGasBatch({
   isAtomicBatchSupported,
   messenger,
   networkClientId,
-  sentinelApiService,
   transactions,
 }: {
   from: Hex;
@@ -278,7 +271,6 @@ export async function estimateGasBatch({
   ) => Promise<IsAtomicBatchSupportedResult>;
   messenger: TransactionControllerMessenger;
   networkClientId: NetworkClientId;
-  sentinelApiService: SentinelApiService;
   transactions: BatchTransactionParams[];
 }): Promise<EstimateGasBatchResult> {
   const chainId = getChainId({ messenger, networkClientId });
@@ -328,7 +320,6 @@ export async function estimateGasBatch({
       getSimulationConfig,
       messenger,
       networkClientId,
-      sentinelApiService,
       txParams: params,
     });
 
@@ -366,7 +357,7 @@ export async function estimateGasBatch({
     chainId,
     from,
     getSimulationConfig,
-    sentinelApiService,
+    messenger,
     transactions: transactions.map((transaction) => ({
       params: transaction,
     })),
@@ -433,7 +424,7 @@ export function addGasBuffer(
  * @param options.chainId - The chain ID of the transactions.
  * @param options.from - The address of the sender.
  * @param options.getSimulationConfig - Optional callback to rewrite the simulation request URL.
- * @param options.sentinelApiService - The Sentinel API service used to simulate transactions.
+ * @param options.messenger - The messenger instance used to invoke the Sentinel simulation action.
  * @param options.transactions - The array of transactions within a batch request.
  * @returns An object containing the transactions with their gas limits and the total gas limit.
  */
@@ -441,17 +432,17 @@ export async function simulateGasBatch({
   chainId,
   from,
   getSimulationConfig,
-  sentinelApiService,
+  messenger,
   transactions,
 }: {
   chainId: Hex;
   from: Hex;
   getSimulationConfig?: GetSimulationConfig;
-  sentinelApiService: SentinelApiService;
+  messenger: TransactionControllerMessenger;
   transactions: TransactionBatchSingleRequest[];
 }): Promise<{ totalGasLimit: Hex; gasLimits: Hex[] }> {
   try {
-    const response = await simulateTransactions(sentinelApiService, chainId, {
+    const response = await simulateTransactions(messenger, chainId, {
       getSimulationConfig,
       transactions: transactions.map((transaction) => ({
         ...transaction.params,
@@ -511,7 +502,6 @@ async function getGas(
     isSimulationEnabled,
     getSimulationConfig,
     messenger,
-    sentinelApiService,
     txMeta,
   } = request;
   const { networkClientId } = txMeta;
@@ -539,7 +529,6 @@ async function getGas(
     getSimulationConfig,
     messenger,
     networkClientId,
-    sentinelApiService,
     txParams: txMeta.txParams,
   });
 
@@ -657,7 +646,6 @@ async function getLatestBlock(
  * @param messenger - The messenger instance for communication.
  * @param networkClientId - The network client ID.
  * @param chainId - The chain ID of the transaction.
- * @param sentinelApiService - The Sentinel API service used to simulate transactions.
  * @param getSimulationConfig - Optional callback to rewrite the simulation request URL.
  * @returns The estimated gas.
  */
@@ -666,7 +654,6 @@ async function estimateGasUpgradeWithDataToSelf(
   messenger: TransactionControllerMessenger,
   networkClientId: NetworkClientId,
   chainId: Hex,
-  sentinelApiService: SentinelApiService,
   getSimulationConfig?: GetSimulationConfig,
 ): Promise<Hex> {
   const upgradeGas = (await rpcRequest({
@@ -693,7 +680,7 @@ async function estimateGasUpgradeWithDataToSelf(
       chainId,
       delegationAddress,
       getSimulationConfig,
-      sentinelApiService,
+      messenger,
       transaction: txParams,
     });
   } catch (error: unknown) {
@@ -734,7 +721,7 @@ async function estimateGasUpgradeWithDataToSelf(
  * @param options.chainId - The chain ID of the transaction.
  * @param options.delegationAddress - The delegation address of the sender to mock.
  * @param options.getSimulationConfig - Optional callback to rewrite the simulation request URL.
- * @param options.sentinelApiService - The Sentinel API service used to simulate transactions.
+ * @param options.messenger - The messenger instance used to invoke the Sentinel simulation action.
  * @param options.transaction - The transaction parameters.
  * @returns The simulated gas.
  */
@@ -742,16 +729,16 @@ async function simulateGas({
   chainId,
   delegationAddress,
   getSimulationConfig,
-  sentinelApiService,
+  messenger,
   transaction,
 }: {
   chainId: Hex;
   delegationAddress?: Hex;
   getSimulationConfig?: GetSimulationConfig;
-  sentinelApiService: SentinelApiService;
+  messenger: TransactionControllerMessenger;
   transaction: TransactionParams;
 }): Promise<Hex> {
-  const response = await simulateTransactions(sentinelApiService, chainId, {
+  const response = await simulateTransactions(messenger, chainId, {
     getSimulationConfig,
     transactions: [
       {

--- a/packages/transaction-controller/src/utils/gas.ts
+++ b/packages/transaction-controller/src/utils/gas.ts
@@ -5,6 +5,7 @@ import {
   toHex,
 } from '@metamask/controller-utils';
 import type { NetworkClientId } from '@metamask/network-controller';
+import type { SentinelApiService } from '@metamask/sentinel-api-service';
 import type { Hex, Json } from '@metamask/utils';
 import { add0x, createModuleLogger, remove0x } from '@metamask/utils';
 import { BigNumber } from 'bignumber.js';
@@ -16,7 +17,6 @@ import { TransactionEnvelopeType } from '../types';
 import type {
   AuthorizationList,
   BatchTransactionParams,
-  GetSimulationConfig,
   IsAtomicBatchSupportedRequest,
   IsAtomicBatchSupportedResult,
   Revert,
@@ -36,8 +36,8 @@ import { decodeRevert } from './revert-reason';
 export type UpdateGasRequest = {
   isCustomNetwork: boolean;
   isSimulationEnabled: boolean;
-  getSimulationConfig: GetSimulationConfig;
   messenger: TransactionControllerMessenger;
+  sentinelApiService: SentinelApiService;
   txMeta: TransactionMeta;
 };
 
@@ -92,25 +92,25 @@ export async function updateGas(request: UpdateGasRequest): Promise<void> {
  * @param options - The options object.
  * @param options.ignoreDelegationSignatures - Ignore signature errors if submitting delegations to the DelegationManager.
  * @param options.isSimulationEnabled - Whether the simulation is enabled.
- * @param options.getSimulationConfig - The function to get the simulation configuration.
  * @param options.messenger - The messenger instance for communication.
  * @param options.networkClientId - The network client ID.
+ * @param options.sentinelApiService - The Sentinel API service used to simulate transactions.
  * @param options.txParams - The transaction parameters.
  * @returns The estimated gas and related info.
  */
 export async function estimateGas({
   ignoreDelegationSignatures,
   isSimulationEnabled,
-  getSimulationConfig,
   messenger,
   networkClientId,
+  sentinelApiService,
   txParams,
 }: {
   ignoreDelegationSignatures?: boolean;
   isSimulationEnabled: boolean;
-  getSimulationConfig: GetSimulationConfig;
   messenger: TransactionControllerMessenger;
   networkClientId: NetworkClientId;
+  sentinelApiService: SentinelApiService;
   txParams: TransactionParams;
 }): Promise<{
   blockGasLimit: string;
@@ -186,12 +186,12 @@ export async function estimateGas({
         messenger,
         networkClientId,
         chainId,
-        getSimulationConfig,
+        sentinelApiService,
       );
     } else if (ignoreDelegationSignatures && isSimulationEnabled) {
       estimatedGas = await simulateGas({
         chainId,
-        getSimulationConfig,
+        sentinelApiService,
         transaction: request,
       });
     } else {
@@ -257,19 +257,19 @@ export function getProvidedBatchGasLimits(
 
 export async function estimateGasBatch({
   from,
-  getSimulationConfig,
   isAtomicBatchSupported,
   messenger,
   networkClientId,
+  sentinelApiService,
   transactions,
 }: {
   from: Hex;
-  getSimulationConfig: GetSimulationConfig;
   isAtomicBatchSupported: (
     request: IsAtomicBatchSupportedRequest,
   ) => Promise<IsAtomicBatchSupportedResult>;
   messenger: TransactionControllerMessenger;
   networkClientId: NetworkClientId;
+  sentinelApiService: SentinelApiService;
   transactions: BatchTransactionParams[];
 }): Promise<EstimateGasBatchResult> {
   const chainId = getChainId({ messenger, networkClientId });
@@ -316,9 +316,9 @@ export async function estimateGasBatch({
     // first sub-call provides source-token balance to subsequent sub-calls).
     const { estimatedGas: gasLimitHex, simulationFails } = await estimateGas({
       isSimulationEnabled: true,
-      getSimulationConfig,
       messenger,
       networkClientId,
+      sentinelApiService,
       txParams: params,
     });
 
@@ -355,7 +355,7 @@ export async function estimateGasBatch({
   const { gasLimits: gasLimitsHex } = await simulateGasBatch({
     chainId,
     from,
-    getSimulationConfig,
+    sentinelApiService,
     transactions: transactions.map((transaction) => ({
       params: transaction,
     })),
@@ -421,24 +421,23 @@ export function addGasBuffer(
  * @param options - The options object.
  * @param options.chainId - The chain ID of the transactions.
  * @param options.from - The address of the sender.
- * @param options.getSimulationConfig - The function to get the simulation configuration.
+ * @param options.sentinelApiService - The Sentinel API service used to simulate transactions.
  * @param options.transactions - The array of transactions within a batch request.
  * @returns An object containing the transactions with their gas limits and the total gas limit.
  */
 export async function simulateGasBatch({
   chainId,
   from,
-  getSimulationConfig,
+  sentinelApiService,
   transactions,
 }: {
   chainId: Hex;
   from: Hex;
-  getSimulationConfig: GetSimulationConfig;
+  sentinelApiService: SentinelApiService;
   transactions: TransactionBatchSingleRequest[];
 }): Promise<{ totalGasLimit: Hex; gasLimits: Hex[] }> {
   try {
-    const response = await simulateTransactions(chainId, {
-      getSimulationConfig,
+    const response = await simulateTransactions(sentinelApiService, chainId, {
       transactions: transactions.map((transaction) => ({
         ...transaction.params,
         from,
@@ -495,8 +494,8 @@ async function getGas(
   const {
     isCustomNetwork,
     isSimulationEnabled,
-    getSimulationConfig,
     messenger,
+    sentinelApiService,
     txMeta,
   } = request;
   const { networkClientId } = txMeta;
@@ -521,9 +520,9 @@ async function getGas(
     simulationFails,
   } = await estimateGas({
     isSimulationEnabled,
-    getSimulationConfig,
     messenger,
     networkClientId,
+    sentinelApiService,
     txParams: txMeta.txParams,
   });
 
@@ -641,7 +640,7 @@ async function getLatestBlock(
  * @param messenger - The messenger instance for communication.
  * @param networkClientId - The network client ID.
  * @param chainId - The chain ID of the transaction.
- * @param getSimulationConfig - The function to get the simulation configuration.
+ * @param sentinelApiService - The Sentinel API service used to simulate transactions.
  * @returns The estimated gas.
  */
 async function estimateGasUpgradeWithDataToSelf(
@@ -649,7 +648,7 @@ async function estimateGasUpgradeWithDataToSelf(
   messenger: TransactionControllerMessenger,
   networkClientId: NetworkClientId,
   chainId: Hex,
-  getSimulationConfig: GetSimulationConfig,
+  sentinelApiService: SentinelApiService,
 ): Promise<Hex> {
   const upgradeGas = (await rpcRequest({
     messenger,
@@ -674,7 +673,7 @@ async function estimateGasUpgradeWithDataToSelf(
     executeGas = await simulateGas({
       chainId,
       delegationAddress,
-      getSimulationConfig,
+      sentinelApiService,
       transaction: txParams,
     });
   } catch (error: unknown) {
@@ -714,23 +713,22 @@ async function estimateGasUpgradeWithDataToSelf(
  * @param options - The options object.
  * @param options.chainId - The chain ID of the transaction.
  * @param options.delegationAddress - The delegation address of the sender to mock.
- * @param options.getSimulationConfig - The function to get the simulation configuration.
+ * @param options.sentinelApiService - The Sentinel API service used to simulate transactions.
  * @param options.transaction - The transaction parameters.
  * @returns The simulated gas.
  */
 async function simulateGas({
   chainId,
   delegationAddress,
-  getSimulationConfig,
+  sentinelApiService,
   transaction,
 }: {
   chainId: Hex;
   delegationAddress?: Hex;
-  getSimulationConfig: GetSimulationConfig;
+  sentinelApiService: SentinelApiService;
   transaction: TransactionParams;
 }): Promise<Hex> {
-  const response = await simulateTransactions(chainId, {
-    getSimulationConfig,
+  const response = await simulateTransactions(sentinelApiService, chainId, {
     transactions: [
       {
         to: transaction.to as Hex,


### PR DESCRIPTION
## Explanation

Migrates `TransactionController`'s simulation stack from its inline Sentinel client (`api/simulation-api.ts` + a hardcoded fetch/URL/error layer) to the new `@metamask/sentinel-api-service` data service.

The controller gains a new **required** `sentinelApiService` constructor option, threaded through the simulation utility layers (`gas.ts`, `gas-fee-tokens.ts`, `balance-changes.ts`, `batch.ts`) and passed as the first argument to the refactored `simulateTransactions(sentinelApiService, chainId, request, options?)`. The leaf drops its own `fetch`/URL-resolution/RPC-method plumbing and delegates the request to the injected service. `finalizeRequest` (delegation-manager `overrides` handling on the request body) is preserved.

The existing `getSimulationConfig` option is retained with a reduced return shape — `{ newUrl?: string }` — the old `authorization` field is dropped because bearer-token auth is now the service's responsibility. At the leaf, `getSimulationConfig` is stripped from the forwarded request body and wrapped into the service's new optional `options.getUrl` callback (`newUrl ?? defaultUrl`), so consumers (e.g. Shield URL proxying) keep the same override hook without the controller owning the transport.

## References

Depends on #9466 (introduces `@metamask/sentinel-api-service`).

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them