### PR TITLE
feat(wallet-cli): wire the TransactionController slot in the daemon wallet

### DIFF
--- a/packages/wallet-cli/CHANGELOG.md
+++ b/packages/wallet-cli/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Wire the `transactionController` slot in the daemon wallet's instance options, so the daemon runs the `TransactionController` with an explicit CLI-appropriate configuration (swaps processing disabled, no client hooks) rather than relying on the controller's implicit defaults ([#9539](https://github.com/MetaMask/core/pull/9539))
+- Wire the `transactionController` slot in the daemon wallet's instance options, so the daemon runs the `TransactionController` with an explicit CLI-appropriate configuration (swaps processing disabled, no client hooks) rather than relying on the controller's implicit defaults ([#9509](https://github.com/MetaMask/core/pull/9509))
 - Add the `mm wallet unlock` command, which dispatches `KeyringController:submitPassword` over the daemon socket, allowing the keyring to be unlocked after a daemon start with no password or after a `mm daemon call KeyringController:setLocked` ([#8821](https://github.com/MetaMask/core/pull/8821))
 - Add the `mm daemon list` command, which prints the messenger actions the running daemon can dispatch via `daemon call`, enumerated from the live messenger so the list cannot drift from what `call` accepts ([#9339](https://github.com/MetaMask/core/pull/9339))
 - Add the `mm daemon` command suite (`start`, `stop`, `status`, `purge`, and `call`) for running the wallet daemon and dispatching messenger actions over its socket ([#9255](https://github.com/MetaMask/core/pull/9255))

--- a/packages/wallet-cli/CHANGELOG.md
+++ b/packages/wallet-cli/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Wire the `transactionController` slot in the daemon wallet's instance options, so the daemon runs the `TransactionController` with an explicit CLI-appropriate configuration (swaps processing disabled, no client hooks) rather than relying on the controller's implicit defaults ([#9539](https://github.com/MetaMask/core/pull/9539))
 - Add the `mm wallet unlock` command, which dispatches `KeyringController:submitPassword` over the daemon socket, allowing the keyring to be unlocked after a daemon start with no password or after a `mm daemon call KeyringController:setLocked` ([#8821](https://github.com/MetaMask/core/pull/8821))
 - Add the `mm daemon list` command, which prints the messenger actions the running daemon can dispatch via `daemon call`, enumerated from the live messenger so the list cannot drift from what `call` accepts ([#9339](https://github.com/MetaMask/core/pull/9339))
 - Add the `mm daemon` command suite (`start`, `stop`, `status`, `purge`, and `call`) for running the wallet daemon and dispatching messenger actions over its socket ([#9255](https://github.com/MetaMask/core/pull/9255))

--- a/packages/wallet-cli/src/daemon/wallet-factory.test.ts
+++ b/packages/wallet-cli/src/daemon/wallet-factory.test.ts
@@ -118,6 +118,8 @@ describe('createWallet', () => {
     expect(instanceOptions.storageService.storage).toBeInstanceOf(
       InMemoryStorageAdapter,
     );
+    expect(instanceOptions.transactionController?.disableSwaps).toBe(true);
+    expect(instanceOptions.transactionController?.hooks).toStrictEqual({});
     expect(ClientConfigApiService).toHaveBeenCalled();
 
     await dispose();

--- a/packages/wallet-cli/src/daemon/wallet-factory.ts
+++ b/packages/wallet-cli/src/daemon/wallet-factory.ts
@@ -62,6 +62,9 @@ export type CreateWalletResult = {
  *   flags over the network.
  * - `approvalController` — a no-op `showApprovalRequest` (the daemon is
  *   headless).
+ * - `transactionController` — swaps processing disabled and no client hooks;
+ *   see the slot's inline comment for why the daemon relies on the
+ *   controller's defaults for everything else.
  *
  * The optional `keyringController` slot is intentionally omitted so the
  * controller's built-in defaults (e.g. the PBKDF2 encryptor) apply.
@@ -100,7 +103,19 @@ function buildInstanceOptions(
     storageService: {
       storage: new InMemoryStorageAdapter(),
     },
-    // TODO(#8975): add the `transactionController` slot once it is wired.
+    transactionController: {
+      // The CLI exposes no swaps surface, so skip the swaps-specific
+      // post-processing a full wallet client runs (mobile makes the same
+      // choice; the extension keeps swaps enabled).
+      disableSwaps: true,
+      // No CLI-specific transaction hooks: the controller's built-in publish
+      // path broadcasts through the wired `NetworkController` provider, and the
+      // remaining hooks (metrics, notifications, gas-fee tokens) are client-UI
+      // concerns the headless daemon has no equivalent for. Every other option
+      // (`getPermittedAccounts`, `isSimulationEnabled`, `trace`, …) is left at
+      // the controller's default.
+      hooks: {},
+    },
   };
 }
 


### PR DESCRIPTION
## Explanation

`TransactionController` was wired into `@metamask/wallet` in #8975, which left the daemon's wallet factory with a stubbed slot: `// TODO(#8975): add the transactionController slot once it is wired`. Until now the daemon still *constructed* the controller (it runs during `wallet.init()`), but only with the controller's implicit defaults, because `buildInstanceOptions` passed no `transactionController` options.

This PR populates that slot so the daemon's transaction configuration is explicit and reviewable alongside the other wired slots.

## What changed

`buildInstanceOptions` now sets:

```ts
transactionController: {
  disableSwaps: true,
  hooks: {},
},
```

- **`disableSwaps: true`** — the headless CLI has no swaps feature, so the swaps-specific post-processing a full wallet client runs would only produce data nothing reads. This mirrors mobile's choice; the extension keeps swaps enabled because it ships the full Swaps UI.
- **`hooks: {}`** — no CLI-specific transaction hooks. The controller's built-in publish path already broadcasts through the wired `NetworkController` provider (the default `publish` hook returns an undefined hash, and the controller then falls back to its own network-client broadcast), and the remaining hooks (metrics, notifications, gas-fee tokens) are client-UI concerns the daemon has no equivalent for.
- Every other option (`getPermittedAccounts`, `isSimulationEnabled`, `trace`, …) is left at the controller's default.

This is a configuration change only — no new command surface. Mutating RPC (sign/send) hardening remains future work (see the retry-idempotency note in the wallet-cli plan).

### Client references for the `disableSwaps` posture

- Extension (`disableSwaps: false`): [`app/scripts/wallet-init/instance-options/transaction-controller.ts`](https://github.com/MetaMask/metamask-extension/blob/main/app/scripts/wallet-init/instance-options/transaction-controller.ts)
- Mobile (`disableSwaps: true`): [`app/core/Engine/wallet-init/instance-options/transaction-controller.ts`](https://github.com/MetaMask/metamask-mobile/blob/main/app/core/Engine/wallet-init/instance-options/transaction-controller.ts)

## References

- Wires the consumer side of #8975.

## Follow-ups (making the daemon able to send)

This PR only wires the controller's config slot. The path to an actual send:

- #9510 — wire `GasFeeController` into `@metamask/wallet` (upstream)
- #9512 — daemon transaction-capable: consume `GasFeeController` + headless auto-approval
- #9511 — make `sendCommand` retry idempotency-safe (mutating-RPC prerequisite)
- #9513 — add the `mm` send-transaction command

## Testing

- Unit (`wallet-factory.test.ts`): asserts the wired slot values.
- Integration (`wallet-factory.integration.test.ts`): the real `Wallet` path constructs and runs with the new options.
- Gates: full test suite at 100% coverage, dep-subtree build/type-check, ESLint, oxfmt, changelog validation — all green.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, `CHANGELOG.md`) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for affected packages](https://github.com/MetaMask/core/tree/main/docs/contributing.md#updating-changelogs), highlighting breaking changes as necessary
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes (n/a — no breaking changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
