### PR TITLE
fix(ramps-controller): drop unused headless minimumVersion helper

### DIFF
--- a/packages/ramps-controller/CHANGELOG.md
+++ b/packages/ramps-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- **BREAKING:** Remove `getHeadlessAllProvidersMinimumVersion`; app-version gating for `moneyHeadlessAllProviders` is owned by the LaunchDarkly `versions` wrapper (processed by `RemoteFeatureFlagController`), not a payload `minimumVersion` field. `featureVersion` fail-closed enablement and `providerIds` allowlisting are unchanged. ([#9658](https://github.com/MetaMask/core/pull/9658))
+- **BREAKING:** Remove `getHeadlessAllProvidersMinimumVersion`; app-version gating for `moneyHeadlessAllProviders` is owned by the LaunchDarkly `versions` wrapper (processed by `RemoteFeatureFlagController`), not a payload `minimumVersion` field. `featureVersion` fail-closed enablement and `providerIds` allowlisting are unchanged. ([#9668](https://github.com/MetaMask/core/pull/9668))
 
 ## [17.2.0]
 

--- a/packages/ramps-controller/CHANGELOG.md
+++ b/packages/ramps-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **BREAKING:** Remove `getHeadlessAllProvidersMinimumVersion`; app-version gating for `moneyHeadlessAllProviders` is owned by the LaunchDarkly `versions` wrapper (processed by `RemoteFeatureFlagController`), not a payload `minimumVersion` field. `featureVersion` fail-closed enablement and `providerIds` allowlisting are unchanged. ([#9658](https://github.com/MetaMask/core/pull/9658))
+
 ## [17.2.0]
 
 ### Added

--- a/packages/ramps-controller/src/featureFlags.test.ts
+++ b/packages/ramps-controller/src/featureFlags.test.ts
@@ -2,7 +2,6 @@ import type { Json } from '@metamask/utils';
 
 import {
   HEADLESS_ALL_PROVIDERS_FEATURE_VERSION,
-  getHeadlessAllProvidersMinimumVersion,
   MONEY_HEADLESS_ALL_PROVIDERS_FLAG_KEY,
   getHeadlessProviderAllowlist,
   isHeadlessAllProvidersEnabled,
@@ -325,55 +324,6 @@ describe('featureVersion gating', () => {
         },
       }),
     ).toBe(true);
-  });
-});
-
-describe('getHeadlessAllProvidersMinimumVersion', () => {
-  it('returns the minimumVersion carried by an enabled payload', () => {
-    expect(
-      getHeadlessAllProvidersMinimumVersion({
-        remoteFeatureFlags: {
-          [MONEY_HEADLESS_ALL_PROVIDERS_FLAG_KEY]: {
-            enabled: true,
-            featureVersion: '1',
-            minimumVersion: '8.6.0',
-          } as Json,
-        },
-      }),
-    ).toBe('8.6.0');
-  });
-
-  it('returns undefined for the boolean form, disabled payloads, and blank values', () => {
-    expect(
-      getHeadlessAllProvidersMinimumVersion({
-        remoteFeatureFlags: {
-          [MONEY_HEADLESS_ALL_PROVIDERS_FLAG_KEY]: true,
-        },
-      }),
-    ).toBeUndefined();
-    expect(
-      getHeadlessAllProvidersMinimumVersion({
-        remoteFeatureFlags: {
-          [MONEY_HEADLESS_ALL_PROVIDERS_FLAG_KEY]: {
-            enabled: false,
-            featureVersion: '1',
-            minimumVersion: '8.6.0',
-          } as Json,
-        },
-      }),
-    ).toBeUndefined();
-    expect(
-      getHeadlessAllProvidersMinimumVersion({
-        remoteFeatureFlags: {
-          [MONEY_HEADLESS_ALL_PROVIDERS_FLAG_KEY]: {
-            enabled: true,
-            featureVersion: '1',
-            minimumVersion: '   ',
-          } as Json,
-        },
-      }),
-    ).toBeUndefined();
-    expect(getHeadlessAllProvidersMinimumVersion(null)).toBeUndefined();
   });
 });
 

--- a/packages/ramps-controller/src/featureFlags.ts
+++ b/packages/ramps-controller/src/featureFlags.ts
@@ -83,30 +83,6 @@ function isEnabledPayload(value: Json | undefined): value is {
 }
 
 /**
- * The `minimumVersion` carried by an enabled payload, or `undefined` for the
- * boolean form, a disabled payload, or a malformed field. This package cannot
- * compare app versions itself; mobile validates the value through its shared
- * `validatedVersionGatedFeatureFlag` util, and the LaunchDarkly `versions`
- * wrapper provides the server-side gate.
- *
- * @param remoteFeatureFlagState - `RemoteFeatureFlagController` state (or the
- * relevant subset of it).
- * @returns The minimum app version the payload declares, or `undefined`.
- */
-export function getHeadlessAllProvidersMinimumVersion(
-  remoteFeatureFlagState: HeadlessFeatureFlagsLookup | null | undefined,
-): string | undefined {
-  const value = resolveFlagValue(remoteFeatureFlagState);
-  if (!isEnabledPayload(value)) {
-    return undefined;
-  }
-  const { minimumVersion } = value;
-  return typeof minimumVersion === 'string' && minimumVersion.trim() !== ''
-    ? minimumVersion
-    : undefined;
-}
-
-/**
  * Coerces a payload field into a provider-id list: keeps only string entries,
  * trims them, and drops empties. An empty or malformed level is treated as
  * "not provided" so resolution falls through to the next level rather than

--- a/packages/ramps-controller/src/index.ts
+++ b/packages/ramps-controller/src/index.ts
@@ -144,7 +144,6 @@ export type { HeadlessFeatureFlagsLookup } from './featureFlags.js';
 export {
   HEADLESS_ALL_PROVIDERS_FEATURE_VERSION,
   MONEY_HEADLESS_ALL_PROVIDERS_FLAG_KEY,
-  getHeadlessAllProvidersMinimumVersion,
   getHeadlessProviderAllowlist,
   isHeadlessAllProvidersEnabled,
 } from './featureFlags.js';


### PR DESCRIPTION
## Explanation

Removes `getHeadlessAllProvidersMinimumVersion` from `@metamask/ramps-controller`. App-version gating for `moneyHeadlessAllProviders` is owned by the LaunchDarkly `versions` wrapper (processed by `RemoteFeatureFlagController`), not a payload `minimumVersion` field. `featureVersion` fail-closed enablement and `providerIds` allowlisting are unchanged.

Supersedes #9658 (fork PR with CI issues). Changes are identical; this PR is from the org repo so the merge-queue CI can resolve the branch correctly.

## References

* Related to #9524

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by updating changelogs for packages I've changed
- [ ] I've introduced breaking changes in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public API removal; consumers importing the helper must update, though runtime headless enablement and allowlisting behavior in this package is unchanged.
> 
> **Overview**
> **Breaking:** Drops the exported `getHeadlessAllProvidersMinimumVersion` helper from `@metamask/ramps-controller` (implementation, package export, and unit tests). The unreleased changelog records that **app-version gating** for `moneyHeadlessAllProviders` is expected to come from the LaunchDarkly **`versions` wrapper** handled by `RemoteFeatureFlagController`, not from a `minimumVersion` field on the flag object payload.
> 
> `isHeadlessAllProvidersEnabled`, `getHeadlessProviderAllowlist`, and `featureVersion` fail-closed behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa04b1508b70baa406af8c795948ec31072867d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->