### PR TITLE
revert: "ci: fix changelog RC validation"

### DIFF
--- a/scripts/validate-changelog.sh
+++ b/scripts/validate-changelog.sh
@@ -10,20 +10,7 @@ fi
 package_name="$1"
 shift  # remove package name from arguments
 
-if [[ "${CI:-}" = "true" ]]; then
-  if [[ -n "${GITHUB_HEAD_REF:-}" ]]; then
-    branch_name="${GITHUB_HEAD_REF}"
-  elif [[ -n "${GITHUB_REF_NAME:-}" ]]; then
-    branch_name="${GITHUB_REF_NAME}"
-  else
-    echo "Cannot determine branch name in CI environment, missing GITHUB_HEAD_REF and GITHUB_REF_NAME"
-    exit 1
-  fi;
-else
-  branch_name="$(git branch --show-current)"
-fi
-
-if [[ "${branch_name}" =~ ^release/ ]]; then
+if [[ "${GITHUB_REF:-}" =~ '^release/' ]]; then
   yarn auto-changelog validate --formatter oxfmt --tag-prefix "${package_name}@" --rc "$@"
 else
   yarn auto-changelog validate --formatter oxfmt --tag-prefix "${package_name}@" "$@"


### PR DESCRIPTION
Reverts MetaMask/core#9559.

This broke validation in release PRs, see https://github.com/MetaMask/core/actions/runs/29904309514/job/88874212283?pr=9589 for example.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CI script revert with no product runtime or security impact; restores previously working release changelog checks.
> 
> **Overview**
> Reverts the **#9559** changelog validation change that derived the branch name from `GITHUB_HEAD_REF`, `GITHUB_REF_NAME`, or local `git branch` in CI.
> 
> **`scripts/validate-changelog.sh`** again enables `--rc` for `auto-changelog validate` only when **`GITHUB_REF`** matches `^release/`, which restores correct RC validation on release pull requests where the previous logic failed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e9c1450348d296e58630a5b96701f4cbf820e9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->