### PR TITLE
feat: correct defi response types

### DIFF
--- a/packages/core-backend/CHANGELOG.md
+++ b/packages/core-backend/CHANGELOG.md
@@ -9,12 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Export `V6_DEFI_POSITION_TYPES` and inferred `V6DeFiPositionType`, and type `V6BalanceMetadata.positionType` with the Accounts API v6 DeFi position module values (`deposit`, `lending`, `yield`, `liquidity_pool`, `staked`, `leveraged_farming`, `nft_staked`, `farming`, `locked`, `vesting`, `rewards`, `investment`) ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
-- Add `groupId` to `V6BalanceMetadata` to match Accounts API v6 DeFi metadata ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
+- Export `V6_DEFI_POSITION_TYPES` and inferred `V6DeFiPositionType`, and type `V6BalanceMetadata.positionType` with the Accounts API v6 DeFi position module values (`deposit`, `lending`, `yield`, `liquidity_pool`, `staked`, `leveraged_farming`, `nft_staked`, `farming`, `locked`, `vesting`, `rewards`, `investment`) ([#9557](https://github.com/MetaMask/core/pull/9557))
+- Add `groupId` to `V6BalanceMetadata` to match Accounts API v6 DeFi metadata ([#9557](https://github.com/MetaMask/core/pull/9557))
 
 ### Changed
 
-- **BREAKING:** Rename `V6BalanceMetadata.protocolName` to `productName` to match the Accounts API v6 DeFi metadata field ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
+- **BREAKING:** Rename `V6BalanceMetadata.protocolName` to `productName` to match the Accounts API v6 DeFi metadata field ([#9557](https://github.com/MetaMask/core/pull/9557))
 - **BREAKING:** `AccountActivityService` now determines which non-EVM chains to subscribe to from remote feature flags instead of a bundled list ([#9379](https://github.com/MetaMask/core/pull/9379))
   - The `AccountActivityServiceMessenger` now requires the following delegate actions and events:
     - `RemoteFeatureFlagController:getState` action and `RemoteFeatureFlagController:stateChange` event

--- a/packages/core-backend/CHANGELOG.md
+++ b/packages/core-backend/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Export `V6_DEFI_POSITION_TYPES` and inferred `V6DeFiPositionType`, and type `V6BalanceMetadata.positionType` with the Accounts API v6 DeFi position module values (`deposit`, `lending`, `yield`, `liquidity_pool`, `staked`, `leveraged_farming`, `nft_staked`, `farming`, `locked`, `vesting`, `rewards`, `investment`) ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
+- Add `groupId` to `V6BalanceMetadata` to match Accounts API v6 DeFi metadata ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
+
 ### Changed
 
+- **BREAKING:** Rename `V6BalanceMetadata.protocolName` to `productName` to match the Accounts API v6 DeFi metadata field ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
 - **BREAKING:** `AccountActivityService` now determines which non-EVM chains to subscribe to from remote feature flags instead of a bundled list ([#9379](https://github.com/MetaMask/core/pull/9379))
   - The `AccountActivityServiceMessenger` now requires the following delegate actions and events:
     - `RemoteFeatureFlagController:getState` action and `RemoteFeatureFlagController:stateChange` event

--- a/packages/core-backend/src/api/accounts/client.test.ts
+++ b/packages/core-backend/src/api/accounts/client.test.ts
@@ -292,7 +292,8 @@ describe('AccountsApiClient', () => {
                 balance: '1.0',
                 metadata: {
                   protocolId: 'metamask',
-                  protocolName: 'MetaMask Swaps',
+                  productName: 'MetaMask Swaps',
+                  groupId: 'group-1',
                   description: 'MetaMask Swaps on ethereum',
                   protocolUrl: 'https://metamask.io/',
                   protocolIconUrl: 'https://example.com/icon.jpg',

--- a/packages/core-backend/src/api/accounts/index.ts
+++ b/packages/core-backend/src/api/accounts/index.ts
@@ -3,6 +3,7 @@
  */
 
 export { AccountsApiClient } from './client';
+export { V6_DEFI_POSITION_TYPES } from './types';
 export type {
   V5BalanceItem,
   V5BalancesResponse,
@@ -10,6 +11,7 @@ export type {
   V2BalancesResponse,
   V4BalancesResponse,
   V6VsCurrency,
+  V6DeFiPositionType,
   V6BalanceMetadata,
   V6TokenMetadata,
   V6BalanceItem,

--- a/packages/core-backend/src/api/accounts/types.ts
+++ b/packages/core-backend/src/api/accounts/types.ts
@@ -64,17 +64,43 @@ export type V4BalancesResponse = {
 export type V6VsCurrency = string;
 
 /**
+ * Possible `positionType` values on DeFi rows in the v6 balances response.
+ * Categorizes the protocol module where the position is held.
+ */
+export const V6_DEFI_POSITION_TYPES = [
+  'deposit',
+  'lending',
+  'yield',
+  'liquidity_pool',
+  'staked',
+  'leveraged_farming',
+  'nft_staked',
+  'farming',
+  'locked',
+  'vesting',
+  'rewards',
+  'investment',
+] as const;
+
+/**
+ * The specific module or functionality within a DeFi protocol where a position
+ * is held.
+ */
+export type V6DeFiPositionType = (typeof V6_DEFI_POSITION_TYPES)[number];
+
+/**
  * DeFi protocol metadata attached to a `category: defi` row in the v6 balances
  * response (`BalanceMetadataV3ResponseDto`).
  */
 export type V6BalanceMetadata = {
   protocolId: string;
-  protocolName: string;
+  productName: string;
   description: string;
   protocolUrl: string;
   protocolIconUrl: string;
-  positionType: string;
+  positionType: V6DeFiPositionType;
   poolAddress: string;
+  groupId: string;
 };
 
 /**

--- a/packages/core-backend/src/api/index.ts
+++ b/packages/core-backend/src/api/index.ts
@@ -23,7 +23,7 @@ export {
 } from './shared-types';
 
 // Accounts API
-export { AccountsApiClient } from './accounts';
+export { AccountsApiClient, V6_DEFI_POSITION_TYPES } from './accounts';
 export type {
   V5BalanceItem,
   V5BalancesResponse,
@@ -31,6 +31,7 @@ export type {
   V2BalancesResponse,
   V4BalancesResponse,
   V6VsCurrency,
+  V6DeFiPositionType,
   V6BalanceMetadata,
   V6TokenMetadata,
   V6BalanceItem,

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -121,6 +121,7 @@ export {
   API_URLS,
   STALE_TIMES,
   GC_TIMES,
+  V6_DEFI_POSITION_TYPES,
   // Helpers
   calculateRetryDelay,
   getQueryOptionsOverrides,
@@ -148,6 +149,7 @@ export type {
   V2BalancesResponse,
   V4BalancesResponse,
   V6VsCurrency,
+  V6DeFiPositionType,
   V6BalanceMetadata,
   V6TokenMetadata,
   V6BalanceItem,


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

The API does not return `protocolName` field any longer, only `productName`. So even though this is a breaking change. It is to reflect the existing API.

The API is not yet being used, so no changes in the clients are required.

It also includes the list of possible position types, since they need to be consumed and translated in the clients. 

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [X] I've updated the test suite for new or updated code as appropriate
- [X] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [X] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [X] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only alignment with a documented breaking rename on unused v6 metadata fields; no runtime or auth/data-path changes in this diff.
> 
> **Overview**
> Aligns **`V6BalanceMetadata`** with the Accounts API v6 DeFi payload: **`protocolName` is renamed to `productName`** (breaking), **`groupId` is added**, and **`positionType` is narrowed** from `string` to a fixed union via new **`V6_DEFI_POSITION_TYPES`** / **`V6DeFiPositionType`**.
> 
> Those symbols are re-exported from the accounts API barrel, `api`, and package entrypoints. The v6 balances client test fixture and changelog are updated; there is no fetch/parsing logic change beyond typing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4205518fcef1017cd3cfd2068914a392ebe3c613. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->