### PR TITLE
refactor: add `.js` import extensions to Networks packages

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -466,6 +466,8 @@ const config = createConfig([
       'packages/smart-transactions-controller/**',
       'packages/snap-account-service/**',
       'packages/social-controllers/**',
+      'packages/solana-test-validator-up/**',
+      'packages/stellar-quickstart-up/**',
       'packages/storage-service/**',
       'packages/subscription-controller/**',
       'packages/transaction-controller/**',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -425,6 +425,7 @@ const config = createConfig([
       'packages/json-rpc-engine/**',
       'packages/json-rpc-middleware-stream/**',
       'packages/keyring-controller/**',
+      'packages/local-node-utils/**',
       'packages/logging-controller/**',
       'packages/message-manager/**',
       'packages/messenger/**',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -393,6 +393,7 @@ const config = createConfig([
       'packages/authenticated-user-storage/**',
       'packages/base-controller/**',
       'packages/base-data-service/**',
+      'packages/bitcoin-regtest-up/**',
       'packages/bridge-controller/**',
       'packages/bridge-status-controller/**',
       'packages/build-utils/**',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -421,6 +421,7 @@ const config = createConfig([
       'packages/gas-fee-controller/**',
       'packages/gator-permissions-controller/**',
       'packages/geolocation-controller/**',
+      'packages/java-tron-up/**',
       'packages/json-rpc-engine/**',
       'packages/json-rpc-middleware-stream/**',
       'packages/keyring-controller/**',

--- a/packages/bitcoin-regtest-up/src/bin/bitcoin-regtest-up.ts
+++ b/packages/bitcoin-regtest-up/src/bin/bitcoin-regtest-up.ts
@@ -5,7 +5,7 @@ import {
   installBitcoinRegtest,
   parseBitcoinRegtestInstallCliOptions,
   readBitcoinRegtestInstallOptionsFromPackageJson,
-} from '../install';
+} from '../install.js';
 
 async function main(): Promise<void> {
   const [command, ...args] = process.argv.slice(2);

--- a/packages/bitcoin-regtest-up/src/index.ts
+++ b/packages/bitcoin-regtest-up/src/index.ts
@@ -5,11 +5,11 @@ export {
   installBitcoinRegtest,
   parseBitcoinRegtestInstallCliOptions,
   readBitcoinRegtestInstallOptionsFromPackageJson,
-} from './install';
+} from './install.js';
 export type {
   BitcoinRegtestArtifactConfig,
   BitcoinRegtestArtifactPlatformConfig,
   BitcoinRegtestInstallDependencies,
   BitcoinRegtestInstallOptions,
   BitcoinRegtestInstallResult,
-} from './install';
+} from './install.js';

--- a/packages/bitcoin-regtest-up/src/install.test.ts
+++ b/packages/bitcoin-regtest-up/src/install.test.ts
@@ -23,8 +23,8 @@ import {
   installBitcoinRegtest,
   parseBitcoinRegtestInstallCliOptions,
   readBitcoinRegtestInstallOptionsFromPackageJson,
-} from './install';
-import type { BitcoinRegtestInstallDependencies } from './install';
+} from './install.js';
+import type { BitcoinRegtestInstallDependencies } from './install.js';
 
 describe('bitcoin-regtest-up installer', () => {
   let tempDirs: string[] = [];

--- a/packages/java-tron-up/src/bin/java-tron-up.ts
+++ b/packages/java-tron-up/src/bin/java-tron-up.ts
@@ -5,7 +5,7 @@ import {
   installJavaTron,
   parseJavaTronInstallCliOptions,
   readJavaTronInstallOptionsFromPackageJson,
-} from '../install';
+} from '../install.js';
 
 async function main(): Promise<void> {
   const [command, ...args] = process.argv.slice(2);

--- a/packages/java-tron-up/src/index.ts
+++ b/packages/java-tron-up/src/index.ts
@@ -7,7 +7,7 @@ export {
   installJavaTron,
   parseJavaTronInstallCliOptions,
   readJavaTronInstallOptionsFromPackageJson,
-} from './install';
+} from './install.js';
 export type {
   JavaTronArtifactConfig,
   JavaTronArtifactPlatformConfig,
@@ -15,4 +15,4 @@ export type {
   JavaTronInstallOptions,
   JavaTronInstallResult,
   JavaTronJavaRuntimeConfig,
-} from './install';
+} from './install.js';

--- a/packages/java-tron-up/src/install.test.ts
+++ b/packages/java-tron-up/src/install.test.ts
@@ -23,8 +23,8 @@ import {
   installJavaTron,
   parseJavaTronInstallCliOptions,
   readJavaTronInstallOptionsFromPackageJson,
-} from './install';
-import type { JavaTronInstallDependencies } from './install';
+} from './install.js';
+import type { JavaTronInstallDependencies } from './install.js';
 
 describe('java-tron-up installer', () => {
   let tempDirs: string[] = [];

--- a/packages/local-node-utils/src/archive.ts
+++ b/packages/local-node-utils/src/archive.ts
@@ -1,4 +1,4 @@
-import { runCommand } from './command';
+import { runCommand } from './command.js';
 
 export async function extractTarGzArchive(
   archivePath: string,

--- a/packages/local-node-utils/src/artifact.ts
+++ b/packages/local-node-utils/src/artifact.ts
@@ -1,7 +1,7 @@
 /* eslint-disable import-x/no-nodejs-modules */
 import { createHash } from 'node:crypto';
 
-import type { ArtifactConfig, ArtifactPlatformConfig } from './types';
+import type { ArtifactConfig, ArtifactPlatformConfig } from './types.js';
 
 export function mergeArtifactConfig(
   defaults: ArtifactConfig,

--- a/packages/local-node-utils/src/cache-directory.ts
+++ b/packages/local-node-utils/src/cache-directory.ts
@@ -4,7 +4,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { parse as parseYaml } from 'yaml';
 
-import { isFileMissingError } from './errors';
+import { isFileMissingError } from './errors.js';
 
 export function getMetamaskCacheDirectory({
   cwd = process.cwd(),

--- a/packages/local-node-utils/src/command.test.ts
+++ b/packages/local-node-utils/src/command.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable jest/expect-expect */
 import assert from 'node:assert/strict';
 
-import { runCommand } from './command';
+import { runCommand } from './command.js';
 
 describe('runCommand', () => {
   it('runs a successful command', async () => {

--- a/packages/local-node-utils/src/executable-wrapper.ts
+++ b/packages/local-node-utils/src/executable-wrapper.ts
@@ -2,7 +2,7 @@
 import { chmod, mkdir, unlink, writeFile } from 'node:fs/promises';
 import { join, relative, resolve } from 'node:path';
 
-import { isFileMissingError } from './errors';
+import { isFileMissingError } from './errors.js';
 
 export type ExecutableWrapperPathResolution = 'absolute' | 'relative';
 

--- a/packages/local-node-utils/src/index.test.ts
+++ b/packages/local-node-utils/src/index.test.ts
@@ -10,11 +10,11 @@ import {
   mergeArtifactConfig,
   requireCompletePlatformConfig,
   resolvePlatformConfig,
-} from './artifact';
-import { getMetamaskCacheDirectory } from './cache-directory';
-import { readCliValue } from './cli';
-import { readPackageJsonToolConfig } from './package-json';
-import type { ArtifactConfig } from './types';
+} from './artifact.js';
+import { getMetamaskCacheDirectory } from './cache-directory.js';
+import { readCliValue } from './cli.js';
+import { readPackageJsonToolConfig } from './package-json.js';
+import type { ArtifactConfig } from './types.js';
 
 describe('artifact helpers', () => {
   const defaults: ArtifactConfig = {

--- a/packages/local-node-utils/src/index.ts
+++ b/packages/local-node-utils/src/index.ts
@@ -2,23 +2,23 @@ export type {
   ArtifactConfig,
   ArtifactPlatformConfig,
   InstallDependencies,
-} from './types';
+} from './types.js';
 export {
   getCacheKey,
   mergeArtifactConfig,
   requireCompletePlatformConfig,
   resolvePlatformConfig,
-} from './artifact';
-export { cleanInstallerCache } from './cache';
-export { getMetamaskCacheDirectory } from './cache-directory';
-export { verifyFileChecksum } from './checksum';
-export { readCliValue } from './cli';
-export { runCommand } from './command';
-export { isFileMissingError } from './errors';
-export { extractTarBz2Archive, extractTarGzArchive } from './archive';
-export { downloadFileFromUrl } from './download';
-export { installExecutableWrapper } from './executable-wrapper';
-export type { ExecutableWrapperPathResolution } from './executable-wrapper';
-export { findExecutable, isDirectory, isFile } from './filesystem';
-export { getPlatformKey, normalizeSystemArchitecture } from './platform';
-export { readPackageJsonToolConfig } from './package-json';
+} from './artifact.js';
+export { cleanInstallerCache } from './cache.js';
+export { getMetamaskCacheDirectory } from './cache-directory.js';
+export { verifyFileChecksum } from './checksum.js';
+export { readCliValue } from './cli.js';
+export { runCommand } from './command.js';
+export { isFileMissingError } from './errors.js';
+export { extractTarBz2Archive, extractTarGzArchive } from './archive.js';
+export { downloadFileFromUrl } from './download.js';
+export { installExecutableWrapper } from './executable-wrapper.js';
+export type { ExecutableWrapperPathResolution } from './executable-wrapper.js';
+export { findExecutable, isDirectory, isFile } from './filesystem.js';
+export { getPlatformKey, normalizeSystemArchitecture } from './platform.js';
+export { readPackageJsonToolConfig } from './package-json.js';

--- a/packages/local-node-utils/src/integration.test.ts
+++ b/packages/local-node-utils/src/integration.test.ts
@@ -12,16 +12,16 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { extractTarBz2Archive, extractTarGzArchive } from './archive';
-import { cleanInstallerCache } from './cache';
-import { getMetamaskCacheDirectory } from './cache-directory';
-import { verifyFileChecksum } from './checksum';
-import { runCommand } from './command';
-import { downloadFileFromUrl, openDownloadStream } from './download';
-import { isFileMissingError } from './errors';
-import { installExecutableWrapper } from './executable-wrapper';
-import { findExecutable, isDirectory, isFile } from './filesystem';
-import { getPlatformKey, normalizeSystemArchitecture } from './platform';
+import { extractTarBz2Archive, extractTarGzArchive } from './archive.js';
+import { getMetamaskCacheDirectory } from './cache-directory.js';
+import { cleanInstallerCache } from './cache.js';
+import { verifyFileChecksum } from './checksum.js';
+import { runCommand } from './command.js';
+import { downloadFileFromUrl, openDownloadStream } from './download.js';
+import { isFileMissingError } from './errors.js';
+import { installExecutableWrapper } from './executable-wrapper.js';
+import { findExecutable, isDirectory, isFile } from './filesystem.js';
+import { getPlatformKey, normalizeSystemArchitecture } from './platform.js';
 
 jest.mock('./command', () => ({
   runCommand: jest.fn(),

--- a/packages/local-node-utils/src/package-json.ts
+++ b/packages/local-node-utils/src/package-json.ts
@@ -2,7 +2,7 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { isFileMissingError } from './errors';
+import { isFileMissingError } from './errors.js';
 
 export function readPackageJsonToolConfig({
   cwd = process.cwd(),

--- a/packages/solana-test-validator-up/src/bin/solana-test-validator-up.ts
+++ b/packages/solana-test-validator-up/src/bin/solana-test-validator-up.ts
@@ -5,7 +5,7 @@ import {
   installSolanaTestValidator,
   parseSolanaTestValidatorInstallCliOptions,
   readSolanaTestValidatorInstallOptionsFromPackageJson,
-} from '../install';
+} from '../install.js';
 
 async function main(): Promise<void> {
   const [command, ...args] = process.argv.slice(2);

--- a/packages/solana-test-validator-up/src/index.ts
+++ b/packages/solana-test-validator-up/src/index.ts
@@ -5,11 +5,11 @@ export {
   installSolanaTestValidator,
   parseSolanaTestValidatorInstallCliOptions,
   readSolanaTestValidatorInstallOptionsFromPackageJson,
-} from './install';
+} from './install.js';
 export type {
   SolanaTestValidatorArtifactConfig,
   SolanaTestValidatorArtifactPlatformConfig,
   SolanaTestValidatorInstallDependencies,
   SolanaTestValidatorInstallOptions,
   SolanaTestValidatorInstallResult,
-} from './install';
+} from './install.js';

--- a/packages/solana-test-validator-up/src/install.test.ts
+++ b/packages/solana-test-validator-up/src/install.test.ts
@@ -23,8 +23,8 @@ import {
   installSolanaTestValidator,
   parseSolanaTestValidatorInstallCliOptions,
   readSolanaTestValidatorInstallOptionsFromPackageJson,
-} from './install';
-import type { SolanaTestValidatorInstallDependencies } from './install';
+} from './install.js';
+import type { SolanaTestValidatorInstallDependencies } from './install.js';
 
 describe('solana-test-validator-up installer', () => {
   let tempDirs: string[] = [];

--- a/packages/stellar-quickstart-up/src/index.test.ts
+++ b/packages/stellar-quickstart-up/src/index.test.ts
@@ -1,4 +1,4 @@
-import greeter from '.';
+import greeter from './index.js';
 
 describe('Test', () => {
   it('greets', () => {


### PR DESCRIPTION
## Explanation

Adds `.js` extensions to all relative imports in the `bitcoin-regtest-up`, `java-tron-up`, `local-node-utils`, `solana-test-validator-up`, and `stellar-quickstart-up` packages, as required for ESM compatibility.

These packages were inadvertently missed in the earlier team-by-team migration.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" label where appropriate

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical import-path and ESLint scope updates with no consumer-facing or security-sensitive logic changes.
> 
> **Overview**
> Completes the repo’s **ESM import-extension migration** for the local-chain installer packages that were skipped earlier: `bitcoin-regtest-up`, `java-tron-up`, `local-node-utils`, `solana-test-validator-up`, and `stellar-quickstart-up`.
> 
> All relative TypeScript imports in those packages now use explicit **`.js`** specifiers (e.g. `'./install.js'`), matching Node ESM resolution. **`eslint.config.mjs`** adds the same five package globs to the shared block that enforces `n/file-extension-in-import: always`, so lint stays aligned with the new style.
> 
> No API or runtime behavior changes—import path strings only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e59e315c43dc1318e3ea14ca857138d11e248c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->