### PR TITLE
chore(base-data-service): improve constructor type safety

### DIFF
--- a/packages/base-data-service/CHANGELOG.md
+++ b/packages/base-data-service/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **BREAKING:** Remove `TPageData` type parameter from `invalidateQueries` method ([#9526](https://github.com/MetaMask/core/pull/9526))
   - This is technically a breaking change, but this was not used in any of our codebases
+- **BREAKING:** Improve type safety of constructor by ensuring the messenger has required actions/events ([#9525](https://github.com/MetaMask/core/pull/9525))
+  - No change needed, unless the messenger being passed into the constructor was typed incorrectly.
 - Bump `@metamask/utils` from `^11.9.0` to `^11.11.0` ([#9074](https://github.com/MetaMask/core/pull/9074))
 - Bump `@metamask/controller-utils` from `^12.1.0` to `^12.3.0` ([#9058](https://github.com/MetaMask/core/pull/9058), [#9083](https://github.com/MetaMask/core/pull/9083), [#9218](https://github.com/MetaMask/core/pull/9218))
 - Bump `@metamask/messenger` from `^1.2.0` to `^2.0.0` ([#9392](https://github.com/MetaMask/core/pull/9392))

--- a/packages/base-data-service/CHANGELOG.md
+++ b/packages/base-data-service/CHANGELOG.md
@@ -44,6 +44,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The option types accepted by `fetchQuery`, `fetchInfiniteQuery`, and `invalidateQueries` now follow the query-core v5 API. Subclasses need to rename `cacheTime` to `gcTime`.
   - `fetchInfiniteQuery` now requires `initialPageParam` and `getNextPageParam`, matching query-core's options for infinite queries. This also lets `TPageParam` be inferred instead of spelled out in the type parameters.
 - **BREAKING:** `fetchQuery` and `fetchInfiniteQuery` now take one more type parameter: `TDataStruct` is the third parameter and the others have been shifted up ([#9540](https://github.com/MetaMask/core/pull/9540))
+- **BREAKING:** Improve type safety of constructor by ensuring the messenger has required actions/events ([#9525](https://github.com/MetaMask/core/pull/9525))
+  - No change needed, unless the messenger being passed into the constructor was typed incorrectly.
 - Bump `@metamask/utils` from `^11.9.0` to `^11.11.0` ([#9074](https://github.com/MetaMask/core/pull/9074))
 - Bump `@metamask/controller-utils` from `^12.1.0` to `^12.3.0` ([#9058](https://github.com/MetaMask/core/pull/9058), [#9083](https://github.com/MetaMask/core/pull/9083), [#9218](https://github.com/MetaMask/core/pull/9218))
 - Bump `@metamask/messenger` from `^1.2.0` to `^2.0.0` ([#9392](https://github.com/MetaMask/core/pull/9392))

--- a/packages/base-data-service/src/BaseDataService.ts
+++ b/packages/base-data-service/src/BaseDataService.ts
@@ -2,6 +2,8 @@ import {
   Messenger,
   ActionConstraint,
   EventConstraint,
+  MessengerActions,
+  MessengerEvents,
 } from '@metamask/messenger';
 import type {
   StorageServiceGetItemAction,
@@ -161,7 +163,13 @@ export class BaseDataService<
     persistenceConfig,
   }: {
     name: ServiceName;
-    messenger: ServiceMessenger;
+    messenger: DataServiceActions<ServiceName>['type'] extends
+      | MessengerActions<ServiceMessenger>['type']
+      | DataServiceAllowedActions['type']
+      ? DataServiceEvents<ServiceName>['type'] extends MessengerEvents<ServiceMessenger>['type']
+        ? ServiceMessenger
+        : never
+      : never;
     queryClientConfig?: QueryClientConfig;
     policyOptions?: CreateServicePolicyOptions;
     persistenceConfig?: PersistenceConfiguration;

--- a/packages/base-data-service/src/BaseDataService.ts
+++ b/packages/base-data-service/src/BaseDataService.ts
@@ -2,6 +2,8 @@ import {
   Messenger,
   ActionConstraint,
   EventConstraint,
+  MessengerActions,
+  MessengerEvents,
 } from '@metamask/messenger';
 import type {
   StorageServiceGetItemAction,
@@ -173,7 +175,13 @@ export class BaseDataService<
     persistenceConfig,
   }: {
     name: ServiceName;
-    messenger: ServiceMessenger;
+    messenger: DataServiceActions<ServiceName>['type'] extends
+      | MessengerActions<ServiceMessenger>['type']
+      | DataServiceAllowedActions['type']
+      ? DataServiceEvents<ServiceName>['type'] extends MessengerEvents<ServiceMessenger>['type']
+        ? ServiceMessenger
+        : never
+      : never;
     queryClientConfig?: QueryClientConfig;
     policyOptions?: CreateServicePolicyOptions;
     persistenceConfig?: PersistenceConfiguration;


### PR DESCRIPTION
## Explanation

Improve the constructor type safety by using conditional types to ensure the messenger passed in has the necessary actions/events.

## References

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them
  - Skipped because this is a change we're fairly confident in (we use the exact same type guards already elsewhere), and testing would be impossible without drafting a PR to fix the other 4 pending breaking changes first. We should have had a draft PR for those others to build upon here. Oh well.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only constructor constraint with no runtime behavior change. Breaking only if a messenger was already typed incorrectly.
> 
> **Overview**
> The `BaseDataService` constructor now uses conditional types so `messenger` is only accepted when it includes the required data-service actions and events (plus allowed storage actions).
> 
> This is a compile-time check: incorrectly typed messengers fail to type-check; correctly typed callers need no change. Changelog notes it as **BREAKING**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cfd8be9ca3504ee599667c8322a5aa906cf1b7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->