### PR TITLE
fix: disable in-request retries on `ProfileMetricsService:submitMetrics`  by default

### DIFF
--- a/packages/profile-metrics-controller/CHANGELOG.md
+++ b/packages/profile-metrics-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `@metamask/transaction-controller` from `^69.0.0` to `^69.2.1` ([#9568](https://github.com/MetaMask/core/pull/9568), [#9589](https://github.com/MetaMask/core/pull/9589), [#9593](https://github.com/MetaMask/core/pull/9593))
+
 ### Fixed
 
 - Disable in-request retries on `ProfileMetricsService` by default (`maxRetries: 0`) ([#9667](https://github.com/MetaMask/core/pull/9667))
@@ -14,10 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     after a spent nonce caused `PUT /profile/accounts` 400s (`nonce-session`
     key not found). The controller poll already re-fetches nonces and retries
     failed batches.
-
-### Changed
-
-- Bump `@metamask/transaction-controller` from `^69.0.0` to `^69.2.1` ([#9568](https://github.com/MetaMask/core/pull/9568), [#9589](https://github.com/MetaMask/core/pull/9589), [#9593](https://github.com/MetaMask/core/pull/9593))
 
 ## [4.0.2]
 

--- a/packages/profile-metrics-controller/CHANGELOG.md
+++ b/packages/profile-metrics-controller/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Disable in-request retries on `ProfileMetricsService` by default (`maxRetries: 0`) ([#XXX](https://github.com/MetaMask/core/pull/XXX))
+  - Proof-of-ownership nonces are single-use; retrying the same signed payload
+    after a spent nonce caused `PUT /profile/accounts` 400s (`nonce-session`
+    key not found). The controller poll already re-fetches nonces and retries
+    failed batches.
+
 ### Changed
 
 - Bump `@metamask/transaction-controller` from `^69.0.0` to `^69.2.1` ([#9568](https://github.com/MetaMask/core/pull/9568), [#9589](https://github.com/MetaMask/core/pull/9589), [#9593](https://github.com/MetaMask/core/pull/9593))

--- a/packages/profile-metrics-controller/CHANGELOG.md
+++ b/packages/profile-metrics-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Disable in-request retries on `ProfileMetricsService` by default (`maxRetries: 0`) ([#XXX](https://github.com/MetaMask/core/pull/XXX))
+- Disable in-request retries on `ProfileMetricsService` by default (`maxRetries: 0`) ([#9667](https://github.com/MetaMask/core/pull/9667))
   - Proof-of-ownership nonces are single-use; retrying the same signed payload
     after a spent nonce caused `PUT /profile/accounts` 400s (`nonce-session`
     key not found). The controller poll already re-fetches nonces and retries

--- a/packages/profile-metrics-controller/CHANGELOG.md
+++ b/packages/profile-metrics-controller/CHANGELOG.md
@@ -13,11 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Disable in-request retries on `ProfileMetricsService:submitMetrics` by
-  default (`maxRetries: 0`) ([#9667](https://github.com/MetaMask/core/pull/9667))
-  - Proof nonces are single-use, so retrying a spent `submitMetrics` payload
-    caused `PUT /profile/accounts` 400s; `fetchNonces` still retries because a
-    failed fetch soft-degrades to a proof-less submit that clears the queue.
+- Disable in-request retries on `ProfileMetricsService:submitMetrics` by default (`maxRetries: 0`) ([#9667](https://github.com/MetaMask/core/pull/9667))
+  - Proof nonces are single-use, so retrying a spent `submitMetrics` payload caused `PUT /profile/accounts` 400s; `fetchNonces` still retries because a failed fetch soft-degrades to a proof-less submit that clears the queue.
 
 ## [4.0.2]
 

--- a/packages/profile-metrics-controller/CHANGELOG.md
+++ b/packages/profile-metrics-controller/CHANGELOG.md
@@ -15,13 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Disable in-request retries on `ProfileMetricsService:submitMetrics` by
   default (`maxRetries: 0`) ([#9667](https://github.com/MetaMask/core/pull/9667))
-  - Proof-of-ownership nonces are single-use; retrying the same signed payload
-    after a spent nonce caused `PUT /profile/accounts` 400s (`nonce-session`
-    key not found). The controller poll already re-fetches nonces and retries
-    failed submits.
-  - `fetchNonces` keeps the normal retry defaults: a failed nonce fetch
-    soft-degrades to a proof-less submit that clears the queue, so in-request
-    retries are what preserve proofs across transient errors.
+  - Proof nonces are single-use, so retrying a spent `submitMetrics` payload
+    caused `PUT /profile/accounts` 400s; `fetchNonces` still retries because a
+    failed fetch soft-degrades to a proof-less submit that clears the queue.
 
 ## [4.0.2]
 

--- a/packages/profile-metrics-controller/CHANGELOG.md
+++ b/packages/profile-metrics-controller/CHANGELOG.md
@@ -13,11 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Disable in-request retries on `ProfileMetricsService` by default (`maxRetries: 0`) ([#9667](https://github.com/MetaMask/core/pull/9667))
+- Disable in-request retries on `ProfileMetricsService:submitMetrics` by
+  default (`maxRetries: 0`) ([#9667](https://github.com/MetaMask/core/pull/9667))
   - Proof-of-ownership nonces are single-use; retrying the same signed payload
     after a spent nonce caused `PUT /profile/accounts` 400s (`nonce-session`
     key not found). The controller poll already re-fetches nonces and retries
-    failed batches.
+    failed submits.
+  - `fetchNonces` keeps the normal retry defaults: a failed nonce fetch
+    soft-degrades to a proof-less submit that clears the queue, so in-request
+    retries are what preserve proofs across transient errors.
 
 ## [4.0.2]
 

--- a/packages/profile-metrics-controller/src/ProfileMetricsService.test.ts
+++ b/packages/profile-metrics-controller/src/ProfileMetricsService.test.ts
@@ -17,6 +17,9 @@ import { getAuthUrl } from './ProfileMetricsService.js';
 
 const defaultBaseEndpoint = getAuthUrl(SDK.Env.DEV);
 
+/** Opt-in retries for tests that exercise the service policy retry path. */
+const RETRY_POLICY = { maxRetries: 3 } as const;
+
 /**
  * Creates a mock request object for testing purposes.
  *
@@ -168,9 +171,26 @@ describe('ProfileMetricsService', () => {
       expect(onDegradedListener).toHaveBeenCalled();
     });
 
-    it('attempts a request that responds with non-200 up to 4 times, throwing if it never succeeds', async () => {
+    it('does not retry by default when a request fails', async () => {
+      nock(defaultBaseEndpoint).put('/profile/accounts').once().reply(500);
+      const { rootMessenger } = getService();
+
+      await expect(
+        rootMessenger.call(
+          'ProfileMetricsService:submitMetrics',
+          createMockRequest(),
+        ),
+      ).rejects.toThrow(
+        `Fetching '${defaultBaseEndpoint}/profile/accounts' failed with status '500'`,
+      );
+      expect(nock.isDone()).toBe(true);
+    });
+
+    it('attempts a request that responds with non-200 up to 4 times when retries are enabled, throwing if it never succeeds', async () => {
       nock(defaultBaseEndpoint).put('/profile/accounts').times(4).reply(500);
-      const { service, rootMessenger } = getService();
+      const { service, rootMessenger } = getService({
+        options: { policyOptions: RETRY_POLICY },
+      });
       service.onRetry(({ delay }: { delay: number }) => {
         jest.advanceTimersByTime(delay);
       });
@@ -187,7 +207,9 @@ describe('ProfileMetricsService', () => {
 
     it('calls onDegraded listeners when the maximum number of retries is exceeded', async () => {
       nock(defaultBaseEndpoint).put('/profile/accounts').times(4).reply(500);
-      const { service, rootMessenger } = getService();
+      const { service, rootMessenger } = getService({
+        options: { policyOptions: RETRY_POLICY },
+      });
       service.onRetry(({ delay }: { delay: number }) => {
         jest.advanceTimersByTime(delay);
       });
@@ -207,7 +229,9 @@ describe('ProfileMetricsService', () => {
 
     it('intercepts requests and throws a circuit break error after the 4th failed attempt, running onBreak listeners', async () => {
       nock(defaultBaseEndpoint).put('/profile/accounts').times(12).reply(500);
-      const { service, rootMessenger } = getService();
+      const { service, rootMessenger } = getService({
+        options: { policyOptions: RETRY_POLICY },
+      });
       service.onRetry(({ delay }: { delay: number }) => {
         jest.advanceTimersByTime(delay);
       });
@@ -273,7 +297,7 @@ describe('ProfileMetricsService', () => {
         });
       const { service, rootMessenger } = getService({
         options: {
-          policyOptions: { circuitBreakDuration },
+          policyOptions: { ...RETRY_POLICY, circuitBreakDuration },
         },
       });
       service.onRetry(({ delay }: { delay: number }) => {
@@ -569,11 +593,11 @@ describe('ProfileMetricsService', () => {
       expect(scope.pendingMocks()).toHaveLength(0);
     });
 
-    it('throws after exhausting retries when the response is short of identifiers', async () => {
+    it('throws when the response is short of identifiers', async () => {
       const identifiers = ['0xAddressOne', '0xAddressTwo'];
       nock(defaultBaseEndpoint)
         .post('/nonce/batch')
-        .times(4)
+        .once()
         .reply(200, [
           {
             expires_in: 300,
@@ -581,10 +605,7 @@ describe('ProfileMetricsService', () => {
             nonce: 'nonce-for-one',
           },
         ]);
-      const { service, rootMessenger } = getService();
-      service.onRetry(({ delay }: { delay: number }) => {
-        jest.advanceTimersByTime(delay);
-      });
+      const { rootMessenger } = getService();
 
       await expect(
         rootMessenger.call('ProfileMetricsService:fetchNonces', {
@@ -595,11 +616,11 @@ describe('ProfileMetricsService', () => {
       );
     });
 
-    it('throws after exhausting retries when the response returns identifiers we did not request', async () => {
+    it('throws when the response returns identifiers we did not request', async () => {
       const identifiers = ['0xAddressOne', '0xAddressTwo'];
       nock(defaultBaseEndpoint)
         .post('/nonce/batch')
-        .times(4)
+        .once()
         .reply(200, [
           {
             expires_in: 300,
@@ -612,10 +633,7 @@ describe('ProfileMetricsService', () => {
             nonce: 'nonce-for-impostor',
           },
         ]);
-      const { service, rootMessenger } = getService();
-      service.onRetry(({ delay }: { delay: number }) => {
-        jest.advanceTimersByTime(delay);
-      });
+      const { rootMessenger } = getService();
 
       await expect(
         rootMessenger.call('ProfileMetricsService:fetchNonces', {
@@ -626,11 +644,11 @@ describe('ProfileMetricsService', () => {
       );
     });
 
-    it('throws after exhausting retries when the response duplicates one identifier in place of another', async () => {
+    it('throws when the response duplicates one identifier in place of another', async () => {
       const identifiers = ['0xAddressOne', '0xAddressTwo'];
       nock(defaultBaseEndpoint)
         .post('/nonce/batch')
-        .times(4)
+        .once()
         .reply(200, [
           {
             expires_in: 300,
@@ -643,10 +661,7 @@ describe('ProfileMetricsService', () => {
             nonce: 'nonce-for-one-b',
           },
         ]);
-      const { service, rootMessenger } = getService();
-      service.onRetry(({ delay }: { delay: number }) => {
-        jest.advanceTimersByTime(delay);
-      });
+      const { rootMessenger } = getService();
 
       await expect(
         rootMessenger.call('ProfileMetricsService:fetchNonces', {
@@ -657,11 +672,11 @@ describe('ProfileMetricsService', () => {
       );
     });
 
-    it('throws after exhausting retries when the response duplicates an identifier alongside a full set (preventing silent overwrite)', async () => {
+    it('throws when the response duplicates an identifier alongside a full set (preventing silent overwrite)', async () => {
       const identifiers = ['0xAddressOne', '0xAddressTwo'];
       nock(defaultBaseEndpoint)
         .post('/nonce/batch')
-        .times(4)
+        .once()
         .reply(200, [
           {
             expires_in: 300,
@@ -679,10 +694,7 @@ describe('ProfileMetricsService', () => {
             nonce: 'nonce-for-two',
           },
         ]);
-      const { service, rootMessenger } = getService();
-      service.onRetry(({ delay }: { delay: number }) => {
-        jest.advanceTimersByTime(delay);
-      });
+      const { rootMessenger } = getService();
 
       await expect(
         rootMessenger.call('ProfileMetricsService:fetchNonces', {
@@ -693,16 +705,13 @@ describe('ProfileMetricsService', () => {
       );
     });
 
-    it('throws after exhausting retries when the response body is not an array', async () => {
+    it('throws when the response body is not an array', async () => {
       const identifiers = ['0xAddressOne'];
       nock(defaultBaseEndpoint)
         .post('/nonce/batch')
-        .times(4)
+        .once()
         .reply(200, { error: 'oops' });
-      const { service, rootMessenger } = getService();
-      service.onRetry(({ delay }: { delay: number }) => {
-        jest.advanceTimersByTime(delay);
-      });
+      const { rootMessenger } = getService();
 
       await expect(
         rootMessenger.call('ProfileMetricsService:fetchNonces', {
@@ -713,16 +722,13 @@ describe('ProfileMetricsService', () => {
       );
     });
 
-    it('throws after exhausting retries when a response entry is missing the `nonce` field', async () => {
+    it('throws when a response entry is missing the `nonce` field', async () => {
       const identifiers = ['0xAddressOne'];
       nock(defaultBaseEndpoint)
         .post('/nonce/batch')
-        .times(4)
+        .once()
         .reply(200, [{ expires_in: 300, identifier: '0xAddressOne' }]);
-      const { service, rootMessenger } = getService();
-      service.onRetry(({ delay }: { delay: number }) => {
-        jest.advanceTimersByTime(delay);
-      });
+      const { rootMessenger } = getService();
 
       await expect(
         rootMessenger.call('ProfileMetricsService:fetchNonces', {
@@ -733,11 +739,11 @@ describe('ProfileMetricsService', () => {
       );
     });
 
-    it('throws after exhausting retries when a response entry has a non-string `nonce`', async () => {
+    it('throws when a response entry has a non-string `nonce`', async () => {
       const identifiers = ['0xAddressOne'];
       nock(defaultBaseEndpoint)
         .post('/nonce/batch')
-        .times(4)
+        .once()
         .reply(200, [
           {
             expires_in: 300,
@@ -745,10 +751,7 @@ describe('ProfileMetricsService', () => {
             nonce: 12345,
           },
         ]);
-      const { service, rootMessenger } = getService();
-      service.onRetry(({ delay }: { delay: number }) => {
-        jest.advanceTimersByTime(delay);
-      });
+      const { rootMessenger } = getService();
 
       await expect(
         rootMessenger.call('ProfileMetricsService:fetchNonces', {
@@ -759,9 +762,11 @@ describe('ProfileMetricsService', () => {
       );
     });
 
-    it('attempts a request that responds with non-200 up to 4 times, throwing if it never succeeds', async () => {
+    it('attempts a request that responds with non-200 up to 4 times when retries are enabled, throwing if it never succeeds', async () => {
       nock(defaultBaseEndpoint).post('/nonce/batch').times(4).reply(500);
-      const { service, rootMessenger } = getService();
+      const { service, rootMessenger } = getService({
+        options: { policyOptions: RETRY_POLICY },
+      });
       service.onRetry(({ delay }: { delay: number }) => {
         jest.advanceTimersByTime(delay);
       });
@@ -775,9 +780,11 @@ describe('ProfileMetricsService', () => {
       );
     });
 
-    it('attempts a request that responds with 4xx up to 4 times, throwing if it never succeeds', async () => {
+    it('attempts a request that responds with 4xx up to 4 times when retries are enabled, throwing if it never succeeds', async () => {
       nock(defaultBaseEndpoint).post('/nonce/batch').times(4).reply(400);
-      const { service, rootMessenger } = getService();
+      const { service, rootMessenger } = getService({
+        options: { policyOptions: RETRY_POLICY },
+      });
       service.onRetry(({ delay }: { delay: number }) => {
         jest.advanceTimersByTime(delay);
       });
@@ -789,6 +796,20 @@ describe('ProfileMetricsService', () => {
       ).rejects.toThrow(
         `Fetching '${defaultBaseEndpoint}/nonce/batch' failed with status '400'`,
       );
+    });
+
+    it('does not retry by default when a nonce batch request fails', async () => {
+      nock(defaultBaseEndpoint).post('/nonce/batch').once().reply(400);
+      const { rootMessenger } = getService();
+
+      await expect(
+        rootMessenger.call('ProfileMetricsService:fetchNonces', {
+          identifiers: ['0xAddressOne'],
+        }),
+      ).rejects.toThrow(
+        `Fetching '${defaultBaseEndpoint}/nonce/batch' failed with status '400'`,
+      );
+      expect(nock.isDone()).toBe(true);
     });
   });
 

--- a/packages/profile-metrics-controller/src/ProfileMetricsService.test.ts
+++ b/packages/profile-metrics-controller/src/ProfileMetricsService.test.ts
@@ -58,6 +58,16 @@ describe('ProfileMetricsService', () => {
           }),
       ).toThrow('invalid environment configuration');
     });
+
+    it('allows policy listeners to be disposed', () => {
+      const { service } = getService();
+
+      expect(() => {
+        service.onRetry(() => undefined).dispose();
+        service.onBreak(() => undefined).dispose();
+        service.onDegraded(() => undefined).dispose();
+      }).not.toThrow();
+    });
   });
 
   describe('ProfileMetricsService:submitMetrics', () => {
@@ -592,11 +602,11 @@ describe('ProfileMetricsService', () => {
       expect(scope.pendingMocks()).toHaveLength(0);
     });
 
-    it('throws when the response is short of identifiers', async () => {
+    it('throws after exhausting retries when the response is short of identifiers', async () => {
       const identifiers = ['0xAddressOne', '0xAddressTwo'];
       nock(defaultBaseEndpoint)
         .post('/nonce/batch')
-        .once()
+        .times(4)
         .reply(200, [
           {
             expires_in: 300,
@@ -604,7 +614,10 @@ describe('ProfileMetricsService', () => {
             nonce: 'nonce-for-one',
           },
         ]);
-      const { rootMessenger } = getService();
+      const { service, rootMessenger } = getService();
+      service.onRetry(({ delay }: { delay: number }) => {
+        jest.advanceTimersByTime(delay);
+      });
 
       await expect(
         rootMessenger.call('ProfileMetricsService:fetchNonces', {
@@ -615,11 +628,11 @@ describe('ProfileMetricsService', () => {
       );
     });
 
-    it('throws when the response returns identifiers we did not request', async () => {
+    it('throws after exhausting retries when the response returns identifiers we did not request', async () => {
       const identifiers = ['0xAddressOne', '0xAddressTwo'];
       nock(defaultBaseEndpoint)
         .post('/nonce/batch')
-        .once()
+        .times(4)
         .reply(200, [
           {
             expires_in: 300,
@@ -632,7 +645,10 @@ describe('ProfileMetricsService', () => {
             nonce: 'nonce-for-impostor',
           },
         ]);
-      const { rootMessenger } = getService();
+      const { service, rootMessenger } = getService();
+      service.onRetry(({ delay }: { delay: number }) => {
+        jest.advanceTimersByTime(delay);
+      });
 
       await expect(
         rootMessenger.call('ProfileMetricsService:fetchNonces', {
@@ -643,11 +659,11 @@ describe('ProfileMetricsService', () => {
       );
     });
 
-    it('throws when the response duplicates one identifier in place of another', async () => {
+    it('throws after exhausting retries when the response duplicates one identifier in place of another', async () => {
       const identifiers = ['0xAddressOne', '0xAddressTwo'];
       nock(defaultBaseEndpoint)
         .post('/nonce/batch')
-        .once()
+        .times(4)
         .reply(200, [
           {
             expires_in: 300,
@@ -660,7 +676,10 @@ describe('ProfileMetricsService', () => {
             nonce: 'nonce-for-one-b',
           },
         ]);
-      const { rootMessenger } = getService();
+      const { service, rootMessenger } = getService();
+      service.onRetry(({ delay }: { delay: number }) => {
+        jest.advanceTimersByTime(delay);
+      });
 
       await expect(
         rootMessenger.call('ProfileMetricsService:fetchNonces', {
@@ -671,11 +690,11 @@ describe('ProfileMetricsService', () => {
       );
     });
 
-    it('throws when the response duplicates an identifier alongside a full set (preventing silent overwrite)', async () => {
+    it('throws after exhausting retries when the response duplicates an identifier alongside a full set (preventing silent overwrite)', async () => {
       const identifiers = ['0xAddressOne', '0xAddressTwo'];
       nock(defaultBaseEndpoint)
         .post('/nonce/batch')
-        .once()
+        .times(4)
         .reply(200, [
           {
             expires_in: 300,
@@ -693,7 +712,10 @@ describe('ProfileMetricsService', () => {
             nonce: 'nonce-for-two',
           },
         ]);
-      const { rootMessenger } = getService();
+      const { service, rootMessenger } = getService();
+      service.onRetry(({ delay }: { delay: number }) => {
+        jest.advanceTimersByTime(delay);
+      });
 
       await expect(
         rootMessenger.call('ProfileMetricsService:fetchNonces', {
@@ -704,13 +726,16 @@ describe('ProfileMetricsService', () => {
       );
     });
 
-    it('throws when the response body is not an array', async () => {
+    it('throws after exhausting retries when the response body is not an array', async () => {
       const identifiers = ['0xAddressOne'];
       nock(defaultBaseEndpoint)
         .post('/nonce/batch')
-        .once()
+        .times(4)
         .reply(200, { error: 'oops' });
-      const { rootMessenger } = getService();
+      const { service, rootMessenger } = getService();
+      service.onRetry(({ delay }: { delay: number }) => {
+        jest.advanceTimersByTime(delay);
+      });
 
       await expect(
         rootMessenger.call('ProfileMetricsService:fetchNonces', {
@@ -721,13 +746,16 @@ describe('ProfileMetricsService', () => {
       );
     });
 
-    it('throws when a response entry is missing the `nonce` field', async () => {
+    it('throws after exhausting retries when a response entry is missing the `nonce` field', async () => {
       const identifiers = ['0xAddressOne'];
       nock(defaultBaseEndpoint)
         .post('/nonce/batch')
-        .once()
+        .times(4)
         .reply(200, [{ expires_in: 300, identifier: '0xAddressOne' }]);
-      const { rootMessenger } = getService();
+      const { service, rootMessenger } = getService();
+      service.onRetry(({ delay }: { delay: number }) => {
+        jest.advanceTimersByTime(delay);
+      });
 
       await expect(
         rootMessenger.call('ProfileMetricsService:fetchNonces', {
@@ -738,11 +766,11 @@ describe('ProfileMetricsService', () => {
       );
     });
 
-    it('throws when a response entry has a non-string `nonce`', async () => {
+    it('throws after exhausting retries when a response entry has a non-string `nonce`', async () => {
       const identifiers = ['0xAddressOne'];
       nock(defaultBaseEndpoint)
         .post('/nonce/batch')
-        .once()
+        .times(4)
         .reply(200, [
           {
             expires_in: 300,
@@ -750,7 +778,10 @@ describe('ProfileMetricsService', () => {
             nonce: 12345,
           },
         ]);
-      const { rootMessenger } = getService();
+      const { service, rootMessenger } = getService();
+      service.onRetry(({ delay }: { delay: number }) => {
+        jest.advanceTimersByTime(delay);
+      });
 
       await expect(
         rootMessenger.call('ProfileMetricsService:fetchNonces', {
@@ -761,11 +792,9 @@ describe('ProfileMetricsService', () => {
       );
     });
 
-    it('attempts a request that responds with non-200 up to 4 times when retries are enabled, throwing if it never succeeds', async () => {
+    it('attempts a request that responds with non-200 up to 4 times, throwing if it never succeeds', async () => {
       nock(defaultBaseEndpoint).post('/nonce/batch').times(4).reply(500);
-      const { service, rootMessenger } = getService({
-        options: { policyOptions: RETRY_POLICY },
-      });
+      const { service, rootMessenger } = getService();
       service.onRetry(({ delay }: { delay: number }) => {
         jest.advanceTimersByTime(delay);
       });
@@ -779,27 +808,12 @@ describe('ProfileMetricsService', () => {
       );
     });
 
-    it('attempts a request that responds with 4xx up to 4 times when retries are enabled, throwing if it never succeeds', async () => {
+    it('attempts a request that responds with 4xx up to 4 times, throwing if it never succeeds', async () => {
       nock(defaultBaseEndpoint).post('/nonce/batch').times(4).reply(400);
-      const { service, rootMessenger } = getService({
-        options: { policyOptions: RETRY_POLICY },
-      });
+      const { service, rootMessenger } = getService();
       service.onRetry(({ delay }: { delay: number }) => {
         jest.advanceTimersByTime(delay);
       });
-
-      await expect(
-        rootMessenger.call('ProfileMetricsService:fetchNonces', {
-          identifiers: ['0xAddressOne'],
-        }),
-      ).rejects.toThrow(
-        `Fetching '${defaultBaseEndpoint}/nonce/batch' failed with status '400'`,
-      );
-    });
-
-    it('does not retry by default when a nonce batch request fails', async () => {
-      nock(defaultBaseEndpoint).post('/nonce/batch').once().reply(400);
-      const { rootMessenger } = getService();
 
       await expect(
         rootMessenger.call('ProfileMetricsService:fetchNonces', {

--- a/packages/profile-metrics-controller/src/ProfileMetricsService.test.ts
+++ b/packages/profile-metrics-controller/src/ProfileMetricsService.test.ts
@@ -183,7 +183,6 @@ describe('ProfileMetricsService', () => {
       ).rejects.toThrow(
         `Fetching '${defaultBaseEndpoint}/profile/accounts' failed with status '500'`,
       );
-      expect(nock.isDone()).toBe(true);
     });
 
     it('attempts a request that responds with non-200 up to 4 times when retries are enabled, throwing if it never succeeds', async () => {
@@ -809,7 +808,6 @@ describe('ProfileMetricsService', () => {
       ).rejects.toThrow(
         `Fetching '${defaultBaseEndpoint}/nonce/batch' failed with status '400'`,
       );
-      expect(nock.isDone()).toBe(true);
     });
   });
 

--- a/packages/profile-metrics-controller/src/ProfileMetricsService.ts
+++ b/packages/profile-metrics-controller/src/ProfileMetricsService.ts
@@ -251,7 +251,7 @@ export class ProfileMetricsService {
     const fetchDisposable = this.#fetchNoncesPolicy.onRetry(listener);
     const submitDisposable = this.#submitMetricsPolicy.onRetry(listener);
     return {
-      dispose: () => {
+      dispose: (): void => {
         fetchDisposable.dispose();
         submitDisposable.dispose();
       },
@@ -271,7 +271,7 @@ export class ProfileMetricsService {
     const fetchDisposable = this.#fetchNoncesPolicy.onBreak(listener);
     const submitDisposable = this.#submitMetricsPolicy.onBreak(listener);
     return {
-      dispose: () => {
+      dispose: (): void => {
         fetchDisposable.dispose();
         submitDisposable.dispose();
       },
@@ -301,7 +301,7 @@ export class ProfileMetricsService {
     const fetchDisposable = this.#fetchNoncesPolicy.onDegraded(listener);
     const submitDisposable = this.#submitMetricsPolicy.onDegraded(listener);
     return {
-      dispose: () => {
+      dispose: (): void => {
         fetchDisposable.dispose();
         submitDisposable.dispose();
       },

--- a/packages/profile-metrics-controller/src/ProfileMetricsService.ts
+++ b/packages/profile-metrics-controller/src/ProfileMetricsService.ts
@@ -167,11 +167,19 @@ export class ProfileMetricsService {
   >[0]['fetch'];
 
   /**
-   * The policy that wraps the request.
+   * Policy for `fetchNonces`. Minting new nonces is safe to retry.
    *
    * @see {@link createServicePolicy}
    */
-  readonly #policy: ServicePolicy;
+  readonly #fetchNoncesPolicy: ServicePolicy;
+
+  /**
+   * Policy for `submitMetrics`. Proof payloads embed single-use nonces, so
+   * in-request retries are disabled by default.
+   *
+   * @see {@link createServicePolicy}
+   */
+  readonly #submitMetricsPolicy: ServicePolicy;
 
   /**
    * The API base URL environment.
@@ -189,9 +197,11 @@ export class ProfileMetricsService {
    * `node-fetch`).
    * @param args.policyOptions - Options to pass to `createServicePolicy`, which
    * is used to wrap each request. See {@link CreateServicePolicyOptions}.
-   * Retries default to `0`: proof-of-ownership nonces are single-use, and
-   * `ProfileMetricsController`'s poll already re-fetches nonces and retries
-   * failed batches, so in-request retries would resubmit spent nonces.
+   * `submitMetrics` defaults to `maxRetries: 0` (proof nonces are single-use;
+   * the controller poll re-fetches nonces and retries failed submits).
+   * `fetchNonces` keeps the normal retry defaults — a failed nonce fetch
+   * soft-degrades to a proof-less submit that clears the queue, so retries
+   * here are what preserve proofs across transient errors.
    * @param args.env - The environment to determine the correct API endpoints.
    */
   constructor({
@@ -208,7 +218,17 @@ export class ProfileMetricsService {
     this.name = serviceName;
     this.#messenger = messenger;
     this.#fetch = fetchFunction;
-    this.#policy = createServicePolicy({ maxRetries: 0, ...policyOptions });
+    this.#fetchNoncesPolicy = createServicePolicy(policyOptions);
+    // Keep the circuit breaker scaled to the retry count the same way
+    // `createServicePolicy` derives `DEFAULT_MAX_CONSECUTIVE_FAILURES`:
+    // `(1 + maxRetries) * 3` failed attempts ≈ 3 failed `execute()` calls.
+    const submitMaxRetries = policyOptions.maxRetries ?? 0;
+    this.#submitMetricsPolicy = createServicePolicy({
+      ...policyOptions,
+      maxRetries: submitMaxRetries,
+      maxConsecutiveFailures:
+        policyOptions.maxConsecutiveFailures ?? (1 + submitMaxRetries) * 3,
+    });
     this.#baseURL = getAuthUrl(env);
 
     this.#messenger.registerMethodActionHandlers(
@@ -228,7 +248,14 @@ export class ProfileMetricsService {
    * @see {@link createServicePolicy}
    */
   onRetry(listener: Parameters<ServicePolicy['onRetry']>[0]): IDisposable {
-    return this.#policy.onRetry(listener);
+    const fetchDisposable = this.#fetchNoncesPolicy.onRetry(listener);
+    const submitDisposable = this.#submitMetricsPolicy.onRetry(listener);
+    return {
+      dispose: () => {
+        fetchDisposable.dispose();
+        submitDisposable.dispose();
+      },
+    };
   }
 
   /**
@@ -241,7 +268,14 @@ export class ProfileMetricsService {
    * @see {@link createServicePolicy}
    */
   onBreak(listener: Parameters<ServicePolicy['onBreak']>[0]): IDisposable {
-    return this.#policy.onBreak(listener);
+    const fetchDisposable = this.#fetchNoncesPolicy.onBreak(listener);
+    const submitDisposable = this.#submitMetricsPolicy.onBreak(listener);
+    return {
+      dispose: () => {
+        fetchDisposable.dispose();
+        submitDisposable.dispose();
+      },
+    };
   }
 
   /**
@@ -264,7 +298,14 @@ export class ProfileMetricsService {
   onDegraded(
     listener: Parameters<ServicePolicy['onDegraded']>[0],
   ): IDisposable {
-    return this.#policy.onDegraded(listener);
+    const fetchDisposable = this.#fetchNoncesPolicy.onDegraded(listener);
+    const submitDisposable = this.#submitMetricsPolicy.onDegraded(listener);
+    return {
+      dispose: () => {
+        fetchDisposable.dispose();
+        submitDisposable.dispose();
+      },
+    };
   }
 
   /**
@@ -310,8 +351,8 @@ export class ProfileMetricsService {
 
   /**
    * Mint nonces for a single ≤ {@link MAX_NONCE_BATCH_SIZE}-sized chunk of
-   * identifiers. Wrapped in {@link #policy} for retry / degraded / circuit
-   * semantics consistent with the rest of the service.
+   * identifiers. Wrapped in {@link #fetchNoncesPolicy} for retry / degraded /
+   * circuit semantics.
    *
    * @param identifiers - The identifiers in this chunk. Must be 1..MAX_NONCE_BATCH_SIZE.
    * @param entropySourceId - The entropy source ID forwarded to the bearer
@@ -322,7 +363,7 @@ export class ProfileMetricsService {
     identifiers: string[],
     entropySourceId: string | null | undefined,
   ): Promise<Record<string, string>> {
-    return await this.#policy.execute(async () => {
+    return await this.#fetchNoncesPolicy.execute(async () => {
       const authToken = await this.#messenger.call(
         'AuthenticationController:getBearerToken',
         entropySourceId ?? undefined,
@@ -372,7 +413,7 @@ export class ProfileMetricsService {
    * @returns The response from the API.
    */
   async submitMetrics(data: ProfileMetricsSubmitMetricsRequest): Promise<void> {
-    await this.#policy.execute(async () => {
+    await this.#submitMetricsPolicy.execute(async () => {
       const authToken = await this.#messenger.call(
         'AuthenticationController:getBearerToken',
         data.entropySourceId ?? undefined,

--- a/packages/profile-metrics-controller/src/ProfileMetricsService.ts
+++ b/packages/profile-metrics-controller/src/ProfileMetricsService.ts
@@ -189,6 +189,9 @@ export class ProfileMetricsService {
    * `node-fetch`).
    * @param args.policyOptions - Options to pass to `createServicePolicy`, which
    * is used to wrap each request. See {@link CreateServicePolicyOptions}.
+   * Retries default to `0`: proof-of-ownership nonces are single-use, and
+   * `ProfileMetricsController`'s poll already re-fetches nonces and retries
+   * failed batches, so in-request retries would resubmit spent nonces.
    * @param args.env - The environment to determine the correct API endpoints.
    */
   constructor({
@@ -205,7 +208,7 @@ export class ProfileMetricsService {
     this.name = serviceName;
     this.#messenger = messenger;
     this.#fetch = fetchFunction;
-    this.#policy = createServicePolicy(policyOptions);
+    this.#policy = createServicePolicy({ maxRetries: 0, ...policyOptions });
     this.#baseURL = getAuthUrl(env);
 
     this.#messenger.registerMethodActionHandlers(


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

Related to: https://consensyssoftware.atlassian.net/browse/MUL-2024

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes metrics submission reliability semantics (fewer automatic HTTP retries) on a path that handles auth proofs; behavior on failure now depends more on controller poll re-fetch rather than in-request retries.
> 
> **Overview**
> **Fixes `PUT /profile/accounts` 400s** caused by the service policy re-sending the same proof-bearing payload after a transient failure—proof nonces are single-use, so in-request retries could burn a nonce and fail on retry.
> 
> `ProfileMetricsService` now uses **two policies** instead of one shared wrapper: **`fetchNonces`** keeps the existing `createServicePolicy` retry/circuit-break behavior (failed nonce fetch can soft-degrade to proof-less submit), while **`submitMetrics` defaults to `maxRetries: 0`** with circuit-breaker thresholds derived from that retry count. `onRetry` / `onBreak` / `onDegraded` listeners attach to both policies and dispose together.
> 
> Tests assert no default retries on failed submit, opt into `RETRY_POLICY` for retry/circuit-break scenarios, and cover listener disposal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91b6a5098a1031007198bc75ceebb183aec1843c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->