### PR TITLE
chore(base-data-service): simplify `invalidateQueries` type

### DIFF
--- a/packages/base-data-service/CHANGELOG.md
+++ b/packages/base-data-service/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING:** Remove `TPageData` type parameter from `invalidateQueries` method ([#9526](https://github.com/MetaMask/core/pull/9526))
+  - This is technically a breaking change, but this was not used in any of our codebases
 - Bump `@metamask/utils` from `^11.9.0` to `^11.11.0` ([#9074](https://github.com/MetaMask/core/pull/9074))
 - Bump `@metamask/controller-utils` from `^12.1.0` to `^12.3.0` ([#9058](https://github.com/MetaMask/core/pull/9058), [#9083](https://github.com/MetaMask/core/pull/9083), [#9218](https://github.com/MetaMask/core/pull/9218))
 - Bump `@metamask/messenger` from `^1.2.0` to `^2.0.0` ([#9392](https://github.com/MetaMask/core/pull/9392))

--- a/packages/base-data-service/src/BaseDataService.ts
+++ b/packages/base-data-service/src/BaseDataService.ts
@@ -336,8 +336,8 @@ export class BaseDataService<
    * @param options - Additional optional options for query invalidations.
    * @returns Nothing.
    */
-  async invalidateQueries<TPageData extends Json>(
-    filters?: InvalidateQueryFilters<TPageData>,
+  async invalidateQueries(
+    filters?: InvalidateQueryFilters<Json>,
     options?: InvalidateOptions,
   ): Promise<void> {
     return this.#queryClient.invalidateQueries(filters, options);


### PR DESCRIPTION
## Explanation

The generic parameter has been removed from the `invalidateQueries` method, simplifying the type signature. In practice this was never used. It also created an odd inconsistency between the method type and the action type, which would be nice to avoid.

## References

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them
  - I didn't test with a preview build, but I did search the entire organization for any references where the generic type param was used, and found none

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow API/type-signature change with identical runtime behavior; breaking only for external callers that explicitly parameterized `invalidateQueries`, which the team reports were none.
> 
> **Overview**
> **Breaking (documented):** `BaseDataService.invalidateQueries` no longer accepts a `TPageData` type parameter; optional filters are now typed as `InvalidateQueryFilters<Json>` and still delegate to the query client unchanged.
> 
> This aligns the public method signature with `DataServiceInvalidateQueriesAction`, which already used `Json` for filters. The unreleased changelog notes the break even though no in-org callers used the generic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2faae3512a4e6a025d91c2dfee0cff6ca55b29af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->