### PR TITLE
Benchmark: CI-only change

### DIFF
--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -27,6 +27,62 @@ jobs:
           echo "child-workspace-package-names=$(yarn workspaces list --no-private --json | jq --slurp --raw-output 'map(.name) | @json')" >> "$GITHUB_OUTPUT"
         shell: bash
 
+
+  get-changed-packages:
+    name: Get changed packages
+    runs-on: ubuntu-latest
+    needs: prepare
+    outputs:
+      merge-base: ${{ steps.fetch-merge-base.outputs.merge-base }}
+      package-names: ${{ steps.packages.outputs.package-names }}
+      eslint-paths: ${{ steps.packages.outputs.eslint-paths }}
+    steps:
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v3
+        with:
+          is-high-risk-environment: false
+          persist-credentials: false
+          node-version: 24.x
+      - name: Fetch merge base
+        id: fetch-merge-base
+        if: github.base_ref != '' || github.event.merge_group.base_ref != ''
+        run: |
+          set -euo pipefail
+
+          PREFIXED_REF_REGEX='refs/heads/(.+)'
+          if [[ "$BASE_REF" =~ $PREFIXED_REF_REGEX ]]; then
+            BASE_REF="${BASH_REMATCH[1]}"
+          fi
+
+          MERGE_BASE=$(gh api "repos/$GITHUB_REPOSITORY/compare/$BASE_REF...$HEAD_SHA" --jq '.merge_base_commit.sha')
+          git fetch --unshallow --filter=blob:none --no-tags origin HEAD
+
+          echo "merge-base=$MERGE_BASE" >> "$GITHUB_OUTPUT"
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+          GH_TOKEN: ${{ github.token }}
+      - name: Get changed package names
+        id: packages
+        run: |
+          if [[ -n "$MERGE_BASE" ]]; then
+            OUTPUT=$(yarn tsx scripts/get-changed-workspaces.mts "$MERGE_BASE" "$HEAD_SHA")
+            PACKAGES=$(echo "$OUTPUT" | jq '.names')
+            if [[ $(echo "$OUTPUT" | jq '.hasRootChange') == "true" ]]; then
+              ESLINT_PATHS="full"
+            else
+              ESLINT_PATHS=$(echo "$OUTPUT" | jq '.locations')
+            fi
+          else
+            PACKAGES=$(yarn workspaces list --no-private --json | jq --slurp --raw-output 'map(.name) | @json')
+            ESLINT_PATHS="full"
+          fi
+          echo "package-names=$PACKAGES" >> "$GITHUB_OUTPUT"
+          echo "eslint-paths=$ESLINT_PATHS" >> "$GITHUB_OUTPUT"
+        env:
+          MERGE_BASE: ${{ steps.fetch-merge-base.outputs.merge-base }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+
   lint:
     name: Lint (${{ matrix.script }})
     runs-on: ubuntu-latest
@@ -38,7 +94,6 @@ jobs:
           - codeowners:check
           - constraints
           - lint:dependencies
-          - lint:eslint
           - lint:misc:check
           - lint:teams
           - lint:tsconfigs:all
@@ -55,6 +110,40 @@ jobs:
         run: yarn "$SCRIPT"
         env:
           SCRIPT: ${{ matrix.script }}
+      - name: Require clean working directory
+        shell: bash
+        run: |
+          if ! git diff --exit-code; then
+            echo "Working tree dirty at end of job"
+            exit 1
+          fi
+
+  lint-eslint:
+    name: Lint (lint:eslint)
+    runs-on: ubuntu-latest
+    if: needs.get-changed-packages.outputs.eslint-paths != '[]'
+    needs:
+      - prepare
+      - get-changed-packages
+    strategy:
+      matrix:
+        node-version: [24.x]
+    steps:
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v3
+        with:
+          is-high-risk-environment: false
+          persist-credentials: false
+          node-version: ${{ matrix.node-version }}
+      - name: Lint
+        run: |
+          if [[ "$ESLINT_PATHS" == "full" ]]; then
+            yarn lint:eslint
+          else
+            yarn lint:eslint $(echo "$ESLINT_PATHS" | jq -r '.[]' | tr '\n' ' ')
+          fi
+        env:
+          ESLINT_PATHS: ${{ needs.get-changed-packages.outputs.eslint-paths }}
       - name: Require clean working directory
         shell: bash
         run: |
@@ -94,52 +183,6 @@ jobs:
             echo "Working tree dirty at end of job"
             exit 1
           fi
-
-  get-changed-packages:
-    name: Get changed packages
-    runs-on: ubuntu-latest
-    needs: prepare
-    outputs:
-      merge-base: ${{ steps.fetch-merge-base.outputs.merge-base }}
-      package-names: ${{ steps.packages.outputs.package-names }}
-    steps:
-      - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v3
-        with:
-          is-high-risk-environment: false
-          persist-credentials: false
-          node-version: 24.x
-      - name: Fetch merge base
-        id: fetch-merge-base
-        if: github.base_ref != '' || github.event.merge_group.base_ref != ''
-        run: |
-          set -euo pipefail
-
-          PREFIXED_REF_REGEX='refs/heads/(.+)'
-          if [[ "$BASE_REF" =~ $PREFIXED_REF_REGEX ]]; then
-            BASE_REF="${BASH_REMATCH[1]}"
-          fi
-
-          MERGE_BASE=$(gh api "repos/$GITHUB_REPOSITORY/compare/$BASE_REF...$HEAD_SHA" --jq '.merge_base_commit.sha')
-          git fetch --unshallow --filter=blob:none --no-tags origin HEAD
-
-          echo "merge-base=$MERGE_BASE" >> "$GITHUB_OUTPUT"
-        env:
-          BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
-          GH_TOKEN: ${{ github.token }}
-      - name: Get changed package names
-        id: packages
-        run: |
-          if [[ -n "$MERGE_BASE" ]]; then
-            PACKAGES=$(yarn tsx scripts/get-changed-workspaces.mts "$MERGE_BASE" "$HEAD_SHA")
-          else
-            PACKAGES=$(yarn workspaces list --no-private --json | jq --slurp --raw-output 'map(.name) | @json')
-          fi
-          echo "package-names=$PACKAGES" >> "$GITHUB_OUTPUT"
-        env:
-          MERGE_BASE: ${{ steps.fetch-merge-base.outputs.merge-base }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
 
   validate-changelog-diffs:
     name: Validate changelog diffs

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -149,7 +149,9 @@ jobs:
       - name: Build
         run: |
           if [[ -n "$MERGE_BASE" ]]; then
-            yarn workspaces foreach --since="$MERGE_BASE" --topological --recursive --no-private run build
+            TSCONFIG=$(mktemp --suffix=.json)
+            yarn tsx scripts/generate-partial-build-tsconfig.mts "$MERGE_BASE" > "$TSCONFIG"
+            yarn ts-bridge --project "$TSCONFIG" --verbose
           else
             yarn build
           fi

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -124,6 +124,7 @@ jobs:
         run: |
           if [[ "$CHANGED_PATHS" == "full" ]]; then
             echo "Running ESLint on all packages."
+            echo ""
             yarn lint:eslint
           else
             echo "Running ESLint on:"
@@ -220,6 +221,7 @@ jobs:
             rm -f "$TSCONFIG"
           else
             echo "Building all packages."
+            echo ""
             yarn build
           fi
         env:

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -375,7 +375,7 @@ jobs:
   test-wallet-cli-e2e:
     name: Test wallet-cli daemon e2e (${{ matrix.node-version }})
     runs-on: ubuntu-latest
-    if: needs.get-changed-packages.outputs.package-names == '' || contains(fromJson(needs.get-changed-packages.outputs.package-names), '@metamask/wallet-cli')
+    if: needs.get-changed-packages.outputs.package-names == '[]' || contains(fromJson(needs.get-changed-packages.outputs.package-names), '@metamask/wallet-cli')
     needs:
       - prepare
       - get-changed-packages

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -1,5 +1,7 @@
 name: Lint, Build, and Test
 
+# Benchmark: CI-only change — no packages should be tested.
+
 on:
   workflow_call:
 

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -66,11 +66,13 @@ jobs:
   validate-changelog:
     name: Validate changelog
     runs-on: ubuntu-latest
-    needs: prepare
+    needs:
+      - prepare
+      - get-changed-packages
     strategy:
       matrix:
         node-version: [24.x]
-        package-name: ${{ fromJson(needs.prepare.outputs.child-workspace-package-names) }}
+        package-name: ${{ fromJson(needs.get-changed-packages.outputs.package-names) }}
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v3
@@ -92,6 +94,57 @@ jobs:
             exit 1
           fi
 
+  get-changed-packages:
+    name: Get changed packages
+    runs-on: ubuntu-latest
+    needs: prepare
+    outputs:
+      merge-base: ${{ steps.fetch-merge-base.outputs.merge-base }}
+      package-names: ${{ steps.packages.outputs.package-names }}
+    steps:
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v3
+        with:
+          is-high-risk-environment: false
+          persist-credentials: false
+          node-version: 24.x
+      - name: Fetch merge base
+        id: fetch-merge-base
+        if: github.base_ref != '' || github.event.merge_group.base_ref != ''
+        run: |
+          set -euo pipefail
+
+          PREFIXED_REF_REGEX='refs/heads/(.+)'
+          if [[ "$BASE_REF" =~ $PREFIXED_REF_REGEX ]]; then
+            BASE_REF="${BASH_REMATCH[1]}"
+          fi
+
+          MERGE_BASE=$(gh api "repos/$GITHUB_REPOSITORY/compare/$BASE_REF...$HEAD_SHA" --jq '.merge_base_commit.sha')
+          git fetch --unshallow --filter=blob:none --no-tags origin HEAD
+
+          echo "merge-base=$MERGE_BASE" >> "$GITHUB_OUTPUT"
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+          GH_TOKEN: ${{ github.token }}
+      - name: Get changed package names
+        id: packages
+        run: |
+          if [[ -n "$MERGE_BASE" ]]; then
+            PACKAGES=$(yarn tsx scripts/get-changed-workspaces.mts "$MERGE_BASE" "$HEAD_SHA")
+            # Fall back to all packages if no packages changed (e.g. CI-only PRs),
+            # to ensure required status checks are not skipped.
+            if [[ "$PACKAGES" == "[]" ]]; then
+              PACKAGES=$(yarn workspaces list --no-private --json | jq --slurp --raw-output 'map(.name) | @json')
+            fi
+          else
+            PACKAGES=$(yarn workspaces list --no-private --json | jq --slurp --raw-output 'map(.name) | @json')
+          fi
+          echo "package-names=$PACKAGES" >> "$GITHUB_OUTPUT"
+        env:
+          MERGE_BASE: ${{ steps.fetch-merge-base.outputs.merge-base }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+
   validate-changelog-diffs:
     name: Validate changelog diffs
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
@@ -107,7 +160,9 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: prepare
+    needs:
+      - prepare
+      - get-changed-packages
     strategy:
       matrix:
         node-version: [24.x]
@@ -118,34 +173,13 @@ jobs:
           is-high-risk-environment: false
           persist-credentials: false
           node-version: ${{ matrix.node-version }}
-      - name: Fetch merge base
-        id: fetch-merge-base
-        if: github.base_ref != '' || github.event.merge_group.base_ref != ''
+      - name: Unshallow checkout
+        if: needs.get-changed-packages.outputs.merge-base != ''
         run: |
-          set -euo pipefail
-
-          # Strip invalid prefix from `github.event.merge_group.base_ref`
-          # It comes prefixed with `refs/heads/`, but the branch is not checked out in this context
-          # We need to express it as a remote branch
-          PREFIXED_REF_REGEX='refs/heads/(.+)'
-          if [[ "$BASE_REF" =~ $PREFIXED_REF_REGEX ]]; then
-            BASE_REF="${BASH_REMATCH[1]}"
-          fi
-
-          # Use the GitHub Compare API to get the exact merge base SHA.
-          MERGE_BASE=$(gh api "repos/$GITHUB_REPOSITORY/compare/$BASE_REF...$HEAD_SHA" --jq '.merge_base_commit.sha')
-
-          # Unshallow the checkout so git can confirm the ancestry
-          # relationship required by `--since`. Using `--filter=blob:none`
-          # avoids downloading file content — commit and tree metadata is
-          # all that `git diff --name-only` needs.
+          # Unshallow so git can walk history back to the merge base for
+          # `git diff --name-only`. Using `--filter=blob:none` avoids
+          # downloading file content — only commit and tree objects are needed.
           git fetch --unshallow --filter=blob:none --no-tags origin HEAD
-
-          echo "merge-base=$MERGE_BASE" >> "$GITHUB_OUTPUT"
-        env:
-          BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
-          GH_TOKEN: ${{ github.token }}
       - name: Build
         run: |
           if [[ -n "$MERGE_BASE" ]]; then
@@ -159,7 +193,7 @@ jobs:
             yarn build
           fi
         env:
-          MERGE_BASE: ${{ steps.fetch-merge-base.outputs.merge-base }}
+          MERGE_BASE: ${{ needs.get-changed-packages.outputs.merge-base }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
       - name: Require clean working directory
         shell: bash
@@ -199,10 +233,12 @@ jobs:
   test-18:
     name: Test (18.x)
     runs-on: ubuntu-latest
-    needs: prepare
+    needs:
+      - prepare
+      - get-changed-packages
     strategy:
       matrix:
-        package-name: ${{ fromJson(needs.prepare.outputs.child-workspace-package-names) }}
+        package-name: ${{ fromJson(needs.get-changed-packages.outputs.package-names) }}
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v3
@@ -224,10 +260,12 @@ jobs:
   test-20:
     name: Test (20.x)
     runs-on: ubuntu-latest
-    needs: prepare
+    needs:
+      - prepare
+      - get-changed-packages
     strategy:
       matrix:
-        package-name: ${{ fromJson(needs.prepare.outputs.child-workspace-package-names) }}
+        package-name: ${{ fromJson(needs.get-changed-packages.outputs.package-names) }}
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v3
@@ -249,10 +287,12 @@ jobs:
   test-22:
     name: Test (22.x)
     runs-on: ubuntu-latest
-    needs: prepare
+    needs:
+      - prepare
+      - get-changed-packages
     strategy:
       matrix:
-        package-name: ${{ fromJson(needs.prepare.outputs.child-workspace-package-names) }}
+        package-name: ${{ fromJson(needs.get-changed-packages.outputs.package-names) }}
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v3

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -139,7 +139,7 @@ jobs:
           # relationship required by `--since`. Using `--filter=blob:none`
           # avoids downloading file content — commit and tree metadata is
           # all that `git diff --name-only` needs.
-          git fetch --unshallow --filter=blob:none --no-tags
+          git fetch --unshallow --filter=blob:none --no-tags origin HEAD
 
           echo "merge-base=$MERGE_BASE" >> "$GITHUB_OUTPUT"
         env:

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -150,14 +150,17 @@ jobs:
         run: |
           if [[ -n "$MERGE_BASE" ]]; then
             TSCONFIG=$(mktemp --tmpdir="$GITHUB_WORKSPACE" --suffix=.json)
-            yarn tsx scripts/generate-partial-build-tsconfig.mts "$MERGE_BASE" > "$TSCONFIG"
-            yarn ts-bridge --project "$TSCONFIG" --verbose
+            yarn tsx scripts/generate-partial-build-tsconfig.mts "$MERGE_BASE" "$HEAD_SHA" > "$TSCONFIG"
+            if [[ -s "$TSCONFIG" ]]; then
+              yarn ts-bridge --project "$TSCONFIG" --verbose
+            fi
             rm -f "$TSCONFIG"
           else
             yarn build
           fi
         env:
           MERGE_BASE: ${{ steps.fetch-merge-base.outputs.merge-base }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
       - name: Require clean working directory
         shell: bash
         run: |

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -130,7 +130,7 @@ jobs:
             BASE_REF="${BASH_REMATCH[1]}"
           fi
 
-          git fetch origin "$BASE_REF" --depth=1
+          git fetch origin "$BASE_REF" --no-tags
           echo "base-ref=$BASE_REF" >> "$GITHUB_OUTPUT"
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -123,8 +123,10 @@ jobs:
       - name: Lint
         run: |
           if [[ "$ESLINT_PATHS" == "full" ]]; then
+            echo "Running ESLint on all packages."
             yarn lint:eslint
           else
+            echo "Running ESLint on: $(echo "$ESLINT_PATHS" | jq -r '[.[]] | join(", ")')."
             echo "$ESLINT_PATHS" | jq -r '.[]' | xargs yarn lint:eslint
           fi
         env:
@@ -206,10 +208,14 @@ jobs:
             TSCONFIG=$(mktemp --tmpdir="$GITHUB_WORKSPACE" --suffix=.json)
             yarn tsx scripts/generate-partial-build-tsconfig.mts "$MERGE_BASE" "$HEAD_SHA" > "$TSCONFIG"
             if [[ -s "$TSCONFIG" ]]; then
+              echo "Building changed packages: $(jq -r '[.references[].path | ltrimstr("./") | rtrimstr("/tsconfig.build.json")] | join(", ")' "$TSCONFIG")."
               yarn ts-bridge --project "$TSCONFIG" --verbose
+            else
+              echo "No packages to build."
             fi
             rm -f "$TSCONFIG"
           else
+            echo "Building all packages."
             yarn build
           fi
         env:

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -126,7 +126,9 @@ jobs:
             echo "Running ESLint on all packages."
             yarn lint:eslint
           else
-            echo "Running ESLint on: $(echo "$ESLINT_PATHS" | jq -r '[.[]] | join(", ")')."
+            echo "Running ESLint on:"
+            echo "$ESLINT_PATHS" | jq -r '"- " + .[]'
+            echo ""
             echo "$ESLINT_PATHS" | jq -r '.[]' | xargs yarn lint:eslint
           fi
         env:
@@ -208,7 +210,9 @@ jobs:
             TSCONFIG=$(mktemp --tmpdir="$GITHUB_WORKSPACE" --suffix=.json)
             yarn tsx scripts/generate-partial-build-tsconfig.mts "$MERGE_BASE" "$HEAD_SHA" > "$TSCONFIG"
             if [[ -s "$TSCONFIG" ]]; then
-              echo "Building changed packages: $(jq -r '[.references[].path | ltrimstr("./") | rtrimstr("/tsconfig.build.json")] | join(", ")' "$TSCONFIG")."
+              echo "Building changed packages:"
+              jq -r '"- " + (.references[].path | ltrimstr("./") | rtrimstr("/tsconfig.build.json"))' "$TSCONFIG"
+              echo ""
               yarn ts-bridge --project "$TSCONFIG" --verbose
             else
               echo "No packages to build."

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -66,6 +66,7 @@ jobs:
   validate-changelog:
     name: Validate changelog
     runs-on: ubuntu-latest
+    if: needs.get-changed-packages.outputs.package-names != '[]'
     needs:
       - prepare
       - get-changed-packages
@@ -228,6 +229,7 @@ jobs:
   test-18:
     name: Test (18.x)
     runs-on: ubuntu-latest
+    if: needs.get-changed-packages.outputs.package-names != '[]'
     needs:
       - prepare
       - get-changed-packages
@@ -255,6 +257,7 @@ jobs:
   test-20:
     name: Test (20.x)
     runs-on: ubuntu-latest
+    if: needs.get-changed-packages.outputs.package-names != '[]'
     needs:
       - prepare
       - get-changed-packages
@@ -282,6 +285,7 @@ jobs:
   test-22:
     name: Test (22.x)
     runs-on: ubuntu-latest
+    if: needs.get-changed-packages.outputs.package-names != '[]'
     needs:
       - prepare
       - get-changed-packages

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -132,10 +132,15 @@ jobs:
             BASE_REF="${BASH_REMATCH[1]}"
           fi
 
-          # Use the GitHub Compare API to get the exact merge base SHA,
-          # then fetch only that single commit.
+          # Use the GitHub Compare API to get the exact merge base SHA.
           MERGE_BASE=$(gh api "repos/$GITHUB_REPOSITORY/compare/$BASE_REF...$HEAD_SHA" --jq '.merge_base_commit.sha')
-          git fetch origin "$MERGE_BASE" --depth=1 --no-tags
+
+          # Unshallow the checkout so git can confirm the ancestry
+          # relationship required by `--since`. Using `--filter=blob:none`
+          # avoids downloading file content — commit and tree metadata is
+          # all that `git diff --name-only` needs.
+          git fetch --unshallow --filter=blob:none --no-tags
+
           echo "merge-base=$MERGE_BASE" >> "$GITHUB_OUTPUT"
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -176,7 +176,7 @@ jobs:
     needs: get-changed-packages
     uses: MetaMask/action-security-code-scanner/.github/workflows/security-scan.yml@da7cf8b27792d992d87cf37c2e0e7e27b4c4ad0a
     with:
-      scanner-ref: v2
+      scanner-ref: da7cf8b27792d992d87cf37c2e0e7e27b4c4ad0a
       paths: ${{ needs.get-changed-packages.outputs.scan-paths }}
       paths-ignored: |
         .storybook/

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -2,6 +2,11 @@ name: Lint, Build, and Test
 
 on:
   workflow_call:
+    secrets:
+      SECURITY_SCAN_METRICS_TOKEN:
+        required: false
+      APPSEC_BOT_SLACK_WEBHOOK:
+        required: false
 
 jobs:
   prepare:
@@ -35,6 +40,7 @@ jobs:
       merge-base: ${{ steps.fetch-merge-base.outputs.merge-base }}
       package-names: ${{ steps.packages.outputs.package-names }}
       eslint-paths: ${{ steps.packages.outputs.eslint-paths }}
+      scan-paths: ${{ steps.packages.outputs.scan-paths }}
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v3
@@ -69,15 +75,29 @@ jobs:
             PACKAGES=$(echo "$OUTPUT" | jq -c '.names')
             if [[ $(echo "$OUTPUT" | jq '.hasRootChange') == "true" ]]; then
               ESLINT_PATHS="full"
+              SCAN_PATHS=""
             else
               ESLINT_PATHS=$(echo "$OUTPUT" | jq -c '.locations')
+              SCAN_PATHS=$(echo "$OUTPUT" | jq -r '.locations[] | . + "/"')
             fi
           else
             PACKAGES=$(yarn workspaces list --no-private --json | jq --slurp --raw-output 'map(.name) | @json')
             ESLINT_PATHS="full"
+            SCAN_PATHS=""
           fi
+
           echo "package-names=$PACKAGES" >> "$GITHUB_OUTPUT"
           echo "eslint-paths=$ESLINT_PATHS" >> "$GITHUB_OUTPUT"
+
+          if [[ -n "$SCAN_PATHS" ]]; then
+            {
+              echo "scan-paths<<SCAN_PATHS_EOF"
+              echo "$SCAN_PATHS"
+              echo "SCAN_PATHS_EOF"
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "scan-paths=" >> "$GITHUB_OUTPUT"
+          fi
         env:
           MERGE_BASE: ${{ steps.fetch-merge-base.outputs.merge-base }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
@@ -150,6 +170,41 @@ jobs:
             echo "Working tree dirty at end of job"
             exit 1
           fi
+
+  analyse-code:
+    name: Analyse code
+    needs: get-changed-packages
+    uses: MetaMask/action-security-code-scanner/.github/workflows/security-scan.yml@da7cf8b27792d992d87cf37c2e0e7e27b4c4ad0a
+    with:
+      scanner-ref: v2
+      paths: ${{ needs.get-changed-packages.outputs.scan-paths }}
+      paths-ignored: |
+        .storybook/
+        **/__snapshots__/
+        **/*.snap
+        **/*.stories.js
+        **/*.stories.tsx
+        **/*.test.browser.ts*
+        **/*.test.js*
+        **/*.test.ts*
+        **/fixtures/
+        **/jest.config.js
+        **/jest.environment.js
+        **/mocks/
+        **/test*/
+        docs/
+        e2e/
+        merged-packages/
+        node_modules/
+        storybook/
+        test*/
+    secrets:
+      project-metrics-token: ${{ secrets.SECURITY_SCAN_METRICS_TOKEN }}
+      slack-webhook: ${{ secrets.APPSEC_BOT_SLACK_WEBHOOK }}
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
 
   validate-changelog:
     name: Validate changelog

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -118,7 +118,31 @@ jobs:
           is-high-risk-environment: false
           persist-credentials: false
           node-version: ${{ matrix.node-version }}
-      - run: yarn build
+      - name: Fetch base branch
+        id: fetch-base-branch
+        if: github.base_ref != '' || github.event.merge_group.base_ref != ''
+        run: |
+          # Strip invalid prefix from `github.event.merge_group.base_ref`
+          # It comes prefixed with `refs/heads/`, but the branch is not checked out in this context
+          # We need to express it as a remote branch
+          PREFIXED_REF_REGEX='refs/heads/(.+)'
+          if [[ "$BASE_REF" =~ $PREFIXED_REF_REGEX ]]; then
+            BASE_REF="${BASH_REMATCH[1]}"
+          fi
+
+          git fetch origin "$BASE_REF" --depth=1
+          echo "base-ref=$BASE_REF" >> "$GITHUB_OUTPUT"
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+      - name: Build
+        run: |
+          if [[ -n "$BASE_REF" ]]; then
+            yarn workspaces foreach --since="origin/$BASE_REF" --topological --recursive --no-private run build
+          else
+            yarn build
+          fi
+        env:
+          BASE_REF: ${{ steps.fetch-base-branch.outputs.base-ref }}
       - name: Require clean working directory
         shell: bash
         run: |

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -130,6 +130,7 @@ jobs:
             BASE_REF="${BASH_REMATCH[1]}"
           fi
 
+          git fetch --unshallow
           git fetch origin "$BASE_REF" --no-tags
           echo "base-ref=$BASE_REF" >> "$GITHUB_OUTPUT"
         env:

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -333,7 +333,10 @@ jobs:
   test-wallet-cli-e2e:
     name: Test wallet-cli daemon e2e (${{ matrix.node-version }})
     runs-on: ubuntu-latest
-    needs: prepare
+    if: needs.get-changed-packages.outputs.package-names == '' || contains(fromJson(needs.get-changed-packages.outputs.package-names), '@metamask/wallet-cli')
+    needs:
+      - prepare
+      - get-changed-packages
     strategy:
       matrix:
         node-version: [20.x, 22.x, 24.x]

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -140,7 +140,7 @@ jobs:
           if [[ "$ESLINT_PATHS" == "full" ]]; then
             yarn lint:eslint
           else
-            yarn lint:eslint $(echo "$ESLINT_PATHS" | jq -r '.[]' | tr '\n' ' ')
+            echo "$ESLINT_PATHS" | jq -r '.[]' | xargs yarn lint:eslint
           fi
         env:
           ESLINT_PATHS: ${{ needs.get-changed-packages.outputs.eslint-paths }}

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -3,6 +3,9 @@ name: Lint, Build, and Test
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   prepare:
     name: Prepare

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -27,7 +27,6 @@ jobs:
           echo "child-workspace-package-names=$(yarn workspaces list --no-private --json | jq --slurp --raw-output 'map(.name) | @json')" >> "$GITHUB_OUTPUT"
         shell: bash
 
-
   get-changed-packages:
     name: Get changed packages
     runs-on: ubuntu-latest
@@ -67,11 +66,11 @@ jobs:
         run: |
           if [[ -n "$MERGE_BASE" ]]; then
             OUTPUT=$(yarn tsx scripts/get-changed-workspaces.mts "$MERGE_BASE" "$HEAD_SHA")
-            PACKAGES=$(echo "$OUTPUT" | jq '.names')
+            PACKAGES=$(echo "$OUTPUT" | jq -c '.names')
             if [[ $(echo "$OUTPUT" | jq '.hasRootChange') == "true" ]]; then
               ESLINT_PATHS="full"
             else
-              ESLINT_PATHS=$(echo "$OUTPUT" | jq '.locations')
+              ESLINT_PATHS=$(echo "$OUTPUT" | jq -c '.locations')
             fi
           else
             PACKAGES=$(yarn workspaces list --no-private --json | jq --slurp --raw-output 'map(.name) | @json')

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -118,10 +118,12 @@ jobs:
           is-high-risk-environment: false
           persist-credentials: false
           node-version: ${{ matrix.node-version }}
-      - name: Fetch base branch
-        id: fetch-base-branch
+      - name: Fetch merge base
+        id: fetch-merge-base
         if: github.base_ref != '' || github.event.merge_group.base_ref != ''
         run: |
+          set -euo pipefail
+
           # Strip invalid prefix from `github.event.merge_group.base_ref`
           # It comes prefixed with `refs/heads/`, but the branch is not checked out in this context
           # We need to express it as a remote branch
@@ -130,20 +132,24 @@ jobs:
             BASE_REF="${BASH_REMATCH[1]}"
           fi
 
-          git fetch --unshallow
-          git fetch origin "$BASE_REF" --no-tags
-          echo "base-ref=$BASE_REF" >> "$GITHUB_OUTPUT"
+          # Use the GitHub Compare API to get the exact merge base SHA,
+          # then fetch only that single commit.
+          MERGE_BASE=$(gh api "repos/$GITHUB_REPOSITORY/compare/$BASE_REF...$HEAD_SHA" --jq '.merge_base_commit.sha')
+          git fetch origin "$MERGE_BASE" --depth=1 --no-tags
+          echo "merge-base=$MERGE_BASE" >> "$GITHUB_OUTPUT"
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+          GH_TOKEN: ${{ github.token }}
       - name: Build
         run: |
-          if [[ -n "$BASE_REF" ]]; then
-            yarn workspaces foreach --since="origin/$BASE_REF" --topological --recursive --no-private run build
+          if [[ -n "$MERGE_BASE" ]]; then
+            yarn workspaces foreach --since="$MERGE_BASE" --topological --recursive --no-private run build
           else
             yarn build
           fi
         env:
-          BASE_REF: ${{ steps.fetch-base-branch.outputs.base-ref }}
+          MERGE_BASE: ${{ steps.fetch-merge-base.outputs.merge-base }}
       - name: Require clean working directory
         shell: bash
         run: |

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -14,7 +14,7 @@ jobs:
       child-workspace-package-names: ${{ steps.workspace-package-names.outputs.child-workspace-package-names }}
       merge-base: ${{ steps.fetch-merge-base.outputs.merge-base }}
       package-names: ${{ steps.packages.outputs.package-names }}
-      eslint-paths: ${{ steps.packages.outputs.eslint-paths }}
+      changed-paths: ${{ steps.packages.outputs.changed-paths }}
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v3
@@ -56,16 +56,16 @@ jobs:
             OUTPUT=$(yarn tsx scripts/get-changed-workspaces.mts "$MERGE_BASE" "$HEAD_SHA")
             PACKAGES=$(echo "$OUTPUT" | jq -c '.names')
             if [[ $(echo "$OUTPUT" | jq '.hasRootChange') == "true" ]]; then
-              ESLINT_PATHS="full"
+              CHANGED_PATHS="full"
             else
-              ESLINT_PATHS=$(echo "$OUTPUT" | jq -c '.locations')
+              CHANGED_PATHS=$(echo "$OUTPUT" | jq -c '.locations')
             fi
           else
             PACKAGES=$(yarn workspaces list --no-private --json | jq --slurp --raw-output 'map(.name) | @json')
-            ESLINT_PATHS="full"
+            CHANGED_PATHS="full"
           fi
           echo "package-names=$PACKAGES" >> "$GITHUB_OUTPUT"
-          echo "eslint-paths=$ESLINT_PATHS" >> "$GITHUB_OUTPUT"
+          echo "changed-paths=$CHANGED_PATHS" >> "$GITHUB_OUTPUT"
         env:
           MERGE_BASE: ${{ steps.fetch-merge-base.outputs.merge-base }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
@@ -108,7 +108,7 @@ jobs:
   lint-eslint:
     name: Lint (lint:eslint)
     runs-on: ubuntu-latest
-    if: needs.prepare.outputs.eslint-paths != '[]'
+    if: needs.prepare.outputs.changed-paths != '[]'
     needs: prepare
     strategy:
       matrix:
@@ -122,17 +122,17 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Lint
         run: |
-          if [[ "$ESLINT_PATHS" == "full" ]]; then
+          if [[ "$CHANGED_PATHS" == "full" ]]; then
             echo "Running ESLint on all packages."
             yarn lint:eslint
           else
             echo "Running ESLint on:"
-            echo "$ESLINT_PATHS" | jq -r '"- " + .[]'
+            echo "$CHANGED_PATHS" | jq -r '"- " + .[]'
             echo ""
-            echo "$ESLINT_PATHS" | jq -r '.[]' | xargs yarn lint:eslint
+            echo "$CHANGED_PATHS" | jq -r '.[]' | xargs yarn lint:eslint
           fi
         env:
-          ESLINT_PATHS: ${{ needs.prepare.outputs.eslint-paths }}
+          CHANGED_PATHS: ${{ needs.prepare.outputs.changed-paths }}
       - name: Require clean working directory
         shell: bash
         run: |
@@ -206,7 +206,7 @@ jobs:
           git fetch --unshallow --filter=blob:none --no-tags origin HEAD
       - name: Build
         run: |
-          if [[ -n "$MERGE_BASE" ]]; then
+          if [[ -n "$MERGE_BASE" && "$CHANGED_PATHS" != "full" ]]; then
             TSCONFIG=$(mktemp --tmpdir="$GITHUB_WORKSPACE" --suffix=.json)
             yarn tsx scripts/generate-partial-build-tsconfig.mts "$MERGE_BASE" "$HEAD_SHA" > "$TSCONFIG"
             if [[ -s "$TSCONFIG" ]]; then
@@ -225,6 +225,7 @@ jobs:
         env:
           MERGE_BASE: ${{ needs.prepare.outputs.merge-base }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+          CHANGED_PATHS: ${{ needs.prepare.outputs.changed-paths }}
       - name: Require clean working directory
         shell: bash
         run: |

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -149,9 +149,10 @@ jobs:
       - name: Build
         run: |
           if [[ -n "$MERGE_BASE" ]]; then
-            TSCONFIG=$(mktemp --suffix=.json)
+            TSCONFIG=$(mktemp --tmpdir="$GITHUB_WORKSPACE" --suffix=.json)
             yarn tsx scripts/generate-partial-build-tsconfig.mts "$MERGE_BASE" > "$TSCONFIG"
             yarn ts-bridge --project "$TSCONFIG" --verbose
+            rm -f "$TSCONFIG"
           else
             yarn build
           fi

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -2,11 +2,6 @@ name: Lint, Build, and Test
 
 on:
   workflow_call:
-    secrets:
-      SECURITY_SCAN_METRICS_TOKEN:
-        required: false
-      APPSEC_BOT_SLACK_WEBHOOK:
-        required: false
 
 jobs:
   prepare:
@@ -40,7 +35,6 @@ jobs:
       merge-base: ${{ steps.fetch-merge-base.outputs.merge-base }}
       package-names: ${{ steps.packages.outputs.package-names }}
       eslint-paths: ${{ steps.packages.outputs.eslint-paths }}
-      scan-paths: ${{ steps.packages.outputs.scan-paths }}
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v3
@@ -75,29 +69,15 @@ jobs:
             PACKAGES=$(echo "$OUTPUT" | jq -c '.names')
             if [[ $(echo "$OUTPUT" | jq '.hasRootChange') == "true" ]]; then
               ESLINT_PATHS="full"
-              SCAN_PATHS=""
             else
               ESLINT_PATHS=$(echo "$OUTPUT" | jq -c '.locations')
-              SCAN_PATHS=$(echo "$OUTPUT" | jq -r '.locations[] | . + "/"')
             fi
           else
             PACKAGES=$(yarn workspaces list --no-private --json | jq --slurp --raw-output 'map(.name) | @json')
             ESLINT_PATHS="full"
-            SCAN_PATHS=""
           fi
-
           echo "package-names=$PACKAGES" >> "$GITHUB_OUTPUT"
           echo "eslint-paths=$ESLINT_PATHS" >> "$GITHUB_OUTPUT"
-
-          if [[ -n "$SCAN_PATHS" ]]; then
-            {
-              echo "scan-paths<<SCAN_PATHS_EOF"
-              echo "$SCAN_PATHS"
-              echo "SCAN_PATHS_EOF"
-            } >> "$GITHUB_OUTPUT"
-          else
-            echo "scan-paths=" >> "$GITHUB_OUTPUT"
-          fi
         env:
           MERGE_BASE: ${{ steps.fetch-merge-base.outputs.merge-base }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
@@ -170,41 +150,6 @@ jobs:
             echo "Working tree dirty at end of job"
             exit 1
           fi
-
-  analyse-code:
-    name: Analyse code
-    needs: get-changed-packages
-    uses: MetaMask/action-security-code-scanner/.github/workflows/security-scan.yml@da7cf8b27792d992d87cf37c2e0e7e27b4c4ad0a
-    with:
-      scanner-ref: da7cf8b27792d992d87cf37c2e0e7e27b4c4ad0a
-      paths: ${{ needs.get-changed-packages.outputs.scan-paths }}
-      paths-ignored: |
-        .storybook/
-        **/__snapshots__/
-        **/*.snap
-        **/*.stories.js
-        **/*.stories.tsx
-        **/*.test.browser.ts*
-        **/*.test.js*
-        **/*.test.ts*
-        **/fixtures/
-        **/jest.config.js
-        **/jest.environment.js
-        **/mocks/
-        **/test*/
-        docs/
-        e2e/
-        merged-packages/
-        node_modules/
-        storybook/
-        test*/
-    secrets:
-      project-metrics-token: ${{ secrets.SECURITY_SCAN_METRICS_TOKEN }}
-      slack-webhook: ${{ secrets.APPSEC_BOT_SLACK_WEBHOOK }}
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
 
   validate-changelog:
     name: Validate changelog

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -12,6 +12,9 @@ jobs:
         node-version: [18.x, 20.x, 22.x, 24.x]
     outputs:
       child-workspace-package-names: ${{ steps.workspace-package-names.outputs.child-workspace-package-names }}
+      merge-base: ${{ steps.fetch-merge-base.outputs.merge-base }}
+      package-names: ${{ steps.packages.outputs.package-names }}
+      eslint-paths: ${{ steps.packages.outputs.eslint-paths }}
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v3
@@ -26,25 +29,9 @@ jobs:
         run: |
           echo "child-workspace-package-names=$(yarn workspaces list --no-private --json | jq --slurp --raw-output 'map(.name) | @json')" >> "$GITHUB_OUTPUT"
         shell: bash
-
-  get-changed-packages:
-    name: Get changed packages
-    runs-on: ubuntu-latest
-    needs: prepare
-    outputs:
-      merge-base: ${{ steps.fetch-merge-base.outputs.merge-base }}
-      package-names: ${{ steps.packages.outputs.package-names }}
-      eslint-paths: ${{ steps.packages.outputs.eslint-paths }}
-    steps:
-      - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v3
-        with:
-          is-high-risk-environment: false
-          persist-credentials: false
-          node-version: 24.x
       - name: Fetch merge base
         id: fetch-merge-base
-        if: github.base_ref != '' || github.event.merge_group.base_ref != ''
+        if: matrix.node-version == '24.x' && (github.base_ref != '' || github.event.merge_group.base_ref != '')
         run: |
           set -euo pipefail
 
@@ -63,6 +50,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
       - name: Get changed package names
         id: packages
+        if: matrix.node-version == '24.x'
         run: |
           if [[ -n "$MERGE_BASE" ]]; then
             OUTPUT=$(yarn tsx scripts/get-changed-workspaces.mts "$MERGE_BASE" "$HEAD_SHA")
@@ -120,10 +108,8 @@ jobs:
   lint-eslint:
     name: Lint (lint:eslint)
     runs-on: ubuntu-latest
-    if: needs.get-changed-packages.outputs.eslint-paths != '[]'
-    needs:
-      - prepare
-      - get-changed-packages
+    if: needs.prepare.outputs.eslint-paths != '[]'
+    needs: prepare
     strategy:
       matrix:
         node-version: [24.x]
@@ -142,7 +128,7 @@ jobs:
             echo "$ESLINT_PATHS" | jq -r '.[]' | xargs yarn lint:eslint
           fi
         env:
-          ESLINT_PATHS: ${{ needs.get-changed-packages.outputs.eslint-paths }}
+          ESLINT_PATHS: ${{ needs.prepare.outputs.eslint-paths }}
       - name: Require clean working directory
         shell: bash
         run: |
@@ -154,14 +140,12 @@ jobs:
   validate-changelog:
     name: Validate changelog
     runs-on: ubuntu-latest
-    if: needs.get-changed-packages.outputs.package-names != '[]'
-    needs:
-      - prepare
-      - get-changed-packages
+    if: needs.prepare.outputs.package-names != '[]'
+    needs: prepare
     strategy:
       matrix:
         node-version: [24.x]
-        package-name: ${{ fromJson(needs.get-changed-packages.outputs.package-names) }}
+        package-name: ${{ fromJson(needs.prepare.outputs.package-names) }}
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v3
@@ -198,9 +182,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs:
-      - prepare
-      - get-changed-packages
+    needs: prepare
     strategy:
       matrix:
         node-version: [24.x]
@@ -212,7 +194,7 @@ jobs:
           persist-credentials: false
           node-version: ${{ matrix.node-version }}
       - name: Unshallow checkout
-        if: needs.get-changed-packages.outputs.merge-base != ''
+        if: needs.prepare.outputs.merge-base != ''
         run: |
           # Unshallow so git can walk history back to the merge base for
           # `git diff --name-only`. Using `--filter=blob:none` avoids
@@ -231,7 +213,7 @@ jobs:
             yarn build
           fi
         env:
-          MERGE_BASE: ${{ needs.get-changed-packages.outputs.merge-base }}
+          MERGE_BASE: ${{ needs.prepare.outputs.merge-base }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
       - name: Require clean working directory
         shell: bash
@@ -271,13 +253,11 @@ jobs:
   test-18:
     name: Test (18.x)
     runs-on: ubuntu-latest
-    if: needs.get-changed-packages.outputs.package-names != '[]'
-    needs:
-      - prepare
-      - get-changed-packages
+    if: needs.prepare.outputs.package-names != '[]'
+    needs: prepare
     strategy:
       matrix:
-        package-name: ${{ fromJson(needs.get-changed-packages.outputs.package-names) }}
+        package-name: ${{ fromJson(needs.prepare.outputs.package-names) }}
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v3
@@ -299,13 +279,11 @@ jobs:
   test-20:
     name: Test (20.x)
     runs-on: ubuntu-latest
-    if: needs.get-changed-packages.outputs.package-names != '[]'
-    needs:
-      - prepare
-      - get-changed-packages
+    if: needs.prepare.outputs.package-names != '[]'
+    needs: prepare
     strategy:
       matrix:
-        package-name: ${{ fromJson(needs.get-changed-packages.outputs.package-names) }}
+        package-name: ${{ fromJson(needs.prepare.outputs.package-names) }}
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v3
@@ -327,13 +305,11 @@ jobs:
   test-22:
     name: Test (22.x)
     runs-on: ubuntu-latest
-    if: needs.get-changed-packages.outputs.package-names != '[]'
-    needs:
-      - prepare
-      - get-changed-packages
+    if: needs.prepare.outputs.package-names != '[]'
+    needs: prepare
     strategy:
       matrix:
-        package-name: ${{ fromJson(needs.get-changed-packages.outputs.package-names) }}
+        package-name: ${{ fromJson(needs.prepare.outputs.package-names) }}
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v3
@@ -375,10 +351,8 @@ jobs:
   test-wallet-cli-e2e:
     name: Test wallet-cli daemon e2e (${{ matrix.node-version }})
     runs-on: ubuntu-latest
-    if: needs.get-changed-packages.outputs.package-names == '[]' || contains(fromJson(needs.get-changed-packages.outputs.package-names), '@metamask/wallet-cli')
-    needs:
-      - prepare
-      - get-changed-packages
+    if: needs.prepare.outputs.package-names == '[]' || contains(fromJson(needs.prepare.outputs.package-names), '@metamask/wallet-cli')
+    needs: prepare
     strategy:
       matrix:
         node-version: [20.x, 22.x, 24.x]

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -132,11 +132,6 @@ jobs:
         run: |
           if [[ -n "$MERGE_BASE" ]]; then
             PACKAGES=$(yarn tsx scripts/get-changed-workspaces.mts "$MERGE_BASE" "$HEAD_SHA")
-            # Fall back to all packages if no packages changed (e.g. CI-only PRs),
-            # to ensure required status checks are not skipped.
-            if [[ "$PACKAGES" == "[]" ]]; then
-              PACKAGES=$(yarn workspaces list --no-private --json | jq --slurp --raw-output 'map(.name) | @json')
-            fi
           else
             PACKAGES=$(yarn workspaces list --no-private --json | jq --slurp --raw-output 'map(.name) | @json')
           fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,44 +51,17 @@ jobs:
         env:
           ACTIONLINT: ${{ steps.download-actionlint.outputs.executable }}
 
-  analyse-code:
-    name: Analyse code
-    needs: check-workflows
-    uses: MetaMask/action-security-code-scanner/.github/workflows/security-scan.yml@v2
-    with:
-      scanner-ref: v2
-      paths-ignored: |
-        .storybook/
-        **/__snapshots__/
-        **/*.snap
-        **/*.stories.js
-        **/*.stories.tsx
-        **/*.test.browser.ts*
-        **/*.test.js*
-        **/*.test.ts*
-        **/fixtures/
-        **/jest.config.js
-        **/jest.environment.js
-        **/mocks/
-        **/test*/
-        docs/
-        e2e/
-        merged-packages/
-        node_modules/
-        storybook/
-        test*/
-    secrets:
-      project-metrics-token: ${{ secrets.SECURITY_SCAN_METRICS_TOKEN }}
-      slack-webhook: ${{ secrets.APPSEC_BOT_SLACK_WEBHOOK }}
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
-
   lint-build-test:
     name: Lint, build, and test
     needs: check-workflows
     uses: ./.github/workflows/lint-build-test.yml
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    secrets:
+      SECURITY_SCAN_METRICS_TOKEN: ${{ secrets.SECURITY_SCAN_METRICS_TOKEN }}
+      APPSEC_BOT_SLACK_WEBHOOK: ${{ secrets.APPSEC_BOT_SLACK_WEBHOOK }}
 
   deploy-platform-api-docs:
     name: Deploy Platform API Docs
@@ -156,7 +129,6 @@ jobs:
     name: All jobs complete
     runs-on: ubuntu-latest
     needs:
-      - analyse-code
       - check-release
       - lint-build-test
     outputs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,13 +55,40 @@ jobs:
     name: Lint, build, and test
     needs: check-workflows
     uses: ./.github/workflows/lint-build-test.yml
+
+  analyse-code:
+    name: Analyse code
+    needs: check-workflows
+    uses: MetaMask/action-security-code-scanner/.github/workflows/security-scan.yml@v2
+    with:
+      scanner-ref: v2
+      paths-ignored: |
+        .storybook/
+        **/__snapshots__/
+        **/*.snap
+        **/*.stories.js
+        **/*.stories.tsx
+        **/*.test.browser.ts*
+        **/*.test.js*
+        **/*.test.ts*
+        **/fixtures/
+        **/jest.config.js
+        **/jest.environment.js
+        **/mocks/
+        **/test*/
+        docs/
+        e2e/
+        merged-packages/
+        node_modules/
+        storybook/
+        test*/
+    secrets:
+      project-metrics-token: ${{ secrets.SECURITY_SCAN_METRICS_TOKEN }}
+      slack-webhook: ${{ secrets.APPSEC_BOT_SLACK_WEBHOOK }}
     permissions:
       actions: read
       contents: read
       security-events: write
-    secrets:
-      SECURITY_SCAN_METRICS_TOKEN: ${{ secrets.SECURITY_SCAN_METRICS_TOKEN }}
-      APPSEC_BOT_SLACK_WEBHOOK: ${{ secrets.APPSEC_BOT_SLACK_WEBHOOK }}
 
   deploy-platform-api-docs:
     name: Deploy Platform API Docs
@@ -129,6 +156,7 @@ jobs:
     name: All jobs complete
     runs-on: ubuntu-latest
     needs:
+      - analyse-code
       - check-release
       - lint-build-test
     outputs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,11 +51,6 @@ jobs:
         env:
           ACTIONLINT: ${{ steps.download-actionlint.outputs.executable }}
 
-  lint-build-test:
-    name: Lint, build, and test
-    needs: check-workflows
-    uses: ./.github/workflows/lint-build-test.yml
-
   analyse-code:
     name: Analyse code
     needs: check-workflows
@@ -89,6 +84,11 @@ jobs:
       actions: read
       contents: read
       security-events: write
+
+  lint-build-test:
+    name: Lint, build, and test
+    needs: check-workflows
+    uses: ./.github/workflows/lint-build-test.yml
 
   deploy-platform-api-docs:
     name: Deploy Platform API Docs

--- a/scripts/generate-partial-build-tsconfig.mts
+++ b/scripts/generate-partial-build-tsconfig.mts
@@ -1,162 +1,40 @@
-import { fileExists } from '@metamask/utils/node';
-import execa from 'execa';
-import { readFile } from 'node:fs/promises';
-import { join } from 'node:path';
-
-const ROOT_WORKSPACE = new URL('..', import.meta.url).pathname;
-
-type Workspace = {
-  location: string;
-  name: string;
-};
-
-/**
- * Get all TypeScript workspaces in the monorepo. This checks for packages
- * containing a "tsconfig.build.json" file.
- *
- * @returns The workspaces in the monorepo.
- */
-async function getWorkspaces(): Promise<Workspace[]> {
-  const { stdout } = await execa('yarn', ['workspaces', 'list', '--json'], {
-    cwd: ROOT_WORKSPACE,
-    encoding: 'utf8',
-  });
-
-  const entries: Workspace[] = stdout
-    .trim()
-    .split('\n')
-    .map((line) => JSON.parse(line))
-    .filter(({ location }: Workspace) => location !== '.');
-
-  return (
-    await Promise.all(
-      entries.map(async (workspace) => {
-        const hasTsConfig = await fileExists(
-          join(ROOT_WORKSPACE, workspace.location, 'tsconfig.build.json'),
-        );
-
-        return hasTsConfig ? workspace : null;
-      }),
-    )
-  ).filter((workspace): workspace is Workspace => workspace !== null);
-}
-
-type DependencyGraph = {
-  dependants: Record<string, Set<string>>;
-  dependencies: Record<string, Set<string>>;
-};
-
-/**
- * Get dependency and dependant maps for all workspaces.
- *
- * @param workspaces - The workspaces in the monorepo.
- * @returns Maps of package name -> dependants and package name -> dependencies.
- */
-async function getWorkspaceDependencies(
-  workspaces: Workspace[],
-): Promise<DependencyGraph> {
-  const dependants: Record<string, Set<string>> = Object.fromEntries(
-    workspaces.map(({ name }) => [name, new Set<string>()]),
-  );
-  const dependencies: Record<string, Set<string>> = Object.fromEntries(
-    workspaces.map(({ name }) => [name, new Set<string>()]),
-  );
-
-  for (const { name, location } of workspaces) {
-    const pkg = JSON.parse(
-      await readFile(join(ROOT_WORKSPACE, location, 'package.json'), {
-        encoding: 'utf-8',
-      }),
-    );
-
-    for (const dependency of Object.keys({
-      ...pkg.dependencies,
-      ...pkg.devDependencies,
-    })) {
-      if (dependants[dependency] !== undefined) {
-        dependants[dependency].add(name);
-        dependencies[name].add(dependency);
-      }
-    }
-  }
-
-  return { dependants, dependencies };
-}
-
-/**
- * Get the list of files changed between the merge base and the PR head.
- *
- * @param mergeBase - The merge base SHA.
- * @param headRef - The PR branch tip SHA (or "HEAD" as fallback).
- * @returns A list of changed file paths.
- */
-async function getChangedFiles(
-  mergeBase: string,
-  headRef: string,
-): Promise<string[]> {
-  const { stdout } = await execa(
-    'git',
-    ['diff', '--name-only', `${mergeBase}...${headRef}`],
-    {
-      cwd: ROOT_WORKSPACE,
-      encoding: 'utf8',
-    },
-  );
-
-  return stdout.trim().split('\n').filter(Boolean);
-}
+import {
+  getTypeScriptWorkspaces,
+  computeChangedWorkspaces,
+} from './lib/workspaces.mjs';
 
 /**
  * Generate a filtered tsconfig.build.json for partial CI builds.
  *
  * Given a merge base SHA, outputs a tsconfig that references only the
- * packages that changed since that commit plus their transitive dependants.
- * Pipe the output to a temp file and pass it to `ts-bridge --project`.
+ * TypeScript packages that changed since that commit plus their transitive
+ * dependants and dependencies. Pipe the output to a temp file and pass it
+ * to `ts-bridge --project`.
  *
- * Usage: `tsx scripts/generate-partial-build-tsconfig.ts <merge-base-sha> [head-sha]`.
+ * Dependencies are always included because TypeScript project references
+ * require every referenced project's dist output to already exist on disk.
+ *
+ * Usage: `tsx scripts/generate-partial-build-tsconfig.mts <merge-base-sha> [<head-sha>]`
  */
 async function main() {
   const mergeBase = process.argv[2];
   if (!mergeBase) {
     console.error(
-      'Usage: generate-partial-build-tsconfig.ts <merge-base-sha> [head-sha]',
+      'Usage: generate-partial-build-tsconfig.mts <merge-base-sha> [<head-sha>]',
     );
-
     process.exitCode = 1;
     return;
   }
 
   const headRef = process.argv[3] ?? 'HEAD';
 
-  const workspaces = await getWorkspaces();
-  const changedFiles = await getChangedFiles(mergeBase, headRef);
-  const { dependants, dependencies } =
-    await getWorkspaceDependencies(workspaces);
-
-  const packagesToBuild = new Set(
-    changedFiles.flatMap((file) => {
-      const workspace = workspaces.find(({ location }) =>
-        file.startsWith(`${location}/`),
-      );
-
-      return workspace ? [workspace.name] : [];
-    }),
+  const workspaces = await getTypeScriptWorkspaces();
+  const packagesToBuild = await computeChangedWorkspaces(
+    workspaces,
+    mergeBase,
+    headRef,
+    true,
   );
-
-  // Expand to transitive dependants (packages that depend on what changed).
-  for (const packageToBuild of packagesToBuild) {
-    for (const dependant of dependants[packageToBuild] ?? []) {
-      packagesToBuild.add(dependant);
-    }
-  }
-
-  // Expand to transitive dependencies (dist files must exist to build
-  // dependants).
-  for (const packageToBuild of packagesToBuild) {
-    for (const dependency of dependencies[packageToBuild] ?? []) {
-      packagesToBuild.add(dependency);
-    }
-  }
 
   const references = workspaces
     .filter(({ name }) => packagesToBuild.has(name))

--- a/scripts/generate-partial-build-tsconfig.mts
+++ b/scripts/generate-partial-build-tsconfig.mts
@@ -1,0 +1,139 @@
+import { fileExists } from '@metamask/utils/node';
+import execa from 'execa';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const ROOT_WORKSPACE = new URL('..', import.meta.url).pathname;
+
+type Workspace = {
+  location: string;
+  name: string;
+};
+
+/**
+ * Get all TypeScript workspaces in the monorepo. This checks for packages
+ * containing a "tsconfig.build.json" file.
+ *
+ * @returns The workspaces in the monorepo.
+ */
+async function getWorkspaces(): Promise<Workspace[]> {
+  const { stdout } = await execa('yarn', ['workspaces', 'list', '--json'], {
+    cwd: ROOT_WORKSPACE,
+    encoding: 'utf8',
+  });
+
+  const entries: Workspace[] = stdout
+    .trim()
+    .split('\n')
+    .map((line) => JSON.parse(line))
+    .filter(({ location }: Workspace) => location !== '.');
+
+  return (
+    await Promise.all(
+      entries.map(async (workspace) => {
+        const hasTsConfig = await fileExists(
+          join(ROOT_WORKSPACE, workspace.location, 'tsconfig.build.json'),
+        );
+
+        return hasTsConfig ? workspace : null;
+      }),
+    )
+  ).filter((workspace): workspace is Workspace => workspace !== null);
+}
+
+/**
+ * Get a map of package name -> names of packages that depend on it.
+ *
+ * @param workspaces - The workspaces in the monorepo.
+ * @returns A map of package name -> names of packages that depend on it.
+ */
+async function getWorkspaceDependencies(
+  workspaces: Workspace[],
+): Promise<Record<string, Set<string>>> {
+  const dependants: Record<string, Set<string>> = Object.fromEntries(
+    workspaces.map(({ name }) => [name, new Set<string>()]),
+  );
+
+  for (const { name, location } of workspaces) {
+    const pkg = JSON.parse(
+      await readFile(join(ROOT_WORKSPACE, location, 'package.json'), {
+        encoding: 'utf-8',
+      }),
+    );
+
+    for (const dependency of Object.keys({
+      ...pkg.dependencies,
+      ...pkg.devDependencies,
+    })) {
+      dependants[dependency]?.add(name);
+    }
+  }
+
+  return dependants;
+}
+
+/**
+ * Get the list of files changed since the given merge base.
+ *
+ * @param mergeBase - The merge base SHA to diff against.
+ * @returns A list of changed file paths.
+ */
+async function getChangedFiles(mergeBase: string): Promise<string[]> {
+  const { stdout } = await execa(
+    'git',
+    ['diff', '--name-only', `${mergeBase}...HEAD`],
+    {
+      cwd: ROOT_WORKSPACE,
+      encoding: 'utf8',
+    },
+  );
+
+  return stdout.trim().split('\n').filter(Boolean);
+}
+
+/**
+ * Generate a filtered tsconfig.build.json for partial CI builds.
+ *
+ * Given a merge base SHA, outputs a tsconfig that references only the
+ * packages that changed since that commit plus their transitive dependants.
+ * Pipe the output to a temp file and pass it to `ts-bridge --project`.
+ *
+ * Usage: `tsx scripts/generate-partial-build-tsconfig.ts <merge-base-sha>`.
+ */
+async function main() {
+  const mergeBase = process.argv[2];
+  if (!mergeBase) {
+    console.error('Usage: generate-partial-build-tsconfig.ts <merge-base-sha>');
+
+    process.exitCode = 1;
+    return;
+  }
+
+  const workspaces = await getWorkspaces();
+  const changedFiles = await getChangedFiles(mergeBase);
+  const dependants = await getWorkspaceDependencies(workspaces);
+
+  const packagesToBuild = new Set(
+    changedFiles.flatMap((file) => {
+      const workspace = workspaces.find(({ location }) =>
+        file.startsWith(`${location}/`),
+      );
+
+      return workspace ? [workspace.name] : [];
+    }),
+  );
+
+  for (const packageToBuild of packagesToBuild) {
+    for (const dependant of dependants[packageToBuild] ?? []) {
+      packagesToBuild.add(dependant);
+    }
+  }
+
+  const references = workspaces
+    .filter(({ name }) => packagesToBuild.has(name))
+    .map(({ location }) => ({ path: `./${location}/tsconfig.build.json` }));
+
+  console.log(JSON.stringify({ files: [], include: [], references }, null, 2));
+}
+
+await main();

--- a/scripts/generate-partial-build-tsconfig.mts
+++ b/scripts/generate-partial-build-tsconfig.mts
@@ -1,4 +1,5 @@
 import {
+  getAllWorkspaces,
   getTypeScriptWorkspaces,
   computeChangedWorkspaces,
 } from './lib/workspaces.mjs';
@@ -28,15 +29,16 @@ async function main() {
 
   const headRef = process.argv[3] ?? 'HEAD';
 
-  const workspaces = await getTypeScriptWorkspaces();
+  const allWorkspaces = await getAllWorkspaces();
+  const typeScriptWorkspaces = await getTypeScriptWorkspaces();
   const packagesToBuild = await computeChangedWorkspaces(
-    workspaces,
+    allWorkspaces,
     mergeBase,
     headRef,
     true,
   );
 
-  const references = workspaces
+  const references = typeScriptWorkspaces
     .filter(({ name }) => packagesToBuild.has(name))
     .map(({ location }) => ({ path: `./${location}/tsconfig.build.json` }));
 

--- a/scripts/generate-partial-build-tsconfig.mts
+++ b/scripts/generate-partial-build-tsconfig.mts
@@ -41,16 +41,24 @@ async function getWorkspaces(): Promise<Workspace[]> {
   ).filter((workspace): workspace is Workspace => workspace !== null);
 }
 
+type DependencyGraph = {
+  dependants: Record<string, Set<string>>;
+  dependencies: Record<string, Set<string>>;
+};
+
 /**
- * Get a map of package name -> names of packages that depend on it.
+ * Get dependency and dependant maps for all workspaces.
  *
  * @param workspaces - The workspaces in the monorepo.
- * @returns A map of package name -> names of packages that depend on it.
+ * @returns Maps of package name -> dependants and package name -> dependencies.
  */
 async function getWorkspaceDependencies(
   workspaces: Workspace[],
-): Promise<Record<string, Set<string>>> {
+): Promise<DependencyGraph> {
   const dependants: Record<string, Set<string>> = Object.fromEntries(
+    workspaces.map(({ name }) => [name, new Set<string>()]),
+  );
+  const dependencies: Record<string, Set<string>> = Object.fromEntries(
     workspaces.map(({ name }) => [name, new Set<string>()]),
   );
 
@@ -65,23 +73,30 @@ async function getWorkspaceDependencies(
       ...pkg.dependencies,
       ...pkg.devDependencies,
     })) {
-      dependants[dependency]?.add(name);
+      if (dependants[dependency] !== undefined) {
+        dependants[dependency].add(name);
+        dependencies[name].add(dependency);
+      }
     }
   }
 
-  return dependants;
+  return { dependants, dependencies };
 }
 
 /**
- * Get the list of files changed since the given merge base.
+ * Get the list of files changed between the merge base and the PR head.
  *
- * @param mergeBase - The merge base SHA to diff against.
+ * @param mergeBase - The merge base SHA.
+ * @param headRef - The PR branch tip SHA (or "HEAD" as fallback).
  * @returns A list of changed file paths.
  */
-async function getChangedFiles(mergeBase: string): Promise<string[]> {
+async function getChangedFiles(
+  mergeBase: string,
+  headRef: string,
+): Promise<string[]> {
   const { stdout } = await execa(
     'git',
-    ['diff', '--name-only', `${mergeBase}...HEAD`],
+    ['diff', '--name-only', `${mergeBase}...${headRef}`],
     {
       cwd: ROOT_WORKSPACE,
       encoding: 'utf8',
@@ -98,20 +113,25 @@ async function getChangedFiles(mergeBase: string): Promise<string[]> {
  * packages that changed since that commit plus their transitive dependants.
  * Pipe the output to a temp file and pass it to `ts-bridge --project`.
  *
- * Usage: `tsx scripts/generate-partial-build-tsconfig.ts <merge-base-sha>`.
+ * Usage: `tsx scripts/generate-partial-build-tsconfig.ts <merge-base-sha> [head-sha]`.
  */
 async function main() {
   const mergeBase = process.argv[2];
   if (!mergeBase) {
-    console.error('Usage: generate-partial-build-tsconfig.ts <merge-base-sha>');
+    console.error(
+      'Usage: generate-partial-build-tsconfig.ts <merge-base-sha> [head-sha]',
+    );
 
     process.exitCode = 1;
     return;
   }
 
+  const headRef = process.argv[3] ?? 'HEAD';
+
   const workspaces = await getWorkspaces();
-  const changedFiles = await getChangedFiles(mergeBase);
-  const dependants = await getWorkspaceDependencies(workspaces);
+  const changedFiles = await getChangedFiles(mergeBase, headRef);
+  const { dependants, dependencies } =
+    await getWorkspaceDependencies(workspaces);
 
   const packagesToBuild = new Set(
     changedFiles.flatMap((file) => {
@@ -123,15 +143,28 @@ async function main() {
     }),
   );
 
+  // Expand to transitive dependants (packages that depend on what changed).
   for (const packageToBuild of packagesToBuild) {
     for (const dependant of dependants[packageToBuild] ?? []) {
       packagesToBuild.add(dependant);
     }
   }
 
+  // Expand to transitive dependencies (dist files must exist to build
+  // dependants).
+  for (const packageToBuild of packagesToBuild) {
+    for (const dependency of dependencies[packageToBuild] ?? []) {
+      packagesToBuild.add(dependency);
+    }
+  }
+
   const references = workspaces
     .filter(({ name }) => packagesToBuild.has(name))
     .map(({ location }) => ({ path: `./${location}/tsconfig.build.json` }));
+
+  if (references.length === 0) {
+    return;
+  }
 
   console.log(JSON.stringify({ files: [], include: [], references }, null, 2));
 }

--- a/scripts/get-changed-workspaces.mts
+++ b/scripts/get-changed-workspaces.mts
@@ -1,0 +1,43 @@
+import {
+  getAllWorkspaces,
+  computeChangedWorkspaces,
+} from './lib/workspaces.mjs';
+
+/**
+ * List workspace package names that need to be checked given a merge base.
+ *
+ * Outputs a JSON array of package names to stdout. Always includes packages
+ * that changed since the merge base plus their transitive dependants. Pass
+ * `--include-dependencies` to also include transitive dependencies (needed
+ * for TypeScript project reference builds where dist outputs must exist).
+ *
+ * Usage: `tsx scripts/get-changed-workspaces.mts <merge-base-sha> [<head-sha>] [--include-dependencies]`
+ */
+const args = process.argv.slice(2);
+const includeDependencies = args.includes('--include-dependencies');
+const positional = args.filter((arg) => !arg.startsWith('--'));
+
+const mergeBase = positional[0];
+if (!mergeBase) {
+  console.error(
+    'Usage: get-changed-workspaces.mts <merge-base-sha> [<head-sha>] [--include-dependencies]',
+  );
+  process.exitCode = 1;
+  process.exit();
+}
+
+const headRef = positional[1] ?? 'HEAD';
+
+const workspaces = await getAllWorkspaces();
+const changed = await computeChangedWorkspaces(
+  workspaces,
+  mergeBase,
+  headRef,
+  includeDependencies,
+);
+
+const names = workspaces
+  .filter(({ name }) => changed.has(name))
+  .map(({ name }) => name);
+
+console.log(JSON.stringify(names));

--- a/scripts/get-changed-workspaces.mts
+++ b/scripts/get-changed-workspaces.mts
@@ -1,5 +1,6 @@
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
+
 import {
   getAllWorkspaces,
   checkRootChange,

--- a/scripts/get-changed-workspaces.mts
+++ b/scripts/get-changed-workspaces.mts
@@ -1,43 +1,63 @@
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
 import {
   getAllWorkspaces,
+  checkRootChange,
   computeChangedWorkspaces,
+  getChangedFiles,
 } from './lib/workspaces.mjs';
 
 /**
- * List workspace package names that need to be checked given a merge base.
+ * List workspaces that need to be checked given a merge base.
  *
- * Outputs a JSON array of package names to stdout. Always includes packages
- * that changed since the merge base plus their transitive dependants. Pass
- * `--include-dependencies` to also include transitive dependencies (needed
- * for TypeScript project reference builds where dist outputs must exist).
+ * Outputs a JSON object to stdout:
+ * - `names`: package names of changed workspaces and their transitive dependants
+ * - `locations`: workspace-relative paths (e.g. `packages/foo`) for the same set
+ * - `hasRootChange`: true if any non-ignored root file changed (triggers a full run)
  *
- * Usage: `tsx scripts/get-changed-workspaces.mts <merge-base-sha> [<head-sha>] [--include-dependencies]`
+ * Usage: `tsx scripts/get-changed-workspaces.mts <merge-base-sha> [<head-sha>] [options]`
  */
-const args = process.argv.slice(2);
-const includeDependencies = args.includes('--include-dependencies');
-const positional = args.filter((arg) => !arg.startsWith('--'));
+const argv = await yargs(hideBin(process.argv))
+  .usage('$0 <merge-base> [head-sha] [options]')
+  .positional('merge-base', {
+    type: 'string',
+    describe: 'Merge base SHA',
+  })
+  .positional('head-sha', {
+    type: 'string',
+    describe: 'PR branch tip SHA (defaults to HEAD)',
+  })
+  .option('include-dependencies', {
+    type: 'boolean',
+    default: false,
+    describe:
+      'Also expand to transitive dependencies (needed for TypeScript builds)',
+  })
+  .demandCommand(1, 'merge-base is required')
+  .help()
+  .parseAsync();
 
-const mergeBase = positional[0];
-if (!mergeBase) {
-  console.error(
-    'Usage: get-changed-workspaces.mts <merge-base-sha> [<head-sha>] [--include-dependencies]',
-  );
-  process.exitCode = 1;
-  process.exit();
-}
-
-const headRef = positional[1] ?? 'HEAD';
-
+const mergeBase = argv._[0] as string;
+const headRef = (argv._[1] as string | undefined) ?? 'HEAD';
 const workspaces = await getAllWorkspaces();
+
+const changedFiles = await getChangedFiles(mergeBase, headRef);
+const hasRootChange = checkRootChange(workspaces, changedFiles);
+
 const changed = await computeChangedWorkspaces(
   workspaces,
   mergeBase,
   headRef,
-  includeDependencies,
+  argv['include-dependencies'],
+  changedFiles,
 );
 
-const names = workspaces
-  .filter(({ name }) => changed.has(name))
-  .map(({ name }) => name);
+const changedWorkspaces = workspaces.filter(({ name }) => changed.has(name));
 
-console.log(JSON.stringify(names));
+console.log(
+  JSON.stringify({
+    names: changedWorkspaces.map(({ name }) => name),
+    locations: changedWorkspaces.map(({ location }) => location),
+    hasRootChange,
+  }),
+);

--- a/scripts/lib/workspaces.mts
+++ b/scripts/lib/workspaces.mts
@@ -11,7 +11,6 @@ const IGNORED_ROOT_FILES = new Set([
   'AGENTS.md',
   'CLAUDE.md',
   'README.md',
-  'eslint-suppressions.json',
   'teams.json',
   'yarn.lock',
 ]);
@@ -85,13 +84,16 @@ export async function getWorkspaceDependencies(
     workspaces.map(({ name }) => [name, new Set<string>()]),
   );
 
-  for (const { name, location } of workspaces) {
-    const pkg = JSON.parse(
-      await readFile(join(ROOT_WORKSPACE, location, 'package.json'), {
+  const packages = await Promise.all(
+    workspaces.map(({ location }) =>
+      readFile(join(ROOT_WORKSPACE, location, 'package.json'), {
         encoding: 'utf-8',
-      }),
-    );
+      }).then(JSON.parse),
+    ),
+  );
 
+  for (const [index, { name }] of workspaces.entries()) {
+    const pkg = packages[index];
     for (const dependency of Object.keys({
       ...pkg.dependencies,
       ...pkg.devDependencies,

--- a/scripts/lib/workspaces.mts
+++ b/scripts/lib/workspaces.mts
@@ -1,0 +1,167 @@
+import { fileExists } from '@metamask/utils/node';
+import execa from 'execa';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+export const ROOT_WORKSPACE = new URL('../..', import.meta.url).pathname;
+
+export type Workspace = {
+  location: string;
+  name: string;
+};
+
+export type DependencyGraph = {
+  dependants: Record<string, Set<string>>;
+  dependencies: Record<string, Set<string>>;
+};
+
+/**
+ * Get all non-root workspaces in the monorepo.
+ *
+ * @returns All workspaces.
+ */
+export async function getAllWorkspaces(): Promise<Workspace[]> {
+  const { stdout } = await execa('yarn', ['workspaces', 'list', '--json'], {
+    cwd: ROOT_WORKSPACE,
+    encoding: 'utf8',
+  });
+
+  return stdout
+    .trim()
+    .split('\n')
+    .map((line) => JSON.parse(line))
+    .filter(({ location }: Workspace) => location !== '.');
+}
+
+/**
+ * Get all TypeScript workspaces in the monorepo. This filters to packages
+ * containing a "tsconfig.build.json" file.
+ *
+ * @returns All TypeScript workspaces.
+ */
+export async function getTypeScriptWorkspaces(): Promise<Workspace[]> {
+  const workspaces = await getAllWorkspaces();
+
+  return (
+    await Promise.all(
+      workspaces.map(async (workspace) => {
+        const hasTsConfig = await fileExists(
+          join(ROOT_WORKSPACE, workspace.location, 'tsconfig.build.json'),
+        );
+        return hasTsConfig ? workspace : null;
+      }),
+    )
+  ).filter((workspace): workspace is Workspace => workspace !== null);
+}
+
+/**
+ * Get dependency and dependant maps for all workspaces.
+ *
+ * @param workspaces - The workspaces to build the graph for.
+ * @returns Maps of package name to dependants and package name to dependencies.
+ */
+export async function getWorkspaceDependencies(
+  workspaces: Workspace[],
+): Promise<DependencyGraph> {
+  const dependants: Record<string, Set<string>> = Object.fromEntries(
+    workspaces.map(({ name }) => [name, new Set<string>()]),
+  );
+  const dependencies: Record<string, Set<string>> = Object.fromEntries(
+    workspaces.map(({ name }) => [name, new Set<string>()]),
+  );
+
+  for (const { name, location } of workspaces) {
+    const pkg = JSON.parse(
+      await readFile(join(ROOT_WORKSPACE, location, 'package.json'), {
+        encoding: 'utf-8',
+      }),
+    );
+
+    for (const dependency of Object.keys({
+      ...pkg.dependencies,
+      ...pkg.devDependencies,
+    })) {
+      if (dependants[dependency] !== undefined) {
+        dependants[dependency].add(name);
+        dependencies[name].add(dependency);
+      }
+    }
+  }
+
+  return { dependants, dependencies };
+}
+
+/**
+ * Get the list of files changed between the merge base and the PR head.
+ *
+ * @param mergeBase - The merge base SHA.
+ * @param headRef - The PR branch tip SHA (or "HEAD" as fallback).
+ * @returns A list of changed file paths.
+ */
+export async function getChangedFiles(
+  mergeBase: string,
+  headRef: string,
+): Promise<string[]> {
+  const { stdout } = await execa(
+    'git',
+    ['diff', '--name-only', `${mergeBase}...${headRef}`],
+    {
+      cwd: ROOT_WORKSPACE,
+      encoding: 'utf8',
+    },
+  );
+
+  return stdout.trim().split('\n').filter(Boolean);
+}
+
+/**
+ * Compute the set of workspace names that need to be checked given a merge
+ * base, by finding changed packages and expanding to transitive dependants.
+ *
+ * When `includeDependencies` is true, also expands to transitive dependencies.
+ * This is needed for TypeScript project reference builds, where every
+ * referenced project's dist output must already exist on disk.
+ *
+ * @param workspaces - The workspace set to compute against.
+ * @param mergeBase - The merge base SHA.
+ * @param headRef - The PR branch tip SHA (or "HEAD" as fallback).
+ * @param includeDependencies - Whether to also expand to transitive dependencies.
+ * @returns The set of workspace names to check.
+ */
+export async function computeChangedWorkspaces(
+  workspaces: Workspace[],
+  mergeBase: string,
+  headRef: string,
+  includeDependencies: boolean,
+): Promise<Set<string>> {
+  const changedFiles = await getChangedFiles(mergeBase, headRef);
+  const { dependants, dependencies } =
+    await getWorkspaceDependencies(workspaces);
+
+  const result = new Set(
+    changedFiles.flatMap((file) => {
+      const workspace = workspaces.find(({ location }) =>
+        file.startsWith(`${location}/`),
+      );
+      return workspace ? [workspace.name] : [];
+    }),
+  );
+
+  // Expand to transitive dependants (packages that depend on what changed).
+  for (const pkg of result) {
+    for (const dependant of dependants[pkg] ?? []) {
+      result.add(dependant);
+    }
+  }
+
+  if (includeDependencies) {
+    // Expand to transitive dependencies (dist files must exist to build dependants).
+    for (const pkg of result) {
+      for (const dependency of dependencies[pkg] ?? []) {
+        result.add(dependency);
+      }
+    }
+  }
+
+  return result;
+}

--- a/scripts/lib/workspaces.mts
+++ b/scripts/lib/workspaces.mts
@@ -32,10 +32,14 @@ export type DependencyGraph = {
  * @returns All workspaces.
  */
 export async function getAllWorkspaces(): Promise<Workspace[]> {
-  const { stdout } = await execa('yarn', ['workspaces', 'list', '--no-private', '--json'], {
-    cwd: ROOT_WORKSPACE,
-    encoding: 'utf8',
-  });
+  const { stdout } = await execa(
+    'yarn',
+    ['workspaces', 'list', '--no-private', '--json'],
+    {
+      cwd: ROOT_WORKSPACE,
+      encoding: 'utf8',
+    },
+  );
 
   return stdout
     .trim()

--- a/scripts/lib/workspaces.mts
+++ b/scripts/lib/workspaces.mts
@@ -130,6 +130,26 @@ export async function getChangedFiles(
 }
 
 /**
+ * Check whether any changed file lives outside all package directories and
+ * is not in the ignored root files list. When true, a full
+ * rebuild/test/lint run is required.
+ *
+ * @param workspaces - The workspace set to check against.
+ * @param changedFiles - The list of changed file paths.
+ * @returns Whether any non-ignored root file changed.
+ */
+export function checkRootChange(
+  workspaces: Workspace[],
+  changedFiles: string[],
+): boolean {
+  return changedFiles.some(
+    (file) =>
+      !IGNORED_ROOT_FILES.has(file) &&
+      !workspaces.some(({ location }) => file.startsWith(`${location}/`)),
+  );
+}
+
+/**
  * Compute the set of workspace names that need to be checked given a merge
  * base, by finding changed packages and expanding to transitive dependants.
  *
@@ -141,6 +161,7 @@ export async function getChangedFiles(
  * @param mergeBase - The merge base SHA.
  * @param headRef - The PR branch tip SHA (or "HEAD" as fallback).
  * @param includeDependencies - Whether to also expand to transitive dependencies.
+ * @param changedFiles - Pre-fetched list of changed files; fetched if omitted.
  * @returns The set of workspace names to check.
  */
 export async function computeChangedWorkspaces(
@@ -148,25 +169,20 @@ export async function computeChangedWorkspaces(
   mergeBase: string,
   headRef: string,
   includeDependencies: boolean,
+  changedFiles?: string[],
 ): Promise<Set<string>> {
-  const changedFiles = await getChangedFiles(mergeBase, headRef);
+  const files = changedFiles ?? (await getChangedFiles(mergeBase, headRef));
   const { dependants, dependencies } =
     await getWorkspaceDependencies(workspaces);
 
   // If any changed file lives outside all package directories (e.g. root
   // configs, workflow files, scripts), rebuild and test everything.
-  const hasRootChange = changedFiles.some(
-    (file) =>
-      !IGNORED_ROOT_FILES.has(file) &&
-      !workspaces.some(({ location }) => file.startsWith(`${location}/`)),
-  );
-
-  if (hasRootChange) {
+  if (checkRootChange(workspaces, files)) {
     return new Set(workspaces.map(({ name }) => name));
   }
 
   const result = new Set(
-    changedFiles.flatMap((file) => {
+    files.flatMap((file) => {
       const workspace = workspaces.find(({ location }) =>
         file.startsWith(`${location}/`),
       );

--- a/scripts/lib/workspaces.mts
+++ b/scripts/lib/workspaces.mts
@@ -32,7 +32,7 @@ export type DependencyGraph = {
  * @returns All workspaces.
  */
 export async function getAllWorkspaces(): Promise<Workspace[]> {
-  const { stdout } = await execa('yarn', ['workspaces', 'list', '--json'], {
+  const { stdout } = await execa('yarn', ['workspaces', 'list', '--no-private', '--json'], {
     cwd: ROOT_WORKSPACE,
     encoding: 'utf8',
   });

--- a/scripts/lib/workspaces.mts
+++ b/scripts/lib/workspaces.mts
@@ -5,6 +5,17 @@ import { join } from 'node:path';
 
 export const ROOT_WORKSPACE = new URL('../..', import.meta.url).pathname;
 
+// Files that can change without requiring a full rebuild/test run.
+const IGNORED_ROOT_FILES = new Set([
+  '.gitignore',
+  'AGENTS.md',
+  'CLAUDE.md',
+  'README.md',
+  'eslint-suppressions.json',
+  'teams.json',
+  'yarn.lock',
+]);
+
 export type Workspace = {
   location: string;
   name: string;
@@ -137,6 +148,18 @@ export async function computeChangedWorkspaces(
   const changedFiles = await getChangedFiles(mergeBase, headRef);
   const { dependants, dependencies } =
     await getWorkspaceDependencies(workspaces);
+
+  // If any changed file lives outside all package directories (e.g. root
+  // configs, workflow files, scripts), rebuild and test everything.
+  const hasRootChange = changedFiles.some(
+    (file) =>
+      !IGNORED_ROOT_FILES.has(file) &&
+      !workspaces.some(({ location }) => file.startsWith(`${location}/`)),
+  );
+
+  if (hasRootChange) {
+    return new Set(workspaces.map(({ name }) => name));
+  }
 
   const result = new Set(
     changedFiles.flatMap((file) => {

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -18,6 +18,6 @@
     "noErrorTruncation": true,
     "noUncheckedIndexedAccess": true
   },
-  "include": ["./scripts/**/*.ts"],
+  "include": ["./scripts/**/*.ts", "./scripts/**/*.mts"],
   "exclude": ["**/node_modules"]
 }


### PR DESCRIPTION
Only changes a comment in the workflow file. Since `.github/workflows/lint-build-test.yml` is not in `IGNORED_ROOT_FILES`, this counts as a root change. Expected: full run — all packages tested.