### PR TITLE
feat(config-registry-controller): add `getNetworkConfigByCaip2ChainId`

### DIFF
--- a/packages/config-registry-controller/CHANGELOG.md
+++ b/packages/config-registry-controller/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `ConfigRegistryControllerStateChangedEvent` (`ConfigRegistryController:stateChanged`) to the controller's events ([#9595](https://github.com/MetaMask/core/pull/9595))
+- Add `ConfigRegistryController.getNetworkConfigByCaip2ChainId` method to retrieve a network config by its CAIP-2 chain ID ([#0000](https://github.com/MetaMask/core/pull/0000))
+  - The method returns the network config if found, or `undefined` if not found.
+  - The method is also accessible via the controller's messenger as `ConfigRegistryController:getNetworkConfigByCaip2ChainId`.
 
 ### Changed
 

--- a/packages/config-registry-controller/CHANGELOG.md
+++ b/packages/config-registry-controller/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `ConfigRegistryControllerStateChangedEvent` (`ConfigRegistryController:stateChanged`) to the controller's events ([#9595](https://github.com/MetaMask/core/pull/9595))
-- Add `ConfigRegistryController.getNetworkConfigByCaip2ChainId` method to retrieve a network config by its CAIP-2 chain ID ([#0000](https://github.com/MetaMask/core/pull/0000))
+- Add `ConfigRegistryController.getNetworkConfigByCaip2ChainId` method to retrieve a network config by its CAIP-2 chain ID ([#9597](https://github.com/MetaMask/core/pull/9597))
   - The method returns the network config if found, or `undefined` if not found.
   - The method is also accessible via the controller's messenger as `ConfigRegistryController:getNetworkConfigByCaip2ChainId`.
 

--- a/packages/config-registry-controller/src/ConfigRegistryController-method-action-types.ts
+++ b/packages/config-registry-controller/src/ConfigRegistryController-method-action-types.ts
@@ -6,6 +6,17 @@
 import type { ConfigRegistryController } from './ConfigRegistryController.js';
 
 /**
+ * Get the network configuration for a given CAIP-2 chain ID.
+ *
+ * @param caip2ChainId - The CAIP-2 chain ID (e.g., "eip155:1").
+ * @returns The network configuration if found, otherwise undefined.
+ */
+export type ConfigRegistryControllerGetNetworkConfigByCaip2ChainIdAction = {
+  type: `ConfigRegistryController:getNetworkConfigByCaip2ChainId`;
+  handler: ConfigRegistryController['getNetworkConfigByCaip2ChainId'];
+};
+
+/**
  * Stop all polling.
  */
 export type ConfigRegistryControllerStopPollingAction = {
@@ -22,5 +33,6 @@ export type ConfigRegistryControllerStartPollingAction = {
  * Union of all ConfigRegistryController action types.
  */
 export type ConfigRegistryControllerMethodActions =
+  | ConfigRegistryControllerGetNetworkConfigByCaip2ChainIdAction
   | ConfigRegistryControllerStopPollingAction
   | ConfigRegistryControllerStartPollingAction;

--- a/packages/config-registry-controller/src/ConfigRegistryController.test.ts
+++ b/packages/config-registry-controller/src/ConfigRegistryController.test.ts
@@ -927,6 +927,46 @@ describe('ConfigRegistryController', () => {
     });
   });
 
+  describe('getNetworkConfigByCaip2ChainId', () => {
+    it('returns the correct network config for a given CAIP-2 chainId', async () => {
+      const mockNetworkConfig = createMockNetworkConfig({
+        chainId: 'eip155:1',
+        name: 'Ethereum Mainnet',
+      });
+      await withController(
+        {
+          options: {
+            state: {
+              configs: {
+                networks: {
+                  'eip155:1': createMockNetworkConfig({
+                    chainId: 'eip155:1',
+                    name: 'Ethereum Mainnet',
+                  }),
+                },
+              },
+            },
+          },
+        },
+        async ({ controller }) => {
+          const networkConfig =
+            controller.getNetworkConfigByCaip2ChainId('eip155:1');
+
+          expect(networkConfig).toStrictEqual(mockNetworkConfig);
+        },
+      );
+    });
+
+    it('returns undefined for a non-existent CAIP-2 chainId', async () => {
+      await withController(async ({ controller }) => {
+        const networkConfig =
+          controller.getNetworkConfigByCaip2ChainId('eip155:9999');
+
+        expect(networkConfig).toBeUndefined();
+      });
+    });
+  });
+
   describe('feature flag', () => {
     it('uses API when feature flag is enabled', async () => {
       await withController(

--- a/packages/config-registry-controller/src/ConfigRegistryController.ts
+++ b/packages/config-registry-controller/src/ConfigRegistryController.ts
@@ -94,7 +94,11 @@ const stateMetadata = {
  */
 const DEFAULT_FALLBACK_CONFIG: Record<string, RegistryNetworkConfig> = {};
 
-const MESSENGER_EXPOSED_METHODS = ['startPolling', 'stopPolling'] as const;
+const MESSENGER_EXPOSED_METHODS = [
+  'startPolling',
+  'stopPolling',
+  'getNetworkConfigByCaip2ChainId',
+] as const;
 
 /**
  * Published when the state of {@link ConfigRegistryController} changes.
@@ -203,6 +207,18 @@ export class ConfigRegistryController extends StaticIntervalPollingController<nu
       MESSENGER_EXPOSED_METHODS,
     );
     this.#setupEventListeners();
+  }
+
+  /**
+   * Get the network configuration for a given CAIP-2 chain ID.
+   *
+   * @param caip2ChainId - The CAIP-2 chain ID (e.g., "eip155:1").
+   * @returns The network configuration if found, otherwise undefined.
+   */
+  getNetworkConfigByCaip2ChainId(
+    caip2ChainId: string,
+  ): RegistryNetworkConfig | undefined {
+    return this.state.configs.networks[caip2ChainId];
   }
 
   async _executePoll(_input: null): Promise<void> {


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->
Adding `ConfigRegistryController:getNetworkConfigByCaip2ChainId` to make it more ergonomic for other controllers to consume ConfigRegistryController's network configs.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->
* Related to https://consensyssoftware.atlassian.net/browse/WPN-1562

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only state lookup with no mutation, polling, or security-sensitive logic; additive API only.
> 
> **Overview**
> Adds **`getNetworkConfigByCaip2ChainId`** so consumers can resolve a network config by CAIP-2 chain ID (e.g. `eip155:1`) without reading controller state directly. The method returns the matching **`RegistryNetworkConfig`** or **`undefined`**.
> 
> The method is registered in **`MESSENGER_EXPOSED_METHODS`**, so other controllers can call **`ConfigRegistryController:getNetworkConfigByCaip2ChainId`** through the messenger. Auto-generated method action types and changelog are updated; unit tests cover a hit and a missing chain ID.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 318ec0e315072b47aa988ba49662fcc83cff47fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->