### PR TITLE
fix: network enablement imparity

### DIFF
--- a/packages/network-enablement-controller/CHANGELOG.md
+++ b/packages/network-enablement-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove Sei Mainnet (`0x531`) from the default-enabled EVM network map, fixing a crash in consumers that call `findNetworkClientIdByChainId` for chains with no built-in `NetworkController` client ([#9542](https://github.com/MetaMask/core/pull/9542))
+
 ## [5.6.0]
 
 ### Added

--- a/packages/network-enablement-controller/src/NetworkEnablementController.test.ts
+++ b/packages/network-enablement-controller/src/NetworkEnablementController.test.ts
@@ -195,7 +195,6 @@ describe('NetworkEnablementController', () => {
           [ChainId[BuiltInNetworkName.BscMainnet]]: true,
           [ChainId[BuiltInNetworkName.OptimismMainnet]]: true,
           [ChainId[BuiltInNetworkName.PolygonMainnet]]: true,
-          [ChainId[BuiltInNetworkName.SeiMainnet]]: true,
           [ChainId[BuiltInNetworkName.MonadMainnet]]: true,
         },
         [KnownCaipNamespace.Solana]: {
@@ -255,7 +254,6 @@ describe('NetworkEnablementController', () => {
           [ChainId[BuiltInNetworkName.BscMainnet]]: true,
           [ChainId[BuiltInNetworkName.OptimismMainnet]]: true,
           [ChainId[BuiltInNetworkName.PolygonMainnet]]: true,
-          [ChainId[BuiltInNetworkName.SeiMainnet]]: true,
           [ChainId[BuiltInNetworkName.MonadMainnet]]: true,
           '0xa86a': true, // Avalanche network added and enabled (keeps current selection)
         },
@@ -324,7 +322,6 @@ describe('NetworkEnablementController', () => {
           [ChainId[BuiltInNetworkName.BscMainnet]]: true,
           [ChainId[BuiltInNetworkName.OptimismMainnet]]: true,
           [ChainId[BuiltInNetworkName.PolygonMainnet]]: true,
-          [ChainId[BuiltInNetworkName.SeiMainnet]]: true,
           [ChainId[BuiltInNetworkName.MonadMainnet]]: true,
         },
         [KnownCaipNamespace.Solana]: {
@@ -433,7 +430,6 @@ describe('NetworkEnablementController', () => {
     controller.disableNetwork('0x38'); // BSC Mainnet
     controller.disableNetwork('0xa'); // Optimism Mainnet
     controller.disableNetwork('0x89'); // Polygon Mainnet
-    controller.disableNetwork('0x531'); // Sei Mainnet
     controller.disableNetwork('0x8f'); // Monad Mainnet
 
     // Publish an update with linea network removed
@@ -471,7 +467,6 @@ describe('NetworkEnablementController', () => {
           [ChainId[BuiltInNetworkName.BscMainnet]]: false,
           [ChainId[BuiltInNetworkName.OptimismMainnet]]: false,
           [ChainId[BuiltInNetworkName.PolygonMainnet]]: false,
-          [ChainId[BuiltInNetworkName.SeiMainnet]]: false,
           [ChainId[BuiltInNetworkName.MonadMainnet]]: false,
         },
         [KnownCaipNamespace.Solana]: {
@@ -576,7 +571,6 @@ describe('NetworkEnablementController', () => {
             [ChainId[BuiltInNetworkName.BscMainnet]]: true,
             [ChainId[BuiltInNetworkName.OptimismMainnet]]: true,
             [ChainId[BuiltInNetworkName.PolygonMainnet]]: true,
-            [ChainId[BuiltInNetworkName.SeiMainnet]]: true,
             [ChainId[BuiltInNetworkName.MonadMainnet]]: true,
           },
           [KnownCaipNamespace.Solana]: {
@@ -1227,7 +1221,6 @@ describe('NetworkEnablementController', () => {
             [ChainId[BuiltInNetworkName.BscMainnet]]: true,
             [ChainId[BuiltInNetworkName.OptimismMainnet]]: true,
             [ChainId[BuiltInNetworkName.PolygonMainnet]]: true,
-            [ChainId[BuiltInNetworkName.SeiMainnet]]: true,
             [ChainId[BuiltInNetworkName.MonadMainnet]]: true,
           },
           [KnownCaipNamespace.Solana]: {
@@ -1266,7 +1259,6 @@ describe('NetworkEnablementController', () => {
             [ChainId[BuiltInNetworkName.BscMainnet]]: false, // Not in mocked config
             [ChainId[BuiltInNetworkName.OptimismMainnet]]: false, // Not in mocked config
             [ChainId[BuiltInNetworkName.PolygonMainnet]]: false, // Not in mocked config
-            [ChainId[BuiltInNetworkName.SeiMainnet]]: false, // Not in mocked config
             [ChainId[BuiltInNetworkName.MonadMainnet]]: false, // Not in mocked config
           },
           [KnownCaipNamespace.Solana]: {
@@ -1538,7 +1530,6 @@ describe('NetworkEnablementController', () => {
             [ChainId[BuiltInNetworkName.BscMainnet]]: true,
             [ChainId[BuiltInNetworkName.OptimismMainnet]]: true,
             [ChainId[BuiltInNetworkName.PolygonMainnet]]: true,
-            [ChainId[BuiltInNetworkName.SeiMainnet]]: true,
             [ChainId[BuiltInNetworkName.MonadMainnet]]: true,
           },
           [KnownCaipNamespace.Solana]: {
@@ -1577,7 +1568,6 @@ describe('NetworkEnablementController', () => {
             [ChainId[BuiltInNetworkName.BscMainnet]]: false,
             [ChainId[BuiltInNetworkName.OptimismMainnet]]: false,
             [ChainId[BuiltInNetworkName.PolygonMainnet]]: false,
-            [ChainId[BuiltInNetworkName.SeiMainnet]]: false,
             [ChainId[BuiltInNetworkName.MonadMainnet]]: false,
           },
           [KnownCaipNamespace.Solana]: {
@@ -1636,7 +1626,6 @@ describe('NetworkEnablementController', () => {
             [ChainId[BuiltInNetworkName.BscMainnet]]: false,
             [ChainId[BuiltInNetworkName.OptimismMainnet]]: false,
             [ChainId[BuiltInNetworkName.PolygonMainnet]]: false,
-            [ChainId[BuiltInNetworkName.SeiMainnet]]: false,
             [ChainId[BuiltInNetworkName.MonadMainnet]]: false,
           },
           [KnownCaipNamespace.Solana]: {
@@ -1679,7 +1668,6 @@ describe('NetworkEnablementController', () => {
             [ChainId[BuiltInNetworkName.BscMainnet]]: false,
             [ChainId[BuiltInNetworkName.OptimismMainnet]]: false,
             [ChainId[BuiltInNetworkName.PolygonMainnet]]: false,
-            [ChainId[BuiltInNetworkName.SeiMainnet]]: false,
             [ChainId[BuiltInNetworkName.MonadMainnet]]: false,
           },
           [KnownCaipNamespace.Solana]: {
@@ -1722,7 +1710,6 @@ describe('NetworkEnablementController', () => {
             [ChainId[BuiltInNetworkName.BscMainnet]]: false,
             [ChainId[BuiltInNetworkName.OptimismMainnet]]: false,
             [ChainId[BuiltInNetworkName.PolygonMainnet]]: false,
-            [ChainId[BuiltInNetworkName.SeiMainnet]]: false,
             [ChainId[BuiltInNetworkName.MonadMainnet]]: false,
           },
           [KnownCaipNamespace.Solana]: {
@@ -1776,7 +1763,6 @@ describe('NetworkEnablementController', () => {
             [ChainId[BuiltInNetworkName.BscMainnet]]: false,
             [ChainId[BuiltInNetworkName.OptimismMainnet]]: false,
             [ChainId[BuiltInNetworkName.PolygonMainnet]]: false,
-            [ChainId[BuiltInNetworkName.SeiMainnet]]: false,
             [ChainId[BuiltInNetworkName.MonadMainnet]]: false,
           },
           [KnownCaipNamespace.Solana]: {
@@ -1827,7 +1813,6 @@ describe('NetworkEnablementController', () => {
             [ChainId[BuiltInNetworkName.BscMainnet]]: false,
             [ChainId[BuiltInNetworkName.OptimismMainnet]]: false,
             [ChainId[BuiltInNetworkName.PolygonMainnet]]: false,
-            [ChainId[BuiltInNetworkName.SeiMainnet]]: false,
             [ChainId[BuiltInNetworkName.MonadMainnet]]: false,
           },
           [KnownCaipNamespace.Solana]: {
@@ -1881,7 +1866,6 @@ describe('NetworkEnablementController', () => {
             [ChainId[BuiltInNetworkName.BscMainnet]]: false,
             [ChainId[BuiltInNetworkName.OptimismMainnet]]: false,
             [ChainId[BuiltInNetworkName.PolygonMainnet]]: false,
-            [ChainId[BuiltInNetworkName.SeiMainnet]]: false,
             [ChainId[BuiltInNetworkName.MonadMainnet]]: false,
           },
           [KnownCaipNamespace.Solana]: {
@@ -1932,7 +1916,6 @@ describe('NetworkEnablementController', () => {
             [ChainId[BuiltInNetworkName.BscMainnet]]: true,
             [ChainId[BuiltInNetworkName.OptimismMainnet]]: true,
             [ChainId[BuiltInNetworkName.PolygonMainnet]]: true,
-            [ChainId[BuiltInNetworkName.SeiMainnet]]: true,
             [ChainId[BuiltInNetworkName.MonadMainnet]]: true,
           },
           [KnownCaipNamespace.Solana]: {
@@ -1985,7 +1968,6 @@ describe('NetworkEnablementController', () => {
             [ChainId[BuiltInNetworkName.BscMainnet]]: true,
             [ChainId[BuiltInNetworkName.OptimismMainnet]]: true,
             [ChainId[BuiltInNetworkName.PolygonMainnet]]: true,
-            [ChainId[BuiltInNetworkName.SeiMainnet]]: true,
             [ChainId[BuiltInNetworkName.MonadMainnet]]: true,
           },
           [KnownCaipNamespace.Solana]: {

--- a/packages/network-enablement-controller/src/NetworkEnablementController.ts
+++ b/packages/network-enablement-controller/src/NetworkEnablementController.ts
@@ -158,6 +158,9 @@ export type NetworkConfig = {
 const getDefaultNetworkEnablementControllerState =
   (): NetworkEnablementControllerState => ({
     enabledNetworkMap: {
+      // Each chain ID here must have a built-in client in NetworkController
+      // (see DEFAULT_INFURA_NETWORKS). A missing client causes
+      // findNetworkClientIdByChainId to throw silently in consumers.
       [KnownCaipNamespace.Eip155]: {
         [ChainId[BuiltInNetworkName.Mainnet]]: true,
         [ChainId[BuiltInNetworkName.LineaMainnet]]: true,

--- a/packages/network-enablement-controller/src/NetworkEnablementController.ts
+++ b/packages/network-enablement-controller/src/NetworkEnablementController.ts
@@ -166,7 +166,6 @@ const getDefaultNetworkEnablementControllerState =
         [ChainId[BuiltInNetworkName.BscMainnet]]: true,
         [ChainId[BuiltInNetworkName.OptimismMainnet]]: true,
         [ChainId[BuiltInNetworkName.PolygonMainnet]]: true,
-        [ChainId[BuiltInNetworkName.SeiMainnet]]: true,
         [ChainId[BuiltInNetworkName.MonadMainnet]]: true,
       },
       [KnownCaipNamespace.Solana]: {


### PR DESCRIPTION
## Explanation

`NetworkEnablementController`'s default state had **Sei Mainnet (`0x531`)** enabled, but `NetworkController` has no built-in client for `0x531`. This created a silent inconsistency: the enablement layer said "Sei is on" while the network layer had no idea what Sei was.

This was discovered during a performance investigation in MetaMask Mobile — `Engine.lookupEnabledNetworks()` calls `findNetworkClientIdByChainId()` for each enabled chain, which threw synchronously on `0x531` and silently crashed the entire probe. The full story and the defensive fix for existing users is in the companion PR: [MetaMask/metamask-mobile#33379](https://github.com/MetaMask/metamask-mobile/pull/33379).

This PR removes `SeiMainnet` from `getDefaultNetworkEnablementControllerState` so fresh installs start with a consistent state. Sei remains in `POPULAR_NETWORKS` and can still be added by the user. Persisted state for existing users is unchanged — only the initial default changes.

Removal rather than setting `false` is intentional: the default map should only list networks that `NetworkController` actually manages. A `false` entry would still assert an opinion about a network the controller doesn't know about.

A comment has been added above the default EVM map noting that every entry must have a corresponding built-in client in `NetworkController` (see `DEFAULT_INFURA_NETWORKS`).

## References

- Companion mobile PR (full investigation + fix for existing users): [MetaMask/metamask-mobile#33379](https://github.com/MetaMask/metamask-mobile/pull/33379)

https://consensyssoftware.atlassian.net/browse/ASSETS-3622

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small default-state fix for fresh installs; no auth or payment paths, and Sei remains available via popular networks.
> 
> **Overview**
> **Removes Sei Mainnet (`0x531`) from the default `enabledNetworkMap`** in `getDefaultNetworkEnablementControllerState` so new installs no longer mark Sei as enabled when `NetworkController` has no built-in client for that chain. That mismatch caused consumers (e.g. mobile `lookupEnabledNetworks`) to throw in `findNetworkClientIdByChainId` and fail silently.
> 
> Sei is **not** removed from `POPULAR_NETWORKS`; users can still add it manually. **Persisted** enablement for existing profiles is unchanged—only the initial default changes.
> 
> A **comment** on the default EVM map documents that each entry must have a corresponding built-in `NetworkController` client (`DEFAULT_INFURA_NETWORKS`). Tests and the package **changelog** are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0777bbafd6d5a4867006969bd28af2ac0a488a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

