### PR TITLE
feat: stable tokens feature flag for use in @metamask/transaction-pay-controller

### DIFF
--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -9,11 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `getStablecoins` feature flag reader that resolves the stablecoin list from the `stable-tokens` LaunchDarkly flag, falling back to the hardcoded constant when absent ([#9495](https://github.com/MetaMask/core/pull/9495))
 - Add generic signature steps to the server pay strategy, supporting EIP-712 sign-then-POST flows ([#9051](https://github.com/MetaMask/core/pull/9051))
   - Trigger quote refresh when `txParams.to` or `requiredAssets` changes on a transaction, in addition to the existing `txParams.data` trigger
 
 ### Changed
 
+- Replace hardcoded `STABLECOINS` usage in `token.ts` and `relay-quotes.ts` with the remotely configurable `getStablecoins(messenger)` lookup ([#9495](https://github.com/MetaMask/core/pull/9495))
 - Bump `@metamask/assets-controller` from `^10.2.1` to `^11.0.0` ([#9485](https://github.com/MetaMask/core/pull/9485))
 - Bump `@metamask/ramps-controller` from `^16.0.0` to `^17.0.0` ([#9491](https://github.com/MetaMask/core/pull/9491))
 

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.ts
@@ -21,7 +21,6 @@ import {
   NATIVE_TOKEN_ADDRESS,
   PERPS_DEPOSIT_TYPES,
   USDC_DECIMALS,
-  STABLECOINS,
   PaymentOverride,
 } from '../../constants';
 import { projectLogger } from '../../logger';
@@ -38,6 +37,7 @@ import {
   getFeatureFlags,
   getRelayOriginGasOverhead,
   getSlippage,
+  getStablecoins,
   isEIP7702Chain,
   isRelayExecuteEnabled,
 } from '../../utils/feature-flags';
@@ -598,7 +598,7 @@ async function normalizeQuote(
     usdToFiatRate,
   );
 
-  const subsidizedFeeUsd = getSubsidizedFeeAmountUsd(quote);
+  const subsidizedFeeUsd = getSubsidizedFeeAmountUsd(messenger, quote);
 
   const appFeeUsd = new BigNumber(quote.fees?.app?.amountUsd ?? '0');
   const metaMaskFee = getFiatValueFromUsd(appFeeUsd, usdToFiatRate);
@@ -639,6 +639,7 @@ async function normalizeQuote(
   };
 
   const isTargetStablecoin = isStablecoin(
+    messenger,
     request.targetChainId,
     request.targetTokenAddress,
   );
@@ -1215,7 +1216,10 @@ function getTransferRecipient(data: Hex): Hex {
     .decodeFunctionData('transfer', data)
     .to.toLowerCase();
 }
-function getSubsidizedFeeAmountUsd(quote: RelayQuote): BigNumber {
+function getSubsidizedFeeAmountUsd(
+  messenger: TransactionPayControllerMessenger,
+  quote: RelayQuote,
+): BigNumber {
   const subsidizedFee = quote.fees?.subsidized;
   const amountUsd = new BigNumber(subsidizedFee?.amountUsd ?? '0');
   const amountFormatted = new BigNumber(subsidizedFee?.amountFormatted ?? '0');
@@ -1225,6 +1229,7 @@ function getSubsidizedFeeAmountUsd(quote: RelayQuote): BigNumber {
   }
 
   const isSubsidizedStablecoin = isStablecoin(
+    messenger,
     toHex(subsidizedFee.currency.chainId),
     subsidizedFee.currency.address,
   );
@@ -1232,8 +1237,14 @@ function getSubsidizedFeeAmountUsd(quote: RelayQuote): BigNumber {
   return isSubsidizedStablecoin ? amountFormatted : amountUsd;
 }
 
-function isStablecoin(chainId: string, tokenAddress: string): boolean {
+function isStablecoin(
+  messenger: TransactionPayControllerMessenger,
+  chainId: string,
+  tokenAddress: string,
+): boolean {
   return Boolean(
-    STABLECOINS[chainId as Hex]?.includes(tokenAddress.toLowerCase() as Hex),
+    getStablecoins(messenger)[chainId as Hex]?.includes(
+      tokenAddress.toLowerCase() as Hex,
+    ),
   );
 }

--- a/packages/transaction-pay-controller/src/utils/feature-flags.test.ts
+++ b/packages/transaction-pay-controller/src/utils/feature-flags.test.ts
@@ -31,6 +31,7 @@ import {
   getRelayOriginGasOverhead,
   getRelayPollingInterval,
   getRelayPollingTimeout,
+  getStablecoins,
   isChainExcludedFromInfura,
   isEIP7702Chain,
   isRelayExecuteEnabled,
@@ -1941,6 +1942,87 @@ describe('Feature Flags Utils', () => {
         getHyperliquidActivationFeeConfig(messenger, TRANSACTION_TYPE)
           .amountUsd,
       ).toBe(DEFAULT_HYPERLIQUID_ACTIVATION_FEE_USD);
+    });
+  });
+
+  describe('getStablecoins', () => {
+    it('returns hardcoded fallback when flag is absent', () => {
+      const result = getStablecoins(messenger);
+      expect(result).toHaveProperty('0x1');
+      expect(result['0x1' as Hex]).toContain(
+        '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+      );
+    });
+
+    it('returns flag value when stable-tokens is a valid object', () => {
+      const flagValue = {
+        '0x1': ['0xaaa', '0xbbb'],
+        '0xa4b1': ['0xccc'],
+      };
+
+      getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+        ...getDefaultRemoteFeatureFlagControllerState(),
+        remoteFeatureFlags: {
+          'stable-tokens': flagValue,
+        },
+      });
+
+      expect(getStablecoins(messenger)).toStrictEqual(flagValue);
+    });
+
+    it('normalizes addresses and chain IDs to lowercase', () => {
+      getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+        ...getDefaultRemoteFeatureFlagControllerState(),
+        remoteFeatureFlags: {
+          'stable-tokens': {
+            '0xA4B1': ['0xAf88d065e77c8cC2239327C5EDb3A432268e5831'],
+          },
+        },
+      });
+
+      const result = getStablecoins(messenger);
+      expect(result).toStrictEqual({
+        '0xa4b1': ['0xaf88d065e77c8cc2239327c5edb3a432268e5831'],
+      });
+    });
+
+    it('skips non-array entries in flag value', () => {
+      getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+        ...getDefaultRemoteFeatureFlagControllerState(),
+        remoteFeatureFlags: {
+          'stable-tokens': {
+            '0x1': ['0xaaa'],
+            '0xa4b1': 'not-an-array',
+          },
+        },
+      });
+
+      const result = getStablecoins(messenger);
+      expect(result).toStrictEqual({ '0x1': ['0xaaa'] });
+    });
+
+    it('returns fallback when flag is an array', () => {
+      getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+        ...getDefaultRemoteFeatureFlagControllerState(),
+        remoteFeatureFlags: {
+          'stable-tokens': ['not', 'an', 'object'],
+        },
+      });
+
+      const result = getStablecoins(messenger);
+      expect(result).toHaveProperty('0x1');
+    });
+
+    it('returns fallback when flag is a primitive', () => {
+      getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+        ...getDefaultRemoteFeatureFlagControllerState(),
+        remoteFeatureFlags: {
+          'stable-tokens': true,
+        },
+      });
+
+      const result = getStablecoins(messenger);
+      expect(result).toHaveProperty('0x1');
     });
   });
 });

--- a/packages/transaction-pay-controller/src/utils/feature-flags.ts
+++ b/packages/transaction-pay-controller/src/utils/feature-flags.ts
@@ -4,7 +4,11 @@ import { createModuleLogger } from '@metamask/utils';
 import { BigNumber } from 'bignumber.js';
 import { uniq } from 'lodash';
 
-import { isTransactionPayStrategy, TransactionPayStrategy } from '../constants';
+import {
+  isTransactionPayStrategy,
+  STABLECOINS,
+  TransactionPayStrategy,
+} from '../constants';
 import { projectLogger } from '../logger';
 import type { TransactionPayFiatAsset } from '../strategy/fiat/constants';
 import {
@@ -522,6 +526,38 @@ export function getFeatureFlags(
   log('Feature flags:', { raw: featureFlags, result });
 
   return result;
+}
+
+/**
+ * Get the stablecoins map from the `stable-tokens` feature flag.
+ * Falls back to the hardcoded {@link STABLECOINS} constant when the flag is
+ * absent or not a valid object.
+ *
+ * @param messenger - Controller messenger.
+ * @returns Stablecoins keyed by chain ID.
+ */
+export function getStablecoins(
+  messenger: TransactionPayControllerMessenger,
+): Record<Hex, Hex[]> {
+  const state = messenger.call('RemoteFeatureFlagController:getState');
+  const flag = state.remoteFeatureFlags?.['stable-tokens'];
+
+  if (flag && typeof flag === 'object' && !Array.isArray(flag)) {
+    const raw = flag as Record<string, string[]>;
+    return Object.entries(raw).reduce<Record<Hex, Hex[]>>(
+      (acc, [chainId, addresses]) => {
+        if (Array.isArray(addresses)) {
+          acc[chainId.toLowerCase() as Hex] = addresses.map(
+            (a) => a.toLowerCase() as Hex,
+          );
+        }
+        return acc;
+      },
+      {},
+    );
+  }
+
+  return STABLECOINS;
 }
 
 /**

--- a/packages/transaction-pay-controller/src/utils/token.ts
+++ b/packages/transaction-pay-controller/src/utils/token.ts
@@ -10,11 +10,11 @@ import {
   CHAIN_ID_POLYGON,
   NATIVE_TOKEN_ADDRESS,
   SLIP44_COIN_TYPE_BY_CHAIN,
-  STABLECOINS,
 } from '../constants';
 import type { FiatRates, TransactionPayControllerMessenger } from '../types';
 import {
   getAssetsUnifyStateFeature,
+  getStablecoins,
   isChainExcludedFromInfura,
 } from './feature-flags';
 import { getNetworkClientId, rpcRequest } from './provider';
@@ -209,7 +209,7 @@ export function getTokenFiatRate(
   if (nativeToFiatRate === null || nativeToUsdRate === null) {
     return undefined;
   }
-  const isStablecoin = STABLECOINS[chainId]?.includes(
+  const isStablecoin = getStablecoins(messenger)[chainId]?.includes(
     tokenAddress.toLowerCase() as Hex,
   );
 


### PR DESCRIPTION
## Explanation

Use LD flag for stable coins list in transaction-pay-controller

## References
Related to https://consensyssoftware.atlassian.net/browse/CONF-1671

## Checklist

- [X] I've updated the test suite for new or updated code as appropriate
- [X] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [X] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [X] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which tokens count as stablecoins for quote amounts and fiat pricing; misconfigured flags could skew displayed values until fallback applies, but behavior matches the prior constant when the flag is absent.
> 
> **Overview**
> Adds **`getStablecoins(messenger)`**, which loads chain→address lists from the LaunchDarkly **`stable-tokens`** flag (normalized lowercase keys/addresses, invalid shapes ignored) and **falls back to the existing `STABLECOINS` constant** when the flag is missing or malformed.
> 
> **Relay quotes** and **token fiat-rate logic** no longer read `STABLECOINS` directly; they call `getStablecoins` so stablecoin detection (target USD display, subsidized-fee handling, $1 USD peg for rates) can be updated remotely without a release. Unit tests cover flag parsing and fallback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e5fc7362a8b45da70447e45c24a9047971df43f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->