### PR TITLE
fix(ramps-controller): drop unused headless minimumVersion helper

### DIFF
--- a/packages/ramps-controller/CHANGELOG.md
+++ b/packages/ramps-controller/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **BREAKING:** Remove `getHeadlessAllProvidersMinimumVersion`; app-version
+  gating for `moneyHeadlessAllProviders` is owned by the LaunchDarkly
+  `versions` wrapper (processed by `RemoteFeatureFlagController`), not a
+  payload `minimumVersion` field. `featureVersion` fail-closed enablement and
+  `providerIds` allowlisting are unchanged.
+
 ## [17.2.0]
 
 ### Added

--- a/packages/ramps-controller/src/featureFlags.test.ts
+++ b/packages/ramps-controller/src/featureFlags.test.ts
@@ -2,7 +2,6 @@ import type { Json } from '@metamask/utils';
 
 import {
   HEADLESS_ALL_PROVIDERS_FEATURE_VERSION,
-  getHeadlessAllProvidersMinimumVersion,
   MONEY_HEADLESS_ALL_PROVIDERS_FLAG_KEY,
   getHeadlessProviderAllowlist,
   isHeadlessAllProvidersEnabled,
@@ -325,55 +324,6 @@ describe('featureVersion gating', () => {
         },
       }),
     ).toBe(true);
-  });
-});
-
-describe('getHeadlessAllProvidersMinimumVersion', () => {
-  it('returns the minimumVersion carried by an enabled payload', () => {
-    expect(
-      getHeadlessAllProvidersMinimumVersion({
-        remoteFeatureFlags: {
-          [MONEY_HEADLESS_ALL_PROVIDERS_FLAG_KEY]: {
-            enabled: true,
-            featureVersion: '1',
-            minimumVersion: '8.6.0',
-          } as Json,
-        },
-      }),
-    ).toBe('8.6.0');
-  });
-
-  it('returns undefined for the boolean form, disabled payloads, and blank values', () => {
-    expect(
-      getHeadlessAllProvidersMinimumVersion({
-        remoteFeatureFlags: {
-          [MONEY_HEADLESS_ALL_PROVIDERS_FLAG_KEY]: true,
-        },
-      }),
-    ).toBeUndefined();
-    expect(
-      getHeadlessAllProvidersMinimumVersion({
-        remoteFeatureFlags: {
-          [MONEY_HEADLESS_ALL_PROVIDERS_FLAG_KEY]: {
-            enabled: false,
-            featureVersion: '1',
-            minimumVersion: '8.6.0',
-          } as Json,
-        },
-      }),
-    ).toBeUndefined();
-    expect(
-      getHeadlessAllProvidersMinimumVersion({
-        remoteFeatureFlags: {
-          [MONEY_HEADLESS_ALL_PROVIDERS_FLAG_KEY]: {
-            enabled: true,
-            featureVersion: '1',
-            minimumVersion: '   ',
-          } as Json,
-        },
-      }),
-    ).toBeUndefined();
-    expect(getHeadlessAllProvidersMinimumVersion(null)).toBeUndefined();
   });
 });
 

--- a/packages/ramps-controller/src/featureFlags.ts
+++ b/packages/ramps-controller/src/featureFlags.ts
@@ -83,30 +83,6 @@ function isEnabledPayload(value: Json | undefined): value is {
 }
 
 /**
- * The `minimumVersion` carried by an enabled payload, or `undefined` for the
- * boolean form, a disabled payload, or a malformed field. This package cannot
- * compare app versions itself; mobile validates the value through its shared
- * `validatedVersionGatedFeatureFlag` util, and the LaunchDarkly `versions`
- * wrapper provides the server-side gate.
- *
- * @param remoteFeatureFlagState - `RemoteFeatureFlagController` state (or the
- * relevant subset of it).
- * @returns The minimum app version the payload declares, or `undefined`.
- */
-export function getHeadlessAllProvidersMinimumVersion(
-  remoteFeatureFlagState: HeadlessFeatureFlagsLookup | null | undefined,
-): string | undefined {
-  const value = resolveFlagValue(remoteFeatureFlagState);
-  if (!isEnabledPayload(value)) {
-    return undefined;
-  }
-  const { minimumVersion } = value;
-  return typeof minimumVersion === 'string' && minimumVersion.trim() !== ''
-    ? minimumVersion
-    : undefined;
-}
-
-/**
  * Coerces a payload field into a provider-id list: keeps only string entries,
  * trims them, and drops empties. An empty or malformed level is treated as
  * "not provided" so resolution falls through to the next level rather than

--- a/packages/ramps-controller/src/index.ts
+++ b/packages/ramps-controller/src/index.ts
@@ -144,7 +144,6 @@ export type { HeadlessFeatureFlagsLookup } from './featureFlags.js';
 export {
   HEADLESS_ALL_PROVIDERS_FEATURE_VERSION,
   MONEY_HEADLESS_ALL_PROVIDERS_FLAG_KEY,
-  getHeadlessAllProvidersMinimumVersion,
   getHeadlessProviderAllowlist,
   isHeadlessAllProvidersEnabled,
 } from './featureFlags.js';


### PR DESCRIPTION
## Summary
- Remove `getHeadlessAllProvidersMinimumVersion` from `@metamask/ramps-controller`.
- App-version gating for `moneyHeadlessAllProviders` is already owned by the LaunchDarkly `versions` wrapper (processed by `RemoteFeatureFlagController`), matching the live LD shape:
  ```json
  {
    "versions": {
      "0.0.0": { "enabled": false, "featureVersion": "1" },
      "8.4.0": { "enabled": true, "featureVersion": "1" }
    }
  }
  ```
- Keeps `featureVersion` fail-closed enablement and `providerIds` allowlisting unchanged.

Follow-up to #9524. Avoids clients reinventing version gating via payload `minimumVersion` + `validatedVersionGatedFeatureFlag`.

## Test plan
- [x] `packages/ramps-controller` `featureFlags.test.ts` (46 tests) pass
- [ ] Confirm MetaMask Mobile #33362 no longer imports `getHeadlessAllProvidersMinimumVersion` (already true on latest PR head)


Made with [Cursor](https://cursor.com)