### PR TITLE
chore: remove Stellar and Arc from the bridge controller default chain ranking

### DIFF
--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement `mergeQuoteMetadata` util which appends QuoteMetadata to QuoteResponse ([#9507](https://github.com/MetaMask/core/pull/9507))
 - Bump `@metamask/assets-controller` from `^11.1.1` to `^11.2.0` ([#9629](https://github.com/MetaMask/core/pull/9629))
 - Bump `@metamask/gas-fee-controller` from `^26.2.4` to `^26.3.0` ([#9629](https://github.com/MetaMask/core/pull/9629))
+- Remove Stellar and Arc from `DEFAULT_CHAIN_RANKING` ([#9633](https://github.com/MetaMask/core/pull/9633))  
 
 ## [77.8.0]
 

--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement `mergeQuoteMetadata` util which appends QuoteMetadata to QuoteResponse ([#9507](https://github.com/MetaMask/core/pull/9507))
 - Bump `@metamask/assets-controller` from `^11.1.1` to `^11.2.0` ([#9629](https://github.com/MetaMask/core/pull/9629))
 - Bump `@metamask/gas-fee-controller` from `^26.2.4` to `^26.3.0` ([#9629](https://github.com/MetaMask/core/pull/9629))
-- Remove Stellar and Arc from `DEFAULT_CHAIN_RANKING` ([#9633](https://github.com/MetaMask/core/pull/9633))  
+- Remove Stellar and Arc from `DEFAULT_CHAIN_RANKING` ([#9633](https://github.com/MetaMask/core/pull/9633))
 
 ## [77.8.0]
 

--- a/packages/bridge-controller/src/constants/bridge.ts
+++ b/packages/bridge-controller/src/constants/bridge.ts
@@ -60,7 +60,6 @@ export const DEFAULT_CHAIN_RANKING = [
   { chainId: 'bip122:000000000019d6689c085ae165831e93', name: 'BTC' },
   { chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp', name: 'Solana' },
   { chainId: 'tron:728126428', name: 'Tron' },
-  { chainId: 'stellar:pubnet', name: 'Stellar' },
   { chainId: 'eip155:8453', name: 'Base' },
   { chainId: 'eip155:42161', name: 'Arbitrum' },
   { chainId: 'eip155:59144', name: 'Linea' },
@@ -71,7 +70,6 @@ export const DEFAULT_CHAIN_RANKING = [
   { chainId: 'eip155:1329', name: 'Sei' },
   { chainId: 'eip155:999', name: 'HyperEVM' },
   { chainId: 'eip155:4326', name: 'MegaETH' },
-  { chainId: 'eip155:5042', name: 'Arc' },
   { chainId: 'eip155:4663', name: 'Robinhood Chain' },
   { chainId: 'eip155:324', name: 'zkSync' },
 ] as const;


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small constant-only change to default UI ordering; Stellar/Arc bridge support elsewhere is untouched.
> 
> **Overview**
> Removes **Stellar** (`stellar:pubnet`) and **Arc** (`eip155:5042`) from the `DEFAULT_CHAIN_RANKING` list in `bridge.ts`, so they no longer appear in the controller’s default ordered chain list when feature flags use that fallback (`DEFAULT_FEATURE_FLAG_CONFIG.chainRanking`).
> 
> The **Unreleased** changelog documents the change; no other bridge logic or chain allowlists are modified in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bfddfc85980119b572ed5d1f94cae71bec2ee97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->