### PR TITLE
ci: add team label workflow

### DIFF
--- a/.github/workflows/add-team-label.yml
+++ b/.github/workflows/add-team-label.yml
@@ -1,0 +1,38 @@
+name: Add team label
+
+on:
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  add-team-label:
+    name: Add team label
+    if: ${{ !github.event.pull_request.head.repo.fork }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Get planning token
+        id: planning-token
+        uses: MetaMask/github-tools/.github/actions/get-token@v1
+        with:
+          token-exchange-url: ${{ vars.TOKEN_EXCHANGE_URL }}
+          target-repository: MetaMask/MetaMask-planning
+          permissions: |
+            contents: read
+
+      - name: Get label token
+        id: label-token
+        uses: MetaMask/github-tools/.github/actions/get-token@v1
+        with:
+          token-exchange-url: ${{ vars.TOKEN_EXCHANGE_URL }}
+          permissions: |
+            contents: read
+            pull_requests: write
+
+      - name: Add team label
+        uses: MetaMask/github-tools/.github/actions/add-team-label@v1
+        with:
+          planning-token: ${{ steps.planning-token.outputs.token }}
+          team-label-token: ${{ steps.label-token.outputs.token }}


### PR DESCRIPTION
## Explanation

`metamask-core` is the only one of the three major MetaMask client-adjacent repos without automated PR team-labeling — `metamask-mobile` and `metamask-extension` both run `add-team-label.yml` on every PR open, applying a `team-*` label based on the author's entry in `MetaMask/MetaMask-planning`'s `topology.json`. In `core`, no PR has ever been labeled automatically; any `team-*` label present today was applied manually by whoever happened to remember, and that's sparse and inconsistent across every team in this repo, not specific to any one package.

This adds the same workflow already proven in production in `mobile`/`extension`, closing that gap repo-wide.

Benefits:
- Consistent, automatic team attribution on PRs across all `core` packages, matching the already-proven pattern in `mobile`/`extension`.
- Enables reliable team-scoped GitHub/Slack filters (`+label:team-x`) for any team working in this repo.
- Removes reliance on manual labeling discipline, which today is inconsistent across the board.

**Scope note (why this is a draft):** this workflow runs on every PR opened in `core`, for any author, so it's a repo-wide behavior change rather than something scoped to a single team's packages. It's also worth noting the underlying `add-team-label` action currently fails the CI check (`exit 1`) for any author not registered in `topology.json` (e.g. external contributors, new hires, bots) — that failure mode should be understood and accepted by whoever owns `core`'s CI before this merges, since it will surface on PRs from every team, not just one.

**Blocked (2026-07-11): token-exchange access policy.** The "Get planning token" step currently fails:
```
Error: Token exchange failed: 403 Forbidden – {"status":"fail","message":"Access denied by policy for MetaMask/core to target MetaMask/MetaMask-planning"}
```
The token-exchange service's access policy doesn't yet allow `MetaMask/core` to request a token scoped to `MetaMask/MetaMask-planning` (needed to read `topology.json`), even though `metamask-mobile` and `metamask-extension` are already allowed. This requires an allowlist change on the policy side by whoever administers it — not a change to this workflow file. No existing tracked ticket for this was found; one likely needs to be filed against whatever repo/team owns that policy config before this can go green.

## References

* Mirrors `.github/workflows/add-team-label.yml` in [metamask-mobile](https://github.com/MetaMask/metamask-mobile/blob/main/.github/workflows/add-team-label.yml) and [metamask-extension](https://github.com/MetaMask/metamask-extension/blob/main/.github/workflows/add-team-label.yml)

## Checklist

- [x] No runtime code changes — CI workflow addition only, copied from repos where it's already in production use
- [ ] Needs sign-off from core repo/CI owners given the repo-wide labeling impact (see scope note above)
- [ ] Blocked on token-exchange policy allowlisting `MetaMask/core` → `MetaMask/MetaMask-planning` (see error above)
