### PR TITLE
refactor: add `.js` import extensions to Swaps-Bridge packages

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -385,6 +385,7 @@ const config = createConfig([
       'packages/base-controller/**',
       'packages/base-data-service/**',
       'packages/bridge-controller/**',
+      'packages/bridge-status-controller/**',
       'packages/build-utils/**',
       'packages/chain-agnostic-permission/**',
       'packages/composable-controller/**',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -384,6 +384,7 @@ const config = createConfig([
       'packages/authenticated-user-storage/**',
       'packages/base-controller/**',
       'packages/base-data-service/**',
+      'packages/bridge-controller/**',
       'packages/build-utils/**',
       'packages/chain-agnostic-permission/**',
       'packages/composable-controller/**',

--- a/packages/bridge-controller/src/bridge-controller-method-action-types.ts
+++ b/packages/bridge-controller/src/bridge-controller-method-action-types.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  */
 
-import type { BridgeController } from './bridge-controller';
+import type { BridgeController } from './bridge-controller.js';
 
 export type BridgeControllerUpdateBridgeQuoteRequestParamsAction = {
   type: `BridgeController:updateBridgeQuoteRequestParams`;

--- a/packages/bridge-controller/src/bridge-controller.sse.batch.test.ts
+++ b/packages/bridge-controller/src/bridge-controller.sse.batch.test.ts
@@ -6,26 +6,26 @@ import type {
   MockAnyNamespace,
 } from '@metamask/messenger';
 
-import { flushPromises } from '../../../tests/helpers';
-import { mockBridgeQuotesErc20Erc20V1 } from '../tests/mock-quotes-erc20-erc20';
-import { mockBridgeQuotesNativeErc20V1 } from '../tests/mock-quotes-native-erc20';
+import { flushPromises } from '../../../tests/helpers.js';
+import { mockBridgeQuotesErc20Erc20V1 } from '../tests/mock-quotes-erc20-erc20.js';
+import { mockBridgeQuotesNativeErc20V1 } from '../tests/mock-quotes-native-erc20.js';
 import {
   advanceToNthTimerThenFlush,
   mockSseBatchSellEventSource,
-} from '../tests/mock-sse';
-import { BridgeController } from './bridge-controller';
+} from '../tests/mock-sse.js';
+import { BridgeController } from './bridge-controller.js';
 import {
   BridgeClientId,
   BRIDGE_PROD_API_BASE_URL,
   DEFAULT_BRIDGE_CONTROLLER_STATE,
-} from './constants/bridge';
-import * as selectors from './selectors';
-import { ChainId, RequestStatus } from './types';
-import type { BridgeControllerMessenger } from './types';
-import * as balanceUtils from './utils/balance';
-import * as featureFlagUtils from './utils/feature-flags';
-import * as fetchUtils from './utils/fetch';
-import { FeatureId } from './validators/feature-flags';
+} from './constants/bridge.js';
+import * as selectors from './selectors.js';
+import { ChainId, RequestStatus } from './types.js';
+import type { BridgeControllerMessenger } from './types.js';
+import * as balanceUtils from './utils/balance.js';
+import * as featureFlagUtils from './utils/feature-flags.js';
+import * as fetchUtils from './utils/fetch.js';
+import { FeatureId } from './validators/feature-flags.js';
 
 type RootMessenger = Messenger<
   MockAnyNamespace,

--- a/packages/bridge-controller/src/bridge-controller.sse.test.ts
+++ b/packages/bridge-controller/src/bridge-controller.sse.test.ts
@@ -10,10 +10,10 @@ import type {
 import { abiERC20 } from '@metamask/metamask-eth-abis';
 import { merge } from 'lodash';
 
-import { flushPromises } from '../../../tests/helpers';
-import { mockBridgeQuotesErc20Erc20V1 } from '../tests/mock-quotes-erc20-erc20';
-import { mockBridgeQuotesNativeErc20V1 } from '../tests/mock-quotes-native-erc20';
-import { mockBridgeQuotesNativeErc20EthV1 } from '../tests/mock-quotes-native-erc20-eth';
+import { flushPromises } from '../../../tests/helpers.js';
+import { mockBridgeQuotesErc20Erc20V1 } from '../tests/mock-quotes-erc20-erc20.js';
+import { mockBridgeQuotesNativeErc20EthV1 } from '../tests/mock-quotes-native-erc20-eth.js';
+import { mockBridgeQuotesNativeErc20V1 } from '../tests/mock-quotes-native-erc20.js';
 import {
   advanceToNthTimer,
   advanceToNthTimerThenFlush,
@@ -22,28 +22,28 @@ import {
   mockSseEventSourceWithMultipleDelays,
   mockSseEventSourceWithWarnings,
   mockSseServerError,
-} from '../tests/mock-sse';
-import { BridgeController } from './bridge-controller';
+} from '../tests/mock-sse.js';
+import { BridgeController } from './bridge-controller.js';
 import {
   BridgeClientId,
   BRIDGE_PROD_API_BASE_URL,
   DEFAULT_BRIDGE_CONTROLLER_STATE,
   ETH_USDT_ADDRESS,
-} from './constants/bridge';
-import { ChainId, RequestStatus } from './types';
-import type { BridgeControllerMessenger } from './types';
-import * as balanceUtils from './utils/balance';
+} from './constants/bridge.js';
+import { ChainId, RequestStatus } from './types.js';
+import type { BridgeControllerMessenger } from './types.js';
+import * as balanceUtils from './utils/balance.js';
 import {
   formatChainIdToCaip,
   formatChainIdToDec,
-} from './utils/caip-formatters';
-import * as featureFlagUtils from './utils/feature-flags';
-import * as fetchUtils from './utils/fetch';
-import { FeatureId } from './validators/feature-flags';
-import { validateQuoteResponseV1 } from './validators/quote-response-v1';
-import { QuoteStreamCompleteReason } from './validators/quote-stream-complete';
-import { TokenFeatureType } from './validators/token-feature';
-import type { TxData } from './validators/trade';
+} from './utils/caip-formatters.js';
+import * as featureFlagUtils from './utils/feature-flags.js';
+import * as fetchUtils from './utils/fetch.js';
+import { FeatureId } from './validators/feature-flags.js';
+import { validateQuoteResponseV1 } from './validators/quote-response-v1.js';
+import { QuoteStreamCompleteReason } from './validators/quote-stream-complete.js';
+import { TokenFeatureType } from './validators/token-feature.js';
+import type { TxData } from './validators/trade.js';
 
 type RootMessenger = Messenger<
   MockAnyNamespace,

--- a/packages/bridge-controller/src/bridge-controller.test.ts
+++ b/packages/bridge-controller/src/bridge-controller.test.ts
@@ -16,32 +16,35 @@ import type {
 import type { CaipAssetType } from '@metamask/utils';
 import nock from 'nock';
 
-import { flushPromises } from '../../../tests/helpers';
-import { handleFetch } from '../../controller-utils/src';
-import { mockBridgeQuotesErc20NativeV1 } from '../tests/mock-quotes-erc20-native';
-import { mockBridgeQuotesNativeErc20V1 } from '../tests/mock-quotes-native-erc20';
-import { mockBridgeQuotesNativeErc20EthV1 } from '../tests/mock-quotes-native-erc20-eth';
-import { mockBridgeQuotesSolErc20V1 } from '../tests/mock-quotes-sol-erc20';
-import { advanceToNthTimerThenFlush } from '../tests/mock-sse';
-import { BridgeController } from './bridge-controller';
+import { flushPromises } from '../../../tests/helpers.js';
+import { handleFetch } from '../../controller-utils/src/index.js';
+import { mockBridgeQuotesErc20NativeV1 } from '../tests/mock-quotes-erc20-native.js';
+import { mockBridgeQuotesNativeErc20EthV1 } from '../tests/mock-quotes-native-erc20-eth.js';
+import { mockBridgeQuotesNativeErc20V1 } from '../tests/mock-quotes-native-erc20.js';
+import { mockBridgeQuotesSolErc20V1 } from '../tests/mock-quotes-sol-erc20.js';
+import { advanceToNthTimerThenFlush } from '../tests/mock-sse.js';
+import { BridgeController } from './bridge-controller.js';
 import {
   BridgeClientId,
   BRIDGE_PROD_API_BASE_URL,
   DEFAULT_BRIDGE_CONTROLLER_STATE,
   ETH_USDT_ADDRESS,
-} from './constants/bridge';
-import { SWAPS_API_V2_BASE_URL } from './constants/swaps';
-import * as selectors from './selectors';
-import { ChainId, RequestStatus, SortOrder, StatusTypes } from './types';
-import type { BridgeControllerMessenger, GenericQuoteRequest } from './types';
-import * as balanceUtils from './utils/balance';
-import { getNativeAssetForChainId, isSolanaChainId } from './utils/bridge';
+} from './constants/bridge.js';
+import { SWAPS_API_V2_BASE_URL } from './constants/swaps.js';
+import * as selectors from './selectors.js';
+import { ChainId, RequestStatus, SortOrder, StatusTypes } from './types.js';
+import type {
+  BridgeControllerMessenger,
+  GenericQuoteRequest,
+} from './types.js';
+import * as balanceUtils from './utils/balance.js';
+import { getNativeAssetForChainId, isSolanaChainId } from './utils/bridge.js';
 import {
   formatAddressToAssetId,
   formatChainIdToCaip,
-} from './utils/caip-formatters';
-import * as featureFlagUtils from './utils/feature-flags';
-import * as fetchUtils from './utils/fetch';
+} from './utils/caip-formatters.js';
+import * as featureFlagUtils from './utils/feature-flags.js';
+import * as fetchUtils from './utils/fetch.js';
 import {
   BatchSellMetricsEventName,
   BatchSellMetricsLocation,
@@ -50,9 +53,9 @@ import {
   MetricsActionType,
   MetricsSwapType,
   UnifiedSwapBridgeEventName,
-} from './utils/metrics/constants';
-import { FeatureId } from './validators/feature-flags';
-import type { QuoteResponseV1 } from './validators/quote-response-v1';
+} from './utils/metrics/constants.js';
+import { FeatureId } from './validators/feature-flags.js';
+import type { QuoteResponseV1 } from './validators/quote-response-v1.js';
 
 const EMPTY_INIT_STATE = DEFAULT_BRIDGE_CONTROLLER_STATE;
 

--- a/packages/bridge-controller/src/bridge-controller.ts
+++ b/packages/bridge-controller/src/bridge-controller.ts
@@ -10,22 +10,22 @@ import { StaticIntervalPollingController } from '@metamask/polling-controller';
 import type { TransactionController } from '@metamask/transaction-controller';
 import type { CaipAssetType, Hex } from '@metamask/utils';
 
-import type { BridgeClientId } from './constants/bridge';
+import type { BridgeClientId } from './constants/bridge.js';
 import {
   BRIDGE_CONTROLLER_NAME,
   BRIDGE_PROD_API_BASE_URL,
   DEFAULT_BRIDGE_CONTROLLER_STATE,
   METABRIDGE_ETHEREUM_ADDRESS,
   REFRESH_INTERVAL_MS,
-} from './constants/bridge';
-import { CHAIN_IDS } from './constants/chains';
-import { SWAPS_CONTRACT_ADDRESSES } from './constants/swaps';
-import { TraceName } from './constants/traces';
+} from './constants/bridge.js';
+import { CHAIN_IDS } from './constants/chains.js';
+import { SWAPS_CONTRACT_ADDRESSES } from './constants/swaps.js';
+import { TraceName } from './constants/traces.js';
 import {
   ExchangeRateSourcesForLookup,
   selectIsAssetExchangeRateInState,
-} from './selectors';
-import { RequestStatus } from './types';
+} from './selectors.js';
+import { RequestStatus } from './types.js';
 import type {
   L1GasFees,
   GenericQuoteRequest,
@@ -35,42 +35,42 @@ import type {
   BridgeControllerMessenger,
   FetchFunction,
   InputPrimaryDenomination,
-} from './types';
-import { getAssetIdsForToken, toExchangeRates } from './utils/assets';
-import { hasSufficientBalance } from './utils/balance';
+} from './types.js';
+import { getAssetIdsForToken, toExchangeRates } from './utils/assets.js';
+import { hasSufficientBalance } from './utils/balance.js';
 import {
   getDefaultBridgeControllerState,
   isCrossChain,
   isEthUsdt,
   isNonEvmChainId,
   isSolanaChainId,
-} from './utils/bridge';
+} from './utils/bridge.js';
 import {
   formatAddressToCaipReference,
   formatChainIdToCaip,
   formatChainIdToHex,
-} from './utils/caip-formatters';
+} from './utils/caip-formatters.js';
 import {
   getBridgeFeatureFlags,
   hasMinimumRequiredVersion,
-} from './utils/feature-flags';
+} from './utils/feature-flags.js';
 import {
   fetchAssetPrices,
   fetchBridgeQuotes,
   fetchBridgeQuoteStream,
   fetchBatchSellTrades,
-} from './utils/fetch';
+} from './utils/fetch.js';
 import {
   AbortReason,
   BatchSellMetricsEventName,
   MetaMetricsSwapsEventSource,
   MetricsActionType,
   UnifiedSwapBridgeEventName,
-} from './utils/metrics/constants';
+} from './utils/metrics/constants.js';
 import type {
   BridgeControllerMetricsEventName,
   BridgeControllerMetricsLocation,
-} from './utils/metrics/constants';
+} from './utils/metrics/constants.js';
 import {
   formatProviderLabel,
   getAccountHardwareType,
@@ -79,22 +79,22 @@ import {
   isCustomSlippage,
   toInputChangedPropertyKey,
   toInputChangedPropertyValue,
-} from './utils/metrics/properties';
+} from './utils/metrics/properties.js';
 import type {
   QuoteFetchData,
   RequestMetadata,
   RequiredEventContextFromClient,
-} from './utils/metrics/types';
-import type { CrossChainSwapsEventProperties } from './utils/metrics/types';
-import { appendFeesToQuotes } from './utils/quote-fees';
-import { getMinimumBalanceForRentExemptionInLamports } from './utils/snaps';
-import { sortQuotes } from './utils/sort-quotes';
-import type { FeatureId } from './validators/feature-flags';
+} from './utils/metrics/types.js';
+import type { CrossChainSwapsEventProperties } from './utils/metrics/types.js';
+import { appendFeesToQuotes } from './utils/quote-fees.js';
+import { getMinimumBalanceForRentExemptionInLamports } from './utils/snaps.js';
+import { sortQuotes } from './utils/sort-quotes.js';
+import type { FeatureId } from './validators/feature-flags.js';
 import {
   isValidQuoteRequest,
   isValidBatchSellQuoteRequest,
-} from './validators/quote-request';
-import type { QuoteResponseV1 } from './validators/quote-response-v1';
+} from './validators/quote-request.js';
+import type { QuoteResponseV1 } from './validators/quote-response-v1.js';
 
 const metadata: StateMetadata<BridgeControllerState> = {
   quoteRequest: {

--- a/packages/bridge-controller/src/constants/bridge.ts
+++ b/packages/bridge-controller/src/constants/bridge.ts
@@ -5,8 +5,8 @@ import type { Hex } from '@metamask/utils';
 import type {
   BridgeControllerState,
   FeatureFlagsPlatformConfig,
-} from '../types';
-import { CHAIN_IDS } from './chains';
+} from '../types.js';
+import { CHAIN_IDS } from './chains.js';
 
 export const ALLOWED_BRIDGE_CHAIN_IDS = [
   CHAIN_IDS.MAINNET,

--- a/packages/bridge-controller/src/constants/swaps.ts
+++ b/packages/bridge-controller/src/constants/swaps.ts
@@ -1,6 +1,6 @@
 import type { Hex } from '@metamask/utils';
 
-import { CHAIN_IDS } from './chains';
+import { CHAIN_IDS } from './chains.js';
 
 export const SWAPS_API_V2_BASE_URL = 'https://swap.api.cx.metamask.io';
 

--- a/packages/bridge-controller/src/constants/tokens.ts
+++ b/packages/bridge-controller/src/constants/tokens.ts
@@ -1,7 +1,7 @@
 import { BtcScope, SolScope, TrxScope, XlmScope } from '@metamask/keyring-api';
 
-import type { AllowedBridgeChainIds } from './bridge';
-import { CHAIN_IDS } from './chains';
+import type { AllowedBridgeChainIds } from './bridge.js';
+import { CHAIN_IDS } from './chains.js';
 
 export type SwapsTokenObject = {
   /**

--- a/packages/bridge-controller/src/index.ts
+++ b/packages/bridge-controller/src/index.ts
@@ -1,4 +1,4 @@
-export { BridgeController } from './bridge-controller';
+export { BridgeController } from './bridge-controller.js';
 
 export {
   BatchSellMetricsEventName,
@@ -9,10 +9,10 @@ export {
   InputAmountPreset,
   MetaMetricsSwapsEventSource,
   PollingStatus,
-} from './utils/metrics/constants';
+} from './utils/metrics/constants.js';
 
-export type { BridgeControllerMetricsEventName } from './utils/metrics/constants';
-export type { BridgeControllerMetricsLocation } from './utils/metrics/constants';
+export type { BridgeControllerMetricsEventName } from './utils/metrics/constants.js';
+export type { BridgeControllerMetricsLocation } from './utils/metrics/constants.js';
 
 export type {
   AccountHardwareType,
@@ -25,7 +25,7 @@ export type {
   QuoteFetchData,
   QuoteWarning,
   InputPrimaryDenominationData,
-} from './utils/metrics/types';
+} from './utils/metrics/types.js';
 
 export {
   getAccountHardwareType,
@@ -35,7 +35,7 @@ export {
   isHardwareWallet,
   isCustomSlippage,
   getQuotesReceivedProperties,
-} from './utils/metrics/properties';
+} from './utils/metrics/properties.js';
 
 export type {
   ChainConfiguration,
@@ -66,17 +66,17 @@ export type {
   BridgeControllerGetStateAction,
   BridgeControllerStateChangeEvent,
   DeepPartial,
-} from './types';
+} from './types.js';
 
 export {
   type QuoteMetadata,
   type TokenAmountValues,
-} from './utils/quote-metadata/types';
+} from './utils/quote-metadata/types.js';
 export {
   validateQuoteResponseV1,
   QuoteResponseSchemaV1,
-} from './validators/quote-response-v1';
-export { mergeQuoteMetadata } from './utils/quote-metadata/merge';
+} from './validators/quote-response-v1.js';
+export { mergeQuoteMetadata } from './utils/quote-metadata/merge.js';
 
 export {
   AssetType,
@@ -84,7 +84,7 @@ export {
   ChainId,
   RequestStatus,
   StatusTypes,
-} from './types';
+} from './types.js';
 
 export type {
   BridgeControllerUpdateBridgeQuoteRequestParamsAction,
@@ -97,9 +97,9 @@ export type {
   BridgeControllerSetChainIntervalLengthAction,
   BridgeControllerTrackUnifiedSwapBridgeEventAction,
   BridgeControllerUpdateBatchSellTradesAction,
-} from './bridge-controller-method-action-types';
+} from './bridge-controller-method-action-types.js';
 
-export { AbortReason } from './utils/metrics/constants';
+export { AbortReason } from './utils/metrics/constants.js';
 
 export type {
   TxData,
@@ -107,31 +107,31 @@ export type {
   TronTradeData,
   StellarTradeData,
   Trade,
-} from './validators/trade';
+} from './validators/trade.js';
 export {
   isBitcoinTrade,
   isTronTrade,
   isEvmTxData,
   isStellarTrade,
-} from './validators/trade';
+} from './validators/trade.js';
 export type {
   QuoteResponseV1 as QuoteResponse,
   QuoteResponseV1,
-} from './validators/quote-response-v1';
-export type { Quote } from './validators/quote';
-export { FeeType, DiscountType } from './validators/quote';
-export { ActionTypes } from './validators/step';
+} from './validators/quote-response-v1.js';
+export type { Quote } from './validators/quote.js';
+export { FeeType, DiscountType } from './validators/quote.js';
+export { ActionTypes } from './validators/step.js';
 export {
   validateQuoteStreamComplete,
   QuoteStreamCompleteReason,
-} from './validators/quote-stream-complete';
-export { BatchSellTransactionType } from './validators/batch-sell';
-export { TokenFeatureType } from './validators/token-feature';
+} from './validators/quote-stream-complete.js';
+export { BatchSellTransactionType } from './validators/batch-sell.js';
+export { TokenFeatureType } from './validators/token-feature.js';
 export {
   BridgeAssetSchema,
   validateBridgeAsset,
-} from './validators/bridge-asset';
-export { FeatureId } from './validators/feature-flags';
+} from './validators/bridge-asset.js';
+export { FeatureId } from './validators/feature-flags.js';
 
 export {
   ALLOWED_BRIDGE_CHAIN_IDS,
@@ -148,9 +148,9 @@ export {
   BRIDGE_DEV_API_BASE_URL,
   BRIDGE_UAT_API_BASE_URL,
   BRIDGE_PROD_API_BASE_URL,
-} from './constants/bridge';
+} from './constants/bridge.js';
 
-export type { AllowedBridgeChainIds } from './constants/bridge';
+export type { AllowedBridgeChainIds } from './constants/bridge.js';
 
 export {
   /**
@@ -161,16 +161,19 @@ export {
    * @deprecated This map should not be used. Use getNativeAssetForChainId" } instead.
    */
   SWAPS_CHAINID_DEFAULT_TOKEN_MAP,
-} from './constants/tokens';
+} from './constants/tokens.js';
 
 export {
   SWAPS_API_V2_BASE_URL,
   SWAPS_CONTRACT_ADDRESSES,
   SWAPS_WRAPPED_TOKENS_ADDRESSES,
   ALLOWED_CONTRACT_ADDRESSES,
-} from './constants/swaps';
+} from './constants/swaps.js';
 
-export { MetricsActionType, MetricsSwapType } from './utils/metrics/constants';
+export {
+  MetricsActionType,
+  MetricsSwapType,
+} from './utils/metrics/constants.js';
 
 export {
   isEthUsdt,
@@ -183,36 +186,36 @@ export {
   getNativeAssetForChainId,
   getDefaultBridgeControllerState,
   isCrossChain,
-} from './utils/bridge';
+} from './utils/bridge.js';
 
 export {
   isValidQuoteRequest,
   isValidBatchSellQuoteRequest,
-} from './validators/quote-request';
+} from './validators/quote-request.js';
 
 export {
   calcSlippagePercentage,
   calcQuoteMetadata,
-} from './utils/quote-metadata/calculators';
+} from './utils/quote-metadata/calculators.js';
 
-export { calcLatestSrcBalance } from './utils/balance';
+export { calcLatestSrcBalance } from './utils/balance.js';
 
 export {
   fetchBridgeTokens,
   getClientHeaders,
   fetchBridgeQuoteStream,
-} from './utils/fetch';
+} from './utils/fetch.js';
 
-export { appendFeesToQuotes } from './utils/quote-fees';
+export { appendFeesToQuotes } from './utils/quote-fees.js';
 
 export {
   formatChainIdToCaip,
   formatChainIdToHex,
   formatAddressToCaipReference,
   formatAddressToAssetId,
-} from './utils/caip-formatters';
+} from './utils/caip-formatters.js';
 
-export { extractTradeData } from './utils/trade-utils';
+export { extractTradeData } from './utils/trade-utils.js';
 
 export {
   selectBridgeQuotes,
@@ -225,17 +228,17 @@ export {
   selectBridgeFeatureFlags,
   selectMinimumBalanceForRentExemptionInSOL,
   selectTokenWarnings,
-} from './selectors';
+} from './selectors.js';
 
-export { DEFAULT_FEATURE_FLAG_CONFIG } from './constants/bridge';
+export { DEFAULT_FEATURE_FLAG_CONFIG } from './constants/bridge.js';
 
-export { getBridgeFeatureFlags } from './utils/feature-flags';
+export { getBridgeFeatureFlags } from './utils/feature-flags.js';
 
-export { BRIDGE_DEFAULT_SLIPPAGE } from './utils/slippage';
+export { BRIDGE_DEFAULT_SLIPPAGE } from './utils/slippage.js';
 
 export {
   isValidSwapsContractAddress,
   getSwapsContractAddress,
   fetchTokens,
   type SwapsToken,
-} from './utils/swaps';
+} from './utils/swaps.js';

--- a/packages/bridge-controller/src/selectors.test.ts
+++ b/packages/bridge-controller/src/selectors.test.ts
@@ -6,10 +6,10 @@ import { parseCaipAssetType } from '@metamask/utils';
 import { BigNumber } from 'bignumber.js';
 import { merge } from 'lodash';
 
-import { mockBridgeQuotesErc20Erc20V1 } from '../tests/mock-quotes-erc20-erc20';
-import { mockBridgeQuotesNativeErc20V1 } from '../tests/mock-quotes-native-erc20';
-import { DEFAULT_CHAIN_RANKING, ETH_USDT_ADDRESS } from './constants/bridge';
-import type { BridgeAppState } from './selectors';
+import { mockBridgeQuotesErc20Erc20V1 } from '../tests/mock-quotes-erc20-erc20.js';
+import { mockBridgeQuotesNativeErc20V1 } from '../tests/mock-quotes-native-erc20.js';
+import { DEFAULT_CHAIN_RANKING, ETH_USDT_ADDRESS } from './constants/bridge.js';
+import type { BridgeAppState } from './selectors.js';
 import {
   selectExchangeRateByAssetId,
   selectIsAssetExchangeRateInState,
@@ -21,26 +21,26 @@ import {
   selectTokenWarnings,
   selectBatchSellQuotes,
   selectBatchSellTrades,
-} from './selectors';
+} from './selectors.js';
 import {
   SortOrder,
   RequestStatus,
   ChainId,
   BridgeAsset,
   NonEvmFees,
-} from './types';
-import { getNativeAssetForChainId, isNativeAddress } from './utils/bridge';
+} from './types.js';
+import { getNativeAssetForChainId, isNativeAddress } from './utils/bridge.js';
 import {
   formatAddressToAssetId,
   formatAddressToCaipReference,
   formatChainIdToDec,
   formatChainIdToHex,
-} from './utils/caip-formatters';
-import { calcQuoteMetadata } from './utils/quote-metadata/calculators';
-import { mergeQuoteMetadata } from './utils/quote-metadata/merge';
-import { BatchSellTransactionType } from './validators/batch-sell';
-import type { QuoteResponseV1 } from './validators/quote-response-v1';
-import { validateQuoteResponseV1 } from './validators/quote-response-v1';
+} from './utils/caip-formatters.js';
+import { calcQuoteMetadata } from './utils/quote-metadata/calculators.js';
+import { mergeQuoteMetadata } from './utils/quote-metadata/merge.js';
+import { BatchSellTransactionType } from './validators/batch-sell.js';
+import type { QuoteResponseV1 } from './validators/quote-response-v1.js';
+import { validateQuoteResponseV1 } from './validators/quote-response-v1.js';
 
 const MOCK_USDC_ADDRESS = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
 const MOCK_MUSD_ADDRESS = '0x12345A7890123456789012345678901234567890';

--- a/packages/bridge-controller/src/selectors.ts
+++ b/packages/bridge-controller/src/selectors.ts
@@ -18,30 +18,30 @@ import {
   createStructuredSelector as createStructuredSelector_,
 } from 'reselect';
 
-import { BRIDGE_PREFERRED_GAS_ESTIMATE } from './constants/bridge';
-import type { BridgeControllerState, ExchangeRate } from './types';
-import { RequestStatus, SortOrder } from './types';
+import { BRIDGE_PREFERRED_GAS_ESTIMATE } from './constants/bridge.js';
+import type { BridgeControllerState, ExchangeRate } from './types.js';
+import { RequestStatus, SortOrder } from './types.js';
 import {
   getNativeAssetForChainId,
   isNativeAddress,
   isNonEvmChainId,
-} from './utils/bridge';
+} from './utils/bridge.js';
 import {
   formatAddressToAssetId,
   formatAddressToCaipReference,
   formatChainIdToCaip,
   formatChainIdToHex,
-} from './utils/caip-formatters';
-import { processFeatureFlags } from './utils/feature-flags';
-import { calcBatchFees } from './utils/quote-metadata/calculators';
-import { calcQuoteMetadata } from './utils/quote-metadata/calculators';
-import { mergeQuoteMetadata } from './utils/quote-metadata/merge';
+} from './utils/caip-formatters.js';
+import { processFeatureFlags } from './utils/feature-flags.js';
+import { calcBatchFees } from './utils/quote-metadata/calculators.js';
+import { calcQuoteMetadata } from './utils/quote-metadata/calculators.js';
+import { mergeQuoteMetadata } from './utils/quote-metadata/merge.js';
 import type {
   QuoteMetadata,
   TokenAmountValues,
-} from './utils/quote-metadata/types';
-import { getDefaultSlippagePercentage } from './utils/slippage';
-import type { QuoteResponseV1 } from './validators/quote-response-v1';
+} from './utils/quote-metadata/types.js';
+import { getDefaultSlippagePercentage } from './utils/slippage.js';
+import type { QuoteResponseV1 } from './validators/quote-response-v1.js';
 
 /**
  * The controller states that provide exchange rates

--- a/packages/bridge-controller/src/types.ts
+++ b/packages/bridge-controller/src/types.ts
@@ -27,25 +27,25 @@ import type {
   Hex,
 } from '@metamask/utils';
 
-import type { BridgeController } from './bridge-controller';
-import type { BridgeControllerMethodActions } from './bridge-controller-method-action-types';
-import type { BRIDGE_CONTROLLER_NAME } from './constants/bridge';
-import type { SimulatedGasFeeLimitsSchema } from './validators/batch-sell';
-import type { BatchSellTradesResponseSchema } from './validators/batch-sell';
-import type { BridgeAssetSchema } from './validators/bridge-asset';
+import type { BridgeControllerMethodActions } from './bridge-controller-method-action-types.js';
+import type { BridgeController } from './bridge-controller.js';
+import type { BRIDGE_CONTROLLER_NAME } from './constants/bridge.js';
+import type { SimulatedGasFeeLimitsSchema } from './validators/batch-sell.js';
+import type { BatchSellTradesResponseSchema } from './validators/batch-sell.js';
+import type { BridgeAssetSchema } from './validators/bridge-asset.js';
 import type {
   ChainConfigurationSchema,
   ChainRankingSchema,
   PlatformConfigSchema,
-} from './validators/feature-flags';
-import type { IntentSchema } from './validators/intent';
-import type { TxFeeGasLimitsSchema } from './validators/quote';
-import type { FeeDataSchema } from './validators/quote';
-import type { GaslessPropertiesSchema } from './validators/quote';
-import type { QuoteResponseV1 } from './validators/quote-response-v1';
-import type { QuoteStreamCompleteSchema } from './validators/quote-stream-complete';
-import type { StepSchema } from './validators/step';
-import type { TokenFeatureSchema } from './validators/token-feature';
+} from './validators/feature-flags.js';
+import type { IntentSchema } from './validators/intent.js';
+import type { QuoteResponseV1 } from './validators/quote-response-v1.js';
+import type { QuoteStreamCompleteSchema } from './validators/quote-stream-complete.js';
+import type { TxFeeGasLimitsSchema } from './validators/quote.js';
+import type { FeeDataSchema } from './validators/quote.js';
+import type { GaslessPropertiesSchema } from './validators/quote.js';
+import type { StepSchema } from './validators/step.js';
+import type { TokenFeatureSchema } from './validators/token-feature.js';
 
 export type FetchFunction = (
   input: RequestInfo | URL | string,

--- a/packages/bridge-controller/src/utils/assets.test.ts
+++ b/packages/bridge-controller/src/utils/assets.test.ts
@@ -1,8 +1,8 @@
 import type { CaipAssetType } from '@metamask/utils';
 
-import { getAssetIdsForToken, toExchangeRates } from './assets';
-import { getNativeAssetForChainId } from './bridge';
-import { formatAddressToAssetId } from './caip-formatters';
+import { getAssetIdsForToken, toExchangeRates } from './assets.js';
+import { getNativeAssetForChainId } from './bridge.js';
+import { formatAddressToAssetId } from './caip-formatters.js';
 
 // Mock the imported functions
 jest.mock('./bridge', () => ({

--- a/packages/bridge-controller/src/utils/assets.ts
+++ b/packages/bridge-controller/src/utils/assets.ts
@@ -1,8 +1,8 @@
 import type { CaipAssetType } from '@metamask/utils';
 
-import type { ExchangeRate, GenericQuoteRequest } from '../types';
-import { getNativeAssetForChainId } from './bridge';
-import { formatAddressToAssetId } from './caip-formatters';
+import type { ExchangeRate, GenericQuoteRequest } from '../types.js';
+import { getNativeAssetForChainId } from './bridge.js';
+import { formatAddressToAssetId } from './caip-formatters.js';
 
 export const getAssetIdsForToken = (
   tokenAddress: GenericQuoteRequest['srcTokenAddress'],

--- a/packages/bridge-controller/src/utils/balance.test.ts
+++ b/packages/bridge-controller/src/utils/balance.test.ts
@@ -5,9 +5,9 @@ import { Web3Provider } from '@ethersproject/providers';
 import { abiERC20 } from '@metamask/metamask-eth-abis';
 import type { Provider } from '@metamask/network-controller';
 
-import { FakeProvider } from '../../../../tests/fake-provider';
-import * as balanceUtils from './balance';
-import { fetchTokenBalance } from './balance';
+import { FakeProvider } from '../../../../tests/fake-provider.js';
+import * as balanceUtils from './balance.js';
+import { fetchTokenBalance } from './balance.js';
 
 declare global {
   var ethereumProvider: Provider;

--- a/packages/bridge-controller/src/utils/balance.ts
+++ b/packages/bridge-controller/src/utils/balance.ts
@@ -6,7 +6,7 @@ import { abiERC20 } from '@metamask/metamask-eth-abis';
 import type { Provider } from '@metamask/network-controller';
 import type { Hex } from '@metamask/utils';
 
-import { isNativeAddress } from './bridge';
+import { isNativeAddress } from './bridge.js';
 
 export const fetchTokenBalance = async (
   address: string,

--- a/packages/bridge-controller/src/utils/bridge.test.ts
+++ b/packages/bridge-controller/src/utils/bridge.test.ts
@@ -4,10 +4,10 @@ import type { Hex } from '@metamask/utils';
 import {
   ETH_USDT_ADDRESS,
   METABRIDGE_ETHEREUM_ADDRESS,
-} from '../constants/bridge';
-import { CHAIN_IDS } from '../constants/chains';
-import { SWAPS_CHAINID_DEFAULT_TOKEN_MAP } from '../constants/tokens';
-import { ChainId } from '../types';
+} from '../constants/bridge.js';
+import { CHAIN_IDS } from '../constants/chains.js';
+import { SWAPS_CHAINID_DEFAULT_TOKEN_MAP } from '../constants/tokens.js';
+import { ChainId } from '../types.js';
 import {
   getNativeAssetForChainId,
   isBitcoinChainId,
@@ -19,7 +19,7 @@ import {
   isSwapsDefaultTokenAddress,
   isSwapsDefaultTokenSymbol,
   sumHexes,
-} from './bridge';
+} from './bridge.js';
 
 describe('Bridge utils', () => {
   beforeEach(() => {

--- a/packages/bridge-controller/src/utils/bridge.ts
+++ b/packages/bridge-controller/src/utils/bridge.ts
@@ -10,27 +10,27 @@ import {
   DEFAULT_BRIDGE_CONTROLLER_STATE,
   ETH_USDT_ADDRESS,
   METABRIDGE_ETHEREUM_ADDRESS,
-} from '../constants/bridge';
-import { CHAIN_IDS } from '../constants/chains';
-import { SWAPS_CONTRACT_ADDRESSES } from '../constants/swaps';
+} from '../constants/bridge.js';
+import { CHAIN_IDS } from '../constants/chains.js';
+import { SWAPS_CONTRACT_ADDRESSES } from '../constants/swaps.js';
 import {
   SWAPS_CHAINID_DEFAULT_TOKEN_MAP,
   SYMBOL_TO_SLIP44_MAP,
-} from '../constants/tokens';
-import type { SupportedSwapsNativeCurrencySymbols } from '../constants/tokens';
+} from '../constants/tokens.js';
+import type { SupportedSwapsNativeCurrencySymbols } from '../constants/tokens.js';
 import type {
   BridgeAsset,
   BridgeControllerState,
   GenericQuoteRequest,
-} from '../types';
-import { ChainId } from '../types';
-import type { QuoteResponseV1 } from '../validators/quote-response-v1';
-import type { TxData } from '../validators/trade';
+} from '../types.js';
+import { ChainId } from '../types.js';
+import type { QuoteResponseV1 } from '../validators/quote-response-v1.js';
+import type { TxData } from '../validators/trade.js';
 import {
   formatChainIdToCaip,
   formatChainIdToDec,
   formatChainIdToHex,
-} from './caip-formatters';
+} from './caip-formatters.js';
 
 /**
  * Checks whether the transaction is a cross-chain transaction by comparing the source and destination chainIds

--- a/packages/bridge-controller/src/utils/caip-formatters.test.ts
+++ b/packages/bridge-controller/src/utils/caip-formatters.test.ts
@@ -1,15 +1,15 @@
 import { AddressZero } from '@ethersproject/constants';
 import { BtcScope, SolScope, TrxScope, XlmScope } from '@metamask/keyring-api';
 
-import { CHAIN_IDS } from '../constants/chains';
-import { ChainId } from '../types';
+import { CHAIN_IDS } from '../constants/chains.js';
+import { ChainId } from '../types.js';
 import {
   formatChainIdToCaip,
   formatChainIdToDec,
   formatChainIdToHex,
   formatAddressToCaipReference,
   formatAddressToAssetId,
-} from './caip-formatters';
+} from './caip-formatters.js';
 
 describe('CAIP Formatters', () => {
   describe('formatChainIdToCaip', () => {

--- a/packages/bridge-controller/src/utils/caip-formatters.ts
+++ b/packages/bridge-controller/src/utils/caip-formatters.ts
@@ -18,8 +18,8 @@ import {
 } from '@metamask/utils';
 import type { CaipAssetType, CaipChainId, Hex } from '@metamask/utils';
 
-import type { GenericQuoteRequest } from '../types';
-import { ChainId } from '../types';
+import type { GenericQuoteRequest } from '../types.js';
+import { ChainId } from '../types.js';
 import {
   getNativeAssetForChainId,
   isBitcoinChainId,
@@ -27,7 +27,7 @@ import {
   isSolanaChainId,
   isStellarChainId,
   isTronChainId,
-} from './bridge';
+} from './bridge.js';
 
 /**
  * Converts a chainId to a CaipChainId

--- a/packages/bridge-controller/src/utils/feature-flags.test.ts
+++ b/packages/bridge-controller/src/utils/feature-flags.test.ts
@@ -1,13 +1,13 @@
-import { DEFAULT_CHAIN_RANKING } from '../constants/bridge';
+import { DEFAULT_CHAIN_RANKING } from '../constants/bridge.js';
 import type {
   FeatureFlagsPlatformConfig,
   BridgeControllerMessenger,
-} from '../types';
+} from '../types.js';
 import {
   formatFeatureFlags,
   getBridgeFeatureFlags,
   hasMinimumRequiredVersion,
-} from './feature-flags';
+} from './feature-flags.js';
 
 describe('feature-flags', () => {
   describe('formatFeatureFlags', () => {

--- a/packages/bridge-controller/src/utils/feature-flags.ts
+++ b/packages/bridge-controller/src/utils/feature-flags.ts
@@ -3,10 +3,13 @@ import type { RemoteFeatureFlagControllerState } from '@metamask/remote-feature-
 import {
   DEFAULT_CHAIN_RANKING,
   DEFAULT_FEATURE_FLAG_CONFIG,
-} from '../constants/bridge';
-import type { FeatureFlagsPlatformConfig, ChainConfiguration } from '../types';
-import { validateFeatureFlagsResponse } from '../validators/feature-flags';
-import { formatChainIdToCaip } from './caip-formatters';
+} from '../constants/bridge.js';
+import type {
+  FeatureFlagsPlatformConfig,
+  ChainConfiguration,
+} from '../types.js';
+import { validateFeatureFlagsResponse } from '../validators/feature-flags.js';
+import { formatChainIdToCaip } from './caip-formatters.js';
 
 export const formatFeatureFlags = (
   bridgeFeatureFlags: FeatureFlagsPlatformConfig,

--- a/packages/bridge-controller/src/utils/fetch.test.ts
+++ b/packages/bridge-controller/src/utils/fetch.test.ts
@@ -1,18 +1,21 @@
 import { AddressZero } from '@ethersproject/constants';
 import type { CaipAssetType } from '@metamask/utils';
 
-import { mockBridgeQuotesErc20Erc20V1 } from '../../tests/mock-quotes-erc20-erc20';
-import { mockBridgeQuotesNativeErc20V1 } from '../../tests/mock-quotes-native-erc20';
-import { BridgeClientId, BRIDGE_PROD_API_BASE_URL } from '../constants/bridge';
-import { BatchSellTransactionType } from '../validators/batch-sell';
-import { FeatureId } from '../validators/feature-flags';
+import { mockBridgeQuotesErc20Erc20V1 } from '../../tests/mock-quotes-erc20-erc20.js';
+import { mockBridgeQuotesNativeErc20V1 } from '../../tests/mock-quotes-native-erc20.js';
+import {
+  BridgeClientId,
+  BRIDGE_PROD_API_BASE_URL,
+} from '../constants/bridge.js';
+import { BatchSellTransactionType } from '../validators/batch-sell.js';
+import { FeatureId } from '../validators/feature-flags.js';
 import {
   fetchBridgeQuotes,
   fetchBridgeTokens,
   fetchAssetPrices,
   fetchBatchSellTrades,
   formatBatchSellTradesRequest,
-} from './fetch';
+} from './fetch.js';
 
 const mockFetchFn = jest.fn();
 

--- a/packages/bridge-controller/src/utils/fetch.ts
+++ b/packages/bridge-controller/src/utils/fetch.ts
@@ -11,23 +11,23 @@ import type {
   QuoteStreamCompleteData,
   BatchSellTradesRequest,
   BatchSellTradesResponse,
-} from '../types';
-import { validateBatchSellTradesResponse } from '../validators/batch-sell';
-import { validateBridgeAsset } from '../validators/bridge-asset';
-import type { FeatureId } from '../validators/feature-flags';
-import type { QuoteResponseV1 } from '../validators/quote-response-v1';
-import { validateQuoteResponseV1 } from '../validators/quote-response-v1';
-import { validateQuoteStreamComplete } from '../validators/quote-stream-complete';
-import { validateTokenFeature } from '../validators/token-feature';
-import { isEvmTxData } from '../validators/trade';
-import { getEthUsdtResetData } from './bridge';
+} from '../types.js';
+import { validateBatchSellTradesResponse } from '../validators/batch-sell.js';
+import { validateBridgeAsset } from '../validators/bridge-asset.js';
+import type { FeatureId } from '../validators/feature-flags.js';
+import type { QuoteResponseV1 } from '../validators/quote-response-v1.js';
+import { validateQuoteResponseV1 } from '../validators/quote-response-v1.js';
+import { validateQuoteStreamComplete } from '../validators/quote-stream-complete.js';
+import { validateTokenFeature } from '../validators/token-feature.js';
+import { isEvmTxData } from '../validators/trade.js';
+import { getEthUsdtResetData } from './bridge.js';
 import {
   formatAddressToAssetId,
   formatAddressToCaipReference,
   formatChainIdToDec,
-} from './caip-formatters';
-import { fetchServerEvents } from './fetch-server-events';
-import { formatStructErrors } from './struct-error';
+} from './caip-formatters.js';
+import { fetchServerEvents } from './fetch-server-events.js';
+import { formatStructErrors } from './struct-error.js';
 
 export const getClientHeaders = ({
   clientId,

--- a/packages/bridge-controller/src/utils/metrics/properties.test.ts
+++ b/packages/bridge-controller/src/utils/metrics/properties.test.ts
@@ -1,11 +1,11 @@
 import { SolScope } from '@metamask/keyring-api';
 import type { CaipChainId } from '@metamask/utils';
 
-import type { QuoteResponseV1 } from '../../validators/quote-response-v1';
-import { getNativeAssetForChainId } from '../bridge';
-import { formatChainIdToCaip } from '../caip-formatters';
-import type { QuoteMetadata } from '../quote-metadata/types';
-import { MetricsSwapType } from './constants';
+import type { QuoteResponseV1 } from '../../validators/quote-response-v1.js';
+import { getNativeAssetForChainId } from '../bridge.js';
+import { formatChainIdToCaip } from '../caip-formatters.js';
+import type { QuoteMetadata } from '../quote-metadata/types.js';
+import { MetricsSwapType } from './constants.js';
 import {
   getAccountHardwareType,
   isHardwareWallet,
@@ -15,7 +15,7 @@ import {
   formatProviderLabel,
   getRequestParams,
   getQuotesReceivedProperties,
-} from './properties';
+} from './properties.js';
 
 describe('properties', () => {
   beforeEach(() => {

--- a/packages/bridge-controller/src/utils/metrics/properties.ts
+++ b/packages/bridge-controller/src/utils/metrics/properties.ts
@@ -1,26 +1,26 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 import type { AccountsControllerState } from '@metamask/accounts-controller';
 
-import { DEFAULT_BRIDGE_CONTROLLER_STATE } from '../../constants/bridge';
-import { ChainId } from '../../types';
-import type { GenericQuoteRequest, QuoteRequest } from '../../types';
-import { FeatureId } from '../../validators/feature-flags';
-import type { QuoteResponseV1 } from '../../validators/quote-response-v1';
-import type { TxData } from '../../validators/trade';
-import { getNativeAssetForChainId, isCrossChain } from '../bridge';
+import { DEFAULT_BRIDGE_CONTROLLER_STATE } from '../../constants/bridge.js';
+import { ChainId } from '../../types.js';
+import type { GenericQuoteRequest, QuoteRequest } from '../../types.js';
+import { FeatureId } from '../../validators/feature-flags.js';
+import type { QuoteResponseV1 } from '../../validators/quote-response-v1.js';
+import type { TxData } from '../../validators/trade.js';
+import { getNativeAssetForChainId, isCrossChain } from '../bridge.js';
 import {
   formatAddressToAssetId,
   formatChainIdToCaip,
-} from '../caip-formatters';
-import type { QuoteMetadata } from '../quote-metadata/types';
-import { MetricsSwapType } from './constants';
+} from '../caip-formatters.js';
+import type { QuoteMetadata } from '../quote-metadata/types.js';
+import { MetricsSwapType } from './constants.js';
 import type {
   AccountHardwareType,
   InputKeys,
   InputValues,
   QuoteWarning,
   RequestParams,
-} from './types';
+} from './types.js';
 
 export const toInputChangedPropertyKey: Partial<
   Record<keyof QuoteRequest, InputKeys>

--- a/packages/bridge-controller/src/utils/metrics/types.ts
+++ b/packages/bridge-controller/src/utils/metrics/types.ts
@@ -5,8 +5,8 @@ import type {
   InputPrimaryDenomination,
   SortOrder,
   StatusTypes,
-} from '../../types';
-import type { FeatureId } from '../../validators/feature-flags';
+} from '../../types.js';
+import type { FeatureId } from '../../validators/feature-flags.js';
 import type {
   UnifiedSwapBridgeEventName,
   BatchSellMetricsEventName,
@@ -16,7 +16,7 @@ import type {
   MetricsActionType,
   MetricsSwapType,
   PollingStatus,
-} from './constants';
+} from './constants.js';
 
 /**
  * These properties map to properties required by the segment-schema. For example: https://github.com/Consensys/segment-schema/blob/main/libraries/properties/cross-chain-swaps-action.yaml

--- a/packages/bridge-controller/src/utils/quote-fees.ts
+++ b/packages/bridge-controller/src/utils/quote-fees.ts
@@ -2,19 +2,19 @@ import type { InternalAccount } from '@metamask/keyring-internal-api';
 import type { TransactionController } from '@metamask/transaction-controller';
 import { numberToHex } from '@metamask/utils';
 
-import { CHAIN_IDS } from '../constants/chains';
+import { CHAIN_IDS } from '../constants/chains.js';
 import type {
   L1GasFees,
   NonEvmFees,
   BridgeControllerMessenger,
-} from '../types';
-import type { QuoteResponseV1 } from '../validators/quote-response-v1';
-import { isTronTrade } from '../validators/trade';
-import type { TxData } from '../validators/trade';
-import { isNonEvmChainId, sumHexes } from './bridge';
-import { formatChainIdToCaip } from './caip-formatters';
-import { computeFeeRequest } from './snaps';
-import { extractTradeData } from './trade-utils';
+} from '../types.js';
+import type { QuoteResponseV1 } from '../validators/quote-response-v1.js';
+import { isTronTrade } from '../validators/trade.js';
+import type { TxData } from '../validators/trade.js';
+import { isNonEvmChainId, sumHexes } from './bridge.js';
+import { formatChainIdToCaip } from './caip-formatters.js';
+import { computeFeeRequest } from './snaps.js';
+import { extractTradeData } from './trade-utils.js';
 
 /**
  * Appends transaction fees for EVM chains to quotes

--- a/packages/bridge-controller/src/utils/quote-metadata/calculators.test.ts
+++ b/packages/bridge-controller/src/utils/quote-metadata/calculators.test.ts
@@ -3,16 +3,16 @@ import { convertHexToDecimal } from '@metamask/controller-utils';
 import { BigNumber } from 'bignumber.js';
 import { merge } from 'lodash';
 
-import { mockBridgeQuotesErc20Erc20V1 } from '../../../tests/mock-quotes-erc20-erc20';
-import { mockBridgeQuotesNativeErc20V1 } from '../../../tests/mock-quotes-native-erc20';
-import { getMockBridgeQuotesSolErc20V2 } from '../../../tests/mock-quotes-sol-erc20';
-import type { GenericQuoteRequest, L1GasFees } from '../../types';
-import type { Quote } from '../../validators/quote';
-import { isValidQuoteRequest } from '../../validators/quote-request';
-import { QuoteResponseV1 } from '../../validators/quote-response-v1';
-import type { TxData } from '../../validators/trade';
-import { getNativeAssetForChainId, isNativeAddress } from '../bridge';
-import { formatEtaInMinutes } from '../number-formatters';
+import { mockBridgeQuotesErc20Erc20V1 } from '../../../tests/mock-quotes-erc20-erc20.js';
+import { mockBridgeQuotesNativeErc20V1 } from '../../../tests/mock-quotes-native-erc20.js';
+import { getMockBridgeQuotesSolErc20V2 } from '../../../tests/mock-quotes-sol-erc20.js';
+import type { GenericQuoteRequest, L1GasFees } from '../../types.js';
+import { isValidQuoteRequest } from '../../validators/quote-request.js';
+import { QuoteResponseV1 } from '../../validators/quote-response-v1.js';
+import type { Quote } from '../../validators/quote.js';
+import type { TxData } from '../../validators/trade.js';
+import { getNativeAssetForChainId, isNativeAddress } from '../bridge.js';
+import { formatEtaInMinutes } from '../number-formatters.js';
 import {
   calcNonEvmTotalNetworkFee,
   calcToAmount,
@@ -25,7 +25,7 @@ import {
   calcCost,
   calcSlippagePercentage,
   calcPriceImpact,
-} from './calculators';
+} from './calculators.js';
 
 describe('Quote Utils', () => {
   describe('isValidQuoteRequest', () => {

--- a/packages/bridge-controller/src/utils/quote-metadata/calculators.ts
+++ b/packages/bridge-controller/src/utils/quote-metadata/calculators.ts
@@ -13,13 +13,13 @@ import type {
   NonEvmFees,
   DeepPartial,
   BridgeAsset,
-} from '../../types';
-import { FloatStringSchema } from '../../validators/number';
-import type { QuoteResponseV1 as QuoteResponse } from '../../validators/quote-response-v1';
-import { TxData } from '../../validators/trade';
-import { isEvmQuoteResponse, isNativeAddress } from '../bridge';
-import { calcTokenAmount } from '../number-formatters';
-import type { QuoteMetadata, TokenAmountValues } from './types';
+} from '../../types.js';
+import { FloatStringSchema } from '../../validators/number.js';
+import type { QuoteResponseV1 as QuoteResponse } from '../../validators/quote-response-v1.js';
+import { TxData } from '../../validators/trade.js';
+import { isEvmQuoteResponse, isNativeAddress } from '../bridge.js';
+import { calcTokenAmount } from '../number-formatters.js';
+import type { QuoteMetadata, TokenAmountValues } from './types.js';
 
 export const calcNonEvmTotalNetworkFee = (
   bridgeQuote: QuoteResponse & NonEvmFees,

--- a/packages/bridge-controller/src/utils/quote-metadata/merge.ts
+++ b/packages/bridge-controller/src/utils/quote-metadata/merge.ts
@@ -1,7 +1,7 @@
 import { merge } from 'lodash';
 
-import type { QuoteResponseV1 } from '../../validators/quote-response-v1';
-import type { QuoteMetadata } from './types';
+import type { QuoteResponseV1 } from '../../validators/quote-response-v1.js';
+import type { QuoteMetadata } from './types.js';
 
 /**
  * Merges legacy {@link QuoteMetadata} values into the {@link QuoteResponse}

--- a/packages/bridge-controller/src/utils/quote-metadata/types.ts
+++ b/packages/bridge-controller/src/utils/quote-metadata/types.ts
@@ -1,4 +1,4 @@
-import type { DeepPartial } from '../../types';
+import type { DeepPartial } from '../../types.js';
 
 /**
  * The types of values for the token amount and its values when converted to the user's selected currency and USD

--- a/packages/bridge-controller/src/utils/slippage.ts
+++ b/packages/bridge-controller/src/utils/slippage.ts
@@ -1,5 +1,5 @@
-import type { GenericQuoteRequest } from '../types';
-import { isCrossChain, isSolanaChainId } from './bridge';
+import type { GenericQuoteRequest } from '../types.js';
+import { isCrossChain, isSolanaChainId } from './bridge.js';
 
 export const BRIDGE_DEFAULT_SLIPPAGE = 0.5;
 const SWAP_SOLANA_SLIPPAGE = undefined;

--- a/packages/bridge-controller/src/utils/snaps.test.ts
+++ b/packages/bridge-controller/src/utils/snaps.test.ts
@@ -4,7 +4,7 @@ import { v4 as uuid } from 'uuid';
 import {
   getMinimumBalanceForRentExemptionRequest,
   computeFeeRequest,
-} from './snaps';
+} from './snaps.js';
 
 jest.mock('uuid', () => ({
   v4: jest.fn(),

--- a/packages/bridge-controller/src/utils/snaps.ts
+++ b/packages/bridge-controller/src/utils/snaps.ts
@@ -2,8 +2,8 @@ import { SolScope } from '@metamask/keyring-api';
 import type { CaipChainId } from '@metamask/utils';
 import { v4 as uuid } from 'uuid';
 
-import { DEFAULT_BRIDGE_CONTROLLER_STATE } from '../constants/bridge';
-import type { BridgeControllerMessenger } from '../types';
+import { DEFAULT_BRIDGE_CONTROLLER_STATE } from '../constants/bridge.js';
+import type { BridgeControllerMessenger } from '../types.js';
 
 export const getMinimumBalanceForRentExemptionRequest = (snapId: string) => {
   return {

--- a/packages/bridge-controller/src/utils/sort-quotes.ts
+++ b/packages/bridge-controller/src/utils/sort-quotes.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { FeatureId } from '../validators/feature-flags';
-import type { QuoteResponseV1 } from '../validators/quote-response-v1';
+import { FeatureId } from '../validators/feature-flags.js';
+import type { QuoteResponseV1 } from '../validators/quote-response-v1.js';
 
 export const sortQuotes = (
   quotes: QuoteResponseV1[],

--- a/packages/bridge-controller/src/utils/swaps.test.ts
+++ b/packages/bridge-controller/src/utils/swaps.test.ts
@@ -1,22 +1,22 @@
 import type { Hex } from '@metamask/utils';
 
-import { CHAIN_IDS } from '../constants/chains';
+import { CHAIN_IDS } from '../constants/chains.js';
 import {
   ALLOWED_CONTRACT_ADDRESSES,
   SWAPS_CONTRACT_ADDRESSES,
-} from '../constants/swaps';
+} from '../constants/swaps.js';
 import {
   DEFAULT_TOKEN_ADDRESS,
   SWAPS_CHAINID_DEFAULT_TOKEN_MAP,
-} from '../constants/tokens';
-import type { FetchFunction } from '../types';
+} from '../constants/tokens.js';
+import type { FetchFunction } from '../types.js';
 import {
   API_BASE_URL,
   fetchTokens,
   getSwapsContractAddress,
   isValidSwapsContractAddress,
-} from './swaps';
-import type { SwapsToken } from './swaps';
+} from './swaps.js';
+import type { SwapsToken } from './swaps.js';
 
 describe('Swaps utils', () => {
   beforeEach(() => {

--- a/packages/bridge-controller/src/utils/swaps.ts
+++ b/packages/bridge-controller/src/utils/swaps.ts
@@ -1,16 +1,16 @@
 import type { Hex } from '@metamask/utils';
 
-import { CHAIN_IDS } from '../constants/chains';
+import { CHAIN_IDS } from '../constants/chains.js';
 import {
   ALLOWED_CONTRACT_ADDRESSES,
   SWAPS_CONTRACT_ADDRESSES,
-} from '../constants/swaps';
+} from '../constants/swaps.js';
 import {
   DEFAULT_TOKEN_ADDRESS,
   SWAPS_CHAINID_DEFAULT_TOKEN_MAP,
-} from '../constants/tokens';
-import type { FetchFunction } from '../types';
-import { formatChainIdToDec } from './caip-formatters';
+} from '../constants/tokens.js';
+import type { FetchFunction } from '../types.js';
+import { formatChainIdToDec } from './caip-formatters.js';
 
 /**
  * Checks if the given contract address is valid for the given chain ID.

--- a/packages/bridge-controller/src/utils/trade-utils.test.ts
+++ b/packages/bridge-controller/src/utils/trade-utils.test.ts
@@ -3,14 +3,14 @@ import type {
   BitcoinTradeData,
   TronTradeData,
   Trade,
-} from '../validators/trade';
+} from '../validators/trade.js';
 import {
   isEvmTxData,
   isBitcoinTrade,
   isStellarTrade,
   isTronTrade,
-} from '../validators/trade';
-import { extractTradeData } from './trade-utils';
+} from '../validators/trade.js';
+import { extractTradeData } from './trade-utils.js';
 
 describe('Trade utils', () => {
   describe('isEvmTxData', () => {

--- a/packages/bridge-controller/src/utils/trade-utils.ts
+++ b/packages/bridge-controller/src/utils/trade-utils.ts
@@ -5,7 +5,7 @@ import {
   isEvmTxData,
   isStellarTrade,
   hasOwnProp,
-} from '../validators/trade';
+} from '../validators/trade.js';
 
 /**
  * Extracts the transaction data from different trade formats

--- a/packages/bridge-controller/src/validators/batch-sell.ts
+++ b/packages/bridge-controller/src/validators/batch-sell.ts
@@ -9,10 +9,10 @@ import {
 import type { Infer } from '@metamask/superstruct';
 import { StrictHexStruct } from '@metamask/utils';
 
-import { BridgeAssetSchema } from './bridge-asset';
-import { NumberStringSchema } from './number';
-import { GaslessPropertiesSchema } from './quote';
-import { TxDataSchema } from './trade';
+import { BridgeAssetSchema } from './bridge-asset.js';
+import { NumberStringSchema } from './number.js';
+import { GaslessPropertiesSchema } from './quote.js';
+import { TxDataSchema } from './trade.js';
 
 export enum BatchSellTransactionType {
   TRADE = 'trade',

--- a/packages/bridge-controller/src/validators/intent.ts
+++ b/packages/bridge-controller/src/validators/intent.ts
@@ -11,8 +11,8 @@ import {
   any,
 } from '@metamask/superstruct';
 
-import { TruthyDigitStringSchema } from './number';
-import { HexString } from './trade';
+import { TruthyDigitStringSchema } from './number.js';
+import { HexString } from './trade.js';
 
 // Allow digit strings for amounts/validTo for flexibility across providers
 const DigitStringOrNumberSchema = union([TruthyDigitStringSchema, number()]);

--- a/packages/bridge-controller/src/validators/quote-request.ts
+++ b/packages/bridge-controller/src/validators/quote-request.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-restricted-syntax */
-import type { GenericQuoteRequest } from '../types';
-import { isNonEvmChainId } from '../utils/bridge';
+import type { GenericQuoteRequest } from '../types.js';
+import { isNonEvmChainId } from '../utils/bridge.js';
 
 export const isValidQuoteRequest = (
   partialRequest: Partial<GenericQuoteRequest>,

--- a/packages/bridge-controller/src/validators/quote-response-v1.ts
+++ b/packages/bridge-controller/src/validators/quote-response-v1.ts
@@ -10,21 +10,21 @@ import {
 } from '@metamask/superstruct';
 import { StrictHexStruct } from '@metamask/utils';
 
-import { FeatureId } from './feature-flags';
-import { FloatStringSchema } from './number';
-import { QuoteSchema } from './quote';
+import { FeatureId } from './feature-flags.js';
+import { FloatStringSchema } from './number.js';
+import { QuoteSchema } from './quote.js';
 import {
   TxDataSchema,
   TronTradeDataSchema,
   BitcoinTradeDataSchema,
   StellarTradeDataSchema,
-} from './trade';
+} from './trade.js';
 import type {
   BitcoinTradeData,
   StellarTradeData,
   TronTradeData,
   TxData,
-} from './trade';
+} from './trade.js';
 
 export const QuoteResponseSchemaV1 = type({
   featureId: optional(enums(Object.values(FeatureId))),

--- a/packages/bridge-controller/src/validators/quote.ts
+++ b/packages/bridge-controller/src/validators/quote.ts
@@ -10,10 +10,10 @@ import {
 } from '@metamask/superstruct';
 import type { Infer } from '@metamask/superstruct';
 
-import { ChainIdSchema, BridgeAssetSchema } from './bridge-asset';
-import { IntentSchema } from './intent';
-import { TruthyDigitStringSchema, NumberStringSchema } from './number';
-import { RefuelDataSchema, StepSchema } from './step';
+import { ChainIdSchema, BridgeAssetSchema } from './bridge-asset.js';
+import { IntentSchema } from './intent.js';
+import { TruthyDigitStringSchema, NumberStringSchema } from './number.js';
+import { RefuelDataSchema, StepSchema } from './step.js';
 
 export enum FeeType {
   METABRIDGE = 'metabridge',

--- a/packages/bridge-controller/src/validators/step.ts
+++ b/packages/bridge-controller/src/validators/step.ts
@@ -1,6 +1,6 @@
 import { type, enums, optional } from '@metamask/superstruct';
 
-import { BridgeAssetSchema, ChainIdSchema } from './bridge-asset';
+import { BridgeAssetSchema, ChainIdSchema } from './bridge-asset.js';
 
 export enum ActionTypes {
   BRIDGE = 'bridge',

--- a/packages/bridge-controller/src/validators/validators.test.ts
+++ b/packages/bridge-controller/src/validators/validators.test.ts
@@ -1,15 +1,15 @@
 import { is } from '@metamask/superstruct';
 
-import { mockBridgeQuotesNativeErc20EthV1 } from '../../tests/mock-quotes-native-erc20-eth';
-import { validateFeatureFlagsResponse } from './feature-flags';
-import { IntentSchema } from './intent';
-import { DiscountType } from './quote';
-import { FeeDataSchema } from './quote';
-import { validateQuoteResponseV1 } from './quote-response-v1';
+import { mockBridgeQuotesNativeErc20EthV1 } from '../../tests/mock-quotes-native-erc20-eth.js';
+import { validateFeatureFlagsResponse } from './feature-flags.js';
+import { IntentSchema } from './intent.js';
+import { validateQuoteResponseV1 } from './quote-response-v1.js';
 import {
   validateQuoteStreamComplete,
   QuoteStreamCompleteReason,
-} from './quote-stream-complete';
+} from './quote-stream-complete.js';
+import { DiscountType } from './quote.js';
+import { FeeDataSchema } from './quote.js';
 
 describe('validators', () => {
   describe('validateFeatureFlagsResponse', () => {

--- a/packages/bridge-controller/tests/mock-quotes-erc20-erc20.ts
+++ b/packages/bridge-controller/tests/mock-quotes-erc20-erc20.ts
@@ -1,11 +1,11 @@
 import { merge } from 'lodash';
 
-import type { DeepPartial } from '../src/types';
+import type { DeepPartial } from '../src/types.js';
 import {
   validateQuoteResponseV1,
   QuoteResponseV1,
-} from '../src/validators/quote-response-v1';
-import { ActionTypes } from '../src/validators/step';
+} from '../src/validators/quote-response-v1.js';
+import { ActionTypes } from '../src/validators/step.js';
 
 export const mockBridgeQuotesErc20Erc20V1: QuoteResponseV1[] = [
   {

--- a/packages/bridge-controller/tests/mock-quotes-erc20-native.ts
+++ b/packages/bridge-controller/tests/mock-quotes-erc20-native.ts
@@ -1,9 +1,9 @@
 import { merge } from 'lodash';
 
-import type { DeepPartial } from '../src/types';
-import type { QuoteResponseV1 } from '../src/validators/quote-response-v1';
-import { validateQuoteResponseV1 } from '../src/validators/quote-response-v1';
-import { ActionTypes } from '../src/validators/step';
+import type { DeepPartial } from '../src/types.js';
+import type { QuoteResponseV1 } from '../src/validators/quote-response-v1.js';
+import { validateQuoteResponseV1 } from '../src/validators/quote-response-v1.js';
+import { ActionTypes } from '../src/validators/step.js';
 
 export const mockBridgeQuotesErc20NativeV1: QuoteResponseV1[] = [
   {

--- a/packages/bridge-controller/tests/mock-quotes-native-erc20-eth.ts
+++ b/packages/bridge-controller/tests/mock-quotes-native-erc20-eth.ts
@@ -1,9 +1,9 @@
 import { merge } from 'lodash';
 
-import type { DeepPartial } from '../src/types';
-import type { QuoteResponseV1 } from '../src/validators/quote-response-v1';
-import { validateQuoteResponseV1 } from '../src/validators/quote-response-v1';
-import { ActionTypes } from '../src/validators/step';
+import type { DeepPartial } from '../src/types.js';
+import type { QuoteResponseV1 } from '../src/validators/quote-response-v1.js';
+import { validateQuoteResponseV1 } from '../src/validators/quote-response-v1.js';
+import { ActionTypes } from '../src/validators/step.js';
 
 export const mockBridgeQuotesNativeErc20EthV1: QuoteResponseV1[] = [
   {

--- a/packages/bridge-controller/tests/mock-quotes-native-erc20.ts
+++ b/packages/bridge-controller/tests/mock-quotes-native-erc20.ts
@@ -1,9 +1,9 @@
 import { merge } from 'lodash';
 
-import type { DeepPartial } from '../src/types';
-import type { QuoteResponseV1 } from '../src/validators/quote-response-v1';
-import { validateQuoteResponseV1 } from '../src/validators/quote-response-v1';
-import { ActionTypes } from '../src/validators/step';
+import type { DeepPartial } from '../src/types.js';
+import type { QuoteResponseV1 } from '../src/validators/quote-response-v1.js';
+import { validateQuoteResponseV1 } from '../src/validators/quote-response-v1.js';
+import { ActionTypes } from '../src/validators/step.js';
 
 export const mockBridgeQuotesNativeErc20V1: QuoteResponseV1[] = [
   {

--- a/packages/bridge-controller/tests/mock-quotes-sol-erc20.ts
+++ b/packages/bridge-controller/tests/mock-quotes-sol-erc20.ts
@@ -1,9 +1,9 @@
 import { merge } from 'lodash';
 
-import type { DeepPartial } from '../src/types';
-import type { QuoteResponseV1 } from '../src/validators/quote-response-v1';
-import { validateQuoteResponseV1 } from '../src/validators/quote-response-v1';
-import { ActionTypes } from '../src/validators/step';
+import type { DeepPartial } from '../src/types.js';
+import type { QuoteResponseV1 } from '../src/validators/quote-response-v1.js';
+import { validateQuoteResponseV1 } from '../src/validators/quote-response-v1.js';
+import { ActionTypes } from '../src/validators/step.js';
 
 export const mockBridgeQuotesSolErc20V1: QuoteResponseV1[] = [
   {

--- a/packages/bridge-controller/tests/mock-sse.ts
+++ b/packages/bridge-controller/tests/mock-sse.ts
@@ -1,9 +1,9 @@
 // eslint-disable-next-line @typescript-eslint/no-shadow
 import { ReadableStream } from 'node:stream/web';
 
-import { flushPromises } from '../../../tests/helpers';
-import type { QuoteStreamCompleteData, TokenFeature } from '../src';
-import { QuoteResponseV1 } from '../src/validators/quote-response-v1';
+import { flushPromises } from '../../../tests/helpers.js';
+import type { QuoteStreamCompleteData, TokenFeature } from '../src/index.js';
+import { QuoteResponseV1 } from '../src/validators/quote-response-v1.js';
 
 type MockSseResponse = { status: number; ok: boolean; body: ReadableStream };
 

--- a/packages/bridge-status-controller/src/bridge-status-controller-method-action-types.ts
+++ b/packages/bridge-status-controller/src/bridge-status-controller-method-action-types.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  */
 
-import type { BridgeStatusController } from './bridge-status-controller';
+import type { BridgeStatusController } from './bridge-status-controller.js';
 
 export type BridgeStatusControllerStartPollingForBridgeTxStatusAction = {
   type: `BridgeStatusController:startPollingForBridgeTxStatus`;

--- a/packages/bridge-status-controller/src/bridge-status-controller.batch-sell.test.ts
+++ b/packages/bridge-status-controller/src/bridge-status-controller.batch-sell.test.ts
@@ -26,16 +26,16 @@ import {
   getTxMetasForBatch,
   mockBatchSellErc20Erc20,
   mockBatchSellTradesErc20Erc20,
-} from '../test/mock-batch-sell-erc20-erc20';
-import { BridgeStatusController } from './bridge-status-controller';
-import { BRIDGE_STATUS_CONTROLLER_NAME } from './constants';
-import { BridgeClientId } from './types';
+} from '../test/mock-batch-sell-erc20-erc20.js';
+import { BridgeStatusController } from './bridge-status-controller.js';
+import { BRIDGE_STATUS_CONTROLLER_NAME } from './constants.js';
+import { BridgeClientId } from './types.js';
 import type {
   BridgeHistoryItem,
   BridgeStatusControllerMessenger,
-} from './types';
-import { getBatchSellHistoryItemsForTxHash } from './utils/history';
-import { shouldDisable7702 } from './utils/transaction';
+} from './types.js';
+import { getBatchSellHistoryItemsForTxHash } from './utils/history.js';
+import { shouldDisable7702 } from './utils/transaction.js';
 
 const mockGenerateBatchId = jest.fn();
 jest.mock('@metamask/transaction-controller', () => ({

--- a/packages/bridge-status-controller/src/bridge-status-controller.intent-manager.test.ts
+++ b/packages/bridge-status-controller/src/bridge-status-controller.intent-manager.test.ts
@@ -3,9 +3,9 @@ import { BridgeClientId, StatusTypes } from '@metamask/bridge-controller';
 import { TransactionStatus } from '@metamask/transaction-controller';
 
 import { IntentManager } from './bridge-status-controller.intent';
-import type { BridgeHistoryItem } from './types';
-import { postSubmitOrder } from './utils/intent-api';
-import { IntentOrderStatus } from './utils/validators';
+import type { BridgeHistoryItem } from './types.js';
+import { postSubmitOrder } from './utils/intent-api.js';
+import { IntentOrderStatus } from './utils/validators.js';
 
 const makeHistoryItem = (
   overrides?: Partial<BridgeHistoryItem>,

--- a/packages/bridge-status-controller/src/bridge-status-controller.intent.test.ts
+++ b/packages/bridge-status-controller/src/bridge-status-controller.intent.test.ts
@@ -19,13 +19,13 @@ import {
   TransactionType,
 } from '@metamask/transaction-controller';
 
-import { BridgeStatusController } from './bridge-status-controller';
-import { MAX_ATTEMPTS } from './constants';
-import type { BridgeStatusControllerState } from './types';
-import * as bridgeStatusUtils from './utils/bridge-status';
-import * as historyUtils from './utils/history';
-import * as intentApi from './utils/intent-api';
-import { IntentOrderStatus } from './utils/validators';
+import { BridgeStatusController } from './bridge-status-controller.js';
+import { MAX_ATTEMPTS } from './constants.js';
+import type { BridgeStatusControllerState } from './types.js';
+import * as bridgeStatusUtils from './utils/bridge-status.js';
+import * as historyUtils from './utils/history.js';
+import * as intentApi from './utils/intent-api.js';
+import { IntentOrderStatus } from './utils/validators.js';
 
 jest.spyOn(intentApi, 'postSubmitOrder').mockImplementation(jest.fn());
 jest

--- a/packages/bridge-status-controller/src/bridge-status-controller.intent.ts
+++ b/packages/bridge-status-controller/src/bridge-status-controller.intent.ts
@@ -1,16 +1,22 @@
 import { BridgeClientId, StatusTypes } from '@metamask/bridge-controller';
 
-import type { BridgeStatusControllerMessenger, FetchFunction } from './types';
-import type { BridgeHistoryItem } from './types';
-import { getJwt } from './utils/authentication';
+import type {
+  BridgeStatusControllerMessenger,
+  FetchFunction,
+} from './types.js';
+import type { BridgeHistoryItem } from './types.js';
+import { getJwt } from './utils/authentication.js';
 import {
   IntentApi,
   IntentApiImpl,
   IntentBridgeStatus,
   translateIntentOrderToBridgeStatus,
-} from './utils/intent-api';
-import { getTransactionMetaById, updateTransaction } from './utils/transaction';
-import { IntentStatusResponse, IntentOrderStatus } from './utils/validators';
+} from './utils/intent-api.js';
+import {
+  getTransactionMetaById,
+  updateTransaction,
+} from './utils/transaction.js';
+import { IntentStatusResponse, IntentOrderStatus } from './utils/validators.js';
 
 type IntentStatuses = {
   orderStatus: IntentOrderStatus;

--- a/packages/bridge-status-controller/src/bridge-status-controller.test.ts
+++ b/packages/bridge-status-controller/src/bridge-status-controller.test.ts
@@ -43,19 +43,19 @@ import type { CaipAssetType } from '@metamask/utils';
 import { numberToHex } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
 
-import { flushPromises } from '../../../tests/helpers';
-import { BridgeStatusController } from './bridge-status-controller';
+import { flushPromises } from '../../../tests/helpers.js';
+import { BridgeStatusController } from './bridge-status-controller.js';
 import {
   BRIDGE_STATUS_CONTROLLER_NAME,
   DEFAULT_BRIDGE_STATUS_CONTROLLER_STATE,
   DEFAULT_MAX_PENDING_HISTORY_ITEM_AGE_MS,
   MAX_ATTEMPTS,
-} from './constants';
+} from './constants.js';
 import {
   QUOTE_STATUS_BACKFILL_WINDOW_MS,
   QuoteStatusState,
-} from './quote-status-manager/constants';
-import { BridgeClientId } from './types';
+} from './quote-status-manager/constants.js';
+import { BridgeClientId } from './types.js';
 import type {
   BridgeId,
   StartPollingForBridgeTxStatusArgsSerialized,
@@ -63,11 +63,11 @@ import type {
   BridgeStatusControllerState,
   BridgeStatusControllerMessenger,
   StatusResponse,
-} from './types';
-import * as bridgeStatusUtils from './utils/bridge-status';
-import * as historyUtils from './utils/history';
-import * as metricsUtils from './utils/metrics';
-import * as transactionUtils from './utils/transaction';
+} from './types.js';
+import * as bridgeStatusUtils from './utils/bridge-status.js';
+import * as historyUtils from './utils/history.js';
+import * as metricsUtils from './utils/metrics.js';
+import * as transactionUtils from './utils/transaction.js';
 
 type AllBridgeStatusControllerActions =
   MessengerActions<BridgeStatusControllerMessenger>;

--- a/packages/bridge-status-controller/src/bridge-status-controller.ts
+++ b/packages/bridge-status-controller/src/bridge-status-controller.ts
@@ -39,49 +39,49 @@ import {
   DEFAULT_BRIDGE_STATUS_CONTROLLER_STATE,
   MAX_ATTEMPTS,
   REFRESH_INTERVAL_MS,
-} from './constants';
+} from './constants.js';
 import {
   QUOTE_STATUS_BACKFILL_WINDOW_MS,
   QUOTE_STATUS_UPDATE_ENTRY_TTL,
   QUOTE_STATUS_UPDATE_RETRY_INTERVAL_MS,
-} from './quote-status-manager/constants';
+} from './quote-status-manager/constants.js';
 import {
   QuoteStatusGetError,
   QuoteStatusUpdateError,
-} from './quote-status-manager/errors';
-import { QuoteStatusManager } from './quote-status-manager/quotes-status-manager';
-import executeSubmitStrategy from './strategy';
-import { SubmitStep } from './strategy/types';
-import type { SubmitStrategyParams } from './strategy/types';
+} from './quote-status-manager/errors.js';
+import { QuoteStatusManager } from './quote-status-manager/quotes-status-manager.js';
+import executeSubmitStrategy from './strategy/index.js';
+import { SubmitStep } from './strategy/types.js';
+import type { SubmitStrategyParams } from './strategy/types.js';
 import type {
   BridgeStatusControllerState,
   StartPollingForBridgeTxStatusArgsSerialized,
   FetchFunction,
   BridgeHistoryItem,
-} from './types';
-import type { BridgeStatusControllerMessenger } from './types';
-import { BridgeClientId } from './types';
-import { getAccountByAddress } from './utils/accounts';
-import { getJwt } from './utils/authentication';
-import {
-  getBatchSellTrades,
-  stopPollingForQuotes,
-  trackMetricsEvent,
-} from './utils/bridge';
+} from './types.js';
+import type { BridgeStatusControllerMessenger } from './types.js';
+import { BridgeClientId } from './types.js';
+import { getAccountByAddress } from './utils/accounts.js';
+import { getJwt } from './utils/authentication.js';
 import {
   fetchBridgeTxStatus,
   fetchBridgeQuoteStatus,
   getStatusRequestWithSrcTxHash,
   shouldSkipFetchDueToFetchFailures,
   shouldWaitForFinalBridgeStatus,
-} from './utils/bridge-status';
+} from './utils/bridge-status.js';
+import {
+  getBatchSellTrades,
+  stopPollingForQuotes,
+  trackMetricsEvent,
+} from './utils/bridge.js';
 import {
   getInitialHistoryItem,
   getMatchingHistoryEntryForTxMeta,
   rekeyHistoryItemInState,
   shouldPollHistoryItem,
   getMatchingHistoryEntryForApprovalTxMeta,
-} from './utils/history';
+} from './utils/history.js';
 import {
   getFinalizedTxProperties,
   getPriceImpactFromQuote,
@@ -91,9 +91,9 @@ import {
   getEVMTxPropertiesFromTransactionMeta,
   getTxStatusesFromHistory,
   getPreConfirmationPropertiesFromQuote,
-} from './utils/metrics';
-import { getSelectedChainId } from './utils/network';
-import { getTraceParams } from './utils/trace';
+} from './utils/metrics.js';
+import { getSelectedChainId } from './utils/network.js';
+import { getTraceParams } from './utils/trace.js';
 import {
   getTransactionMetaById,
   getTransactions,
@@ -101,7 +101,7 @@ import {
   isCrossChainTx,
   updateTransactionsInBatch,
   hasNestedSwapTransactions,
-} from './utils/transaction';
+} from './utils/transaction.js';
 
 const metadata: StateMetadata<BridgeStatusControllerState> = {
   // We want to persist the bridge status state so that we can show the proper data for the Activity list

--- a/packages/bridge-status-controller/src/constants.ts
+++ b/packages/bridge-status-controller/src/constants.ts
@@ -1,6 +1,6 @@
 import { FeatureId } from '@metamask/bridge-controller';
 
-import type { BridgeStatusControllerState } from './types';
+import type { BridgeStatusControllerState } from './types.js';
 
 export const REFRESH_INTERVAL_MS = 10 * 1000; // 10 seconds
 export const MAX_ATTEMPTS = 7; // at 7 attempts, delay is 10:40, cumulative time is 21:10

--- a/packages/bridge-status-controller/src/index.ts
+++ b/packages/bridge-status-controller/src/index.ts
@@ -2,8 +2,8 @@
 export {
   QuoteStatusUpdateError,
   QuoteStatusGetError,
-} from './quote-status-manager/errors';
-export { BaseQuoteStatusUpdateErrorTypes } from './quote-status-manager/constants';
+} from './quote-status-manager/errors.js';
+export { BaseQuoteStatusUpdateErrorTypes } from './quote-status-manager/constants.js';
 
 // Export constants
 export {
@@ -11,7 +11,7 @@ export {
   DEFAULT_BRIDGE_STATUS_CONTROLLER_STATE,
   BRIDGE_STATUS_CONTROLLER_NAME,
   MAX_ATTEMPTS,
-} from './constants';
+} from './constants.js';
 
 export type {
   FetchFunction,
@@ -32,7 +32,7 @@ export type {
   StartPollingForBridgeTxStatusArgsSerialized,
   TokenAmountValuesSerialized,
   QuoteMetadataSerialized,
-} from './types';
+} from './types.js';
 
 export type {
   BridgeStatusControllerStartPollingForBridgeTxStatusAction,
@@ -42,13 +42,13 @@ export type {
   BridgeStatusControllerSubmitIntentAction,
   BridgeStatusControllerRestartPollingForFailedAttemptsAction,
   BridgeStatusControllerGetBridgeHistoryItemByTxMetaIdAction,
-} from './bridge-status-controller-method-action-types';
+} from './bridge-status-controller-method-action-types.js';
 
-export { BridgeId, BridgeStatusAction } from './types';
+export { BridgeId, BridgeStatusAction } from './types.js';
 
-export { BridgeStatusController } from './bridge-status-controller';
+export { BridgeStatusController } from './bridge-status-controller.js';
 
 export {
   getBatchSellHistoryItemsForTxHash,
   isBatchSellHistoryItem,
-} from './utils/history';
+} from './utils/history.js';

--- a/packages/bridge-status-controller/src/quote-status-manager/errors.test.ts
+++ b/packages/bridge-status-controller/src/quote-status-manager/errors.test.ts
@@ -1,5 +1,5 @@
-import { QuoteStatusUpdateBackendErrorType } from './constants';
-import { QuoteStatusGetError, QuoteStatusUpdateError } from './errors';
+import { QuoteStatusUpdateBackendErrorType } from './constants.js';
+import { QuoteStatusGetError, QuoteStatusUpdateError } from './errors.js';
 
 describe('QuoteStatusUpdateError', () => {
   describe('constructor', () => {

--- a/packages/bridge-status-controller/src/quote-status-manager/errors.ts
+++ b/packages/bridge-status-controller/src/quote-status-manager/errors.ts
@@ -1,7 +1,7 @@
 import {
   QuoteStatusGetErrorDetails,
   QuoteStatusUpdateErrorDetails,
-} from './types';
+} from './types.js';
 
 /**
  * Error thrown for quote status update failures.

--- a/packages/bridge-status-controller/src/quote-status-manager/quote-status-api-service.test.ts
+++ b/packages/bridge-status-controller/src/quote-status-manager/quote-status-api-service.test.ts
@@ -1,18 +1,18 @@
 import { StatusTypes } from '@metamask/bridge-controller';
 
-import { BridgeClientId, BridgeStatusControllerMessenger } from '../types';
+import { BridgeClientId, BridgeStatusControllerMessenger } from '../types.js';
 import {
   QuoteStatusUpdateBackendErrorType,
   QuoteStatusBackendStatus,
   QuoteStatusFetchWithRetryOutcomeType,
-} from './constants';
-import { QuoteStatusGetError, QuoteStatusUpdateError } from './errors';
-import { QuoteStatusApiService } from './quote-status-api-service';
+} from './constants.js';
+import { QuoteStatusGetError, QuoteStatusUpdateError } from './errors.js';
+import { QuoteStatusApiService } from './quote-status-api-service.js';
 import type {
   QuoteStatusApiServiceOptions,
   QuoteStatusGetResponse,
-} from './types';
-import * as validators from './validators';
+} from './types.js';
+import * as validators from './validators.js';
 
 const API_BASE_URL = 'https://bridge.api.test';
 

--- a/packages/bridge-status-controller/src/quote-status-manager/quote-status-api-service.ts
+++ b/packages/bridge-status-controller/src/quote-status-manager/quote-status-api-service.ts
@@ -1,26 +1,26 @@
 import { getClientHeaders } from '@metamask/bridge-controller';
 import { StructError } from '@metamask/superstruct';
 
-import { BridgeClientId, BridgeStatusControllerMessenger } from '../types';
-import { getJwt } from '../utils/authentication';
+import { BridgeClientId, BridgeStatusControllerMessenger } from '../types.js';
+import { getJwt } from '../utils/authentication.js';
 import {
   QuoteStatusBackendStatus,
   QuoteStatusUpdateRetryableBackendTypes,
   QuoteStatusFetchWithRetryOutcomeType,
-} from './constants';
-import { QuoteStatusGetError, QuoteStatusUpdateError } from './errors';
-import { QuoteStatusGetWithRetryOutcome } from './quote-status-get-with-retry-outcome';
-import { QuoteStatusUpdateWithRetryOutcome } from './quote-status-update-with-retry-outcome';
+} from './constants.js';
+import { QuoteStatusGetError, QuoteStatusUpdateError } from './errors.js';
+import { QuoteStatusGetWithRetryOutcome } from './quote-status-get-with-retry-outcome.js';
+import { QuoteStatusUpdateWithRetryOutcome } from './quote-status-update-with-retry-outcome.js';
 import {
   QuoteStatusApiServiceOptions,
   QuoteStatusGetResponse,
   QuoteStatusUpdateResponse,
-} from './types';
-import { sleep } from './utils';
+} from './types.js';
+import { sleep } from './utils.js';
 import {
   validateQuoteStatusGetResponse,
   validateQuoteStatusUpdateResponse,
-} from './validators';
+} from './validators.js';
 
 /**
  * Service responsible for calling bridge quote status update APIs.

--- a/packages/bridge-status-controller/src/quote-status-manager/quote-status-entry-store.test.ts
+++ b/packages/bridge-status-controller/src/quote-status-manager/quote-status-entry-store.test.ts
@@ -1,7 +1,10 @@
-import { QuoteStatusState } from './constants';
-import { QuoteStatusEntryStore } from './quote-status-entry-store';
-import { QuoteStatusStateFsm } from './quote-status-state-fsm';
-import type { QuoteStatusPersistEntry, QuoteStatusRuntimeEntry } from './types';
+import { QuoteStatusState } from './constants.js';
+import { QuoteStatusEntryStore } from './quote-status-entry-store.js';
+import { QuoteStatusStateFsm } from './quote-status-state-fsm.js';
+import type {
+  QuoteStatusPersistEntry,
+  QuoteStatusRuntimeEntry,
+} from './types.js';
 
 const TTL_MS = 1000;
 const NOW = 1_000_000;

--- a/packages/bridge-status-controller/src/quote-status-manager/quote-status-entry-store.ts
+++ b/packages/bridge-status-controller/src/quote-status-manager/quote-status-entry-store.ts
@@ -1,10 +1,10 @@
-import { QuoteStatusState } from './constants';
-import { QuoteStatusStateFsm } from './quote-status-state-fsm';
+import { QuoteStatusState } from './constants.js';
+import { QuoteStatusStateFsm } from './quote-status-state-fsm.js';
 import {
   QuoteStatusEntryStoreOptions,
   QuoteStatusPersistEntry,
   QuoteStatusRuntimeEntry,
-} from './types';
+} from './types.js';
 
 /**
  * In-memory store for quote status update entries.

--- a/packages/bridge-status-controller/src/quote-status-manager/quote-status-get-with-retry-outcome.test.ts
+++ b/packages/bridge-status-controller/src/quote-status-manager/quote-status-get-with-retry-outcome.test.ts
@@ -1,9 +1,9 @@
 import { StatusTypes } from '@metamask/bridge-controller';
 
-import { QuoteStatusFetchWithRetryOutcomeType } from './constants';
-import { QuoteStatusGetError } from './errors';
-import { QuoteStatusGetWithRetryOutcome } from './quote-status-get-with-retry-outcome';
-import type { QuoteStatusGetResponse } from './types';
+import { QuoteStatusFetchWithRetryOutcomeType } from './constants.js';
+import { QuoteStatusGetError } from './errors.js';
+import { QuoteStatusGetWithRetryOutcome } from './quote-status-get-with-retry-outcome.js';
+import type { QuoteStatusGetResponse } from './types.js';
 
 describe('QuoteStatusGetWithRetryOutcome', () => {
   it('exposes the outcome type', () => {

--- a/packages/bridge-status-controller/src/quote-status-manager/quote-status-get-with-retry-outcome.ts
+++ b/packages/bridge-status-controller/src/quote-status-manager/quote-status-get-with-retry-outcome.ts
@@ -1,6 +1,6 @@
-import { QuoteStatusFetchWithRetryOutcomeType } from './constants';
-import { QuoteStatusGetError } from './errors';
-import { QuoteStatusGetResponse } from './types';
+import { QuoteStatusFetchWithRetryOutcomeType } from './constants.js';
+import { QuoteStatusGetError } from './errors.js';
+import { QuoteStatusGetResponse } from './types.js';
 
 /**
  * Result of a retrying quote status fetch

--- a/packages/bridge-status-controller/src/quote-status-manager/quote-status-state-fsm.test.ts
+++ b/packages/bridge-status-controller/src/quote-status-manager/quote-status-state-fsm.test.ts
@@ -1,5 +1,5 @@
-import { QuoteStatusState } from './constants';
-import { QuoteStatusStateFsm } from './quote-status-state-fsm';
+import { QuoteStatusState } from './constants.js';
+import { QuoteStatusStateFsm } from './quote-status-state-fsm.js';
 
 describe('QuoteStatusStateFsm', () => {
   describe('constructor', () => {

--- a/packages/bridge-status-controller/src/quote-status-manager/quote-status-state-fsm.ts
+++ b/packages/bridge-status-controller/src/quote-status-manager/quote-status-state-fsm.ts
@@ -1,11 +1,11 @@
 import {
   AllowedQuoteStatusStateTransitions,
   QuoteStatusState,
-} from './constants';
+} from './constants.js';
 import type {
   QuoteStatusStateUpdateEvent,
   QuoteStatusStateUpdateListener,
-} from './types';
+} from './types.js';
 
 /**
  * Finite state machine that enforces forward-only quote status transitions.

--- a/packages/bridge-status-controller/src/quote-status-manager/quote-status-update-with-retry-outcome.test.ts
+++ b/packages/bridge-status-controller/src/quote-status-manager/quote-status-update-with-retry-outcome.test.ts
@@ -1,9 +1,9 @@
 import {
   QuoteStatusUpdateBackendErrorType,
   QuoteStatusFetchWithRetryOutcomeType,
-} from './constants';
-import { QuoteStatusUpdateWithRetryOutcome } from './quote-status-update-with-retry-outcome';
-import type { QuoteStatusUpdateResponse } from './types';
+} from './constants.js';
+import { QuoteStatusUpdateWithRetryOutcome } from './quote-status-update-with-retry-outcome.js';
+import type { QuoteStatusUpdateResponse } from './types.js';
 
 describe('QuoteStatusUpdateWithRetryOutcome', () => {
   it('exposes the outcome type', () => {

--- a/packages/bridge-status-controller/src/quote-status-manager/quote-status-update-with-retry-outcome.ts
+++ b/packages/bridge-status-controller/src/quote-status-manager/quote-status-update-with-retry-outcome.ts
@@ -1,5 +1,5 @@
-import { QuoteStatusFetchWithRetryOutcomeType } from './constants';
-import { QuoteStatusUpdateResponse } from './types';
+import { QuoteStatusFetchWithRetryOutcomeType } from './constants.js';
+import { QuoteStatusUpdateResponse } from './types.js';
 
 /**
  * Result of a retrying quote status update

--- a/packages/bridge-status-controller/src/quote-status-manager/quotes-status-manager.test.ts
+++ b/packages/bridge-status-controller/src/quote-status-manager/quotes-status-manager.test.ts
@@ -4,21 +4,21 @@ import {
 } from '@metamask/transaction-controller';
 import type { TransactionMeta } from '@metamask/transaction-controller';
 
-import { BridgeClientId, BridgeStatusControllerMessenger } from '../types';
+import { BridgeClientId, BridgeStatusControllerMessenger } from '../types.js';
 import {
   QuoteStatusState,
   QuoteStatusUpdateBackendErrorType,
   QuoteStatusBackendStatus,
   QuoteStatusFetchWithRetryOutcomeType,
-} from './constants';
-import { QuoteStatusApiService } from './quote-status-api-service';
-import { QuoteStatusGetWithRetryOutcome } from './quote-status-get-with-retry-outcome';
-import { QuoteStatusUpdateWithRetryOutcome } from './quote-status-update-with-retry-outcome';
-import { QuoteStatusManager } from './quotes-status-manager';
+} from './constants.js';
+import { QuoteStatusApiService } from './quote-status-api-service.js';
+import { QuoteStatusGetWithRetryOutcome } from './quote-status-get-with-retry-outcome.js';
+import { QuoteStatusUpdateWithRetryOutcome } from './quote-status-update-with-retry-outcome.js';
+import { QuoteStatusManager } from './quotes-status-manager.js';
 import type {
   QuoteStatusPersistEntry,
   QuoteStatusUpdateResponse,
-} from './types';
+} from './types.js';
 
 jest.mock('./quote-status-api-service');
 

--- a/packages/bridge-status-controller/src/quote-status-manager/quotes-status-manager.ts
+++ b/packages/bridge-status-controller/src/quote-status-manager/quotes-status-manager.ts
@@ -1,25 +1,25 @@
 import { TransactionStatus } from '@metamask/transaction-controller';
 
-import { BridgeClientId, BridgeStatusControllerMessenger } from '../types';
+import { BridgeClientId, BridgeStatusControllerMessenger } from '../types.js';
 import {
   getTransactionMetaById,
   hasNestedSwapTransactions,
   isCrossChainTx,
-} from '../utils/transaction';
+} from '../utils/transaction.js';
 import {
   QuoteStatusState,
   QuoteStatusStateToBackendStatus,
   QuoteStatusUpdateBackendErrorType,
   QuoteStatusBackendStatus,
   QuoteStatusFetchWithRetryOutcomeType,
-} from './constants';
-import { QuoteStatusUpdateError } from './errors';
-import { QuoteStatusApiService } from './quote-status-api-service';
-import { QuoteStatusEntryStore } from './quote-status-entry-store';
-import { QuoteStatusGetWithRetryOutcome } from './quote-status-get-with-retry-outcome';
-import { QuoteStatusStateFsm } from './quote-status-state-fsm';
-import { QuoteStatusUpdateWithRetryOutcome } from './quote-status-update-with-retry-outcome';
-import { QuoteStatusPersistEntry, QuoteStatusRuntimeEntry } from './types';
+} from './constants.js';
+import { QuoteStatusUpdateError } from './errors.js';
+import { QuoteStatusApiService } from './quote-status-api-service.js';
+import { QuoteStatusEntryStore } from './quote-status-entry-store.js';
+import { QuoteStatusGetWithRetryOutcome } from './quote-status-get-with-retry-outcome.js';
+import { QuoteStatusStateFsm } from './quote-status-state-fsm.js';
+import { QuoteStatusUpdateWithRetryOutcome } from './quote-status-update-with-retry-outcome.js';
+import { QuoteStatusPersistEntry, QuoteStatusRuntimeEntry } from './types.js';
 
 /**
  * Tracks bridge/swap quotes through their lifecycle and keeps the backend in

--- a/packages/bridge-status-controller/src/quote-status-manager/types.ts
+++ b/packages/bridge-status-controller/src/quote-status-manager/types.ts
@@ -1,17 +1,17 @@
 import { BridgeClientId } from '@metamask/bridge-controller';
 import { Infer } from '@metamask/superstruct';
 
-import { BridgeStatusControllerMessenger } from '../types';
+import { BridgeStatusControllerMessenger } from '../types.js';
 import {
   QuoteStatusState,
   QuoteStatusUpdateBackendErrorType,
-} from './constants';
-import { QuoteStatusGetError, QuoteStatusUpdateError } from './errors';
-import { QuoteStatusStateFsm } from './quote-status-state-fsm';
+} from './constants.js';
+import { QuoteStatusGetError, QuoteStatusUpdateError } from './errors.js';
+import { QuoteStatusStateFsm } from './quote-status-state-fsm.js';
 import {
   QuoteStatusGetResponseSchema,
   QuoteStatusUpdateResponseSchema,
-} from './validators';
+} from './validators.js';
 
 /**
  * Persisted queue entry describing a single quote status update attempt.

--- a/packages/bridge-status-controller/src/quote-status-manager/utils.test.ts
+++ b/packages/bridge-status-controller/src/quote-status-manager/utils.test.ts
@@ -1,4 +1,4 @@
-import { sleep } from './utils';
+import { sleep } from './utils.js';
 
 describe('sleep', () => {
   beforeEach(() => {

--- a/packages/bridge-status-controller/src/quote-status-manager/validators.test.ts
+++ b/packages/bridge-status-controller/src/quote-status-manager/validators.test.ts
@@ -3,11 +3,11 @@ import { StatusTypes } from '@metamask/bridge-controller';
 import {
   QuoteStatusBackendStatus,
   QuoteStatusUpdateBackendErrorType,
-} from './constants';
+} from './constants.js';
 import {
   validateQuoteStatusGetResponse,
   validateQuoteStatusUpdateResponse,
-} from './validators';
+} from './validators.js';
 
 describe('quote-status validators', () => {
   describe('validateQuoteStatusUpdateResponse', () => {

--- a/packages/bridge-status-controller/src/quote-status-manager/validators.ts
+++ b/packages/bridge-status-controller/src/quote-status-manager/validators.ts
@@ -8,13 +8,13 @@ import {
   optional,
 } from '@metamask/superstruct';
 
-import { StatusResponseSchema } from '../utils/validators';
+import { StatusResponseSchema } from '../utils/validators.js';
 import {
   BaseQuoteStatusUpdateErrorTypes,
   QuoteStatusUpdateBackendOnChainMismatchTypes,
   QuoteStatusBackendValues,
-} from './constants';
-import { QuoteStatusGetResponse, QuoteStatusUpdateResponse } from './types';
+} from './constants.js';
+import { QuoteStatusGetResponse, QuoteStatusUpdateResponse } from './types.js';
 
 const QuoteStatusUpdateResponseWithCurrentStatusSchema = type({
   statusCode: number(),

--- a/packages/bridge-status-controller/src/strategy/batch-sell-strategy.ts
+++ b/packages/bridge-status-controller/src/strategy/batch-sell-strategy.ts
@@ -4,7 +4,7 @@ import {
   TransactionType,
 } from '@metamask/transaction-controller';
 
-import { QuoteAndTxMetadata } from '../types';
+import { QuoteAndTxMetadata } from '../types.js';
 import {
   findAllTransactionsInBatch,
   getAddTransactionBatchParams,
@@ -13,9 +13,9 @@ import {
   isTradeTx,
   shouldDisable7702,
   toQuoteAndTxMetadataBatch,
-} from '../utils/transaction';
-import { SubmitStep } from './types';
-import type { SubmitStrategyParams, SubmitStepResult } from './types';
+} from '../utils/transaction.js';
+import { SubmitStep } from './types.js';
+import type { SubmitStrategyParams, SubmitStepResult } from './types.js';
 
 const getHistoryKeyForQuote = ({
   quoteResponse: { quoteId, quote },

--- a/packages/bridge-status-controller/src/strategy/batch-strategy.ts
+++ b/packages/bridge-status-controller/src/strategy/batch-strategy.ts
@@ -7,9 +7,9 @@ import {
   isTradeTx,
   shouldDisable7702,
   toQuoteAndTxMetadata,
-} from '../utils/transaction';
-import { SubmitStep } from './types';
-import type { SubmitStrategyParams, SubmitStepResult } from './types';
+} from '../utils/transaction.js';
+import { SubmitStep } from './types.js';
+import type { SubmitStrategyParams, SubmitStepResult } from './types.js';
 
 /**
  * Submits batched EVM transactions to the TransactionController

--- a/packages/bridge-status-controller/src/strategy/evm-strategy.ts
+++ b/packages/bridge-status-controller/src/strategy/evm-strategy.ts
@@ -7,10 +7,10 @@ import {
   TransactionType,
 } from '@metamask/transaction-controller';
 
-import { BridgeStatusControllerMessenger } from '../types';
-import { getAccountByAddress } from '../utils/accounts';
-import { getNetworkClientIdByChainId } from '../utils/network';
-import { getApprovalTraceParams } from '../utils/trace';
+import { BridgeStatusControllerMessenger } from '../types.js';
+import { getAccountByAddress } from '../utils/accounts.js';
+import { getNetworkClientIdByChainId } from '../utils/network.js';
+import { getApprovalTraceParams } from '../utils/trace.js';
 import {
   addTransaction,
   generateActionId,
@@ -18,9 +18,9 @@ import {
   handleMobileHardwareWalletDelay,
   toTransactionParams,
   waitForTxConfirmation,
-} from '../utils/transaction';
-import { SubmitStep } from './types';
-import type { SubmitStrategyParams, SubmitStepResult } from './types';
+} from '../utils/transaction.js';
+import { SubmitStep } from './types.js';
+import type { SubmitStrategyParams, SubmitStepResult } from './types.js';
 
 /**
  * Submits a single tx to the TransactionController and returns the txMetaId

--- a/packages/bridge-status-controller/src/strategy/index.ts
+++ b/packages/bridge-status-controller/src/strategy/index.ts
@@ -14,12 +14,12 @@ import {
   TxData,
 } from '@metamask/bridge-controller';
 
-import { submitBatchSellHandler } from './batch-sell-strategy';
-import { submitBatchHandler } from './batch-strategy';
-import { submitEvmHandler as defaultSubmitHandler } from './evm-strategy';
-import { submitIntentHandler } from './intent-strategy';
-import { submitNonEvmHandler } from './non-evm-strategy';
-import type { SubmitStrategyParams, SubmitStepResult } from './types';
+import { submitBatchSellHandler } from './batch-sell-strategy.js';
+import { submitBatchHandler } from './batch-strategy.js';
+import { submitEvmHandler as defaultSubmitHandler } from './evm-strategy.js';
+import { submitIntentHandler } from './intent-strategy.js';
+import { submitNonEvmHandler } from './non-evm-strategy.js';
+import type { SubmitStrategyParams, SubmitStepResult } from './types.js';
 
 const validateParams = <
   TxDataType extends

--- a/packages/bridge-status-controller/src/strategy/intent-strategy.ts
+++ b/packages/bridge-status-controller/src/strategy/intent-strategy.ts
@@ -6,20 +6,20 @@ import {
 } from '@metamask/bridge-controller';
 import { TransactionType } from '@metamask/transaction-controller';
 
-import { getJwt } from '../utils/authentication';
+import { getJwt } from '../utils/authentication.js';
 import {
   getIntentFromQuote,
   mapIntentOrderStatusToTransactionStatus,
   postSubmitOrder,
-} from '../utils/intent-api';
-import { signTypedMessage } from '../utils/keyring';
-import { getNetworkClientIdByChainId } from '../utils/network';
+} from '../utils/intent-api.js';
+import { signTypedMessage } from '../utils/keyring.js';
+import { getNetworkClientIdByChainId } from '../utils/network.js';
 import {
   addSyntheticTransaction,
   waitForTxConfirmation,
-} from '../utils/transaction';
-import { handleEvmApprovals } from './evm-strategy';
-import { SubmitStrategyParams, SubmitStepResult, SubmitStep } from './types';
+} from '../utils/transaction.js';
+import { handleEvmApprovals } from './evm-strategy.js';
+import { SubmitStrategyParams, SubmitStepResult, SubmitStep } from './types.js';
 
 /**
  * Submits a synthetic EVM transaction to the TransactionController in order to display the intent order's

--- a/packages/bridge-status-controller/src/strategy/non-evm-strategy.ts
+++ b/packages/bridge-status-controller/src/strategy/non-evm-strategy.ts
@@ -7,11 +7,11 @@ import type {
   TxData,
 } from '@metamask/bridge-controller';
 
-import { handleNonEvmTx } from '../utils/snaps';
-import { getApprovalTraceParams } from '../utils/trace';
-import { handleApprovalDelay } from '../utils/transaction';
-import { SubmitStep } from './types';
-import type { SubmitStrategyParams, SubmitStepResult } from './types';
+import { handleNonEvmTx } from '../utils/snaps.js';
+import { getApprovalTraceParams } from '../utils/trace.js';
+import { handleApprovalDelay } from '../utils/transaction.js';
+import { SubmitStep } from './types.js';
+import type { SubmitStrategyParams, SubmitStepResult } from './types.js';
 
 /**
  * Submits the approval transaction for a non-EVM transaction if present

--- a/packages/bridge-status-controller/src/strategy/types.ts
+++ b/packages/bridge-status-controller/src/strategy/types.ts
@@ -19,7 +19,7 @@ import type {
   FetchFunction,
   QuoteAndTxMetadata,
   StartPollingForBridgeTxStatusArgs,
-} from '../types';
+} from '../types.js';
 
 export enum SubmitStep {
   /**

--- a/packages/bridge-status-controller/src/types.ts
+++ b/packages/bridge-status-controller/src/types.ts
@@ -43,10 +43,10 @@ import type {
 } from '@metamask/transaction-controller';
 import type { CaipAssetType } from '@metamask/utils';
 
-import type { BridgeStatusControllerMethodActions } from './bridge-status-controller-method-action-types';
-import { BRIDGE_STATUS_CONTROLLER_NAME } from './constants';
-import { QuoteStatusState } from './quote-status-manager/constants';
-import { StatusResponseSchema } from './utils/validators';
+import type { BridgeStatusControllerMethodActions } from './bridge-status-controller-method-action-types.js';
+import { BRIDGE_STATUS_CONTROLLER_NAME } from './constants.js';
+import { QuoteStatusState } from './quote-status-manager/constants.js';
+import { StatusResponseSchema } from './utils/validators.js';
 
 // All fields need to be types not interfaces, same with their children fields
 // o/w you get a type error

--- a/packages/bridge-status-controller/src/utils/accounts.ts
+++ b/packages/bridge-status-controller/src/utils/accounts.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
-import { BridgeStatusControllerMessenger } from '../types';
+import { BridgeStatusControllerMessenger } from '../types.js';
 
 export const getAccountByAddress = (
   messenger: BridgeStatusControllerMessenger,

--- a/packages/bridge-status-controller/src/utils/authentication.ts
+++ b/packages/bridge-status-controller/src/utils/authentication.ts
@@ -1,4 +1,4 @@
-import type { BridgeStatusControllerMessenger } from '../types';
+import type { BridgeStatusControllerMessenger } from '../types.js';
 
 export const getJwt = async (
   messenger: BridgeStatusControllerMessenger,

--- a/packages/bridge-status-controller/src/utils/bridge-status.test.ts
+++ b/packages/bridge-status-controller/src/utils/bridge-status.test.ts
@@ -1,17 +1,17 @@
-import { BRIDGE_PROD_API_BASE_URL, REFRESH_INTERVAL_MS } from '../constants';
-import { QuoteStatusFetchWithRetryOutcomeType } from '../quote-status-manager/constants';
-import { QuoteStatusGetError } from '../quote-status-manager/errors';
-import { QuoteStatusGetWithRetryOutcome } from '../quote-status-manager/quote-status-get-with-retry-outcome';
-import type { QuoteStatusManager } from '../quote-status-manager/quotes-status-manager';
-import { BridgeClientId } from '../types';
-import type { StatusRequestWithSrcTxHash, FetchFunction } from '../types';
+import { BRIDGE_PROD_API_BASE_URL, REFRESH_INTERVAL_MS } from '../constants.js';
+import { QuoteStatusFetchWithRetryOutcomeType } from '../quote-status-manager/constants.js';
+import { QuoteStatusGetError } from '../quote-status-manager/errors.js';
+import { QuoteStatusGetWithRetryOutcome } from '../quote-status-manager/quote-status-get-with-retry-outcome.js';
+import type { QuoteStatusManager } from '../quote-status-manager/quotes-status-manager.js';
+import { BridgeClientId } from '../types.js';
+import type { StatusRequestWithSrcTxHash, FetchFunction } from '../types.js';
 import {
   fetchBridgeQuoteStatus,
   fetchBridgeTxStatus,
   getBridgeStatusUrl,
   getStatusRequestDto,
   shouldSkipFetchDueToFetchFailures,
-} from './bridge-status';
+} from './bridge-status.js';
 
 describe('utils', () => {
   const mockStatusRequest: StatusRequestWithSrcTxHash = {

--- a/packages/bridge-status-controller/src/utils/bridge-status.ts
+++ b/packages/bridge-status-controller/src/utils/bridge-status.ts
@@ -7,8 +7,8 @@ import type { Quote, QuoteResponse } from '@metamask/bridge-controller';
 import type { Provider } from '@metamask/network-controller';
 import { StructError } from '@metamask/superstruct';
 
-import { REFRESH_INTERVAL_MS } from '../constants';
-import { QuoteStatusManager } from '../quote-status-manager/quotes-status-manager';
+import { REFRESH_INTERVAL_MS } from '../constants.js';
+import { QuoteStatusManager } from '../quote-status-manager/quotes-status-manager.js';
 import type {
   StatusResponse,
   StatusRequestWithSrcTxHash,
@@ -17,10 +17,10 @@ import type {
   BridgeHistoryItem,
   StatusRequest,
   BridgeStatusControllerMessenger,
-} from '../types';
-import { isHistoryItemTooOld } from './history';
-import { getNetworkClientByChainId } from './network';
-import { validateBridgeStatusResponse } from './validators';
+} from '../types.js';
+import { isHistoryItemTooOld } from './history.js';
+import { getNetworkClientByChainId } from './network.js';
+import { validateBridgeStatusResponse } from './validators.js';
 
 export const getBridgeStatusUrl = (bridgeApiBaseUrl: string): string =>
   `${bridgeApiBaseUrl}/getTxStatus`;

--- a/packages/bridge-status-controller/src/utils/bridge.ts
+++ b/packages/bridge-status-controller/src/utils/bridge.ts
@@ -5,7 +5,7 @@ import {
   RequiredEventContextFromClient,
 } from '@metamask/bridge-controller';
 
-import { BridgeStatusControllerMessenger } from '../types';
+import { BridgeStatusControllerMessenger } from '../types.js';
 
 export const stopPollingForQuotes = (
   messenger: BridgeStatusControllerMessenger,

--- a/packages/bridge-status-controller/src/utils/feature-flags.ts
+++ b/packages/bridge-status-controller/src/utils/feature-flags.ts
@@ -1,7 +1,7 @@
 import { getBridgeFeatureFlags } from '@metamask/bridge-controller';
 
-import { DEFAULT_MAX_PENDING_HISTORY_ITEM_AGE_MS } from '../constants';
-import { BridgeStatusControllerMessenger } from '../types';
+import { DEFAULT_MAX_PENDING_HISTORY_ITEM_AGE_MS } from '../constants.js';
+import { BridgeStatusControllerMessenger } from '../types.js';
 
 export const getMaxPendingHistoryItemAgeMs = (
   messenger: BridgeStatusControllerMessenger,

--- a/packages/bridge-status-controller/src/utils/gas.ts
+++ b/packages/bridge-status-controller/src/utils/gas.ts
@@ -3,7 +3,7 @@ import type { TokenAmountValues } from '@metamask/bridge-controller';
 import type { TransactionReceipt } from '@metamask/transaction-controller';
 import { BigNumber } from 'bignumber.js';
 
-import type { BridgeHistoryItem } from '../types';
+import type { BridgeHistoryItem } from '../types.js';
 
 const calcGasInHexWei = (gasLimit?: string, gasPrice?: string) => {
   return gasLimit && gasPrice

--- a/packages/bridge-status-controller/src/utils/history.test.ts
+++ b/packages/bridge-status-controller/src/utils/history.test.ts
@@ -6,12 +6,12 @@ import type {
   BridgeHistoryItem,
   StartPollingForBridgeTxStatusArgsSerialized,
   StatusResponse,
-} from '../types';
+} from '../types.js';
 import {
   getHistoryKey,
   getInitialHistoryItem,
   rekeyHistoryItemInState,
-} from './history';
+} from './history.js';
 
 describe('History Utils', () => {
   describe('rekeyHistoryItemInState', () => {

--- a/packages/bridge-status-controller/src/utils/history.ts
+++ b/packages/bridge-status-controller/src/utils/history.ts
@@ -11,8 +11,8 @@ import type {
   BridgeStatusControllerMessenger,
   BridgeStatusControllerState,
   StartPollingForBridgeTxStatusArgsSerialized,
-} from '../types';
-import { getMaxPendingHistoryItemAgeMs } from './feature-flags';
+} from '../types.js';
+import { getMaxPendingHistoryItemAgeMs } from './feature-flags.js';
 
 const updateHistoryItem = (
   oldHistoryItem: BridgeHistoryItem,

--- a/packages/bridge-status-controller/src/utils/intent-api.test.ts
+++ b/packages/bridge-status-controller/src/utils/intent-api.test.ts
@@ -2,16 +2,16 @@
 import { BridgeClientId, StatusTypes } from '@metamask/bridge-controller';
 import { TransactionStatus } from '@metamask/transaction-controller';
 
-import type { FetchFunction } from '../types';
+import type { FetchFunction } from '../types.js';
 import {
   getIntentFromQuote,
   IntentApiImpl,
   mapIntentOrderStatusToTransactionStatus,
   postSubmitOrder,
   translateIntentOrderToBridgeStatus,
-} from './intent-api';
-import type { IntentSubmissionParams } from './intent-api';
-import { IntentOrderStatus } from './validators';
+} from './intent-api.js';
+import type { IntentSubmissionParams } from './intent-api.js';
+import { IntentOrderStatus } from './validators.js';
 
 describe('IntentApiImpl', () => {
   const baseUrl = 'https://example.com/api';

--- a/packages/bridge-status-controller/src/utils/intent-api.ts
+++ b/packages/bridge-status-controller/src/utils/intent-api.ts
@@ -8,12 +8,12 @@ import {
 } from '@metamask/bridge-controller';
 import { TransactionStatus } from '@metamask/transaction-controller';
 
-import type { FetchFunction, StatusResponse } from '../types';
+import type { FetchFunction, StatusResponse } from '../types.js';
 import {
   IntentStatusResponse,
   IntentOrderStatus,
   validateIntentStatusResponse,
-} from './validators';
+} from './validators.js';
 
 export type IntentSubmissionParams = {
   srcChainId: ChainId;

--- a/packages/bridge-status-controller/src/utils/keyring.ts
+++ b/packages/bridge-status-controller/src/utils/keyring.ts
@@ -1,7 +1,7 @@
 import type { Intent } from '@metamask/bridge-controller';
 import { SignTypedDataVersion } from '@metamask/keyring-controller';
 
-import type { BridgeStatusControllerMessenger } from '../types';
+import type { BridgeStatusControllerMessenger } from '../types.js';
 
 export const signTypedMessage = async ({
   messenger,

--- a/packages/bridge-status-controller/src/utils/metrics.test.ts
+++ b/packages/bridge-status-controller/src/utils/metrics.test.ts
@@ -16,7 +16,7 @@ import type {
 import { TransactionType } from '@metamask/transaction-controller';
 import { TransactionStatus } from '@metamask/transaction-controller';
 
-import type { BridgeHistoryItem } from '../types';
+import type { BridgeHistoryItem } from '../types.js';
 import {
   getTxStatusesFromHistory,
   getFinalizedTxProperties,
@@ -25,7 +25,7 @@ import {
   getRequestMetadataFromHistory,
   getEVMTxPropertiesFromTransactionMeta,
   getPreConfirmationPropertiesFromQuote,
-} from './metrics';
+} from './metrics.js';
 
 describe('metrics utils', () => {
   const mockHistoryItem: BridgeHistoryItem = {

--- a/packages/bridge-status-controller/src/utils/metrics.ts
+++ b/packages/bridge-status-controller/src/utils/metrics.ts
@@ -36,12 +36,12 @@ import type { TransactionMeta } from '@metamask/transaction-controller';
 import type { CaipAssetType, Hex } from '@metamask/utils';
 import { BigNumber } from 'bignumber.js';
 
-import type { BridgeHistoryItem } from '../types';
-import { calcActualGasUsed } from './gas';
+import type { BridgeHistoryItem } from '../types.js';
+import { calcActualGasUsed } from './gas.js';
 import {
   getActualBridgeReceivedAmount,
   getActualSwapReceivedAmount,
-} from './swap-received-amount';
+} from './swap-received-amount.js';
 
 export const getTxStatusesFromHistory = ({
   status,

--- a/packages/bridge-status-controller/src/utils/network.ts
+++ b/packages/bridge-status-controller/src/utils/network.ts
@@ -3,7 +3,7 @@ import { formatChainIdToHex } from '@metamask/bridge-controller';
 import type { GenericQuoteRequest } from '@metamask/bridge-controller';
 import type { NetworkClient } from '@metamask/network-controller';
 
-import type { BridgeStatusControllerMessenger } from '../types';
+import type { BridgeStatusControllerMessenger } from '../types.js';
 
 export const getSelectedChainId = (
   messenger: BridgeStatusControllerMessenger,

--- a/packages/bridge-status-controller/src/utils/snaps.test.ts
+++ b/packages/bridge-status-controller/src/utils/snaps.test.ts
@@ -2,8 +2,8 @@ import { ChainId, mergeQuoteMetadata } from '@metamask/bridge-controller';
 /* eslint-disable consistent-return */
 import { v4 as uuid } from 'uuid';
 
-import { BridgeStatusControllerMessenger } from '../types';
-import { createClientTransactionRequest, handleNonEvmTx } from './snaps';
+import { BridgeStatusControllerMessenger } from '../types.js';
+import { createClientTransactionRequest, handleNonEvmTx } from './snaps.js';
 
 jest.mock('uuid', () => ({
   v4: jest.fn(),

--- a/packages/bridge-status-controller/src/utils/snaps.ts
+++ b/packages/bridge-status-controller/src/utils/snaps.ts
@@ -26,7 +26,7 @@ import { v4 as uuid } from 'uuid';
 import type {
   BridgeStatusControllerMessenger,
   SolanaTransactionMeta,
-} from '../types';
+} from '../types.js';
 
 /**
  * Creates a client request object for signing and sending a transaction

--- a/packages/bridge-status-controller/src/utils/swap-received-amount.ts
+++ b/packages/bridge-status-controller/src/utils/swap-received-amount.ts
@@ -3,7 +3,7 @@ import { isNativeAddress } from '@metamask/bridge-controller';
 import type { TransactionMeta } from '@metamask/transaction-controller';
 import { BigNumber } from 'bignumber.js';
 
-import type { BridgeHistoryItem } from '../types';
+import type { BridgeHistoryItem } from '../types.js';
 
 const getReceivedNativeAmount = (
   historyItem: BridgeHistoryItem,

--- a/packages/bridge-status-controller/src/utils/trace.ts
+++ b/packages/bridge-status-controller/src/utils/trace.ts
@@ -5,7 +5,7 @@ import {
   QuoteResponse,
 } from '@metamask/bridge-controller';
 
-import { TraceName } from '../constants';
+import { TraceName } from '../constants.js';
 
 export const getTraceParams = (
   quoteResponse: QuoteResponse,

--- a/packages/bridge-status-controller/src/utils/transaction.test.ts
+++ b/packages/bridge-status-controller/src/utils/transaction.test.ts
@@ -18,13 +18,13 @@ import {
 } from '@metamask/transaction-controller';
 import type { TransactionMeta } from '@metamask/transaction-controller';
 
-import { APPROVAL_DELAY_MS } from '../constants';
+import { APPROVAL_DELAY_MS } from '../constants.js';
 import type {
   BridgeStatusControllerMessenger,
   QuoteAndTxMetadata,
-} from '../types';
-import { getStatusRequestParams } from './bridge-status';
-import * as snaps from './snaps';
+} from '../types.js';
+import { getStatusRequestParams } from './bridge-status.js';
+import * as snaps from './snaps.js';
 import {
   handleApprovalDelay,
   handleMobileHardwareWalletDelay,
@@ -35,7 +35,7 @@ import {
   findAllTransactionsInBatch,
   isApprovalTx,
   updateTransactionsInBatch,
-} from './transaction';
+} from './transaction.js';
 
 describe('Bridge Status Controller Transaction Utils', () => {
   describe('waitForTxConfirmation', () => {

--- a/packages/bridge-status-controller/src/utils/transaction.ts
+++ b/packages/bridge-status-controller/src/utils/transaction.ts
@@ -32,11 +32,11 @@ import type {
 import { createProjectLogger, isStrictHexString } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
 
-import { APPROVAL_DELAY_MS } from '../constants';
-import type { BridgeStatusControllerMessenger } from '../types';
-import type { QuoteAndTxMetadata } from '../types';
-import { getAccountByAddress } from './accounts';
-import { getNetworkClientIdByChainId } from './network';
+import { APPROVAL_DELAY_MS } from '../constants.js';
+import type { BridgeStatusControllerMessenger } from '../types.js';
+import type { QuoteAndTxMetadata } from '../types.js';
+import { getAccountByAddress } from './accounts.js';
+import { getNetworkClientIdByChainId } from './network.js';
 
 export const isApprovalTx = (type: TransactionType) =>
   type === TransactionType.bridgeApproval ||

--- a/packages/bridge-status-controller/src/utils/validators.test.ts
+++ b/packages/bridge-status-controller/src/utils/validators.test.ts
@@ -1,4 +1,4 @@
-import { validateBridgeStatusResponse } from './validators';
+import { validateBridgeStatusResponse } from './validators.js';
 
 const BridgeTxStatusResponses = {
   STATUS_PENDING_VALID: {

--- a/packages/bridge-status-controller/test/mock-batch-sell-erc20-erc20.ts
+++ b/packages/bridge-status-controller/test/mock-batch-sell-erc20-erc20.ts
@@ -16,7 +16,7 @@ import {
   TransactionType,
 } from '@metamask/transaction-controller';
 
-import { BridgeHistoryItem } from '../src';
+import { BridgeHistoryItem } from '../src/index.js';
 
 export const mockBatchSellErc20Erc20: QuoteResponse<TxData, TxData>[] = [
   {


### PR DESCRIPTION
## Summary

This PR adds `.js` import extensions to all relative imports in the
Swaps-Bridge packages, in preparation for the ESM refactor.

The ESLint rule that enforces this (`n/file-extension-in-import` +
`import-x/extensions`) has been added for these packages in
`eslint.config.mjs`.

## Packages

- `@metamask/bridge-controller`
- `@metamask/bridge-status-controller`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical import-path and ESLint scope updates with no changes to bridge or transaction submission logic.
> 
> **Overview**
> Prepares **@metamask/bridge-controller** and **@metamask/bridge-status-controller** for ESM by appending **`.js`** to relative imports across source, tests, and mocks (including cross-package test helpers like `controller-utils`).
> 
> **`eslint.config.mjs`** now includes both bridge packages in the scoped rule set that enforces **`n/file-extension-in-import`** and related **`import-x/extensions`** settings, so new code stays consistent.
> 
> No bridge or status behavior changes—import paths and lint coverage only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bfc07a08290e22e378b2717f4c881092a17e737. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->