### PR TITLE
feat(wallet)!: wire `GasFeeController` into default initialization

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -150,6 +150,7 @@
 /packages/wallet/src/initialization/instances/address-book-controller/           @MetaMask/confirmations
 /packages/wallet/src/initialization/instances/approval-controller/               @MetaMask/confirmations
 /packages/wallet/src/initialization/instances/connectivity-controller/           @MetaMask/core-platform
+/packages/wallet/src/initialization/instances/gas-fee-controller/                @MetaMask/confirmations
 /packages/wallet/src/initialization/instances/keyring-controller/                @MetaMask/accounts-engineers @MetaMask/core-platform
 /packages/wallet/src/initialization/instances/passkey-controller/                @MetaMask/web3auth
 /packages/wallet/src/initialization/instances/remote-feature-flag-controller/    @MetaMask/extension-platform @MetaMask/mobile-platform @MetaMask/core-platform

--- a/README.md
+++ b/README.md
@@ -649,6 +649,7 @@ linkStyle default opacity:0.5
   wallet --> base_controller;
   wallet --> connectivity_controller;
   wallet --> controller_utils;
+  wallet --> gas_fee_controller;
   wallet --> keyring_controller;
   wallet --> messenger;
   wallet --> network_controller;

--- a/codeowners.ts
+++ b/codeowners.ts
@@ -160,6 +160,7 @@ const PACKAGES: Record<string, PackageInfo> = {
   },
   'gas-fee-controller': {
     teams: ['@MetaMask/confirmations'],
+    initializationPath: 'gas-fee-controller',
   },
   'gator-permissions-controller': {
     teams: ['@MetaMask/delegation'],

--- a/packages/wallet-cli/CHANGELOG.md
+++ b/packages/wallet-cli/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Wire the `transactionController` slot in the daemon wallet's instance options, so the daemon runs the `TransactionController` with an explicit CLI-appropriate configuration (swaps processing disabled, no client hooks) rather than relying on the controller's implicit defaults ([#9509](https://github.com/MetaMask/core/pull/9509))
+- Wire the `gasFeeController` slot in the daemon wallet's instance options, passing `clientId: 'cli'` so the CLI identifies itself to the gas estimation API, now that `@metamask/wallet` requires this option ([#9527](https://github.com/MetaMask/core/pull/9527))
 - Add the `mm wallet unlock` command, which dispatches `KeyringController:submitPassword` over the daemon socket, allowing the keyring to be unlocked after a daemon start with no password or after a `mm daemon call KeyringController:setLocked` ([#8821](https://github.com/MetaMask/core/pull/8821))
 - Add the `mm daemon list` command, which prints the messenger actions the running daemon can dispatch via `daemon call`, enumerated from the live messenger so the list cannot drift from what `call` accepts ([#9339](https://github.com/MetaMask/core/pull/9339))
 - Add the `mm daemon` command suite (`start`, `stop`, `status`, `purge`, and `call`) for running the wallet daemon and dispatching messenger actions over its socket ([#9255](https://github.com/MetaMask/core/pull/9255))

--- a/packages/wallet-cli/src/daemon/wallet-factory.test.ts
+++ b/packages/wallet-cli/src/daemon/wallet-factory.test.ts
@@ -103,6 +103,7 @@ describe('createWallet', () => {
     expect(
       instanceOptions.connectivityController.connectivityAdapter,
     ).toBeInstanceOf(AlwaysOnlineAdapter);
+    expect(instanceOptions.gasFeeController.clientId).toBe('cli');
     expect(instanceOptions.networkController.infuraProjectId).toBe(
       'test-infura-id',
     );

--- a/packages/wallet-cli/src/daemon/wallet-factory.ts
+++ b/packages/wallet-cli/src/daemon/wallet-factory.ts
@@ -83,6 +83,11 @@ function buildInstanceOptions(
     connectivityController: {
       connectivityAdapter: new AlwaysOnlineAdapter(),
     },
+    gasFeeController: {
+      // Identifies the CLI to the gas estimation API via the `X-Client-Id`
+      // header.
+      clientId: 'cli',
+    },
     networkController: {
       infuraProjectId,
     },

--- a/packages/wallet/CHANGELOG.md
+++ b/packages/wallet/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **BREAKING:** Wire `GasFeeController` into the default wallet initialization ([#9527](https://github.com/MetaMask/core/pull/9527))
+  - Adds a required `instanceOptions.gasFeeController` option whose `clientId` (sent as `X-Client-Id` to the gas API) is required, so every client identifies itself; all other fields are optional and fall back to platform-agnostic defaults.
 - **BREAKING** Wire `SeedlessOnboardingController` and `PasskeyController` into the default wallet initialization ([#9533](https://github.com/MetaMask/core/pull/9533))
 
 ### Changed

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -62,6 +62,7 @@
     "@metamask/browser-passworder": "^6.0.0",
     "@metamask/connectivity-controller": "^0.3.0",
     "@metamask/controller-utils": "^12.3.0",
+    "@metamask/gas-fee-controller": "^26.2.4",
     "@metamask/keyring-controller": "^27.1.0",
     "@metamask/messenger": "^2.0.0",
     "@metamask/network-controller": "^34.0.0",

--- a/packages/wallet/src/Wallet.test.ts
+++ b/packages/wallet/src/Wallet.test.ts
@@ -29,6 +29,9 @@ async function setupWallet(): Promise<Wallet> {
       connectivityController: {
         connectivityAdapter: new AlwaysOnlineAdapter(),
       },
+      gasFeeController: {
+        clientId: 'test',
+      },
       networkController: {
         infuraProjectId: 'fake-infura-project-id',
       },
@@ -89,6 +92,9 @@ describe('Wallet', () => {
         connectivityController: {
           connectivityAdapter: new AlwaysOnlineAdapter(),
         },
+        gasFeeController: {
+          clientId: 'test',
+        },
         keyringController: {
           encryptor: new MockEncryptor(),
         },
@@ -141,6 +147,9 @@ describe('Wallet', () => {
         connectivityController: {
           connectivityAdapter: new AlwaysOnlineAdapter(),
         },
+        gasFeeController: {
+          clientId: 'test',
+        },
         networkController: {
           infuraProjectId: 'fake-infura-project-id',
         },
@@ -183,6 +192,9 @@ describe('Wallet', () => {
       instanceOptions: {
         connectivityController: {
           connectivityAdapter: new AlwaysOnlineAdapter(),
+        },
+        gasFeeController: {
+          clientId: 'test',
         },
         networkController: {
           infuraProjectId: 'fake-infura-project-id',
@@ -294,6 +306,9 @@ describe('Wallet', () => {
           connectivityController: {
             connectivityAdapter: new AlwaysOnlineAdapter(),
           },
+          gasFeeController: {
+            clientId: 'test',
+          },
           networkController: {
             infuraProjectId: 'fake-infura-project-id',
           },
@@ -325,6 +340,9 @@ describe('Wallet', () => {
         instanceOptions: {
           connectivityController: {
             connectivityAdapter: new AlwaysOnlineAdapter(),
+          },
+          gasFeeController: {
+            clientId: 'test',
           },
           networkController: {
             infuraProjectId: 'fake-infura-project-id',
@@ -365,6 +383,9 @@ describe('Wallet', () => {
         instanceOptions: {
           connectivityController: {
             connectivityAdapter: new AlwaysOnlineAdapter(),
+          },
+          gasFeeController: {
+            clientId: 'test',
           },
           networkController: {
             infuraProjectId: 'fake-infura-project-id',
@@ -453,6 +474,9 @@ describe('Wallet', () => {
         instanceOptions: {
           connectivityController: {
             connectivityAdapter: new AlwaysOnlineAdapter(),
+          },
+          gasFeeController: {
+            clientId: 'test',
           },
           networkController: {
             infuraProjectId: 'fake-infura-project-id',

--- a/packages/wallet/src/initialization/instances/gas-fee-controller/gas-fee-controller.test.ts
+++ b/packages/wallet/src/initialization/instances/gas-fee-controller/gas-fee-controller.test.ts
@@ -1,0 +1,239 @@
+import { GasFeeController } from '@metamask/gas-fee-controller';
+import { Messenger } from '@metamask/messenger';
+import { InMemoryStorageAdapter } from '@metamask/storage-service';
+
+import type { WalletOptions } from '../../../types.js';
+import { Wallet } from '../../../Wallet.js';
+import { defaultConfigurations } from '../../defaults.js';
+import type {
+  DefaultActions,
+  DefaultEvents,
+  RootMessenger,
+} from '../../defaults.js';
+import { AlwaysOnlineAdapter } from '../connectivity-controller/always-online-adapter.js';
+import { gasFeeController } from './gas-fee-controller.js';
+
+const controllers: GasFeeController[] = [];
+const wallets: Wallet[] = [];
+
+const REMOTE_FEATURE_FLAG_OPTIONS = {
+  clientConfigApiService: {
+    fetchRemoteFeatureFlags: async (): Promise<{
+      remoteFeatureFlags: Record<string, boolean>;
+      cacheTimestamp: number;
+    }> => ({ remoteFeatureFlags: {}, cacheTimestamp: Date.now() }),
+  },
+};
+
+type ActionHandler = (...args: unknown[]) => unknown;
+
+type AnyMessenger = Messenger<string>;
+
+describe('gasFeeController', () => {
+  afterEach(async () => {
+    for (const controller of controllers.splice(0)) {
+      controller.destroy();
+    }
+
+    await Promise.all(wallets.splice(0).map((wallet) => wallet.destroy()));
+  });
+
+  it('is registered as a default initialization configuration', () => {
+    expect(Object.values(defaultConfigurations)).toContain(gasFeeController);
+  });
+
+  it('initializes a GasFeeController with default state', () => {
+    const rootMessenger = getRootMessenger();
+    const messenger = gasFeeController.getMessenger(rootMessenger);
+
+    const instance = gasFeeController.init({
+      state: undefined,
+      messenger,
+      options: { clientId: 'test' },
+    });
+    controllers.push(instance);
+
+    expect(instance).toBeInstanceOf(GasFeeController);
+    expect(rootMessenger.call('GasFeeController:getState')).toStrictEqual({
+      gasFeeEstimatesByChainId: {},
+      gasFeeEstimates: {},
+      estimatedGasFeeTimeBounds: {},
+      gasEstimateType: 'none',
+      nonRPCGasFeeApisDisabled: false,
+    });
+  });
+
+  it('is initialized by the default Wallet configuration', () => {
+    const wallet = new Wallet({
+      instanceOptions: getInstanceOptions(),
+    });
+    wallets.push(wallet);
+
+    expect(wallet.getInstance('GasFeeController')).toBeInstanceOf(
+      GasFeeController,
+    );
+  });
+
+  it('exposes GasFeeController:fetchGasFeeEstimates over the shared bus, resolving the TransactionController delegation', async () => {
+    // The messenger binds the method at construction, so spy on the prototype
+    // before building the wallet. This also avoids the real network fetch.
+    const fetchGasFeeEstimates = jest
+      .spyOn(GasFeeController.prototype, 'fetchGasFeeEstimates')
+      .mockResolvedValue({
+        gasFeeEstimatesByChainId: {},
+        gasFeeEstimates: {},
+        estimatedGasFeeTimeBounds: {},
+        gasEstimateType: 'none',
+        nonRPCGasFeeApisDisabled: false,
+      });
+
+    const wallet = new Wallet({
+      instanceOptions: getInstanceOptions(),
+    });
+    wallets.push(wallet);
+
+    await wallet.messenger.call('GasFeeController:fetchGasFeeEstimates');
+
+    expect(fetchGasFeeEstimates).toHaveBeenCalled();
+  });
+
+  it('forwards the provided state to the controller', () => {
+    const rootMessenger = getRootMessenger();
+    const messenger = gasFeeController.getMessenger(rootMessenger);
+
+    const instance = gasFeeController.init({
+      state: {
+        gasFeeEstimatesByChainId: {},
+        gasFeeEstimates: {},
+        estimatedGasFeeTimeBounds: {},
+        gasEstimateType: 'none',
+        nonRPCGasFeeApisDisabled: true,
+      },
+      messenger,
+      options: { clientId: 'test' },
+    });
+    controllers.push(instance);
+
+    expect(instance.state.nonRPCGasFeeApisDisabled).toBe(true);
+  });
+
+  it('builds the network callbacks from the wired NetworkController', async () => {
+    const rootMessenger = getRootMessenger();
+    const messenger = gasFeeController.getMessenger(rootMessenger);
+
+    const instance = gasFeeController.init({
+      state: undefined,
+      messenger,
+      options: { clientId: 'test' },
+    });
+    controllers.push(instance);
+
+    // Drives `getProvider` and the EIP-1559/legacy/account callbacks; the
+    // estimate then fails at the offline provider, which is irrelevant here.
+    await expect(instance.fetchGasFeeEstimates()).rejects.toThrow(
+      'Gas fee/price estimation failed',
+    );
+  });
+
+  it('applies injectable options over the defaults', () => {
+    const rootMessenger = getRootMessenger();
+    const messenger = gasFeeController.getMessenger(rootMessenger);
+    const getCurrentAccountEIP1559Compatibility = jest
+      .fn()
+      .mockReturnValue(false);
+    const getCurrentNetworkLegacyGasAPICompatibility = jest
+      .fn()
+      .mockReturnValue(true);
+
+    const instance = gasFeeController.init({
+      state: undefined,
+      messenger,
+      options: {
+        EIP1559APIEndpoint: 'https://example.test/<chain_id>/eip1559',
+        legacyAPIEndpoint: 'https://example.test/<chain_id>/legacy',
+        clientId: 'test-client',
+        interval: 30_000,
+        getCurrentAccountEIP1559Compatibility,
+        getCurrentNetworkLegacyGasAPICompatibility,
+      },
+    });
+    controllers.push(instance);
+
+    expect(instance).toBeInstanceOf(GasFeeController);
+  });
+});
+
+function getRootMessenger(): RootMessenger<DefaultActions, DefaultEvents> {
+  const rootMessenger = new Messenger<'Root', DefaultActions, DefaultEvents>({
+    namespace: 'Root',
+  });
+
+  registerActionHandler(
+    rootMessenger,
+    'NetworkController',
+    'NetworkController:getState',
+    jest.fn().mockReturnValue({ selectedNetworkClientId: 'mainnet' }),
+  );
+
+  registerActionHandler(
+    rootMessenger,
+    'NetworkController',
+    'NetworkController:getNetworkClientById',
+    jest.fn().mockReturnValue({
+      // Errors immediately so `eth_gasPrice` fallback settles without a network
+      // call rather than hanging.
+      provider: {
+        sendAsync: (_request: unknown, callback: (error: Error) => void) =>
+          callback(new Error('offline')),
+      },
+      configuration: { chainId: '0x1' },
+    }),
+  );
+
+  registerActionHandler(
+    rootMessenger,
+    'NetworkController',
+    'NetworkController:getEIP1559Compatibility',
+    // `false` skips the EIP-1559/legacy API fetches, so a fetch goes straight to
+    // the offline provider above.
+    jest.fn().mockResolvedValue(false),
+  );
+
+  return rootMessenger;
+}
+
+function getInstanceOptions(): WalletOptions['instanceOptions'] {
+  return {
+    connectivityController: {
+      connectivityAdapter: new AlwaysOnlineAdapter(),
+    },
+    gasFeeController: {
+      clientId: 'test',
+    },
+    networkController: {
+      infuraProjectId: 'test-infura-project-id',
+    },
+    storageService: {
+      storage: new InMemoryStorageAdapter(),
+    },
+    remoteFeatureFlagController: REMOTE_FEATURE_FLAG_OPTIONS,
+  };
+}
+
+function registerActionHandler(
+  parent: RootMessenger<DefaultActions, DefaultEvents>,
+  namespace: string,
+  actionType: string,
+  handler: ActionHandler,
+): void {
+  const messenger = new Messenger({
+    namespace,
+    parent: parent as unknown as AnyMessenger,
+  });
+
+  (
+    messenger as unknown as {
+      registerActionHandler(type: string, handler: ActionHandler): void;
+    }
+  ).registerActionHandler(actionType, handler);
+}

--- a/packages/wallet/src/initialization/instances/gas-fee-controller/gas-fee-controller.ts
+++ b/packages/wallet/src/initialization/instances/gas-fee-controller/gas-fee-controller.ts
@@ -1,0 +1,77 @@
+import type { GasFeeMessenger } from '@metamask/gas-fee-controller';
+import { GasFeeController } from '@metamask/gas-fee-controller';
+import { Messenger } from '@metamask/messenger';
+import type { ProviderProxy } from '@metamask/network-controller';
+
+import type { InitializationConfiguration } from '../../types.js';
+
+export type { GasFeeControllerInstanceOptions } from './types.js';
+
+const GAS_API_BASE_URL = 'https://gas.api.cx.metamask.io';
+
+// The controller substitutes `<chain_id>` with the decimal chain ID per request.
+const DEFAULT_EIP1559_API_ENDPOINT = `${GAS_API_BASE_URL}/networks/<chain_id>/suggestedGasFees`;
+const DEFAULT_LEGACY_API_ENDPOINT = `${GAS_API_BASE_URL}/networks/<chain_id>/gasPrices`;
+
+export const gasFeeController: InitializationConfiguration<
+  GasFeeController,
+  GasFeeMessenger
+> = {
+  name: 'GasFeeController',
+  init: ({ state, messenger, options }) => {
+    const {
+      clientId,
+      EIP1559APIEndpoint = DEFAULT_EIP1559_API_ENDPOINT,
+      legacyAPIEndpoint = DEFAULT_LEGACY_API_ENDPOINT,
+      interval,
+      getCurrentNetworkLegacyGasAPICompatibility = (): boolean => false,
+      getCurrentAccountEIP1559Compatibility = (): boolean => true,
+    } = options;
+
+    return new GasFeeController({
+      messenger,
+      state,
+      interval,
+      EIP1559APIEndpoint,
+      legacyAPIEndpoint,
+      clientId,
+      getCurrentNetworkLegacyGasAPICompatibility,
+      getCurrentAccountEIP1559Compatibility,
+      // Built from `NetworkController`, which the controller expects as direct
+      // callbacks rather than messenger actions.
+      getProvider: (): ProviderProxy => {
+        const { selectedNetworkClientId } = messenger.call(
+          'NetworkController:getState',
+        );
+        // The client's provider proxy lacks `setTarget`, which `ProviderProxy`
+        // nominally requires but `GasFeeController` never calls.
+        return messenger.call(
+          'NetworkController:getNetworkClientById',
+          selectedNetworkClientId,
+        ).provider as ProviderProxy;
+      },
+      getCurrentNetworkEIP1559Compatibility: async () =>
+        Boolean(
+          await messenger.call('NetworkController:getEIP1559Compatibility'),
+        ),
+    });
+  },
+  getMessenger: (parent) => {
+    const messenger: GasFeeMessenger = new Messenger({
+      namespace: 'GasFeeController',
+      parent,
+    });
+
+    parent.delegate({
+      messenger,
+      actions: [
+        'NetworkController:getEIP1559Compatibility',
+        'NetworkController:getNetworkClientById',
+        'NetworkController:getState',
+      ],
+      events: ['NetworkController:networkDidChange'],
+    });
+
+    return messenger;
+  },
+};

--- a/packages/wallet/src/initialization/instances/gas-fee-controller/types.ts
+++ b/packages/wallet/src/initialization/instances/gas-fee-controller/types.ts
@@ -1,0 +1,30 @@
+import type { GasFeeController } from '@metamask/gas-fee-controller';
+
+type GasFeeControllerOptions = ConstructorParameters<
+  typeof GasFeeController
+>[0];
+
+/**
+ * Per-instance options for the wallet's `GasFeeController`. `clientId` is
+ * required so every client (extension, mobile, wallet-cli) identifies itself to
+ * the gas API; the remaining fields are optional and the instance's `init`
+ * applies a platform-agnostic default for each one, which clients may override.
+ */
+export type GasFeeControllerInstanceOptions = {
+  /**
+   * Sent as `X-Client-Id` to the gas API to identify the calling client. Has no
+   * platform-agnostic default, so each client must set it explicitly.
+   */
+  clientId: NonNullable<GasFeeControllerOptions['clientId']>;
+  /** EIP-1559 gas price API URL. Defaults to the production endpoint. */
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  EIP1559APIEndpoint?: GasFeeControllerOptions['EIP1559APIEndpoint'];
+  /** Legacy gas price API URL. Defaults to the production endpoint. */
+  legacyAPIEndpoint?: GasFeeControllerOptions['legacyAPIEndpoint'];
+  /** Milliseconds between polls. Defaults to the controller's own 15 seconds. */
+  interval?: GasFeeControllerOptions['interval'];
+  /** Defaults to `() => false`. */
+  getCurrentNetworkLegacyGasAPICompatibility?: GasFeeControllerOptions['getCurrentNetworkLegacyGasAPICompatibility'];
+  /** Defaults to `() => true`. */
+  getCurrentAccountEIP1559Compatibility?: GasFeeControllerOptions['getCurrentAccountEIP1559Compatibility'];
+};

--- a/packages/wallet/src/initialization/instances/index.ts
+++ b/packages/wallet/src/initialization/instances/index.ts
@@ -2,6 +2,7 @@ export { accountsController } from './accounts-controller/accounts-controller.js
 export { addressBookController } from './address-book-controller/address-book-controller.js';
 export { approvalController } from './approval-controller/approval-controller.js';
 export { connectivityController } from './connectivity-controller/connectivity-controller.js';
+export { gasFeeController } from './gas-fee-controller/gas-fee-controller.js';
 export { keyringController } from './keyring-controller/keyring-controller.js';
 export { networkController } from './network-controller/network-controller.js';
 export { passkeyController } from './passkey-controller/passkey-controller.js';

--- a/packages/wallet/src/initialization/instances/transaction-controller/transaction-controller.test.ts
+++ b/packages/wallet/src/initialization/instances/transaction-controller/transaction-controller.test.ts
@@ -115,6 +115,9 @@ function getInstanceOptions(): WalletOptions['instanceOptions'] {
     connectivityController: {
       connectivityAdapter: new AlwaysOnlineAdapter(),
     },
+    gasFeeController: {
+      clientId: 'test',
+    },
     networkController: {
       infuraProjectId: 'test-infura-project-id',
     },

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -7,6 +7,7 @@ import type {
 } from './initialization/defaults.js';
 import type { ApprovalControllerInstanceOptions } from './initialization/instances/approval-controller/types.js';
 import type { ConnectivityControllerInstanceOptions } from './initialization/instances/connectivity-controller/types.js';
+import type { GasFeeControllerInstanceOptions } from './initialization/instances/gas-fee-controller/types.js';
 import type { KeyringControllerInstanceOptions } from './initialization/instances/keyring-controller/types.js';
 import type { NetworkControllerInstanceOptions } from './initialization/instances/network-controller/types.js';
 import type { PasskeyControllerInstanceOptions } from './initialization/instances/passkey-controller/types.js';
@@ -29,6 +30,7 @@ export type WalletOptions = {
 export type InstanceSpecificOptions = {
   approvalController?: ApprovalControllerInstanceOptions;
   connectivityController: ConnectivityControllerInstanceOptions;
+  gasFeeController: GasFeeControllerInstanceOptions;
   keyringController?: KeyringControllerInstanceOptions;
   networkController: NetworkControllerInstanceOptions;
   remoteFeatureFlagController: RemoteFeatureFlagControllerInstanceOptions;

--- a/packages/wallet/tsconfig.build.json
+++ b/packages/wallet/tsconfig.build.json
@@ -12,6 +12,7 @@
     { "path": "../base-controller/tsconfig.build.json" },
     { "path": "../connectivity-controller/tsconfig.build.json" },
     { "path": "../controller-utils/tsconfig.build.json" },
+    { "path": "../gas-fee-controller/tsconfig.build.json" },
     { "path": "../keyring-controller/tsconfig.build.json" },
     { "path": "../messenger/tsconfig.build.json" },
     { "path": "../network-controller/tsconfig.build.json" },

--- a/packages/wallet/tsconfig.json
+++ b/packages/wallet/tsconfig.json
@@ -23,6 +23,9 @@
       "path": "../controller-utils"
     },
     {
+      "path": "../gas-fee-controller"
+    },
+    {
       "path": "../keyring-controller"
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9170,6 +9170,7 @@ __metadata:
     "@metamask/browser-passworder": "npm:^6.0.0"
     "@metamask/connectivity-controller": "npm:^0.3.0"
     "@metamask/controller-utils": "npm:^12.3.0"
+    "@metamask/gas-fee-controller": "npm:^26.2.4"
     "@metamask/keyring-controller": "npm:^27.1.0"
     "@metamask/messenger": "npm:^2.0.0"
     "@metamask/network-controller": "npm:^34.0.0"


### PR DESCRIPTION
## Explanation

Wires `GasFeeController` into `@metamask/wallet`'s default initialization set as its own `InitializationConfiguration` under `src/initialization/instances/gas-fee-controller/`, mirroring the most recently merged instances (`transaction-controller`, `network-controller`).

`TransactionController` is already wired and its messenger delegates `GasFeeController:fetchGasFeeEstimates`. Delegation registers a *lazy* handler, so the wallet boots fine today — but the first transaction flow that needs gas estimates throws `A handler for GasFeeController:fetchGasFeeEstimates has not been registered`. Wiring `GasFeeController` is the missing piece that lets a wired `TransactionController` actually estimate gas.

`@metamask/wallet` is the shared controller-integration layer that `metamask-extension`, `metamask-mobile`, and `@metamask/wallet-cli` all adopt, so every value that differs between clients is an injectable `instanceOptions.gasFeeController` slot with a platform-agnostic default — nothing is baked to one client.

### Constructor callbacks

`GasFeeController` takes direct callbacks rather than pure messenger delegation. The instance builds them from the wired `NetworkController`:

- `getProvider` → `NetworkController:getState` (`selectedNetworkClientId`) then `NetworkController:getNetworkClientById(id).provider`
- `getCurrentNetworkEIP1559Compatibility` → `NetworkController:getEIP1559Compatibility` (coerced to a defined `boolean`)

`onNetworkDidChange` / `getChainId` are omitted — the constructor already has a messenger-based network-tracking fallback when both are absent (subscribes `NetworkController:networkDidChange`).

### Injectable options + per-environment values

| Option | Extension | Mobile | Default (wallet-cli / package) |
| ------ | --------- | ------ | ------------------------------ |
| `EIP1559APIEndpoint` | `.../networks/<chain_id>/suggestedGasFees` (dev override → `gas.uat-api.cx.metamask.io`) | same prod URL | prod URL; injectable |
| `legacyAPIEndpoint` | `${GAS_API}/networks/<chain_id>/gasPrices` | same prod URL | prod URL; injectable |
| `clientId` | `'extension'` | `'mobile'` | `'cli'` (sent as `X-Client-Id`); injectable |
| `interval` | `10_000` | `15_000` | controller default `15_000`; injectable |
| `getCurrentNetworkLegacyGasAPICompatibility` | `chainId === BSC` | `mainnet \|\| BSC \|\| POLYGON` | `() => false`; injectable |
| `getCurrentAccountEIP1559Compatibility` | `() => true` | omitted | `() => true`; injectable |

### Initialization ordering

No construction-ordering machinery is needed. `GasFeeController` was made initialization-order-agnostic upstream ([#9569](https://github.com/MetaMask/core/pull/9569)): the constructor no longer eagerly resolves `NetworkController` (the `getProvider` / `getCurrentNetworkEIP1559Compatibility` callbacks resolve it lazily at call time), so it can be constructed before `NetworkController`. `initialize` therefore constructs the default set in its natural order, and the `dependencies` field / `orderByDependencies` sort that an earlier revision of this PR added were dropped in favor of that upstream refactor.

### `fetch` decision

`GasFeeController` fetches gas estimates via the **global `fetch`** inside `@metamask/gas-fee-controller` (it has no injectable `fetch` option). This PR takes **path (a): accept the global `fetch`** — no upstream change; works on Node 18+ (wallet-cli daemon), modern browsers, and React Native. The global-`fetch` usage lives inside the controller package, not inside `@metamask/wallet` code, and both clients already rely on this today. Adding an injectable `fetch` option to `@metamask/gas-fee-controller` is tracked as a possible follow-up if the convention is to be enforced strictly.

## Client adoption PRs

- Extension — https://github.com/MetaMask/metamask-extension/pull/44534
- Mobile — https://github.com/MetaMask/metamask-mobile/pull/33430

## References

- Upstream controller: [`packages/gas-fee-controller/src/GasFeeController.ts`](https://github.com/MetaMask/core/blob/main/packages/gas-fee-controller/src/GasFeeController.ts)
- Mirror template: [`packages/wallet/src/initialization/instances/transaction-controller/`](https://github.com/MetaMask/core/tree/main/packages/wallet/src/initialization/instances/transaction-controller)
- Extension init: [`app/scripts/messenger-client-init/confirmations/gas-fee-controller-init.ts`](https://github.com/MetaMask/metamask-extension/blob/main/app/scripts/messenger-client-init/confirmations/gas-fee-controller-init.ts)
- Mobile init: [`app/core/Engine/controllers/gas-fee-controller/gas-fee-controller-init.ts`](https://github.com/MetaMask/metamask-mobile/blob/main/app/core/Engine/controllers/gas-fee-controller/gas-fee-controller-init.ts)

## Related

- Closes #9510

## Checklist

- [x] I've read the [contributing guidelines](https://github.com/MetaMask/core/blob/main/docs/contributing.md).
- [x] I've completed the PR template to the best of my ability.
- [x] I've included tests if applicable (100% coverage; colocated instance test).
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable.
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/core/blob/main/docs/contributing.md#labeling-guidelines)). Not required for external contributors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking API for all Wallet consumers and changes the transaction gas-estimation path, but the integration follows existing controller init patterns and includes dedicated tests.
> 
> **Overview**
> **Breaking:** `@metamask/wallet` now boots `GasFeeController` as part of default initialization, so wired `TransactionController` flows can call `GasFeeController:fetchGasFeeEstimates` instead of failing with a missing handler.
> 
> Consumers must pass **`instanceOptions.gasFeeController`** with a required **`clientId`** (sent as `X-Client-Id` to the gas API); other gas settings stay optional with shared defaults (production API URLs, network callbacks built from `NetworkController`).
> 
> `@metamask/wallet-cli` sets **`clientId: 'cli'`** on the daemon wallet. Extension/mobile adoption is expected in separate PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baa44729ae6b80d7c695412eb9228b1cbbf1dcec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


