### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,3 +219,17 @@ When adding or updating data services in packages, follow these guidelines:
 - Make sure to write comprehensive tests for the service class.
 
 Use the `sample-gas-prices-service/` directory in the `sample-controllers` package as examples for implementation and tests.
+
+## Cursor Cloud specific instructions
+
+This repo is a **library monorepo** — a collection of `@metamask/*` TypeScript packages published to npm and consumed by MetaMask clients. There is **no long-running server/app to start**; "running" the code means building packages, running their test suites, or invoking one of the CLI packages (e.g. `messenger-cli`, `wallet-cli`). Do not look for a dev server.
+
+Environment prerequisites (Node LTS + Yarn 4 via Corepack + `yarn install`) are handled by the startup update script, so you normally don't need to reinstall. If you do run it manually, use `corepack enable` before any `yarn` command — the base image's global `yarn` is Classic (1.x), and this repo requires Yarn 4 (pinned via `packageManager`).
+
+Standard lint/test/build commands are documented above and in `docs/processes/`. Non-obvious caveats for this environment:
+
+- `yarn build` (whole monorepo, via `ts-bridge`) takes ~100s. `yarn lint:eslint` takes ~3–4 minutes.
+- `yarn lint:eslint` runs `build:only-clean` first, which **deletes all `packages/*/dist`**. Run `yarn build` again afterward if you need the built artifacts (tests don't need `dist`; they run TS/Babel directly).
+- The full `yarn lint` does much more than ESLint (constraints, `knip` dependency checks, changelog/teams/tsconfig/codeowners checks); prefer `yarn lint:eslint` for a quick code-quality pass.
+- Per-package tests are fast: `yarn workspace <package-name> run test`. `yarn test` across all packages is heavy.
+- `yarn install` emits `YN0060`/`YN0002`/`YN0086` peer-dependency warnings — these are expected and not failures.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Explanation

Sets up the development environment for Cursor Cloud agents and documents non-obvious operating caveats for this library monorepo.

This monorepo is a collection of `@metamask/*` TypeScript packages (no long-running server/app). Development readiness means installing dependencies, building packages, running package test suites, and running the CLI packages.

### What was done

- Verified the environment: Node LTS (v22) + Yarn 4 (via Corepack) + `yarn install`.
- Configured the startup update script: `corepack enable` then `yarn install`.
- Ran the full monorepo build (`yarn build`) — succeeded.
- Ran ESLint across the monorepo (`yarn lint:eslint`) — no violations.
- Ran a representative package test suite (`yarn workspace @metamask/base-controller run test`) — pass, 100% coverage.
- Verified a built CLI artifact runs end-to-end (`messenger-cli --check` against `sample-controllers`).

### Changes

- **AGENTS.md**: Added a `## Cursor Cloud specific instructions` section documenting durable, non-obvious caveats (library monorepo with no dev server, Corepack requirement, `yarn lint:eslint` deletes `dist/`, build/lint timings, expected peer-dependency warnings).

No application/source code was modified.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dbadf234-6e02-4497-ad1c-c70c0c26e7c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dbadf234-6e02-4497-ad1c-c70c0c26e7c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

