### PR TITLE
ci: scope changelog RC validation to released packages

### DIFF
--- a/scripts/validate-changelog.sh
+++ b/scripts/validate-changelog.sh
@@ -10,7 +10,71 @@ fi
 package_name="$1"
 shift  # remove package name from arguments
 
-if [[ "${GITHUB_REF:-}" =~ '^release/' ]]; then
+if [[ "${CI:-}" = "true" ]]; then
+  if [[ -n "${GITHUB_HEAD_REF:-}" ]]; then
+    branch_name="${GITHUB_HEAD_REF}"
+  elif [[ -n "${GITHUB_REF_NAME:-}" ]]; then
+    branch_name="${GITHUB_REF_NAME}"
+  else
+    echo "Cannot determine branch name in CI environment, missing GITHUB_HEAD_REF and GITHUB_REF_NAME"
+    exit 1
+  fi;
+else
+  branch_name="$(git branch --show-current)"
+fi
+
+# A release only bumps a subset of packages. The `--rc` validation requires the
+# `[Unreleased]` section to be empty, so it must run only for the packages that
+# are actually part of this release. Any other package legitimately keeps
+# unreleased entries and would fail `--rc` for no reason.
+#
+# We detect "part of this release" by comparing the package version against the
+# point where this branch diverged from the base branch (the merge base, so it
+# stays correct even as the base branch moves on): if this branch bumped the
+# version, the package is being released. When we can't determine the base
+# version we default to skipping `--rc`, so an undetermined base never blocks a
+# release PR.
+is_release_candidate=false
+if [[ "${branch_name}" =~ ^release/ ]]; then
+  base_ref="${CHANGELOG_BASE_REF:-}"
+  if [[ -z "${base_ref}" ]]; then
+    for candidate in "origin/main" "main"; do
+      if git rev-parse --verify --quiet "${candidate}" >/dev/null; then
+        base_ref="${candidate}"
+        break
+      fi
+    done
+    if [[ -z "${base_ref}" ]] && git fetch --quiet --depth=1 origin main 2>/dev/null; then
+      base_ref="FETCH_HEAD"
+    fi
+  fi
+
+  # Compare against the common ancestor, deepening the history if a shallow CI
+  # checkout hides it.
+  base_commit=""
+  if [[ -n "${base_ref}" ]]; then
+    base_commit="$(git merge-base "${base_ref}" HEAD 2>/dev/null || true)"
+    if [[ -z "${base_commit}" ]]; then
+      git fetch --quiet --deepen=100 origin main 2>/dev/null || git fetch --quiet --unshallow origin 2>/dev/null || true
+      base_commit="$(git merge-base "${base_ref}" HEAD 2>/dev/null || true)"
+    fi
+  fi
+
+  current_version="$(node -p "require('./package.json').version")"
+  base_version=""
+  if [[ -n "${base_commit}" ]]; then
+    base_version="$(git show "${base_commit}:./package.json" 2>/dev/null | node -e "const fs=require('fs');try{process.stdout.write(String(JSON.parse(fs.readFileSync(0,'utf8')).version||''))}catch{process.stdout.write('')}" || true)"
+  fi
+
+  # Only treat as a release candidate when we positively confirm the version was
+  # bumped on this branch. `0.0.0` marks an unpublished package with no released
+  # version, so `--rc` (which requires a matching version heading) never applies.
+  if [[ -n "${base_version}" && "${current_version}" != "0.0.0" && "${current_version}" != "${base_version}" ]]; then
+    is_release_candidate=true
+  fi
+fi
+
+if [[ "${is_release_candidate}" = "true" ]]; then
   yarn auto-changelog validate --formatter oxfmt --tag-prefix "${package_name}@" --rc "$@"
 else
   yarn auto-changelog validate --formatter oxfmt --tag-prefix "${package_name}@" "$@"


### PR DESCRIPTION
## Explanation

#9559 fixed release branch detection so `--rc` actually runs, but that surfaced a second problem and the PR was reverted in #9590.

A release only bumps a subset of packages, while `changelog:validate` runs across every workspace (the CI matrix validates all package names). The `--rc` check requires an empty `[Unreleased]` section, so applying it to every package on a release branch made all the packages that legitimately carry unreleased entries fail, even though they are not part of the release. On a real release branch only a couple of packages get a new version, so almost everything failed.

This scopes `--rc` per package: it runs only when the package version was bumped on this branch. "Bumped on this branch" is decided by comparing the current `package.json` version against the version at the merge base with the base branch, so it stays correct even as the base branch moves on. Packages that are not part of the release validate without `--rc`, exactly as before.

Other details:

* The corrected release detection from #9559 (`GITHUB_HEAD_REF` / `GITHUB_REF_NAME` plus an unquoted `^release/` pattern) is kept.
* When the base version cannot be determined, we default to skipping `--rc` so an undetermined base never blocks a release PR.
* `0.0.0` (unpublished) packages never get `--rc`, since there is no released version to match a heading against.

## Verification

Checked against a real release branch (`release/1136.0.0`, which bumps only `transaction-controller` and `transaction-pay-controller`):

* Before: `yarn changelog:validate` failed for 72 packages with `Unreleased changes present in the changelog`.
* After: passes. Only the two bumped packages get `--rc`; injecting an `[Unreleased]` entry into a bumped package still fails validation, so RC enforcement is intact.

## References

* Reverted PR: #9559
* Revert: #9590

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only shell script change for changelog validation; no runtime product code, with conservative defaults when the base version cannot be determined.
> 
> **Overview**
> Fixes release PR CI where **every** workspace package ran `auto-changelog validate --rc` on `release/*` branches, causing packages not in the release to fail because they still have `[Unreleased]` entries.
> 
> `scripts/validate-changelog.sh` now resolves the branch in CI via `GITHUB_HEAD_REF` / `GITHUB_REF_NAME` (and locally via `git branch --show-current`), then on `release/*` compares the current `package.json` version to the version at the **merge base** with `main` (with optional `CHANGELOG_BASE_REF`, shallow-fetch fallbacks). **`--rc` is passed only when that comparison shows a real version bump**; `0.0.0` and unknown base versions skip `--rc` so release PRs are not blocked. Non-release branches and non-bumped packages keep standard validation without `--rc`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee1950a323ce629d952b2fcc8882fccc7ce5b46c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->