### PR TITLE
[snap-account-service] Remove extra account-tree-controller dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,7 +583,6 @@ linkStyle default opacity:0.5
   smart_transactions_controller --> remote_feature_flag_controller;
   smart_transactions_controller --> transaction_controller;
   smart_transactions_controller --> json_rpc_engine;
-  snap_account_service --> account_tree_controller;
   snap_account_service --> keyring_controller;
   snap_account_service --> messenger;
   social_controllers --> base_controller;

--- a/packages/snap-account-service/package.json
+++ b/packages/snap-account-service/package.json
@@ -54,7 +54,6 @@
   },
   "dependencies": {
     "@metamask/account-api": "^1.0.4",
-    "@metamask/account-tree-controller": "^7.5.5",
     "@metamask/eth-snap-keyring": "^23.0.0",
     "@metamask/keyring-api": "^23.5.0",
     "@metamask/keyring-controller": "^27.1.0",

--- a/packages/snap-account-service/tsconfig.build.json
+++ b/packages/snap-account-service/tsconfig.build.json
@@ -6,15 +6,6 @@
     "rootDir": "./src"
   },
   "references": [
-    // READ THIS CAREFULLY:
-    // `account-tree-controller` is intentionally NOT referenced here to break
-    // a project-reference cycle:
-    //   account-tree-controller -> multichain-account-service
-    //                           -> snap-account-service
-    //                           -> account-tree-controller
-    // The types we'd otherwise pull from `@metamask/account-tree-controller`
-    // are mirrored locally in `./src/types.ts` — keep them in sync.
-    // { "path": "../account-tree-controller/tsconfig.build.json" },
     { "path": "../keyring-controller/tsconfig.build.json" },
     { "path": "../messenger/tsconfig.build.json" }
   ],

--- a/packages/snap-account-service/tsconfig.json
+++ b/packages/snap-account-service/tsconfig.json
@@ -4,15 +4,6 @@
     "baseUrl": "./"
   },
   "references": [
-    // READ THIS CAREFULLY:
-    // `account-tree-controller` is intentionally NOT referenced here to break
-    // a project-reference cycle:
-    //   account-tree-controller -> multichain-account-service
-    //                           -> snap-account-service
-    //                           -> account-tree-controller
-    // The types we'd otherwise pull from `@metamask/account-tree-controller`
-    // are mirrored locally in `./src/types.ts` — keep them in sync.
-    // { "path": "../account-tree-controller" },
     { "path": "../keyring-controller" },
     { "path": "../messenger" }
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -8585,7 +8585,6 @@ __metadata:
   resolution: "@metamask/snap-account-service@workspace:packages/snap-account-service"
   dependencies:
     "@metamask/account-api": "npm:^1.0.4"
-    "@metamask/account-tree-controller": "npm:^7.5.5"
     "@metamask/auto-changelog": "npm:^6.1.0"
     "@metamask/eth-snap-keyring": "npm:^23.0.0"
     "@metamask/keyring-api": "npm:^23.5.0"


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

In a future commit, we want to automatically synchronize the `references` field in each package's tsconfig files with its dependencies. Currently, we would have to make an exception for `snap-account-service`, as it lists `account-tree-controller` as a dependency but purposefully excludes it from its tsconfig files to avoid a circular reference. However, this manual bookkeeping is unnecessary, as `snap-account-service` already works around the circular dependency by copying types from `account-tree-controller` instead of importing them. So the dependency is unnecessary and we can drop it from `snap-account-service`'s `package.json`.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Unblocks https://github.com/MetaMask/core/pull/8384.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and documentation-only change; no runtime or API code changes, with types already duplicated locally.
> 
> **Overview**
> Removes **`@metamask/account-tree-controller`** from `@metamask/snap-account-service`’s declared dependencies and updates the monorepo dependency graph (`README.md`, `yarn.lock`). The package already avoids importing that controller and uses **locally mirrored types** in `src/types.ts` to break the `account-tree-controller` ↔ `multichain-account-service` ↔ `snap-account-service` cycle.
> 
> The long **tsconfig** comments that documented why `account-tree-controller` was omitted from project references are deleted now that the npm dependency no longer exists—references stay limited to `keyring-controller` and `messenger`. This aligns `package.json` with actual build/runtime usage so future automation can sync tsconfig `references` from dependencies without a special-case exception.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7c3e84fd88167194e43274d3974dc1d206d0db3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->