### PR TITLE
feat: assets suggested occurrence floors

### DIFF
--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `TokenDataSource` EVM spam filtering now uses per-chain floors from Token API `GET /v1/suggestedOccurrenceFloors` (`queryApiClient.token.fetchV1SuggestedOccurrenceFloors`) instead of a hardcoded minimum of 3 occurrences. Chains missing from the response (or a failed floors fetch) still fall back to 3.
+- `TokensApiClient` (used by `RpcDataSource` / `TokenDetector`) now sets the token-list `occurrenceFloor` query param from the same Token API `GET /v1/suggestedOccurrenceFloors` endpoint (cached 1h), replacing the hardcoded Linea/MegaETH/Tempo special cases. Missing chains or failed fetches fall back to 3.
 - Bump `@metamask/network-enablement-controller` from `^5.5.0` to `^5.6.0` ([#9520](https://github.com/MetaMask/core/pull/9520))
 - Bump `@metamask/phishing-controller` from `^17.2.1` to `^17.3.0` ([#9532](https://github.com/MetaMask/core/pull/9532))
 

--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -13,8 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `TokenDataSource` EVM spam filtering now uses per-chain floors from Token API `GET /v1/suggestedOccurrenceFloors` (`queryApiClient.token.fetchV1SuggestedOccurrenceFloors`) instead of a hardcoded minimum of 3 occurrences. Chains missing from the response (or a failed floors fetch) still fall back to 3.
-- `TokensApiClient` (used by `RpcDataSource` / `TokenDetector`) now sets the token-list `occurrenceFloor` query param from the same Token API `GET /v1/suggestedOccurrenceFloors` endpoint (cached 1h), replacing the hardcoded Linea/MegaETH/Tempo special cases. Missing chains or failed fetches fall back to 3.
+- `TokenDataSource` EVM spam filtering now uses per-chain floors from Token API `GET /v1/suggestedOccurrenceFloors` (`queryApiClient.token.fetchV1SuggestedOccurrenceFloors`) instead of a hardcoded minimum of 3 occurrences. Chains missing from the response (or a failed floors fetch) still fall back to 3 ([#9537](https://github.com/MetaMask/core/pull/9537))
+- `TokensApiClient` (used by `RpcDataSource` / `TokenDetector`) now sets the token-list `occurrenceFloor` query param from the same Token API `GET /v1/suggestedOccurrenceFloors` endpoint (cached 1h), replacing the hardcoded Linea/MegaETH/Tempo special cases. Missing chains or failed fetches fall back to 3 ([#9537](https://github.com/MetaMask/core/pull/9537))
 - Bump `@metamask/network-enablement-controller` from `^5.5.0` to `^5.6.0` ([#9520](https://github.com/MetaMask/core/pull/9520))
 - Bump `@metamask/phishing-controller` from `^17.2.1` to `^17.3.0` ([#9532](https://github.com/MetaMask/core/pull/9532))
 

--- a/packages/assets-controller/src/data-sources/TokenDataSource.test.ts
+++ b/packages/assets-controller/src/data-sources/TokenDataSource.test.ts
@@ -33,6 +33,9 @@ type MockApiClient = {
     fetchTokenV2SupportedNetworks: jest.Mock;
     fetchV3Assets: jest.Mock;
   };
+  token: {
+    fetchV1SuggestedOccurrenceFloors: jest.Mock;
+  };
 };
 
 type SetupResult = {
@@ -57,6 +60,7 @@ function createTestMessenger(
 function createMockApiClient(
   supportedNetworks: string[] = ['eip155:1'],
   assetsResponse: V3AssetResponse[] = [],
+  suggestedOccurrenceFloors: Record<string, number> = { '1': 3 },
 ): MockApiClient {
   return {
     tokens: {
@@ -65,6 +69,11 @@ function createMockApiClient(
         partialSupport: [],
       }),
       fetchV3Assets: jest.fn().mockResolvedValue(assetsResponse),
+    },
+    token: {
+      fetchV1SuggestedOccurrenceFloors: jest
+        .fn()
+        .mockResolvedValue(suggestedOccurrenceFloors),
     },
   };
 }
@@ -131,15 +140,21 @@ function setupController(options: {
   supportedNetworks?: string[];
   assetsResponse?: V3AssetResponse[];
   nativeAssetIds?: string[];
+  suggestedOccurrenceFloors?: Record<string, number>;
 }): SetupResult {
   const {
     messenger,
     supportedNetworks = ['eip155:1'],
     assetsResponse = [],
     nativeAssetIds = [],
+    suggestedOccurrenceFloors = { '1': 3 },
   } = options;
 
-  const apiClient = createMockApiClient(supportedNetworks, assetsResponse);
+  const apiClient = createMockApiClient(
+    supportedNetworks,
+    assetsResponse,
+    suggestedOccurrenceFloors,
+  );
 
   const controller = new TokenDataSource(messenger, {
     queryApiClient:
@@ -806,13 +821,14 @@ describe('TokenDataSource', () => {
     const spamAsset =
       'eip155:1/erc20:0x1111111111111111111111111111111111111111' as Caip19AssetId;
 
-    const { controller } = setupController({
+    const { controller, apiClient } = setupController({
       messenger: createTestMessenger(),
       supportedNetworks: ['eip155:1'],
       assetsResponse: [
         createMockAssetResponse(MOCK_TOKEN_ASSET, { occurrences: 5 }),
         createMockAssetResponse(spamAsset, { occurrences: 1 }),
       ],
+      suggestedOccurrenceFloors: { '1': 3 },
     });
 
     const next = jest.fn().mockResolvedValue(undefined);
@@ -832,6 +848,7 @@ describe('TokenDataSource', () => {
 
     await controller.assetsMiddleware(context, next);
 
+    expect(apiClient.token.fetchV1SuggestedOccurrenceFloors).toHaveBeenCalled();
     expect(context.response.assetsInfo?.[MOCK_TOKEN_ASSET]).toBeDefined();
     expect(context.response.assetsInfo?.[spamAsset]).toBeUndefined();
 
@@ -847,6 +864,94 @@ describe('TokenDataSource', () => {
     expect(context.response.detectedAssets?.['mock-account-id']).not.toContain(
       spamAsset,
     );
+  });
+
+  it('middleware uses per-chain suggested occurrence floors from Token API', async () => {
+    // Monad (143) suggests floor 1 — a token with occurrences=1 should pass.
+    const monadToken =
+      'eip155:143/erc20:0x1111111111111111111111111111111111111111' as Caip19AssetId;
+
+    const { controller, apiClient } = setupController({
+      messenger: createTestMessenger(),
+      supportedNetworks: ['eip155:143'],
+      assetsResponse: [
+        createMockAssetResponse(monadToken, { occurrences: 1 }),
+      ],
+      suggestedOccurrenceFloors: { '1': 3, '143': 1 },
+    });
+
+    const next = jest.fn().mockResolvedValue(undefined);
+    const context = createMiddlewareContext({
+      request: createDataRequest({ chainIds: ['eip155:143' as ChainId] }),
+      response: {
+        detectedAssets: {
+          'mock-account-id': [monadToken],
+        },
+      },
+    });
+
+    await controller.assetsMiddleware(context, next);
+
+    expect(apiClient.token.fetchV1SuggestedOccurrenceFloors).toHaveBeenCalled();
+    expect(context.response.assetsInfo?.[monadToken]).toBeDefined();
+  });
+
+  it('middleware falls back to occurrence floor 3 when chain is missing from suggested floors', async () => {
+    const polygonToken =
+      'eip155:137/erc20:0x1111111111111111111111111111111111111111' as Caip19AssetId;
+
+    const { controller } = setupController({
+      messenger: createTestMessenger(),
+      supportedNetworks: ['eip155:137'],
+      assetsResponse: [
+        createMockAssetResponse(polygonToken, { occurrences: 1 }),
+      ],
+      // No entry for 137 — should use default floor 3.
+      suggestedOccurrenceFloors: { '1': 3 },
+    });
+
+    const next = jest.fn().mockResolvedValue(undefined);
+    const context = createMiddlewareContext({
+      request: createDataRequest({ chainIds: ['eip155:137' as ChainId] }),
+      response: {
+        detectedAssets: {
+          'mock-account-id': [polygonToken],
+        },
+      },
+    });
+
+    await controller.assetsMiddleware(context, next);
+
+    expect(context.response.assetsInfo?.[polygonToken]).toBeUndefined();
+  });
+
+  it('middleware falls back to occurrence floor 3 when suggested floors fetch fails', async () => {
+    const spamAsset =
+      'eip155:1/erc20:0x1111111111111111111111111111111111111111' as Caip19AssetId;
+
+    const { controller, apiClient } = setupController({
+      messenger: createTestMessenger(),
+      supportedNetworks: ['eip155:1'],
+      assetsResponse: [createMockAssetResponse(spamAsset, { occurrences: 1 })],
+    });
+
+    apiClient.token.fetchV1SuggestedOccurrenceFloors.mockRejectedValueOnce(
+      new Error('floors unavailable'),
+    );
+
+    const next = jest.fn().mockResolvedValue(undefined);
+    const context = createMiddlewareContext({
+      response: {
+        detectedAssets: {
+          'mock-account-id': [spamAsset],
+        },
+      },
+    });
+
+    await controller.assetsMiddleware(context, next);
+
+    expect(context.response.assetsInfo?.[spamAsset]).toBeUndefined();
+    expect(next).toHaveBeenCalledWith(context);
   });
 
   it('middleware bypasses occurrence filter for custom assets when state-stored ID is checksummed and API returns lower-case', async () => {

--- a/packages/assets-controller/src/data-sources/TokenDataSource.test.ts
+++ b/packages/assets-controller/src/data-sources/TokenDataSource.test.ts
@@ -874,9 +874,7 @@ describe('TokenDataSource', () => {
     const { controller, apiClient } = setupController({
       messenger: createTestMessenger(),
       supportedNetworks: ['eip155:143'],
-      assetsResponse: [
-        createMockAssetResponse(monadToken, { occurrences: 1 }),
-      ],
+      assetsResponse: [createMockAssetResponse(monadToken, { occurrences: 1 })],
       suggestedOccurrenceFloors: { '1': 3, '143': 1 },
     });
 

--- a/packages/assets-controller/src/data-sources/TokenDataSource.ts
+++ b/packages/assets-controller/src/data-sources/TokenDataSource.ts
@@ -39,10 +39,11 @@ const TOKENS_API_BATCH_SIZE = 50;
 const BULK_SCAN_BATCH_SIZE = 100;
 
 /**
- * Minimum number of aggregator occurrences required for an EVM ERC-20 token to
- * pass the spam filter. Non-EVM tokens are filtered via Blockaid bulk scan instead.
+ * Fallback minimum aggregator occurrences for EVM ERC-20 spam filtering when
+ * Token API `/v1/suggestedOccurrenceFloors` has no entry for the chain (or
+ * the floors request fails). Non-EVM tokens are filtered via Blockaid instead.
  */
-const MIN_TOKEN_OCCURRENCES = 3;
+const DEFAULT_OCCURRENCE_FLOOR = 3;
 
 /** CAIP-19 `assetNamespace` segments used across filtering logic. */
 export enum CaipAssetNamespace {
@@ -124,6 +125,26 @@ function transformV3AssetResponseToMetadata(
   return metadata;
 }
 
+/**
+ * Resolve the occurrence floor for an EVM asset from suggested floors keyed by
+ * decimal chain ID (e.g. `{ "1": 3, "143": 1 }`).
+ *
+ * @param assetId - CAIP-19 asset ID.
+ * @param floors - Map of decimal chain ID → suggested floor.
+ * @returns Floor to apply, or {@link DEFAULT_OCCURRENCE_FLOOR} when missing.
+ */
+function getOccurrenceFloorForAsset(
+  assetId: string,
+  floors: Record<string, number>,
+): number {
+  try {
+    const { chain } = parseCaipAssetType(assetId as CaipAssetType);
+    return floors[chain.reference] ?? DEFAULT_OCCURRENCE_FLOOR;
+  } catch {
+    return DEFAULT_OCCURRENCE_FLOOR;
+  }
+}
+
 // ============================================================================
 // TOKEN DATA SOURCE
 // ============================================================================
@@ -134,6 +155,8 @@ function transformV3AssetResponseToMetadata(
  * This middleware-based data source:
  * - Checks detected assets for missing metadata/images
  * - Fetches metadata from Tokens API v3 for assets needing enrichment
+ * - Filters EVM ERC-20 spam using per-chain floors from Token API
+ *   `/v1/suggestedOccurrenceFloors` (default floor 3)
  * - Merges fetched metadata into the response
  *
  * Pass the same {@link AssetsControllerMessenger} as other data sources for Blockaid
@@ -195,6 +218,26 @@ export class TokenDataSource {
     } catch (error) {
       log('Failed to fetch supported networks', { error });
       return new Set();
+    }
+  }
+
+  /**
+   * Fetches per-chain suggested occurrence floors from Token API
+   * (`GET /v1/suggestedOccurrenceFloors`). Caching is handled by
+   * ApiPlatformClient. Fails open to an empty map so callers fall back to
+   * {@link DEFAULT_OCCURRENCE_FLOOR}.
+   *
+   * @returns Map of decimal chain ID → suggested occurrence floor.
+   */
+  async #getSuggestedOccurrenceFloors(): Promise<Record<string, number>> {
+    try {
+      return await fetchWithTimeout(
+        () => this.#apiClient.token.fetchV1SuggestedOccurrenceFloors(),
+        this.#fetchTimeoutMs,
+      );
+    } catch (error) {
+      log('Failed to fetch suggested occurrence floors', { error });
+      return {};
     }
   }
 
@@ -371,8 +414,12 @@ export class TokenDataSource {
         return next(ctx);
       }
 
-      // Filter asset IDs to only include supported networks
-      const supportedNetworks = await this.#getSupportedNetworks();
+      // Filter asset IDs to only include supported networks; load per-chain
+      // occurrence floors in parallel (Token API suggested floors).
+      const [supportedNetworks, suggestedOccurrenceFloors] = await Promise.all([
+        this.#getSupportedNetworks(),
+        this.#getSuggestedOccurrenceFloors(),
+      ]);
       const supportedAssetIds = this.#filterAssetsByNetwork(
         [...assetIdsNeedingMetadata],
         supportedNetworks,
@@ -433,17 +480,19 @@ export class TokenDataSource {
           }
         }
 
-        // EVM: require minimum occurrence count to suppress low-signal tokens.
-        // Tokens with no occurrence data (undefined) are treated the same as
-        // zero occurrences and filtered out.
+        // EVM: require per-chain suggested occurrence floor (from Token API
+        // `/v1/suggestedOccurrenceFloors`, default {@link DEFAULT_OCCURRENCE_FLOOR})
+        // to suppress low-signal tokens. Tokens with no occurrence data
+        // (undefined) are treated the same as zero occurrences and filtered out.
         // Custom assets (user-imported) bypass the occurrence filter — users
         // can import whatever they want and we must keep their metadata even
-        // if the API has fewer than `MIN_TOKEN_OCCURRENCES` aggregator hits.
+        // if the API has fewer aggregator hits than the floor.
         const allowedEvmIds = new Set(
           evmErc20Ids.filter(
             (id) =>
               customAssetIds.has(id.toLowerCase()) ||
-              (occurrencesByAssetId.get(id) ?? 0) >= MIN_TOKEN_OCCURRENCES ||
+              (occurrencesByAssetId.get(id) ?? 0) >=
+                getOccurrenceFloorForAsset(id, suggestedOccurrenceFloors) ||
               id.includes(`/erc20:${MUSD_ADDRESS_LOWERCASE}`),
           ),
         );

--- a/packages/assets-controller/src/data-sources/evm-rpc-services/clients/TokensApiClient.test.ts
+++ b/packages/assets-controller/src/data-sources/evm-rpc-services/clients/TokensApiClient.test.ts
@@ -83,7 +83,10 @@ function createMockFetch(
     fullSupport?: string[];
     partialSupport?: string[];
   } = DEFAULT_SUPPORTED_NETWORKS,
-  suggestedOccurrenceFloors: Record<string, number> = DEFAULT_SUGGESTED_OCCURRENCE_FLOORS,
+  suggestedOccurrenceFloors: Record<
+    string,
+    number
+  > = DEFAULT_SUGGESTED_OCCURRENCE_FLOORS,
 ): jest.MockedFunction<typeof globalThis.fetch> {
   return jest.fn((url: string | URL) => {
     const urlString = url.toString();

--- a/packages/assets-controller/src/data-sources/evm-rpc-services/clients/TokensApiClient.test.ts
+++ b/packages/assets-controller/src/data-sources/evm-rpc-services/clients/TokensApiClient.test.ts
@@ -13,7 +13,6 @@ const MAINNET_CHAIN_ID = '0x1' as ChainId;
 const POLYGON_CHAIN_ID = '0x89' as ChainId;
 const LINEA_MAINNET_CHAIN_ID = '0xe708' as ChainId;
 const MEGAETH_MAINNET_CHAIN_ID = '0x10e6' as ChainId;
-const TEMPO_MAINNET_CHAIN_ID = '0x1079' as ChainId;
 // 0xDEF1 = 57073 decimal — intentionally absent from DEFAULT_SUPPORTED_NETWORKS
 const UNSUPPORTED_CHAIN_ID = '0xDEF1' as ChainId;
 
@@ -33,7 +32,20 @@ const DEFAULT_SUPPORTED_NETWORKS = {
   partialSupport: [
     'eip155:4326', // MEGAETH_MAINNET_CHAIN_ID (0x10e6)
     'eip155:4217', // TEMPO_MAINNET_CHAIN_ID   (0x1079)
+    'eip155:143', // Monad — used for per-chain floor tests
   ],
+};
+
+/**
+ * Default `/v1/suggestedOccurrenceFloors` payload for `createMockFetch`.
+ * Mirrors production shape (decimal chain ID → floor). Linea is 1; mainnet
+ * and polygon are 3; MegaETH/Tempo omitted so tests can assert the fallback.
+ */
+const DEFAULT_SUGGESTED_OCCURRENCE_FLOORS: Record<string, number> = {
+  '1': 3,
+  '137': 3,
+  '143': 1,
+  '59144': 1,
 };
 
 // =============================================================================
@@ -53,15 +65,16 @@ function createMockResponse(
 }
 
 /**
- * Creates a mock fetch that routes `/v2/supportedNetworks` to
- * `DEFAULT_SUPPORTED_NETWORKS` and every other URL to `tokenListResponse`.
- * This mirrors production behaviour and avoids breaking existing tests that
- * only care about the token-list response.
+ * Creates a mock fetch that routes:
+ * - `/v2/supportedNetworks` → `supportedNetworks`
+ * - `/v1/suggestedOccurrenceFloors` → `suggestedOccurrenceFloors`
+ * - everything else → `tokenListResponse`
  *
  * @param tokenListResponse - The mocked response for token-list requests.
  * @param supportedNetworks - Override for the supported-networks payload.
  * @param supportedNetworks.fullSupport - Chains with full support.
  * @param supportedNetworks.partialSupport - Chains with partial support.
+ * @param suggestedOccurrenceFloors - Override for suggested floors payload.
  * @returns A Jest mock of the global `fetch` function.
  */
 function createMockFetch(
@@ -70,13 +83,37 @@ function createMockFetch(
     fullSupport?: string[];
     partialSupport?: string[];
   } = DEFAULT_SUPPORTED_NETWORKS,
+  suggestedOccurrenceFloors: Record<string, number> = DEFAULT_SUGGESTED_OCCURRENCE_FLOORS,
 ): jest.MockedFunction<typeof globalThis.fetch> {
   return jest.fn((url: string | URL) => {
-    if (url.toString().includes('/v2/supportedNetworks')) {
+    const urlString = url.toString();
+    if (urlString.includes('/v2/supportedNetworks')) {
       return Promise.resolve(createMockResponse(supportedNetworks));
+    }
+    if (urlString.includes('/v1/suggestedOccurrenceFloors')) {
+      return Promise.resolve(createMockResponse(suggestedOccurrenceFloors));
     }
     return Promise.resolve(tokenListResponse);
   }) as unknown as jest.MockedFunction<typeof globalThis.fetch>;
+}
+
+/**
+ * Find the token-list request URL from a mock fetch (skips supported-networks
+ * and suggested-floors calls).
+ *
+ * @param mockFetch - Mocked fetch.
+ * @returns The token-list URL string.
+ */
+function getTokenListUrl(
+  mockFetch: jest.MockedFunction<typeof globalThis.fetch>,
+): string {
+  const call = (mockFetch.mock.calls as [string][]).find(([url]) =>
+    /\/tokens\/\d+/u.test(url),
+  );
+  if (call === undefined) {
+    throw new Error('Expected a /tokens/{chainId} fetch call');
+  }
+  return call[0];
 }
 
 function buildClient(config?: TokensApiClientConfig): TokensApiClient {
@@ -109,28 +146,25 @@ describe('TokensApiClient', () => {
     });
 
     it('uses the provided fetch function instead of globalThis.fetch', async () => {
-      // With routing: 1 supported-networks call + 1 token-list call = 2 total.
+      // With routing: supported-networks + floors + token-list = 3 total.
       const mockFetch = createMockFetch(createMockResponse([]));
       const client = buildClient({ fetch: mockFetch });
 
       await client.fetchTokenList(MAINNET_CHAIN_ID);
 
-      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
     });
   });
 
   describe('fetchTokenList', () => {
     describe('URL construction', () => {
-      // The supported-networks check is call[0]; the token-list request is call[1].
-
       it('hits the same `token.api.cx.metamask.io/tokens/{decimalChainId}` endpoint as TokenListController', async () => {
         const mockFetch = createMockFetch(createMockResponse([]));
         const client = buildClient({ fetch: mockFetch });
 
         await client.fetchTokenList(MAINNET_CHAIN_ID);
 
-        const [url] = mockFetch.mock.calls[1] as [string];
-        expect(url).toContain(`${EXPECTED_BASE_URL}/1?`);
+        expect(getTokenListUrl(mockFetch)).toContain(`${EXPECTED_BASE_URL}/1?`);
       });
 
       it('converts non-mainnet hex chain IDs to their decimal form in the URL', async () => {
@@ -139,8 +173,9 @@ describe('TokensApiClient', () => {
 
         await client.fetchTokenList(POLYGON_CHAIN_ID);
 
-        const [url] = mockFetch.mock.calls[1] as [string];
-        expect(url).toContain(`${EXPECTED_BASE_URL}/137?`);
+        expect(getTokenListUrl(mockFetch)).toContain(
+          `${EXPECTED_BASE_URL}/137?`,
+        );
       });
 
       it('includes the same query parameters as TokenListController', async () => {
@@ -149,7 +184,7 @@ describe('TokensApiClient', () => {
 
         await client.fetchTokenList(MAINNET_CHAIN_ID);
 
-        const [url] = mockFetch.mock.calls[1] as [string];
+        const url = getTokenListUrl(mockFetch);
         expect(url).toContain('occurrenceFloor=3');
         expect(url).toContain('includeNativeAssets=false');
         expect(url).toContain('includeTokenFees=false');
@@ -167,27 +202,72 @@ describe('TokensApiClient', () => {
 
         await client.fetchTokenList(MAINNET_CHAIN_ID);
 
-        const [url] = mockFetch.mock.calls[1] as [string];
-        expect(url).not.toMatch(/[?&]first=/u);
+        expect(getTokenListUrl(mockFetch)).not.toMatch(/[?&]first=/u);
       });
 
-      it.each([
-        ['Linea mainnet', LINEA_MAINNET_CHAIN_ID],
-        ['MegaETH mainnet', MEGAETH_MAINNET_CHAIN_ID],
-        ['Tempo mainnet', TEMPO_MAINNET_CHAIN_ID],
-      ])(
-        'lowers occurrenceFloor to 1 on %s (matching TokenListController)',
-        async (_label, chainId) => {
-          const mockFetch = createMockFetch(createMockResponse([]));
-          const client = buildClient({ fetch: mockFetch });
+      it('uses suggested occurrence floor from Token API for Linea', async () => {
+        const mockFetch = createMockFetch(createMockResponse([]));
+        const client = buildClient({ fetch: mockFetch });
 
-          await client.fetchTokenList(chainId);
+        await client.fetchTokenList(LINEA_MAINNET_CHAIN_ID);
 
-          const [url] = mockFetch.mock.calls[1] as [string];
-          expect(url).toContain('occurrenceFloor=1');
-          expect(url).not.toContain('occurrenceFloor=3');
-        },
-      );
+        const url = getTokenListUrl(mockFetch);
+        expect(url).toContain('occurrenceFloor=1');
+        expect(url).not.toContain('occurrenceFloor=3');
+      });
+
+      it('uses per-chain suggested occurrence floor (Monad → 1)', async () => {
+        const monadChainId = '0x8f' as ChainId; // 143
+        const mockFetch = createMockFetch(createMockResponse([]));
+        const client = buildClient({ fetch: mockFetch });
+
+        await client.fetchTokenList(monadChainId);
+
+        expect(getTokenListUrl(mockFetch)).toContain('occurrenceFloor=1');
+      });
+
+      it('falls back to occurrenceFloor=3 when chain is missing from suggested floors', async () => {
+        // MegaETH is supported but omitted from DEFAULT_SUGGESTED_OCCURRENCE_FLOORS.
+        const mockFetch = createMockFetch(createMockResponse([]));
+        const client = buildClient({ fetch: mockFetch });
+
+        await client.fetchTokenList(MEGAETH_MAINNET_CHAIN_ID);
+
+        expect(getTokenListUrl(mockFetch)).toContain('occurrenceFloor=3');
+      });
+
+      it('falls back to occurrenceFloor=3 when suggested floors fetch fails', async () => {
+        const mockFetch = jest.fn((url: string | URL) => {
+          const urlString = url.toString();
+          if (urlString.includes('/v2/supportedNetworks')) {
+            return Promise.resolve(
+              createMockResponse(DEFAULT_SUPPORTED_NETWORKS),
+            );
+          }
+          if (urlString.includes('/v1/suggestedOccurrenceFloors')) {
+            return Promise.reject(new Error('floors unavailable'));
+          }
+          return Promise.resolve(createMockResponse([]));
+        }) as unknown as jest.MockedFunction<typeof globalThis.fetch>;
+        const client = buildClient({ fetch: mockFetch });
+
+        await client.fetchTokenList(MAINNET_CHAIN_ID);
+
+        expect(getTokenListUrl(mockFetch)).toContain('occurrenceFloor=3');
+      });
+
+      it('caches suggested occurrence floors within TTL', async () => {
+        const mockFetch = createMockFetch(createMockResponse([]));
+        const client = buildClient({ fetch: mockFetch });
+
+        await client.fetchTokenList(MAINNET_CHAIN_ID);
+        await client.fetchTokenList(POLYGON_CHAIN_ID);
+
+        const floorsCalls = (mockFetch.mock.calls as [string][]).filter(
+          ([url]) => url.includes('/v1/suggestedOccurrenceFloors'),
+        );
+        expect(floorsCalls).toHaveLength(1);
+      });
     });
 
     describe('successful responses', () => {
@@ -682,8 +762,8 @@ describe('TokensApiClient', () => {
         const first = await client.fetchTokenList(MAINNET_CHAIN_ID);
         const second = await client.fetchTokenList(MAINNET_CHAIN_ID);
 
-        // 1 supported-networks call + 1 token-list call on first; nothing on second.
-        expect(mockFetch).toHaveBeenCalledTimes(2);
+        // supported-networks + floors + token-list on first; nothing on second.
+        expect(mockFetch).toHaveBeenCalledTimes(3);
         expect(second).toStrictEqual(first);
       });
 
@@ -695,18 +775,24 @@ describe('TokensApiClient', () => {
         await client.fetchTokenList(MAINNET_CHAIN_ID);
         await client.fetchTokenList(POLYGON_CHAIN_ID);
 
-        // 1 supported-networks + 1 mainnet token-list + 1 polygon token-list = 3
-        expect(mockFetch).toHaveBeenCalledTimes(3);
+        // supported-networks + floors + mainnet list + polygon list = 4
+        expect(mockFetch).toHaveBeenCalledTimes(4);
       });
 
       it('dedupes concurrent in-flight token-list requests for the same chain', async () => {
-        // The supported-networks call resolves immediately; the token-list
-        // response is held pending so we can assert deduplication.
+        // The supported-networks + floors calls resolve immediately; the
+        // token-list response is held pending so we can assert deduplication.
         let resolveTokenList: ((value: Response) => void) | undefined;
         const mockFetch = jest.fn((url: string | URL) => {
-          if (url.toString().includes('/v2/supportedNetworks')) {
+          const urlString = url.toString();
+          if (urlString.includes('/v2/supportedNetworks')) {
             return Promise.resolve(
               createMockResponse(DEFAULT_SUPPORTED_NETWORKS),
+            );
+          }
+          if (urlString.includes('/v1/suggestedOccurrenceFloors')) {
+            return Promise.resolve(
+              createMockResponse(DEFAULT_SUGGESTED_OCCURRENCE_FLOORS),
             );
           }
           return new Promise<Response>((resolve) => {
@@ -720,15 +806,15 @@ describe('TokensApiClient', () => {
         const a = client.fetchTokenList(MAINNET_CHAIN_ID);
         const b = client.fetchTokenList(MAINNET_CHAIN_ID);
 
-        // Yield to the event loop so the supported-networks microtasks drain
-        // and both callers reach queryClient.fetchQuery (setting resolveTokenList).
+        // Yield to the event loop so the supported-networks / floors
+        // microtasks drain and both callers reach queryClient.fetchQuery.
         await new Promise<void>((resolve) => setTimeout(resolve, 0));
 
         resolveTokenList?.(createMockResponse([]));
         await Promise.all([a, b]);
 
-        // 1 supported-networks call + 1 deduplicated token-list call = 2 total
-        expect(mockFetch).toHaveBeenCalledTimes(2);
+        // supported-networks + floors + 1 deduplicated token-list = 3
+        expect(mockFetch).toHaveBeenCalledTimes(3);
       });
 
       it('does not cap the page size in the cached path either', async () => {
@@ -738,8 +824,7 @@ describe('TokensApiClient', () => {
 
         await client.fetchTokenList(MAINNET_CHAIN_ID);
 
-        const [url] = mockFetch.mock.calls[1] as [string];
-        expect(url).not.toMatch(/[?&]first=/u);
+        expect(getTokenListUrl(mockFetch)).not.toMatch(/[?&]first=/u);
       });
 
       it('falls back to direct fetch when no queryClient is provided', async () => {
@@ -750,10 +835,10 @@ describe('TokensApiClient', () => {
         await client.fetchTokenList(MAINNET_CHAIN_ID);
 
         // Without a queryClient there is no token-list cache:
-        // call 1: 1 supported-networks + 1 token-list = 2
-        // call 2: supported-networks cached + 1 token-list = 1
-        // total = 3
-        expect(mockFetch).toHaveBeenCalledTimes(3);
+        // call 1: supported-networks + floors + token-list = 3
+        // call 2: both caches hit + 1 token-list = 1
+        // total = 4
+        expect(mockFetch).toHaveBeenCalledTimes(4);
       });
     });
   });

--- a/packages/assets-controller/src/data-sources/evm-rpc-services/clients/TokensApiClient.ts
+++ b/packages/assets-controller/src/data-sources/evm-rpc-services/clients/TokensApiClient.ts
@@ -21,6 +21,19 @@ const TOKEN_END_POINT_API = 'https://token.api.cx.metamask.io';
 const SUPPORTED_NETWORKS_URL = `${TOKEN_END_POINT_API}/v2/supportedNetworks`;
 
 /**
+ * Per-chain suggested occurrence floors used as the `occurrenceFloor` query
+ * param when fetching token lists (and aligned with TokenDataSource spam
+ * filtering). Keys are decimal chain IDs.
+ */
+const SUGGESTED_OCCURRENCE_FLOORS_URL = `${TOKEN_END_POINT_API}/v1/suggestedOccurrenceFloors`;
+
+/**
+ * Fallback `occurrenceFloor` when `/v1/suggestedOccurrenceFloors` has no entry
+ * for the chain, or the floors request fails.
+ */
+const DEFAULT_OCCURRENCE_FLOOR = 3;
+
+/**
  * How long to keep the supported-networks response in the instance-level
  * cache before refreshing it. One hour is sufficient — the list rarely
  * changes and a stale cache just means we may do an unnecessary token-list
@@ -29,30 +42,10 @@ const SUPPORTED_NETWORKS_URL = `${TOKEN_END_POINT_API}/v2/supportedNetworks`;
 const SUPPORTED_NETWORKS_CACHE_TTL_MS = 60 * 60_000;
 
 /**
- * Tempo Mainnet — not yet present in `@metamask/controller-utils`'s `ChainId`
- * map at the time of writing, so it's spelled out as a literal here exactly as
- * `TokenListController` does (see `token-service.ts:getTokensURL`).
+ * How long to keep suggested occurrence floors cached. Same TTL as supported
+ * networks — floors change infrequently.
  */
-const TEMPO_MAINNET_CHAIN_ID = '0x1079' as const;
-
-/**
- * Per-chain occurrence floor, mirroring `TokenListController.getTokensURL`:
- * Linea mainnet, MegaETH mainnet, and Tempo mainnet have thinner aggregator
- * coverage so we lower the floor; everything else uses the default 3.
- *
- * @param hexChainId - Hex chain ID.
- * @returns The occurrence floor to send to the Tokens API.
- */
-function getOccurrenceFloor(hexChainId: ChainId): number {
-  if (
-    hexChainId === ControllerChainId['linea-mainnet'] ||
-    hexChainId === ControllerChainId['megaeth-mainnet'] ||
-    hexChainId === TEMPO_MAINNET_CHAIN_ID
-  ) {
-    return 1;
-  }
-  return 3;
-}
+const SUGGESTED_OCCURRENCE_FLOORS_CACHE_TTL_MS = 60 * 60_000;
 
 /**
  * TanStack-Query cache config for the cached `fetchTokenList` path.
@@ -121,9 +114,10 @@ export type TokensApiClientConfig = {
  *
  * Fetches the per-chain ERC-20 token list from the same endpoint that
  * `TokenListController` uses (`token.api.cx.metamask.io/tokens/{chainId}`),
- * with the same query parameters and the same per-chain occurrence floor /
- * Linea aggregator filter. This keeps RPC token detection in lockstep with
- * the wallet's primary token list.
+ * with the same query parameters. The `occurrenceFloor` query param comes from
+ * Token API `/v1/suggestedOccurrenceFloors` (fallback {@link DEFAULT_OCCURRENCE_FLOOR}),
+ * matching `TokenDataSource` spam filtering. Linea's post-response aggregator
+ * filter is still applied client-side.
  *
  * Before fetching a chain's token list, the client checks
  * `/v2/supportedNetworks` and returns `[]` immediately for chains that are
@@ -151,6 +145,15 @@ export class TokensApiClient {
    * calls arrive before the first one resolves.
    */
   #supportedChainIdsRefreshPromise: Promise<void> | undefined;
+
+  /** Decimal chain ID → suggested occurrence floor from Token API. */
+  #suggestedOccurrenceFloors: Record<string, number> | undefined;
+
+  /** Timestamp of the last successful floors fetch. */
+  #suggestedOccurrenceFloorsCachedAt = 0;
+
+  /** In-flight floors request shared across concurrent callers. */
+  #suggestedOccurrenceFloorsRefreshPromise: Promise<void> | undefined;
 
   constructor(config?: TokensApiClientConfig) {
     this.#fetch = config?.fetch ?? globalThis.fetch.bind(globalThis);
@@ -250,13 +253,75 @@ export class TokensApiClient {
     return this.#supportedChainIdsRefreshPromise;
   }
 
+  /**
+   * Resolve the `occurrenceFloor` query param for a chain from Token API
+   * `/v1/suggestedOccurrenceFloors`. Falls back to
+   * {@link DEFAULT_OCCURRENCE_FLOOR} when the chain is missing or the request
+   * fails.
+   *
+   * @param hexChainId - Hex chain ID.
+   * @returns Occurrence floor to send to `/tokens/{chainId}`.
+   */
+  async #getOccurrenceFloor(hexChainId: ChainId): Promise<number> {
+    const now = Date.now();
+    if (
+      this.#suggestedOccurrenceFloors === undefined ||
+      now - this.#suggestedOccurrenceFloorsCachedAt >=
+        SUGGESTED_OCCURRENCE_FLOORS_CACHE_TTL_MS
+    ) {
+      await this.#refreshSuggestedOccurrenceFloors(now);
+    }
+
+    const decimalChainId = String(convertHexToDecimal(hexChainId));
+    return (
+      this.#suggestedOccurrenceFloors?.[decimalChainId] ??
+      DEFAULT_OCCURRENCE_FLOOR
+    );
+  }
+
+  /**
+   * Fetch `/v1/suggestedOccurrenceFloors` and update the instance cache.
+   * Concurrent callers share the in-flight Promise. Failures leave the cache
+   * empty so {@link #getOccurrenceFloor} falls back to the default.
+   *
+   * @param now - Current timestamp used to stamp the cache entry.
+   */
+  async #refreshSuggestedOccurrenceFloors(now: number): Promise<void> {
+    if (this.#suggestedOccurrenceFloorsRefreshPromise !== undefined) {
+      return this.#suggestedOccurrenceFloorsRefreshPromise;
+    }
+
+    this.#suggestedOccurrenceFloorsRefreshPromise = (async (): Promise<void> => {
+      try {
+        const response = await this.#fetch(SUGGESTED_OCCURRENCE_FLOORS_URL);
+        if (response.ok) {
+          const data = (await response.json()) as Record<string, number>;
+          this.#suggestedOccurrenceFloors =
+            data && typeof data === 'object' && !Array.isArray(data) ? data : {};
+          this.#suggestedOccurrenceFloorsCachedAt = now;
+        } else {
+          this.#suggestedOccurrenceFloors = {};
+          this.#suggestedOccurrenceFloorsCachedAt = now;
+        }
+      } catch {
+        this.#suggestedOccurrenceFloors = {};
+        this.#suggestedOccurrenceFloorsCachedAt = now;
+      } finally {
+        this.#suggestedOccurrenceFloorsRefreshPromise = undefined;
+      }
+    })();
+
+    return this.#suggestedOccurrenceFloorsRefreshPromise;
+  }
+
   async #fetchTokenListUncached(
     hexChainId: ChainId,
   ): Promise<TokenListEntry[]> {
     const decimalChainId = convertHexToDecimal(hexChainId);
-    const occurrenceFloor = getOccurrenceFloor(hexChainId);
+    const occurrenceFloor = await this.#getOccurrenceFloor(hexChainId);
 
-    // Mirrors `TokenListController.getTokensURL` exactly (token-service.ts).
+    // Same query shape as `TokenListController.getTokensURL` (token-service.ts),
+    // but `occurrenceFloor` comes from `/v1/suggestedOccurrenceFloors`.
     // No `first=...` cap — the API returns the full per-chain list bounded
     // server-side by `occurrenceFloor`.
     const url =

--- a/packages/assets-controller/src/data-sources/evm-rpc-services/clients/TokensApiClient.ts
+++ b/packages/assets-controller/src/data-sources/evm-rpc-services/clients/TokensApiClient.ts
@@ -285,6 +285,7 @@ export class TokensApiClient {
    * empty so {@link #getOccurrenceFloor} falls back to the default.
    *
    * @param now - Current timestamp used to stamp the cache entry.
+   * @returns A promise that resolves once the cache has been refreshed.
    */
   async #refreshSuggestedOccurrenceFloors(now: number): Promise<void> {
     if (this.#suggestedOccurrenceFloorsRefreshPromise !== undefined) {

--- a/packages/assets-controller/src/data-sources/evm-rpc-services/clients/TokensApiClient.ts
+++ b/packages/assets-controller/src/data-sources/evm-rpc-services/clients/TokensApiClient.ts
@@ -292,25 +292,28 @@ export class TokensApiClient {
       return this.#suggestedOccurrenceFloorsRefreshPromise;
     }
 
-    this.#suggestedOccurrenceFloorsRefreshPromise = (async (): Promise<void> => {
-      try {
-        const response = await this.#fetch(SUGGESTED_OCCURRENCE_FLOORS_URL);
-        if (response.ok) {
-          const data = (await response.json()) as Record<string, number>;
-          this.#suggestedOccurrenceFloors =
-            data && typeof data === 'object' && !Array.isArray(data) ? data : {};
-          this.#suggestedOccurrenceFloorsCachedAt = now;
-        } else {
+    this.#suggestedOccurrenceFloorsRefreshPromise =
+      (async (): Promise<void> => {
+        try {
+          const response = await this.#fetch(SUGGESTED_OCCURRENCE_FLOORS_URL);
+          if (response.ok) {
+            const data = (await response.json()) as Record<string, number>;
+            this.#suggestedOccurrenceFloors =
+              data && typeof data === 'object' && !Array.isArray(data)
+                ? data
+                : {};
+            this.#suggestedOccurrenceFloorsCachedAt = now;
+          } else {
+            this.#suggestedOccurrenceFloors = {};
+            this.#suggestedOccurrenceFloorsCachedAt = now;
+          }
+        } catch {
           this.#suggestedOccurrenceFloors = {};
           this.#suggestedOccurrenceFloorsCachedAt = now;
+        } finally {
+          this.#suggestedOccurrenceFloorsRefreshPromise = undefined;
         }
-      } catch {
-        this.#suggestedOccurrenceFloors = {};
-        this.#suggestedOccurrenceFloorsCachedAt = now;
-      } finally {
-        this.#suggestedOccurrenceFloorsRefreshPromise = undefined;
-      }
-    })();
+      })();
 
     return this.#suggestedOccurrenceFloorsRefreshPromise;
   }

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `fetchTokenListByChainId` (`token-service`) now sets the token-list `occurrenceFloor` query param from Token API `GET /v1/suggestedOccurrenceFloors` (cached 1h), replacing hardcoded Linea/MegaETH/Tempo special cases. Missing chains or failed fetches fall back to 3. This affects `TokenDetectionController` and `TokenListController`, which both use this helper ([#9537](https://github.com/MetaMask/core/pull/9537))
 - Bump `@metamask/network-enablement-controller` from `^5.5.0` to `^5.6.0` ([#9520](https://github.com/MetaMask/core/pull/9520))
 - Bump `@metamask/phishing-controller` from `^17.2.1` to `^17.3.0` ([#9532](https://github.com/MetaMask/core/pull/9532))
 - Modified native asset addresses for Stable (`988`), Rootstock (`30`) and Gnosis (`100`) in `codefi-v2.ts` ([#9386](https://github.com/MetaMask/core/pull/9386))

--- a/packages/assets-controllers/src/TokenDetectionController.test.ts
+++ b/packages/assets-controllers/src/TokenDetectionController.test.ts
@@ -39,7 +39,10 @@ import {
 } from '../../network-controller/tests/helpers';
 import { formatAggregatorNames } from './assetsUtil';
 import { MUSD_ERC20_ADDRESS_LOWER } from './constants';
-import { TOKEN_END_POINT_API } from './token-service';
+import {
+  resetSuggestedOccurrenceFloorsCacheForTesting,
+  TOKEN_END_POINT_API,
+} from './token-service';
 import type { TokenDetectionControllerMessenger } from './TokenDetectionController';
 import {
   TokenDetectionController,
@@ -231,7 +234,10 @@ describe('TokenDetectionController', () => {
   const defaultSelectedAccount = createMockInternalAccount();
 
   beforeEach(async () => {
+    resetSuggestedOccurrenceFloorsCacheForTesting();
     nock(TOKEN_END_POINT_API)
+      .get('/v1/suggestedOccurrenceFloors')
+      .reply(200, { '1': 3, '59144': 1 })
       .get(getTokensPath(ChainId.mainnet))
       .reply(200, sampleTokenList)
       .get(
@@ -4072,7 +4078,7 @@ describe('TokenDetectionController', () => {
 function getTokensPath(chainId: Hex): string {
   return `/tokens/${convertHexToDecimal(
     chainId,
-  )}?occurrenceFloor=3&includeNativeAssets=false&includeTokenFees=false&includeAssetType=false`;
+  )}?occurrenceFloor=3&includeNativeAssets=false&includeTokenFees=false&includeAssetType=false&includeERC20Permit=false&includeStorage=false&includeRwaData=true`;
 }
 
 type WithControllerCallback<ReturnValue> = ({

--- a/packages/assets-controllers/src/TokenListController.test.ts
+++ b/packages/assets-controllers/src/TokenListController.test.ts
@@ -15,7 +15,7 @@ import type {
 import type { NetworkState } from '@metamask/network-controller';
 import { StorageGetResult } from '@metamask/storage-service';
 import type { Hex } from '@metamask/utils';
-import nock from 'nock';
+import nock, { cleanAll } from 'nock';
 
 import { jestAdvanceTime } from '../../../tests/helpers';
 import {
@@ -558,10 +558,17 @@ describe('TokenListController', () => {
   beforeEach(() => {
     // Clear mock storage between tests
     mockStorage.clear();
+    tokenService.resetSuggestedOccurrenceFloorsCacheForTesting();
+    nock(tokenService.TOKEN_END_POINT_API)
+      .get('/v1/suggestedOccurrenceFloors')
+      .reply(200, { '1': 3, '59144': 1 })
+      .persist();
   });
 
   afterEach(() => {
     jest.clearAllTimers();
+    cleanAll();
+    tokenService.resetSuggestedOccurrenceFloorsCacheForTesting();
   });
 
   it('should set default state', async () => {

--- a/packages/assets-controllers/src/token-service.test.ts
+++ b/packages/assets-controllers/src/token-service.test.ts
@@ -1,7 +1,7 @@
 import { toHex } from '@metamask/controller-utils';
 import type { CaipChainId } from '@metamask/utils';
 import type { CaipAssetType } from '@metamask/utils';
-import nock from 'nock';
+import nock, { cleanAll } from 'nock';
 
 import type { SortTrendingBy } from './token-service';
 import {
@@ -10,6 +10,7 @@ import {
   fetchTokenListByChainId,
   fetchTokenMetadata,
   getTrendingTokens,
+  resetSuggestedOccurrenceFloorsCacheForTesting,
   searchTokens,
   TOKEN_END_POINT_API,
   TOKEN_METADATA_NO_SUPPORT_ERROR,
@@ -17,6 +18,30 @@ import {
 
 const ONE_MILLISECOND = 1;
 const ONE_SECOND_IN_MILLISECONDS = 1_000;
+
+/**
+ * Default `/v1/suggestedOccurrenceFloors` payload for token-list tests.
+ * Mirrors production shape (decimal chain ID → floor).
+ */
+const DEFAULT_SUGGESTED_OCCURRENCE_FLOORS: Record<string, number> = {
+  '1': 3,
+  '59144': 1,
+};
+
+/**
+ * Persist a nock for suggested occurrence floors.
+ *
+ * @param floors - Override payload; defaults to {@link DEFAULT_SUGGESTED_OCCURRENCE_FLOORS}.
+ * @returns The nock scope for the floors endpoint.
+ */
+function nockSuggestedOccurrenceFloors(
+  floors: Record<string, number> = DEFAULT_SUGGESTED_OCCURRENCE_FLOORS,
+): nock.Scope {
+  return nock(TOKEN_END_POINT_API)
+    .get('/v1/suggestedOccurrenceFloors')
+    .reply(200, floors)
+    .persist();
+}
 
 const sampleTokenList = [
   {
@@ -292,6 +317,16 @@ const polygonCaipChainId: CaipChainId = 'eip155:137';
 
 describe('Token service', () => {
   describe('fetchTokenListByChainId', () => {
+    beforeEach(() => {
+      resetSuggestedOccurrenceFloorsCacheForTesting();
+      nockSuggestedOccurrenceFloors();
+    });
+
+    afterEach(() => {
+      cleanAll();
+      resetSuggestedOccurrenceFloorsCacheForTesting();
+    });
+
     it('should call the tokens api and return the list of tokens', async () => {
       const { signal } = new AbortController();
       nock(TOKEN_END_POINT_API)
@@ -321,6 +356,74 @@ describe('Token service', () => {
       const tokens = await fetchTokenListByChainId(lineaHexChain, signal);
 
       expect(tokens).toStrictEqual(sampleTokenListLinea);
+    });
+
+    it('should use occurrenceFloor from suggestedOccurrenceFloors for the chain', async () => {
+      const { signal } = new AbortController();
+      cleanAll();
+      resetSuggestedOccurrenceFloorsCacheForTesting();
+      nockSuggestedOccurrenceFloors({ '1': 5 });
+      nock(TOKEN_END_POINT_API)
+        .get(
+          `/tokens/${sampleDecimalChainId}?occurrenceFloor=5&includeNativeAssets=false&includeTokenFees=false&includeAssetType=false&includeERC20Permit=false&includeStorage=false&includeRwaData=true`,
+        )
+        .reply(200, sampleTokenList);
+
+      const tokens = await fetchTokenListByChainId(sampleChainId, signal);
+
+      expect(tokens).toStrictEqual(sampleTokenList);
+    });
+
+    it('should fall back to occurrenceFloor 3 when the chain is missing from suggestedOccurrenceFloors', async () => {
+      const { signal } = new AbortController();
+      cleanAll();
+      resetSuggestedOccurrenceFloorsCacheForTesting();
+      nockSuggestedOccurrenceFloors({ '59144': 1 });
+      nock(TOKEN_END_POINT_API)
+        .get(
+          `/tokens/${sampleDecimalChainId}?occurrenceFloor=3&includeNativeAssets=false&includeTokenFees=false&includeAssetType=false&includeERC20Permit=false&includeStorage=false&includeRwaData=true`,
+        )
+        .reply(200, sampleTokenList);
+
+      const tokens = await fetchTokenListByChainId(sampleChainId, signal);
+
+      expect(tokens).toStrictEqual(sampleTokenList);
+    });
+
+    it('should fall back to occurrenceFloor 3 when suggestedOccurrenceFloors fails', async () => {
+      const { signal } = new AbortController();
+      cleanAll();
+      resetSuggestedOccurrenceFloorsCacheForTesting();
+      nock(TOKEN_END_POINT_API).get('/v1/suggestedOccurrenceFloors').reply(500);
+      nock(TOKEN_END_POINT_API)
+        .get(
+          `/tokens/${sampleDecimalChainId}?occurrenceFloor=3&includeNativeAssets=false&includeTokenFees=false&includeAssetType=false&includeERC20Permit=false&includeStorage=false&includeRwaData=true`,
+        )
+        .reply(200, sampleTokenList);
+
+      const tokens = await fetchTokenListByChainId(sampleChainId, signal);
+
+      expect(tokens).toStrictEqual(sampleTokenList);
+    });
+
+    it('should cache suggestedOccurrenceFloors across token list fetches', async () => {
+      const { signal } = new AbortController();
+      cleanAll();
+      resetSuggestedOccurrenceFloorsCacheForTesting();
+      const floorsScope = nock(TOKEN_END_POINT_API)
+        .get('/v1/suggestedOccurrenceFloors')
+        .reply(200, DEFAULT_SUGGESTED_OCCURRENCE_FLOORS);
+      nock(TOKEN_END_POINT_API)
+        .get(
+          `/tokens/${sampleDecimalChainId}?occurrenceFloor=3&includeNativeAssets=false&includeTokenFees=false&includeAssetType=false&includeERC20Permit=false&includeStorage=false&includeRwaData=true`,
+        )
+        .times(2)
+        .reply(200, sampleTokenList);
+
+      await fetchTokenListByChainId(sampleChainId, signal);
+      await fetchTokenListByChainId(sampleChainId, signal);
+
+      expect(floorsScope.isDone()).toBe(true);
     });
 
     it('should correctly filter linea tokens: include if has lineaTeam OR >= 3 aggregators', async () => {

--- a/packages/assets-controllers/src/token-service.ts
+++ b/packages/assets-controllers/src/token-service.ts
@@ -13,18 +13,110 @@ export const TOKEN_METADATA_NO_SUPPORT_ERROR =
   'TokenService Error: Network does not support fetchTokenMetadata';
 
 /**
+ * Per-chain suggested occurrence floors endpoint. Used as the `occurrenceFloor`
+ * query param when fetching token lists (aligned with assets-controller
+ * TokenDataSource / TokensApiClient).
+ */
+const SUGGESTED_OCCURRENCE_FLOORS_URL = `${TOKEN_END_POINT_API}/v1/suggestedOccurrenceFloors`;
+
+/**
+ * Fallback `occurrenceFloor` when `/v1/suggestedOccurrenceFloors` has no entry
+ * for the chain, or the floors request fails.
+ */
+const DEFAULT_OCCURRENCE_FLOOR = 3;
+
+/** How long to keep suggested occurrence floors cached (1 hour). */
+const SUGGESTED_OCCURRENCE_FLOORS_CACHE_TTL_MS = 60 * 60_000;
+
+/** Decimal chain ID → suggested occurrence floor. */
+let suggestedOccurrenceFloorsCache: Record<string, number> | undefined;
+
+/** Timestamp of the last successful (or failed-open) floors fetch. */
+let suggestedOccurrenceFloorsCachedAt = 0;
+
+/** In-flight floors request shared across concurrent callers. */
+let suggestedOccurrenceFloorsRefreshPromise:
+  | Promise<Record<string, number>>
+  | undefined;
+
+/**
+ * Clears the suggested occurrence floors cache. Exported for unit tests only.
+ */
+export function resetSuggestedOccurrenceFloorsCacheForTesting(): void {
+  suggestedOccurrenceFloorsCache = undefined;
+  suggestedOccurrenceFloorsCachedAt = 0;
+  suggestedOccurrenceFloorsRefreshPromise = undefined;
+}
+
+/**
+ * Fetch `/v1/suggestedOccurrenceFloors` with a 1h in-memory cache. Failures
+ * return an empty map so callers fall back to {@link DEFAULT_OCCURRENCE_FLOOR}.
+ *
+ * @returns Map of decimal chain ID → suggested occurrence floor.
+ */
+async function getSuggestedOccurrenceFloors(): Promise<Record<string, number>> {
+  const now = Date.now();
+  if (
+    suggestedOccurrenceFloorsCache !== undefined &&
+    now - suggestedOccurrenceFloorsCachedAt <
+      SUGGESTED_OCCURRENCE_FLOORS_CACHE_TTL_MS
+  ) {
+    return suggestedOccurrenceFloorsCache;
+  }
+
+  if (suggestedOccurrenceFloorsRefreshPromise !== undefined) {
+    return suggestedOccurrenceFloorsRefreshPromise;
+  }
+
+  suggestedOccurrenceFloorsRefreshPromise = (async (): Promise<
+    Record<string, number>
+  > => {
+    try {
+      const response = await fetch(SUGGESTED_OCCURRENCE_FLOORS_URL);
+      if (response.ok) {
+        const data = (await response.json()) as unknown;
+        suggestedOccurrenceFloorsCache =
+          data && typeof data === 'object' && !Array.isArray(data)
+            ? (data as Record<string, number>)
+            : {};
+      } else {
+        suggestedOccurrenceFloorsCache = {};
+      }
+    } catch {
+      suggestedOccurrenceFloorsCache = {};
+    } finally {
+      suggestedOccurrenceFloorsCachedAt = Date.now();
+      suggestedOccurrenceFloorsRefreshPromise = undefined;
+    }
+    return suggestedOccurrenceFloorsCache ?? {};
+  })();
+
+  return suggestedOccurrenceFloorsRefreshPromise;
+}
+
+/**
+ * Resolve the `occurrenceFloor` query param for a chain from Token API
+ * `/v1/suggestedOccurrenceFloors`. Falls back to
+ * {@link DEFAULT_OCCURRENCE_FLOOR} when the chain is missing or the request
+ * fails.
+ *
+ * @param chainId - Hex chain ID.
+ * @returns Occurrence floor to send to `/tokens/{chainId}`.
+ */
+async function getOccurrenceFloor(chainId: Hex): Promise<number> {
+  const floors = await getSuggestedOccurrenceFloors();
+  const decimalChainId = String(convertHexToDecimal(chainId));
+  return floors[decimalChainId] ?? DEFAULT_OCCURRENCE_FLOOR;
+}
+
+/**
  * Get the tokens URL for a specific network.
  *
  * @param chainId - The chain ID of the network the tokens requested are on.
  * @returns The tokens URL.
  */
-function getTokensURL(chainId: Hex): string {
-  const occurrenceFloor =
-    chainId === ChainId['linea-mainnet'] ||
-    chainId === ChainId['megaeth-mainnet'] ||
-    chainId === '0x1079' // Tempo Mainnet
-      ? 1
-      : 3;
+async function getTokensURL(chainId: Hex): Promise<string> {
+  const occurrenceFloor = await getOccurrenceFloor(chainId);
 
   return `${TOKEN_END_POINT_API}/tokens/${convertHexToDecimal(
     chainId,
@@ -263,7 +355,7 @@ export async function fetchTokenListByChainId(
   abortSignal: AbortSignal,
   { timeout = defaultTimeout } = {},
 ): Promise<unknown> {
-  const tokenURL = getTokensURL(chainId);
+  const tokenURL = await getTokensURL(chainId);
   const response = await queryApi(tokenURL, abortSignal, timeout);
   if (response) {
     const result = await parseJsonResponse(response);


### PR DESCRIPTION
## Explanation

UI PR: https://github.com/MetaMask/metamask-extension/pull/44525

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which ERC-20 tokens are listed or shown as assets on some chains, but behavior degrades safely to the previous default floor when the API is unavailable.
> 
> **Overview**
> EVM token **spam filtering** and **token-list fetches** now use per-chain **occurrence floors** from Token API `GET /v1/suggestedOccurrenceFloors` instead of hardcoded values (global `3`, with special-case `1` for Linea/MegaETH/Tempo).
> 
> **`TokenDataSource`** loads suggested floors in parallel with supported networks and applies them when filtering ERC-20 assets by aggregator occurrences. **`TokensApiClient`** and legacy **`token-service`** (`fetchTokenListByChainId`) set the `occurrenceFloor` query param from the same endpoint, with a **1-hour in-memory cache** and shared in-flight deduplication where applicable.
> 
> Missing chains, failed floors requests, or parse errors **fail open to floor `3`**. Custom/imported assets and existing bypasses (e.g. MUSD) are unchanged. Tests and changelogs cover per-chain floors, fallbacks, caching, and controller nock setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90a23ca678f51ca3b12a7a9d51fc10f00c43c569. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->