### PR TITLE
chore: Expose `PasskeyController` public methods through the messenger

### DIFF
--- a/packages/passkey-controller/CHANGELOG.md
+++ b/packages/passkey-controller/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Expose public `PasskeyController` methods through its messenger ([#9515](https://github.com/MetaMask/core/pull/9515))
+  - The following actions are now available:
+    - `PasskeyController:isPasskeyEnrolled`
+    - `PasskeyController:generateRegistrationOptions`
+    - `PasskeyController:verifyRegistrationResponse`
+    - `PasskeyController:generatePostRegistrationAuthenticationOptions`
+    - `PasskeyController:generateAuthenticationOptions`
+    - `PasskeyController:verifyAuthenticationResponse`
+    - `PasskeyController:protectVaultKeyWithPasskey`
+    - `PasskeyController:retrieveVaultKeyWithPasskey`
+    - `PasskeyController:verifyPasskeyAuthentication`
+    - `PasskeyController:renewVaultKeyProtection`
+    - `PasskeyController:removePasskey`
+    - `PasskeyController:clearState`
+    - `PasskeyController:destroy`
+  - Corresponding action types (e.g. `PasskeyControllerIsPasskeyEnrolledAction`) are available as well.
+
 ### Changed
 
 - Bump `@metamask/utils` from `^11.9.0` to `^11.11.0` ([#9074](https://github.com/MetaMask/core/pull/9074))

--- a/packages/passkey-controller/package.json
+++ b/packages/passkey-controller/package.json
@@ -44,6 +44,8 @@
     "build:docs": "typedoc",
     "changelog:update": "../../scripts/update-changelog.sh @metamask/passkey-controller",
     "changelog:validate": "../../scripts/validate-changelog.sh @metamask/passkey-controller",
+    "messenger-action-types:check": "tsx ../../packages/messenger-cli/src/cli.ts --formatter oxfmt --check",
+    "messenger-action-types:generate": "tsx ../../packages/messenger-cli/src/cli.ts --formatter oxfmt --generate",
     "publish:preview": "yarn npm publish --tag preview",
     "since-latest-release": "../../scripts/since-latest-release.sh",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest --reporters=jest-silent-reporter",
@@ -68,6 +70,7 @@
     "jest": "^29.7.0",
     "jest-environment-node": "^29.7.0",
     "ts-jest": "^29.2.5",
+    "tsx": "^4.20.5",
     "typedoc": "^0.25.13",
     "typedoc-plugin-missing-exports": "^2.0.0",
     "typescript": "~5.3.3"

--- a/packages/passkey-controller/src/PasskeyController-method-action-types.ts
+++ b/packages/passkey-controller/src/PasskeyController-method-action-types.ts
@@ -1,0 +1,150 @@
+/**
+ * This file is auto generated.
+ * Do not edit manually.
+ */
+
+import type { PasskeyController } from './PasskeyController';
+
+/**
+ * Whether a passkey is enrolled and vault key material is stored.
+ *
+ * @returns `true` if enrolled, otherwise `false`.
+ */
+export type PasskeyControllerIsPasskeyEnrolledAction = {
+  type: `PasskeyController:isPasskeyEnrolled`;
+  handler: PasskeyController['isPasskeyEnrolled'];
+};
+
+/**
+ * Builds WebAuthn credential creation options for passkey enrollment.
+ *
+ * @param creationOptionsConfig - Optional creation behavior.
+ * @param creationOptionsConfig.prfAvailable - Request the PRF extension unless `false`. Defaults to `true`.
+ * @returns Public key credential creation options for `navigator.credentials.create()`.
+ */
+export type PasskeyControllerGenerateRegistrationOptionsAction = {
+  type: `PasskeyController:generateRegistrationOptions`;
+  handler: PasskeyController['generateRegistrationOptions'];
+};
+
+/**
+ * Builds WebAuthn credential request options for the post-registration
+ * authentication step (between `create` and {@link protectVaultKeyWithPasskey}).
+ *
+ * @param params - Input for the pending registration ceremony.
+ * @param params.registrationResponse - Result of `navigator.credentials.create()`.
+ * @returns Public key credential request options for `navigator.credentials.get()`.
+ */
+export type PasskeyControllerGeneratePostRegistrationAuthenticationOptionsAction =
+  {
+    type: `PasskeyController:generatePostRegistrationAuthenticationOptions`;
+    handler: PasskeyController['generatePostRegistrationAuthenticationOptions'];
+  };
+
+/**
+ * Builds WebAuthn credential request options for the enrolled passkey.
+ *
+ * @returns Public key credential request options for `navigator.credentials.get()`.
+ */
+export type PasskeyControllerGenerateAuthenticationOptionsAction = {
+  type: `PasskeyController:generateAuthenticationOptions`;
+  handler: PasskeyController['generateAuthenticationOptions'];
+};
+
+/**
+ * Verifies registration and post-registration authentication, then stores the
+ * vault key encrypted under the new passkey.
+ *
+ * @param params - Enrollment completion inputs.
+ * @param params.registrationResponse - Result of `navigator.credentials.create()`.
+ * @param params.authenticationResponse - Result of `navigator.credentials.get()` after {@link generatePostRegistrationAuthenticationOptions}.
+ * @param params.vaultKey - Vault encryption key to encrypt and persist.
+ */
+export type PasskeyControllerProtectVaultKeyWithPasskeyAction = {
+  type: `PasskeyController:protectVaultKeyWithPasskey`;
+  handler: PasskeyController['protectVaultKeyWithPasskey'];
+};
+
+/**
+ * Verifies an authentication assertion and returns the decrypted vault key.
+ *
+ * @param authenticationResponse - Result of `navigator.credentials.get()`.
+ * @returns The plaintext vault encryption key.
+ */
+export type PasskeyControllerRetrieveVaultKeyWithPasskeyAction = {
+  type: `PasskeyController:retrieveVaultKeyWithPasskey`;
+  handler: PasskeyController['retrieveVaultKeyWithPasskey'];
+};
+
+/**
+ * Checks whether the given authentication assertion is valid for the enrolled passkey.
+ *
+ * On failure, returns `false` for {@link PasskeyControllerError} with a `code`;
+ * other errors propagate.
+ *
+ * @param authenticationResponse - Result of `navigator.credentials.get()`.
+ * @returns `true` if verification succeeds, otherwise `false`.
+ */
+export type PasskeyControllerVerifyPasskeyAuthenticationAction = {
+  type: `PasskeyController:verifyPasskeyAuthentication`;
+  handler: PasskeyController['verifyPasskeyAuthentication'];
+};
+
+/**
+ * Re-wraps the vault key after rotation. Updates persisted `encryptedVaultKey` on success.
+ *
+ * Does not verify WebAuthn or ceremony state—call only after your layer has authenticated
+ * the user (passkey `get()` + verified assertion, or verified password). On passkey paths,
+ * pass the same `authenticationResponse` you just verified (e.g. from
+ * {@link retrieveVaultKeyWithPasskey} / {@link verifyPasskeyAuthentication}).
+ *
+ * @param params - Re-wrap inputs.
+ * @param params.authenticationResponse - Used to derive the wrapping key.
+ * @param params.oldVaultKey - Expected current vault key.
+ * @param params.newVaultKey - New vault key to encrypt under the passkey.
+ */
+export type PasskeyControllerRenewVaultKeyProtectionAction = {
+  type: `PasskeyController:renewVaultKeyProtection`;
+  handler: PasskeyController['renewVaultKeyProtection'];
+};
+
+/**
+ * Clears enrolled passkey state and in-flight ceremonies. Call only after the same
+ * auth gate as renewal (verified passkey assertion or password).
+ */
+export type PasskeyControllerRemovePasskeyAction = {
+  type: `PasskeyController:removePasskey`;
+  handler: PasskeyController['removePasskey'];
+};
+
+/**
+ * Resets state and clears in-flight registration/authentication ceremonies.
+ */
+export type PasskeyControllerClearStateAction = {
+  type: `PasskeyController:clearState`;
+  handler: PasskeyController['clearState'];
+};
+
+/**
+ * Releases all in-flight ceremony state and tears down the messenger.
+ */
+export type PasskeyControllerDestroyAction = {
+  type: `PasskeyController:destroy`;
+  handler: PasskeyController['destroy'];
+};
+
+/**
+ * Union of all PasskeyController action types.
+ */
+export type PasskeyControllerMethodActions =
+  | PasskeyControllerIsPasskeyEnrolledAction
+  | PasskeyControllerGenerateRegistrationOptionsAction
+  | PasskeyControllerGeneratePostRegistrationAuthenticationOptionsAction
+  | PasskeyControllerGenerateAuthenticationOptionsAction
+  | PasskeyControllerProtectVaultKeyWithPasskeyAction
+  | PasskeyControllerRetrieveVaultKeyWithPasskeyAction
+  | PasskeyControllerVerifyPasskeyAuthenticationAction
+  | PasskeyControllerRenewVaultKeyProtectionAction
+  | PasskeyControllerRemovePasskeyAction
+  | PasskeyControllerClearStateAction
+  | PasskeyControllerDestroyAction;

--- a/packages/passkey-controller/src/PasskeyController.ts
+++ b/packages/passkey-controller/src/PasskeyController.ts
@@ -39,6 +39,7 @@ import type {
 } from './webauthn/types';
 import { verifyAuthenticationResponse } from './webauthn/verify-authentication-response';
 import { verifyRegistrationResponse } from './webauthn/verify-registration-response';
+import { PasskeyControllerMethodActions } from './PasskeyController-method-action-types';
 
 export type PasskeyControllerState = {
   passkeyRecord: PasskeyRecord | null;
@@ -59,7 +60,9 @@ export type PasskeyControllerGetStateAction = ControllerGetStateAction<
  * return non-`Json` runtime values (WebAuthn `PublicKeyCredential` objects
  * and the vault key string), so they require a direct controller reference.
  */
-export type PasskeyControllerActions = PasskeyControllerGetStateAction;
+export type PasskeyControllerActions =
+  | PasskeyControllerGetStateAction
+  | PasskeyControllerMethodActions;
 
 export type PasskeyControllerStateChangedEvent = ControllerStateChangedEvent<
   typeof controllerName,
@@ -105,6 +108,20 @@ export const passkeyControllerSelectors = {
   selectIsPasskeyEnrolled: (state: PasskeyControllerState): boolean =>
     state.passkeyRecord !== null,
 };
+
+const MESSENGER_EXPOSED_METHODS = [
+  'isPasskeyEnrolled',
+  'generateRegistrationOptions',
+  'generatePostRegistrationAuthenticationOptions',
+  'generateAuthenticationOptions',
+  'protectVaultKeyWithPasskey',
+  'retrieveVaultKeyWithPasskey',
+  'verifyPasskeyAuthentication',
+  'renewVaultKeyProtection',
+  'removePasskey',
+  'clearState',
+  'destroy',
+] as const;
 
 /**
  * Controller that enrolls a WebAuthn passkey and uses it to protect and unlock
@@ -180,6 +197,11 @@ export class PasskeyController extends BaseController<
     this.#expectedOrigin = expectedOrigin;
     this.#userName = userName ?? rpName;
     this.#userDisplayName = userDisplayName ?? rpName;
+
+    this.messenger.registerMethodActionHandlers(
+      this,
+      MESSENGER_EXPOSED_METHODS,
+    );
   }
 
   #requireEnrolled(): PasskeyRecord {

--- a/packages/passkey-controller/src/PasskeyController.ts
+++ b/packages/passkey-controller/src/PasskeyController.ts
@@ -16,6 +16,7 @@ import {
 import { PasskeyControllerError } from './errors';
 import { deriveKeyFromAuthenticationResponse } from './key-derivation';
 import { createModuleLogger, projectLogger } from './logger';
+import { PasskeyControllerMethodActions } from './PasskeyController-method-action-types';
 import type {
   AuthenticatorTransportFuture,
   PasskeyCredentialInfo,
@@ -39,7 +40,6 @@ import type {
 } from './webauthn/types';
 import { verifyAuthenticationResponse } from './webauthn/verify-authentication-response';
 import { verifyRegistrationResponse } from './webauthn/verify-registration-response';
-import { PasskeyControllerMethodActions } from './PasskeyController-method-action-types';
 
 export type PasskeyControllerState = {
   passkeyRecord: PasskeyRecord | null;

--- a/packages/passkey-controller/src/index.ts
+++ b/packages/passkey-controller/src/index.ts
@@ -30,3 +30,16 @@ export type {
   PasskeyAuthenticationOptions,
   PasskeyAuthenticationResponse,
 } from './webauthn/types';
+export type {
+  PasskeyControllerIsPasskeyEnrolledAction,
+  PasskeyControllerGenerateRegistrationOptionsAction,
+  PasskeyControllerGeneratePostRegistrationAuthenticationOptionsAction,
+  PasskeyControllerGenerateAuthenticationOptionsAction,
+  PasskeyControllerProtectVaultKeyWithPasskeyAction,
+  PasskeyControllerRetrieveVaultKeyWithPasskeyAction,
+  PasskeyControllerVerifyPasskeyAuthenticationAction,
+  PasskeyControllerRenewVaultKeyProtectionAction,
+  PasskeyControllerRemovePasskeyAction,
+  PasskeyControllerClearStateAction,
+  PasskeyControllerDestroyAction,
+} from './PasskeyController-method-action-types';

--- a/yarn.lock
+++ b/yarn.lock
@@ -7922,6 +7922,7 @@ __metadata:
     jest: "npm:^29.7.0"
     jest-environment-node: "npm:^29.7.0"
     ts-jest: "npm:^29.2.5"
+    tsx: "npm:^4.20.5"
     typedoc: "npm:^0.25.13"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:~5.3.3"


### PR DESCRIPTION
## Explanation

This exposes the `PasskeyController` methods through the messenger.

## References

N/A

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Messenger exposure adds a new integration surface for vault-key and passkey lifecycle operations; behavior of the underlying methods is unchanged, but callers must ensure messenger allowlists restrict who can dispatch these actions.
> 
> **Overview**
> **Passkey enrollment, unlock, renewal, and teardown** can now be driven through the controller messenger, matching the pattern used by other MetaMask controllers.
> 
> `PasskeyController` calls `registerMethodActionHandlers` for eleven public methods (e.g. `generateRegistrationOptions`, `protectVaultKeyWithPasskey`, `retrieveVaultKeyWithPasskey`, `removePasskey`, `destroy`). `PasskeyControllerActions` is extended with a generated `PasskeyController-method-action-types` union, and those action types are re-exported from the package entrypoint.
> 
> The package adds **messenger-cli** `messenger-action-types:generate` / `:check` scripts (plus `tsx`) to keep the generated action-types file in sync with the controller API. The changelog documents the new `PasskeyController:*` actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ff47b0050eab546b1d7677d990fb4e78d274e3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->