### PR TITLE
ci: fix changelog RC validation

### DIFF
--- a/scripts/validate-changelog.sh
+++ b/scripts/validate-changelog.sh
@@ -10,7 +10,20 @@ fi
 package_name="$1"
 shift  # remove package name from arguments
 
-if [[ "${GITHUB_REF:-}" =~ '^release/' ]]; then
+if [[ "${CI:-}" = "true" ]]; then
+  if [[ -n "${GITHUB_HEAD_REF:-}" ]]; then
+    branch_name="${GITHUB_HEAD_REF}"
+  elif [[ -n "${GITHUB_REF_NAME:-}" ]]; then
+    branch_name="${GITHUB_REF_NAME}"
+  else
+    echo "Cannot determine branch name in CI environment, missing GITHUB_HEAD_REF and GITHUB_REF_NAME"
+    exit 1
+  fi;
+else
+  branch_name="$(git branch --show-current)"
+fi
+
+if [[ "${branch_name}" =~ ^release/ ]]; then
   yarn auto-changelog validate --formatter oxfmt --tag-prefix "${package_name}@" --rc "$@"
 else
   yarn auto-changelog validate --formatter oxfmt --tag-prefix "${package_name}@" "$@"


### PR DESCRIPTION
## Explanation

The changelog validation script was incorrectly detecting release branches. There were two problems:

* The script expected `GITHUB_REF` to be the branch name, but it's not (see https://docs.github.com/en/actions/reference/workflows-and-actions/variables)
* The regular expression pattern was quoted, so it was looking for a literal `^` rather than that denoting the start of the branch name

Both errors have been corrected. We're now using a combination of `GITHUB_HEAD_REF` (for `pull_request` events) and `GITHUB_REF_NAME` (for `push`/`merge_queue` events) to get the branch name instead of `GITHUB_REF`.

## References

Example branch where this did not work correctly: https://github.com/MetaMask/core/tree/release/1130.0.0

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes a CI validation shell script; no runtime application or security-sensitive logic.
> 
> **Overview**
> Fixes **changelog validation** so release branches correctly run with the `--rc` flag in CI.
> 
> Branch detection no longer uses `GITHUB_REF` (which is a full ref, not a branch name). In CI it now picks **`GITHUB_HEAD_REF`** for pull requests or **`GITHUB_REF_NAME`** for push/merge queue; locally it uses **`git branch --show-current`**. The release-branch check also fixes the pattern so `^release/` is a real regex anchor instead of a quoted literal.
> 
> Non-release branches keep validating without `--rc`; `release/*` branches validate with RC rules as intended.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 335fde1c2138fd5468f079c35df83f5e650c4d33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->