### PR TITLE
docs: fix broken links and stale controller names

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -1,3 +1,3 @@
 # Guidance for Bugbot
 
-Please read the [agents file](./AGENTS.md) in the root of the project for instructions.
+Please read the [agents file](../AGENTS.md) in the root of the project for instructions.

--- a/packages/assets-controllers/README.md
+++ b/packages/assets-controllers/README.md
@@ -16,12 +16,12 @@ This package features the following controllers:
 
 - [**AccountTrackerController**](src/AccountTrackerController.ts) keeps a updated list of the accounts in the currently selected keychain which is updated automatically on a schedule or on demand.
 - [**AssetsContractController**](src/AssetsContractController.ts) provides a set of convenience methods that use contracts to retrieve information about tokens, read token balances, and transfer tokens.
-- [**CollectibleDetectionController**](src/CollectibleDetectionController.ts) keeps a periodically updated list of ERC-721 tokens assigned to the currently selected address.
-- [**CollectiblesController**](src/CollectiblesController.ts) tracks ERC-721 and ERC-1155 tokens assigned to the currently selected address, using OpenSea to retrieve token information.
 - [**CurrencyRateController**](src/CurrencyRateController.ts) keeps a periodically updated value of the exchange rate from the currently selected "native" currency to another (handling testnet tokens specially).
-- [**DeFiPositionsController**](src/DeFiPositionsController/DeFiPositionsController.ts.ts) keeps a periodically updated value of the DeFi positions for the owner EVM addresses.
+- [**DeFiPositionsController**](src/DeFiPositionsController/DeFiPositionsController.ts) keeps a periodically updated value of the DeFi positions for the owner EVM addresses.
+- [**NftController**](src/NftController.ts) tracks ERC-721 and ERC-1155 tokens assigned to the currently selected address, using OpenSea to retrieve token information.
+- [**NftDetectionController**](src/NftDetectionController.ts) keeps a periodically updated list of ERC-721 tokens assigned to the currently selected address.
 - [**RatesController**](src/RatesController/RatesController.ts) keeps a periodically updated value for the exchange rates for different cryptocurrencies. The difference between the `RatesController` and `CurrencyRateController` is that the second one is coupled to the `NetworksController` and is EVM specific, whilst the first one can handle different blockchain currencies like BTC and SOL.
-- [**TokenBalancesController**](src/TokenBalancesController.ts) keeps a periodically updated set of balances for the current set of ERC-20 tokens. It supports real-time balance updates via WebSocket and intelligent polling management. See [Real-Time Balance Updates Flow](./REAL_TIME_BALANCE_UPDATES.md) for details.
+- [**TokenBalancesController**](src/TokenBalancesController.ts) keeps a periodically updated set of balances for the current set of ERC-20 tokens. It supports real-time balance updates via WebSocket and intelligent polling management. See [Real-Time Balance Updates Flow](../core-backend/docs/real-time-balance-updates-flow.md) for details.
 - [**TokenDetectionController**](src/TokenDetectionController.ts) keeps a periodically updated list of ERC-20 tokens assigned to the currently selected address.
 - [**TokenListController**](src/TokenListController.ts) uses the MetaSwap API to keep a periodically updated list of known ERC-20 tokens along with their metadata.
 - [**TokenRatesController**](src/TokenRatesController.ts) keeps a periodically updated list of exchange rates for known ERC-20 tokens relative to the currently selected native currency.

--- a/packages/core-backend/docs/real-time-balance-updates-flow.md
+++ b/packages/core-backend/docs/real-time-balance-updates-flow.md
@@ -246,8 +246,8 @@ When balance updates include previously unknown tokens:
 
 ## References
 
-- [`TokenBalancesController.ts`](../packages/assets-controllers/src/TokenBalancesController.ts) - Main controller implementation
-- [`AccountActivityService.ts`](../packages/core-backend/src/AccountActivityService.ts) - Account activity monitoring
-- [`BackendWebSocketService.ts`](../packages/core-backend/src/BackendWebSocketService.ts) - WebSocket connection management
-- [`types.ts`](../packages/core-backend/src/types.ts) - Type definitions
-- [Core Backend README](../packages/core-backend/README.md) - Package overview
+- [`TokenBalancesController.ts`](../../assets-controllers/src/TokenBalancesController.ts) - Main controller implementation
+- [`AccountActivityService.ts`](../src/ws/AccountActivityService.ts) - Account activity monitoring
+- [`BackendWebSocketService.ts`](../src/ws/BackendWebSocketService.ts) - WebSocket connection management
+- [`types.ts`](../src/types.ts) - Type definitions
+- [Core Backend README](../README.md) - Package overview

--- a/packages/permission-controller/ARCHITECTURE.md
+++ b/packages/permission-controller/ARCHITECTURE.md
@@ -222,7 +222,7 @@ If no merger exists for a caveat that must be merged, the request will fail.
 
 ## Examples
 
-In addition to the below examples, the [`PermissionController` unit tests](./PermissionController.test.ts) show how to set up the controller.
+In addition to the below examples, the [`PermissionController` unit tests](./src/PermissionController.test.ts) show how to set up the controller.
 
 ### Construction
 

--- a/packages/transaction-pay-controller/ARCHITECTURE.md
+++ b/packages/transaction-pay-controller/ARCHITECTURE.md
@@ -14,7 +14,7 @@ The tokens required by a transaction are automatically identified from various s
 - Gas Fees
   - A required native token is generated from the gas limit and gas fee parameters, including estimates from the `GasFeeController`.
 
-See [required-tokens.ts](/packages/transaction-pay-controller/src/utils/required-tokens.ts).
+See [required-tokens.ts](./src/utils/required-tokens.ts).
 
 ## Payment Token
 


### PR DESCRIPTION
## Explanation

A mechanical link audit of every markdown file in the repo (resolving each relative link target against the filesystem) found 12 broken links across 5 files. Docs-only change; no code touched.

**`packages/assets-controllers/README.md`**
- The controller list still names **CollectibleDetectionController** and **CollectiblesController**, which were renamed to `NftDetectionController` / `NftController` long ago — both links 404. Updated the names and links, and moved the two entries so the list stays alphabetical.
- `DeFiPositionsController.ts.ts` double-extension typo in the link target.
- `./REAL_TIME_BALANCE_UPDATES.md` doesn't exist; the doc lives at `packages/core-backend/docs/real-time-balance-updates-flow.md`.

**`packages/core-backend/docs/real-time-balance-updates-flow.md`**
- The five links in "Related files" were written relative to the repo root (`../packages/...`), so they resolve to nonexistent paths from the file's directory. Also, `AccountActivityService.ts` and `BackendWebSocketService.ts` live under `src/ws/`, not `src/`.

**`packages/transaction-pay-controller/ARCHITECTURE.md`** — `/packages/...` absolute path doesn't resolve on GitHub → `./src/utils/required-tokens.ts`.

**`packages/permission-controller/ARCHITECTURE.md`** — `./PermissionController.test.ts` → `./src/PermissionController.test.ts`.

**`.cursor/BUGBOT.md`** — `./AGENTS.md` → `../AGENTS.md` (AGENTS.md is at the repo root).

## References

N/A — found via link audit, no tracking issue.

## Changelog

Docs-only; no consumer-facing package behavior change, so no changelog entries added. Happy to add them if preferred.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate — N/A, docs only
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by updating changelogs for packages I've changed — N/A, docs only
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no impact on application behavior, APIs, or security-sensitive code paths.
> 
> **Overview**
> Documentation-only fixes from a markdown link audit: **12 broken links across five files**, with no runtime or package code changes.
> 
> In **`packages/assets-controllers/README.md`**, the controller list now uses **`NftController`** / **`NftDetectionController`** (replacing stale Collectibles names), fixes the **`DeFiPositionsController.ts.ts`** typo, and points the real-time balance doc at **`../core-backend/docs/real-time-balance-updates-flow.md`**.
> 
> **`packages/core-backend/docs/real-time-balance-updates-flow.md`** “References” links are corrected to paths relative to that file, including **`src/ws/`** for WebSocket services. **`permission-controller`** and **`transaction-pay-controller`** ARCHITECTURE docs use **`./src/...`** instead of wrong root paths. **`.cursor/BUGBOT.md`** now links to **`../AGENTS.md`** at the repo root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af6958c3745ea8d911319e1d8cca7e1ce5809e6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->