### PR TITLE
chore: pass marketCap on Trade  (social-trading)

### DIFF
--- a/packages/social-controllers/CHANGELOG.md
+++ b/packages/social-controllers/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add optional `marketCap` to the `Trade` type (and `TradeStruct`) — historical token market cap at trade time from the social API ([#9605](https://github.com/MetaMask/core/pull/9605))
+
 ## [2.5.0]
 
 ### Added

--- a/packages/social-controllers/CHANGELOG.md
+++ b/packages/social-controllers/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.6.0]
-
-### Added
-
-- Add optional `marketCap` to the `Trade` type (and `TradeStruct`) — historical token market cap at trade time from the social API ([#9605](https://github.com/MetaMask/core/pull/9605))
-
 ## [2.5.0]
 
 ### Added

--- a/packages/social-controllers/CHANGELOG.md
+++ b/packages/social-controllers/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.0]
+
+### Added
+
+- Add optional `marketCap` to the `Trade` type (and `TradeStruct`) — historical token market cap at trade time from the social API ([#TBD](https://github.com/MetaMask/core/pull/TBD))
+
 ## [2.5.0]
 
 ### Added

--- a/packages/social-controllers/CHANGELOG.md
+++ b/packages/social-controllers/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add optional `marketCap` to the `Trade` type (and `TradeStruct`) — historical token market cap at trade time from the social API ([#TBD](https://github.com/MetaMask/core/pull/TBD))
+- Add optional `marketCap` to the `Trade` type (and `TradeStruct`) — historical token market cap at trade time from the social API ([#9605](https://github.com/MetaMask/core/pull/9605))
 
 ## [2.5.0]
 

--- a/packages/social-controllers/package.json
+++ b/packages/social-controllers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/social-controllers",
-  "version": "2.6.0",
+  "version": "2.5.0",
   "description": "A collection of social related controllers",
   "keywords": [
     "Ethereum",

--- a/packages/social-controllers/package.json
+++ b/packages/social-controllers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/social-controllers",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "A collection of social related controllers",
   "keywords": [
     "Ethereum",

--- a/packages/social-controllers/src/social-types.ts
+++ b/packages/social-controllers/src/social-types.ts
@@ -50,6 +50,8 @@ export const TradeStruct = structType({
   perpLeverage: optional(nullable(number())),
   tokenAmount: number(),
   usdCost: number(),
+  /** Token market cap in USD at trade time. `null` when Clicker has no mark. */
+  marketCap: optional(nullable(number())),
   timestamp: number(),
   transactionHash: string(),
 });


### PR DESCRIPTION
## Explanation

Pass `marketCap` to `Trade`, meaning `TradeStruct` + `Trade` type get `marketCap?: number | null`..

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible optional field on trade validation/types only; no auth, persistence, or behavior changes.
> 
> **Overview**
> Extends **`Trade`** / **`TradeStruct`** with an optional **`marketCap`** field (`number | null`) so consumers can show the token’s USD market cap at trade time when the social API (Clicker) provides it.
> 
> The superstruct schema in `social-types.ts` is updated and **`Trade`** is still derived via **`Infer`**, so any API responses that already validate trades through **`TradeStruct`** (e.g. position **`trades`** in **`SocialService`**) accept the new property without breaking older payloads that omit it. The package changelog records the addition under **Unreleased**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eab250d0dfe9dcdcab51cd71a6be5004b9b818fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->