### PR TITLE
feat!: wire gas strategy to `ConfigRegistryController`

### DIFF
--- a/packages/config-registry-controller/src/config-registry-api-service/types.ts
+++ b/packages/config-registry-controller/src/config-registry-api-service/types.ts
@@ -7,8 +7,11 @@ import {
   optional,
   string,
   type,
+  union,
+  object,
+  literal,
 } from '@metamask/superstruct';
-import { CaipChainIdStruct } from '@metamask/utils';
+import { CaipChainIdStruct, StrictHexStruct } from '@metamask/utils';
 
 const AssetSchema = type({
   assetId: string(),
@@ -41,6 +44,13 @@ const BlockExplorerUrlsSchema = type({
   fallbacks: array(string()),
 });
 
+const GasEstimationStrategySchema = union([
+  object({
+    type: literal('l1Oracle'),
+    l1OracleAddress: optional(StrictHexStruct),
+  }),
+]);
+
 const ChainConfigSchema = type({
   isActive: boolean(),
   isTestnet: boolean(),
@@ -49,6 +59,7 @@ const ChainConfigSchema = type({
   isDeprecated: boolean(),
   isDeletable: boolean(),
   priority: number(),
+  gasEstimationStrategy: optional(GasEstimationStrategySchema),
 });
 
 /**
@@ -77,6 +88,8 @@ export const RegistryConfigApiResponseSchema = type({
     chains: array(RegistryNetworkConfigSchema),
   }),
 });
+
+export type GasEstimationStrategy = Infer<typeof GasEstimationStrategySchema>;
 
 export type RegistryNetworkConfig = Infer<typeof RegistryNetworkConfigSchema>;
 

--- a/packages/config-registry-controller/src/index.ts
+++ b/packages/config-registry-controller/src/index.ts
@@ -9,7 +9,7 @@ export type {
 export type {
   ConfigRegistryControllerStartPollingAction,
   ConfigRegistryControllerStopPollingAction,
-  ConfigRegistryControllerMethodActions,
+  ConfigRegistryControllerGetNetworkConfigByCaip2ChainIdAction,
 } from './ConfigRegistryController-method-action-types.js';
 export {
   ConfigRegistryController,
@@ -21,6 +21,7 @@ export type {
   FetchConfigResult,
   RegistryNetworkConfig,
   RegistryConfigApiResponse,
+  GasEstimationStrategy,
 } from './config-registry-api-service/types.js';
 export type {
   ConfigRegistryApiServiceOptions,
@@ -28,10 +29,7 @@ export type {
   ConfigRegistryApiServiceEvents,
   ConfigRegistryApiServiceMessenger,
 } from './config-registry-api-service/config-registry-api-service.js';
-export type {
-  ConfigRegistryApiServiceFetchConfigAction,
-  ConfigRegistryApiServiceMethodActions,
-} from './config-registry-api-service/config-registry-api-service-method-action-types.js';
+export type { ConfigRegistryApiServiceFetchConfigAction } from './config-registry-api-service/config-registry-api-service-method-action-types.js';
 export type { NetworkFilterOptions } from './config-registry-api-service/filters.js';
 export { ConfigRegistryApiService } from './config-registry-api-service/config-registry-api-service.js';
 export { filterNetworks } from './config-registry-api-service/filters.js';

--- a/packages/transaction-controller/jest.config.js
+++ b/packages/transaction-controller/jest.config.js
@@ -17,9 +17,9 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 93.49,
-      functions: 93.77,
-      lines: 97.15,
+      branches: 93.51,
+      functions: 93.79,
+      lines: 97.16,
       statements: 97.12,
     },
   },

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -64,6 +64,7 @@
     "@metamask/accounts-controller": "^39.0.5",
     "@metamask/approval-controller": "^9.0.2",
     "@metamask/base-controller": "^9.1.0",
+    "@metamask/config-registry-controller": "^0.4.1",
     "@metamask/controller-utils": "^12.3.0",
     "@metamask/core-backend": "^7.0.0",
     "@metamask/gas-fee-controller": "^26.3.0",

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -16,6 +16,7 @@ import type {
   StateMetadata,
 } from '@metamask/base-controller';
 import { BaseController } from '@metamask/base-controller';
+import { ConfigRegistryControllerGetNetworkConfigByCaip2ChainIdAction } from '@metamask/config-registry-controller';
 import {
   ApprovalType,
   ORIGIN_METAMASK,
@@ -64,7 +65,7 @@ import {
   JsonRpcError,
 } from '@metamask/rpc-errors';
 import type { Hex, Json } from '@metamask/utils';
-import { add0x } from '@metamask/utils';
+import { add0x, hexToNumber } from '@metamask/utils';
 // This package purposefully relies on Node's EventEmitter module.
 // eslint-disable-next-line import-x/no-nodejs-modules
 import { EventEmitter } from 'events';
@@ -435,6 +436,7 @@ export type AllowedActions =
   | AccountsControllerGetSelectedAccountAction
   | AccountsControllerGetStateAction
   | ApprovalControllerAddRequestAction
+  | ConfigRegistryControllerGetNetworkConfigByCaip2ChainIdAction
   | GasFeeControllerFetchGasFeeEstimatesAction
   | KeyringControllerGetStateAction
   | KeyringControllerSignEip7702AuthorizationAction
@@ -3959,7 +3961,13 @@ export class TransactionController extends BaseController<
   #getLayer1GasFeeFlows(): Layer1GasFeeFlow[] {
     return [
       new MantleLayer1GasFeeFlow(),
-      new OptimismLayer1GasFeeFlow(),
+      new OptimismLayer1GasFeeFlow({
+        getRegistryGasStrategyForChain: (chainId: Hex) =>
+          this.messenger.call(
+            'ConfigRegistryController:getNetworkConfigByCaip2ChainId',
+            `eip155:${hexToNumber(chainId)}`,
+          )?.config.gasEstimationStrategy,
+      }),
       new ScrollLayer1GasFeeFlow(),
     ];
   }

--- a/packages/transaction-controller/src/TransactionControllerIntegration.test.ts
+++ b/packages/transaction-controller/src/TransactionControllerIntegration.test.ts
@@ -274,6 +274,7 @@ const setupController = async (
       'AccountsController:getSelectedAccount',
       'AccountsController:getState',
       'ApprovalController:addRequest',
+      'ConfigRegistryController:getNetworkConfigByCaip2ChainId',
       'GasFeeController:fetchGasFeeEstimates',
       'KeyringController:signTransaction',
       'NetworkController:findNetworkClientIdByChainId',
@@ -317,6 +318,11 @@ const setupController = async (
     'KeyringController:signTransaction',
     async (transaction: TypedTransaction) =>
       transaction.toJSON() as TypedTxData,
+  );
+
+  rootMessenger.registerActionHandler(
+    'ConfigRegistryController:getNetworkConfigByCaip2ChainId',
+    () => undefined,
   );
 
   const options: TransactionControllerOptions = {

--- a/packages/transaction-controller/src/gas-flows/OptimismLayer1GasFeeFlow.test.ts
+++ b/packages/transaction-controller/src/gas-flows/OptimismLayer1GasFeeFlow.test.ts
@@ -1,3 +1,4 @@
+import { GasEstimationStrategy } from '@metamask/config-registry-controller';
 import * as ControllerUtils from '@metamask/controller-utils';
 import { hexToNumber } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
@@ -89,6 +90,24 @@ describe('OptimismLayer1GasFeeFlow', () => {
           messenger,
         }),
       ).toBe(true);
+    });
+
+    it('returns true when the config registry lists the gas strategy for the chain as `l1Oracle`', async () => {
+      const flow = new OptimismLayer1GasFeeFlow({
+        getRegistryGasStrategyForChain: (): GasEstimationStrategy => ({
+          type: 'l1Oracle',
+          l1OracleAddress: '0x123',
+        }),
+      });
+      const transactionMeta = createTransaction(CHAIN_IDS.OPTIMISM);
+
+      expect(
+        await flow.matchesTransaction({
+          transactionMeta,
+          messenger,
+        }),
+      ).toBe(true);
+      expect(handleFetchMock).not.toHaveBeenCalled();
     });
 
     it('falls back to static list when remote list omits the chain', async () => {

--- a/packages/transaction-controller/src/gas-flows/OptimismLayer1GasFeeFlow.ts
+++ b/packages/transaction-controller/src/gas-flows/OptimismLayer1GasFeeFlow.ts
@@ -39,6 +39,14 @@ export class OptimismLayer1GasFeeFlow extends OracleLayer1GasFeeFlow {
     transactionMeta: TransactionMeta;
     messenger: TransactionControllerMessenger;
   }): Promise<boolean> {
+    const registryGasStrategy = this.getRegistryGasStrategyForChain?.(
+      transactionMeta.chainId,
+    );
+
+    if (registryGasStrategy?.type === 'l1Oracle') {
+      return true;
+    }
+
     const chainIdAsNumber = hexToNumber(transactionMeta.chainId);
 
     const supportedChains = await this.#fetchOptimismSupportedChains();

--- a/packages/transaction-controller/src/gas-flows/OracleLayer1GasFeeFlow.test.ts
+++ b/packages/transaction-controller/src/gas-flows/OracleLayer1GasFeeFlow.test.ts
@@ -13,6 +13,7 @@ import type { Layer1GasFeeFlowRequest, TransactionMeta } from '../types.js';
 import { rpcRequest } from '../utils/provider.js';
 import { bnFromHex, padHexToEvenLength } from '../utils/utils.js';
 import { OracleLayer1GasFeeFlow } from './OracleLayer1GasFeeFlow.js';
+import { GasEstimationStrategy } from '../../../config-registry-controller/src/config-registry-api-service/types.js';
 
 jest.mock('../utils/provider');
 
@@ -258,7 +259,35 @@ describe('OracleLayer1GasFeeFlow', () => {
       });
     });
 
-    it('uses default oracle configuration when subclasses do not override helpers', async () => {
+    it('uses the registry network configuration oracle address when subclasses do not override helpers', async () => {
+      const serializedTransactionMock = Buffer.from(
+        SERIALIZED_TRANSACTION_MOCK,
+        'hex',
+      );
+
+      const typedTransactionMock = createMockTypedTransaction(
+        serializedTransactionMock,
+      );
+
+      jest
+        .spyOn(TransactionFactory, 'fromTxData')
+        .mockReturnValueOnce(typedTransactionMock);
+
+      const flow = new DefaultOracleLayer1GasFeeFlow({
+        getRegistryGasStrategyForChain: (): GasEstimationStrategy => ({
+          type: 'l1Oracle',
+          l1OracleAddress: '0x123',
+        }),
+      });
+      await flow.getLayer1Fee(request);
+
+      expect(rpcRequestMock).toHaveBeenCalledTimes(1);
+      const { to } = getEthCallObject(rpcRequestMock.mock.calls[0]);
+      expect(to).toBe('0x123');
+      expect(typedTransactionMock.sign).not.toHaveBeenCalled();
+    });
+
+    it('uses default oracle configuration when subclasses do not override helpers and registry config is undefined', async () => {
       const serializedTransactionMock = Buffer.from(
         SERIALIZED_TRANSACTION_MOCK,
         'hex',

--- a/packages/transaction-controller/src/gas-flows/OracleLayer1GasFeeFlow.ts
+++ b/packages/transaction-controller/src/gas-flows/OracleLayer1GasFeeFlow.ts
@@ -1,4 +1,5 @@
 import { Interface } from '@ethersproject/abi';
+import type { GasEstimationStrategy } from '@metamask/config-registry-controller';
 import type { Hex } from '@metamask/utils';
 import { add0x, createModuleLogger } from '@metamask/utils';
 import BN from 'bn.js';
@@ -70,20 +71,43 @@ const DEFAULT_GAS_PRICE_ORACLE_ADDRESS =
 
 const GAS_PRICE_ORACLE_INTERFACE = new Interface(GAS_PRICE_ORACLE_ABI);
 
+type GetRegistryGasStrategyForChain = (
+  chainId: Hex,
+) => GasEstimationStrategy | undefined;
+
 /**
  * Layer 1 gas fee flow that obtains gas fee estimate using an oracle smart contract.
  */
 export abstract class OracleLayer1GasFeeFlow implements Layer1GasFeeFlow {
   /**
+   * Optional lookup of the Config Registry network configuration,
+   * used to source the layer 1 oracle address from the registry before
+   * falling back to bundled constants.
+   */
+  protected readonly getRegistryGasStrategyForChain?: GetRegistryGasStrategyForChain;
+
+  constructor({
+    getRegistryGasStrategyForChain,
+  }: {
+    getRegistryGasStrategyForChain?: GetRegistryGasStrategyForChain;
+  } = {}) {
+    this.getRegistryGasStrategyForChain = getRegistryGasStrategyForChain;
+  }
+
+  /**
    * Resolves the oracle address for the given chain. Subclasses can override
    * this method to provide chain-specific oracle addresses. By default, this
-   * returns the standard OP Stack gas price oracle address.
+   * uses the registry-provided oracle address when present, otherwise the
+   * standard OP Stack gas price oracle address.
    *
-   * @param _chainId - The chain ID to resolve the oracle address for.
+   * @param chainId - The chain ID to resolve the oracle address for.
    * @returns The oracle address for the given chain.
    */
-  protected getOracleAddressForChain(_chainId: Hex): Hex {
-    return DEFAULT_GAS_PRICE_ORACLE_ADDRESS;
+  protected getOracleAddressForChain(chainId: Hex): Hex {
+    return (
+      this.getRegistryGasStrategyForChain?.(chainId)?.l1OracleAddress ??
+      DEFAULT_GAS_PRICE_ORACLE_ADDRESS
+    );
   }
 
   /**

--- a/packages/transaction-controller/tsconfig.build.json
+++ b/packages/transaction-controller/tsconfig.build.json
@@ -16,6 +16,9 @@
       "path": "../base-controller/tsconfig.build.json"
     },
     {
+      "path": "../config-registry-controller/tsconfig.build.json"
+    },
+    {
       "path": "../controller-utils/tsconfig.build.json"
     },
     {

--- a/packages/transaction-controller/tsconfig.json
+++ b/packages/transaction-controller/tsconfig.json
@@ -15,6 +15,9 @@
       "path": "../base-controller"
     },
     {
+      "path": "../config-registry-controller"
+    },
+    {
       "path": "../controller-utils"
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9035,6 +9035,7 @@ __metadata:
     "@metamask/approval-controller": "npm:^9.0.2"
     "@metamask/auto-changelog": "npm:^6.1.0"
     "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/config-registry-controller": "npm:^0.4.1"
     "@metamask/connectivity-controller": "npm:^0.3.0"
     "@metamask/controller-utils": "npm:^12.3.0"
     "@metamask/core-backend": "npm:^7.0.0"


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->
The gas strategy selection is being wired to the network configuration coming from `config-registry-controller`. Currently only enabled for `OracleLayer1GasFeeFlow` and `OptimismLayer1GasFeeFlow`.

It allows to control the L1 Oracle address via a registry config parameter, and to force the `OracleLayer1GasFeeFlow` gas strategy selection 

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->
* Related to https://consensyssoftware.atlassian.net/browse/WPN-1566

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them
