### PR TITLE
feat: add bearer token to money account api requests

### DIFF
--- a/packages/money-account-api-data-service/CHANGELOG.md
+++ b/packages/money-account-api-data-service/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add best-effort profile JWT authentication to Money Account API requests, falling back to unauthenticated requests when a token is unavailable
+
 ## [0.3.0]
 
 ### Added

--- a/packages/money-account-api-data-service/CHANGELOG.md
+++ b/packages/money-account-api-data-service/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Add best-effort profile JWT authentication to Money Account API requests, falling back to unauthenticated requests when a token is unavailable
+- Add best-effort profile JWT authentication to Money Account API requests, falling back to unauthenticated requests when a token is unavailable ([#9661](https://github.com/MetaMask/core/pull/9661))
 
 ## [0.3.0]
 

--- a/packages/money-account-api-data-service/src/money-account-api-data-service.test.ts
+++ b/packages/money-account-api-data-service/src/money-account-api-data-service.test.ts
@@ -153,7 +153,13 @@ function createServiceMessenger(
 
 function createService(
   env: Env = Env.DEV,
-  { trace }: { trace?: MoneyAccountApiDataServiceTraceCallback } = {},
+  {
+    trace,
+    getBearerToken,
+  }: {
+    trace?: MoneyAccountApiDataServiceTraceCallback;
+    getBearerToken?: () => Promise<string>;
+  } = {},
 ): {
   service: MoneyAccountApiDataService;
   rootMessenger: RootMessenger;
@@ -161,6 +167,17 @@ function createService(
 } {
   const rootMessenger = createRootMessenger();
   const messenger = createServiceMessenger(rootMessenger);
+  if (getBearerToken) {
+    rootMessenger.registerActionHandler(
+      'AuthenticationController:getBearerToken',
+      getBearerToken,
+    );
+  }
+  rootMessenger.delegate({
+    messenger,
+    actions: ['AuthenticationController:getBearerToken'],
+    events: [],
+  });
   const service = new MoneyAccountApiDataService({
     messenger,
     env,
@@ -190,6 +207,96 @@ describe('MoneyAccountApiDataService', () => {
     it('initializes with specified environment', () => {
       const { service } = createService(Env.UAT);
       expect(service.name).toBe(serviceName);
+      service.destroy();
+    });
+  });
+
+  describe('authentication headers', () => {
+    it('attaches the profile bearer token to every API request', async () => {
+      const getBearerToken = jest.fn().mockResolvedValue('jwt-token');
+      const { service } = createService(Env.DEV, { getBearerToken });
+      const requestHeaders = {
+        reqheaders: { authorization: 'Bearer jwt-token' },
+      };
+
+      const positionsScope = nock(
+        MONEY_ACCOUNT_API_URL_MAP[Env.DEV],
+        requestHeaders,
+      )
+        .get(`/v1/positions/${MOCK_ADDRESS}`)
+        .reply(200, MOCK_POSITION_RESPONSE);
+      const interestScope = nock(
+        MONEY_ACCOUNT_API_URL_MAP[Env.DEV],
+        requestHeaders,
+      )
+        .get(`/v1/positions/${MOCK_ADDRESS}/interest`)
+        .query({
+          vault_address: MOCK_VAULT_ADDRESS,
+          window: '7d',
+        })
+        .reply(200, MOCK_INTEREST_RESPONSE);
+      const historyScope = nock(
+        MONEY_ACCOUNT_API_URL_MAP[Env.DEV],
+        requestHeaders,
+      )
+        .get(`/v1/positions/${MOCK_ADDRESS}/history`)
+        .reply(200, MOCK_HISTORY_RESPONSE);
+      const rateHistoryScope = nock(
+        MONEY_ACCOUNT_API_URL_MAP[Env.DEV],
+        requestHeaders,
+      )
+        .get(`/v1/vaults/${MOCK_VAULT_ADDRESS}/rate-history`)
+        .reply(200, MOCK_RATE_HISTORY_RESPONSE);
+
+      await service.fetchPositions(MOCK_ADDRESS);
+      await service.fetchInterest(MOCK_ADDRESS, {
+        vaultAddress: MOCK_VAULT_ADDRESS,
+        window: '7d',
+      });
+      await service.fetchHistory(MOCK_ADDRESS);
+      await service.fetchRateHistory(MOCK_VAULT_ADDRESS);
+
+      expect(getBearerToken).toHaveBeenCalledTimes(4);
+      positionsScope.done();
+      interestScope.done();
+      historyScope.done();
+      rateHistoryScope.done();
+      service.destroy();
+    });
+
+    it('proceeds unauthenticated when token retrieval fails', async () => {
+      const { service } = createService(Env.DEV, {
+        getBearerToken: async () => {
+          throw new Error('wallet is locked');
+        },
+      });
+      const scope = nock(MONEY_ACCOUNT_API_URL_MAP[Env.DEV], {
+        badheaders: ['authorization'],
+      })
+        .get(`/v1/positions/${MOCK_ADDRESS}`)
+        .reply(200, MOCK_POSITION_RESPONSE);
+
+      const result = await service.fetchPositions(MOCK_ADDRESS);
+
+      expect(result).toStrictEqual(MOCK_POSITION_RESPONSE);
+      scope.done();
+      service.destroy();
+    });
+
+    it('omits the authorization header when the token is empty', async () => {
+      const { service } = createService(Env.DEV, {
+        getBearerToken: async () => '',
+      });
+      const scope = nock(MONEY_ACCOUNT_API_URL_MAP[Env.DEV], {
+        badheaders: ['authorization'],
+      })
+        .get(`/v1/positions/${MOCK_ADDRESS}`)
+        .reply(200, MOCK_POSITION_RESPONSE);
+
+      const result = await service.fetchPositions(MOCK_ADDRESS);
+
+      expect(result).toStrictEqual(MOCK_POSITION_RESPONSE);
+      scope.done();
       service.destroy();
     });
   });
@@ -231,6 +338,36 @@ describe('MoneyAccountApiDataService', () => {
       await expect(service.fetchPositions(MOCK_ADDRESS)).rejects.toThrow(
         HttpError,
       );
+      service.destroy();
+    });
+
+    it('does not retry an authorization failure', async () => {
+      const { service } = createService(Env.DEV);
+      const scope = nock(MONEY_ACCOUNT_API_URL_MAP[Env.DEV])
+        .get(`/v1/positions/${MOCK_ADDRESS}`)
+        .once()
+        .reply(403);
+
+      await expect(service.fetchPositions(MOCK_ADDRESS)).rejects.toThrow(
+        HttpError,
+      );
+
+      scope.done();
+      service.destroy();
+    });
+
+    it('retries a rate-limit response', async () => {
+      const { service } = createService(Env.DEV);
+      const scope = nock(MONEY_ACCOUNT_API_URL_MAP[Env.DEV])
+        .get(`/v1/positions/${MOCK_ADDRESS}`)
+        .times(DEFAULT_MAX_RETRIES + 1)
+        .reply(429);
+
+      await expect(service.fetchPositions(MOCK_ADDRESS)).rejects.toThrow(
+        HttpError,
+      );
+
+      scope.done();
       service.destroy();
     });
 

--- a/packages/money-account-api-data-service/src/money-account-api-data-service.ts
+++ b/packages/money-account-api-data-service/src/money-account-api-data-service.ts
@@ -101,7 +101,12 @@ export type MoneyAccountApiDataServiceActions =
 /**
  * Actions from other messengers that {@link MoneyAccountApiDataService} calls.
  */
-type AllowedActions = never;
+type AuthenticationControllerGetBearerTokenAction = {
+  type: 'AuthenticationController:getBearerToken';
+  handler: (entropySourceId?: string) => Promise<string>;
+};
+
+type AllowedActions = AuthenticationControllerGetBearerTokenAction;
 
 /**
  * Published when {@link MoneyAccountApiDataService}'s cache is updated.
@@ -185,7 +190,9 @@ export class MoneyAccountApiDataService extends BaseDataService<
       queryClientConfig,
       policyOptions: {
         retryFilterPolicy: handleWhen(
-          (error) => !(error instanceof MoneyAccountApiResponseValidationError),
+          (error) =>
+            !(error instanceof MoneyAccountApiResponseValidationError) &&
+            !(error instanceof HttpError && error.httpStatus === 403),
         ),
         ...policyOptions,
       },
@@ -211,6 +218,27 @@ export class MoneyAccountApiDataService extends BaseDataService<
   }
 
   /**
+   * Builds best-effort authentication headers for a Money Account API request.
+   *
+   * Requests proceed without authentication when the wallet is locked, the
+   * user is signed out, or the token is otherwise unavailable. The API edge
+   * rate limiter falls back to IP-based limiting when the header is omitted.
+   *
+   * @returns The Authorization header when a profile token is available.
+   */
+  async #getRequestHeaders(): Promise<Record<string, string>> {
+    try {
+      const token = await this.messenger.call(
+        'AuthenticationController:getBearerToken',
+      );
+      return token ? { Authorization: `Bearer ${token}` } : {};
+    } catch (error: unknown) {
+      log('Auth token unavailable, proceeding unauthenticated', error);
+      return {};
+    }
+  }
+
+  /**
    * Fetches the current vault positions for a given user address.
    *
    * @param address - The user's Ethereum address.
@@ -233,7 +261,9 @@ export class MoneyAccountApiDataService extends BaseDataService<
             data: { operation: 'fetchPositions' },
           },
           async () => {
-            const response = await fetch(url);
+            const response = await fetch(url, {
+              headers: await this.#getRequestHeaders(),
+            });
 
             if (!response.ok) {
               throw new HttpError(
@@ -299,7 +329,9 @@ export class MoneyAccountApiDataService extends BaseDataService<
             data: { operation: 'fetchInterest' },
           },
           async () => {
-            const response = await fetch(url);
+            const response = await fetch(url, {
+              headers: await this.#getRequestHeaders(),
+            });
 
             if (!response.ok) {
               throw new HttpError(
@@ -380,7 +412,9 @@ export class MoneyAccountApiDataService extends BaseDataService<
               data: { operation: 'fetchHistory' },
             },
             async () => {
-              const response = await fetch(url);
+              const response = await fetch(url, {
+                headers: await this.#getRequestHeaders(),
+              });
 
               if (!response.ok) {
                 throw new HttpError(
@@ -448,7 +482,9 @@ export class MoneyAccountApiDataService extends BaseDataService<
             data: { operation: 'fetchRateHistory' },
           },
           async () => {
-            const response = await fetch(url);
+            const response = await fetch(url, {
+              headers: await this.#getRequestHeaders(),
+            });
 
             if (!response.ok) {
               throw new HttpError(


### PR DESCRIPTION
## Explanation

Money Account API requests were made without a profile JWT, so the Cloudflare authorizer could only apply IP-based rate limiting. This could cause unrelated users behind the same IP address to share a rate-limit bucket.

This change integrates `MoneyAccountApiDataService` with the existing `AuthenticationController:getBearerToken` messenger action. The service now adds `Authorization: Bearer <token>` to position, interest, history, and rate
history requests when a profile token is available.

Authentication is best effort to preserve existing behavior for locked or signed-out wallets. If token retrieval fails or returns an empty token, the request proceeds without the Authorization header and the Cloudflare worker
falls back to IP-based rate limiting. HTTP 403 responses are not retried, while HTTP 429 responses retain the existing retry behavior.

Tests cover authenticated requests across all four endpoints, unavailable and empty-token fallbacks, and the 403/429 retry behavior.

## References

- Related authorizer:
  https://github.com/consensys-vertical-apps/va-mmcx-cloudflare-authorizer

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth integration and HTTP retry semantics for all Money Account API traffic; failures degrade to unauthenticated calls rather than blocking fetches.
> 
> **Overview**
> **Money Account API** calls now send a profile JWT when available via `AuthenticationController:getBearerToken`, so edge rate limiting can use per-user buckets instead of shared IP limits.
> 
> A private `#getRequestHeaders()` helper adds `Authorization: Bearer <token>` on `fetchPositions`, `fetchInterest`, `fetchHistory`, and `fetchRateHistory`. If token lookup throws or returns an empty string, requests continue **without** the header (same as locked/signed-out wallets). The retry policy **skips** retries on HTTP **403** but still retries **429** and other transient errors.
> 
> Tests cover authenticated headers on all four endpoints, unauthenticated fallbacks, and 403 vs 429 retry behavior; the changelog documents the change under Unreleased.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a699899d9a9e9027ecd94c59a53a784d7535d4f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->