### PR TITLE
feat: add createWidgetUrl method and related functionality for Transa…

### DIFF
--- a/packages/ramps-controller/CHANGELOG.md
+++ b/packages/ramps-controller/CHANGELOG.md
@@ -9,12 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `TransakService.createWidgetUrl` and `RampsController.transakCreateWidgetUrl`, which create the Transak payment widget URL through the ramps API proxy (`POST /providers/{providerId}/widget-url`) so the partner API key never leaves the backend. Requires the host to delegate `AuthenticationController:getBearerToken` to the `TransakService` messenger.
-- Add a `rampsApiBaseUrlOverride` constructor option to `TransakService` (same semantics as `RampsService`'s `baseUrlOverride`) that overrides the ramps API base URL for local development; it applies to the orders and widget-url proxy requests only.
+- Add `TransakService.createWidgetUrl` and `RampsController.transakCreateWidgetUrl`, which create the Transak payment widget URL through the ramps API proxy (`POST /providers/{providerId}/widget-url`) so the partner API key never leaves the backend. Requires the host to delegate `AuthenticationController:getBearerToken` to the `TransakService` messenger. ([#9632](https://github.com/MetaMask/core/pull/9632))
+- Add a `rampsApiBaseUrlOverride` constructor option to `TransakService` (same semantics as `RampsService`'s `baseUrlOverride`) that overrides the ramps API base URL for local development; it applies to the orders and widget-url proxy requests only. ([#9632](https://github.com/MetaMask/core/pull/9632))
+- Add a `referrerDomain` constructor option to `TransakService` that identifies the client to Transak in `widgetParams` (defaults to `metamask.io`). ([#9632](https://github.com/MetaMask/core/pull/9632))
+- Add `TransakEnvironment.Development`, which routes ramps API requests to `https://on-ramp.dev-api.cx.metamask.io` while direct Transak API calls use the staging gateway. ([#9632](https://github.com/MetaMask/core/pull/9632))
 
 ### Deprecated
 
-- Deprecate `TransakService.requestOtt` and `TransakService.generatePaymentWidgetUrl` in favor of `createWidgetUrl`; the OTT flow requires the partner API key on the client.
+- Deprecate `TransakService.requestOtt` and `TransakService.generatePaymentWidgetUrl` in favor of `createWidgetUrl`; the OTT flow requires the partner API key on the client. ([#9632](https://github.com/MetaMask/core/pull/9632))
 
 ## [17.0.0]
 

--- a/packages/ramps-controller/CHANGELOG.md
+++ b/packages/ramps-controller/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `TransakService.createWidgetUrl` and `RampsController.transakCreateWidgetUrl`, which create the Transak payment widget URL through the ramps API proxy (`POST /providers/{providerId}/widget-url`) so the partner API key never leaves the backend. Requires the host to delegate `AuthenticationController:getBearerToken` to the `TransakService` messenger.
+- Add a `rampsApiBaseUrlOverride` constructor option to `TransakService` (same semantics as `RampsService`'s `baseUrlOverride`) that overrides the ramps API base URL for local development; it applies to the orders and widget-url proxy requests only.
+
+### Deprecated
+
+- Deprecate `TransakService.requestOtt` and `TransakService.generatePaymentWidgetUrl` in favor of `createWidgetUrl`; the OTT flow requires the partner API key on the client.
+
 ## [17.0.0]
 
 ### Added

--- a/packages/ramps-controller/src/RampsController-method-action-types.ts
+++ b/packages/ramps-controller/src/RampsController-method-action-types.ts
@@ -525,6 +525,21 @@ export type RampsControllerTransakGeneratePaymentWidgetUrlAction = {
 };
 
 /**
+ * Creates a Transak payment widget URL via the ramps API proxy, which
+ * injects the partner API key server-side. Replaces the OTT flow
+ * ({@link transakRequestOtt} + {@link transakGeneratePaymentWidgetUrl}).
+ *
+ * @param quote - The buy quote to pre-fill in the widget.
+ * @param walletAddress - The destination wallet address.
+ * @param extraParams - Optional additional widget parameters (e.g. theming).
+ * @returns The single-use widget URL.
+ */
+export type RampsControllerTransakCreateWidgetUrlAction = {
+  type: `RampsController:transakCreateWidgetUrl`;
+  handler: RampsController['transakCreateWidgetUrl'];
+};
+
+/**
  * Submits the user's purpose of usage form for KYC compliance.
  *
  * @param purpose - Array of purpose strings selected by the user.
@@ -666,6 +681,7 @@ export type RampsControllerMethodActions =
   | RampsControllerTransakGetUserLimitsAction
   | RampsControllerTransakRequestOttAction
   | RampsControllerTransakGeneratePaymentWidgetUrlAction
+  | RampsControllerTransakCreateWidgetUrlAction
   | RampsControllerTransakSubmitPurposeOfUsageFormAction
   | RampsControllerTransakPatchUserAction
   | RampsControllerTransakSubmitSsnDetailsAction

--- a/packages/ramps-controller/src/RampsController.test.ts
+++ b/packages/ramps-controller/src/RampsController.test.ts
@@ -10463,6 +10463,73 @@ describe('RampsController', () => {
       });
     });
 
+    describe('transakCreateWidgetUrl', () => {
+      const mockQuote: TransakBuyQuote = {
+        quoteId: 'quote-1',
+        conversionPrice: 50000,
+        marketConversionPrice: 50100,
+        slippage: 0.5,
+        fiatCurrency: 'USD',
+        cryptoCurrency: 'BTC',
+        paymentMethod: 'credit_debit_card',
+        fiatAmount: 100,
+        cryptoAmount: 0.002,
+        isBuyOrSell: 'BUY',
+        network: 'bitcoin',
+        feeDecimal: 0.01,
+        totalFee: 1,
+        feeBreakdown: [],
+        nonce: 1,
+        cryptoLiquidityProvider: 'provider-1',
+        notes: [],
+      };
+
+      it('calls messenger with correct arguments and returns the widget URL', async () => {
+        await withController(async ({ rootMessenger }) => {
+          const handler = jest
+            .fn()
+            .mockResolvedValue('https://global.transak.com?sessionId=sess-1');
+          rootMessenger.registerActionHandler(
+            'TransakService:createWidgetUrl',
+            handler,
+          );
+          const extraParams = { themeColor: '037dd6' };
+          const result = await rootMessenger.call(
+            'RampsController:transakCreateWidgetUrl',
+            mockQuote,
+            '0x123',
+            extraParams,
+          );
+          expect(result).toBe('https://global.transak.com?sessionId=sess-1');
+          expect(handler).toHaveBeenCalledWith(mockQuote, '0x123', extraParams);
+        });
+      });
+
+      it('sets isAuthenticated to false when a 401 HttpError is thrown', async () => {
+        await withController(async ({ controller, rootMessenger }) => {
+          rootMessenger.call('RampsController:transakSetAuthenticated', true);
+          rootMessenger.registerActionHandler(
+            'TransakService:createWidgetUrl',
+            async () => {
+              throw Object.assign(new Error('Token expired'), {
+                httpStatus: 401,
+              });
+            },
+          );
+          await expect(
+            rootMessenger.call(
+              'RampsController:transakCreateWidgetUrl',
+              mockQuote,
+              '0x123',
+            ),
+          ).rejects.toThrow('Token expired');
+          expect(controller.state.nativeProviders.transak.isAuthenticated).toBe(
+            false,
+          );
+        });
+      });
+    });
+
     describe('transakSubmitPurposeOfUsageForm', () => {
       it('calls messenger with purpose array', async () => {
         await withController(async ({ rootMessenger }) => {

--- a/packages/ramps-controller/src/RampsController.ts
+++ b/packages/ramps-controller/src/RampsController.ts
@@ -76,6 +76,7 @@ import type {
   TransakServiceGetUserLimitsAction,
   TransakServiceRequestOttAction,
   TransakServiceGeneratePaymentWidgetUrlAction,
+  TransakServiceCreateWidgetUrlAction,
   TransakServiceSubmitPurposeOfUsageFormAction,
   TransakServicePatchUserAction,
   TransakServiceSubmitSsnDetailsAction,
@@ -146,6 +147,7 @@ export const RAMPS_CONTROLLER_REQUIRED_SERVICE_ACTIONS: readonly (
   'TransakService:getUserLimits',
   'TransakService:requestOtt',
   'TransakService:generatePaymentWidgetUrl',
+  'TransakService:createWidgetUrl',
   'TransakService:submitPurposeOfUsageForm',
   'TransakService:patchUser',
   'TransakService:submitSsnDetails',
@@ -613,6 +615,7 @@ type AllowedActions =
   | TransakServiceGetUserLimitsAction
   | TransakServiceRequestOttAction
   | TransakServiceGeneratePaymentWidgetUrlAction
+  | TransakServiceCreateWidgetUrlAction
   | TransakServiceSubmitPurposeOfUsageFormAction
   | TransakServicePatchUserAction
   | TransakServiceSubmitSsnDetailsAction
@@ -841,6 +844,7 @@ const MESSENGER_EXPOSED_METHODS = [
   'transakGetUserLimits',
   'transakRequestOtt',
   'transakGeneratePaymentWidgetUrl',
+  'transakCreateWidgetUrl',
   'transakSubmitPurposeOfUsageForm',
   'transakPatchUser',
   'transakSubmitSsnDetails',
@@ -3064,6 +3068,34 @@ export class RampsController extends BaseController<
       walletAddress,
       extraParams,
     );
+  }
+
+  /**
+   * Creates a Transak payment widget URL via the ramps API proxy, which
+   * injects the partner API key server-side. Replaces the OTT flow
+   * ({@link transakRequestOtt} + {@link transakGeneratePaymentWidgetUrl}).
+   *
+   * @param quote - The buy quote to pre-fill in the widget.
+   * @param walletAddress - The destination wallet address.
+   * @param extraParams - Optional additional widget parameters (e.g. theming).
+   * @returns The single-use widget URL.
+   */
+  async transakCreateWidgetUrl(
+    quote: TransakBuyQuote,
+    walletAddress: string,
+    extraParams?: Record<string, string>,
+  ): Promise<string> {
+    try {
+      return await this.messenger.call(
+        'TransakService:createWidgetUrl',
+        quote,
+        walletAddress,
+        extraParams,
+      );
+    } catch (error) {
+      throw this.#getNormalizedTransakError(error, { syncAuth: true })
+        .normalizedError;
+    }
   }
 
   /**

--- a/packages/ramps-controller/src/TransakService-method-action-types.ts
+++ b/packages/ramps-controller/src/TransakService-method-action-types.ts
@@ -70,14 +70,49 @@ export type TransakServiceGetUserLimitsAction = {
   handler: TransakService['getUserLimits'];
 };
 
+/**
+ * @deprecated Use {@link createWidgetUrl} instead. The OTT flow requires the
+ * partner API key on the client and Transak is deprecating `request-ott`.
+ * @returns The one-time token response.
+ */
 export type TransakServiceRequestOttAction = {
   type: `TransakService:requestOtt`;
   handler: TransakService['requestOtt'];
 };
 
+/**
+ * @deprecated Use {@link createWidgetUrl} instead. This builds the widget
+ * URL client-side and embeds the partner API key in it.
+ * @param ottToken - The one-time token for widget authentication.
+ * @param quote - The buy quote to pre-fill in the widget.
+ * @param walletAddress - The destination wallet address.
+ * @param extraParams - Optional additional URL parameters.
+ * @returns The fully constructed widget URL string.
+ */
 export type TransakServiceGeneratePaymentWidgetUrlAction = {
   type: `TransakService:generatePaymentWidgetUrl`;
   handler: TransakService['generatePaymentWidgetUrl'];
+};
+
+/**
+ * Creates a Transak payment widget URL through the ramps API proxy
+ * (`POST {rampsBaseUrl}/providers/{providerId}/widget-url`). The proxy
+ * injects the partner API key and derives the user IP server-side, so
+ * neither leaves the backend. Replaces the OTT flow ({@link requestOtt} +
+ * {@link generatePaymentWidgetUrl}).
+ *
+ * Requires both a Transak access token (user must be logged in to Transak)
+ * and a MetaMask bearer token from `AuthenticationController`.
+ *
+ * @param quote - The buy quote to pre-fill in the widget.
+ * @param walletAddress - The destination wallet address.
+ * @param extraParams - Optional additional widget parameters (e.g. theming).
+ * Keys must be on the proxy's allowlist or the request is rejected.
+ * @returns The single-use widget URL (expires after 5 minutes).
+ */
+export type TransakServiceCreateWidgetUrlAction = {
+  type: `TransakService:createWidgetUrl`;
+  handler: TransakService['createWidgetUrl'];
 };
 
 export type TransakServiceSubmitPurposeOfUsageFormAction = {
@@ -144,6 +179,7 @@ export type TransakServiceMethodActions =
   | TransakServiceGetUserLimitsAction
   | TransakServiceRequestOttAction
   | TransakServiceGeneratePaymentWidgetUrlAction
+  | TransakServiceCreateWidgetUrlAction
   | TransakServiceSubmitPurposeOfUsageFormAction
   | TransakServicePatchUserAction
   | TransakServiceSubmitSsnDetailsAction

--- a/packages/ramps-controller/src/TransakService.test.ts
+++ b/packages/ramps-controller/src/TransakService.test.ts
@@ -7,6 +7,7 @@ import type {
 import nock, { cleanAll, isDone } from 'nock';
 
 import { flushPromises } from '../../../tests/helpers.js';
+import packageJson from '../package.json';
 import type {
   TransakServiceMessenger,
   TransakAccessToken,
@@ -216,22 +217,37 @@ function getRootMessenger(): RootMessenger {
 }
 
 function getMessenger(rootMessenger: RootMessenger): TransakServiceMessenger {
-  return new Messenger({
+  const messenger: TransakServiceMessenger = new Messenger({
     namespace: 'TransakService',
     parent: rootMessenger,
   });
+  rootMessenger.delegate({
+    actions: ['AuthenticationController:getBearerToken'],
+    events: [],
+    messenger,
+  });
+  return messenger;
 }
 
 function getService({
   options = {},
+  mockGetBearerToken,
 }: {
   options?: Partial<ConstructorParameters<typeof TransakService>[0]>;
+  mockGetBearerToken?: jest.Mock;
 } = {}): {
   service: TransakService;
   rootMessenger: RootMessenger;
   messenger: TransakServiceMessenger;
+  mockGetBearerToken: jest.Mock;
 } {
   const rootMessenger = getRootMessenger();
+  const getBearerTokenMock =
+    mockGetBearerToken ?? jest.fn().mockResolvedValue('mock-bearer-token');
+  rootMessenger.registerActionHandler(
+    'AuthenticationController:getBearerToken',
+    getBearerTokenMock,
+  );
   const messenger = getMessenger(rootMessenger);
   const service = new TransakService({
     fetch,
@@ -243,7 +259,12 @@ function getService({
     ...options,
   });
 
-  return { service, rootMessenger, messenger };
+  return {
+    service,
+    rootMessenger,
+    messenger,
+    mockGetBearerToken: getBearerTokenMock,
+  };
 }
 
 function authenticateService(service: TransakService): void {
@@ -1951,6 +1972,158 @@ describe('TransakService', () => {
         'credit_debit_card',
       );
       expect(parsed.searchParams.get('hideMenu')).toBe('true');
+    });
+  });
+
+  describe('createWidgetUrl', () => {
+    const WIDGET_URL_PATH = `${STAGING_PROVIDER_PATH}/widget-url`;
+    const MOCK_WIDGET_URL = 'https://global-stg.transak.com?sessionId=sess-1';
+
+    it('creates a widget URL via the ramps API proxy', async () => {
+      let requestBody: Record<string, unknown> | undefined;
+      const scope = nock(STAGING_ORDERS_BASE)
+        .post(WIDGET_URL_PATH, (body) => {
+          requestBody = body;
+          return true;
+        })
+        .query({
+          action: 'deposit',
+          sdk: '2.1.6',
+          controller: packageJson.version,
+          context: MOCK_CONTEXT,
+        })
+        .matchHeader('authorization', 'Bearer mock-bearer-token')
+        .matchHeader('x-transak-access-token', MOCK_ACCESS_TOKEN.accessToken)
+        .reply(200, { widgetUrl: MOCK_WIDGET_URL });
+
+      const { service } = getService();
+      authenticateService(service);
+
+      const promise = service.createWidgetUrl(MOCK_BUY_QUOTE, '0xWALLET', {
+        themeColor: '037dd6',
+      });
+      await jest.runAllTimersAsync();
+      await flushPromises();
+      const result = await promise;
+
+      expect(result).toBe(MOCK_WIDGET_URL);
+      expect(scope.isDone()).toBe(true);
+      expect(requestBody).toStrictEqual({
+        widgetParams: {
+          referrerDomain: 'metamask.io',
+          fiatCurrency: 'USD',
+          cryptoCurrencyCode: 'ETH',
+          fiatAmount: 100,
+          network: 'ethereum',
+          paymentMethod: 'credit_debit_card',
+          walletAddress: '0xWALLET',
+          hideExchangeScreen: 'true',
+          disableWalletAddressEdit: 'true',
+          hideMenu: 'true',
+          redirectURL:
+            'https://on-ramp-content.api.cx.metamask.io/regions/fake-callback',
+          themeColor: '037dd6',
+        },
+      });
+    });
+
+    it('throws when not authenticated with Transak', async () => {
+      const { service } = getService();
+
+      await expect(
+        service.createWidgetUrl(MOCK_BUY_QUOTE, '0xWALLET'),
+      ).rejects.toThrow('Authentication required');
+    });
+
+    it('propagates failures from the bearer token fetch', async () => {
+      const { service } = getService({
+        mockGetBearerToken: jest
+          .fn()
+          .mockRejectedValue(new Error('wallet is locked')),
+      });
+      authenticateService(service);
+
+      await expect(
+        service.createWidgetUrl(MOCK_BUY_QUOTE, '0xWALLET'),
+      ).rejects.toThrow('wallet is locked');
+    });
+
+    it('throws a TransakApiError on a non-2xx proxy response', async () => {
+      nock(STAGING_ORDERS_BASE)
+        .post(WIDGET_URL_PATH)
+        .query(true)
+        .reply(400, {
+          error: { message: 'referrerDomain is required' },
+        });
+
+      const { service } = getService();
+      authenticateService(service);
+
+      const promise = service.createWidgetUrl(MOCK_BUY_QUOTE, '0xWALLET');
+      await jest.runAllTimersAsync();
+      await flushPromises();
+
+      await expect(promise).rejects.toThrow(TransakApiError);
+    });
+
+    it('respects rampsApiBaseUrlOverride for local development', async () => {
+      const scope = nock('http://localhost:3000')
+        .post(WIDGET_URL_PATH)
+        .query(true)
+        .reply(200, { widgetUrl: MOCK_WIDGET_URL });
+
+      const { service } = getService({
+        options: { rampsApiBaseUrlOverride: 'http://localhost:3000' },
+      });
+      authenticateService(service);
+
+      const promise = service.createWidgetUrl(MOCK_BUY_QUOTE, '0xWALLET');
+      await jest.runAllTimersAsync();
+      await flushPromises();
+      const result = await promise;
+
+      expect(result).toBe(MOCK_WIDGET_URL);
+      expect(scope.isDone()).toBe(true);
+    });
+
+    it('uses the production proxy path when environment is Production', async () => {
+      const scope = nock(PRODUCTION_ORDERS_BASE)
+        .post(`${PRODUCTION_PROVIDER_PATH}/widget-url`)
+        .query(true)
+        .reply(200, { widgetUrl: MOCK_WIDGET_URL });
+
+      const { service } = getService({
+        options: { environment: TransakEnvironment.Production },
+      });
+      authenticateService(service);
+
+      const promise = service.createWidgetUrl(MOCK_BUY_QUOTE, '0xWALLET');
+      await jest.runAllTimersAsync();
+      await flushPromises();
+      const result = await promise;
+
+      expect(result).toBe(MOCK_WIDGET_URL);
+      expect(scope.isDone()).toBe(true);
+    });
+
+    it('uses the dev ramps API with the staging provider path when environment is Development', async () => {
+      const scope = nock('https://on-ramp.dev-api.cx.metamask.io')
+        .post(WIDGET_URL_PATH)
+        .query(true)
+        .reply(200, { widgetUrl: MOCK_WIDGET_URL });
+
+      const { service } = getService({
+        options: { environment: TransakEnvironment.Development },
+      });
+      authenticateService(service);
+
+      const promise = service.createWidgetUrl(MOCK_BUY_QUOTE, '0xWALLET');
+      await jest.runAllTimersAsync();
+      await flushPromises();
+      const result = await promise;
+
+      expect(result).toBe(MOCK_WIDGET_URL);
+      expect(scope.isDone()).toBe(true);
     });
   });
 

--- a/packages/ramps-controller/src/TransakService.test.ts
+++ b/packages/ramps-controller/src/TransakService.test.ts
@@ -1052,6 +1052,36 @@ describe('TransakService', () => {
       expect(result).toStrictEqual(MOCK_BUY_QUOTE);
     });
 
+    it('omits query parameters whose values are undefined', async () => {
+      nockTranslation();
+
+      nock(STAGING_TRANSAK_BASE)
+        .get('/api/v2/lookup/quotes')
+        .query(
+          (query) =>
+            query.fiatAmount === undefined &&
+            query.fiatCurrency === 'USD' &&
+            query.apiKey === MOCK_API_KEY,
+        )
+        .reply(200, { data: MOCK_BUY_QUOTE });
+
+      const { service } = getService();
+
+      const promise = service.getBuyQuote(
+        'USD',
+        'eip155:1/slip44:60',
+        'eip155:1',
+        'credit_debit_card',
+        // A JS consumer can pass undefined despite the type; it must not
+        // become a literal "undefined" query parameter.
+        undefined as unknown as string,
+      );
+      await jest.runAllTimersAsync();
+      await flushPromises();
+
+      expect(await promise).toStrictEqual(MOCK_BUY_QUOTE);
+    });
+
     it('normalizes ramps API payment method IDs before translation', async () => {
       nock(STAGING_ORDERS_BASE)
         .get(`${STAGING_PROVIDER_PATH}/native/translate`)
@@ -1636,6 +1666,34 @@ describe('TransakService', () => {
       expect(result.orderType).toBe('DEPOSIT');
     });
 
+    it('omits the wallet query parameter when it is undefined', async () => {
+      const depositOrderId = `${STAGING_PROVIDER_PATH}/orders/order-abc-123`;
+
+      nock(STAGING_ORDERS_BASE)
+        .get(`${STAGING_PROVIDER_PATH}/orders/order-abc-123`)
+        .query(
+          (query) =>
+            query.wallet === undefined &&
+            query.action === 'deposit' &&
+            query.context === MOCK_CONTEXT,
+        )
+        .reply(200, MOCK_DEPOSIT_ORDER);
+
+      const { service } = getService();
+
+      const promise = service.getOrder(
+        depositOrderId,
+        // A JS consumer can pass undefined despite the type; it must not
+        // become a literal "undefined" query parameter.
+        undefined as unknown as string,
+      );
+      await jest.runAllTimersAsync();
+      await flushPromises();
+      const result = await promise;
+
+      expect(result.id).toBe(depositOrderId);
+    });
+
     it('converts a raw Transak order ID to deposit format', async () => {
       nock(STAGING_ORDERS_BASE)
         .get(`${STAGING_PROVIDER_PATH}/orders/raw-order-id`)
@@ -2033,6 +2091,36 @@ describe('TransakService', () => {
       await expect(
         service.createWidgetUrl(MOCK_BUY_QUOTE, '0xWALLET'),
       ).rejects.toThrow('Authentication required');
+    });
+
+    it('omits the Transak access token header when the token is cleared while awaiting the bearer token', async () => {
+      const scope = nock(STAGING_ORDERS_BASE, {
+        badheaders: ['x-transak-access-token'],
+      })
+        .post(WIDGET_URL_PATH)
+        .query({
+          action: 'deposit',
+          sdk: '2.1.6',
+          controller: packageJson.version,
+          context: MOCK_CONTEXT,
+        })
+        .matchHeader('authorization', 'Bearer mock-bearer-token')
+        .reply(200, { widgetUrl: MOCK_WIDGET_URL });
+
+      const { service, mockGetBearerToken } = getService();
+      authenticateService(service);
+      mockGetBearerToken.mockImplementation(async () => {
+        service.clearAccessToken();
+        return 'mock-bearer-token';
+      });
+
+      const promise = service.createWidgetUrl(MOCK_BUY_QUOTE, '0xWALLET');
+      await jest.runAllTimersAsync();
+      await flushPromises();
+      const result = await promise;
+
+      expect(result).toBe(MOCK_WIDGET_URL);
+      expect(scope.isDone()).toBe(true);
     });
 
     it('propagates failures from the bearer token fetch', async () => {

--- a/packages/ramps-controller/src/TransakService.ts
+++ b/packages/ramps-controller/src/TransakService.ts
@@ -4,7 +4,10 @@ import type {
 } from '@metamask/controller-utils';
 import { createServicePolicy, HttpError } from '@metamask/controller-utils';
 import type { Messenger } from '@metamask/messenger';
+import type { AuthenticationController } from '@metamask/profile-sync-controller';
 
+import packageJson from '../package.json';
+import { RAMPS_SDK_VERSION } from './RampsService.js';
 import { TRANSAK_ERROR_CODES } from './transakErrorCodes.js';
 import type { TransakServiceMethodActions } from './TransakService-method-action-types.js';
 
@@ -265,6 +268,7 @@ export type TransakIdProofStatus = {
 export enum TransakEnvironment {
   Production = 'production',
   Staging = 'staging',
+  Development = 'development',
 }
 
 enum TransakApiProviders {
@@ -285,9 +289,9 @@ export class TransakOrderIdTransformer {
     environment: TransakEnvironment,
   ): string {
     const provider =
-      environment === TransakEnvironment.Staging
-        ? 'transak-native-staging'
-        : 'transak-native';
+      environment === TransakEnvironment.Production
+        ? 'transak-native'
+        : 'transak-native-staging';
     return `/providers/${provider}/orders/${transakOrderId}`;
   }
 
@@ -322,6 +326,7 @@ const MESSENGER_EXPOSED_METHODS = [
   'getUserLimits',
   'requestOtt',
   'generatePaymentWidgetUrl',
+  'createWidgetUrl',
   'submitPurposeOfUsageForm',
   'patchUser',
   'submitSsnDetails',
@@ -335,7 +340,11 @@ const MESSENGER_EXPOSED_METHODS = [
 
 export type TransakServiceActions = TransakServiceMethodActions;
 
-type AllowedActions = never;
+/**
+ * Actions from other messengers that {@link TransakService} calls.
+ */
+type AllowedActions =
+  AuthenticationController.AuthenticationControllerGetBearerTokenAction;
 
 export type TransakServiceEvents = never;
 
@@ -391,7 +400,9 @@ function getTransakApiBaseUrl(environment: TransakEnvironment): string {
   switch (environment) {
     case TransakEnvironment.Production:
       return 'https://api-gateway.transak.com';
+    // Transak has no dev environment; development uses their staging gateway.
     case TransakEnvironment.Staging:
+    case TransakEnvironment.Development:
       return 'https://api-gateway-stg.transak.com';
     default:
       throw new Error(`Invalid Transak environment: ${String(environment)}`);
@@ -404,16 +415,20 @@ function getRampsBaseUrl(environment: TransakEnvironment): string {
       return 'https://on-ramp.api.cx.metamask.io';
     case TransakEnvironment.Staging:
       return 'https://on-ramp.uat-api.cx.metamask.io';
+    case TransakEnvironment.Development:
+      return 'https://on-ramp.dev-api.cx.metamask.io';
     default:
       throw new Error(`Invalid Transak environment: ${String(environment)}`);
   }
 }
 
 function getRampsProviderPath(environment: TransakEnvironment): string {
+  // The dev ramps API registers the same `transak-native-staging` provider
+  // id as UAT; only production uses `transak-native`.
   const providerId =
-    environment === TransakEnvironment.Staging
-      ? TransakApiProviders.TransakNativeStaging
-      : TransakApiProviders.TransakNative;
+    environment === TransakEnvironment.Production
+      ? TransakApiProviders.TransakNative
+      : TransakApiProviders.TransakNativeStaging;
   return `/providers/${providerId}`;
 }
 
@@ -421,12 +436,23 @@ function getPaymentWidgetBaseUrl(environment: TransakEnvironment): string {
   switch (environment) {
     case TransakEnvironment.Production:
       return 'https://global.transak.com';
+    // Transak has no dev environment; development uses their staging widget.
     case TransakEnvironment.Staging:
+    case TransakEnvironment.Development:
       return 'https://global-stg.transak.com';
     default:
       throw new Error(`Invalid Transak environment: ${String(environment)}`);
   }
 }
+
+/**
+ * Transak requires `referrerDomain` in `widgetParams` alongside the partner
+ * API key (which the ramps API proxy injects server-side). Identifies the
+ * MetaMask client to Transak. Default when the client does not pass a
+ * `referrerDomain` constructor option (e.g. the mobile app passes its
+ * package name / bundle id).
+ */
+const TRANSAK_REFERRER_DOMAIN = 'metamask.io';
 
 // === TRANSAK API ERROR ===
 
@@ -470,6 +496,20 @@ export class TransakService {
 
   #accessToken: TransakAccessToken | null = null;
 
+  /**
+   * Optional ramps API base URL override for local development (mirrors
+   * `RampsService`'s `baseUrlOverride`). Applies to the requests this service
+   * sends to the ramps API (orders, widget-url proxy), not to direct Transak
+   * API calls.
+   */
+  readonly #rampsApiBaseUrlOverride?: string;
+
+  /**
+   * Identifies the client to Transak in `widgetParams` (e.g. the mobile app's
+   * package name / bundle id). Defaults to `metamask.io`.
+   */
+  readonly #referrerDomain: string;
+
   constructor({
     messenger,
     environment = TransakEnvironment.Staging,
@@ -478,6 +518,8 @@ export class TransakService {
     apiKey,
     policyOptions = {},
     orderRetryDelayMs = 2000,
+    rampsApiBaseUrlOverride,
+    referrerDomain = TRANSAK_REFERRER_DOMAIN,
   }: {
     messenger: TransakServiceMessenger;
     environment?: TransakEnvironment;
@@ -486,6 +528,8 @@ export class TransakService {
     apiKey?: string;
     policyOptions?: CreateServicePolicyOptions;
     orderRetryDelayMs?: number;
+    rampsApiBaseUrlOverride?: string;
+    referrerDomain?: string;
   }) {
     this.name = serviceName;
     this.#messenger = messenger;
@@ -499,6 +543,8 @@ export class TransakService {
     this.#context = context;
     this.#apiKey = apiKey ?? null;
     this.#orderRetryDelayMs = orderRetryDelayMs;
+    this.#rampsApiBaseUrlOverride = rampsApiBaseUrlOverride;
+    this.#referrerDomain = referrerDomain;
 
     this.#messenger.registerMethodActionHandlers(
       this,
@@ -715,11 +761,34 @@ export class TransakService {
     });
   }
 
+  /**
+   * Gets the ramps API base URL, respecting the local-development override
+   * when set (same semantics as `RampsService`'s `baseUrlOverride`).
+   *
+   * @returns The ramps API base URL to use.
+   */
+  #getRampsApiBaseUrl(): string {
+    return this.#rampsApiBaseUrlOverride ?? getRampsBaseUrl(this.#environment);
+  }
+
+  /**
+   * Adds the common request parameters to a ramps API proxy URL, mirroring
+   * `RampsService`'s `#addCommonParams`.
+   *
+   * @param url - The URL to add parameters to.
+   */
+  #addRampsCommonParams(url: URL): void {
+    url.searchParams.set('action', 'deposit');
+    url.searchParams.set('sdk', RAMPS_SDK_VERSION);
+    url.searchParams.set('controller', packageJson.version);
+    url.searchParams.set('context', this.#context);
+  }
+
   async #ordersApiGet<ResponseType>(
     path: string,
     params?: Record<string, string>,
   ): Promise<ResponseType> {
-    const baseUrl = getRampsBaseUrl(this.#environment);
+    const baseUrl = this.#getRampsApiBaseUrl();
     const providerPath = getRampsProviderPath(this.#environment);
     const url = new URL(`${providerPath}${path}`, baseUrl);
 
@@ -1020,6 +1089,11 @@ export class TransakService {
     );
   }
 
+  /**
+   * @deprecated Use {@link createWidgetUrl} instead. The OTT flow requires the
+   * partner API key on the client and Transak is deprecating `request-ott`.
+   * @returns The one-time token response.
+   */
   async requestOtt(): Promise<TransakOttResponse> {
     this.#ensureAccessToken();
     const result = await this.#transakPost<TransakOttResponse>(
@@ -1028,6 +1102,15 @@ export class TransakService {
     return result;
   }
 
+  /**
+   * @deprecated Use {@link createWidgetUrl} instead. This builds the widget
+   * URL client-side and embeds the partner API key in it.
+   * @param ottToken - The one-time token for widget authentication.
+   * @param quote - The buy quote to pre-fill in the widget.
+   * @param walletAddress - The destination wallet address.
+   * @param extraParams - Optional additional URL parameters.
+   * @returns The fully constructed widget URL string.
+   */
   generatePaymentWidgetUrl(
     ottToken: string,
     quote: TransakBuyQuote,
@@ -1062,6 +1145,78 @@ export class TransakService {
     const widgetUrl = new URL(widgetBaseUrl);
     widgetUrl.search = params.toString();
     return widgetUrl.toString();
+  }
+
+  /**
+   * Creates a Transak payment widget URL through the ramps API proxy
+   * (`POST {rampsBaseUrl}/providers/{providerId}/widget-url`). The proxy
+   * injects the partner API key and derives the user IP server-side, so
+   * neither leaves the backend. Replaces the OTT flow ({@link requestOtt} +
+   * {@link generatePaymentWidgetUrl}).
+   *
+   * Requires both a Transak access token (user must be logged in to Transak)
+   * and a MetaMask bearer token from `AuthenticationController`.
+   *
+   * @param quote - The buy quote to pre-fill in the widget.
+   * @param walletAddress - The destination wallet address.
+   * @param extraParams - Optional additional widget parameters (e.g. theming).
+   * Keys must be on the proxy's allowlist or the request is rejected.
+   * @returns The single-use widget URL (expires after 5 minutes).
+   */
+  async createWidgetUrl(
+    quote: TransakBuyQuote,
+    walletAddress: string,
+    extraParams?: Record<string, string>,
+  ): Promise<string> {
+    this.#ensureAccessToken();
+    const bearerToken = await this.#messenger.call(
+      'AuthenticationController:getBearerToken',
+    );
+
+    const baseUrl = this.#getRampsApiBaseUrl();
+    const providerPath = getRampsProviderPath(this.#environment);
+    const url = new URL(`${providerPath}/widget-url`, baseUrl);
+
+    this.#addRampsCommonParams(url);
+
+    const widgetParams: Record<string, string | number> = {
+      referrerDomain: this.#referrerDomain,
+      fiatCurrency: quote.fiatCurrency,
+      cryptoCurrencyCode: quote.cryptoCurrency,
+      fiatAmount: quote.fiatAmount,
+      network: quote.network,
+      paymentMethod: quote.paymentMethod,
+      walletAddress,
+      hideExchangeScreen: 'true',
+      disableWalletAddressEdit: 'true',
+      hideMenu: 'true',
+      redirectURL:
+        'https://on-ramp-content.api.cx.metamask.io/regions/fake-callback',
+      ...extraParams,
+    };
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      Authorization: `Bearer ${bearerToken}`,
+    };
+    if (this.#accessToken?.accessToken) {
+      headers['x-transak-access-token'] = this.#accessToken.accessToken;
+    }
+
+    const response = await this.#policy.execute(async () => {
+      const fetchResponse = await this.#fetch(url.toString(), {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ widgetParams }),
+      });
+      if (!fetchResponse.ok) {
+        await this.#throwTransakApiError(fetchResponse, url);
+      }
+      return fetchResponse.json() as Promise<{ widgetUrl: string }>;
+    });
+
+    return response.widgetUrl;
   }
 
   async submitPurposeOfUsageForm(purpose: string[]): Promise<void> {

--- a/packages/ramps-controller/src/index.ts
+++ b/packages/ramps-controller/src/index.ts
@@ -209,4 +209,5 @@ export type {
   TransakServiceGetOrderAction,
   TransakServiceRequestOttAction,
   TransakServiceGeneratePaymentWidgetUrlAction,
+  TransakServiceCreateWidgetUrlAction,
 } from './TransakService-method-action-types.js';


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Today, clients build the Transak payment widget URL themselves via the OTT flow (`TransakService.requestOtt` + `TransakService.generatePaymentWidgetUrl`), which requires embedding the Transak partner API key in the client-generated URL. That key should never leave the backend.

This PR adds a proxy-based flow to `@metamask/ramps-controller`:

- **`TransakService.createWidgetUrl`**: calls `POST {rampsBaseUrl}/providers/{providerId}/widget-url` on the ramps API, which injects the partner API key and derives the user IP server-side, then returns a ready-to-use widget URL. The request is authenticated with a bearer token obtained via a new `AuthenticationController:getBearerToken` delegated action on the `TransakService` messenger, and includes the common ramps API params (`action`, `sdk`, `controller`, `context`), mirroring `RampsService`.
- **`RampsController.transakCreateWidgetUrl`**: a wrapper exposed through the controller messenger that manages auth state around the service call.
- **Deprecates `requestOtt` and `generatePaymentWidgetUrl`** in favor of `createWidgetUrl`, since the OTT flow requires the partner API key on the client.


https://github.com/user-attachments/assets/3ae7fde1-68cf-44ef-a26f-1d4fb2b0f07a



Supporting changes:

- New `TransakEnvironment.Development` value: ramps API requests go to `https://on-ramp.dev-api.cx.metamask.io`, while direct Transak calls fall back to the staging gateway (Transak has no dev environment). The provider ID resolution was also flipped to treat Production as the special case, so Development correctly routes to `transak-native-staging`.
- New `TransakService` constructor options: `rampsApiBaseUrlOverride` (local-development override for ramps API requests only, same semantics as `RampsService`'s `baseUrlOverride`) and `referrerDomain` (identifies the client to Transak in `widgetParams`, defaulting to `metamask.io`; mobile passes its bundle ID).

The corresponding server-side endpoint lives in the onramp API (TRAM-3763) behind an `ENABLE_TRANSAK_WIDGET_PROXY` flag, and the mobile client gates the new path behind the `isTransakWidgetUrlProxyEnabled` deposit feature flag, so this addition is safe to ship independently: nothing changes for consumers until they opt into the new method.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

- Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-3488
- Related backend work (widget URL proxy endpoint): https://consensyssoftware.atlassian.net/browse/TRAM-3763

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches payment-widget creation and new cross-controller auth delegation; legacy OTT APIs remain, so risk is mainly for adopters of the proxy path and hosts that must wire `getBearerToken`.
> 
> **Overview**
> Replaces the client-side Transak OTT + `generatePaymentWidgetUrl` flow with **`createWidgetUrl`**, which calls `POST …/providers/{providerId}/widget-url` on the ramps API so the partner API key and user IP stay on the backend. **`RampsController.transakCreateWidgetUrl`** exposes the same path through the controller messenger and clears Transak auth on 401.
> 
> Hosts must delegate **`AuthenticationController:getBearerToken`** to `TransakService` for MetaMask bearer auth on proxy requests. **`requestOtt`** and **`generatePaymentWidgetUrl`** are deprecated but unchanged for existing callers.
> 
> Also adds **`TransakEnvironment.Development`** (dev ramps API + staging Transak gateway), constructor options **`rampsApiBaseUrlOverride`** and **`referrerDomain`** (default `metamask.io`), and fixes ramps/Transak requests so **`undefined` optional args are omitted** from query strings instead of sending `"undefined"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09d771b4b6da1fadbe23239a0cbcfa2567ae5a69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->