### PR TITLE
fix(gas-fee-controller): make GasFeeController initialization-order-agnostic

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1100,7 +1100,7 @@
       "count": 1
     },
     "no-restricted-syntax": {
-      "count": 16
+      "count": 14
     }
   },
   "packages/gas-fee-controller/src/gas-util.ts": {

--- a/packages/gas-fee-controller/CHANGELOG.md
+++ b/packages/gas-fee-controller/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Defer the `GasFeeController` constructor's `NetworkController` and provider reads until the first gas fee fetch ([#9563](https://github.com/MetaMask/core/pull/9563))
+  - The constructor no longer eagerly calls `NetworkController:getState`, `NetworkController:getNetworkClientById`, the `getChainId` option, or the `getProvider` option; the provider (`EthQuery`) and the current chain ID are now resolved lazily on first use. This makes the controller initialization-order-agnostic, so it can be constructed before `NetworkController` is ready. The constructor signature and gas fee fetching behavior are unchanged.
 - Bump `@metamask/messenger` from `^1.2.0` to `^2.0.0` ([#9392](https://github.com/MetaMask/core/pull/9392))
 
 ## [26.2.4]

--- a/packages/gas-fee-controller/CHANGELOG.md
+++ b/packages/gas-fee-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Defer the `GasFeeController` constructor's `NetworkController` and provider reads until the first gas fee fetch ([#9563](https://github.com/MetaMask/core/pull/9563))
+- Defer the `GasFeeController` constructor's `NetworkController` and provider reads until the first gas fee fetch ([#9569](https://github.com/MetaMask/core/pull/9569))
   - The constructor no longer eagerly calls `NetworkController:getState`, `NetworkController:getNetworkClientById`, the `getChainId` option, or the `getProvider` option; the provider (`EthQuery`) and the current chain ID are now resolved lazily on first use. This makes the controller initialization-order-agnostic, so it can be constructed before `NetworkController` is ready. The constructor signature and gas fee fetching behavior are unchanged.
 - Bump `@metamask/messenger` from `^1.2.0` to `^2.0.0` ([#9392](https://github.com/MetaMask/core/pull/9392))
 

--- a/packages/gas-fee-controller/CHANGELOG.md
+++ b/packages/gas-fee-controller/CHANGELOG.md
@@ -9,8 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Defer the `GasFeeController` constructor's `NetworkController` and provider reads until the first gas fee fetch ([#9569](https://github.com/MetaMask/core/pull/9569))
-  - The constructor no longer eagerly calls `NetworkController:getState`, `NetworkController:getNetworkClientById`, the `getChainId` option, or the `getProvider` option; the provider (`EthQuery`) and the current chain ID are now resolved lazily on first use. This makes the controller initialization-order-agnostic, so it can be constructed before `NetworkController` is ready. The constructor signature and gas fee fetching behavior are unchanged.
+- Defer the `GasFeeController` constructor's `NetworkController` and provider reads to the first gas fee fetch, making the controller initialization-order-agnostic; the constructor signature and fetching behavior are unchanged ([#9569](https://github.com/MetaMask/core/pull/9569))
 - Bump `@metamask/messenger` from `^1.2.0` to `^2.0.0` ([#9392](https://github.com/MetaMask/core/pull/9392))
 
 ## [26.2.4]

--- a/packages/gas-fee-controller/src/GasFeeController.test.ts
+++ b/packages/gas-fee-controller/src/GasFeeController.test.ts
@@ -19,6 +19,7 @@ import type {
 import type { Hex } from '@metamask/utils';
 import nock from 'nock';
 
+import { flushPromises } from '../../../tests/helpers';
 import {
   buildCustomNetworkConfiguration,
   buildCustomRpcEndpoint,
@@ -365,6 +366,110 @@ describe('GasFeeController', () => {
 
     it('should set the name of the controller to GasFeeController', () => {
       expect(gasFeeController.name).toBe(name);
+    });
+
+    describe('initialization-order independence', () => {
+      /**
+       * Builds a messenger whose NetworkController action handlers throw if
+       * called, so that a test can assert the constructor never reads from the
+       * NetworkController.
+       *
+       * @returns The messenger along with spies for its handlers.
+       */
+      const getMessengerWithThrowingNetworkHandlers = (): {
+        messenger: ReturnType<typeof getGasFeeControllerMessenger>;
+        getState: jest.Mock;
+        getNetworkClientById: jest.Mock;
+      } => {
+        const rootMessenger = getRootMessenger();
+        const getState = jest.fn(() => {
+          throw new Error('NetworkController:getState should not be called');
+        });
+        const getNetworkClientById = jest.fn(() => {
+          throw new Error(
+            'NetworkController:getNetworkClientById should not be called',
+          );
+        });
+        rootMessenger.registerActionHandler(
+          'NetworkController:getState',
+          getState,
+        );
+        rootMessenger.registerActionHandler(
+          'NetworkController:getNetworkClientById',
+          getNetworkClientById,
+        );
+        return {
+          messenger: getGasFeeControllerMessenger(rootMessenger),
+          getState,
+          getNetworkClientById,
+        };
+      };
+
+      it('does not read the chain ID or provider from the network when constructed without getChainId/onNetworkDidChange', () => {
+        const { messenger, getState, getNetworkClientById } =
+          getMessengerWithThrowingNetworkHandlers();
+        const getProvider = jest.fn(() => {
+          throw new Error('getProvider should not be called');
+        });
+
+        let controller: GasFeeController | undefined;
+        expect(() => {
+          controller = new GasFeeController({
+            messenger,
+            getProvider,
+            getCurrentNetworkLegacyGasAPICompatibility: jest
+              .fn()
+              .mockReturnValue(false),
+            getCurrentNetworkEIP1559Compatibility: jest
+              .fn()
+              .mockResolvedValue(true),
+            EIP1559APIEndpoint: 'http://eip-1559.endpoint/<chain_id>',
+          });
+        }).not.toThrow();
+
+        expect(getState).not.toHaveBeenCalled();
+        expect(getNetworkClientById).not.toHaveBeenCalled();
+        expect(getProvider).not.toHaveBeenCalled();
+
+        controller?.destroy();
+      });
+
+      it('does not read the chain ID or provider from the network when constructed with getChainId/onNetworkDidChange', () => {
+        const { messenger, getState, getNetworkClientById } =
+          getMessengerWithThrowingNetworkHandlers();
+        const getProvider = jest.fn(() => {
+          throw new Error('getProvider should not be called');
+        });
+        const getChainId = jest.fn(() => {
+          throw new Error('getChainId should not be called');
+        });
+        const onNetworkDidChange = jest.fn();
+
+        let controller: GasFeeController | undefined;
+        expect(() => {
+          controller = new GasFeeController({
+            messenger,
+            getProvider,
+            getChainId,
+            onNetworkDidChange,
+            getCurrentNetworkLegacyGasAPICompatibility: jest
+              .fn()
+              .mockReturnValue(false),
+            getCurrentNetworkEIP1559Compatibility: jest
+              .fn()
+              .mockResolvedValue(true),
+            EIP1559APIEndpoint: 'http://eip-1559.endpoint/<chain_id>',
+          });
+        }).not.toThrow();
+
+        expect(getState).not.toHaveBeenCalled();
+        expect(getNetworkClientById).not.toHaveBeenCalled();
+        expect(getProvider).not.toHaveBeenCalled();
+        expect(getChainId).not.toHaveBeenCalled();
+        expect(onNetworkDidChange).toHaveBeenCalledTimes(1);
+
+        controller?.destroy();
+      });
     });
   });
 
@@ -1285,6 +1390,90 @@ describe('GasFeeController', () => {
       });
       await jest.advanceTimersByTimeAsync(pollingInterval);
       expect(mockedDetermineGasFeeCalculations).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fetchGasEstimatesUrl: `https://some-eip-1559-endpoint/${convertHexToDecimal(
+            ChainId.sepolia,
+          )}`,
+        }),
+      );
+    });
+  });
+
+  describe('when the selected network changes', () => {
+    it('resets the eth query and updates the chain ID when notified via the onNetworkDidChange callback', async () => {
+      let networkDidChangeListener:
+        | ((networkControllerState: NetworkState) => Promise<void>)
+        | undefined;
+      const onNetworkDidChange = jest.fn((listener) => {
+        networkDidChangeListener = listener;
+      });
+      await setupGasFeeController({
+        getIsEIP1559Compatible: jest.fn().mockResolvedValue(true),
+        EIP1559APIEndpoint: 'https://some-eip-1559-endpoint/<chain_id>',
+        getChainId: jest.fn().mockReturnValue(ChainId.mainnet),
+        onNetworkDidChange,
+      });
+
+      await gasFeeController.fetchGasFeeEstimates();
+      expect(mockedDetermineGasFeeCalculations).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          fetchGasEstimatesUrl: `https://some-eip-1559-endpoint/${convertHexToDecimal(
+            ChainId.mainnet,
+          )}`,
+        }),
+      );
+
+      // Simulate the network switching to Sepolia.
+      await networkDidChangeListener?.({
+        selectedNetworkClientId: 'sepolia',
+      } as NetworkState);
+
+      await gasFeeController.fetchGasFeeEstimates();
+      expect(mockedDetermineGasFeeCalculations).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          fetchGasEstimatesUrl: `https://some-eip-1559-endpoint/${convertHexToDecimal(
+            ChainId.sepolia,
+          )}`,
+        }),
+      );
+    });
+
+    it('resets the eth query and updates the chain ID when notified via NetworkController:networkDidChange', async () => {
+      const rootMessenger = getRootMessenger();
+      networkController = await setupNetworkController({
+        rootMessenger,
+        state: {},
+        initializeProvider: false,
+      });
+      gasFeeController = new GasFeeController({
+        getProvider: jest.fn(),
+        messenger: getGasFeeControllerMessenger(rootMessenger),
+        getCurrentNetworkLegacyGasAPICompatibility: jest
+          .fn()
+          .mockReturnValue(false),
+        getCurrentNetworkEIP1559Compatibility: jest
+          .fn()
+          .mockResolvedValue(true),
+        EIP1559APIEndpoint: 'https://some-eip-1559-endpoint/<chain_id>',
+      });
+
+      await gasFeeController.fetchGasFeeEstimates();
+      expect(mockedDetermineGasFeeCalculations).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          fetchGasEstimatesUrl: `https://some-eip-1559-endpoint/${convertHexToDecimal(
+            ChainId.mainnet,
+          )}`,
+        }),
+      );
+
+      // Simulate the network switching to Sepolia.
+      rootMessenger.publish('NetworkController:networkDidChange', {
+        selectedNetworkClientId: 'sepolia',
+      } as NetworkState);
+      await flushPromises();
+
+      await gasFeeController.fetchGasFeeEstimates();
+      expect(mockedDetermineGasFeeCalculations).toHaveBeenLastCalledWith(
         expect.objectContaining({
           fetchGasEstimatesUrl: `https://some-eip-1559-endpoint/${convertHexToDecimal(
             ChainId.sepolia,

--- a/packages/gas-fee-controller/src/GasFeeController.test.ts
+++ b/packages/gas-fee-controller/src/GasFeeController.test.ts
@@ -15,6 +15,7 @@ import { NetworkController, NetworkStatus } from '@metamask/network-controller';
 import type {
   NetworkControllerMessenger,
   NetworkState,
+  ProviderProxy,
 } from '@metamask/network-controller';
 import type { Hex } from '@metamask/utils';
 import nock from 'nock';
@@ -279,6 +280,7 @@ describe('GasFeeController', () => {
    *
    * @param options - The options.
    * @param options.getChainId - Sets getChainId on the GasFeeController.
+   * @param options.getProvider - Sets getProvider on the GasFeeController.
    * @param options.onNetworkDidChange - A function for registering an event handler for the
    * @param options.getIsEIP1559Compatible - Sets getCurrentNetworkEIP1559Compatibility on the
    * GasFeeController.
@@ -293,6 +295,7 @@ describe('GasFeeController', () => {
    * @param options.state - The initial GasFeeController state
    * @param options.initializeNetworkProvider - Whether to instruct the
    * NetworkController to initialize its provider.
+   * @returns The root messenger, so tests can publish network events to it.
    */
   async function setupGasFeeController({
     getIsEIP1559Compatible = jest.fn().mockResolvedValue(true),
@@ -303,6 +306,7 @@ describe('GasFeeController', () => {
     EIP1559APIEndpoint = 'http://eip-1559.endpoint/<chain_id>',
     clientId,
     getChainId,
+    getProvider = jest.fn(),
     onNetworkDidChange,
     networkControllerState = {},
     state,
@@ -310,6 +314,7 @@ describe('GasFeeController', () => {
     initializeNetworkProvider = true,
   }: {
     getChainId?: jest.Mock<Hex>;
+    getProvider?: jest.Mock<ProviderProxy>;
     onNetworkDidChange?: jest.Mock<void>;
     getIsEIP1559Compatible?: jest.Mock<Promise<boolean>>;
     getCurrentNetworkLegacyGasAPICompatibility?: jest.Mock<boolean>;
@@ -329,7 +334,7 @@ describe('GasFeeController', () => {
     });
     const restrictedMessenger = getGasFeeControllerMessenger(rootMessenger);
     gasFeeController = new GasFeeController({
-      getProvider: jest.fn(),
+      getProvider,
       getChainId,
       onNetworkDidChange,
       messenger: restrictedMessenger,
@@ -341,6 +346,7 @@ describe('GasFeeController', () => {
       clientId,
       interval,
     });
+    return { rootMessenger };
   }
 
   beforeEach(() => {
@@ -1400,7 +1406,7 @@ describe('GasFeeController', () => {
   });
 
   describe('when the selected network changes', () => {
-    it('resets the eth query and updates the chain ID when notified via the onNetworkDidChange callback', async () => {
+    it('updates the chain ID used for the next fetch when notified via the onNetworkDidChange callback', async () => {
       let networkDidChangeListener:
         | ((networkControllerState: NetworkState) => Promise<void>)
         | undefined;
@@ -1438,23 +1444,10 @@ describe('GasFeeController', () => {
       );
     });
 
-    it('resets the eth query and updates the chain ID when notified via NetworkController:networkDidChange', async () => {
-      const rootMessenger = getRootMessenger();
-      networkController = await setupNetworkController({
-        rootMessenger,
-        state: {},
-        initializeProvider: false,
-      });
-      gasFeeController = new GasFeeController({
-        getProvider: jest.fn(),
-        messenger: getGasFeeControllerMessenger(rootMessenger),
-        getCurrentNetworkLegacyGasAPICompatibility: jest
-          .fn()
-          .mockReturnValue(false),
-        getCurrentNetworkEIP1559Compatibility: jest
-          .fn()
-          .mockResolvedValue(true),
+    it('updates the chain ID used for the next fetch when notified via NetworkController:networkDidChange', async () => {
+      const { rootMessenger } = await setupGasFeeController({
         EIP1559APIEndpoint: 'https://some-eip-1559-endpoint/<chain_id>',
+        initializeNetworkProvider: false,
       });
 
       await gasFeeController.fetchGasFeeEstimates();
@@ -1480,6 +1473,41 @@ describe('GasFeeController', () => {
           )}`,
         }),
       );
+    });
+
+    it('reads the provider once, caches the eth query, then rebuilds it from the provider after a network change', async () => {
+      const provider1 = { id: 1 } as unknown as ProviderProxy;
+      const provider2 = { id: 2 } as unknown as ProviderProxy;
+      const getProvider = jest
+        .fn<ProviderProxy, []>()
+        .mockReturnValueOnce(provider1)
+        .mockReturnValueOnce(provider2);
+      const { rootMessenger } = await setupGasFeeController({
+        getProvider,
+        EIP1559APIEndpoint: 'https://some-eip-1559-endpoint/<chain_id>',
+        initializeNetworkProvider: false,
+      });
+
+      // The provider is read lazily on the first fetch, and the resulting eth
+      // query is cached across subsequent fetches.
+      await gasFeeController.fetchGasFeeEstimates();
+      await gasFeeController.fetchGasFeeEstimates();
+      expect(getProvider).toHaveBeenCalledTimes(1);
+      const ethQueryBeforeChange =
+        mockedDetermineGasFeeCalculations.mock.lastCall?.[0].ethQuery;
+
+      // Simulate the network switching to Sepolia.
+      rootMessenger.publish('NetworkController:networkDidChange', {
+        selectedNetworkClientId: 'sepolia',
+      } as NetworkState);
+      await flushPromises();
+
+      // The next fetch rebuilds the eth query from the provider.
+      await gasFeeController.fetchGasFeeEstimates();
+      expect(getProvider).toHaveBeenCalledTimes(2);
+      const ethQueryAfterChange =
+        mockedDetermineGasFeeCalculations.mock.lastCall?.[0].ethQuery;
+      expect(ethQueryAfterChange).not.toBe(ethQueryBeforeChange);
     });
   });
 

--- a/packages/gas-fee-controller/src/GasFeeController.ts
+++ b/packages/gas-fee-controller/src/GasFeeController.ts
@@ -323,13 +323,15 @@ export class GasFeeController extends StaticIntervalPollingController<GasFeePoll
 
   private readonly getCurrentAccountEIP1559Compatibility;
 
-  private currentChainId;
+  private currentChainId?: Hex;
 
   private ethQuery?: EthQuery;
 
   private readonly clientId?: string;
 
   readonly #getProvider: () => ProviderProxy;
+
+  readonly #getChainId?: () => Hex;
 
   /**
    * Creates a GasFeeController instance.
@@ -401,28 +403,19 @@ export class GasFeeController extends StaticIntervalPollingController<GasFeePoll
     this.legacyAPIEndpoint = legacyAPIEndpoint;
     this.clientId = clientId;
 
-    this.ethQuery = new EthQuery(this.#getProvider());
-
     this.messenger.registerMethodActionHandlers(
       this,
       MESSENGER_EXPOSED_METHODS,
     );
 
     if (onNetworkDidChange && getChainId) {
-      this.currentChainId = getChainId();
+      this.#getChainId = getChainId;
       // TODO: Either fix this lint violation or explain why it's necessary to ignore.
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
       onNetworkDidChange(async (networkControllerState) => {
         await this.#onNetworkControllerDidChange(networkControllerState);
       });
     } else {
-      const { selectedNetworkClientId } = this.messenger.call(
-        'NetworkController:getState',
-      );
-      this.currentChainId = this.messenger.call(
-        'NetworkController:getNetworkClientById',
-        selectedNetworkClientId,
-      ).configuration.chainId;
       this.messenger.subscribe(
         'NetworkController:networkDidChange',
         // TODO: Either fix this lint violation or explain why it's necessary to ignore.
@@ -520,12 +513,12 @@ export class GasFeeController extends StaticIntervalPollingController<GasFeePoll
       ethQuery = new EthQuery(networkClient.provider);
     }
 
-    ethQuery ??= this.ethQuery;
+    ethQuery ??= this.#getEthQuery();
 
     isLegacyGasAPICompatible ??=
       this.getCurrentNetworkLegacyGasAPICompatibility();
 
-    decimalChainId ??= convertHexToDecimal(this.currentChainId);
+    decimalChainId ??= convertHexToDecimal(this.#getCurrentChainId());
 
     try {
       isEIP1559Compatible ??= await this.getEIP1559Compatibility();
@@ -557,7 +550,7 @@ export class GasFeeController extends StaticIntervalPollingController<GasFeePoll
     if (shouldUpdateState) {
       const chainId = toHex(decimalChainId);
       this.update((state) => {
-        if (this.currentChainId === chainId) {
+        if (this.#getCurrentChainId() === chainId) {
           state.gasFeeEstimates = gasFeeCalculations.gasFeeEstimates;
           state.estimatedGasFeeTimeBounds =
             gasFeeCalculations.estimatedGasFeeTimeBounds;
@@ -683,11 +676,33 @@ export class GasFeeController extends StaticIntervalPollingController<GasFeePoll
     ).configuration.chainId;
 
     if (newChainId !== this.currentChainId) {
-      this.ethQuery = new EthQuery(this.#getProvider());
+      // Reset so the next fetch rebuilds it from the new network's provider.
+      this.ethQuery = undefined;
       await this.resetPolling();
 
       this.currentChainId = newChainId;
     }
+  }
+
+  #getEthQuery(): EthQuery {
+    this.ethQuery ??= new EthQuery(this.#getProvider());
+    return this.ethQuery;
+  }
+
+  #getCurrentChainId(): Hex {
+    this.currentChainId ??=
+      this.#getChainId?.() ?? this.#getChainIdFromNetworkController();
+    return this.currentChainId;
+  }
+
+  #getChainIdFromNetworkController(): Hex {
+    const { selectedNetworkClientId } = this.messenger.call(
+      'NetworkController:getState',
+    );
+    return this.messenger.call(
+      'NetworkController:getNetworkClientById',
+      selectedNetworkClientId,
+    ).configuration.chainId;
   }
 
   enableNonRPCGasFeeApis() {

--- a/packages/gas-fee-controller/src/GasFeeController.ts
+++ b/packages/gas-fee-controller/src/GasFeeController.ts
@@ -549,8 +549,9 @@ export class GasFeeController extends StaticIntervalPollingController<GasFeePoll
 
     if (shouldUpdateState) {
       const chainId = toHex(decimalChainId);
+      const currentChainId = this.#getCurrentChainId();
       this.update((state) => {
-        if (this.#getCurrentChainId() === chainId) {
+        if (currentChainId === chainId) {
           state.gasFeeEstimates = gasFeeCalculations.gasFeeEstimates;
           state.estimatedGasFeeTimeBounds =
             gasFeeCalculations.estimatedGasFeeTimeBounds;
@@ -670,10 +671,7 @@ export class GasFeeController extends StaticIntervalPollingController<GasFeePoll
   async #onNetworkControllerDidChange({
     selectedNetworkClientId,
   }: NetworkState) {
-    const newChainId = this.messenger.call(
-      'NetworkController:getNetworkClientById',
-      selectedNetworkClientId,
-    ).configuration.chainId;
+    const newChainId = this.#getChainIdForNetworkClient(selectedNetworkClientId);
 
     if (newChainId !== this.currentChainId) {
       // Reset so the next fetch rebuilds it from the new network's provider.
@@ -699,9 +697,13 @@ export class GasFeeController extends StaticIntervalPollingController<GasFeePoll
     const { selectedNetworkClientId } = this.messenger.call(
       'NetworkController:getState',
     );
+    return this.#getChainIdForNetworkClient(selectedNetworkClientId);
+  }
+
+  #getChainIdForNetworkClient(networkClientId: NetworkClientId): Hex {
     return this.messenger.call(
       'NetworkController:getNetworkClientById',
-      selectedNetworkClientId,
+      networkClientId,
     ).configuration.chainId;
   }
 

--- a/packages/gas-fee-controller/src/GasFeeController.ts
+++ b/packages/gas-fee-controller/src/GasFeeController.ts
@@ -671,7 +671,9 @@ export class GasFeeController extends StaticIntervalPollingController<GasFeePoll
   async #onNetworkControllerDidChange({
     selectedNetworkClientId,
   }: NetworkState) {
-    const newChainId = this.#getChainIdForNetworkClient(selectedNetworkClientId);
+    const newChainId = this.#getChainIdForNetworkClient(
+      selectedNetworkClientId,
+    );
 
     if (newChainId !== this.currentChainId) {
       // Reset so the next fetch rebuilds it from the new network's provider.


### PR DESCRIPTION
## Explanation

The `GasFeeController` constructor was the only currently-wired-or-wireable controller that performed **eager, construction-time reads** of `NetworkController` and the network provider:

- `new EthQuery(this.#getProvider())` — unconditional.
- Seeding `currentChainId` — either via an eager `getChainId()` call or via `NetworkController:getState` + `getNetworkClientById`.

This forced any shared initialization (e.g. `@metamask/wallet`) to guarantee `NetworkController` is constructed *before* `GasFeeController`, which is exactly the construction-order coupling we want to avoid. Every other order-agnostic controller resolves its collaborators lazily.

This PR defers those reads to first use so the controller can be constructed in any order, matching the pattern already used elsewhere. **No public API change** — the constructor signature and gas-fee-fetching behavior are unchanged.

## Changes

- Removed the eager `EthQuery` build and the eager `currentChainId` seeding from the constructor. Network-change subscription wiring is kept as-is (subscribing is safe regardless of construction order).
- Added lazy, memoized resolution:
  - `#getEthQuery()` — builds the `EthQuery` from `getProvider` on first use.
  - `#getCurrentChainId()` — resolves the chain ID from the `getChainId` callback when provided (only when paired with `onNetworkDidChange`, preserving the original coupling), otherwise from `NetworkController`.
- `#onNetworkControllerDidChange` now resets `ethQuery` to `undefined` (rebuilt lazily on the next fetch) instead of rebuilding it eagerly per network change, and still updates `currentChainId`.

## Testing

- New tests assert construction performs **no** `NetworkController:getState` / `getNetworkClientById` / `getProvider` / `getChainId` calls — even when those handlers throw — for both the callback and no-callback constructor branches.
- New test covers network-change handling via both the `onNetworkDidChange` callback and the `NetworkController:networkDidChange` messenger subscription (chain ID + eth query update on the next fetch).
- All existing tests pass unchanged (53 total). 100% coverage on the changed lines; remaining uncovered lines are pre-existing.

## References

Splits out the root-cause fix from the wiring PR #9527, so that `GasFeeController` can be migrated into the shared `@metamask/wallet` init set without a dependency-ordering mechanism. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core gas-estimation initialization and network-switch caching; behavior is intended to stay the same but timing of first network reads shifts to first fetch.
> 
> **Overview**
> **`GasFeeController` no longer touches `NetworkController` or the RPC provider during construction**, so it can be instantiated before the network stack is ready (e.g. shared `@metamask/wallet` init) without changing the public constructor or fetch semantics.
> 
> The constructor drops eager `EthQuery` creation and immediate chain-ID resolution (`getChainId()` / `getState` + `getNetworkClientById`). Instead, **`#getEthQuery()`** and **`#getCurrentChainId()`** memoize provider and chain ID on first use inside **`_fetchGasFeeEstimateData`**. When **`onNetworkDidChange` + `getChainId`** are supplied, the callback is stored without calling `getChainId` at construct time.
> 
> On network change, **`#onNetworkControllerDidChange`** clears the cached `ethQuery` (rebuilt on the next fetch) and still updates `currentChainId` and polling. Tests lock in zero constructor-time network/provider/`getChainId` calls and correct chain ID + provider refresh after network switches via callback or **`NetworkController:networkDidChange`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66c249d85b7293e9667f044363cbb44b04ef7a04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->