### PR TITLE
feat(config-registry-controller)!: index configs by caip chain id

### DIFF
--- a/packages/config-registry-controller/CHANGELOG.md
+++ b/packages/config-registry-controller/CHANGELOG.md
@@ -10,13 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `ConfigRegistryControllerStateChangedEvent` (`ConfigRegistryController:stateChanged`) to the controller's events ([#9595](https://github.com/MetaMask/core/pull/9595))
-- Add `ConfigRegistryController.getNetworkConfigByCaip2ChainId` method to retrieve a network config by its CAIP-2 chain ID ([#9597](https://github.com/MetaMask/core/pull/9597), [#0000](https://github.com/MetaMask/core/pull/0000))
+- Add `ConfigRegistryController.getNetworkConfigByCaip2ChainId` method to retrieve a network config by its CAIP-2 chain ID ([#9597](https://github.com/MetaMask/core/pull/9597), [#9606](https://github.com/MetaMask/core/pull/9606))
   - The method returns the network config if found, or `undefined` if not found.
   - The method is also accessible via the controller's messenger as `ConfigRegistryController:getNetworkConfigByCaip2ChainId`.
 
 ### Changed
 
-**BREAKING:** `ConfigRegistryControllerState.configs.networks` is now a `Record<Caip2ChainId, RegistryNetworkConfig>` instead of a `Record<string, RegistryNetworkConfig>` ([#0000](https://github.com/MetaMask/core/pull/0000))
+**BREAKING:** `ConfigRegistryControllerState.configs.networks` is now a `Record<Caip2ChainId, RegistryNetworkConfig>` instead of a `Record<string, RegistryNetworkConfig>` ([#9606](https://github.com/MetaMask/core/pull/9606))
 - Bump `@metamask/utils` from `^11.9.0` to `^11.11.0` ([#9074](https://github.com/MetaMask/core/pull/9074))
 - Bump `@metamask/controller-utils` from `^12.1.1` to `^12.3.0` ([#9083](https://github.com/MetaMask/core/pull/9083), [#9218](https://github.com/MetaMask/core/pull/9218))
 - Bump `@metamask/profile-sync-controller` from `^28.1.1` to `^28.3.0` ([#9119](https://github.com/MetaMask/core/pull/9119), [#9463](https://github.com/MetaMask/core/pull/9463))

--- a/packages/config-registry-controller/CHANGELOG.md
+++ b/packages/config-registry-controller/CHANGELOG.md
@@ -10,12 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `ConfigRegistryControllerStateChangedEvent` (`ConfigRegistryController:stateChanged`) to the controller's events ([#9595](https://github.com/MetaMask/core/pull/9595))
-- Add `ConfigRegistryController.getNetworkConfigByCaip2ChainId` method to retrieve a network config by its CAIP-2 chain ID ([#9597](https://github.com/MetaMask/core/pull/9597))
+- Add `ConfigRegistryController.getNetworkConfigByCaip2ChainId` method to retrieve a network config by its CAIP-2 chain ID ([#9597](https://github.com/MetaMask/core/pull/9597), [#0000](https://github.com/MetaMask/core/pull/0000))
   - The method returns the network config if found, or `undefined` if not found.
   - The method is also accessible via the controller's messenger as `ConfigRegistryController:getNetworkConfigByCaip2ChainId`.
 
 ### Changed
 
+**BREAKING:** `ConfigRegistryControllerState.configs.networks` is now a `Record<Caip2ChainId, RegistryNetworkConfig>` instead of a `Record<string, RegistryNetworkConfig>` ([#0000](https://github.com/MetaMask/core/pull/0000))
 - Bump `@metamask/utils` from `^11.9.0` to `^11.11.0` ([#9074](https://github.com/MetaMask/core/pull/9074))
 - Bump `@metamask/controller-utils` from `^12.1.1` to `^12.3.0` ([#9083](https://github.com/MetaMask/core/pull/9083), [#9218](https://github.com/MetaMask/core/pull/9218))
 - Bump `@metamask/profile-sync-controller` from `^28.1.1` to `^28.3.0` ([#9119](https://github.com/MetaMask/core/pull/9119), [#9463](https://github.com/MetaMask/core/pull/9463))

--- a/packages/config-registry-controller/CHANGELOG.md
+++ b/packages/config-registry-controller/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-**BREAKING:** `ConfigRegistryControllerState.configs.networks` is now a `Record<Caip2ChainId, RegistryNetworkConfig>` instead of a `Record<string, RegistryNetworkConfig>` ([#9606](https://github.com/MetaMask/core/pull/9606))
+- **BREAKING:** `ConfigRegistryControllerState.configs.networks` is now a `Record<Caip2ChainId, RegistryNetworkConfig>` instead of a `Record<string, RegistryNetworkConfig>` ([#9606](https://github.com/MetaMask/core/pull/9606))
 - Bump `@metamask/utils` from `^11.9.0` to `^11.11.0` ([#9074](https://github.com/MetaMask/core/pull/9074))
 - Bump `@metamask/controller-utils` from `^12.1.1` to `^12.3.0` ([#9083](https://github.com/MetaMask/core/pull/9083), [#9218](https://github.com/MetaMask/core/pull/9218))
 - Bump `@metamask/profile-sync-controller` from `^28.1.1` to `^28.3.0` ([#9119](https://github.com/MetaMask/core/pull/9119), [#9463](https://github.com/MetaMask/core/pull/9463))

--- a/packages/config-registry-controller/src/ConfigRegistryController.ts
+++ b/packages/config-registry-controller/src/ConfigRegistryController.ts
@@ -12,7 +12,7 @@ import type { Messenger } from '@metamask/messenger';
 import { StaticIntervalPollingController } from '@metamask/polling-controller';
 import type { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
 import type { RemoteFeatureFlagControllerStateChangeEvent } from '@metamask/remote-feature-flag-controller';
-import { Duration, inMilliseconds, Json } from '@metamask/utils';
+import { CaipChainId, Duration, inMilliseconds, Json } from '@metamask/utils';
 
 import type { ConfigRegistryApiServiceFetchConfigAction } from './config-registry-api-service/config-registry-api-service-method-action-types.js';
 import type { RegistryNetworkConfig } from './config-registry-api-service/types.js';
@@ -37,7 +37,7 @@ export type ConfigRegistryControllerState = {
    * Use selectors (e.g. selectFeaturedNetworks) to filter when needed.
    */
   configs: {
-    networks: Record<string, RegistryNetworkConfig>;
+    networks: Record<CaipChainId, RegistryNetworkConfig>;
   };
   /**
    * Semantic version string of the configuration data from the API.
@@ -216,7 +216,7 @@ export class ConfigRegistryController extends StaticIntervalPollingController<nu
    * @returns The network configuration if found, otherwise undefined.
    */
   getNetworkConfigByCaip2ChainId(
-    caip2ChainId: string,
+    caip2ChainId: CaipChainId,
   ): RegistryNetworkConfig | undefined {
     return this.state.configs.networks[caip2ChainId];
   }

--- a/packages/config-registry-controller/src/config-registry-api-service/types.ts
+++ b/packages/config-registry-controller/src/config-registry-api-service/types.ts
@@ -8,6 +8,7 @@ import {
   string,
   type,
 } from '@metamask/superstruct';
+import { CaipChainIdStruct } from '@metamask/utils';
 
 const AssetSchema = type({
   assetId: string(),
@@ -55,7 +56,7 @@ const ChainConfigSchema = type({
  * chainId is in CAIP-2 format (e.g. "eip155:1", "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp").
  */
 export const RegistryNetworkConfigSchema = type({
-  chainId: string(),
+  chainId: CaipChainIdStruct,
   name: string(),
   imageUrl: string(),
   coingeckoPlatformId: string(),


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->
The `ConfigRegistryControllerState.configs.networks` type is being narrowed down to `Record<CaipChainId, RegistryNetworkConfig>` instead of `Record<string, RegistryNetworkConfig>`

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->
* Related to https://consensyssoftware.atlassian.net/browse/WPN-1562

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking TypeScript types for `configs.networks` and lookup parameters require consumer updates; runtime behavior is mostly unchanged aside from stricter chain ID validation on API responses.
> 
> **Overview**
> **BREAKING:** Network configs in controller state are now keyed and typed as **`CaipChainId`** instead of arbitrary strings. `ConfigRegistryControllerState.configs.networks` becomes `Record<CaipChainId, RegistryNetworkConfig>`, and `getNetworkConfigByCaip2ChainId` takes a `CaipChainId` argument.
> 
> Registry API parsing now validates each chain’s `chainId` with **`CaipChainIdStruct`** from `@metamask/utils`, so only CAIP-2-shaped IDs (e.g. `eip155:1`) are accepted at the type/schema layer. The changelog documents the breaking state shape change and ties it to the existing lookup API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c8a1f8170ef2cbdae9d97bc87cd8d0da1921648. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->