### PR TITLE
feat(client-utils): formatters

### DIFF
--- a/packages/client-utils/CHANGELOG.md
+++ b/packages/client-utils/CHANGELOG.md
@@ -21,6 +21,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `createFormatters` factory for shared display formatters ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
+  - `formatNumber` — generic number with optional `Intl.NumberFormat` overrides
+  - `formatCurrency` — currency string (ISO 4217 code)
+  - `formatCurrencyCompact` — compact currency (e.g. `$1.2K`, `$3.4M`)
+  - `formatCurrencyWithMinThreshold` — currency with `<$0.01` floor
+  - `formatCurrencyTokenPrice` — token price with tiered precision
+  - `formatToken` — number with token symbol
+  - `formatTokenQuantity` — token quantity with tiered precision
+  - `formatTokenAmount` — token quantity without trailing zeros
+  - `formatPercentWithMinThreshold` — percent with 0.01% floor
+  - `formatCompact` — compact non-currency number
+  - `formatDateTime` — localized date+time string
 - Initial release of the `@metamask/client-utils` package for functions and utilities shared across MetaMask clients (extension and mobile) ([#9375](https://github.com/MetaMask/core/pull/9375))
 - Add transaction activity mappers and shared activity types ([#9376](https://github.com/MetaMask/core/pull/9376))
   - `mapApiTransaction` for mapping EVM API transactions to activity items

--- a/packages/client-utils/CHANGELOG.md
+++ b/packages/client-utils/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `createFormatters` factory for shared display formatters ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
+- Add `createFormatters` factory for shared display formatters ([#9504](https://github.com/MetaMask/core/pull/9504))
   - `formatNumber` — generic number with optional `Intl.NumberFormat` overrides
   - `formatCurrency` — currency string (ISO 4217 code)
   - `formatCurrencyCompact` — compact currency (e.g. `$1.2K`, `$3.4M`)

--- a/packages/client-utils/CHANGELOG.md
+++ b/packages/client-utils/CHANGELOG.md
@@ -21,18 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `createFormatters` factory for shared display formatters ([#9504](https://github.com/MetaMask/core/pull/9504))
-  - `formatNumber` — generic number with optional `Intl.NumberFormat` overrides
-  - `formatCurrency` — currency string (ISO 4217 code)
-  - `formatCurrencyCompact` — compact currency (e.g. `$1.2K`, `$3.4M`)
-  - `formatCurrencyWithMinThreshold` — currency with `<$0.01` floor
-  - `formatCurrencyTokenPrice` — token price with tiered precision
-  - `formatToken` — number with token symbol
-  - `formatTokenQuantity` — token quantity with tiered precision
-  - `formatTokenAmount` — token quantity without trailing zeros
-  - `formatPercentWithMinThreshold` — percent with 0.01% floor
-  - `formatCompact` — compact non-currency number
-  - `formatDateTime` — localized date+time string
+- Add `createFormatters` factory with shared display formatters (`formatNumber`, `formatCurrency`, `formatCurrencyCompact`, `formatCurrencyWithMinThreshold`, `formatCurrencyTokenPrice`, `formatToken`, `formatTokenQuantity`, `formatTokenAmount`, `formatPercentWithMinThreshold`, `formatCompact`, `formatDateTime`) ([#9504](https://github.com/MetaMask/core/pull/9504))
 - Initial release of the `@metamask/client-utils` package for functions and utilities shared across MetaMask clients (extension and mobile) ([#9375](https://github.com/MetaMask/core/pull/9375))
 - Add transaction activity mappers and shared activity types ([#9376](https://github.com/MetaMask/core/pull/9376))
   - `mapApiTransaction` for mapping EVM API transactions to activity items

--- a/packages/client-utils/CHANGELOG.md
+++ b/packages/client-utils/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `createFormatters` factory with shared display formatters (`formatNumber`, `formatCurrency`, `formatCurrencyCompact`, `formatCurrencyWithMinThreshold`, `formatCurrencyTokenPrice`, `formatToken`, `formatTokenQuantity`, `formatTokenAmount`, `formatPercentWithMinThreshold`, `formatCompact`, `formatDateTime`) ([#9504](https://github.com/MetaMask/core/pull/9504))
+
 ## [1.1.0]
 
 ### Added
@@ -21,7 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `createFormatters` factory with shared display formatters (`formatNumber`, `formatCurrency`, `formatCurrencyCompact`, `formatCurrencyWithMinThreshold`, `formatCurrencyTokenPrice`, `formatToken`, `formatTokenQuantity`, `formatTokenAmount`, `formatPercentWithMinThreshold`, `formatCompact`, `formatDateTime`) ([#9504](https://github.com/MetaMask/core/pull/9504))
 - Initial release of the `@metamask/client-utils` package for functions and utilities shared across MetaMask clients (extension and mobile) ([#9375](https://github.com/MetaMask/core/pull/9375))
 - Add transaction activity mappers and shared activity types ([#9376](https://github.com/MetaMask/core/pull/9376))
   - `mapApiTransaction` for mapping EVM API transactions to activity items

--- a/packages/client-utils/src/formatters/create-formatters.test.ts
+++ b/packages/client-utils/src/formatters/create-formatters.test.ts
@@ -1,0 +1,312 @@
+import { createFormatters } from './create-formatters';
+
+const locale = 'en-US';
+
+const invalidValues = [
+  Number.NaN,
+  Number.POSITIVE_INFINITY,
+  Number.NEGATIVE_INFINITY,
+];
+
+describe('formatNumber', () => {
+  const { formatNumber } = createFormatters({ locale });
+
+  it('formats a basic integer', () => {
+    expect(formatNumber(1234)).toBe('1,234');
+  });
+
+  it('respects fraction digit options', () => {
+    expect(
+      formatNumber(1.2345, {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      }),
+    ).toBe('1.23');
+  });
+
+  it('returns empty string for invalid number', () => {
+    expect(formatNumber(NaN)).toBe('');
+  });
+});
+
+describe('formatCurrency', () => {
+  const { formatCurrency } = createFormatters({ locale });
+
+  const testCases = [
+    { value: 1_234.56, expected: '$1,234.56' },
+    { value: 0, expected: '$0.00' },
+    { value: -42.5, expected: '-$42.50' },
+  ];
+
+  it('formats values correctly', () => {
+    testCases.forEach(({ value, expected }) => {
+      expect(formatCurrency(value, 'USD')).toBe(expected);
+    });
+  });
+
+  it('handles invalid values', () => {
+    invalidValues.forEach((input) => {
+      expect(formatCurrency(input, 'USD')).toBe('');
+    });
+  });
+
+  it('formats values correctly with different locale', () => {
+    const { formatCurrency: formatCurrencyGB } = createFormatters({
+      locale: 'en-GB',
+    });
+    expect(formatCurrencyGB(1234.56, 'GBP')).toBe('£1,234.56');
+  });
+});
+
+describe('formatCurrencyWithMinThreshold', () => {
+  const { formatCurrencyWithMinThreshold } = createFormatters({ locale });
+
+  const testCases = [
+    { value: 0, expected: '$0.00' },
+
+    // Values below minimum threshold
+    { value: 0.000001, expected: '<$0.01' },
+    { value: 0.001, expected: '<$0.01' },
+    { value: -0.001, expected: '<$0.01' },
+
+    // Values at and above minimum threshold
+    { value: 0.01, expected: '$0.01' },
+    { value: 0.1, expected: '$0.10' },
+    { value: 1, expected: '$1.00' },
+    { value: -0.01, expected: '-$0.01' },
+    { value: -1, expected: '-$1.00' },
+    { value: -100, expected: '-$100.00' },
+    { value: 1_000, expected: '$1,000.00' },
+    { value: 1_000_000, expected: '$1,000,000.00' },
+  ];
+
+  it('formats values correctly', () => {
+    testCases.forEach(({ value, expected }) => {
+      expect(formatCurrencyWithMinThreshold(value, 'USD')).toBe(expected);
+    });
+  });
+
+  it('handles invalid values', () => {
+    invalidValues.forEach((input) => {
+      expect(formatCurrencyWithMinThreshold(input, 'USD')).toBe('');
+    });
+  });
+});
+
+describe('formatCurrencyTokenPrice', () => {
+  const { formatCurrencyTokenPrice } = createFormatters({ locale });
+
+  const testCases = [
+    { value: 0, expected: '$0.00' },
+
+    // Values below minimum threshold
+    { value: 0.000000001, expected: '<$0.00000001' },
+    { value: -0.000000001, expected: '<$0.00000001' },
+
+    // Values above minimum threshold but less than 1
+    { value: 0.0000123, expected: '$0.0000123' },
+    { value: 0.001, expected: '$0.00100' },
+    { value: 0.999, expected: '$0.999' },
+
+    // Values at and above 1 but less than 1,000,000
+    { value: 1, expected: '$1.00' },
+    { value: -1, expected: '-$1.00' },
+    { value: -500, expected: '-$500.00' },
+
+    // Values 1,000,000 and above
+    { value: 1_000_000, expected: '$1.00M' },
+    { value: -2_000_000, expected: '-$2.00M' },
+  ];
+
+  it('formats values correctly', () => {
+    testCases.forEach(({ value, expected }) => {
+      expect(formatCurrencyTokenPrice(value, 'USD')).toBe(expected);
+    });
+  });
+
+  it('handles invalid values', () => {
+    invalidValues.forEach((input) => {
+      expect(formatCurrencyTokenPrice(input, 'USD')).toBe('');
+    });
+  });
+});
+
+describe('formatToken', () => {
+  const { formatToken } = createFormatters({ locale });
+
+  const testCases = [
+    { value: 1.234, symbol: 'ETH', expected: '1.234 ETH' },
+    { value: 0, symbol: 'USDC', expected: '0 USDC' },
+    { value: 1_000, symbol: 'DAI', expected: '1,000 DAI' },
+  ];
+
+  it('formats token values', () => {
+    testCases.forEach(({ value, symbol, expected }) => {
+      expect(formatToken(value, symbol)).toBe(expected);
+    });
+  });
+
+  it('handles invalid values', () => {
+    invalidValues.forEach((input) => {
+      expect(formatToken(input, 'ETH')).toBe('');
+    });
+  });
+});
+
+describe('formatTokenQuantity', () => {
+  const { formatTokenQuantity } = createFormatters({ locale });
+
+  const testCases = [
+    { value: 0, symbol: 'ETH', expected: '0 ETH' },
+
+    // Values below minimum threshold
+    { value: 0.000000001, symbol: 'ETH', expected: '<0.00001 ETH' },
+    { value: -0.000000001, symbol: 'ETH', expected: '<0.00001 ETH' },
+    { value: 0.0000005, symbol: 'USDC', expected: '<0.00001 USDC' },
+
+    // Values above minimum threshold but less than 1
+    { value: 0.00001, symbol: 'ETH', expected: '0.0000100 ETH' },
+    { value: 0.001234, symbol: 'BTC', expected: '0.00123 BTC' },
+    { value: 0.123456, symbol: 'USDC', expected: '0.123 USDC' },
+
+    // Values 1 and above but less than 1,000,000
+    { value: 1, symbol: 'ETH', expected: '1 ETH' },
+    { value: -1, symbol: 'ETH', expected: '-1 ETH' },
+    { value: -25.5, symbol: 'ETH', expected: '-25.5 ETH' },
+    { value: 1.2345678, symbol: 'BTC', expected: '1.235 BTC' },
+    { value: 123.45678, symbol: 'USDC', expected: '123.457 USDC' },
+    { value: 999_999, symbol: 'DAI', expected: '999,999 DAI' },
+
+    // Values 1,000,000 and above
+    { value: 1_000_000, symbol: 'ETH', expected: '1.00M ETH' },
+    { value: -1_500_000, symbol: 'ETH', expected: '-1.50M ETH' },
+    { value: 1_234_567, symbol: 'BTC', expected: '1.23M BTC' },
+    { value: 1_000_000_000, symbol: 'USDC', expected: '1.00B USDC' },
+  ];
+
+  it('formats token quantities correctly', () => {
+    testCases.forEach(({ value, symbol, expected }) => {
+      expect(formatTokenQuantity(value, symbol)).toBe(expected);
+    });
+  });
+
+  it('handles invalid values', () => {
+    invalidValues.forEach((input) => {
+      expect(formatTokenQuantity(input, 'ETH')).toBe('');
+    });
+  });
+});
+
+describe('formatTokenAmount', () => {
+  const { formatTokenAmount } = createFormatters({ locale });
+
+  const testCases = [
+    // Zero: no trailing decimal
+    { value: 0, symbol: 'ETH', expected: '0 ETH' },
+
+    // Values below minimum threshold
+    { value: 0.000000001, symbol: 'ETH', expected: '<0.00001 ETH' },
+    { value: -0.000000001, symbol: 'ETH', expected: '<0.00001 ETH' },
+
+    // Values above threshold but less than 1 (1-4 significant digits)
+    { value: 0.5, symbol: 'ETH', expected: '0.5 ETH' },
+    { value: 0.1234, symbol: 'BTC', expected: '0.1234 BTC' },
+
+    // Values 1 and above but less than 1,000,000 (no trailing zeros)
+    { value: 1, symbol: 'ETH', expected: '1 ETH' },
+    { value: 1.5, symbol: 'ETH', expected: '1.5 ETH' },
+    { value: 1.2345678, symbol: 'BTC', expected: '1.2346 BTC' },
+    { value: 999_999, symbol: 'DAI', expected: '999,999 DAI' },
+
+    // Values 1,000,000 and above (compact, no trailing zeros)
+    { value: 1_000_000, symbol: 'ETH', expected: '1M ETH' },
+    { value: 1_500_000, symbol: 'ETH', expected: '1.5M ETH' },
+    { value: 1_234_567, symbol: 'BTC', expected: '1.23M BTC' },
+  ];
+
+  it('formats token amounts without trailing zeros', () => {
+    testCases.forEach(({ value, symbol, expected }) => {
+      expect(formatTokenAmount(value, symbol)).toBe(expected);
+    });
+  });
+
+  it('handles invalid values', () => {
+    invalidValues.forEach((input) => {
+      expect(formatTokenAmount(input, 'ETH')).toBe('');
+    });
+  });
+});
+
+describe('formatPercentWithMinThreshold', () => {
+  const { formatPercentWithMinThreshold } = createFormatters({ locale });
+
+  it('formats zero as 0.00%', () => {
+    expect(formatPercentWithMinThreshold(0)).toBe('0.00%');
+  });
+
+  it('clamps small positive values to 0.01%', () => {
+    // 0.00001 ratio = 0.001% which is below 0.01% floor
+    expect(formatPercentWithMinThreshold(0.00001)).toBe('0.01%');
+  });
+
+  it('clamps small negative values to -0.01%', () => {
+    expect(formatPercentWithMinThreshold(-0.00001)).toBe('-0.01%');
+  });
+
+  it('formats values at or above threshold normally', () => {
+    // 0.1234 ratio = 12.34%
+    expect(formatPercentWithMinThreshold(0.1234)).toBe('12.34%');
+  });
+
+  it('formats negative values correctly', () => {
+    expect(formatPercentWithMinThreshold(-0.05)).toBe('-5.00%');
+  });
+
+  it('returns empty string for invalid values', () => {
+    invalidValues.forEach((input) => {
+      expect(formatPercentWithMinThreshold(input)).toBe('');
+    });
+  });
+});
+
+describe('formatCompact', () => {
+  const { formatCompact } = createFormatters({ locale });
+
+  it('formats large numbers in compact notation', () => {
+    expect(formatCompact(1_000)).toBe('1.00K');
+    expect(formatCompact(1_500_000)).toBe('1.50M');
+  });
+
+  it('formats small numbers with two decimal places', () => {
+    expect(formatCompact(1.5)).toBe('1.50');
+  });
+
+  it('returns empty string for invalid values', () => {
+    invalidValues.forEach((input) => {
+      expect(formatCompact(input)).toBe('');
+    });
+  });
+});
+
+describe('formatDateTime', () => {
+  const { formatDateTime } = createFormatters({ locale });
+
+  it('formats a timestamp as a localized date+time string', () => {
+    // March 15, 2024, 2:30 PM UTC
+    const timestamp = new Date('2024-03-15T14:30:00Z').getTime();
+    const result = formatDateTime(timestamp);
+    expect(result).toMatch(/Mar/u);
+    expect(result).toMatch(/15/u);
+    expect(result).toMatch(/2024/u);
+  });
+
+  it('returns empty string for falsy timestamp', () => {
+    expect(formatDateTime(0)).toBe('');
+    expect(formatDateTime('')).toBe('');
+  });
+
+  it('accepts string timestamps', () => {
+    const result = formatDateTime('2024-03-15T14:30:00Z');
+    expect(result).toMatch(/2024/u);
+  });
+});

--- a/packages/client-utils/src/formatters/create-formatters.test.ts
+++ b/packages/client-utils/src/formatters/create-formatters.test.ts
@@ -338,6 +338,10 @@ describe('formatDateTime', () => {
     expect(formatDateTime('')).toBe('');
   });
 
+  it('returns empty string for an invalid date string', () => {
+    expect(formatDateTime('not-a-date')).toBe('');
+  });
+
   it('accepts string timestamps', () => {
     const result = formatDateTime('2024-03-15T14:30:00Z');
     expect(result).toMatch(/2024/u);

--- a/packages/client-utils/src/formatters/create-formatters.test.ts
+++ b/packages/client-utils/src/formatters/create-formatters.test.ts
@@ -8,6 +8,13 @@ const invalidValues = [
   Number.NEGATIVE_INFINITY,
 ];
 
+describe('createFormatters', () => {
+  it('uses the fallback locale when none is provided', () => {
+    const { formatCurrency } = createFormatters({});
+    expect(formatCurrency(1, 'USD')).toBe('$1.00');
+  });
+});
+
 describe('formatNumber', () => {
   const { formatNumber } = createFormatters({ locale });
 
@@ -55,6 +62,32 @@ describe('formatCurrency', () => {
       locale: 'en-GB',
     });
     expect(formatCurrencyGB(1234.56, 'GBP')).toBe('£1,234.56');
+  });
+
+  it('falls back to two-decimal format when given an invalid currency code (RangeError)', () => {
+    // An invalid currency code causes Intl.NumberFormat to throw RangeError;
+    // the implementation falls back to a plain decimal format.
+    expect(() => formatCurrency(1, 'INVALID_CURRENCY')).not.toThrow();
+    expect(formatCurrency(1, 'INVALID_CURRENCY')).toBe('1.00');
+  });
+
+  it('re-throws non-RangeError errors from Intl.NumberFormat', () => {
+    const original = Intl.NumberFormat;
+    const typeError = new TypeError('unexpected');
+    Intl.NumberFormat = jest.fn().mockImplementation(() => {
+      throw typeError;
+    }) as unknown as typeof Intl.NumberFormat;
+
+    // Use a unique locale so the cache doesn't short-circuit the constructor call.
+    const { formatCurrency: formatFresh } = createFormatters({
+      locale: 'zz-ZZ-rethrow',
+    });
+
+    try {
+      expect(() => formatFresh(1, 'USD')).toThrow(typeError);
+    } finally {
+      Intl.NumberFormat = original;
+    }
   });
 });
 

--- a/packages/client-utils/src/formatters/create-formatters.ts
+++ b/packages/client-utils/src/formatters/create-formatters.ts
@@ -18,10 +18,12 @@ const threeSignificantDigits = {
 const numberFormatCache: Record<string, Intl.NumberFormat> = {};
 const dateTimeFormatCache: Record<string, Intl.DateTimeFormat> = {};
 
+type Value = number | bigint | `${number}`;
+
 function getCachedNumberFormat(
   locale: string,
   options: Intl.NumberFormatOptions,
-) {
+): Intl.NumberFormat {
   const key = `${locale}_${JSON.stringify(options)}`;
 
   let format = numberFormatCache[key];
@@ -47,7 +49,7 @@ function getCachedNumberFormat(
 function getCachedDateTimeFormat(
   locale: string,
   options: Intl.DateTimeFormatOptions,
-) {
+): Intl.DateTimeFormat {
   const key = `${locale}_${JSON.stringify(options)}`;
   if (!dateTimeFormatCache[key]) {
     dateTimeFormatCache[key] = new Intl.DateTimeFormat(locale, options);
@@ -55,13 +57,11 @@ function getCachedDateTimeFormat(
   return dateTimeFormatCache[key];
 }
 
-type Value = number | bigint | `${number}`;
-
 function formatNumber(
   config: { locale: string },
   value: Value,
   options: Intl.NumberFormatOptions = {},
-) {
+): string {
   if (!Number.isFinite(Number(value))) {
     return '';
   }
@@ -77,7 +77,7 @@ function formatCurrency(
   value: Value,
   currency: Intl.NumberFormatOptions['currency'],
   options: Intl.NumberFormatOptions = {},
-) {
+): string {
   if (!Number.isFinite(Number(value))) {
     return '';
   }
@@ -96,7 +96,7 @@ function formatCurrencyCompact(
   config: { locale: string },
   value: Value,
   currency: Intl.NumberFormatOptions['currency'],
-) {
+): string {
   return formatCurrency(config, value, currency, {
     notation: 'compact',
     ...twoDecimals,
@@ -107,7 +107,7 @@ function formatCurrencyWithMinThreshold(
   config: { locale: string },
   value: Value,
   currency: Intl.NumberFormatOptions['currency'],
-) {
+): string {
   const minThreshold = 0.01;
   const number = Number(value);
   const absoluteValue = Math.abs(number);
@@ -132,7 +132,7 @@ function formatCurrencyTokenPrice(
   config: { locale: string },
   value: Value,
   currency: Intl.NumberFormatOptions['currency'],
-) {
+): string {
   const minThreshold = 0.00000001;
   const number = Number(value);
   const absoluteValue = Math.abs(number);
@@ -165,7 +165,7 @@ function formatToken(
   value: Value,
   symbol: string,
   options: Intl.NumberFormatOptions = {},
-) {
+): string {
   if (!Number.isFinite(Number(value))) {
     return '';
   }
@@ -185,7 +185,7 @@ function formatTokenQuantity(
   config: { locale: string },
   value: Value,
   symbol: string,
-) {
+): string {
   const minThreshold = 0.00001;
   const number = Number(value);
   const absoluteValue = Math.abs(number);
@@ -221,7 +221,7 @@ function formatTokenAmount(
   config: { locale: string },
   value: Value,
   symbol: string,
-) {
+): string {
   const minThreshold = 0.00001;
   const number = Number(value);
   const absoluteValue = Math.abs(number);
@@ -266,7 +266,7 @@ function formatPercentWithMinThreshold(
   config: { locale: string },
   value: Value,
   options: Intl.NumberFormatOptions = {},
-) {
+): string {
   const minThreshold = 0.0001; // 0.01%
   const number = Number(value);
 
@@ -287,7 +287,7 @@ function formatPercentWithMinThreshold(
   });
 }
 
-function formatCompact(config: { locale: string }, value: Value) {
+function formatCompact(config: { locale: string }, value: Value): string {
   return formatNumber(config, value, {
     notation: 'compact',
     minimumFractionDigits: 2,
@@ -299,7 +299,7 @@ function formatDateTime(
   config: { locale: string },
   timestamp: string | number,
   options?: Intl.DateTimeFormatOptions,
-) {
+): string {
   if (!timestamp) {
     return '';
   }
@@ -314,7 +314,48 @@ function formatDateTime(
   }).format(new Date(timestamp));
 }
 
-export function createFormatters({ locale = FALLBACK_LOCALE }) {
+export type Formatters = {
+  formatNumber: (value: Value, options?: Intl.NumberFormatOptions) => string;
+  formatCurrency: (
+    value: Value,
+    currency: Intl.NumberFormatOptions['currency'],
+    options?: Intl.NumberFormatOptions,
+  ) => string;
+  formatCurrencyCompact: (
+    value: Value,
+    currency: Intl.NumberFormatOptions['currency'],
+  ) => string;
+  formatCurrencyWithMinThreshold: (
+    value: Value,
+    currency: Intl.NumberFormatOptions['currency'],
+  ) => string;
+  formatCurrencyTokenPrice: (
+    value: Value,
+    currency: Intl.NumberFormatOptions['currency'],
+  ) => string;
+  formatToken: (
+    value: Value,
+    symbol: string,
+    options?: Intl.NumberFormatOptions,
+  ) => string;
+  formatTokenQuantity: (value: Value, symbol: string) => string;
+  formatTokenAmount: (value: Value, symbol: string) => string;
+  formatPercentWithMinThreshold: (
+    value: Value,
+    options?: Intl.NumberFormatOptions,
+  ) => string;
+  formatCompact: (value: Value) => string;
+  formatDateTime: (
+    timestamp: string | number,
+    options?: Intl.DateTimeFormatOptions,
+  ) => string;
+};
+
+export function createFormatters({
+  locale = FALLBACK_LOCALE,
+}: {
+  locale?: string;
+}): Formatters {
   const config = { locale };
   return {
     formatNumber: formatNumber.bind(null, config),

--- a/packages/client-utils/src/formatters/create-formatters.ts
+++ b/packages/client-utils/src/formatters/create-formatters.ts
@@ -20,7 +20,7 @@ const dateTimeFormatCache: Record<string, Intl.DateTimeFormat> = {};
 
 function getCachedNumberFormat(
   locale: string,
-  options: Intl.NumberFormatOptions = {},
+  options: Intl.NumberFormatOptions,
 ) {
   const key = `${locale}_${JSON.stringify(options)}`;
 
@@ -46,7 +46,7 @@ function getCachedNumberFormat(
 
 function getCachedDateTimeFormat(
   locale: string,
-  options: Intl.DateTimeFormatOptions = {},
+  options: Intl.DateTimeFormatOptions,
 ) {
   const key = `${locale}_${JSON.stringify(options)}`;
   if (!dateTimeFormatCache[key]) {

--- a/packages/client-utils/src/formatters/create-formatters.ts
+++ b/packages/client-utils/src/formatters/create-formatters.ts
@@ -303,6 +303,10 @@ function formatDateTime(
   if (!timestamp) {
     return '';
   }
+  const date = new Date(timestamp);
+  if (isNaN(date.getTime())) {
+    return '';
+  }
   return getCachedDateTimeFormat(config.locale, {
     month: 'short',
     day: 'numeric',
@@ -311,7 +315,7 @@ function formatDateTime(
     minute: 'numeric',
     hour12: true,
     ...options,
-  }).format(new Date(timestamp));
+  }).format(date);
 }
 
 export type Formatters = {

--- a/packages/client-utils/src/formatters/create-formatters.ts
+++ b/packages/client-utils/src/formatters/create-formatters.ts
@@ -1,0 +1,338 @@
+const FALLBACK_LOCALE = 'en';
+
+const twoDecimals = {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+};
+
+const oneSignificantDigit = {
+  minimumSignificantDigits: 1,
+  maximumSignificantDigits: 1,
+};
+
+const threeSignificantDigits = {
+  minimumSignificantDigits: 3,
+  maximumSignificantDigits: 3,
+};
+
+const numberFormatCache: Record<string, Intl.NumberFormat> = {};
+const dateTimeFormatCache: Record<string, Intl.DateTimeFormat> = {};
+
+function getCachedNumberFormat(
+  locale: string,
+  options: Intl.NumberFormatOptions = {},
+) {
+  const key = `${locale}_${JSON.stringify(options)}`;
+
+  let format = numberFormatCache[key];
+
+  if (format) {
+    return format;
+  }
+
+  try {
+    format = new Intl.NumberFormat(locale, options);
+  } catch (error) {
+    if (error instanceof RangeError) {
+      format = new Intl.NumberFormat(locale, twoDecimals);
+    } else {
+      throw error;
+    }
+  }
+
+  numberFormatCache[key] = format;
+  return format;
+}
+
+function getCachedDateTimeFormat(
+  locale: string,
+  options: Intl.DateTimeFormatOptions = {},
+) {
+  const key = `${locale}_${JSON.stringify(options)}`;
+  if (!dateTimeFormatCache[key]) {
+    dateTimeFormatCache[key] = new Intl.DateTimeFormat(locale, options);
+  }
+  return dateTimeFormatCache[key];
+}
+
+type Value = number | bigint | `${number}`;
+
+function formatNumber(
+  config: { locale: string },
+  value: Value,
+  options: Intl.NumberFormatOptions = {},
+) {
+  if (!Number.isFinite(Number(value))) {
+    return '';
+  }
+
+  const numberFormat = getCachedNumberFormat(config.locale, options);
+
+  // @ts-expect-error Remove this comment once TypeScript is updated to 5.5+
+  return numberFormat.format(value);
+}
+
+function formatCurrency(
+  config: { locale: string },
+  value: Value,
+  currency: Intl.NumberFormatOptions['currency'],
+  options: Intl.NumberFormatOptions = {},
+) {
+  if (!Number.isFinite(Number(value))) {
+    return '';
+  }
+
+  const numberFormat = getCachedNumberFormat(config.locale, {
+    style: 'currency',
+    currency,
+    ...options,
+  });
+
+  // @ts-expect-error Remove this comment once TypeScript is updated to 5.5+
+  return numberFormat.format(value);
+}
+
+function formatCurrencyCompact(
+  config: { locale: string },
+  value: Value,
+  currency: Intl.NumberFormatOptions['currency'],
+) {
+  return formatCurrency(config, value, currency, {
+    notation: 'compact',
+    ...twoDecimals,
+  });
+}
+
+function formatCurrencyWithMinThreshold(
+  config: { locale: string },
+  value: Value,
+  currency: Intl.NumberFormatOptions['currency'],
+) {
+  const minThreshold = 0.01;
+  const number = Number(value);
+  const absoluteValue = Math.abs(number);
+
+  if (!Number.isFinite(number)) {
+    return '';
+  }
+
+  if (number === 0) {
+    return formatCurrency(config, 0, currency);
+  }
+
+  if (absoluteValue < minThreshold) {
+    const formattedMin = formatCurrency(config, minThreshold, currency);
+    return `<${formattedMin}`;
+  }
+
+  return formatCurrency(config, number, currency);
+}
+
+function formatCurrencyTokenPrice(
+  config: { locale: string },
+  value: Value,
+  currency: Intl.NumberFormatOptions['currency'],
+) {
+  const minThreshold = 0.00000001;
+  const number = Number(value);
+  const absoluteValue = Math.abs(number);
+
+  if (!Number.isFinite(number)) {
+    return '';
+  }
+
+  if (number === 0) {
+    return formatCurrency(config, 0, currency);
+  }
+
+  if (absoluteValue < minThreshold) {
+    return `<${formatCurrency(config, minThreshold, currency, oneSignificantDigit)}`;
+  }
+
+  if (absoluteValue < 1) {
+    return formatCurrency(config, number, currency, threeSignificantDigits);
+  }
+
+  if (absoluteValue < 1_000_000) {
+    return formatCurrency(config, number, currency);
+  }
+
+  return formatCurrencyCompact(config, number, currency);
+}
+
+function formatToken(
+  config: { locale: string },
+  value: Value,
+  symbol: string,
+  options: Intl.NumberFormatOptions = {},
+) {
+  if (!Number.isFinite(Number(value))) {
+    return '';
+  }
+
+  const numberFormat = getCachedNumberFormat(config.locale, {
+    style: 'decimal',
+    ...options,
+  });
+
+  // @ts-expect-error Remove this comment once TypeScript is updated to 5.5+
+  const formattedNumber = numberFormat.format(value);
+
+  return `${formattedNumber} ${symbol}`;
+}
+
+function formatTokenQuantity(
+  config: { locale: string },
+  value: Value,
+  symbol: string,
+) {
+  const minThreshold = 0.00001;
+  const number = Number(value);
+  const absoluteValue = Math.abs(number);
+
+  if (!Number.isFinite(number)) {
+    return '';
+  }
+
+  if (number === 0) {
+    return formatToken(config, 0, symbol);
+  }
+
+  if (absoluteValue < minThreshold) {
+    return `<${formatToken(config, minThreshold, symbol, oneSignificantDigit)}`;
+  }
+
+  if (absoluteValue < 1) {
+    return formatToken(config, number, symbol, threeSignificantDigits);
+  }
+
+  if (absoluteValue < 1_000_000) {
+    return formatToken(config, number, symbol);
+  }
+
+  return formatToken(config, number, symbol, {
+    notation: 'compact',
+    ...twoDecimals,
+  });
+}
+
+// Format token quantity without trailing zeros.
+function formatTokenAmount(
+  config: { locale: string },
+  value: Value,
+  symbol: string,
+) {
+  const minThreshold = 0.00001;
+  const number = Number(value);
+  const absoluteValue = Math.abs(number);
+
+  if (!Number.isFinite(number)) {
+    return '';
+  }
+
+  if (number === 0) {
+    return formatToken(config, 0, symbol, { maximumFractionDigits: 0 });
+  }
+
+  if (absoluteValue < minThreshold) {
+    return `<${formatToken(config, minThreshold, symbol, {
+      minimumSignificantDigits: 1,
+      maximumSignificantDigits: 1,
+    })}`;
+  }
+
+  if (absoluteValue < 1) {
+    return formatToken(config, number, symbol, {
+      minimumSignificantDigits: 1,
+      maximumSignificantDigits: 4,
+    });
+  }
+
+  if (absoluteValue < 1_000_000) {
+    return formatToken(config, number, symbol, {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 4,
+    });
+  }
+
+  return formatToken(config, number, symbol, {
+    notation: 'compact',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  });
+}
+
+function formatPercentWithMinThreshold(
+  config: { locale: string },
+  value: Value,
+  options: Intl.NumberFormatOptions = {},
+) {
+  const minThreshold = 0.0001; // 0.01%
+  const number = Number(value);
+
+  if (!Number.isFinite(number)) {
+    return '';
+  }
+
+  const clamped =
+    number === 0
+      ? 0
+      : Math.sign(number) * Math.max(Math.abs(number), minThreshold);
+
+  return formatNumber(config, clamped, {
+    style: 'percent',
+    maximumFractionDigits: 2,
+    minimumFractionDigits: 2,
+    ...options,
+  });
+}
+
+function formatCompact(config: { locale: string }, value: Value) {
+  return formatNumber(config, value, {
+    notation: 'compact',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}
+
+function formatDateTime(
+  config: { locale: string },
+  timestamp: string | number,
+  options?: Intl.DateTimeFormatOptions,
+) {
+  if (!timestamp) {
+    return '';
+  }
+  return getCachedDateTimeFormat(config.locale, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+    hour12: true,
+    ...options,
+  }).format(new Date(timestamp));
+}
+
+export function createFormatters({ locale = FALLBACK_LOCALE }) {
+  const config = { locale };
+  return {
+    formatNumber: formatNumber.bind(null, config),
+    formatCurrency: formatCurrency.bind(null, config),
+    formatCurrencyCompact: formatCurrencyCompact.bind(null, config),
+    formatCurrencyWithMinThreshold: formatCurrencyWithMinThreshold.bind(
+      null,
+      config,
+    ),
+    formatCurrencyTokenPrice: formatCurrencyTokenPrice.bind(null, config),
+    formatToken: formatToken.bind(null, config),
+    formatTokenQuantity: formatTokenQuantity.bind(null, config),
+    formatTokenAmount: formatTokenAmount.bind(null, config),
+    formatPercentWithMinThreshold: formatPercentWithMinThreshold.bind(
+      null,
+      config,
+    ),
+    formatCompact: formatCompact.bind(null, config),
+    formatDateTime: formatDateTime.bind(null, config),
+  };
+}

--- a/packages/client-utils/src/formatters/index.ts
+++ b/packages/client-utils/src/formatters/index.ts
@@ -1,1 +1,0 @@
-export { createFormatters } from './create-formatters';

--- a/packages/client-utils/src/formatters/index.ts
+++ b/packages/client-utils/src/formatters/index.ts
@@ -1,0 +1,1 @@
+export { createFormatters } from './create-formatters';

--- a/packages/client-utils/src/index.ts
+++ b/packages/client-utils/src/index.ts
@@ -1,4 +1,4 @@
-export { createFormatters } from './formatters';
+export { createFormatters } from './formatters/create-formatters';
 
 export { mapApiTransaction } from './mappers/api-transaction-mapper';
 export { mapKeyringTransaction } from './mappers/keyring-transaction-mapper';

--- a/packages/client-utils/src/index.ts
+++ b/packages/client-utils/src/index.ts
@@ -1,3 +1,5 @@
+export { createFormatters } from './formatters';
+
 export { mapApiTransaction } from './mappers/api-transaction-mapper';
 export { mapKeyringTransaction } from './mappers/keyring-transaction-mapper';
 export { mapLocalTransaction } from './mappers/local-transaction-mapper';

--- a/packages/client-utils/src/index.ts
+++ b/packages/client-utils/src/index.ts
@@ -1,4 +1,5 @@
 export { createFormatters } from './formatters/create-formatters';
+export type { Formatters } from './formatters/create-formatters';
 
 export { mapApiTransaction } from './mappers/api-transaction-mapper';
 export { mapKeyringTransaction } from './mappers/keyring-transaction-mapper';


### PR DESCRIPTION
## Explanation

Moving the formatting utilities from `@metamask/assets-controllers` to `@metamask/client-utils`

Additionally add these format definitions used in the clients:
- `formatTokenAmount`
- `formatPercentWithMinThreshold`
- `formatCompact`
- `formatDateTime`

 Follow-up PRs will update extension and mobile references, then deprecate the copy in `assets-controllers`.

## References

<!--
None yet — follow-up client PRs to be opened once this lands.
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive library API for UI display strings only; no runtime wiring in this PR and no security or persistence changes.
> 
> **Overview**
> Introduces **`createFormatters({ locale? })`** in `@metamask/client-utils`, moving shared display formatting out of `@metamask/assets-controllers` (follow-ups will point clients here and deprecate the old export).
> 
> The factory returns locale-bound helpers for numbers, fiat, tokens, percents, compact notation, and date/time—including **`formatTokenAmount`**, **`formatPercentWithMinThreshold`**, **`formatCompact`**, and **`formatDateTime`** alongside the existing currency/token threshold formatters. Implementation uses cached `Intl` formatters, empty strings for non-finite values, and a currency-code `RangeError` fallback to two-decimal decimals.
> 
> **`createFormatters`** and the **`Formatters`** type are re-exported from the package entry; changelog and a broad Jest suite cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94994028d7625af2219337f8dd6b81393d1e5c25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->