### PR TITLE
fix: query layer 1 gas fee oracles via direct eth_call instead of ethers Web3Provider

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Add `messenger` property to `Layer1GasFeeFlowRequest` ([#9502](https://github.com/MetaMask/core/pull/9502))
-- Query layer 1 gas fee oracles via direct `eth_call` RPC requests instead of an ethers `Contract` backed by `Web3Provider` ([#9502](https://github.com/MetaMask/core/pull/9502))
+- Add `messenger` property to `Layer1GasFeeFlowRequest` ([#9505](https://github.com/MetaMask/core/pull/9505))
+- Query layer 1 gas fee oracles via direct `eth_call` RPC requests instead of an ethers `Contract` backed by `Web3Provider` ([#9505](https://github.com/MetaMask/core/pull/9505))
   - `Web3Provider` schedules its JSON-RPC dispatch with `setTimeout`, which never fires on React Native iOS when the timer pump is starved, blocking `addTransaction` indefinitely and preventing dapp confirmations from appearing ([MetaMask/metamask-mobile#32863](https://github.com/MetaMask/metamask-mobile/issues/32863))
 
 ## [69.0.0]

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add `messenger` property to `Layer1GasFeeFlowRequest` ([#9502](https://github.com/MetaMask/core/pull/9502))
+- Query layer 1 gas fee oracles via direct `eth_call` RPC requests instead of an ethers `Contract` backed by `Web3Provider` ([#9502](https://github.com/MetaMask/core/pull/9502))
+  - `Web3Provider` schedules its JSON-RPC dispatch with `setTimeout`, which never fires on React Native iOS when the timer pump is starved, blocking `addTransaction` indefinitely and preventing dapp confirmations from appearing ([MetaMask/metamask-mobile#32863](https://github.com/MetaMask/metamask-mobile/issues/32863))
+
 ## [69.0.0]
 
 ### Changed

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Add `messenger` property to `Layer1GasFeeFlowRequest` ([#9505](https://github.com/MetaMask/core/pull/9505))
 - Query layer 1 gas fee oracles via direct `eth_call` RPC requests instead of an ethers `Contract` backed by `Web3Provider` ([#9505](https://github.com/MetaMask/core/pull/9505))
   - `Web3Provider` schedules its JSON-RPC dispatch with `setTimeout`, which never fires on React Native iOS when the timer pump is starved, blocking `addTransaction` indefinitely and preventing dapp confirmations from appearing ([MetaMask/metamask-mobile#32863](https://github.com/MetaMask/metamask-mobile/issues/32863))
 

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -58,7 +58,6 @@
     "@ethereumjs/util": "^9.1.0",
     "@ethersproject/abi": "^5.7.0",
     "@ethersproject/contracts": "^5.7.0",
-    "@ethersproject/providers": "^5.7.0",
     "@ethersproject/wallet": "^5.7.0",
     "@metamask/accounts-controller": "^39.0.5",
     "@metamask/approval-controller": "^9.0.2",

--- a/packages/transaction-controller/src/gas-flows/MantleLayer1GasFeeFlow.test.ts
+++ b/packages/transaction-controller/src/gas-flows/MantleLayer1GasFeeFlow.test.ts
@@ -1,6 +1,6 @@
 import { TransactionFactory } from '@ethereumjs/tx';
 import type { TypedTransaction } from '@ethereumjs/tx';
-import { Contract } from '@ethersproject/contracts';
+import { Interface } from '@ethersproject/abi';
 import type { Provider } from '@metamask/network-controller';
 import { add0x } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
@@ -10,14 +10,20 @@ import { CHAIN_IDS } from '../constants';
 import type { TransactionControllerMessenger } from '../TransactionController';
 import { TransactionStatus } from '../types';
 import type { Layer1GasFeeFlowRequest, TransactionMeta } from '../types';
+import { rpcRequest } from '../utils/provider';
 import { bnFromHex, padHexToEvenLength } from '../utils/utils';
 import { MantleLayer1GasFeeFlow } from './MantleLayer1GasFeeFlow';
 
-jest.mock('@ethersproject/contracts', () => ({
-  Contract: jest.fn(),
-}));
+jest.mock('../utils/provider');
 
-jest.mock('@ethersproject/providers');
+const ORACLE_INTERFACE = new Interface([
+  'function getL1Fee(bytes _data)',
+  'function getOperatorFee(uint256 _gasUsed)',
+  'function tokenRatio()',
+]);
+
+const GET_L1_FEE_SELECTOR = ORACLE_INTERFACE.getSighash('getL1Fee');
+const TOKEN_RATIO_SELECTOR = ORACLE_INTERFACE.getSighash('tokenRatio');
 
 const TRANSACTION_PARAMS_MOCK = {
   from: '0x123',
@@ -41,6 +47,8 @@ const TRANSACTION_META_TESTNET_MOCK: TransactionMeta = {
   time: 0,
   txParams: TRANSACTION_PARAMS_MOCK,
 };
+
+const MESSENGER_MOCK = {} as TransactionControllerMessenger;
 
 const SERIALIZED_TRANSACTION_MOCK = '0x1234';
 // L1 fee in ETH (returned by oracle)
@@ -69,37 +77,42 @@ function createMockTypedTransaction(
 }
 
 describe('MantleLayer1GasFeeFlow', () => {
-  const contractMock = jest.mocked(Contract);
-  const contractGetL1FeeMock: jest.MockedFn<() => Promise<BN>> = jest.fn();
-  const contractGetOperatorFeeMock: jest.MockedFn<() => Promise<BN>> =
-    jest.fn();
-  const contractTokenRatioMock: jest.MockedFn<() => Promise<BN>> = jest.fn();
+  const rpcRequestMock = jest.mocked(rpcRequest);
+  const getL1FeeMock: jest.MockedFn<() => Promise<unknown>> = jest.fn();
+  const getOperatorFeeMock: jest.MockedFn<() => Promise<unknown>> = jest.fn();
+  const tokenRatioMock: jest.MockedFn<() => Promise<unknown>> = jest.fn();
 
   let request: Layer1GasFeeFlowRequest;
 
   beforeEach(() => {
     request = {
+      messenger: MESSENGER_MOCK,
       provider: {} as Provider,
       transactionMeta: TRANSACTION_META_MOCK,
     };
 
-    contractMock.mockClear();
-    contractGetL1FeeMock.mockClear();
-    contractGetOperatorFeeMock.mockClear();
-    contractTokenRatioMock.mockClear();
+    rpcRequestMock.mockClear();
+    getL1FeeMock.mockClear();
+    getOperatorFeeMock.mockClear();
+    tokenRatioMock.mockClear();
 
-    contractGetL1FeeMock.mockResolvedValue(bnFromHex(L1_FEE_MOCK));
-    contractGetOperatorFeeMock.mockResolvedValue(new BN(0));
-    contractTokenRatioMock.mockResolvedValue(TOKEN_RATIO_MOCK);
+    getL1FeeMock.mockResolvedValue(L1_FEE_MOCK);
+    getOperatorFeeMock.mockResolvedValue('0x0');
+    tokenRatioMock.mockResolvedValue(add0x(TOKEN_RATIO_MOCK.toString(16)));
 
-    // The base class creates a contract first (for getL1Fee/getOperatorFee),
-    // then transformOracleFee creates a second contract (for tokenRatio).
-    // Both use the same mock constructor.
-    contractMock.mockReturnValue({
-      getL1Fee: contractGetL1FeeMock,
-      getOperatorFee: contractGetOperatorFeeMock,
-      tokenRatio: contractTokenRatioMock,
-    } as unknown as Contract);
+    rpcRequestMock.mockImplementation(async (args) => {
+      const { data } = (args.params as [{ data: Hex }, string])[0];
+
+      if (data.startsWith(GET_L1_FEE_SELECTOR)) {
+        return await getL1FeeMock();
+      }
+
+      if (data.startsWith(TOKEN_RATIO_SELECTOR)) {
+        return await tokenRatioMock();
+      }
+
+      return await getOperatorFeeMock();
+    });
   });
 
   describe('matchesTransaction', () => {
@@ -153,9 +166,7 @@ describe('MantleLayer1GasFeeFlow', () => {
         },
       };
 
-      contractGetOperatorFeeMock.mockResolvedValueOnce(
-        bnFromHex(OPERATOR_FEE_MOCK),
-      );
+      getOperatorFeeMock.mockResolvedValueOnce(OPERATOR_FEE_MOCK);
 
       jest
         .spyOn(TransactionFactory, 'fromTxData')
@@ -173,17 +184,15 @@ describe('MantleLayer1GasFeeFlow', () => {
         bnFromHex(OPERATOR_FEE_MOCK),
       );
 
-      expect(contractTokenRatioMock).toHaveBeenCalledTimes(1);
-      expect(contractGetOperatorFeeMock).toHaveBeenCalledTimes(1);
+      expect(tokenRatioMock).toHaveBeenCalledTimes(1);
+      expect(getOperatorFeeMock).toHaveBeenCalledTimes(1);
       expect(response).toStrictEqual({
         layer1Fee: add0x(padHexToEvenLength(expectedTotal.toString(16))),
       });
     });
 
     it('falls back to txParams.gas for operator fee when gasUsed is missing', async () => {
-      contractGetOperatorFeeMock.mockResolvedValueOnce(
-        bnFromHex(OPERATOR_FEE_MOCK),
-      );
+      getOperatorFeeMock.mockResolvedValueOnce(OPERATOR_FEE_MOCK);
 
       jest
         .spyOn(TransactionFactory, 'fromTxData')
@@ -201,9 +210,19 @@ describe('MantleLayer1GasFeeFlow', () => {
         bnFromHex(OPERATOR_FEE_MOCK),
       );
 
-      expect(contractGetOperatorFeeMock).toHaveBeenCalledTimes(1);
-      expect(contractGetOperatorFeeMock).toHaveBeenCalledWith(
-        TRANSACTION_PARAMS_MOCK.gas,
+      expect(getOperatorFeeMock).toHaveBeenCalledTimes(1);
+      expect(rpcRequestMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: 'eth_call',
+          params: [
+            expect.objectContaining({
+              data: ORACLE_INTERFACE.encodeFunctionData('getOperatorFee', [
+                TRANSACTION_PARAMS_MOCK.gas,
+              ]),
+            }),
+            'latest',
+          ],
+        }),
       );
       expect(response).toStrictEqual({
         layer1Fee: add0x(padHexToEvenLength(expectedTotal.toString(16))),
@@ -223,9 +242,7 @@ describe('MantleLayer1GasFeeFlow', () => {
         },
       };
 
-      contractGetOperatorFeeMock.mockResolvedValueOnce(
-        bnFromHex(OPERATOR_FEE_MOCK),
-      );
+      getOperatorFeeMock.mockResolvedValueOnce(OPERATOR_FEE_MOCK);
 
       jest
         .spyOn(TransactionFactory, 'fromTxData')
@@ -243,8 +260,20 @@ describe('MantleLayer1GasFeeFlow', () => {
         bnFromHex(OPERATOR_FEE_MOCK),
       );
 
-      expect(contractGetOperatorFeeMock).toHaveBeenCalledTimes(1);
-      expect(contractGetOperatorFeeMock).toHaveBeenCalledWith(gasLimit);
+      expect(getOperatorFeeMock).toHaveBeenCalledTimes(1);
+      expect(rpcRequestMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          method: 'eth_call',
+          params: [
+            expect.objectContaining({
+              data: ORACLE_INTERFACE.encodeFunctionData('getOperatorFee', [
+                gasLimit,
+              ]),
+            }),
+            'latest',
+          ],
+        }),
+      );
       expect(response).toStrictEqual({
         layer1Fee: add0x(padHexToEvenLength(expectedTotal.toString(16))),
       });
@@ -272,7 +301,7 @@ describe('MantleLayer1GasFeeFlow', () => {
 
       const expectedL1FeeInMnt = bnFromHex(L1_FEE_MOCK).mul(TOKEN_RATIO_MOCK);
 
-      expect(contractGetOperatorFeeMock).not.toHaveBeenCalled();
+      expect(getOperatorFeeMock).not.toHaveBeenCalled();
       expect(response).toStrictEqual({
         layer1Fee: add0x(padHexToEvenLength(expectedL1FeeInMnt.toString(16))),
       });
@@ -288,7 +317,7 @@ describe('MantleLayer1GasFeeFlow', () => {
         },
       };
 
-      contractGetOperatorFeeMock.mockRejectedValueOnce(new Error('revert'));
+      getOperatorFeeMock.mockRejectedValueOnce(new Error('revert'));
 
       jest
         .spyOn(TransactionFactory, 'fromTxData')
@@ -309,7 +338,25 @@ describe('MantleLayer1GasFeeFlow', () => {
     });
 
     it('throws if tokenRatio call fails', async () => {
-      contractTokenRatioMock.mockRejectedValue(new Error('error'));
+      tokenRatioMock.mockRejectedValue(new Error('error'));
+
+      jest
+        .spyOn(TransactionFactory, 'fromTxData')
+        .mockReturnValueOnce(
+          createMockTypedTransaction(
+            Buffer.from(SERIALIZED_TRANSACTION_MOCK, 'hex'),
+          ),
+        );
+
+      const flow = new MantleLayer1GasFeeFlow();
+
+      await expect(flow.getLayer1Fee(request)).rejects.toThrow(
+        'Failed to get oracle layer 1 gas fee',
+      );
+    });
+
+    it('throws if tokenRatio call returns empty result', async () => {
+      tokenRatioMock.mockResolvedValue('0x');
 
       jest
         .spyOn(TransactionFactory, 'fromTxData')
@@ -362,9 +409,7 @@ describe('MantleLayer1GasFeeFlow', () => {
         },
       };
 
-      contractGetOperatorFeeMock.mockResolvedValueOnce(
-        bnFromHex(OPERATOR_FEE_MOCK),
-      );
+      getOperatorFeeMock.mockResolvedValueOnce(OPERATOR_FEE_MOCK);
 
       jest
         .spyOn(TransactionFactory, 'fromTxData')
@@ -382,8 +427,8 @@ describe('MantleLayer1GasFeeFlow', () => {
         bnFromHex(OPERATOR_FEE_MOCK),
       );
 
-      expect(contractTokenRatioMock).toHaveBeenCalledTimes(1);
-      expect(contractGetOperatorFeeMock).toHaveBeenCalledTimes(1);
+      expect(tokenRatioMock).toHaveBeenCalledTimes(1);
+      expect(getOperatorFeeMock).toHaveBeenCalledTimes(1);
       expect(response).toStrictEqual({
         layer1Fee: add0x(padHexToEvenLength(expectedTotal.toString(16))),
       });

--- a/packages/transaction-controller/src/gas-flows/MantleLayer1GasFeeFlow.ts
+++ b/packages/transaction-controller/src/gas-flows/MantleLayer1GasFeeFlow.ts
@@ -1,12 +1,11 @@
-import { Contract } from '@ethersproject/contracts';
-import { Web3Provider } from '@ethersproject/providers';
-import type { ExternalProvider } from '@ethersproject/providers';
+import { Interface } from '@ethersproject/abi';
 import type { Hex } from '@metamask/utils';
 import type BN from 'bn.js';
 
 import { CHAIN_IDS } from '../constants';
 import type { TransactionControllerMessenger } from '../TransactionController';
 import type { Layer1GasFeeFlowRequest, TransactionMeta } from '../types';
+import { rpcRequest } from '../utils/provider';
 import { toBN } from '../utils/utils';
 import { OracleLayer1GasFeeFlow } from './OracleLayer1GasFeeFlow';
 
@@ -27,6 +26,8 @@ const TOKEN_RATIO_ABI = [
     type: 'function',
   },
 ];
+
+const TOKEN_RATIO_INTERFACE = new Interface(TOKEN_RATIO_ABI);
 
 /**
  * Mantle layer 1 gas fee flow.
@@ -60,18 +61,31 @@ export class MantleLayer1GasFeeFlow extends OracleLayer1GasFeeFlow {
     oracleFee: BN,
     request: Layer1GasFeeFlowRequest,
   ): Promise<BN> {
-    const { provider, transactionMeta } = request;
-    const oracleAddress = this.getOracleAddressForChain(
-      transactionMeta.chainId,
-    );
+    const { messenger, transactionMeta } = request;
+    const { chainId, networkClientId } = transactionMeta;
 
-    const contract = new Contract(
-      oracleAddress,
-      TOKEN_RATIO_ABI,
-      new Web3Provider(provider as unknown as ExternalProvider),
-    );
+    const to = this.getOracleAddressForChain(chainId);
+    const data = TOKEN_RATIO_INTERFACE.encodeFunctionData(
+      'tokenRatio',
+      [],
+    ) as Hex;
 
-    const tokenRatio = toBN(await contract.tokenRatio());
+    // Direct `eth_call` RPC request rather than an ethers `Contract` with
+    // `Web3Provider`, whose `setTimeout`-based dispatch never fires on React
+    // Native when the timer pump is starved (e.g. iOS display link freeze).
+    // See https://github.com/MetaMask/metamask-mobile/issues/32863
+    const result = await rpcRequest({
+      messenger,
+      networkClientId,
+      method: 'eth_call',
+      params: [{ to, data }, 'latest'],
+    });
+
+    if (typeof result !== 'string' || result === '0x') {
+      throw new Error('No value returned from token ratio contract');
+    }
+
+    const tokenRatio = toBN(result);
     return oracleFee.mul(tokenRatio);
   }
 }

--- a/packages/transaction-controller/src/gas-flows/OracleLayer1GasFeeFlow.test.ts
+++ b/packages/transaction-controller/src/gas-flows/OracleLayer1GasFeeFlow.test.ts
@@ -1,6 +1,6 @@
 import type { TypedTransaction } from '@ethereumjs/tx';
 import { TransactionFactory } from '@ethereumjs/tx';
-import { Contract } from '@ethersproject/contracts';
+import { Interface } from '@ethersproject/abi';
 import type { Provider } from '@metamask/network-controller';
 import { add0x } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
@@ -10,18 +10,22 @@ import { CHAIN_IDS } from '../constants';
 import type { TransactionControllerMessenger } from '../TransactionController';
 import { TransactionStatus } from '../types';
 import type { Layer1GasFeeFlowRequest, TransactionMeta } from '../types';
+import { rpcRequest } from '../utils/provider';
 import { bnFromHex, padHexToEvenLength } from '../utils/utils';
 import { OracleLayer1GasFeeFlow } from './OracleLayer1GasFeeFlow';
 
-jest.mock('@ethersproject/contracts', () => ({
-  Contract: jest.fn(),
-}));
+jest.mock('../utils/provider');
 
 jest.mock('../utils/layer1-gas-fee-flow', () => ({
   buildUnserializedTransaction: jest.fn(),
 }));
 
-jest.mock('@ethersproject/providers');
+const ORACLE_INTERFACE = new Interface([
+  'function getL1Fee(bytes _data)',
+  'function getOperatorFee(uint256 _gasUsed)',
+]);
+
+const GET_L1_FEE_SELECTOR = ORACLE_INTERFACE.getSighash('getL1Fee');
 
 const TRANSACTION_PARAMS_MOCK = {
   from: '0x123',
@@ -36,6 +40,8 @@ const TRANSACTION_META_MOCK: TransactionMeta = {
   time: 0,
   txParams: TRANSACTION_PARAMS_MOCK,
 };
+
+const MESSENGER_MOCK = {} as TransactionControllerMessenger;
 
 const SERIALIZED_TRANSACTION_MOCK = '0x1234';
 const ORACLE_ADDRESS_MOCK = '0x5678' as Hex;
@@ -61,6 +67,19 @@ function createMockTypedTransaction(
   jest.spyOn(instance, 'sign').mockReturnValue(instance);
 
   return instance as unknown as jest.Mocked<TypedTransaction>;
+}
+
+/**
+ * Extracts the call object from a mocked rpcRequest invocation.
+ *
+ * @param call - The arguments of a single rpcRequest call.
+ * @returns The `eth_call` transaction object.
+ */
+function getEthCallObject(call: Parameters<typeof rpcRequest>): {
+  to: Hex;
+  data: Hex;
+} {
+  return (call[0].params as [{ to: Hex; data: Hex }, string])[0];
 }
 
 class MockOracleLayer1GasFeeFlow extends OracleLayer1GasFeeFlow {
@@ -103,34 +122,39 @@ class DefaultOracleLayer1GasFeeFlow extends OracleLayer1GasFeeFlow {
 }
 
 describe('OracleLayer1GasFeeFlow', () => {
-  const contractMock = jest.mocked(Contract);
-  const contractGetL1FeeMock: jest.MockedFn<() => Promise<BN>> = jest.fn();
-  const contractGetOperatorFeeMock: jest.MockedFn<() => Promise<BN>> =
-    jest.fn();
+  const rpcRequestMock = jest.mocked(rpcRequest);
+  const getL1FeeMock: jest.MockedFn<() => Promise<unknown>> = jest.fn();
+  const getOperatorFeeMock: jest.MockedFn<() => Promise<unknown>> = jest.fn();
 
   let request: Layer1GasFeeFlowRequest;
 
   beforeEach(() => {
     request = {
+      messenger: MESSENGER_MOCK,
       provider: {} as Provider,
       transactionMeta: TRANSACTION_META_MOCK,
     };
 
-    contractMock.mockClear();
-    contractGetL1FeeMock.mockClear();
-    contractGetOperatorFeeMock.mockClear();
+    rpcRequestMock.mockClear();
+    getL1FeeMock.mockClear();
+    getOperatorFeeMock.mockClear();
 
-    contractGetL1FeeMock.mockResolvedValue(bnFromHex(LAYER_1_FEE_MOCK));
-    contractGetOperatorFeeMock.mockResolvedValue(new BN(0));
+    getL1FeeMock.mockResolvedValue(LAYER_1_FEE_MOCK);
+    getOperatorFeeMock.mockResolvedValue('0x0');
 
-    contractMock.mockReturnValue({
-      getL1Fee: contractGetL1FeeMock,
-      getOperatorFee: contractGetOperatorFeeMock,
-    } as unknown as Contract);
+    rpcRequestMock.mockImplementation(async (args) => {
+      const { data } = getEthCallObject([args]);
+
+      if (data.startsWith(GET_L1_FEE_SELECTOR)) {
+        return await getL1FeeMock();
+      }
+
+      return await getOperatorFeeMock();
+    });
   });
 
   describe('getLayer1GasFee', () => {
-    it('returns value from smart contract call', async () => {
+    it('returns value from oracle eth_call', async () => {
       const serializedTransactionMock = Buffer.from(
         SERIALIZED_TRANSACTION_MOCK,
         'hex',
@@ -159,11 +183,22 @@ describe('OracleLayer1GasFeeFlow', () => {
         expect.anything(),
       );
 
-      expect(contractGetL1FeeMock).toHaveBeenCalledTimes(1);
-      expect(contractGetL1FeeMock).toHaveBeenCalledWith(
-        serializedTransactionMock,
-      );
-      expect(contractGetOperatorFeeMock).not.toHaveBeenCalled();
+      expect(rpcRequestMock).toHaveBeenCalledTimes(1);
+      expect(rpcRequestMock).toHaveBeenCalledWith({
+        messenger: MESSENGER_MOCK,
+        networkClientId: TRANSACTION_META_MOCK.networkClientId,
+        method: 'eth_call',
+        params: [
+          {
+            to: ORACLE_ADDRESS_MOCK,
+            data: ORACLE_INTERFACE.encodeFunctionData('getL1Fee', [
+              serializedTransactionMock,
+            ]),
+          },
+          'latest',
+        ],
+      });
+      expect(getOperatorFeeMock).not.toHaveBeenCalled();
     });
 
     it('signs transaction with dummy key if supported by flow', async () => {
@@ -188,12 +223,12 @@ describe('OracleLayer1GasFeeFlow', () => {
       });
 
       expect(typedTransactionMock.sign).toHaveBeenCalledTimes(1);
-      expect(contractGetOperatorFeeMock).not.toHaveBeenCalled();
+      expect(getOperatorFeeMock).not.toHaveBeenCalled();
     });
 
     describe('throws', () => {
       it('if getL1Fee fails', async () => {
-        contractGetL1FeeMock.mockRejectedValue(new Error('error'));
+        getL1FeeMock.mockRejectedValue(new Error('error'));
 
         const flow = new MockOracleLayer1GasFeeFlow(false);
 
@@ -203,9 +238,17 @@ describe('OracleLayer1GasFeeFlow', () => {
       });
 
       it('if getL1Fee returns undefined', async () => {
-        contractGetL1FeeMock.mockResolvedValue(
-          undefined as unknown as ReturnType<typeof contractGetL1FeeMock>,
+        getL1FeeMock.mockResolvedValue(undefined);
+
+        const flow = new MockOracleLayer1GasFeeFlow(false);
+
+        await expect(flow.getLayer1Fee(request)).rejects.toThrow(
+          'Failed to get oracle layer 1 gas fee',
         );
+      });
+
+      it('if getL1Fee returns empty result', async () => {
+        getL1FeeMock.mockResolvedValue('0x');
 
         const flow = new MockOracleLayer1GasFeeFlow(false);
 
@@ -232,9 +275,9 @@ describe('OracleLayer1GasFeeFlow', () => {
       const flow = new DefaultOracleLayer1GasFeeFlow();
       await flow.getLayer1Fee(request);
 
-      expect(contractMock).toHaveBeenCalledTimes(1);
-      const [oracleAddress] = contractMock.mock.calls[0];
-      expect(oracleAddress).toBe(DEFAULT_GAS_PRICE_ORACLE_ADDRESS);
+      expect(rpcRequestMock).toHaveBeenCalledTimes(1);
+      const { to } = getEthCallObject(rpcRequestMock.mock.calls[0]);
+      expect(to).toBe(DEFAULT_GAS_PRICE_ORACLE_ADDRESS);
       expect(typedTransactionMock.sign).not.toHaveBeenCalled();
     });
 
@@ -248,15 +291,26 @@ describe('OracleLayer1GasFeeFlow', () => {
         },
       };
 
-      contractGetOperatorFeeMock.mockResolvedValueOnce(
-        bnFromHex(OPERATOR_FEE_MOCK),
-      );
+      getOperatorFeeMock.mockResolvedValueOnce(OPERATOR_FEE_MOCK);
 
       const flow = new MockOracleLayer1GasFeeFlow(false);
       const response = await flow.getLayer1Fee(request);
 
-      expect(contractGetOperatorFeeMock).toHaveBeenCalledTimes(1);
-      expect(contractGetOperatorFeeMock).toHaveBeenCalledWith(gasUsed);
+      expect(getOperatorFeeMock).toHaveBeenCalledTimes(1);
+      expect(rpcRequestMock).toHaveBeenCalledWith({
+        messenger: MESSENGER_MOCK,
+        networkClientId: TRANSACTION_META_MOCK.networkClientId,
+        method: 'eth_call',
+        params: [
+          {
+            to: ORACLE_ADDRESS_MOCK,
+            data: ORACLE_INTERFACE.encodeFunctionData('getOperatorFee', [
+              gasUsed,
+            ]),
+          },
+          'latest',
+        ],
+      });
       expect(response).toStrictEqual({
         layer1Fee: add0x(
           padHexToEvenLength(
@@ -278,12 +332,12 @@ describe('OracleLayer1GasFeeFlow', () => {
         },
       };
 
-      contractGetOperatorFeeMock.mockRejectedValueOnce(new Error('revert'));
+      getOperatorFeeMock.mockRejectedValueOnce(new Error('revert'));
 
       const flow = new MockOracleLayer1GasFeeFlow(false);
       const response = await flow.getLayer1Fee(request);
 
-      expect(contractGetOperatorFeeMock).toHaveBeenCalledTimes(1);
+      expect(getOperatorFeeMock).toHaveBeenCalledTimes(1);
       expect(response).toStrictEqual({
         layer1Fee: LAYER_1_FEE_MOCK,
       });
@@ -299,14 +353,12 @@ describe('OracleLayer1GasFeeFlow', () => {
         },
       };
 
-      contractGetOperatorFeeMock.mockResolvedValueOnce(
-        undefined as unknown as BN,
-      );
+      getOperatorFeeMock.mockResolvedValueOnce(undefined);
 
       const flow = new MockOracleLayer1GasFeeFlow(false);
       const response = await flow.getLayer1Fee(request);
 
-      expect(contractGetOperatorFeeMock).toHaveBeenCalledTimes(1);
+      expect(getOperatorFeeMock).toHaveBeenCalledTimes(1);
       expect(response).toStrictEqual({
         layer1Fee: LAYER_1_FEE_MOCK,
       });
@@ -323,9 +375,7 @@ describe('OracleLayer1GasFeeFlow', () => {
       };
 
       const multiplier = new BN(2);
-      contractGetOperatorFeeMock.mockResolvedValueOnce(
-        bnFromHex(OPERATOR_FEE_MOCK),
-      );
+      getOperatorFeeMock.mockResolvedValueOnce(OPERATOR_FEE_MOCK);
 
       jest
         .spyOn(TransactionFactory, 'fromTxData')

--- a/packages/transaction-controller/src/gas-flows/OracleLayer1GasFeeFlow.ts
+++ b/packages/transaction-controller/src/gas-flows/OracleLayer1GasFeeFlow.ts
@@ -115,7 +115,7 @@ export abstract class OracleLayer1GasFeeFlow implements Layer1GasFeeFlow {
    * Defaults to returning the fee unchanged.
    *
    * @param oracleFee - The raw L1 fee returned by the oracle contract.
-   * @param _request - The original fee flow request (provider + transaction).
+   * @param _request - The original fee flow request (messenger + transaction).
    * @returns The transformed fee.
    */
   protected async transformOracleFee(

--- a/packages/transaction-controller/src/gas-flows/OracleLayer1GasFeeFlow.ts
+++ b/packages/transaction-controller/src/gas-flows/OracleLayer1GasFeeFlow.ts
@@ -1,6 +1,4 @@
-import { Contract } from '@ethersproject/contracts';
-import { Web3Provider } from '@ethersproject/providers';
-import type { ExternalProvider } from '@ethersproject/providers';
+import { Interface } from '@ethersproject/abi';
 import type { Hex } from '@metamask/utils';
 import { add0x, createModuleLogger } from '@metamask/utils';
 import BN from 'bn.js';
@@ -14,6 +12,7 @@ import type {
   TransactionMeta,
 } from '../types';
 import { prepareTransaction } from '../utils/prepare';
+import { rpcRequest } from '../utils/provider';
 import { padHexToEvenLength, toBN } from '../utils/utils';
 
 const log = createModuleLogger(projectLogger, 'oracle-layer1-gas-fee-flow');
@@ -68,6 +67,8 @@ const GAS_PRICE_ORACLE_ABI = [
 // Default OP Stack gas price oracle address used across supported networks
 const DEFAULT_GAS_PRICE_ORACLE_ADDRESS =
   '0x420000000000000000000000000000000000000F' as Hex;
+
+const GAS_PRICE_ORACLE_INTERFACE = new Interface(GAS_PRICE_ORACLE_ABI);
 
 /**
  * Layer 1 gas fee flow that obtains gas fee estimate using an oracle smart contract.
@@ -128,22 +129,9 @@ export abstract class OracleLayer1GasFeeFlow implements Layer1GasFeeFlow {
     request: Layer1GasFeeFlowRequest,
   ): Promise<Layer1GasFeeFlowResponse> {
     try {
-      const { provider, transactionMeta } = request;
-
-      const contract = this.#getGasPriceOracleContract(
-        provider,
-        transactionMeta.chainId,
-      );
-
-      const oracleFee = await this.#getOracleLayer1GasFee(
-        contract,
-        transactionMeta,
-      );
+      const oracleFee = await this.#getOracleLayer1GasFee(request);
       const transformedFee = await this.transformOracleFee(oracleFee, request);
-      const operatorFee = await this.#getOperatorLayer1GasFee(
-        contract,
-        transactionMeta,
-      );
+      const operatorFee = await this.#getOperatorLayer1GasFee(request);
 
       return {
         layer1Fee: add0x(
@@ -156,18 +144,17 @@ export abstract class OracleLayer1GasFeeFlow implements Layer1GasFeeFlow {
     }
   }
 
-  async #getOracleLayer1GasFee(
-    contract: Contract,
-    transactionMeta: TransactionMeta,
-  ): Promise<BN> {
+  async #getOracleLayer1GasFee(request: Layer1GasFeeFlowRequest): Promise<BN> {
     const serializedTransaction = this.#buildUnserializedTransaction(
-      transactionMeta,
+      request.transactionMeta,
       this.shouldSignTransaction(),
     ).serialize();
 
-    const result = await contract.getL1Fee(serializedTransaction);
+    const result = await this.#callGasPriceOracle(request, 'getL1Fee', [
+      serializedTransaction,
+    ]);
 
-    if (result === undefined) {
+    if (typeof result !== 'string' || result === '0x') {
       throw new Error('No value returned from oracle contract');
     }
 
@@ -190,19 +177,20 @@ export abstract class OracleLayer1GasFeeFlow implements Layer1GasFeeFlow {
   }
 
   async #getOperatorLayer1GasFee(
-    contract: Contract,
-    transactionMeta: TransactionMeta,
+    request: Layer1GasFeeFlowRequest,
   ): Promise<BN> {
-    const gas = this.getOperatorFeeGas(transactionMeta);
+    const gas = this.getOperatorFeeGas(request.transactionMeta);
 
     if (!gas) {
       return ZERO;
     }
 
     try {
-      const result = await contract.getOperatorFee(gas);
+      const result = await this.#callGasPriceOracle(request, 'getOperatorFee', [
+        gas,
+      ]);
 
-      if (result === undefined) {
+      if (typeof result !== 'string' || result === '0x') {
         return ZERO;
       }
 
@@ -241,15 +229,31 @@ export abstract class OracleLayer1GasFeeFlow implements Layer1GasFeeFlow {
     };
   }
 
-  #getGasPriceOracleContract(
-    provider: Layer1GasFeeFlowRequest['provider'],
-    chainId: Hex,
-  ): Contract {
-    return new Contract(
-      this.getOracleAddressForChain(chainId),
-      GAS_PRICE_ORACLE_ABI,
-      // Network controller provider type is incompatible with ethers provider
-      new Web3Provider(provider as unknown as ExternalProvider),
-    );
+  // The oracle is called via a direct `eth_call` RPC request rather than an
+  // ethers `Contract` with `Web3Provider`, as `Web3Provider` schedules its
+  // JSON-RPC dispatch with `setTimeout`, which never fires on React Native
+  // when the timer pump is starved (e.g. iOS display link freeze), blocking
+  // `addTransaction` indefinitely.
+  // See https://github.com/MetaMask/metamask-mobile/issues/32863
+  async #callGasPriceOracle(
+    request: Layer1GasFeeFlowRequest,
+    functionName: string,
+    args: readonly unknown[],
+  ): Promise<unknown> {
+    const { messenger, transactionMeta } = request;
+    const { chainId, networkClientId } = transactionMeta;
+
+    const to = this.getOracleAddressForChain(chainId);
+    const data = GAS_PRICE_ORACLE_INTERFACE.encodeFunctionData(
+      functionName,
+      args,
+    ) as Hex;
+
+    return await rpcRequest({
+      messenger,
+      networkClientId,
+      method: 'eth_call',
+      params: [{ to, data }, 'latest'],
+    });
   }
 }

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -1527,6 +1527,9 @@ export type GasFeeFlow = {
 
 /** Request to a layer 1 gas fee flow to obtain layer 1 fee estimate. */
 export type Layer1GasFeeFlowRequest = {
+  /** The messenger instance. */
+  messenger: TransactionControllerMessenger;
+
   /** RPC Provider instance. */
   provider: Provider;
 

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -3,7 +3,7 @@
 import type { AccessList } from '@ethereumjs/tx';
 import type { AccountsController } from '@metamask/accounts-controller';
 import type { GasFeeState } from '@metamask/gas-fee-controller';
-import type { NetworkClientId, Provider } from '@metamask/network-controller';
+import type { NetworkClientId } from '@metamask/network-controller';
 import type { Hex, Json } from '@metamask/utils';
 import type { Operation } from 'fast-json-patch';
 
@@ -1529,9 +1529,6 @@ export type GasFeeFlow = {
 export type Layer1GasFeeFlowRequest = {
   /** The messenger instance. */
   messenger: TransactionControllerMessenger;
-
-  /** RPC Provider instance. */
-  provider: Provider;
 
   /** The metadata of the transaction to obtain estimates for. */
   transactionMeta: TransactionMeta;

--- a/packages/transaction-controller/src/utils/layer1-gas-fee-flow.test.ts
+++ b/packages/transaction-controller/src/utils/layer1-gas-fee-flow.test.ts
@@ -1,20 +1,13 @@
-import type { Provider } from '@metamask/network-controller';
 import type { Hex } from '@metamask/utils';
 
 import type { TransactionControllerMessenger } from '../TransactionController';
 import { TransactionStatus } from '../types';
 import type { Layer1GasFeeFlow, TransactionMeta } from '../types';
 import { updateTransactionLayer1GasFee } from './layer1-gas-fee-flow';
-import { getProvider } from './provider';
 
 jest.mock('@metamask/controller-utils', () => ({
   ...jest.requireActual('@metamask/controller-utils'),
   query: jest.fn(),
-}));
-
-jest.mock('./provider', () => ({
-  ...jest.requireActual('./provider'),
-  getProvider: jest.fn(),
 }));
 
 const LAYER1_GAS_FEE_VALUE_MATCH_MOCK: Hex = '0x1';
@@ -42,9 +35,7 @@ function createLayer1GasFeeFlowMock({
 }
 
 describe('updateTransactionLayer1GasFee', () => {
-  const getProviderMock = jest.mocked(getProvider);
   let layer1GasFeeFlowsMock: jest.Mocked<Layer1GasFeeFlow[]>;
-  let providerMock: Provider;
   let transactionMetaMock: TransactionMeta;
   let messengerMock: TransactionControllerMessenger;
 
@@ -62,8 +53,6 @@ describe('updateTransactionLayer1GasFee', () => {
       }),
     ];
 
-    providerMock = {} as Provider;
-
     transactionMetaMock = {
       id: '1',
       chainId: '0x123',
@@ -76,8 +65,6 @@ describe('updateTransactionLayer1GasFee', () => {
     };
 
     messengerMock = {} as TransactionControllerMessenger;
-
-    getProviderMock.mockReturnValue(providerMock);
   });
 
   it('updates given transaction layer1GasFee property', async () => {
@@ -92,14 +79,8 @@ describe('updateTransactionLayer1GasFee', () => {
 
     expect(unmatchingLayer1GasFeeFlow.getLayer1Fee).not.toHaveBeenCalled();
 
-    expect(getProviderMock).toHaveBeenCalledWith({
-      messenger: messengerMock,
-      networkClientId: transactionMetaMock.networkClientId,
-    });
-
     expect(matchingLayer1GasFeeFlow.getLayer1Fee).toHaveBeenCalledWith({
       messenger: messengerMock,
-      provider: providerMock,
       transactionMeta: transactionMetaMock,
     });
 
@@ -125,7 +106,6 @@ describe('updateTransactionLayer1GasFee', () => {
 
       expect(matchingLayer1GasFeeFlow.getLayer1Fee).toHaveBeenCalledWith({
         messenger: messengerMock,
-        provider: providerMock,
         transactionMeta: transactionMetaMock,
       });
       expect(transactionMetaMock.layer1GasFee).toBeUndefined();
@@ -144,7 +124,6 @@ describe('updateTransactionLayer1GasFee', () => {
         transactionMeta: transactionMetaMock,
       });
 
-      expect(getProviderMock).not.toHaveBeenCalled();
       expect(unmatchingLayer1GasFeeFlow.getLayer1Fee).not.toHaveBeenCalled();
     });
   });

--- a/packages/transaction-controller/src/utils/layer1-gas-fee-flow.test.ts
+++ b/packages/transaction-controller/src/utils/layer1-gas-fee-flow.test.ts
@@ -98,6 +98,7 @@ describe('updateTransactionLayer1GasFee', () => {
     });
 
     expect(matchingLayer1GasFeeFlow.getLayer1Fee).toHaveBeenCalledWith({
+      messenger: messengerMock,
       provider: providerMock,
       transactionMeta: transactionMetaMock,
     });
@@ -123,6 +124,7 @@ describe('updateTransactionLayer1GasFee', () => {
       });
 
       expect(matchingLayer1GasFeeFlow.getLayer1Fee).toHaveBeenCalledWith({
+        messenger: messengerMock,
         provider: providerMock,
         transactionMeta: transactionMetaMock,
       });

--- a/packages/transaction-controller/src/utils/layer1-gas-fee-flow.ts
+++ b/packages/transaction-controller/src/utils/layer1-gas-fee-flow.ts
@@ -102,6 +102,7 @@ export async function getTransactionLayer1GasFee({
     });
 
     const { layer1Fee } = await layer1GasFeeFlow.getLayer1Fee({
+      messenger,
       provider,
       transactionMeta,
     });

--- a/packages/transaction-controller/src/utils/layer1-gas-fee-flow.ts
+++ b/packages/transaction-controller/src/utils/layer1-gas-fee-flow.ts
@@ -4,7 +4,6 @@ import type { Hex } from '@metamask/utils';
 import { projectLogger } from '../logger';
 import type { TransactionControllerMessenger } from '../TransactionController';
 import type { Layer1GasFeeFlow, TransactionMeta } from '../types';
-import { getProvider } from './provider';
 
 const log = createModuleLogger(projectLogger, 'layer-1-gas-fee-flow');
 
@@ -96,14 +95,8 @@ export async function getTransactionLayer1GasFee({
   );
 
   try {
-    const provider = getProvider({
-      messenger,
-      networkClientId: transactionMeta.networkClientId,
-    });
-
     const { layer1Fee } = await layer1GasFeeFlow.getLayer1Fee({
       messenger,
-      provider,
       transactionMeta,
     });
     return layer1Fee;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8879,7 +8879,6 @@ __metadata:
     "@ethereumjs/util": "npm:^9.1.0"
     "@ethersproject/abi": "npm:^5.7.0"
     "@ethersproject/contracts": "npm:^5.7.0"
-    "@ethersproject/providers": "npm:^5.7.0"
     "@ethersproject/wallet": "npm:^5.7.0"
     "@metamask/accounts-controller": "npm:^39.0.5"
     "@metamask/approval-controller": "npm:^9.0.2"


### PR DESCRIPTION
## Explanation

**Current state:** `OracleLayer1GasFeeFlow` and `MantleLayer1GasFeeFlow` call OP-stack gas price oracle contracts using an ethers `Contract` backed by `Web3Provider`. Every read through this path (`contract.getL1Fee` → `BaseProvider.call`) first awaits `getNetwork()` → `detectNetwork()`, which internally depends on zero-delay `setTimeout` calls: the constructor's network-detection `setTimeout(…, 0)`, an `await timer(0)` inside `_uncachedDetectNetwork`, and the detect-network cache-clear `setTimeout(…, 0)`.

**Why it needs to change:** On React Native iOS, the JS timer pump is driven by a single `CADisplayLink` registered in `RCTDisplayLink`. When the display link stops receiving ticks from the render server (backboardd), all `setTimeout` callbacks silently stop firing — while the app remains visually foreground-active. This happens reproducibly when a WKWebView (in-app browser) becomes the active surface. Bridgeless RN has no zero-delay fast path, so even `setTimeout(…, 0)` waits for a display frame that never comes. As a result, ethers' `getNetwork()`/`detectNetwork()` timers never fire, the oracle `eth_call` is never dispatched, `updateTransactionLayer1GasFee` blocks indefinitely inside `addTransaction`, no approval is ever created, and the dapp confirmation modal never appears. This was reported as a Sev1 in MetaMask Mobile (MetaMask/metamask-mobile#32863) and reproduced on both iOS Simulator and physical iPhone.

**The fix:** Replace the `Contract`/`Web3Provider` dispatch path with:
1. `Interface.encodeFunctionData` (from `@ethersproject/abi`, already an indirect dependency) to ABI-encode the calldata for `getL1Fee`, `getOperatorFee`, and `tokenRatio`.
2. The controller's existing `rpcRequest` utility, which calls `provider.request` directly — a plain EIP-1193 call with no timer dependency.

`Layer1GasFeeFlowRequest` gains a `messenger` field so the flows can reach `rpcRequest`. The fix covers both the base oracle flow (`OracleLayer1GasFeeFlow`: `getL1Fee` + `getOperatorFee`) and `MantleLayer1GasFeeFlow` (`tokenRatio` in `transformOracleFee`). The fix was validated end-to-end on a live mobile repro: after the patch, the confirmation modal appears correctly while the RN timer pump is frozen.

No new npm dependencies are introduced — `@ethersproject/abi` was already transitively present; `@ethersproject/contracts` and `@ethersproject/providers` are no longer imported.

## References

* MetaMask/metamask-mobile#32863 — Sev1: dapp eth_sendTransaction confirmation modal never appears on iOS in-app browser

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the `addTransaction` L1 fee path and introduces a breaking shape change on `Layer1GasFeeFlowRequest` for any custom flows, though behavior is covered by updated tests and targets a known mobile deadlock.
> 
> **Overview**
> Layer 1 gas fee flows no longer use ethers `Contract` + `Web3Provider` to read OP-stack and Mantle oracles. They ABI-encode `getL1Fee`, `getOperatorFee`, and `tokenRatio` with `@ethersproject/abi` and call the existing `rpcRequest` helper (`eth_call` on `provider.request`), avoiding ethers’ `setTimeout`-based network detection that can hang indefinitely on React Native iOS and block `addTransaction` / dapp confirmations.
> 
> **`Layer1GasFeeFlowRequest`** now carries **`messenger`** instead of **`provider`**; `updateTransactionLayer1GasFee` passes the messenger through and no longer resolves a provider up front. Oracle responses treat empty `0x` / non-string results as errors for L1 fee and Mantle `tokenRatio` (operator fee still defaults to zero on failure).
> 
> `@ethersproject/providers` is dropped from dependencies; tests are updated to mock `rpcRequest` and assert `eth_call` payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f191b5fc426e46a97ea64ce69accfdd3622e42a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

