### PR TITLE
fix(assets-controller): skip spam filter on balance-only metadata heals

### DIFF
--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `TokenDataSource` balance-only metadata heals no longer apply EVM occurrence / non-EVM Blockaid spam filtering (or delete those holdings from `assetsBalance`); filtering still applies to newly `detectedAssets`. Fixes missing `assetsInfo` for already-tracked balances after [#9547](https://github.com/MetaMask/core/pull/9547)
 - `TokenDataSource` now also fetches token metadata for assets present in `assetsBalance` that are missing `assetsInfo` (previously only detected assets without metadata were enriched) ([#9547](https://github.com/MetaMask/core/pull/9547))
 
 ## [11.0.0]

--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `TokenDataSource` balance-only metadata heals no longer apply EVM occurrence / non-EVM Blockaid spam filtering (or delete those holdings from `assetsBalance`); filtering still applies to newly `detectedAssets`. Fixes missing `assetsInfo` for already-tracked balances after [#9547](https://github.com/MetaMask/core/pull/9547)
+- `TokenDataSource` balance-only metadata heals no longer apply EVM occurrence / non-EVM Blockaid spam filtering (or delete those holdings from `assetsBalance`); filtering still applies to newly `detectedAssets`. Fixes missing `assetsInfo` for already-tracked balances after [#9547](https://github.com/MetaMask/core/pull/9547) ([#9584](https://github.com/MetaMask/core/pull/9584))
 - `TokenDataSource` now also fetches token metadata for assets present in `assetsBalance` that are missing `assetsInfo` (previously only detected assets without metadata were enriched) ([#9547](https://github.com/MetaMask/core/pull/9547))
 
 ## [11.0.0]

--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `TokenDataSource` balance-only metadata heals no longer apply EVM occurrence / non-EVM Blockaid spam filtering (or delete those holdings from `assetsBalance`); filtering still applies to newly `detectedAssets`. Fixes missing `assetsInfo` for already-tracked balances after [#9547](https://github.com/MetaMask/core/pull/9547) ([#9584](https://github.com/MetaMask/core/pull/9584))
+- `TokenDataSource` balance-only metadata heals no longer apply EVM occurrence / non-EVM Blockaid spam filtering (or delete those holdings from `assetsBalance`); filtering still applies to newly `detectedAssets`. Fixes missing `assetsInfo` for already-tracked balances after [#9547](https://github.com/MetaMask/core/pull/9547)
 - `TokenDataSource` now also fetches token metadata for assets present in `assetsBalance` that are missing `assetsInfo` (previously only detected assets without metadata were enriched) ([#9547](https://github.com/MetaMask/core/pull/9547))
 
 ## [11.0.0]

--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `TokenDataSource` balance-only metadata heals no longer apply EVM occurrence / non-EVM Blockaid spam filtering (or delete those holdings from `assetsBalance`); filtering still applies to newly `detectedAssets`. Fixes missing `assetsInfo` for already-tracked balances after [#9547](https://github.com/MetaMask/core/pull/9547) ([#9584](https://github.com/MetaMask/core/pull/9584))
+
 ## [11.1.0]
 
 ### Added
@@ -30,7 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `TokenDataSource` balance-only metadata heals no longer apply EVM occurrence / non-EVM Blockaid spam filtering (or delete those holdings from `assetsBalance`); filtering still applies to newly `detectedAssets`. Fixes missing `assetsInfo` for already-tracked balances after [#9547](https://github.com/MetaMask/core/pull/9547) ([#9584](https://github.com/MetaMask/core/pull/9584))
 - `TokenDataSource` now also fetches token metadata for assets present in `assetsBalance` that are missing `assetsInfo` (previously only detected assets without metadata were enriched) ([#9547](https://github.com/MetaMask/core/pull/9547))
 
 ## [11.0.0]

--- a/packages/assets-controller/src/data-sources/TokenDataSource.test.ts
+++ b/packages/assets-controller/src/data-sources/TokenDataSource.test.ts
@@ -359,9 +359,7 @@ describe('TokenDataSource', () => {
     const { controller } = setupController({
       messenger: createTestMessenger(),
       supportedNetworks: ['eip155:1'],
-      assetsResponse: [
-        createMockAssetResponse(spamAsset, { occurrences: 1 }),
-      ],
+      assetsResponse: [createMockAssetResponse(spamAsset, { occurrences: 1 })],
       suggestedOccurrenceFloors: { '1': 3 },
     });
 

--- a/packages/assets-controller/src/data-sources/TokenDataSource.test.ts
+++ b/packages/assets-controller/src/data-sources/TokenDataSource.test.ts
@@ -312,6 +312,88 @@ describe('TokenDataSource', () => {
     expect(next).toHaveBeenCalledWith(context);
   });
 
+  it('middleware heals low-occurrence balance-only assets without spam-filtering them out', async () => {
+    // Already-tracked balances missing assetsInfo are healed via assetsBalance
+    // (not detectedAssets). Spam filtering must not strip those holdings or
+    // withhold metadata — DetectionMiddleware intentionally skips them.
+    const lowOccurrenceAsset =
+      'eip155:1/erc20:0x1111111111111111111111111111111111111111' as Caip19AssetId;
+
+    const { controller } = setupController({
+      messenger: createTestMessenger(),
+      supportedNetworks: ['eip155:1'],
+      assetsResponse: [
+        createMockAssetResponse(lowOccurrenceAsset, { occurrences: 1 }),
+      ],
+      suggestedOccurrenceFloors: { '1': 3 },
+    });
+
+    const next = jest.fn().mockResolvedValue(undefined);
+    const context = createMiddlewareContext({
+      response: {
+        assetsBalance: {
+          'mock-account-id': {
+            [lowOccurrenceAsset]: { amount: '50' },
+          },
+        },
+      },
+    });
+
+    await controller.assetsMiddleware(context, next);
+
+    expect(context.response.assetsInfo?.[lowOccurrenceAsset]).toBeDefined();
+    expect(
+      (
+        context.response.assetsBalance?.['mock-account-id'] as
+          | Record<string, unknown>
+          | undefined
+      )?.[lowOccurrenceAsset],
+    ).toBeDefined();
+    expect(next).toHaveBeenCalledWith(context);
+  });
+
+  it('middleware still spam-filters newly detected low-occurrence assets even when also in assetsBalance', async () => {
+    const spamAsset =
+      'eip155:1/erc20:0x2222222222222222222222222222222222222222' as Caip19AssetId;
+
+    const { controller } = setupController({
+      messenger: createTestMessenger(),
+      supportedNetworks: ['eip155:1'],
+      assetsResponse: [
+        createMockAssetResponse(spamAsset, { occurrences: 1 }),
+      ],
+      suggestedOccurrenceFloors: { '1': 3 },
+    });
+
+    const next = jest.fn().mockResolvedValue(undefined);
+    const context = createMiddlewareContext({
+      response: {
+        detectedAssets: {
+          'mock-account-id': [spamAsset],
+        },
+        assetsBalance: {
+          'mock-account-id': {
+            [spamAsset]: { amount: '50' },
+          },
+        },
+      },
+    });
+
+    await controller.assetsMiddleware(context, next);
+
+    expect(context.response.assetsInfo?.[spamAsset]).toBeUndefined();
+    expect(
+      (
+        context.response.assetsBalance?.['mock-account-id'] as
+          | Record<string, unknown>
+          | undefined
+      )?.[spamAsset],
+    ).toBeUndefined();
+    expect(context.response.detectedAssets?.['mock-account-id']).not.toContain(
+      spamAsset,
+    );
+  });
+
   it('middleware skips assets with existing metadata containing image in response', async () => {
     const { controller, apiClient } = setupController({
       messenger: createTestMessenger(),

--- a/packages/assets-controller/src/data-sources/TokenDataSource.ts
+++ b/packages/assets-controller/src/data-sources/TokenDataSource.ts
@@ -154,10 +154,11 @@ function getOccurrenceFloorForAsset(
  *
  * This middleware-based data source:
  * - Checks detected assets for missing metadata/images
- * - Also checks `assetsBalance` entries missing metadata/images
+ * - Also checks `assetsBalance` entries missing metadata/images (heal path)
  * - Fetches metadata from Tokens API v3 for assets needing enrichment
  * - Filters EVM ERC-20 spam using per-chain floors from Token API
- *   `/v1/suggestedOccurrenceFloors` (default floor 3)
+ *   `/v1/suggestedOccurrenceFloors` (default floor 3) for newly detected
+ *   assets only; balance-only heals are enriched without spam-filtering
  * - Merges fetched metadata into the response
  *
  * Pass the same {@link AssetsControllerMessenger} as other data sources for Blockaid
@@ -356,6 +357,11 @@ export class TokenDataSource {
    * 3. Enriches the response with fetched metadata
    * 4. Calls next() at the end to continue the middleware chain
    *
+   * Spam filtering (EVM occurrence floors / non-EVM Blockaid) applies only to
+   * newly `detectedAssets`. Balance-only heals — assets already present in
+   * `assetsBalance` but missing `assetsInfo`, which DetectionMiddleware skips —
+   * are enriched without being filtered out of balances.
+   *
    * @returns The middleware function for the assets pipeline.
    */
   get assetsMiddleware(): Middleware {
@@ -365,6 +371,11 @@ export class TokenDataSource {
 
       const { assetsInfo: stateMetadata, customAssets } = ctx.getAssetsState();
       const assetIdsNeedingMetadata = new Set<string>();
+      // Newly detected asset IDs (lowercase) — subject to spam filtering.
+      const detectedAssetIds = new Set<string>();
+      // Balance-only heals (in assetsBalance, not newly detected) — enrich
+      // metadata but do not spam-filter / delete holdings.
+      const balanceHealAssetIds = new Set<string>();
 
       // Custom assets are user-imported — exempt from spam filtering.
       // State stores asset IDs in their normalized (checksummed) form, but the
@@ -406,6 +417,7 @@ export class TokenDataSource {
               continue;
             }
 
+            detectedAssetIds.add(assetId.toLowerCase());
             assetIdsNeedingMetadata.add(assetId);
           }
         }
@@ -427,6 +439,11 @@ export class TokenDataSource {
               continue;
             }
             assetIdsNeedingMetadata.add(assetId);
+            // Only treat as a heal when DetectionMiddleware did not queue it
+            // as newly detected — those remain subject to spam filtering.
+            if (!detectedAssetIds.has(assetId.toLowerCase())) {
+              balanceHealAssetIds.add(assetId.toLowerCase());
+            }
           }
         }
       }
@@ -508,10 +525,12 @@ export class TokenDataSource {
         // Custom assets (user-imported) bypass the occurrence filter — users
         // can import whatever they want and we must keep their metadata even
         // if the API has fewer aggregator hits than the floor.
+        // Balance-only heals also bypass — see `balanceHealAssetIds` below.
         const allowedEvmIds = new Set(
           evmErc20Ids.filter(
             (id) =>
               customAssetIds.has(id.toLowerCase()) ||
+              balanceHealAssetIds.has(id.toLowerCase()) ||
               (occurrencesByAssetId.get(id) ?? 0) >=
                 getOccurrenceFloorForAsset(id, suggestedOccurrenceFloors) ||
               id.includes(`/erc20:${MUSD_ADDRESS_LOWERCASE}`),
@@ -519,13 +538,17 @@ export class TokenDataSource {
         );
 
         // Non-EVM: Blockaid bulk scan.
-        // Custom assets (user-imported) bypass Blockaid filtering.
+        // Custom assets and balance-only heals bypass Blockaid filtering.
         const nonEvmToScan = nonEvmTokenIds.filter(
-          (id) => !customAssetIds.has(id.toLowerCase()),
+          (id) =>
+            !customAssetIds.has(id.toLowerCase()) &&
+            !balanceHealAssetIds.has(id.toLowerCase()),
         );
         const allowedNonEvmIds = new Set([
-          ...nonEvmTokenIds.filter((id) =>
-            customAssetIds.has(id.toLowerCase()),
+          ...nonEvmTokenIds.filter(
+            (id) =>
+              customAssetIds.has(id.toLowerCase()) ||
+              balanceHealAssetIds.has(id.toLowerCase()),
           ),
           ...(await this.#filterBlockaidSpamTokens(nonEvmToScan)),
         ]);


### PR DESCRIPTION
Already-tracked balances missing assetsInfo were re-queued for enrichment but then occurrence/Blockaid filtering deleted them and withheld metadata. Keep spam filtering for newly detected assets only.

## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes spam-filter scope in the assets pipeline; wrongly classifying heals could show low-signal tokens, while the fix intentionally preserves already-held balances that were being stripped.
> 
> **Overview**
> Fixes a regression where **`TokenDataSource`** enriched balances missing **`assetsInfo`** but then treated them like new detections and ran EVM occurrence floors / Blockaid spam filtering, which dropped **`assetsBalance`** entries and blocked metadata.
> 
> The middleware now tracks **`detectedAssetIds`** vs **`balanceHealAssetIds`** (in **`assetsBalance`** only, not newly detected). Spam filtering still applies to **`detectedAssets`**; balance-only heals bypass occurrence and Blockaid checks like custom imports. Assets that appear in both lists stay on the detection path and can still be filtered.
> 
> Changelog and tests cover the heal vs detect split.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a038c660a99651acd35b7f45b338e4da68a08934. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->