### PR TITLE
Fix remove disableUpgrade property for post MA vault batch

### DIFF
--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove `disableUpgrade` from the Money Account vault deposit batch so that freshly-funded fiat accounts that haven't yet been upgraded to EIP-7702 are auto-upgraded instead of failing ([#9567](https://github.com/MetaMask/core/pull/9567))
+
 ## [25.0.0]
 
 ### Added

--- a/packages/transaction-pay-controller/src/utils/ma-vault-deposit.test.ts
+++ b/packages/transaction-pay-controller/src/utils/ma-vault-deposit.test.ts
@@ -137,7 +137,6 @@ describe('submitMoneyAccountVaultDeposit', () => {
       expect.objectContaining({
         disableHook: true,
         disableSequential: true,
-        disableUpgrade: true,
         from: MONEY_ACCOUNT_ADDRESS_MOCK,
         isGasFeeSponsored: true,
         isInternal: true,

--- a/packages/transaction-pay-controller/src/utils/ma-vault-deposit.ts
+++ b/packages/transaction-pay-controller/src/utils/ma-vault-deposit.ts
@@ -168,7 +168,6 @@ export async function submitMoneyAccountVaultDeposit({
     await messenger.call('TransactionController:addTransactionBatch', {
       disableHook: true,
       disableSequential: true,
-      disableUpgrade: true,
       from: moneyAccountAddress,
       isGasFeeSponsored: true,
       isInternal: true,


### PR DESCRIPTION
## Explanation

The Money Account vault deposit batch (post-fiat on-ramp / post-Relay bridge) was submitted with `disableUpgrade: true`, which prevents the `TransactionController` batch logic from upgrading the sending account to EIP-7702 if it isn't already delegated. This was overly conservative: Money Account addresses are EIP-7702 smart-contract wallets and the upgrade step is exactly what enables the sponsored batch to execute correctly. Keeping `disableUpgrade: true` means freshly-funded fiat accounts that haven't yet been upgraded would have their vault batch fail silently instead of being auto-upgraded on the way through.

This PR removes `disableUpgrade` from the `addTransactionBatch` call in `submitMoneyAccountVaultDeposit`, restoring the default behaviour (upgrade the account when needed) and updates the corresponding test assertion.

## References

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes submission options for a sponsored internal batch on a critical deposit path; scope is small but affects EIP-7702 upgrade behavior for Money Account addresses.
> 
> **Overview**
> **Money Account vault deposit batches** no longer pass `disableUpgrade: true` to `TransactionController:addTransactionBatch` in `submitMoneyAccountVaultDeposit`. The batch can again trigger the default EIP-7702 upgrade when the sending Money Account is not yet delegated.
> 
> This targets post–fiat on-ramp / post–Relay flows where a newly funded account would previously fail the sponsored vault batch instead of being upgraded as part of submission. The vault-deposit unit test expectation is updated accordingly, and the package changelog records the fix under **Unreleased**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbcf87e4bcb600e9dd0772b421de8c270dca2daf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->