### PR TITLE
feat!: add `ConfigRegistryController:stateChanged` event

### DIFF
--- a/packages/config-registry-controller/CHANGELOG.md
+++ b/packages/config-registry-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `ConfigRegistryControllerStateChangedEvent` (`ConfigRegistryController:stateChanged`) to the controller's events ([#9595](https://github.com/MetaMask/core/pull/9595))
+
 ### Changed
 
 - Bump `@metamask/utils` from `^11.9.0` to `^11.11.0` ([#9074](https://github.com/MetaMask/core/pull/9074))
@@ -15,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/keyring-controller` from `^27.0.0` to `^27.1.0` ([#9129](https://github.com/MetaMask/core/pull/9129))
 - Bump `@metamask/polling-controller` from `^16.0.6` to `^16.0.8` ([#9218](https://github.com/MetaMask/core/pull/9218), [#9349](https://github.com/MetaMask/core/pull/9349))
 - Bump `@metamask/messenger` from `^1.2.0` to `^2.0.0` ([#9392](https://github.com/MetaMask/core/pull/9392))
+
+### Removed
+
+- **BREAKING:** Removed `ConfigRegistryControllerStateChangeEvent` type in favor of `ConfigRegistryControllerStateChangedEvent` ([#9595](https://github.com/MetaMask/core/pull/9595))
 
 ## [0.4.1]
 

--- a/packages/config-registry-controller/src/ConfigRegistryController.ts
+++ b/packages/config-registry-controller/src/ConfigRegistryController.ts
@@ -1,6 +1,6 @@
 import type {
   ControllerGetStateAction,
-  ControllerStateChangeEvent,
+  ControllerStateChangedEvent,
   StateMetadata,
 } from '@metamask/base-controller';
 import type {
@@ -99,8 +99,8 @@ const MESSENGER_EXPOSED_METHODS = ['startPolling', 'stopPolling'] as const;
 /**
  * Published when the state of {@link ConfigRegistryController} changes.
  */
-export type ConfigRegistryControllerStateChangeEvent =
-  ControllerStateChangeEvent<
+export type ConfigRegistryControllerStateChangedEvent =
+  ControllerStateChangedEvent<
     typeof controllerName,
     ConfigRegistryControllerState
   >;
@@ -133,7 +133,7 @@ type AllowedActions =
  * Events that {@link ConfigRegistryControllerMessenger} exposes to other consumers.
  */
 export type ConfigRegistryControllerEvents =
-  ConfigRegistryControllerStateChangeEvent;
+  ConfigRegistryControllerStateChangedEvent;
 
 /**
  * Events from other messengers that {@link ConfigRegistryControllerMessenger}

--- a/packages/config-registry-controller/src/index.ts
+++ b/packages/config-registry-controller/src/index.ts
@@ -4,7 +4,6 @@ export type {
   ConfigRegistryControllerActions,
   ConfigRegistryControllerGetStateAction,
   ConfigRegistryControllerEvents,
-  ConfigRegistryControllerStateChangeEvent,
   ConfigRegistryControllerMessenger,
 } from './ConfigRegistryController.js';
 export type {


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->
Adding `ConfigRegistryController:stateChanged` action. The existing `ConfigRegistryController:stateChange` and related `ConfigRegistryControllerStateChangeEvent` type are being removed

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->
Related: https://consensyssoftware.atlassian.net/browse/WPN-1562

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public TypeScript and messenger event contract; consumers must migrate off `ConfigRegistryControllerStateChangeEvent`, though controller runtime behavior in this diff is unchanged.
> 
> **Overview**
> **Breaking:** Aligns `ConfigRegistryController` messenger events with the newer `@metamask/base-controller` naming by exposing `ConfigRegistryController:stateChanged` via `ConfigRegistryControllerStateChangedEvent` (`ControllerStateChangedEvent`) instead of the old `ConfigRegistryControllerStateChangeEvent` type.
> 
> The controller’s exported events union and package public API no longer export `ConfigRegistryControllerStateChangeEvent`; consumers must update subscriptions and TypeScript types to the `stateChanged` / `StateChangedEvent` names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a03c277757faacd092424ff3e8723daaf4d1a5c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->