### PR TITLE
fix: using RPC instead of accounts API V4 for linea

### DIFF
--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -3303,9 +3303,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial release
-
   - As a result of converting our shared controllers repo into a monorepo ([#831](https://github.com/MetaMask/core/pull/831)), we've created this package from select parts of [`@metamask/controllers` v33.0.0](https://github.com/MetaMask/core/tree/v33.0.0), namely:
-
     - Everything in `src/assets`
     - Asset-related functions from `src/util.ts` and accompanying tests
 

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Remove optional `accountAssetInfo` from selector `Asset` items.
   - `MultichainAssetsController:accountAssetListUpdated` no longer includes a `refreshed` asset list for already-tracked snap adds;
 
+### Fixed
+
+- Fix incorrect Linea chain ID (`0xe728` → `0xe708`) in `SUPPORTED_NETWORKS_ACCOUNTS_API_V4`, which caused the legacy `AssetsController` (used in production when the Unified Assets Controller feature flag is off) to fall back to RPC instead of the Accounts API V4 ([#9519](https://github.com/MetaMask/core/pull/9519))
+
 ## [109.4.1]
 
 ### Changed
@@ -3299,7 +3303,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial release
+
   - As a result of converting our shared controllers repo into a monorepo ([#831](https://github.com/MetaMask/core/pull/831)), we've created this package from select parts of [`@metamask/controllers` v33.0.0](https://github.com/MetaMask/core/tree/v33.0.0), namely:
+
     - Everything in `src/assets`
     - Asset-related functions from `src/util.ts` and accompanying tests
 

--- a/packages/assets-controllers/src/constants.ts
+++ b/packages/assets-controllers/src/constants.ts
@@ -12,7 +12,7 @@ export const SUPPORTED_NETWORKS_ACCOUNTS_API_V4 = [
   '0x1', // 1
   '0x89', // 137
   '0x38', // 56
-  '0xe728', // 59144
+  '0xe708', // 59144
   '0x2105', // 8453
   '0xa', // 10
   '0xa4b1', // 42161


### PR DESCRIPTION
## Explanation

The `assets-controllers` package contains a legacy `AssetsController` that, despite being legacy, is still actively used in production today. This branch fixes a bug where the controller was unintentionally calling the RPC endpoint instead of the Accounts API V4 when fetching data for Linea. The root cause was a typo that caused the wrong code path to be taken. This only affected users who do not have the Unified Assets Controller feature enabled — when that flag is off, the legacy controller is used, and it was silently falling back to RPC rather than the intended Accounts API V4, resulting in an incorrect chain ID being used for Linea.
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

https://consensyssoftware.atlassian.net/browse/ASSETS-3633

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant typo fix with no API or auth changes; restores the intended Accounts API path for Linea on the legacy controller.
> 
> **Overview**
> Corrects Linea’s hex chain ID in `SUPPORTED_NETWORKS_ACCOUNTS_API_V4` from `0xe728` to `0xe708` (59144).
> 
> With the wrong ID, the legacy `AssetsController` did not treat Linea as API-supported when the Unified Assets Controller flag is off, so Linea asset fetches used RPC instead of Accounts API V4. The changelog documents the fix under **Fixed**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30aedf4b88636fcfad53e7fcd7da1a3abff154c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->