### PR TITLE
chore: Expose `restoreEnabledNetworkMap` to `NetworkEnablementController` messenger

### DIFF
--- a/packages/network-enablement-controller/CHANGELOG.md
+++ b/packages/network-enablement-controller/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Expose missing public `NetworkEnablementController` method through its messenger ([#9660](https://github.com/MetaMask/core/pull/9660))
+  - The following action is now available:
+    - `NetworkEnablementController:restoreEnabledNetworkMap`
+  - Corresponding action type (`NetworkEnablementControllerRestoreEnabledNetworkMapAction`) is available as well.
+
 ### Changed
 
 - **BREAKING:** Popular-network classification is now augmented by `ConfigRegistryController` ([#9611](https://github.com/MetaMask/core/pull/9611))

--- a/packages/network-enablement-controller/src/NetworkEnablementController-method-action-types.ts
+++ b/packages/network-enablement-controller/src/NetworkEnablementController-method-action-types.ts
@@ -126,6 +126,21 @@ export type NetworkEnablementControllerDisableNetworkAction = {
 };
 
 /**
+ * Restores the enabled network map to a previously snapshotted state.
+ *
+ * Not a general merge API: only updates keys already present in the current
+ * map. Missing snapshot values default to `false`. Intended for callers with
+ * direct controller access (e.g. extension) to undo `#onAddNetwork` filter
+ * switches when adding a network without changing the active selection.
+ *
+ * @param enabledNetworkMap - Previously snapshotted enabledNetworkMap.
+ */
+export type NetworkEnablementControllerRestoreEnabledNetworkMapAction = {
+  type: `NetworkEnablementController:restoreEnabledNetworkMap`;
+  handler: NetworkEnablementController['restoreEnabledNetworkMap'];
+};
+
+/**
  * Checks if a network is enabled.
  *
  * @param chainId - The chain ID of the network to check. Can be either:
@@ -186,6 +201,7 @@ export type NetworkEnablementControllerMethodActions =
   | NetworkEnablementControllerInitAction
   | NetworkEnablementControllerInitNativeAssetIdentifiersAction
   | NetworkEnablementControllerDisableNetworkAction
+  | NetworkEnablementControllerRestoreEnabledNetworkMapAction
   | NetworkEnablementControllerIsNetworkEnabledAction
   | NetworkEnablementControllerListPopularEvmNetworksAction
   | NetworkEnablementControllerListPopularMultichainNetworksAction

--- a/packages/network-enablement-controller/src/NetworkEnablementController.ts
+++ b/packages/network-enablement-controller/src/NetworkEnablementController.ts
@@ -37,6 +37,7 @@ const MESSENGER_EXPOSED_METHODS = [
   'listPopularNetworks',
   'listPopularEvmNetworks',
   'listPopularMultichainNetworks',
+  'restoreEnabledNetworkMap',
 ] as const;
 
 /**


### PR DESCRIPTION
## Explanation

Exposes `restoreEnabledNetworkMap` through the `NetworkEnablementController` messenger.

## References

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive messenger surface only; no change to restore logic. Consumers must opt in to the new action on restricted messengers.
> 
> **Overview**
> **Exposes** the existing `restoreEnabledNetworkMap` controller API through the `NetworkEnablementController` messenger so other packages can invoke it without direct controller access.
> 
> Adds `NetworkEnablementController:restoreEnabledNetworkMap` to the public method list, documents `NetworkEnablementControllerRestoreEnabledNetworkMapAction`, and includes it in the method-actions union. The changelog records the new messenger action under **Unreleased**.
> 
> Behavior is unchanged: callers still pass a snapshotted `enabledNetworkMap` to undo filter changes when adding a network (e.g. extension flows).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d327b23f024889c2635c3c1cc94c0ed7f869eeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->