### PR TITLE
fix: fetch metadata for balances missing assetsInfo

### DIFF
--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fetch token metadata for assets in `assetsBalance` that are missing `assetsInfo`
+- `TokenDataSource` now also fetches token metadata for assets present in `assetsBalance` that are missing `assetsInfo` (previously only detected assets without metadata were enriched) ([#9547](https://github.com/MetaMask/core/pull/9547))
 
 ## [11.0.0]
 

--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/network-enablement-controller` from `^5.5.0` to `^5.6.0` ([#9520](https://github.com/MetaMask/core/pull/9520))
 - Bump `@metamask/phishing-controller` from `^17.2.1` to `^17.3.0` ([#9532](https://github.com/MetaMask/core/pull/9532))
 
+### Fixed
+
+- Fetch token metadata for assets in `assetsBalance` that are missing `assetsInfo`
+
 ## [11.0.0]
 
 ### Fixed

--- a/packages/assets-controller/src/data-sources/TokenDataSource.test.ts
+++ b/packages/assets-controller/src/data-sources/TokenDataSource.test.ts
@@ -284,6 +284,34 @@ describe('TokenDataSource', () => {
     expect(next).toHaveBeenCalledWith(context);
   });
 
+  it('middleware heals metadata for balances missing assetsInfo even when not detected', async () => {
+    const { controller, apiClient } = setupController({
+      messenger: createTestMessenger(),
+      supportedNetworks: ['eip155:1'],
+      assetsResponse: [createMockAssetResponse(MOCK_TOKEN_ASSET)],
+    });
+
+    const next = jest.fn().mockResolvedValue(undefined);
+    const context = createMiddlewareContext({
+      response: {
+        assetsBalance: {
+          'mock-account-id': {
+            [MOCK_TOKEN_ASSET]: { amount: '1.5' },
+          },
+        },
+      },
+    });
+
+    await controller.assetsMiddleware(context, next);
+
+    expect(apiClient.tokens.fetchV3Assets).toHaveBeenCalledWith(
+      [MOCK_TOKEN_ASSET],
+      expect.objectContaining({ includeIconUrl: true }),
+    );
+    expect(context.response.assetsInfo?.[MOCK_TOKEN_ASSET]).toBeDefined();
+    expect(next).toHaveBeenCalledWith(context);
+  });
+
   it('middleware skips assets with existing metadata containing image in response', async () => {
     const { controller, apiClient } = setupController({
       messenger: createTestMessenger(),

--- a/packages/assets-controller/src/data-sources/TokenDataSource.ts
+++ b/packages/assets-controller/src/data-sources/TokenDataSource.ts
@@ -154,6 +154,7 @@ function getOccurrenceFloorForAsset(
  *
  * This middleware-based data source:
  * - Checks detected assets for missing metadata/images
+ * - Also checks `assetsBalance` entries missing metadata/images
  * - Fetches metadata from Tokens API v3 for assets needing enrichment
  * - Filters EVM ERC-20 spam using per-chain floors from Token API
  *   `/v1/suggestedOccurrenceFloors` (default floor 3)
@@ -351,7 +352,7 @@ export class TokenDataSource {
    *
    * This middleware:
    * 1. Extracts the response from context
-   * 2. Fetches metadata for detected assets (assets without metadata)
+   * 2. Fetches metadata for detected assets and balances missing metadata
    * 3. Enriches the response with fetched metadata
    * 4. Calls next() at the end to continue the middleware chain
    *
@@ -405,6 +406,24 @@ export class TokenDataSource {
               continue;
             }
 
+            assetIdsNeedingMetadata.add(assetId);
+          }
+        }
+      }
+
+      // Also fetch metadata for balances that are missing it
+      if (response.assetsBalance) {
+        for (const accountBalances of Object.values(response.assetsBalance)) {
+          for (const assetId of Object.keys(accountBalances)) {
+            if (response.assetsInfo?.[assetId]?.image) {
+              continue;
+            }
+            if (stateMetadata[assetId]?.image) {
+              continue;
+            }
+            if (isStakingContractAssetId(assetId)) {
+              continue;
+            }
             assetIdsNeedingMetadata.add(assetId);
           }
         }

--- a/packages/assets-controller/src/data-sources/TokenDataSource.ts
+++ b/packages/assets-controller/src/data-sources/TokenDataSource.ts
@@ -414,7 +414,9 @@ export class TokenDataSource {
       // Also fetch metadata for balances that are missing it
       if (response.assetsBalance) {
         for (const accountBalances of Object.values(response.assetsBalance)) {
-          for (const assetId of Object.keys(accountBalances)) {
+          for (const assetId of Object.keys(
+            accountBalances,
+          ) as Caip19AssetId[]) {
             if (response.assetsInfo?.[assetId]?.image) {
               continue;
             }

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add Robinhood Chain (`4663`/`0x1237`) to `SUPPORTED_NETWORKS_ACCOUNTS_API_V4` so balances and token detection use the Accounts API instead of RPC-only ([#9547](https://github.com/MetaMask/core/pull/9547))
 - Add Robinhood Chain (`4663`/`0x1237`) BalanceFetcher support for legacy single-call token detection ([#9473](https://github.com/MetaMask/core/pull/9473))
   - Add `Robinhood` in `SupportedTokenDetectionNetworks`
   - Add Robinhood BalanceFetcher address in `SINGLE_CALL_BALANCES_ADDRESS_BY_CHAINID`

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `fetchTokenListByChainId` (`token-service`) now sets the token-list `occurrenceFloor` query param from Token API `GET /v1/suggestedOccurrenceFloors` (cached 1h), replacing hardcoded Linea/MegaETH/Tempo special cases. Missing chains or failed fetches fall back to 3. This affects `TokenDetectionController` and `TokenListController`, which both use this helper ([#9547](https://github.com/MetaMask/core/pull/9547))
+- `fetchTokenListByChainId` (`token-service`) now sets the token-list `occurrenceFloor` query param from Token API `GET /v1/suggestedOccurrenceFloors` (cached 1h), replacing hardcoded Linea/MegaETH/Tempo special cases. Missing chains or failed fetches fall back to 3. This affects `TokenDetectionController` and `TokenListController`, which both use this helper ([#9537](https://github.com/MetaMask/core/pull/9537))
 - Bump `@metamask/network-enablement-controller` from `^5.5.0` to `^5.6.0` ([#9520](https://github.com/MetaMask/core/pull/9520))
 - Bump `@metamask/phishing-controller` from `^17.2.1` to `^17.3.0` ([#9532](https://github.com/MetaMask/core/pull/9532))
 - Modified native asset addresses for Stable (`988`), Rootstock (`30`) and Gnosis (`100`) in `codefi-v2.ts` ([#9386](https://github.com/MetaMask/core/pull/9386))

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `fetchTokenListByChainId` (`token-service`) now sets the token-list `occurrenceFloor` query param from Token API `GET /v1/suggestedOccurrenceFloors` (cached 1h), replacing hardcoded Linea/MegaETH/Tempo special cases. Missing chains or failed fetches fall back to 3. This affects `TokenDetectionController` and `TokenListController`, which both use this helper ([#9537](https://github.com/MetaMask/core/pull/9537))
+- `fetchTokenListByChainId` (`token-service`) now sets the token-list `occurrenceFloor` query param from Token API `GET /v1/suggestedOccurrenceFloors` (cached 1h), replacing hardcoded Linea/MegaETH/Tempo special cases. Missing chains or failed fetches fall back to 3. This affects `TokenDetectionController` and `TokenListController`, which both use this helper ([#9547](https://github.com/MetaMask/core/pull/9547))
 - Bump `@metamask/network-enablement-controller` from `^5.5.0` to `^5.6.0` ([#9520](https://github.com/MetaMask/core/pull/9520))
 - Bump `@metamask/phishing-controller` from `^17.2.1` to `^17.3.0` ([#9532](https://github.com/MetaMask/core/pull/9532))
 - Modified native asset addresses for Stable (`988`), Rootstock (`30`) and Gnosis (`100`) in `codefi-v2.ts` ([#9386](https://github.com/MetaMask/core/pull/9386))

--- a/packages/assets-controllers/src/constants.ts
+++ b/packages/assets-controllers/src/constants.ts
@@ -21,6 +21,7 @@ export const SUPPORTED_NETWORKS_ACCOUNTS_API_V4 = [
   '0x8f', // 143
   '0x3e7', // 999 HyperEVM
   '0x13b2', // 5042 Arc
+  '0x1237', // 4663 Robinhood
 ];
 
 /** Lowercase ERC-20 address for MetaMask USD (mUSD), same contract on listed chains. */


### PR DESCRIPTION
DetectionMiddleware only queues brand-new assets, so already-tracked balances without metadata never got enriched and stayed invisible in clients.

## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped enrichment and network-list changes in the assets pipeline; no auth or breaking API changes, with regression coverage for the balance-only metadata path.
> 
> **Overview**
> **Token metadata enrichment** now covers tokens that already appear in `assetsBalance` but lack `assetsInfo` (or an image), not only assets queued via `detectedAssets`. That closes a gap where tracked balances could stay invisible in clients because detection middleware only queues brand-new assets.
> 
> `TokenDataSource` middleware walks `response.assetsBalance` with the same skip rules as detection (existing image in response/state, staking contracts) and batches those asset IDs into the existing Tokens API v3 fetch.
> 
> **Robinhood Chain** (`4663` / `0x1237`) is added to `SUPPORTED_NETWORKS_ACCOUNTS_API_V4` in `@metamask/assets-controllers` so balances and token detection use the Accounts API instead of RPC-only paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7e9195203fdb82039c2bc935251ec950007a4dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->