### PR TITLE
feat(profile-sync-controller): add authentication selectors for cached session data

### DIFF
--- a/packages/profile-sync-controller/CHANGELOG.md
+++ b/packages/profile-sync-controller/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `authenticationControllerSelectors` for best-effort reads of cached session identity from `AuthenticationController` state
+  - `selectSrpSessionData` — raw `srpSessionData` map
+  - `selectSessionData` — primary (first) SRP session entry
+  - `selectCanonicalProfileId` — cached `canonicalProfileId`, treating `''` as missing
+  - Intended for sync consumers (e.g. Braze) that should not wait on `getSessionProfile()`. Same staleness as a valid cached session; use `refreshCanonicalProfileId()` when freshness is required.
+
 ## [28.3.0]
 
 ### Added

--- a/packages/profile-sync-controller/CHANGELOG.md
+++ b/packages/profile-sync-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `authenticationControllerSelectors` for best-effort reads of cached session identity from `AuthenticationController` state
+- Add `authenticationControllerSelectors` for best-effort reads of cached session identity from `AuthenticationController` state ([#9604](https://github.com/MetaMask/core/pull/9604))
   - `selectSrpSessionData` — raw `srpSessionData` map
   - `selectSessionData` — primary (first) SRP session entry
   - `selectCanonicalProfileId` — cached `canonicalProfileId`, treating `''` as missing

--- a/packages/profile-sync-controller/src/controllers/authentication/index.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/index.ts
@@ -4,6 +4,7 @@ export { AuthenticationController as Controller };
 export default AuthenticationController;
 export * from './AuthenticationController.js';
 export * as Mocks from './mocks/index.js';
+export { authenticationControllerSelectors } from './selectors.js';
 
 export type {
   AuthenticationControllerPerformSignInAction,

--- a/packages/profile-sync-controller/src/controllers/authentication/selectors.test.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/selectors.test.ts
@@ -1,0 +1,147 @@
+import type { LoginResponse } from '../../sdk';
+import type { AuthenticationControllerState } from './AuthenticationController';
+import { authenticationControllerSelectors } from './selectors';
+
+const createLoginResponse = (
+  overrides: Partial<LoginResponse['profile']> = {},
+): LoginResponse => ({
+  token: {
+    accessToken: 'access-token',
+    expiresIn: 3600,
+    obtainedAt: Date.now(),
+  },
+  profile: {
+    identifierId: 'identifier-id',
+    profileId: 'profile-id',
+    canonicalProfileId: 'canonical-profile-id',
+    metaMetricsId: 'metametrics-id',
+    ...overrides,
+  },
+});
+
+describe('authenticationControllerSelectors', () => {
+  describe('selectSrpSessionData', () => {
+    it('returns undefined when srpSessionData is missing', () => {
+      const state: AuthenticationControllerState = {
+        isSignedIn: false,
+      };
+
+      expect(
+        authenticationControllerSelectors.selectSrpSessionData(state),
+      ).toBeUndefined();
+    });
+
+    it('returns the srpSessionData map when present', () => {
+      const srpSessionData = {
+        'entropy-1': createLoginResponse(),
+      };
+      const state: AuthenticationControllerState = {
+        isSignedIn: true,
+        srpSessionData,
+      };
+
+      expect(
+        authenticationControllerSelectors.selectSrpSessionData(state),
+      ).toBe(srpSessionData);
+    });
+  });
+
+  describe('selectSessionData', () => {
+    it('returns undefined when srpSessionData is missing', () => {
+      const state: AuthenticationControllerState = {
+        isSignedIn: false,
+      };
+
+      expect(
+        authenticationControllerSelectors.selectSessionData(state),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined when srpSessionData is empty', () => {
+      const state: AuthenticationControllerState = {
+        isSignedIn: true,
+        srpSessionData: {},
+      };
+
+      expect(
+        authenticationControllerSelectors.selectSessionData(state),
+      ).toBeUndefined();
+    });
+
+    it('returns the first session entry', () => {
+      const primary = createLoginResponse({ profileId: 'primary-profile' });
+      const secondary = createLoginResponse({ profileId: 'secondary-profile' });
+      const state: AuthenticationControllerState = {
+        isSignedIn: true,
+        srpSessionData: {
+          'entropy-1': primary,
+          'entropy-2': secondary,
+        },
+      };
+
+      expect(authenticationControllerSelectors.selectSessionData(state)).toBe(
+        primary,
+      );
+    });
+  });
+
+  describe('selectCanonicalProfileId', () => {
+    it('returns undefined when srpSessionData is missing', () => {
+      const state: AuthenticationControllerState = {
+        isSignedIn: false,
+      };
+
+      expect(
+        authenticationControllerSelectors.selectCanonicalProfileId(state),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined when canonicalProfileId is an empty string', () => {
+      const state: AuthenticationControllerState = {
+        isSignedIn: true,
+        srpSessionData: {
+          'entropy-1': createLoginResponse({ canonicalProfileId: '' }),
+        },
+      };
+
+      expect(
+        authenticationControllerSelectors.selectCanonicalProfileId(state),
+      ).toBeUndefined();
+    });
+
+    it('returns the canonical profile ID on the happy path', () => {
+      const state: AuthenticationControllerState = {
+        isSignedIn: true,
+        srpSessionData: {
+          'entropy-1': createLoginResponse({
+            canonicalProfileId: 'canonical-profile-id',
+          }),
+        },
+      };
+
+      expect(
+        authenticationControllerSelectors.selectCanonicalProfileId(state),
+      ).toBe('canonical-profile-id');
+    });
+
+    it('returns the shared canonical when multiple SRP sessions are present after propagation', () => {
+      const state: AuthenticationControllerState = {
+        isSignedIn: true,
+        srpSessionData: {
+          'entropy-1': createLoginResponse({
+            profileId: 'original-1',
+            canonicalProfileId: 'shared-canonical',
+          }),
+          'entropy-2': createLoginResponse({
+            profileId: 'original-2',
+            canonicalProfileId: 'shared-canonical',
+          }),
+        },
+      };
+
+      expect(
+        authenticationControllerSelectors.selectCanonicalProfileId(state),
+      ).toBe('shared-canonical');
+    });
+  });
+});

--- a/packages/profile-sync-controller/src/controllers/authentication/selectors.test.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/selectors.test.ts
@@ -1,6 +1,6 @@
-import type { LoginResponse } from '../../sdk';
-import type { AuthenticationControllerState } from './AuthenticationController';
-import { authenticationControllerSelectors } from './selectors';
+import type { LoginResponse } from '../../sdk/index.js';
+import type { AuthenticationControllerState } from './AuthenticationController.js';
+import { authenticationControllerSelectors } from './selectors.js';
 
 const createLoginResponse = (
   overrides: Partial<LoginResponse['profile']> = {},

--- a/packages/profile-sync-controller/src/controllers/authentication/selectors.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/selectors.ts
@@ -1,5 +1,5 @@
-import type { LoginResponse } from '../../sdk';
-import type { AuthenticationControllerState } from './AuthenticationController';
+import type { LoginResponse } from '../../sdk/index.js';
+import type { AuthenticationControllerState } from './AuthenticationController.js';
 
 /**
  * Selects the raw SRP session map from AuthenticationController state.
@@ -55,7 +55,10 @@ const selectCanonicalProfileId = (
   const canonicalProfileId =
     selectSessionData(state)?.profile?.canonicalProfileId;
   // `''` is used by `#invalidateSrpSession` to mark the session as invalid.
-  return canonicalProfileId ? canonicalProfileId : undefined;
+  if (!canonicalProfileId) {
+    return undefined;
+  }
+  return canonicalProfileId;
 };
 
 /**

--- a/packages/profile-sync-controller/src/controllers/authentication/selectors.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/selectors.ts
@@ -1,0 +1,70 @@
+import type { LoginResponse } from '../../sdk';
+import type { AuthenticationControllerState } from './AuthenticationController';
+
+/**
+ * Selects the raw SRP session map from AuthenticationController state.
+ *
+ * @param state - The AuthenticationController state.
+ * @returns The `srpSessionData` map, or `undefined` when not signed in / cleared.
+ */
+const selectSrpSessionData = (
+  state: AuthenticationControllerState,
+): AuthenticationControllerState['srpSessionData'] => state.srpSessionData;
+
+/**
+ * Selects the primary (first) SRP session entry from cached `srpSessionData`.
+ *
+ * Uses the first `Object.entries` value — the same "primary / first written"
+ * convention as extension `selectSessionData`. During `performSignIn`, sessions
+ * are written sequentially with the primary SRP first.
+ *
+ * @param state - The AuthenticationController state.
+ * @returns The primary session login response, or `undefined` if unavailable.
+ */
+const selectSessionData = (
+  state: AuthenticationControllerState,
+): LoginResponse | undefined => {
+  const srpSessionData = selectSrpSessionData(state);
+  if (!srpSessionData) {
+    return undefined;
+  }
+  const firstEntry = Object.entries(srpSessionData)[0];
+  return firstEntry?.[1];
+};
+
+/**
+ * Selects the best-effort cached canonical profile ID.
+ *
+ * Reads from the primary SRP session in `srpSessionData` without triggering
+ * login or unlock checks. Suitable for non-security consumers.
+ *
+ * Empty string is treated as missing (`undefined`) because the controller sets
+ * `canonicalProfileId` to `''` when invalidating a session
+ * (`#invalidateSrpSession`).
+ *
+ * Staleness: same as a valid cached `getSessionProfile()` result. Cross-device
+ * pairing can change the canonical without updating this cache until the next
+ * login or pair. Use `refreshCanonicalProfileId()` when freshness is required.
+ *
+ * @param state - The AuthenticationController state.
+ * @returns The cached canonical profile ID, or `undefined` if unavailable.
+ */
+const selectCanonicalProfileId = (
+  state: AuthenticationControllerState,
+): string | undefined => {
+  const canonicalProfileId =
+    selectSessionData(state)?.profile?.canonicalProfileId;
+  // `''` is used by `#invalidateSrpSession` to mark the session as invalid.
+  return canonicalProfileId ? canonicalProfileId : undefined;
+};
+
+/**
+ * Selectors for AuthenticationController state.
+ * These take controller state (not client `RootState`) and can be composed
+ * with Redux `createSelector` in clients.
+ */
+export const authenticationControllerSelectors = {
+  selectSrpSessionData,
+  selectSessionData,
+  selectCanonicalProfileId,
+};


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Clients (especially mobile Braze banners) need a **sync** way to read the cached `canonicalProfileId` for identity (`Braze.changeUser`) before refreshing banners. Today the shared path is `AuthenticationController.getSessionProfile()`, which can take 2s+ when it falls into a re-login / unlock-gated path — too slow for this use case.

Cached `canonicalProfileId` in persisted `srpSessionData` is enough for Braze (best-effort identity; canonical rarely changes between sessions). Mobile currently has a temporary client-side helper; Core should own this as the shared source of truth.

This PR adds guideline-aligned derived-state selectors on `AuthenticationController` (no new state field, no getter, no messenger action):

- `selectSrpSessionData` — raw `srpSessionData` map
- `selectSessionData` — primary / first SRP session entry (same convention as extension)
- `selectCanonicalProfileId` — cached canonical ID; treats `''` as missing (controller invalidation marker)

Exported from `@metamask/profile-sync-controller/auth`. Staleness matches a valid cached `getSessionProfile()`; use `refreshCanonicalProfileId()` when freshness is required. Existing auth APIs are unchanged.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only derived selectors with no auth flow changes; main caveat is documented cache staleness for identity use cases.
> 
> **Overview**
> Adds **`authenticationControllerSelectors`** on `AuthenticationController` so clients can read cached session identity **synchronously** from persisted state instead of calling `getSessionProfile()` (which can block on unlock/re-login).
> 
> New selectors: **`selectSrpSessionData`** (raw map), **`selectSessionData`** (first/primary SRP entry, same convention as extension), and **`selectCanonicalProfileId`** (best-effort canonical ID; treats `''` as missing to match `#invalidateSrpSession`). Exported from the auth package entrypoint; no new state, messenger actions, or changes to existing auth APIs.
> 
> Docs note the same staleness as a valid cached session and point consumers that need freshness at **`refreshCanonicalProfileId()`**. Unit tests cover empty/missing session data and multi-SRP cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 064aea96da50fc22b75c7fcec8fadad7f495d756. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->