### PR TITLE
fix(assets-controller): increase stale and gc time for accounts api request

### DIFF
--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `AccountsApiDataSource` `forceUpdate` balance fetches now use `staleTime`/`gcTime` of `100`ms (previously `0`/`0`) so bursts of near-simultaneous forced refreshes are de-duplicated by TanStack Query into a single Accounts API request instead of one request per trigger ([#9591](https://github.com/MetaMask/core/pull/9591))
 - `TokenDataSource` balance-only metadata heals no longer apply EVM occurrence / non-EVM Blockaid spam filtering (or delete those holdings from `assetsBalance`); filtering still applies to newly `detectedAssets`. Fixes missing `assetsInfo` for already-tracked balances after [#9547](https://github.com/MetaMask/core/pull/9547) ([#9584](https://github.com/MetaMask/core/pull/9584))
 
 ## [11.1.0]

--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `AccountsApiDataSource` `forceUpdate` balance fetches now use `staleTime`/`gcTime` of `100`ms (previously `0`/`0`) so bursts of near-simultaneous forced refreshes are de-duplicated by TanStack Query into a single Accounts API request instead of one request per trigger ([#9591](https://github.com/MetaMask/core/pull/9591))
+
 ## [11.1.1]
 
 ### Changed
@@ -17,7 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `AccountsApiDataSource` `forceUpdate` balance fetches now use `staleTime`/`gcTime` of `100`ms (previously `0`/`0`) so bursts of near-simultaneous forced refreshes are de-duplicated by TanStack Query into a single Accounts API request instead of one request per trigger ([#9591](https://github.com/MetaMask/core/pull/9591))
 - `TokenDataSource` balance-only metadata heals no longer apply EVM occurrence / non-EVM Blockaid spam filtering (or delete those holdings from `assetsBalance`); filtering still applies to newly `detectedAssets`. Fixes missing `assetsInfo` for already-tracked balances after [#9547](https://github.com/MetaMask/core/pull/9547) ([#9584](https://github.com/MetaMask/core/pull/9584))
 
 ## [11.1.0]

--- a/packages/assets-controller/src/data-sources/AccountsApiDataSource.test.ts
+++ b/packages/assets-controller/src/data-sources/AccountsApiDataSource.test.ts
@@ -377,7 +377,7 @@ describe('AccountsApiDataSource', () => {
     controller.destroy();
   });
 
-  it('fetch bypasses TanStack cache when forceUpdate is true', async () => {
+  it('uses a short-lived TanStack cache window when forceUpdate is true', async () => {
     const { controller, apiClient } = await setupController();
 
     await controller.fetch(createDataRequest({ forceUpdate: true }));
@@ -385,7 +385,7 @@ describe('AccountsApiDataSource', () => {
     expect(apiClient.accounts.fetchV5MultiAccountBalances).toHaveBeenCalledWith(
       [`eip155:1:${MOCK_ADDRESS}`],
       undefined,
-      { staleTime: 0, gcTime: 0 },
+      { staleTime: 100, gcTime: 100 },
     );
 
     controller.destroy();

--- a/packages/assets-controller/src/data-sources/AccountsApiDataSource.ts
+++ b/packages/assets-controller/src/data-sources/AccountsApiDataSource.ts
@@ -376,7 +376,7 @@ export class AccountsApiDataSource extends AbstractDataSource<
       }
 
       const fetchOptions = request.forceUpdate
-        ? { staleTime: 0, gcTime: 0 }
+        ? { staleTime: 100, gcTime: 100 }
         : undefined;
 
       // Feature-flagged: v6 endpoint with a fallback to legacy v5. The flag is


### PR DESCRIPTION
## Explanation

Current behavior:
<img width="1917" height="631" alt="image" src="https://github.com/user-attachments/assets/a9eebaab-1ff2-48c4-b788-2ca169c7826e" />

After PR:
<img width="1917" height="631" alt="image" src="https://github.com/user-attachments/assets/7f27a1cf-ccae-43d2-b9d2-70e41d3d0c8a" />



Balance refreshes triggered on-demand go through `AssetsController.getAssets(..., { forceUpdate: true })`, which flows down to `AccountsApiDataSource.fetch` as TanStack Query `fetchOptions`. Previously the `forceUpdate` path used `{ staleTime: 0, gcTime: 0 }`. These values has been added via https://github.com/MetaMask/core/pull/9265 but it was mainly to fix a websocket issue.

That was too aggressive:

- `staleTime: 0` marks the query as stale immediately, so **every** forced refresh refetches — even two identical requests fired microseconds apart.
- `gcTime: 0` evicts the cache entry the instant the query goes inactive (which, for imperative `fetchQuery`, is right after it resolves). Because the forced fetch uses the **same queryKey** as the 30s polling subscription, it not only bypasses the cache but also tears down the entry the poll would have reused.

In practice almost every internal trigger calls `getAssets` with `forceUpdate: true` (unlock, account switch, network change, tx confirmation, price refresh, etc.), and several of these fire near-simultaneously. With `0/0` each trigger produced its own Accounts API request, causing bursts of duplicate `multiaccount/balances` calls.

This PR changes the `forceUpdate` path to `{ staleTime: 200, gcTime: 200 }`. The small 200ms window lets a burst of near-simultaneous forced refreshes de-duplicate into a single Accounts API request while keeping the data effectively fresh (well within a user-perceptible refresh). Keeping `gcTime >= staleTime` also ensures the entry survives its freshness window instead of being evicted immediately.

## References

N/A

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to query cache options for forced balance fetches; balances may share a single response within ~100ms, which is an intentional tradeoff for fewer API calls.
> 
> **Overview**
> **Forced balance refreshes** (`getAssets` with `forceUpdate: true` → `AccountsApiDataSource.fetch`) no longer pass TanStack Query `{ staleTime: 0, gcTime: 0 }`. They now use **`staleTime` and `gcTime` of 100ms**, so near-simultaneous triggers (unlock, account/network switch, tx confirmation, etc.) **collapse to one** `multiaccount/balances` request instead of a burst of duplicates, while still avoiding the default long-lived cache.
> 
> The unit test and changelog are updated to match the new short-lived cache window (replacing the “fully bypass cache” expectation from [#9265](https://github.com/MetaMask/core/pull/9265)).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16592967deb28eaf68954fb68b866e3b3b80e5af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->