### PR TITLE
perf(assets-controller): memoize hot-path asset ID and legacy format converters

### DIFF
--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Memoize hot-path asset ID / legacy-format conversions to cut repeated keccak256 (`toChecksumAddress`) and CAIP parsing
+  - `normalizeAssetId` uses lodash `memoize` so already-normalized IDs skip re-checksumming across the pipeline
+  - `formatExchangeRatesForBridge` caches the last result on input identity (`===` for BaseController slices, lodash `isEqual` for rebuilt native maps); exports `FormatExchangeRatesForBridgeParams`
+  - `formatStateForTransactionPay` caches the last result the same way (`isEqual` for rebuilt `accounts` / `nativeAssetIdentifiers`); exports `FormatStateForTransactionPayParams`
+  - `#getNativeAssetMap` returns a stable empty object when uncached so memoized formatters are not busted by `?? {}` identity churn
 - `TokenDataSource` EVM spam filtering now uses per-chain floors from Token API `GET /v1/suggestedOccurrenceFloors` (`queryApiClient.token.fetchV1SuggestedOccurrenceFloors`) instead of a hardcoded minimum of 3 occurrences. Chains missing from the response (or a failed floors fetch) still fall back to 3 ([#9537](https://github.com/MetaMask/core/pull/9537))
 - `TokensApiClient` (used by `RpcDataSource` / `TokenDetector`) now sets the token-list `occurrenceFloor` query param from the same Token API `GET /v1/suggestedOccurrenceFloors` endpoint (cached 1h), replacing the hardcoded Linea/MegaETH/Tempo special cases. Missing chains or failed fetches fall back to 3 ([#9537](https://github.com/MetaMask/core/pull/9537))
 - Bump `@metamask/network-enablement-controller` from `^5.5.0` to `^5.6.0` ([#9520](https://github.com/MetaMask/core/pull/9520))

--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Memoize hot-path asset ID / legacy-format conversions to cut repeated keccak256 (`toChecksumAddress`) and CAIP parsing
+- Memoize hot-path asset ID / legacy-format conversions to cut repeated keccak256 (`toChecksumAddress`) and CAIP parsing ([#9555](https://github.com/MetaMask/core/pull/9555))
   - `normalizeAssetId` uses lodash `memoize` so already-normalized IDs skip re-checksumming across the pipeline
   - `formatExchangeRatesForBridge` caches the last result on input identity (`===` for BaseController slices, lodash `isEqual` for rebuilt native maps); exports `FormatExchangeRatesForBridgeParams`
   - `formatStateForTransactionPay` caches the last result the same way (`isEqual` for rebuilt `accounts` / `nativeAssetIdentifiers`); exports `FormatStateForTransactionPayParams`

--- a/packages/assets-controller/src/AssetsController.ts
+++ b/packages/assets-controller/src/AssetsController.ts
@@ -151,6 +151,9 @@ import { processAccountActivityBalanceUpdates } from './utils/processAccountActi
 
 const NATIVE_ASSETS_QUERY_KEY = ['nativeAssets'];
 
+/** Stable empty map so memoized formatters are not busted by `?? {}` identity churn. */
+const EMPTY_NATIVE_ASSET_MAP: Record<ChainId, Caip19AssetId> = {};
+
 // ============================================================================
 // PENDING TOKEN METADATA (UI input format for addCustomAsset)
 // ============================================================================
@@ -2246,13 +2249,14 @@ export class AssetsController extends BaseController<
    * Reads the native asset map (CAIP-2 chain ID -> CAIP-19 native asset ID)
    * from the QueryClient cache. Populated at construction via fetchQuery.
    *
-   * @returns Cached map, or empty object if not yet populated.
+   * @returns Cached map, or a stable empty object if not yet populated
+   * (stable identity so downstream memoized formatters can cache-hit).
    */
   #getNativeAssetMap(): Record<ChainId, Caip19AssetId> {
     return (
       this.#queryApiClient.getCachedData<Record<ChainId, Caip19AssetId>>(
         NATIVE_ASSETS_QUERY_KEY,
-      ) ?? {}
+      ) ?? EMPTY_NATIVE_ASSET_MAP
     );
   }
 

--- a/packages/assets-controller/src/index.ts
+++ b/packages/assets-controller/src/index.ts
@@ -178,6 +178,8 @@ export {
 export type {
   AccountForLegacyFormat,
   BridgeExchangeRatesFormat,
+  FormatExchangeRatesForBridgeParams,
+  FormatStateForTransactionPayParams,
   LegacyToken,
   TransactionPayLegacyFormat,
 } from './utils';

--- a/packages/assets-controller/src/utils/formatExchangeRatesForBridge.test.ts
+++ b/packages/assets-controller/src/utils/formatExchangeRatesForBridge.test.ts
@@ -1,5 +1,8 @@
 import type { AssetMetadata, FungibleAssetPrice } from '../types';
-import { formatExchangeRatesForBridge } from './formatExchangeRatesForBridge';
+import {
+  clearFormatExchangeRatesForBridgeCacheForTesting,
+  formatExchangeRatesForBridge,
+} from './formatExchangeRatesForBridge';
 
 /**
  * Builds minimal AssetPrice for tests. Defaults usdPrice to the same
@@ -389,5 +392,67 @@ describe('formatExchangeRatesForBridge', () => {
     expect(result.conversionRates[bitcoinAssetId].currency).toBe(
       'swift:0/iso4217:EUR',
     );
+  });
+
+  describe('memoization', () => {
+    afterEach(() => {
+      clearFormatExchangeRatesForBridgeCacheForTesting();
+    });
+
+    it('returns the same object when inputs are unchanged by identity / value', () => {
+      const assetsInfo = {};
+      const assetsPrice = {
+        'bip122:000000000019d6689c085ae165831e93/slip44:0': price({
+          price: 50000,
+        }),
+      };
+      const params = {
+        assetsInfo,
+        assetsPrice,
+        selectedCurrency: 'usd',
+        nativeAssetIdentifiers: {},
+        networkConfigurationsByChainId: EVM_NETWORK_CONFIGS,
+      };
+
+      const first = formatExchangeRatesForBridge(params);
+      const second = formatExchangeRatesForBridge({
+        ...params,
+        // Rebuilt but deeply equal native map should still hit cache
+        nativeAssetIdentifiers: {},
+      });
+
+      expect(second).toBe(first);
+    });
+
+    it('recomputes when assetsPrice identity changes', () => {
+      const assetsInfo = {};
+      const first = formatExchangeRatesForBridge({
+        assetsInfo,
+        assetsPrice: {
+          'bip122:000000000019d6689c085ae165831e93/slip44:0': price({
+            price: 50000,
+          }),
+        },
+        selectedCurrency: 'usd',
+        nativeAssetIdentifiers: {},
+      });
+      const second = formatExchangeRatesForBridge({
+        assetsInfo,
+        assetsPrice: {
+          'bip122:000000000019d6689c085ae165831e93/slip44:0': price({
+            price: 51000,
+          }),
+        },
+        selectedCurrency: 'usd',
+        nativeAssetIdentifiers: {},
+      });
+
+      expect(second).not.toBe(first);
+      expect(
+        second.conversionRates[
+          'bip122:000000000019d6689c085ae165831e93/slip44:0'
+        ].rate,
+      ).toBe('51000');
+    });
   });
 });

--- a/packages/assets-controller/src/utils/formatExchangeRatesForBridge.ts
+++ b/packages/assets-controller/src/utils/formatExchangeRatesForBridge.ts
@@ -9,6 +9,7 @@ import {
 } from '@metamask/assets-controllers';
 import { Hex, KnownCaipNamespace, numberToHex } from '@metamask/utils';
 import { parseCaipAssetType, parseCaipChainId } from '@metamask/utils';
+import { isEqual } from 'lodash';
 
 import type {
   AssetMetadata,
@@ -29,27 +30,73 @@ export type BridgeExchangeRatesFormat = {
   currentCurrency: string;
 };
 
+/** Parameters accepted by {@link formatExchangeRatesForBridge}. */
+export type FormatExchangeRatesForBridgeParams = {
+  assetsInfo: Record<string, AssetMetadata>;
+  assetsPrice: Record<string, AssetPrice>;
+  selectedCurrency: string;
+  nativeAssetIdentifiers: Record<string, string>;
+  networkConfigurationsByChainId?: Record<string, { nativeCurrency?: string }>;
+};
+
+let lastCall: {
+  params: FormatExchangeRatesForBridgeParams;
+  result: BridgeExchangeRatesFormat;
+} | null = null;
+
 /**
  * Converts AssetsController state (assetsPrice, selectedCurrency) into the
  * same format the bridge expects from MultichainAssetsRatesController,
  * CurrencyRateController, and TokenRatesController so the bridge can use
  * a single action when useAssetsControllerForRates is true.
  *
+ * Memoized on input identity for BaseController state slices (`===`) and
+ * lodash `isEqual` for rebuilt maps (`nativeAssetIdentifiers`). Bridge quote
+ * / rate paths call this repeatedly while assets state is unchanged; recomputing
+ * runs keccak256 (`toChecksumAddress`) and CAIP parsing per priced asset.
+ *
  * @param params - Conversion parameters.
- * @param params.assetsInfo - Metadata map keyed by CAIP-19 asset ID; used to determine native assets via `type === 'native'`.
- * @param params.assetsPrice - Map of CAIP-19 asset ID to price data (must include both `price` and `usdPrice`).
- * @param params.selectedCurrency - ISO 4217 currency code (e.g. 'usd').
- * @param params.nativeAssetIdentifiers - Map of CAIP-2 chain ID to native asset ID. Used for EVM native lookups.
- * @param params.networkConfigurationsByChainId - Optional map of Hex chain ID to network config (e.g. from NetworkController state). Used to resolve native currency symbol via `nativeCurrency`; keys are Hex (e.g. '0x1').
  * @returns Bridge-compatible conversionRates, currencyRates, marketData, currentCurrency.
  */
-export function formatExchangeRatesForBridge(params: {
-  assetsInfo: Record<string, AssetMetadata>;
-  assetsPrice: Record<string, AssetPrice>;
-  selectedCurrency: string;
-  nativeAssetIdentifiers: Record<string, string>;
-  networkConfigurationsByChainId?: Record<string, { nativeCurrency?: string }>;
-}): BridgeExchangeRatesFormat {
+export function formatExchangeRatesForBridge(
+  params: FormatExchangeRatesForBridgeParams,
+): BridgeExchangeRatesFormat {
+  if (
+    lastCall?.params.assetsInfo === params.assetsInfo &&
+    lastCall.params.assetsPrice === params.assetsPrice &&
+    lastCall.params.selectedCurrency === params.selectedCurrency &&
+    lastCall.params.networkConfigurationsByChainId ===
+      params.networkConfigurationsByChainId &&
+    isEqual(
+      lastCall.params.nativeAssetIdentifiers,
+      params.nativeAssetIdentifiers,
+    )
+  ) {
+    return lastCall.result;
+  }
+
+  const result = computeExchangeRatesForBridge(params);
+  lastCall = { params, result };
+  return result;
+}
+
+/**
+ * Clears the {@link formatExchangeRatesForBridge} memoize cache. Exported for tests.
+ */
+export function clearFormatExchangeRatesForBridgeCacheForTesting(): void {
+  lastCall = null;
+}
+
+/**
+ * Performs the actual exchange-rate conversion for
+ * {@link formatExchangeRatesForBridge}.
+ *
+ * @param params - Conversion parameters.
+ * @returns Bridge-compatible rates.
+ */
+function computeExchangeRatesForBridge(
+  params: FormatExchangeRatesForBridgeParams,
+): BridgeExchangeRatesFormat {
   const {
     assetsInfo,
     assetsPrice,

--- a/packages/assets-controller/src/utils/formatStateForTransactionPay.test.ts
+++ b/packages/assets-controller/src/utils/formatStateForTransactionPay.test.ts
@@ -1,5 +1,6 @@
 import type { AssetBalance, AssetMetadata, FungibleAssetPrice } from '../types';
 import {
+  clearFormatStateForTransactionPayCacheForTesting,
   formatStateForTransactionPay,
   AccountForLegacyFormat,
 } from './formatStateForTransactionPay';
@@ -381,5 +382,75 @@ describe('formatStateForTransactionPay', () => {
     expect(
       result.allTokens['0x1'][''].find((token) => token.symbol === 'X'),
     ).toBeUndefined();
+  });
+
+  describe('memoization', () => {
+    afterEach(() => {
+      clearFormatStateForTransactionPayCacheForTesting();
+    });
+
+    it('returns the same object when inputs are unchanged by identity / value', () => {
+      const assetsBalance = {
+        [ACCOUNT_1.id]: {
+          [ETH_NATIVE_ID]: { amount: '100' } as AssetBalance,
+        },
+      };
+      const assetsInfo = {
+        [ETH_NATIVE_ID]: ETH_NATIVE_METADATA,
+      };
+      const assetsPrice = {};
+      const params = {
+        accounts: [ACCOUNT_1],
+        assetsBalance,
+        assetsInfo,
+        assetsPrice,
+        selectedCurrency: 'usd',
+        nativeAssetIdentifiers: EVM_NATIVE_IDS,
+        networkConfigurationsByChainId: EVM_NETWORK_CONFIGS,
+      };
+
+      const first = formatStateForTransactionPay(params);
+      const second = formatStateForTransactionPay({
+        ...params,
+        accounts: [{ ...ACCOUNT_1 }],
+        nativeAssetIdentifiers: { ...EVM_NATIVE_IDS },
+      });
+
+      expect(second).toBe(first);
+    });
+
+    it('recomputes when assetsBalance identity changes', () => {
+      const assetsInfo = {
+        [ETH_NATIVE_ID]: ETH_NATIVE_METADATA,
+      };
+      const first = formatStateForTransactionPay({
+        accounts: [ACCOUNT_1],
+        assetsBalance: {
+          [ACCOUNT_1.id]: {
+            [ETH_NATIVE_ID]: { amount: '100' } as AssetBalance,
+          },
+        },
+        assetsInfo,
+        assetsPrice: {},
+        selectedCurrency: 'usd',
+        nativeAssetIdentifiers: EVM_NATIVE_IDS,
+        networkConfigurationsByChainId: EVM_NETWORK_CONFIGS,
+      });
+      const second = formatStateForTransactionPay({
+        accounts: [ACCOUNT_1],
+        assetsBalance: {
+          [ACCOUNT_1.id]: {
+            [ETH_NATIVE_ID]: { amount: '200' } as AssetBalance,
+          },
+        },
+        assetsInfo,
+        assetsPrice: {},
+        selectedCurrency: 'usd',
+        nativeAssetIdentifiers: EVM_NATIVE_IDS,
+        networkConfigurationsByChainId: EVM_NETWORK_CONFIGS,
+      });
+
+      expect(second).not.toBe(first);
+    });
   });
 });

--- a/packages/assets-controller/src/utils/formatStateForTransactionPay.ts
+++ b/packages/assets-controller/src/utils/formatStateForTransactionPay.ts
@@ -2,6 +2,7 @@ import { toChecksumAddress } from '@ethereumjs/util';
 import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import { numberToHex } from '@metamask/utils';
 import { parseCaipAssetType, parseCaipChainId } from '@metamask/utils';
+import { isEqual } from 'lodash';
 
 import type {
   AssetBalance,
@@ -49,6 +50,22 @@ export type TransactionPayLegacyFormat = {
   currentCurrency: string;
 };
 
+/** Parameters accepted by {@link formatStateForTransactionPay}. */
+export type FormatStateForTransactionPayParams = {
+  assetsBalance: Record<string, Record<string, AssetBalance>>;
+  assetsInfo: Record<string, AssetMetadata>;
+  assetsPrice: Record<string, AssetPrice>;
+  selectedCurrency: string;
+  accounts: AccountForLegacyFormat[];
+  nativeAssetIdentifiers: Record<string, string>;
+  networkConfigurationsByChainId?: Record<string, { nativeCurrency?: string }>;
+};
+
+let lastCall: {
+  params: FormatStateForTransactionPayParams;
+  result: TransactionPayLegacyFormat;
+} | null = null;
+
 function amountToHex(amount: string): `0x${string}` {
   const hexString = BigInt(amount).toString(16);
   return `0x${hexString}`;
@@ -65,25 +82,57 @@ function getAmountFromBalance(balance: AssetBalance): string {
  * transaction-pay-controller (TokenBalancesController, AccountTrackerController,
  * TokensController, TokenRatesController, CurrencyRateController shapes).
  *
+ * Memoized on input identity for BaseController state slices (`===`) and
+ * lodash `isEqual` for rebuilt arrays/maps (`accounts`, `nativeAssetIdentifiers`).
+ * `AssetsController:getStateForTransactionPay` is invoked on every
+ * `TransactionController:stateChange` while its inputs only change when the
+ * assets pipeline updates; recomputing runs keccak256 (`toChecksumAddress`) and
+ * CAIP parsing per asset.
+ *
  * @param params - Conversion parameters.
- * @param params.assetsBalance - Per-account balances by asset ID.
- * @param params.assetsInfo - Metadata by asset ID.
- * @param params.assetsPrice - Prices by asset ID.
- * @param params.selectedCurrency - Current currency code.
- * @param params.accounts - List of accounts (id + address) to map state for.
- * @param params.nativeAssetIdentifiers - Map of CAIP-2 chain ID to native asset ID. Used for EVM native lookups.
- * @param params.networkConfigurationsByChainId - Optional chain ID to network config (for native symbol).
  * @returns Legacy-compatible state for transaction-pay-controller.
  */
-export function formatStateForTransactionPay(params: {
-  assetsBalance: Record<string, Record<string, AssetBalance>>;
-  assetsInfo: Record<string, AssetMetadata>;
-  assetsPrice: Record<string, AssetPrice>;
-  selectedCurrency: string;
-  accounts: AccountForLegacyFormat[];
-  nativeAssetIdentifiers: Record<string, string>;
-  networkConfigurationsByChainId?: Record<string, { nativeCurrency?: string }>;
-}): TransactionPayLegacyFormat {
+export function formatStateForTransactionPay(
+  params: FormatStateForTransactionPayParams,
+): TransactionPayLegacyFormat {
+  if (
+    lastCall?.params.assetsBalance === params.assetsBalance &&
+    lastCall.params.assetsInfo === params.assetsInfo &&
+    lastCall.params.assetsPrice === params.assetsPrice &&
+    lastCall.params.selectedCurrency === params.selectedCurrency &&
+    lastCall.params.networkConfigurationsByChainId ===
+      params.networkConfigurationsByChainId &&
+    isEqual(lastCall.params.accounts, params.accounts) &&
+    isEqual(
+      lastCall.params.nativeAssetIdentifiers,
+      params.nativeAssetIdentifiers,
+    )
+  ) {
+    return lastCall.result;
+  }
+
+  const result = computeStateForTransactionPay(params);
+  lastCall = { params, result };
+  return result;
+}
+
+/**
+ * Clears the {@link formatStateForTransactionPay} memoize cache. Exported for tests.
+ */
+export function clearFormatStateForTransactionPayCacheForTesting(): void {
+  lastCall = null;
+}
+
+/**
+ * Performs the actual legacy-format conversion for
+ * {@link formatStateForTransactionPay}.
+ *
+ * @param params - Conversion parameters.
+ * @returns Legacy-compatible state for transaction-pay-controller.
+ */
+function computeStateForTransactionPay(
+  params: FormatStateForTransactionPayParams,
+): TransactionPayLegacyFormat {
   const {
     assetsBalance,
     assetsInfo,

--- a/packages/assets-controller/src/utils/index.ts
+++ b/packages/assets-controller/src/utils/index.ts
@@ -1,11 +1,24 @@
 export { fetchWithTimeout } from './fetchWithTimeout';
 export { normalizeAmountString } from './normalizeAmountString';
-export { normalizeAssetId } from './normalizeAssetId';
-export { formatExchangeRatesForBridge } from './formatExchangeRatesForBridge';
-export { formatStateForTransactionPay } from './formatStateForTransactionPay';
-export type { BridgeExchangeRatesFormat } from './formatExchangeRatesForBridge';
+export {
+  normalizeAssetId,
+  clearNormalizeAssetIdCacheForTesting,
+} from './normalizeAssetId';
+export {
+  formatExchangeRatesForBridge,
+  clearFormatExchangeRatesForBridgeCacheForTesting,
+} from './formatExchangeRatesForBridge';
+export {
+  formatStateForTransactionPay,
+  clearFormatStateForTransactionPayCacheForTesting,
+} from './formatStateForTransactionPay';
+export type {
+  BridgeExchangeRatesFormat,
+  FormatExchangeRatesForBridgeParams,
+} from './formatExchangeRatesForBridge';
 export type {
   AccountForLegacyFormat,
+  FormatStateForTransactionPayParams,
   LegacyToken,
   TransactionPayLegacyFormat,
 } from './formatStateForTransactionPay';

--- a/packages/assets-controller/src/utils/normalizeAssetId.test.ts
+++ b/packages/assets-controller/src/utils/normalizeAssetId.test.ts
@@ -1,0 +1,37 @@
+import type { Caip19AssetId } from '../types';
+import {
+  clearNormalizeAssetIdCacheForTesting,
+  normalizeAssetId,
+} from './normalizeAssetId';
+
+describe('normalizeAssetId', () => {
+  afterEach(() => {
+    clearNormalizeAssetIdCacheForTesting();
+  });
+
+  it('checksums EVM ERC-20 asset references', () => {
+    const input =
+      'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as Caip19AssetId;
+    const expected =
+      'eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48' as Caip19AssetId;
+
+    expect(normalizeAssetId(input)).toBe(expected);
+  });
+
+  it('returns non-EVM asset IDs unchanged', () => {
+    const solanaId =
+      'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501' as Caip19AssetId;
+
+    expect(normalizeAssetId(solanaId)).toBe(solanaId);
+  });
+
+  it('memoizes results for the same asset ID', () => {
+    const input =
+      'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as Caip19AssetId;
+
+    const first = normalizeAssetId(input);
+    const second = normalizeAssetId(input);
+
+    expect(second).toBe(first);
+  });
+});

--- a/packages/assets-controller/src/utils/normalizeAssetId.ts
+++ b/packages/assets-controller/src/utils/normalizeAssetId.ts
@@ -1,5 +1,7 @@
 import { toChecksumAddress } from '@ethereumjs/util';
 import { parseCaipAssetType, parseCaipChainId } from '@metamask/utils';
+import type { MemoizedFunction } from 'lodash';
+import memoize from 'lodash/memoize';
 
 import type { Caip19AssetId } from '../types';
 
@@ -10,10 +12,15 @@ import type { Caip19AssetId } from '../types';
  * For EVM ERC20 tokens (e.g., "eip155:1/erc20:0x..."), the address is checksummed.
  * All other asset types are returned unchanged.
  *
+ * Results are memoized with lodash: repeated calls with the same ID (common after
+ * the first pipeline pass, when IDs are already checksummed) skip re-parsing and
+ * keccak256 checksum work.
+ *
  * @param assetId - The CAIP-19 asset ID to normalize
  * @returns The normalized asset ID with checksummed address (for EVM tokens)
  */
-export function normalizeAssetId(assetId: Caip19AssetId): Caip19AssetId {
+export const normalizeAssetId: ((assetId: Caip19AssetId) => Caip19AssetId) &
+  MemoizedFunction = memoize((assetId: Caip19AssetId): Caip19AssetId => {
   const parsed = parseCaipAssetType(assetId);
   const chainIdParsed = parseCaipChainId(parsed.chainId);
 
@@ -27,4 +34,11 @@ export function normalizeAssetId(assetId: Caip19AssetId): Caip19AssetId {
   }
 
   return assetId;
+});
+
+/**
+ * Clears the {@link normalizeAssetId} memoize cache. Exported for unit tests.
+ */
+export function clearNormalizeAssetIdCacheForTesting(): void {
+  normalizeAssetId.cache.clear?.();
 }


### PR DESCRIPTION
Avoid repeated keccak256 checksumming and CAIP parsing on read paths that run far more often than assets state changes.

## Explanation

`AssetsController`'s read paths recompute pure, deterministic conversions on
every call, even when the underlying assets state hasn't changed:

- `normalizeAssetId` runs `parseCaipAssetType` + `parseCaipChainId` and, for EVM
  ERC-20 tokens, `toChecksumAddress` (keccak256) on every call — including the
  common case where the same already-checksummed ID is passed repeatedly across
  the pipeline.
- `formatExchangeRatesForBridge` (via `getExchangeRatesForBridge`) and
  `formatStateForTransactionPay` (via `getStateForTransactionPay`) re-run
  keccak256 checksumming and CAIP parsing for every priced/held asset. These are
  invoked on hot paths — e.g. bridge quote/rate refreshes and every
  `TransactionController:stateChange` — far more often than the assets state that
  feeds them actually changes.

This PR memoizes those conversions so unchanged inputs skip the redundant work:

- **`normalizeAssetId`** is wrapped in lodash `memoize`, keyed on the asset ID.
  Repeated calls with the same ID (the norm once IDs are checksummed) return the
  cached result without re-parsing or re-checksumming.
- **`formatExchangeRatesForBridge`** and **`formatStateForTransactionPay`** cache
  their last result. Cache validity is checked by identity (`===`) for
  BaseController state slices — which keep stable references across updates thanks
  to immer — and by lodash `isEqual` for maps/arrays that are rebuilt each call
  (`nativeAssetIdentifiers`, and `accounts` for transaction-pay). The compute
  logic is split into internal `computeExchangeRatesForBridge` /
  `computeStateForTransactionPay` helpers, with the exported functions handling
  the cache check.
- **`#getNativeAssetMap`** now returns a stable empty-object constant
  (`EMPTY_NATIVE_ASSET_MAP`) when the query cache is empty, so `?? {}` identity
  churn doesn't defeat downstream memoization.

Each memoized module exports a `clear*CacheForTesting` helper (from the internal
`utils` barrel) so tests can reset cache state between cases. The
`FormatExchangeRatesForBridgeParams` and `FormatStateForTransactionPayParams`
parameter types are now named and exported for reuse.

No behavior changes for consumers: the functions are pure and the memoized
results are value-equal to the previously recomputed ones. Note that cached
results are returned by reference and should be treated as read-only.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?
-->

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only caching of pure converters with no API or behavior contract changes; main caveat is consumers must not mutate cached return values.
> 
> **Overview**
> Adds **memoization** on read paths that repeatedly run CAIP parsing and EVM address checksumming (`toChecksumAddress` / keccak256) even when underlying assets state is unchanged.
> 
> **`normalizeAssetId`** is wrapped in lodash `memoize` so repeated calls with the same CAIP-19 ID return a cached checksummed result.
> 
> **`formatExchangeRatesForBridge`** and **`formatStateForTransactionPay`** now keep a single-entry cache: controller state slices are compared by reference (`===`), while rebuilt `nativeAssetIdentifiers` / `accounts` use lodash `isEqual`. Heavy work lives in internal `compute*` helpers. Named param types **`FormatExchangeRatesForBridgeParams`** and **`FormatStateForTransactionPayParams`** are exported; test-only **`clear*CacheForTesting`** helpers reset caches between cases.
> 
> **`#getNativeAssetMap`** returns a module-level **`EMPTY_NATIVE_ASSET_MAP`** instead of `?? {}`, so empty native maps keep stable identity and do not invalidate the formatter caches.
> 
> Outputs are intended to be value-equal to before; cached objects are returned by reference and should be treated as read-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1266836163271002efe520ab4a7eca56847eafdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->