### PR TITLE
chore: Add FollowTrader to MetaMetricsSwapsEventSource

### DIFF
--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added `FollowTrader` value to `MetaMetricsSwapsEventSource` enum for attributing swap and bridge flows to the follow trader entry point ([#TBD](https://github.com/MetaMask/core/pull/TBD))
+- Added `FollowTrader` value to `MetaMetricsSwapsEventSource` enum for attributing swap and bridge flows to the follow trader entry point ([#9552](https://github.com/MetaMask/core/pull/9552))
 
 ## [77.5.0]
 

--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added `TopTraders` value to `MetaMetricsSwapsEventSource` enum for attributing swap and bridge flows to the top traders entry point ([#TBD](https://github.com/MetaMask/core/pull/TBD))
+- Added `FollowTrader` value to `MetaMetricsSwapsEventSource` enum for attributing swap and bridge flows to the follow trader entry point ([#TBD](https://github.com/MetaMask/core/pull/TBD))
 
 ## [77.5.0]
 

--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `TopTraders` value to `MetaMetricsSwapsEventSource` enum for attributing swap and bridge flows to the top traders entry point ([#TBD](https://github.com/MetaMask/core/pull/TBD))
+
 ## [77.5.0]
 
 ### Added

--- a/packages/bridge-controller/src/utils/metrics/constants.ts
+++ b/packages/bridge-controller/src/utils/metrics/constants.ts
@@ -63,6 +63,7 @@ export enum MetaMetricsSwapsEventSource {
   TokenView = 'Token View',
   TrendingExplore = 'Trending Explore',
   Rewards = 'Rewards',
+  TopTraders = 'Top Traders',
   ActivityTabEmptyState = 'Activity Tab Empty State',
   TransactionShield = 'Transaction Shield',
   TransactionDetails = 'Transaction Details',

--- a/packages/bridge-controller/src/utils/metrics/constants.ts
+++ b/packages/bridge-controller/src/utils/metrics/constants.ts
@@ -63,7 +63,7 @@ export enum MetaMetricsSwapsEventSource {
   TokenView = 'Token View',
   TrendingExplore = 'Trending Explore',
   Rewards = 'Rewards',
-  TopTraders = 'Top Traders',
+  FollowTrader = 'Follow Trader',
   ActivityTabEmptyState = 'Activity Tab Empty State',
   TransactionShield = 'Transaction Shield',
   TransactionDetails = 'Transaction Details',


### PR DESCRIPTION
## Explanation

Adds `FollowTrader ` to the `MetaMetricsSwapsEventSource` enum in bridge-controller to support attributing swap/bridge flows initiated from the top traders entry point

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e34cd713ca4b44a02dcb79e639ca6df0a199b0ec. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->