### PR TITLE
Release 1125.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "1124.0.0",
+  "version": "1125.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {

--- a/packages/sentinel-api-service/CHANGELOG.md
+++ b/packages/sentinel-api-service/CHANGELOG.md
@@ -7,9 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0]
+
 ### Added
 
 - Initial commit ([#9466](https://github.com/MetaMask/core/pull/9466))
   - Supports `getNetworks`, `simulateTransactions`, `submitRelayTransaction`, and `getSmartTransaction`
 
-[Unreleased]: https://github.com/MetaMask/core/
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/sentinel-api-service@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/core/releases/tag/@metamask/sentinel-api-service@1.0.0

--- a/packages/sentinel-api-service/package.json
+++ b/packages/sentinel-api-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/sentinel-api-service",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "description": "Data service for the MetaMask Sentinel API",
   "keywords": [
     "Ethereum",


### PR DESCRIPTION
Major release of `@metamask/sentinel-api-service`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only release with no application logic changes.
> 
> **Overview**
> **Release 1125.0.0** bumps the monorepo version and cuts the first stable release of **`@metamask/sentinel-api-service`** at **1.0.0** (from `0.0.0`).
> 
> The package **CHANGELOG** is updated with a `[1.0.0]` section and release/compare links; there are **no runtime or API code changes** in this diff—only versioning and release metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c78789ad0d56377d046c74b196d5e79358bb2d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->