### PR TITLE
feat(base-data-service): Add struct option for validation

### DIFF
--- a/packages/base-data-service/CHANGELOG.md
+++ b/packages/base-data-service/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** Bump `@tanstack/query-core` from `^4.43.0` to `^5.62.16` ([#9712](https://github.com/MetaMask/core/pull/9712))
   - The option types accepted by `fetchQuery`, `fetchInfiniteQuery`, and `invalidateQueries` now follow the query-core v5 API. Subclasses need to rename `cacheTime` to `gcTime`.
   - `fetchInfiniteQuery` now requires `initialPageParam` and `getNextPageParam`, matching query-core's options for infinite queries. This also lets `TPageParam` be inferred instead of spelled out in the type parameters.
+- **BREAKING:** `fetchQuery` and `fetchInfiniteQuery` now take one more type parameter: `TDataStruct` is the third parameter and the others have been shifted up ([#9540](https://github.com/MetaMask/core/pull/9540))
 - Bump `@metamask/utils` from `^11.9.0` to `^11.11.0` ([#9074](https://github.com/MetaMask/core/pull/9074))
 - Bump `@metamask/controller-utils` from `^12.1.0` to `^12.3.0` ([#9058](https://github.com/MetaMask/core/pull/9058), [#9083](https://github.com/MetaMask/core/pull/9083), [#9218](https://github.com/MetaMask/core/pull/9218))
 - Bump `@metamask/messenger` from `^1.2.0` to `^2.0.0` ([#9392](https://github.com/MetaMask/core/pull/9392))

--- a/packages/base-data-service/CHANGELOG.md
+++ b/packages/base-data-service/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `handleWhen`
 - Export types `DataServiceActions` and `DataServiceEvents` ([#9475](https://github.com/MetaMask/core/pull/9475))
 - Add `struct` option to `fetchQuery` and `fetchInfiniteQuery` for validating query responses using Superstruct ([#9540](https://github.com/MetaMask/core/pull/9540))
-  - When provided, the struct validates the response and its type is used to infer the return type of the query method
+  - When provided, the struct is used to validate the response and for inferring the return type of the query
 
 ### Changed
 

--- a/packages/base-data-service/CHANGELOG.md
+++ b/packages/base-data-service/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `handleAll`
     - `handleWhen`
 - Export types `DataServiceActions` and `DataServiceEvents` ([#9475](https://github.com/MetaMask/core/pull/9475))
-- Add `struct` option to `fetchQuery` and `fetchInfiniteQuery` for validating query responses using Superstruct ([#9540](https://github.com/MetaMask/core/pull/9540))
+- Add `responseStruct` option to `fetchQuery` and `fetchInfiniteQuery` for validating query responses using Superstruct ([#9540](https://github.com/MetaMask/core/pull/9540))
   - When provided, the struct is used to validate the response and for inferring the return type of the query
 
 ### Changed

--- a/packages/base-data-service/CHANGELOG.md
+++ b/packages/base-data-service/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `handleAll`
     - `handleWhen`
 - Export types `DataServiceActions` and `DataServiceEvents` ([#9475](https://github.com/MetaMask/core/pull/9475))
+- Add `struct` option to `fetchQuery` and `fetchInfiniteQuery` for validating query responses using Superstruct ([#9540](https://github.com/MetaMask/core/pull/9540))
+  - When provided, the struct validates the response and its type is used to infer the return type of the query method
 
 ### Changed
 

--- a/packages/base-data-service/package.json
+++ b/packages/base-data-service/package.json
@@ -58,6 +58,7 @@
   "dependencies": {
     "@metamask/messenger": "^2.0.0",
     "@metamask/storage-service": "^1.0.2",
+    "@metamask/superstruct": "^3.1.0",
     "@metamask/utils": "^11.11.0",
     "@tanstack/query-core": "^4.43.0",
     "cockatiel": "^3.1.2",

--- a/packages/base-data-service/package.json
+++ b/packages/base-data-service/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@metamask/messenger": "^2.0.0",
     "@metamask/storage-service": "^1.0.2",
-    "@metamask/superstruct": "^3.1.0",
+    "@metamask/superstruct": "^3.4.1",
     "@metamask/utils": "^11.11.0",
     "@tanstack/query-core": "^5.62.16",
     "cockatiel": "^3.1.2",

--- a/packages/base-data-service/package.json
+++ b/packages/base-data-service/package.json
@@ -58,6 +58,7 @@
   "dependencies": {
     "@metamask/messenger": "^2.0.0",
     "@metamask/storage-service": "^1.0.2",
+    "@metamask/superstruct": "^3.1.0",
     "@metamask/utils": "^11.11.0",
     "@tanstack/query-core": "^5.62.16",
     "cockatiel": "^3.1.2",

--- a/packages/base-data-service/src/BaseDataService.test.ts
+++ b/packages/base-data-service/src/BaseDataService.test.ts
@@ -222,6 +222,35 @@ describe('BaseDataService', () => {
     expect(publishSpy).toHaveBeenCalledTimes(8);
   });
 
+  describe('validation', () => {
+    beforeAll(() => {
+      jest.useRealTimers();
+    });
+
+    afterAll(() => {
+      jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate'] });
+    });
+
+    beforeEach(() => {
+      cleanAll();
+    });
+
+    it('throws when fetchQuery response fails struct validation', async () => {
+      const messenger = new Messenger({ namespace: serviceName });
+      const service = new ExampleDataService(messenger);
+
+      mockAssets({ status: 200, body: { foo: 'bar' } });
+      mockAssets({ status: 200, body: { foo: 'bar' } });
+      mockAssets({ status: 200, body: { foo: 'bar' } });
+
+      await expect(service.getAssets(MOCK_ASSETS)).rejects.toThrow(
+        /ExampleDataService:getAssets.*returned an invalid response:/u,
+      );
+
+      service.destroy();
+    });
+  });
+
   describe('service policy', () => {
     beforeAll(() => {
       jest.useRealTimers();

--- a/packages/base-data-service/src/BaseDataService.test.ts
+++ b/packages/base-data-service/src/BaseDataService.test.ts
@@ -245,7 +245,7 @@ describe('BaseDataService', () => {
       mockAssets({ status: 200, body: { foo: 'bar' } });
 
       await expect(service.getAssets(MOCK_ASSETS)).rejects.toThrow(
-        'ExampleDataService:getAssets returned an invalid response: Expected an array value, but received: [object Object].',
+        'Query function for "ExampleDataService:getAssets" returned an unexpected response: Expected an array value, but received: [object Object].',
       );
 
       service.destroy();

--- a/packages/base-data-service/src/BaseDataService.test.ts
+++ b/packages/base-data-service/src/BaseDataService.test.ts
@@ -245,7 +245,7 @@ describe('BaseDataService', () => {
       mockAssets({ status: 200, body: { foo: 'bar' } });
 
       await expect(service.getAssets(MOCK_ASSETS)).rejects.toThrow(
-        /ExampleDataService:getAssets.*returned an invalid response:/u,
+        'ExampleDataService:getAssets returned an invalid response: Expected an array value, but received: [object Object].',
       );
 
       service.destroy();

--- a/packages/base-data-service/src/BaseDataService.test.ts
+++ b/packages/base-data-service/src/BaseDataService.test.ts
@@ -225,6 +225,35 @@ describe('BaseDataService', () => {
     expect(publishSpy).toHaveBeenCalledTimes(8);
   });
 
+  describe('validation', () => {
+    beforeAll(() => {
+      jest.useRealTimers();
+    });
+
+    afterAll(() => {
+      jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate'] });
+    });
+
+    beforeEach(() => {
+      cleanAll();
+    });
+
+    it('throws when fetchQuery response fails struct validation', async () => {
+      const messenger = new Messenger({ namespace: serviceName });
+      const service = new ExampleDataService(messenger);
+
+      mockAssets({ status: 200, body: { foo: 'bar' } });
+      mockAssets({ status: 200, body: { foo: 'bar' } });
+      mockAssets({ status: 200, body: { foo: 'bar' } });
+
+      await expect(service.getAssets(MOCK_ASSETS)).rejects.toThrow(
+        /ExampleDataService:getAssets.*returned an invalid response:/u,
+      );
+
+      service.destroy();
+    });
+  });
+
   describe('service policy', () => {
     beforeAll(() => {
       jest.useRealTimers();

--- a/packages/base-data-service/src/BaseDataService.test.ts
+++ b/packages/base-data-service/src/BaseDataService.test.ts
@@ -243,8 +243,6 @@ describe('BaseDataService', () => {
       const service = new ExampleDataService(messenger);
 
       mockAssets({ status: 200, body: { foo: 'bar' } });
-      mockAssets({ status: 200, body: { foo: 'bar' } });
-      mockAssets({ status: 200, body: { foo: 'bar' } });
 
       await expect(service.getAssets(MOCK_ASSETS)).rejects.toThrow(
         /ExampleDataService:getAssets.*returned an invalid response:/u,

--- a/packages/base-data-service/src/BaseDataService.ts
+++ b/packages/base-data-service/src/BaseDataService.ts
@@ -8,7 +8,7 @@ import type {
   StorageServiceRemoveItemAction,
   StorageServiceSetItemAction,
 } from '@metamask/storage-service';
-import { Struct, validate } from '@metamask/superstruct';
+import { Struct } from '@metamask/superstruct';
 import { Duration, inMilliseconds } from '@metamask/utils';
 import type { Json } from '@metamask/utils';
 import {
@@ -83,8 +83,8 @@ type DataServiceEvents<ServiceName extends string> =
   | DataServiceCacheUpdatedEvent<ServiceName>
   | DataServiceGranularCacheUpdatedEvent<ServiceName>;
 
-type AdditionalQueryOptions = {
-  struct?: Struct;
+type AdditionalQueryOptions<QueryFnData> = {
+  struct?: Struct<QueryFnData>;
 };
 
 // Defaults to apply to all data service queries if no default option specified
@@ -246,6 +246,7 @@ export class BaseDataService<
    *
    * @param options - The options defining the query. Keep in mind that `queryKey` and `queryFn` are required when using data services.
    * Additionally `retry` and `retryDelay` are not available, retries can be customized using the `servicePolicyOptions`.
+   * @param options.struct - An optional struct for validating the response of the query function.
    * @returns The query results.
    */
   protected async fetchQuery<
@@ -263,13 +264,14 @@ export class BaseDataService<
     >,
     'queryKey' | 'queryFn'
   > &
-    AdditionalQueryOptions): Promise<TData> {
+    AdditionalQueryOptions<TQueryFnData>): Promise<TData> {
     return this.#queryClient.fetchQuery({
       ...options,
       queryFn: (context) =>
+        // TODO: Consider if the validation should happen outside the policy executor
         this.#policy.execute(async () => {
-          const result = await options.queryFn(context);
-          return processQueryResponse(options.queryKey, result, struct);
+          const response = await options.queryFn(context);
+          return processQueryResponse(options.queryKey, response, struct);
         }),
     });
   }
@@ -279,6 +281,7 @@ export class BaseDataService<
    *
    * @param options - The options defining the query. Keep in mind that `queryKey` and `queryFn` are required when using data services.
    * Additionally `retry` and `retryDelay` are not available, retries can be customized using the `servicePolicyOptions`.
+   * @param options.struct - An optional struct for validating the response of the query function.
    * @param pageParam - An optional page parameter.
    * @returns The query result, exclusively the requested page is returned.
    */
@@ -299,7 +302,7 @@ export class BaseDataService<
       >,
       'queryKey' | 'queryFn'
     > &
-      AdditionalQueryOptions,
+      AdditionalQueryOptions<TQueryFnData>,
     pageParam?: TPageParam,
   ): Promise<TData> {
     const cache = this.#queryClient.getQueryCache();
@@ -313,12 +316,12 @@ export class BaseDataService<
         ...options,
         queryFn: (context) =>
           this.#policy.execute(async () => {
-            const result = await options.queryFn({
+            const response = await options.queryFn({
               ...context,
               pageParam: context.pageParam ?? pageParam,
             });
 
-            return processQueryResponse(options.queryKey, result, struct);
+            return processQueryResponse(options.queryKey, response, struct);
           }),
       });
 

--- a/packages/base-data-service/src/BaseDataService.ts
+++ b/packages/base-data-service/src/BaseDataService.ts
@@ -8,6 +8,7 @@ import type {
   StorageServiceRemoveItemAction,
   StorageServiceSetItemAction,
 } from '@metamask/storage-service';
+import { Struct, validate } from '@metamask/superstruct';
 import { Duration, inMilliseconds } from '@metamask/utils';
 import type { Json } from '@metamask/utils';
 import {
@@ -33,6 +34,7 @@ import {
   CreateServicePolicyOptions,
   ServicePolicy,
 } from './createServicePolicy';
+import { processQueryResponse } from './utils';
 
 // Data service queries use the following format: ['ServiceActionName', ...params]
 export type QueryKey = [string, ...Json[]];
@@ -80,6 +82,10 @@ export type DataServiceGranularCacheUpdatedEvent<ServiceName extends string> = {
 type DataServiceEvents<ServiceName extends string> =
   | DataServiceCacheUpdatedEvent<ServiceName>
   | DataServiceGranularCacheUpdatedEvent<ServiceName>;
+
+type AdditionalQueryOptions = {
+  struct?: Struct;
+};
 
 // Defaults to apply to all data service queries if no default option specified
 const QUERY_CLIENT_DEFAULTS: DefaultOptions = {
@@ -247,19 +253,24 @@ export class BaseDataService<
     TError = unknown,
     TData = TQueryFnData,
     TQueryKey extends QueryKey = QueryKey,
-  >(
-    options: WithRequired<
-      OmitKeyof<
-        FetchQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
-        'retry' | 'retryDelay'
-      >,
-      'queryKey' | 'queryFn'
+  >({
+    struct,
+    ...options
+  }: WithRequired<
+    OmitKeyof<
+      FetchQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+      'retry' | 'retryDelay'
     >,
-  ): Promise<TData> {
+    'queryKey' | 'queryFn'
+  > &
+    AdditionalQueryOptions): Promise<TData> {
     return this.#queryClient.fetchQuery({
       ...options,
       queryFn: (context) =>
-        this.#policy.execute(() => options.queryFn(context)),
+        this.#policy.execute(async () => {
+          const result = await options.queryFn(context);
+          return processQueryResponse(options.queryKey, result, struct);
+        }),
     });
   }
 
@@ -278,13 +289,17 @@ export class BaseDataService<
     TQueryKey extends QueryKey = QueryKey,
     TPageParam extends Json = Json,
   >(
-    options: WithRequired<
+    {
+      struct,
+      ...options
+    }: WithRequired<
       OmitKeyof<
         FetchInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
         'retry' | 'retryDelay'
       >,
       'queryKey' | 'queryFn'
-    >,
+    > &
+      AdditionalQueryOptions,
     pageParam?: TPageParam,
   ): Promise<TData> {
     const cache = this.#queryClient.getQueryCache();
@@ -297,12 +312,14 @@ export class BaseDataService<
       const result = await this.#queryClient.fetchInfiniteQuery({
         ...options,
         queryFn: (context) =>
-          this.#policy.execute(() =>
-            options.queryFn({
+          this.#policy.execute(async () => {
+            const result = await options.queryFn({
               ...context,
               pageParam: context.pageParam ?? pageParam,
-            }),
-          ),
+            });
+
+            return processQueryResponse(options.queryKey, result, struct);
+          }),
       });
 
       return result.pages[0];

--- a/packages/base-data-service/src/BaseDataService.ts
+++ b/packages/base-data-service/src/BaseDataService.ts
@@ -278,12 +278,12 @@ export class BaseDataService<
   }): Promise<TData> {
     return this.#queryClient.fetchQuery({
       ...options,
-      queryFn: (context) =>
-        // TODO: Consider if the validation should happen outside the policy executor
-        this.#policy.execute(async () => {
-          const response = await options.queryFn(context);
-          return processQueryResponse(options.queryKey, response, struct);
-        }),
+      queryFn: async (context) => {
+        const response = await this.#policy.execute(() =>
+          options.queryFn(context),
+        );
+        return processQueryResponse(options.queryKey, response, struct);
+      },
     });
   }
 
@@ -342,15 +342,15 @@ export class BaseDataService<
       const result = await this.#queryClient.fetchInfiniteQuery({
         ...options,
         initialPageParam: pageParam ?? options.initialPageParam,
-        queryFn: (context) =>
-          this.#policy.execute(async () => {
-            const response = await options.queryFn({
+        queryFn: async (context) => {
+          const response = await this.#policy.execute(async () =>
+            options.queryFn({
               ...context,
               pageParam: context.meta?.pageParam ?? context.pageParam,
-            });
-
-            return processQueryResponse(options.queryKey, response, struct);
-          }),
+            }),
+          );
+          return processQueryResponse(options.queryKey, response, struct);
+        },
       });
 
       return result.pages[0];

--- a/packages/base-data-service/src/BaseDataService.ts
+++ b/packages/base-data-service/src/BaseDataService.ts
@@ -101,10 +101,6 @@ export type DataServiceEvents<ServiceName extends string> =
   | DataServiceCacheUpdatedEvent<ServiceName>
   | DataServiceGranularCacheUpdatedEvent<ServiceName>;
 
-type AdditionalQueryOptions<QueryFnData> = {
-  struct?: Struct<QueryFnData>;
-};
-
 // Defaults to apply to all data service queries if no default option specified
 const QUERY_CLIENT_DEFAULTS: DefaultOptions = {
   queries: {
@@ -262,7 +258,10 @@ export class BaseDataService<
   protected async fetchQuery<
     TQueryFnData extends Json,
     TError = DefaultError,
-    TData = TQueryFnData,
+    TStruct extends Struct<TQueryFnData> | undefined = undefined,
+    TData = TStruct extends Struct<infer StructType>
+      ? StructType
+      : TQueryFnData,
     TQueryKey extends QueryKey = QueryKey,
   >({
     struct,
@@ -275,7 +274,8 @@ export class BaseDataService<
     'queryKey'
   > & {
     queryFn: QueryFunction<TQueryFnData, TQueryKey>;
-  } & AdditionalQueryOptions<TQueryFnData>): Promise<TData> {
+    struct?: TStruct;
+  }): Promise<TData> {
     return this.#queryClient.fetchQuery({
       ...options,
       queryFn: (context) =>
@@ -299,7 +299,10 @@ export class BaseDataService<
   protected async fetchInfiniteQuery<
     TQueryFnData extends Json,
     TError = DefaultError,
-    TData extends TQueryFnData = TQueryFnData,
+    TStruct extends Struct<TQueryFnData> | undefined = undefined,
+    TData extends TQueryFnData = TStruct extends Struct<infer StructType>
+      ? StructType
+      : TQueryFnData,
     TQueryKey extends QueryKey = QueryKey,
     TPageParam extends Json = Json,
   >(
@@ -321,7 +324,8 @@ export class BaseDataService<
     > &
       InfiniteQueryPageParamsOptions<TQueryFnData, TPageParam> & {
         queryFn: QueryFunction<TQueryFnData, TQueryKey, TPageParam>;
-      } & AdditionalQueryOptions<TQueryFnData>,
+        struct?: TStruct;
+      },
     pageParam?: TPageParam,
   ): Promise<TData> {
     const cache = this.#queryClient.getQueryCache();

--- a/packages/base-data-service/src/BaseDataService.ts
+++ b/packages/base-data-service/src/BaseDataService.ts
@@ -8,7 +8,7 @@ import type {
   StorageServiceRemoveItemAction,
   StorageServiceSetItemAction,
 } from '@metamask/storage-service';
-import { Struct, validate } from '@metamask/superstruct';
+import { Struct } from '@metamask/superstruct';
 import { Duration, inMilliseconds } from '@metamask/utils';
 import type { Json } from '@metamask/utils';
 import {
@@ -101,8 +101,8 @@ export type DataServiceEvents<ServiceName extends string> =
   | DataServiceCacheUpdatedEvent<ServiceName>
   | DataServiceGranularCacheUpdatedEvent<ServiceName>;
 
-type AdditionalQueryOptions = {
-  struct?: Struct;
+type AdditionalQueryOptions<QueryFnData> = {
+  struct?: Struct<QueryFnData>;
 };
 
 // Defaults to apply to all data service queries if no default option specified
@@ -256,6 +256,7 @@ export class BaseDataService<
    *
    * @param options - The options defining the query. Keep in mind that `queryKey` and `queryFn` are required when using data services.
    * Additionally `retry` and `retryDelay` are not available, retries can be customized using the `servicePolicyOptions`.
+   * @param options.struct - An optional struct for validating the response of the query function.
    * @returns The query results.
    */
   protected async fetchQuery<
@@ -274,13 +275,14 @@ export class BaseDataService<
     'queryKey'
   > & {
     queryFn: QueryFunction<TQueryFnData, TQueryKey>;
-  } & AdditionalQueryOptions): Promise<TData> {
+  } & AdditionalQueryOptions<TQueryFnData>): Promise<TData> {
     return this.#queryClient.fetchQuery({
       ...options,
       queryFn: (context) =>
+        // TODO: Consider if the validation should happen outside the policy executor
         this.#policy.execute(async () => {
-          const result = await options.queryFn(context);
-          return processQueryResponse(options.queryKey, result, struct);
+          const response = await options.queryFn(context);
+          return processQueryResponse(options.queryKey, response, struct);
         }),
     });
   }
@@ -290,6 +292,7 @@ export class BaseDataService<
    *
    * @param options - The options defining the query. Keep in mind that `queryKey` and `queryFn` are required when using data services.
    * Additionally `retry` and `retryDelay` are not available, retries can be customized using the `servicePolicyOptions`.
+   * @param options.struct - An optional struct for validating the response of the query function.
    * @param pageParam - An optional page parameter.
    * @returns The query result, exclusively the requested page is returned.
    */
@@ -318,7 +321,7 @@ export class BaseDataService<
     > &
       InfiniteQueryPageParamsOptions<TQueryFnData, TPageParam> & {
         queryFn: QueryFunction<TQueryFnData, TQueryKey, TPageParam>;
-      } & AdditionalQueryOptions,
+      } & AdditionalQueryOptions<TQueryFnData>,
     pageParam?: TPageParam,
   ): Promise<TData> {
     const cache = this.#queryClient.getQueryCache();
@@ -337,12 +340,12 @@ export class BaseDataService<
         initialPageParam: pageParam ?? options.initialPageParam,
         queryFn: (context) =>
           this.#policy.execute(async () => {
-            const result = await options.queryFn({
+            const response = await options.queryFn({
               ...context,
               pageParam: context.meta?.pageParam ?? context.pageParam,
             });
 
-            return processQueryResponse(options.queryKey, result, struct);
+            return processQueryResponse(options.queryKey, response, struct);
           }),
       });
 

--- a/packages/base-data-service/src/BaseDataService.ts
+++ b/packages/base-data-service/src/BaseDataService.ts
@@ -8,6 +8,7 @@ import type {
   StorageServiceRemoveItemAction,
   StorageServiceSetItemAction,
 } from '@metamask/storage-service';
+import { Struct, validate } from '@metamask/superstruct';
 import { Duration, inMilliseconds } from '@metamask/utils';
 import type { Json } from '@metamask/utils';
 import {
@@ -35,6 +36,7 @@ import {
   CreateServicePolicyOptions,
   ServicePolicy,
 } from './createServicePolicy.js';
+import { processQueryResponse } from './utils.js';
 
 // Data service queries use the following format: ['ServiceActionName', ...params]
 export type QueryKey = [string, ...Json[]];
@@ -98,6 +100,10 @@ export type DataServiceGranularCacheUpdatedEvent<ServiceName extends string> = {
 export type DataServiceEvents<ServiceName extends string> =
   | DataServiceCacheUpdatedEvent<ServiceName>
   | DataServiceGranularCacheUpdatedEvent<ServiceName>;
+
+type AdditionalQueryOptions = {
+  struct?: Struct;
+};
 
 // Defaults to apply to all data service queries if no default option specified
 const QUERY_CLIENT_DEFAULTS: DefaultOptions = {
@@ -257,19 +263,25 @@ export class BaseDataService<
     TError = DefaultError,
     TData = TQueryFnData,
     TQueryKey extends QueryKey = QueryKey,
-  >(
-    options: WithRequired<
-      OmitKeyof<
-        FetchQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
-        'retry' | 'retryDelay' | 'queryFn'
-      >,
-      'queryKey'
-    > & { queryFn: QueryFunction<TQueryFnData, TQueryKey> },
-  ): Promise<TData> {
+  >({
+    struct,
+    ...options
+  }: WithRequired<
+    OmitKeyof<
+      FetchQueryOptions<TQueryFnData, TError, TData, TQueryKey>,
+      'retry' | 'retryDelay' | 'queryFn'
+    >,
+    'queryKey'
+  > & {
+    queryFn: QueryFunction<TQueryFnData, TQueryKey>;
+  } & AdditionalQueryOptions): Promise<TData> {
     return this.#queryClient.fetchQuery({
       ...options,
       queryFn: (context) =>
-        this.#policy.execute(() => options.queryFn(context)),
+        this.#policy.execute(async () => {
+          const result = await options.queryFn(context);
+          return processQueryResponse(options.queryKey, result, struct);
+        }),
     });
   }
 
@@ -288,7 +300,10 @@ export class BaseDataService<
     TQueryKey extends QueryKey = QueryKey,
     TPageParam extends Json = Json,
   >(
-    options: WithRequired<
+    {
+      struct,
+      ...options
+    }: WithRequired<
       OmitKeyof<
         FetchQueryOptions<
           TQueryFnData,
@@ -303,7 +318,7 @@ export class BaseDataService<
     > &
       InfiniteQueryPageParamsOptions<TQueryFnData, TPageParam> & {
         queryFn: QueryFunction<TQueryFnData, TQueryKey, TPageParam>;
-      },
+      } & AdditionalQueryOptions,
     pageParam?: TPageParam,
   ): Promise<TData> {
     const cache = this.#queryClient.getQueryCache();
@@ -321,12 +336,14 @@ export class BaseDataService<
         ...options,
         initialPageParam: pageParam ?? options.initialPageParam,
         queryFn: (context) =>
-          this.#policy.execute(() =>
-            options.queryFn({
+          this.#policy.execute(async () => {
+            const result = await options.queryFn({
               ...context,
               pageParam: context.meta?.pageParam ?? context.pageParam,
-            }),
-          ),
+            });
+
+            return processQueryResponse(options.queryKey, result, struct);
+          }),
       });
 
       return result.pages[0];

--- a/packages/base-data-service/src/BaseDataService.ts
+++ b/packages/base-data-service/src/BaseDataService.ts
@@ -252,19 +252,19 @@ export class BaseDataService<
    *
    * @param options - The options defining the query. Keep in mind that `queryKey` and `queryFn` are required when using data services.
    * Additionally `retry` and `retryDelay` are not available, retries can be customized using the `servicePolicyOptions`.
-   * @param options.struct - An optional struct for validating the response of the query function.
+   * @param options.responseStruct - An optional struct for validating the response of the query function.
    * @returns The query results.
    */
   protected async fetchQuery<
     TQueryFnData extends Json,
     TError = DefaultError,
-    TStruct extends Struct<TQueryFnData> | undefined = undefined,
-    TData = TStruct extends Struct<infer StructType>
+    TDataStruct extends Struct<TQueryFnData> | undefined = undefined,
+    TData = TDataStruct extends Struct<infer StructType>
       ? StructType
       : TQueryFnData,
     TQueryKey extends QueryKey = QueryKey,
   >({
-    struct,
+    responseStruct,
     ...options
   }: WithRequired<
     OmitKeyof<
@@ -274,7 +274,7 @@ export class BaseDataService<
     'queryKey'
   > & {
     queryFn: QueryFunction<TQueryFnData, TQueryKey>;
-    struct?: TStruct;
+    responseStruct?: TDataStruct;
   }): Promise<TData> {
     return this.#queryClient.fetchQuery({
       ...options,
@@ -282,7 +282,7 @@ export class BaseDataService<
         const response = await this.#policy.execute(() =>
           options.queryFn(context),
         );
-        return processQueryResponse(options.queryKey, response, struct);
+        return processQueryResponse(options.queryKey, response, responseStruct);
       },
     });
   }
@@ -292,22 +292,22 @@ export class BaseDataService<
    *
    * @param options - The options defining the query. Keep in mind that `queryKey` and `queryFn` are required when using data services.
    * Additionally `retry` and `retryDelay` are not available, retries can be customized using the `servicePolicyOptions`.
-   * @param options.struct - An optional struct for validating the response of the query function.
+   * @param options.responseStruct - An optional struct for validating the response of the query function.
    * @param pageParam - An optional page parameter.
    * @returns The query result, exclusively the requested page is returned.
    */
   protected async fetchInfiniteQuery<
     TQueryFnData extends Json,
     TError = DefaultError,
-    TStruct extends Struct<TQueryFnData> | undefined = undefined,
-    TData extends TQueryFnData = TStruct extends Struct<infer StructType>
+    TDataStruct extends Struct<TQueryFnData> | undefined = undefined,
+    TData extends TQueryFnData = TDataStruct extends Struct<infer StructType>
       ? StructType
       : TQueryFnData,
     TQueryKey extends QueryKey = QueryKey,
     TPageParam extends Json = Json,
   >(
     {
-      struct,
+      responseStruct,
       ...options
     }: WithRequired<
       OmitKeyof<
@@ -324,7 +324,7 @@ export class BaseDataService<
     > &
       InfiniteQueryPageParamsOptions<TQueryFnData, TPageParam> & {
         queryFn: QueryFunction<TQueryFnData, TQueryKey, TPageParam>;
-        struct?: TStruct;
+        responseStruct?: TDataStruct;
       },
     pageParam?: TPageParam,
   ): Promise<TData> {
@@ -349,7 +349,11 @@ export class BaseDataService<
               pageParam: context.meta?.pageParam ?? context.pageParam,
             }),
           );
-          return processQueryResponse(options.queryKey, response, struct);
+          return processQueryResponse(
+            options.queryKey,
+            response,
+            responseStruct,
+          );
         },
       });
 

--- a/packages/base-data-service/src/utils.ts
+++ b/packages/base-data-service/src/utils.ts
@@ -4,7 +4,7 @@ import { QueryKey } from './BaseDataService';
 
 /**
  * Process query responses, validating them using Superstruct if a struct is defined.
- * 
+ *
  * @param queryKey - The query key.
  * @param response - The query response
  * @param struct - The struct defining the schema for the query response.

--- a/packages/base-data-service/src/utils.ts
+++ b/packages/base-data-service/src/utils.ts
@@ -1,0 +1,23 @@
+import { Struct, validate } from '@metamask/superstruct';
+
+import { QueryKey } from './BaseDataService';
+
+export function processQueryResponse<Response>(
+  queryKey: QueryKey,
+  response: Response,
+  struct?: Struct,
+) {
+  if (!struct) {
+    return response;
+  }
+
+  const [error, result] = validate(response, struct);
+
+  if (error) {
+    throw new Error(
+      `${queryKey} returned an invalid response: ${error.message}.`,
+    );
+  }
+
+  return result;
+}

--- a/packages/base-data-service/src/utils.ts
+++ b/packages/base-data-service/src/utils.ts
@@ -2,11 +2,20 @@ import { Struct, validate } from '@metamask/superstruct';
 
 import { QueryKey } from './BaseDataService';
 
+/**
+ * Process query responses, validating them using Superstruct if a struct is defined.
+ * 
+ * @param queryKey - The query key.
+ * @param response - The query response
+ * @param struct - The struct defining the schema for the query response.
+ * @returns The query response, coerced by Superstruct if needed.
+ * @throws If the query response does not match the struct.
+ */
 export function processQueryResponse<Response>(
   queryKey: QueryKey,
   response: Response,
-  struct?: Struct,
-) {
+  struct?: Struct<Response>,
+): Response {
   if (!struct) {
     return response;
   }
@@ -15,7 +24,7 @@ export function processQueryResponse<Response>(
 
   if (error) {
     throw new Error(
-      `${queryKey} returned an invalid response: ${error.message}.`,
+      `${queryKey[0]} returned an invalid response: ${error.message}.`,
     );
   }
 

--- a/packages/base-data-service/src/utils.ts
+++ b/packages/base-data-service/src/utils.ts
@@ -2,11 +2,20 @@ import { Struct, validate } from '@metamask/superstruct';
 
 import { QueryKey } from './BaseDataService';
 
+/**
+ * Process query responses, validating them using Superstruct if a struct is defined.
+ *
+ * @param queryKey - The query key.
+ * @param response - The query response
+ * @param struct - The struct defining the schema for the query response.
+ * @returns The query response, coerced by Superstruct if needed.
+ * @throws If the query response does not match the struct.
+ */
 export function processQueryResponse<Response>(
   queryKey: QueryKey,
   response: Response,
-  struct?: Struct,
-) {
+  struct?: Struct<Response>,
+): Response {
   if (!struct) {
     return response;
   }
@@ -15,7 +24,7 @@ export function processQueryResponse<Response>(
 
   if (error) {
     throw new Error(
-      `${queryKey} returned an invalid response: ${error.message}.`,
+      `${queryKey[0]} returned an invalid response: ${error.message}.`,
     );
   }
 

--- a/packages/base-data-service/src/utils.ts
+++ b/packages/base-data-service/src/utils.ts
@@ -24,7 +24,7 @@ export function processQueryResponse<Response>(
 
   if (error) {
     throw new Error(
-      `${queryKey[0]} returned an invalid response: ${error.message}.`,
+      `Query function for "${queryKey[0]}" returned an unexpected response: ${error.message}.`,
     );
   }
 

--- a/packages/base-data-service/src/utils.ts
+++ b/packages/base-data-service/src/utils.ts
@@ -1,6 +1,6 @@
 import { Struct, validate } from '@metamask/superstruct';
 
-import { QueryKey } from './BaseDataService';
+import type { QueryKey } from './BaseDataService.js';
 
 /**
  * Process query responses, validating them using Superstruct if a struct is defined.

--- a/packages/base-data-service/tests/ExampleDataService.ts
+++ b/packages/base-data-service/tests/ExampleDataService.ts
@@ -1,5 +1,12 @@
 import { Messenger } from '@metamask/messenger';
-import { CaipAssetId, Duration, inMilliseconds, Json } from '@metamask/utils';
+import { object, number, string, array } from '@metamask/superstruct';
+import {
+  CaipAssetType,
+  CaipAssetTypeStruct,
+  Duration,
+  inMilliseconds,
+  Json,
+} from '@metamask/utils';
 import { ConstantBackoff } from 'cockatiel';
 
 import {
@@ -28,11 +35,20 @@ export type ExampleMessenger = Messenger<
 >;
 
 export type GetAssetsResponse = {
-  assetId: CaipAssetId;
+  assetId: CaipAssetType;
   decimals: number;
   name: string;
   symbol: string;
-};
+}[];
+
+const GetAssetsResponseStruct = array(
+  object({
+    assetId: CaipAssetTypeStruct,
+    decimals: number(),
+    name: string(),
+    symbol: string(),
+  }),
+);
 
 export type GetActivityResponse = {
   data: Json[];
@@ -102,6 +118,7 @@ export class ExampleDataService extends BaseDataService<
       },
       staleTime: inMilliseconds(1, Duration.Day),
       cacheTime: inMilliseconds(1, Duration.Day),
+      struct: GetAssetsResponseStruct,
     });
   }
 

--- a/packages/base-data-service/tests/ExampleDataService.ts
+++ b/packages/base-data-service/tests/ExampleDataService.ts
@@ -1,5 +1,12 @@
 import { Messenger } from '@metamask/messenger';
-import { CaipAssetId, Duration, inMilliseconds, Json } from '@metamask/utils';
+import { object, number, string, array } from '@metamask/superstruct';
+import {
+  CaipAssetType,
+  CaipAssetTypeStruct,
+  Duration,
+  inMilliseconds,
+  Json,
+} from '@metamask/utils';
 import { ConstantBackoff } from 'cockatiel';
 
 import {
@@ -28,11 +35,20 @@ export type ExampleMessenger = Messenger<
 >;
 
 export type GetAssetsResponse = {
-  assetId: CaipAssetId;
+  assetId: CaipAssetType;
   decimals: number;
   name: string;
   symbol: string;
-};
+}[];
+
+const GetAssetsResponseStruct = array(
+  object({
+    assetId: CaipAssetTypeStruct,
+    decimals: number(),
+    name: string(),
+    symbol: string(),
+  }),
+);
 
 export type GetActivityResponse = {
   data: Json[];
@@ -103,6 +119,7 @@ export class ExampleDataService extends BaseDataService<
       },
       staleTime: inMilliseconds(1, Duration.Day),
       gcTime: inMilliseconds(1, Duration.Day),
+      struct: GetAssetsResponseStruct,
     });
   }
 

--- a/packages/base-data-service/tests/ExampleDataService.ts
+++ b/packages/base-data-service/tests/ExampleDataService.ts
@@ -119,7 +119,7 @@ export class ExampleDataService extends BaseDataService<
       },
       staleTime: inMilliseconds(1, Duration.Day),
       gcTime: inMilliseconds(1, Duration.Day),
-      struct: GetAssetsResponseStruct,
+      responseStruct: GetAssetsResponseStruct,
     });
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5893,6 +5893,7 @@ __metadata:
     "@metamask/auto-changelog": "npm:^6.1.0"
     "@metamask/messenger": "npm:^2.0.0"
     "@metamask/storage-service": "npm:^1.0.2"
+    "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^11.11.0"
     "@tanstack/query-core": "npm:^4.43.0"
     "@ts-bridge/cli": "npm:^0.6.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6213,6 +6213,7 @@ __metadata:
     "@metamask/auto-changelog": "npm:^6.1.0"
     "@metamask/messenger": "npm:^2.0.0"
     "@metamask/storage-service": "npm:^1.0.2"
+    "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^11.11.0"
     "@tanstack/query-core": "npm:^5.62.16"
     "@ts-bridge/cli": "npm:^0.6.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6213,7 +6213,7 @@ __metadata:
     "@metamask/auto-changelog": "npm:^6.1.0"
     "@metamask/messenger": "npm:^2.0.0"
     "@metamask/storage-service": "npm:^1.0.2"
-    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/superstruct": "npm:^3.4.1"
     "@metamask/utils": "npm:^11.11.0"
     "@tanstack/query-core": "npm:^5.62.16"
     "@ts-bridge/cli": "npm:^0.6.4"


### PR DESCRIPTION
## Explanation

Since most data services use `fetch` and `response.json()`, they can end up returning `any` without much type safety or runtime validation assuming they don't deal with this inside the data service themselves. This PR aims to improve that by introducing an optional `struct` field, when this is defined the response is validated using Superstruct (and optionally coerced) before being returned back to the caller. Additionally `TData` (and the return value) is adjusted to match the inferred type from the struct.

## References

https://consensyssoftware.atlassian.net/browse/WPC-1039

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the shared query execution path for all data services; adopters that pass `struct` will start failing queries at runtime when APIs return unexpected shapes.
> 
> **Overview**
> Adds an optional **`struct`** argument to **`fetchQuery`** and **`fetchInfiniteQuery`** so subclasses can validate (and coerce) JSON from **`queryFn`** via **`@metamask/superstruct`** before results are cached or returned. When **`struct`** is set, **`TData`** / the method return type is inferred from the struct instead of the raw query function type.
> 
> A new **`processQueryResponse`** helper runs after the service policy executes **`queryFn`**; invalid payloads throw an error that includes the query key prefix (e.g. **`ExampleDataService:getAssets returned an invalid response:`**). **`ExampleDataService.getAssets`** is updated to pass **`GetAssetsResponseStruct`**, and tests cover a failed validation path.
> 
> **`@metamask/superstruct`** is added as a runtime dependency; the changelog documents the feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51ea322aa68f3b291e8cdff2e96b694fdf5290a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->