### PR TITLE
fix: nest AssetsController Sentry sub spans under cold-start parents

### DIFF
--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -14,7 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Nest AssetsController Sentry spans (`AssetsDataSourceTiming`, `AssetsDataSourceError`, `AssetsControllerFirstInitFetch`, pipeline summaries) as subspans under parent `AssetsFullFetch` / `AssetsUpdatePipeline` / `AssetsBackgroundFetch` traces, and emit a single `AggregatedBalanceSelector` span for `calculateBalanceForAllWallets` instead of one root span per account group, to avoid Sentry rate limits ([#9672](https://github.com/MetaMask/core/pull/9672))
-  - Pipeline traces (`AssetsFullFetch`, `AssetsUpdatePipeline`, per-source timings, etc.) run on cold start only (first `#start` fetch per unlock session); later fetches/updates skip Sentry wrapping. Subscription errors and the one-shot state-size trace remain enabled.
+  - `AssetsControllerFirstInitFetch` remains once per unlock session; other pipeline parent traces continue to emit on each full fetch / update.
+  - Dashboard-facing spans (`AssetsFullFetch`, `AssetsUpdatePipeline`, `AggregatedBalanceSelector`, etc.) record `duration_ms` as a Sentry measurement (and backdate `startTime`) so Spans widgets charting `p95(duration_ms)` receive data. Nesting parents use `AssetsFetchPipeline` / `AssetsUpdateEnrichment` / `AssetsBackgroundFetch` / `AggregatedBalance`.
+  - `AggregatedBalanceSelector` is nested under an `AggregatedBalance` parent span via `parentContext`.
 - Bump `@metamask/keyring-api` from `^23.5.0` to `^23.7.0` ([#9676](https://github.com/MetaMask/core/pull/9676))
 - Bump `@metamask/keyring-internal-api` from `^11.0.1` to `^11.0.2` ([#9676](https://github.com/MetaMask/core/pull/9676))
 - Bump `@metamask/keyring-snap-client` from `^9.2.0` to `^9.2.1` ([#9676](https://github.com/MetaMask/core/pull/9676))

--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Nest AssetsController Sentry spans (`AssetsDataSourceTiming`, `AssetsDataSourceError`, `AssetsControllerFirstInitFetch`, pipeline summaries) as subspans under parent `AssetsFullFetch` / `AssetsUpdatePipeline` / `AssetsBackgroundFetch` traces, and emit a single `AggregatedBalanceSelector` span for `calculateBalanceForAllWallets` instead of one root span per account group, to avoid Sentry rate limits
+- Nest AssetsController Sentry spans (`AssetsDataSourceTiming`, `AssetsDataSourceError`, `AssetsControllerFirstInitFetch`, pipeline summaries) as subspans under parent `AssetsFullFetch` / `AssetsUpdatePipeline` / `AssetsBackgroundFetch` traces, and emit a single `AggregatedBalanceSelector` span for `calculateBalanceForAllWallets` instead of one root span per account group, to avoid Sentry rate limits ([#9672](https://github.com/MetaMask/core/pull/9672))
   - Pipeline traces (`AssetsFullFetch`, `AssetsUpdatePipeline`, per-source timings, etc.) run on cold start only (first `#start` fetch per unlock session); later fetches/updates skip Sentry wrapping. Subscription errors and the one-shot state-size trace remain enabled.
 - Bump `@metamask/keyring-api` from `^23.5.0` to `^23.7.0` ([#9676](https://github.com/MetaMask/core/pull/9676))
 - Bump `@metamask/keyring-internal-api` from `^11.0.1` to `^11.0.2` ([#9676](https://github.com/MetaMask/core/pull/9676))

--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Nest AssetsController Sentry spans (`AssetsDataSourceTiming`, `AssetsDataSourceError`, `AssetsControllerFirstInitFetch`, pipeline summaries) as subspans under parent `AssetsFullFetch` / `AssetsUpdatePipeline` / `AssetsBackgroundFetch` traces, and emit a single `AggregatedBalanceSelector` span for `calculateBalanceForAllWallets` instead of one root span per account group, to avoid Sentry rate limits ([#9672](https://github.com/MetaMask/core/pull/9672))
-  - `AssetsControllerFirstInitFetch` remains once per unlock session; other pipeline parent traces continue to emit on each full fetch / update.
+  - Pipeline / data-source / update enrichment spans emit only on the unlock (first-init) fetch per session; later polls, force updates, and subscription enrichment skip tracing.
   - Dashboard-facing spans (`AssetsFullFetch`, `AssetsUpdatePipeline`, `AggregatedBalanceSelector`, etc.) record `duration_ms` as a Sentry measurement (and backdate `startTime`) so Spans widgets charting `p95(duration_ms)` receive data. Nesting parents use `AssetsFetchPipeline` / `AssetsUpdateEnrichment` / `AssetsBackgroundFetch` / `AggregatedBalance`.
   - `AggregatedBalanceSelector` is nested under an `AggregatedBalance` parent span via `parentContext`.
 - Bump `@metamask/keyring-api` from `^23.5.0` to `^23.7.0` ([#9676](https://github.com/MetaMask/core/pull/9676))

--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/keyring-internal-api` from `^11.0.1` to `^11.0.2` ([#9676](https://github.com/MetaMask/core/pull/9676))
 - Bump `@metamask/keyring-snap-client` from `^9.2.0` to `^9.2.1` ([#9676](https://github.com/MetaMask/core/pull/9676))
 
+### Fixed
+
+- `#withTrace` now treats a rejected parent `#trace` promise as best-effort (like `#emitTrace`), so Sentry/adapter failures cannot fail full fetches or `handleAssetsUpdate` enrichment ([#9672](https://github.com/MetaMask/core/pull/9672))
+
 ## [11.2.1]
 
 ### Fixed

--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Nest AssetsController Sentry spans (`AssetsDataSourceTiming`, `AssetsDataSourceError`, `AssetsControllerFirstInitFetch`, pipeline summaries) as subspans under parent `AssetsFullFetch` / `AssetsUpdatePipeline` / `AssetsBackgroundFetch` traces, and emit a single `AggregatedBalanceSelector` span for `calculateBalanceForAllWallets` instead of one root span per account group, to avoid Sentry rate limits
+  - Pipeline traces (`AssetsFullFetch`, `AssetsUpdatePipeline`, per-source timings, etc.) run on cold start only (first `#start` fetch per unlock session); later fetches/updates skip Sentry wrapping. Subscription errors and the one-shot state-size trace remain enabled.
 - Bump `@metamask/keyring-api` from `^23.5.0` to `^23.7.0` ([#9676](https://github.com/MetaMask/core/pull/9676))
 - Bump `@metamask/keyring-internal-api` from `^11.0.1` to `^11.0.2` ([#9676](https://github.com/MetaMask/core/pull/9676))
 - Bump `@metamask/keyring-snap-client` from `^9.2.0` to `^9.2.1` ([#9676](https://github.com/MetaMask/core/pull/9676))

--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Nest AssetsController Sentry spans (`AssetsDataSourceTiming`, `AssetsDataSourceError`, `AssetsControllerFirstInitFetch`, pipeline summaries) as subspans under parent `AssetsFullFetch` / `AssetsUpdatePipeline` / `AssetsBackgroundFetch` traces, and emit a single `AggregatedBalanceSelector` span for `calculateBalanceForAllWallets` instead of one root span per account group, to avoid Sentry rate limits ([#9672](https://github.com/MetaMask/core/pull/9672))
   - Pipeline / data-source / update enrichment spans emit only on the unlock (first-init) fetch per session; later polls, force updates, and subscription enrichment skip tracing.
+  - Tracing helpers live in `utils/trace.ts` (`emitTrace` / `withTrace`); omit `trace` to no-op so call sites stay free of gating `if`s. Fast and background fetch lanes are sibling `withTrace` calls (not nested).
   - Dashboard-facing spans (`AssetsFullFetch`, `AssetsUpdatePipeline`, `AggregatedBalanceSelector`, etc.) record `duration_ms` as a Sentry measurement (and backdate `startTime`) so Spans widgets charting `p95(duration_ms)` receive data. Nesting parents use `AssetsFetchPipeline` / `AssetsUpdateEnrichment` / `AssetsBackgroundFetch` / `AggregatedBalance`.
   - `AggregatedBalanceSelector` is nested under an `AggregatedBalance` parent span via `parentContext`.
 - Bump `@metamask/keyring-api` from `^23.5.0` to `^23.7.0` ([#9676](https://github.com/MetaMask/core/pull/9676))
@@ -23,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `#withTrace` now treats a rejected parent `#trace` promise as best-effort (like `#emitTrace`), so Sentry/adapter failures cannot fail full fetches or `handleAssetsUpdate` enrichment ([#9672](https://github.com/MetaMask/core/pull/9672))
+- `withTrace` treats a rejected parent `trace` promise as best-effort (like `emitTrace`), so Sentry/adapter failures cannot fail full fetches or `handleAssetsUpdate` enrichment ([#9672](https://github.com/MetaMask/core/pull/9672))
 - `SnapDataSource` now delivers snap-sourced balance updates directly to `AssetsController` via a constructor-supplied `onAssetsUpdate` callback instead of fanning out to `activeSubscriptions`, so updates (e.g. Tron energy/bandwidth) are no longer dropped when no active subscription is tracked for the chain in the SnapDataSource ([#9656](https://github.com/MetaMask/core/pull/9656))
 
 ## [11.2.1]

--- a/packages/assets-controller/src/AssetsController.test.ts
+++ b/packages/assets-controller/src/AssetsController.test.ts
@@ -1049,6 +1049,52 @@ describe('AssetsController', () => {
       });
     });
 
+    it('does not fail forceUpdate when parent trace rejects after work completes', async () => {
+      const traceMock = jest.fn().mockImplementation(
+        async (
+          _request: TraceRequest,
+          fn?: (context?: unknown) => unknown,
+        ) => {
+          if (fn) {
+            await fn({ id: 'parent' });
+            // Simulate Sentry/adapter failure after the span callback finishes.
+            throw new Error('telemetry failed');
+          }
+          return undefined;
+        },
+      );
+      const trace = traceMock as unknown as TraceCallback;
+
+      await withController(
+        { controllerOptions: { trace } },
+        async ({ controller }) => {
+          await expect(
+            controller.getAssets([createMockInternalAccount()], {
+              forceUpdate: true,
+            }),
+          ).resolves.toBeDefined();
+        },
+      );
+    });
+
+    it('still runs forceUpdate when parent trace rejects before invoking work', async () => {
+      const traceMock = jest
+        .fn()
+        .mockRejectedValue(new Error('telemetry failed'));
+      const trace = traceMock as unknown as TraceCallback;
+
+      await withController(
+        { controllerOptions: { trace } },
+        async ({ controller }) => {
+          await expect(
+            controller.getAssets([createMockInternalAccount()], {
+              forceUpdate: true,
+            }),
+          ).resolves.toBeDefined();
+        },
+      );
+    });
+
     // Endpoint selection from the flag is unit-tested in AccountsApiDataSource;
     // this asserts the controller wires its messenger through so the
     // `assetsAccountsApiV6` flag drives endpoint selection end-to-end.
@@ -1395,6 +1441,44 @@ describe('AssetsController', () => {
   });
 
   describe('handleAssetsUpdate', () => {
+    it('does not fail when parent trace rejects after enrichment completes', async () => {
+      const traceMock = jest.fn().mockImplementation(
+        async (
+          _request: TraceRequest,
+          fn?: (context?: unknown) => unknown,
+        ) => {
+          if (fn) {
+            await fn({ id: 'parent' });
+            throw new Error('telemetry failed');
+          }
+          return undefined;
+        },
+      );
+      const trace = traceMock as unknown as TraceCallback;
+
+      await withController(
+        { controllerOptions: { trace } },
+        async ({ controller }) => {
+          await expect(
+            controller.handleAssetsUpdate(
+              {
+                updateMode: 'merge',
+                assetsBalance: {
+                  [MOCK_ACCOUNT_ID]: {
+                    [MOCK_ASSET_ID]: { amount: '1' },
+                  },
+                },
+              },
+              'test-source',
+            ),
+          ).resolves.toBeUndefined();
+          expect(
+            controller.state.assetsBalance[MOCK_ACCOUNT_ID]?.[MOCK_ASSET_ID],
+          ).toStrictEqual({ amount: '1' });
+        },
+      );
+    });
+
     it('preserves existing rich metadata when the API response has empty symbol and name', async () => {
       const richMetadata: FungibleAssetMetadata = {
         type: 'erc20',

--- a/packages/assets-controller/src/AssetsController.test.ts
+++ b/packages/assets-controller/src/AssetsController.test.ts
@@ -1068,11 +1068,11 @@ describe('AssetsController', () => {
       await withController(
         { controllerOptions: { trace } },
         async ({ controller }) => {
-          await expect(
-            controller.getAssets([createMockInternalAccount()], {
+          expect(
+            await controller.getAssets([createMockInternalAccount()], {
               forceUpdate: true,
             }),
-          ).resolves.toBeDefined();
+          ).toBeDefined();
         },
       );
     });
@@ -1086,11 +1086,11 @@ describe('AssetsController', () => {
       await withController(
         { controllerOptions: { trace } },
         async ({ controller }) => {
-          await expect(
-            controller.getAssets([createMockInternalAccount()], {
+          expect(
+            await controller.getAssets([createMockInternalAccount()], {
               forceUpdate: true,
             }),
-          ).resolves.toBeDefined();
+          ).toBeDefined();
         },
       );
     });
@@ -1459,8 +1459,8 @@ describe('AssetsController', () => {
       await withController(
         { controllerOptions: { trace } },
         async ({ controller }) => {
-          await expect(
-            controller.handleAssetsUpdate(
+          expect(
+            await controller.handleAssetsUpdate(
               {
                 updateMode: 'merge',
                 assetsBalance: {
@@ -1471,7 +1471,7 @@ describe('AssetsController', () => {
               },
               'test-source',
             ),
-          ).resolves.toBeUndefined();
+          ).toBeUndefined();
           expect(
             controller.state.assetsBalance[MOCK_ACCOUNT_ID]?.[MOCK_ASSET_ID],
           ).toStrictEqual({ amount: '1' });

--- a/packages/assets-controller/src/AssetsController.test.ts
+++ b/packages/assets-controller/src/AssetsController.test.ts
@@ -2481,11 +2481,22 @@ describe('AssetsController', () => {
     });
 
     it('invokes trace with first init fetch trace request on unlock', async () => {
+      const parentSpan = { id: 'assets-full-fetch' };
       const traceMock = jest
         .fn()
         .mockImplementation(
-          async (_request: TraceRequest, fn?: (context?: unknown) => unknown) =>
-            fn?.(),
+          async (
+            request: TraceRequest,
+            fn?: (context?: unknown) => unknown,
+          ) => {
+            if (fn) {
+              // Parent spans (with callback work) provide context for nesting.
+              return fn(
+                request.parentContext === undefined ? parentSpan : undefined,
+              );
+            }
+            return undefined;
+          },
         );
       const trace = traceMock as unknown as TraceCallback;
 
@@ -2520,6 +2531,7 @@ describe('AssetsController', () => {
               chain_ids: expect.any(String),
             }),
             tags: { controller: 'AssetsController' },
+            parentContext: parentSpan,
           });
           const {
             duration_ms: durationMs,
@@ -2529,6 +2541,17 @@ describe('AssetsController', () => {
           expect(durationMs).toBeGreaterThanOrEqual(0);
           expect(typeof chainIds).toBe('string');
           expect(typeof durationByDataSource).toBe('object');
+
+          const timingCalls = traceMock.mock.calls.filter(
+            (call) =>
+              (call[0] as TraceRequest).name === 'AssetsDataSourceTiming',
+          );
+          expect(timingCalls.length).toBeGreaterThan(0);
+          for (const [timingRequest] of timingCalls) {
+            expect(timingRequest).toMatchObject({
+              parentContext: parentSpan,
+            });
+          }
         },
       );
     });
@@ -2605,7 +2628,7 @@ describe('AssetsController', () => {
           clientControllerState: { isUiOpen: true },
           controllerOptions: { trace },
         },
-        async ({ messenger }) => {
+        async ({ controller, messenger }) => {
           // UI must be open and keyring unlocked for asset tracking to run
           (
             messenger as unknown as {
@@ -2624,6 +2647,35 @@ describe('AssetsController', () => {
               'AssetsControllerFirstInitFetch',
           );
           expect(firstInitFetchCalls).toHaveLength(1);
+
+          const fullFetchParentCallsBefore = traceMock.mock.calls.filter(
+            (call) => {
+              const request = call[0] as TraceRequest;
+              return (
+                request.name === 'AssetsFullFetch' &&
+                request.parentContext === undefined &&
+                typeof call[1] === 'function'
+              );
+            },
+          ).length;
+
+          // Later force updates must not open new parent Sentry spans.
+          await controller.getAssets([createMockInternalAccount()], {
+            forceUpdate: true,
+          });
+
+          const fullFetchParentCallsAfter = traceMock.mock.calls.filter(
+            (call) => {
+              const request = call[0] as TraceRequest;
+              return (
+                request.name === 'AssetsFullFetch' &&
+                request.parentContext === undefined &&
+                typeof call[1] === 'function'
+              );
+            },
+          ).length;
+
+          expect(fullFetchParentCallsAfter).toBe(fullFetchParentCallsBefore);
         },
       );
     });

--- a/packages/assets-controller/src/AssetsController.test.ts
+++ b/packages/assets-controller/src/AssetsController.test.ts
@@ -1050,19 +1050,21 @@ describe('AssetsController', () => {
     });
 
     it('does not fail forceUpdate when parent trace rejects after work completes', async () => {
-      const traceMock = jest.fn().mockImplementation(
-        async (
-          _request: TraceRequest,
-          fn?: (context?: unknown) => unknown,
-        ) => {
-          if (fn) {
-            await fn({ id: 'parent' });
-            // Simulate Sentry/adapter failure after the span callback finishes.
-            throw new Error('telemetry failed');
-          }
-          return undefined;
-        },
-      );
+      const traceMock = jest
+        .fn()
+        .mockImplementation(
+          async (
+            _request: TraceRequest,
+            fn?: (context?: unknown) => unknown,
+          ) => {
+            if (fn) {
+              await fn({ id: 'parent' });
+              // Simulate Sentry/adapter failure after the span callback finishes.
+              throw new Error('telemetry failed');
+            }
+            return undefined;
+          },
+        );
       const trace = traceMock as unknown as TraceCallback;
 
       await withController(
@@ -1442,18 +1444,20 @@ describe('AssetsController', () => {
 
   describe('handleAssetsUpdate', () => {
     it('does not fail when parent trace rejects after enrichment completes', async () => {
-      const traceMock = jest.fn().mockImplementation(
-        async (
-          _request: TraceRequest,
-          fn?: (context?: unknown) => unknown,
-        ) => {
-          if (fn) {
-            await fn({ id: 'parent' });
-            throw new Error('telemetry failed');
-          }
-          return undefined;
-        },
-      );
+      const traceMock = jest
+        .fn()
+        .mockImplementation(
+          async (
+            _request: TraceRequest,
+            fn?: (context?: unknown) => unknown,
+          ) => {
+            if (fn) {
+              await fn({ id: 'parent' });
+              throw new Error('telemetry failed');
+            }
+            return undefined;
+          },
+        );
       const trace = traceMock as unknown as TraceCallback;
 
       await withController(

--- a/packages/assets-controller/src/AssetsController.test.ts
+++ b/packages/assets-controller/src/AssetsController.test.ts
@@ -2754,8 +2754,12 @@ describe('AssetsController', () => {
           const fullFetchCallsBefore = traceMock.mock.calls.filter(
             (call) => (call[0] as TraceRequest).name === 'AssetsFullFetch',
           ).length;
+          const timingCallsBefore = traceMock.mock.calls.filter(
+            (call) =>
+              (call[0] as TraceRequest).name === 'AssetsDataSourceTiming',
+          ).length;
 
-          // Later force updates still emit AssetsFullFetch summary spans.
+          // Later force updates must not emit pipeline spans (unlock-only tracing).
           await controller.getAssets([createMockInternalAccount()], {
             forceUpdate: true,
           });
@@ -2763,8 +2767,13 @@ describe('AssetsController', () => {
           const fullFetchCallsAfter = traceMock.mock.calls.filter(
             (call) => (call[0] as TraceRequest).name === 'AssetsFullFetch',
           ).length;
+          const timingCallsAfter = traceMock.mock.calls.filter(
+            (call) =>
+              (call[0] as TraceRequest).name === 'AssetsDataSourceTiming',
+          ).length;
 
-          expect(fullFetchCallsAfter).toBeGreaterThan(fullFetchCallsBefore);
+          expect(fullFetchCallsAfter).toBe(fullFetchCallsBefore);
+          expect(timingCallsAfter).toBe(timingCallsBefore);
         },
       );
     });

--- a/packages/assets-controller/src/AssetsController.test.ts
+++ b/packages/assets-controller/src/AssetsController.test.ts
@@ -2530,7 +2530,11 @@ describe('AssetsController', () => {
               duration_ms: expect.any(Number),
               chain_ids: expect.any(String),
             }),
-            tags: { controller: 'AssetsController' },
+            tags: expect.objectContaining({
+              controller: 'AssetsController',
+              duration_ms: expect.any(Number),
+            }),
+            startTime: expect.any(Number),
             parentContext: parentSpan,
           });
           const {
@@ -2541,6 +2545,21 @@ describe('AssetsController', () => {
           expect(durationMs).toBeGreaterThanOrEqual(0);
           expect(typeof chainIds).toBe('string');
           expect(typeof durationByDataSource).toBe('object');
+
+          const fullFetchCalls = traceMock.mock.calls.filter(
+            (call) => (call[0] as TraceRequest).name === 'AssetsFullFetch',
+          );
+          expect(fullFetchCalls.length).toBeGreaterThan(0);
+          expect(fullFetchCalls[0][0]).toMatchObject({
+            data: expect.objectContaining({
+              duration_ms: expect.any(Number),
+            }),
+            tags: expect.objectContaining({
+              duration_ms: expect.any(Number),
+            }),
+            startTime: expect.any(Number),
+            parentContext: parentSpan,
+          });
 
           const timingCalls = traceMock.mock.calls.filter(
             (call) =>
@@ -2614,7 +2633,7 @@ describe('AssetsController', () => {
       );
     });
 
-    it('invokes trace only once per session until lock', async () => {
+    it('invokes first-init fetch trace only once per session until lock', async () => {
       const traceMock = jest
         .fn()
         .mockImplementation(
@@ -2648,34 +2667,20 @@ describe('AssetsController', () => {
           );
           expect(firstInitFetchCalls).toHaveLength(1);
 
-          const fullFetchParentCallsBefore = traceMock.mock.calls.filter(
-            (call) => {
-              const request = call[0] as TraceRequest;
-              return (
-                request.name === 'AssetsFullFetch' &&
-                request.parentContext === undefined &&
-                typeof call[1] === 'function'
-              );
-            },
+          const fullFetchCallsBefore = traceMock.mock.calls.filter(
+            (call) => (call[0] as TraceRequest).name === 'AssetsFullFetch',
           ).length;
 
-          // Later force updates must not open new parent Sentry spans.
+          // Later force updates still emit AssetsFullFetch summary spans.
           await controller.getAssets([createMockInternalAccount()], {
             forceUpdate: true,
           });
 
-          const fullFetchParentCallsAfter = traceMock.mock.calls.filter(
-            (call) => {
-              const request = call[0] as TraceRequest;
-              return (
-                request.name === 'AssetsFullFetch' &&
-                request.parentContext === undefined &&
-                typeof call[1] === 'function'
-              );
-            },
+          const fullFetchCallsAfter = traceMock.mock.calls.filter(
+            (call) => (call[0] as TraceRequest).name === 'AssetsFullFetch',
           ).length;
 
-          expect(fullFetchParentCallsAfter).toBe(fullFetchParentCallsBefore);
+          expect(fullFetchCallsAfter).toBeGreaterThan(fullFetchCallsBefore);
         },
       );
     });

--- a/packages/assets-controller/src/AssetsController.ts
+++ b/packages/assets-controller/src/AssetsController.ts
@@ -12,7 +12,7 @@ import type {
 } from '@metamask/base-controller';
 import type { ClientControllerStateChangeEvent } from '@metamask/client-controller';
 import { clientControllerSelectors } from '@metamask/client-controller';
-import type { TraceCallback } from '@metamask/controller-utils';
+import type { TraceCallback, TraceContext } from '@metamask/controller-utils';
 import type {
   ApiPlatformClient,
   AccountActivityServiceBalanceUpdatedEvent,
@@ -211,6 +211,7 @@ const DEFAULT_POLLING_INTERVAL_MS = 30_000;
 // ============================================================================
 const TRACE_FIRST_INIT_FETCH = 'AssetsControllerFirstInitFetch';
 const TRACE_FULL_FETCH = 'AssetsFullFetch';
+const TRACE_BACKGROUND_FETCH = 'AssetsBackgroundFetch';
 const TRACE_DATA_SOURCE_TIMING = 'AssetsDataSourceTiming';
 const TRACE_DATA_SOURCE_ERROR = 'AssetsDataSourceError';
 const TRACE_UPDATE_PIPELINE = 'AssetsUpdatePipeline';
@@ -666,10 +667,17 @@ export class AssetsController extends BaseController<
 
   /**
    * Fire-and-forget trace helper. Swallows errors so telemetry never breaks the controller.
+   * Pass `parentContext` to record a Sentry **subspan** instead of a new root transaction
+   * (avoids rate-limiting when many timings fire per fetch).
+   *
+   * After the cold-start fetch has been reported, only nested spans (with
+   * `parentContext`) and always-on traces are emitted — subsequent fetches/updates
+   * do not create new Sentry transactions.
    *
    * @param name - Trace / span name visible in Sentry.
    * @param data - Key-value pairs attached as span data.
    * @param tags - Key-value pairs used for Sentry filtering.
+   * @param parentContext - Optional parent span context for nesting as a subspan.
    */
   #emitTrace(
     name: string,
@@ -677,13 +685,55 @@ export class AssetsController extends BaseController<
     tags: Record<string, number | string | boolean> = {
       controller: 'AssetsController',
     },
+    parentContext?: TraceContext,
   ): void {
     if (!this.#trace) {
       return;
     }
-    this.#trace({ name, data, tags }, () => undefined)?.catch(() => {
-      // Telemetry failure must not break.
-    });
+    // Cold-start only: skip root spans after the first init fetch. Nested
+    // subspans (parentContext set) and error/state-size traces still allowed.
+    if (
+      this.#firstInitFetchReported &&
+      parentContext === undefined &&
+      name !== TRACE_SUBSCRIPTION_ERROR &&
+      name !== TRACE_STATE_SIZE
+    ) {
+      return;
+    }
+    this.#trace({ name, data, tags, parentContext }, () => undefined)?.catch(
+      () => {
+        // Telemetry failure must not break.
+      },
+    );
+  }
+
+  /**
+   * Run work inside a parent Sentry span and pass its context so callers can
+   * emit nested subspans via {@link #emitTrace}.
+   *
+   * Only wraps work on cold start (before the first init fetch is reported).
+   * Later calls still run `fn`, but without creating a Sentry parent span.
+   *
+   * @param name - Parent span name.
+   * @param data - Key-value pairs attached as span data.
+   * @param fn - Work to run; receives the parent span context.
+   * @param tags - Key-value pairs used for Sentry filtering.
+   * @returns The result of `fn`.
+   */
+  async #withTrace<Result>(
+    name: string,
+    data: Record<string, number | string | boolean>,
+    fn: (parentContext?: TraceContext) => Promise<Result>,
+    tags: Record<string, number | string | boolean> = {
+      controller: 'AssetsController',
+    },
+  ): Promise<Result> {
+    if (!this.#trace || this.#firstInitFetchReported) {
+      return fn(undefined);
+    }
+    return await this.#trace({ name, data, tags }, (parentContext) =>
+      fn(parentContext),
+    );
   }
 
   /**
@@ -1499,12 +1549,14 @@ export class AssetsController extends BaseController<
    * @param sources - Data sources or middlewares with getName() and assetsMiddleware (executed in order).
    * @param request - The data request.
    * @param initialResponse - Optional initial response (for enriching existing data).
+   * @param parentContext - Optional parent Sentry span; per-source timings nest under it.
    * @returns Response and durationByDataSource (exclusive ms per source name).
    */
   async #executeMiddlewares(
     sources: AssetsDataSource[],
     request: DataRequest,
     initialResponse: DataResponse = {},
+    parentContext?: TraceContext,
   ): Promise<{
     response: DataResponse;
     durationByDataSource: Record<string, number>;
@@ -1574,16 +1626,21 @@ export class AssetsController extends BaseController<
       }
     }
 
-    // Emit per-source timing traces for the Assets Health dashboard
+    // Emit per-source timing as subspans under the parent fetch/update span
     for (const [sourceName, durationMs] of Object.entries(
       durationByDataSource,
     )) {
-      this.#emitTrace(TRACE_DATA_SOURCE_TIMING, {
-        source: sourceName,
-        duration_ms: durationMs,
-        chain_count: request.chainIds.length,
-        account_count: request.accountsWithSupportedChains.length,
-      });
+      this.#emitTrace(
+        TRACE_DATA_SOURCE_TIMING,
+        {
+          source: sourceName,
+          duration_ms: durationMs,
+          chain_count: request.chainIds.length,
+          account_count: request.accountsWithSupportedChains.length,
+        },
+        { controller: 'AssetsController' },
+        parentContext,
+      );
     }
 
     // Failed middlewares: Issues (optional) + perf/Dashboard spans
@@ -1611,6 +1668,7 @@ export class AssetsController extends BaseController<
           severity: 'error',
           error_type: assetsError.name,
         },
+        parentContext,
       );
     }
 
@@ -1649,115 +1707,154 @@ export class AssetsController extends BaseController<
     }
 
     if (options?.forceUpdate) {
-      const startTime = performance.now();
-      const request = this.#buildDataRequest(accounts, chainIds, {
-        assetTypes,
-        dataTypes,
-        customAssets: customAssets.length > 0 ? customAssets : undefined,
-        forceUpdate: true,
-        assetsForPriceUpdate: options?.assetsForPriceUpdate,
-      });
-      // Fast pipeline: accountsApi + stakedBalance → detection → token + price.
-      // Snap and RPC are excluded here due to their latency (snap triggers account
-      // creation, RPC is slow on many chains). Results are committed to state
-      // immediately so the UI can display balances without waiting for them.
-      //
-      // Fast/slow pipelines use merge so partial API snapshots cannot wipe
-      // tokens missing from the response (e.g. USDC when only native balance
-      // is returned). Balances present in the response are still refreshed.
-      const fastSources = this.#isBasicFunctionality()
-        ? [
-            createParallelBalanceMiddleware([
-              this.#accountsApiDataSource,
-              this.#stakedBalanceDataSource,
-            ]),
-            // Graduation must run BEFORE the RPC fallback so it only sees
-            // AccountsApi/Websocket balances. RPC intentionally carries
-            // custom assets and must never trigger graduation.
-            this.#customAssetGraduationMiddleware,
-            this.#rpcFallbackMiddleware,
-            this.#detectionMiddleware,
-            createParallelMiddleware([
-              this.#tokenDataSource,
-              this.#priceDataSource,
-            ]),
-          ]
-        : [this.#stakedBalanceDataSource, this.#detectionMiddleware];
-      const { response, durationByDataSource } = await this.#executeMiddlewares(
-        fastSources,
-        request,
+      await this.#withTrace(
+        TRACE_FULL_FETCH,
+        {
+          chain_count: chainIds.length,
+          account_count: accounts.length,
+          basic_functionality: this.#isBasicFunctionality(),
+        },
+        async (parentContext) => {
+          const startTime = performance.now();
+          const request = this.#buildDataRequest(accounts, chainIds, {
+            assetTypes,
+            dataTypes,
+            customAssets: customAssets.length > 0 ? customAssets : undefined,
+            forceUpdate: true,
+            assetsForPriceUpdate: options?.assetsForPriceUpdate,
+          });
+          // Fast pipeline: accountsApi + stakedBalance → detection → token + price.
+          // Snap and RPC are excluded here due to their latency (snap triggers account
+          // creation, RPC is slow on many chains). Results are committed to state
+          // immediately so the UI can display balances without waiting for them.
+          //
+          // Fast/slow pipelines use merge so partial API snapshots cannot wipe
+          // tokens missing from the response (e.g. USDC when only native balance
+          // is returned). Balances present in the response are still refreshed.
+          const fastSources = this.#isBasicFunctionality()
+            ? [
+                createParallelBalanceMiddleware([
+                  this.#accountsApiDataSource,
+                  this.#stakedBalanceDataSource,
+                ]),
+                // Graduation must run BEFORE the RPC fallback so it only sees
+                // AccountsApi/Websocket balances. RPC intentionally carries
+                // custom assets and must never trigger graduation.
+                this.#customAssetGraduationMiddleware,
+                this.#rpcFallbackMiddleware,
+                this.#detectionMiddleware,
+                createParallelMiddleware([
+                  this.#tokenDataSource,
+                  this.#priceDataSource,
+                ]),
+              ]
+            : [this.#stakedBalanceDataSource, this.#detectionMiddleware];
+          const { response, durationByDataSource } =
+            await this.#executeMiddlewares(
+              fastSources,
+              request,
+              {},
+              parentContext,
+            );
+          await this.#updateState({
+            ...response,
+            updateMode: 'merge',
+            replaceCoveredChainBalances: true,
+          });
+
+          // Background pipeline: snap and RPC run in parallel after the fast path
+          // commits to state. Their balances are merged together before detection.
+          // Token + price enrichment matches the pre-split behavior: only when basic
+          // functionality is on (RPC-only mode must not call token/price APIs).
+          // Own parent span so timings nest instead of becoming extra root traces
+          // after the fast-path parent has ended.
+          const slowPipelineChainIds = this.#getSlowPipelineChainIds(
+            chainIds,
+            response,
+          );
+
+          if (slowPipelineChainIds.length > 0) {
+            const slowSources = this.#isBasicFunctionality()
+              ? [this.#snapDataSource, this.#rpcDataSource]
+              : [this.#rpcDataSource];
+
+            const slowRequest = { ...request, chainIds: slowPipelineChainIds };
+
+            this.#withTrace(
+              TRACE_BACKGROUND_FETCH,
+              {
+                chain_count: slowPipelineChainIds.length,
+                account_count: accounts.length,
+              },
+              async (slowParentContext) => {
+                const { response: slowResponse } =
+                  await this.#executeMiddlewares(
+                    [
+                      createParallelBalanceMiddleware(slowSources),
+                      this.#detectionMiddleware,
+                      ...(this.#isBasicFunctionality()
+                        ? [
+                            createParallelMiddleware([
+                              this.#tokenDataSource,
+                              this.#priceDataSource,
+                            ]),
+                          ]
+                        : []),
+                    ],
+                    slowRequest,
+                    {},
+                    slowParentContext,
+                  );
+                await this.#updateState({
+                  ...slowResponse,
+                  updateMode: 'merge',
+                });
+              },
+            ).catch((error) => log('Background pipeline failed', { error }));
+          }
+
+          const durationMs = performance.now() - startTime;
+
+          // Summary fields for Assets Health (nested under the parent span so
+          // they do not create additional root transactions).
+          this.#emitTrace(
+            TRACE_FULL_FETCH,
+            {
+              duration_ms: durationMs,
+              chain_count: chainIds.length,
+              account_count: accounts.length,
+              basic_functionality: this.#isBasicFunctionality(),
+              asset_count: response.assetsBalance
+                ? Object.values(response.assetsBalance).reduce(
+                    (sum, acct) => sum + Object.keys(acct).length,
+                    0,
+                  )
+                : 0,
+              price_count: response.assetsPrice
+                ? Object.keys(response.assetsPrice).length
+                : 0,
+              ...durationByDataSource,
+            },
+            { controller: 'AssetsController' },
+            parentContext,
+          );
+
+          if (!this.#firstInitFetchReported) {
+            this.#emitTrace(
+              TRACE_FIRST_INIT_FETCH,
+              {
+                duration_ms: durationMs,
+                chain_ids: JSON.stringify(chainIds),
+                ...durationByDataSource,
+              },
+              { controller: 'AssetsController' },
+              parentContext,
+            );
+            // Mark after emitting so the first-init span itself is not gated.
+            this.#firstInitFetchReported = true;
+          }
+        },
       );
-      await this.#updateState({
-        ...response,
-        updateMode: 'merge',
-        replaceCoveredChainBalances: true,
-      });
-
-      // Background pipeline: snap and RPC run in parallel after the fast path
-      // commits to state. Their balances are merged together before detection.
-      // Token + price enrichment matches the pre-split behavior: only when basic
-      // functionality is on (RPC-only mode must not call token/price APIs).
-      const slowPipelineChainIds = this.#getSlowPipelineChainIds(
-        chainIds,
-        response,
-      );
-
-      if (slowPipelineChainIds.length > 0) {
-        const slowSources = this.#isBasicFunctionality()
-          ? [this.#snapDataSource, this.#rpcDataSource]
-          : [this.#rpcDataSource];
-
-        const slowRequest = { ...request, chainIds: slowPipelineChainIds };
-
-        this.#executeMiddlewares(
-          [
-            createParallelBalanceMiddleware(slowSources),
-            this.#detectionMiddleware,
-            ...(this.#isBasicFunctionality()
-              ? [
-                  createParallelMiddleware([
-                    this.#tokenDataSource,
-                    this.#priceDataSource,
-                  ]),
-                ]
-              : []),
-          ],
-          slowRequest,
-        )
-          .then(({ response: slowResponse }) =>
-            this.#updateState({ ...slowResponse, updateMode: 'merge' }),
-          )
-          .catch((error) => log('Background pipeline failed', { error }));
-      }
-
-      const durationMs = performance.now() - startTime;
-
-      // Emit trace for every full fetch (Assets Health dashboard)
-      this.#emitTrace(TRACE_FULL_FETCH, {
-        duration_ms: durationMs,
-        chain_count: chainIds.length,
-        account_count: accounts.length,
-        basic_functionality: this.#isBasicFunctionality(),
-        asset_count: response.assetsBalance
-          ? Object.values(response.assetsBalance).reduce(
-              (sum, acct) => sum + Object.keys(acct).length,
-              0,
-            )
-          : 0,
-        price_count: response.assetsPrice
-          ? Object.keys(response.assetsPrice).length
-          : 0,
-        ...durationByDataSource,
-      });
-
-      if (!this.#firstInitFetchReported) {
-        this.#firstInitFetchReported = true;
-        this.#emitTrace(TRACE_FIRST_INIT_FETCH, {
-          duration_ms: durationMs,
-          chain_ids: JSON.stringify(chainIds),
-          ...durationByDataSource,
-        });
-      }
     }
 
     const result = this.#getAssetsFromState(accounts, chainIds, assetTypes);
@@ -3676,75 +3773,95 @@ export class AssetsController extends BaseController<
     sourceId: string,
     request?: DataRequest,
   ): Promise<void> {
-    const updateStart = performance.now();
-
     log('Assets updated from data source', {
       sourceId,
       hasBalance: Boolean(response.assetsBalance),
       hasPrice: Boolean(response.assetsPrice),
     });
 
-    const resolvedRequest: DataRequest = request ?? {
-      accountsWithSupportedChains: [],
-      chainIds: [],
-      dataTypes: ['balance', 'metadata', 'price'],
-    };
+    await this.#withTrace(
+      TRACE_UPDATE_PIPELINE,
+      {
+        source: sourceId,
+        has_balance: Boolean(response.assetsBalance),
+        has_price: Boolean(response.assetsPrice),
+        balance_account_count: response.assetsBalance
+          ? Object.keys(response.assetsBalance).length
+          : 0,
+      },
+      async (parentContext) => {
+        const updateStart = performance.now();
 
-    // RPC-only mode (basic functionality off): never run token/price APIs. Strip
-    // those data types so downstream middleware cannot treat them as requested.
-    const pipelineRequest: DataRequest = this.#isBasicFunctionality()
-      ? resolvedRequest
-      : {
-          ...resolvedRequest,
-          dataTypes: resolvedRequest.dataTypes.filter(
-            (dt) => dt !== 'metadata' && dt !== 'price',
-          ),
+        const resolvedRequest: DataRequest = request ?? {
+          accountsWithSupportedChains: [],
+          chainIds: [],
+          dataTypes: ['balance', 'metadata', 'price'],
         };
 
-    // Graduate custom assets only when AccountsAPI / Websocket reports them.
-    // RPC already fetches custom assets on purpose, and Snap handles non-EVM
-    // chains the rule does not apply to, so skip the middleware for those.
-    const shouldGraduateCustomAssets =
-      sourceId === 'AccountsApiDataSource' ||
-      sourceId === 'BackendWebsocketDataSource' ||
-      sourceId === 'AccountActivityService';
+        // RPC-only mode (basic functionality off): never run token/price APIs. Strip
+        // those data types so downstream middleware cannot treat them as requested.
+        const pipelineRequest: DataRequest = this.#isBasicFunctionality()
+          ? resolvedRequest
+          : {
+              ...resolvedRequest,
+              dataTypes: resolvedRequest.dataTypes.filter(
+                (dt) => dt !== 'metadata' && dt !== 'price',
+              ),
+            };
 
-    const enrichmentSources: AssetsDataSource[] = [
-      ...(shouldGraduateCustomAssets
-        ? [this.#customAssetGraduationMiddleware]
-        : []),
-      this.#detectionMiddleware,
-    ];
-    if (this.#isBasicFunctionality()) {
-      enrichmentSources.push(
-        createParallelMiddleware([
-          this.#tokenDataSource,
-          this.#priceDataSource,
-        ]),
-      );
-    }
+        // Graduate custom assets only when AccountsAPI / Websocket reports them.
+        // RPC already fetches custom assets on purpose, and Snap handles non-EVM
+        // chains the rule does not apply to, so skip the middleware for those.
+        const shouldGraduateCustomAssets =
+          sourceId === 'AccountsApiDataSource' ||
+          sourceId === 'BackendWebsocketDataSource' ||
+          sourceId === 'AccountActivityService';
 
-    const { response: enrichedResponse } = await this.#executeMiddlewares(
-      enrichmentSources,
-      pipelineRequest,
-      response,
+        const enrichmentSources: AssetsDataSource[] = [
+          ...(shouldGraduateCustomAssets
+            ? [this.#customAssetGraduationMiddleware]
+            : []),
+          this.#detectionMiddleware,
+        ];
+        if (this.#isBasicFunctionality()) {
+          enrichmentSources.push(
+            createParallelMiddleware([
+              this.#tokenDataSource,
+              this.#priceDataSource,
+            ]),
+          );
+        }
+
+        const { response: enrichedResponse } = await this.#executeMiddlewares(
+          enrichmentSources,
+          pipelineRequest,
+          response,
+          parentContext,
+        );
+
+        await this.#updateState({
+          ...enrichedResponse,
+          replaceCoveredChainBalances: response.replaceCoveredChainBalances,
+        });
+
+        // Summary fields for Assets Health (nested under the parent span).
+        this.#emitTrace(
+          TRACE_UPDATE_PIPELINE,
+          {
+            source: sourceId,
+            duration_ms: performance.now() - updateStart,
+            has_balance: Boolean(response.assetsBalance),
+            has_price: Boolean(response.assetsPrice),
+            has_metadata: Boolean(enrichedResponse.assetsInfo),
+            balance_account_count: response.assetsBalance
+              ? Object.keys(response.assetsBalance).length
+              : 0,
+          },
+          { controller: 'AssetsController' },
+          parentContext,
+        );
+      },
     );
-
-    await this.#updateState({
-      ...enrichedResponse,
-      replaceCoveredChainBalances: response.replaceCoveredChainBalances,
-    });
-
-    this.#emitTrace(TRACE_UPDATE_PIPELINE, {
-      source: sourceId,
-      duration_ms: performance.now() - updateStart,
-      has_balance: Boolean(response.assetsBalance),
-      has_price: Boolean(response.assetsPrice),
-      has_metadata: Boolean(enrichedResponse.assetsInfo),
-      balance_account_count: response.assetsBalance
-        ? Object.keys(response.assetsBalance).length
-        : 0,
-    });
   }
 
   // ============================================================================

--- a/packages/assets-controller/src/AssetsController.ts
+++ b/packages/assets-controller/src/AssetsController.ts
@@ -1778,7 +1778,9 @@ export class AssetsController extends BaseController<
       // tracing so polling does not flood Sentry.
       const shouldTrace = !this.#firstInitFetchReported;
 
-      const runFullFetch = async (parentContext?: TraceContext) => {
+      const runFullFetch = async (
+        parentContext?: TraceContext,
+      ): Promise<void> => {
         const startTime = performance.now();
         const request = this.#buildDataRequest(accounts, chainIds, {
           assetTypes,
@@ -1845,7 +1847,9 @@ export class AssetsController extends BaseController<
 
           const slowRequest = { ...request, chainIds: slowPipelineChainIds };
 
-          const runBackground = async (slowParentContext?: TraceContext) => {
+          const runBackground = async (
+            slowParentContext?: TraceContext,
+          ): Promise<void> => {
             const { response: slowResponse } = await this.#executeMiddlewares(
               [
                 createParallelBalanceMiddleware(slowSources),
@@ -3870,7 +3874,7 @@ export class AssetsController extends BaseController<
     // Enrichment spans only before unlock/first-init fetch completes.
     const shouldTrace = !this.#firstInitFetchReported;
 
-    const runUpdate = async (parentContext?: TraceContext) => {
+    const runUpdate = async (parentContext?: TraceContext): Promise<void> => {
       const updateStart = performance.now();
 
       const resolvedRequest: DataRequest = request ?? {

--- a/packages/assets-controller/src/AssetsController.ts
+++ b/packages/assets-controller/src/AssetsController.ts
@@ -1604,6 +1604,7 @@ export class AssetsController extends BaseController<
    * @param request - The data request.
    * @param initialResponse - Optional initial response (for enriching existing data).
    * @param parentContext - Optional parent Sentry span; per-source timings nest under it.
+   * @param emitTraces - When true, emit timing/error spans (unlock/first-init only).
    * @returns Response and durationByDataSource (exclusive ms per source name).
    */
   async #executeMiddlewares(
@@ -1611,6 +1612,7 @@ export class AssetsController extends BaseController<
     request: DataRequest,
     initialResponse: DataResponse = {},
     parentContext?: TraceContext,
+    emitTraces = false,
   ): Promise<{
     response: DataResponse;
     durationByDataSource: Record<string, number>;
@@ -1680,25 +1682,28 @@ export class AssetsController extends BaseController<
       }
     }
 
-    // Emit per-source timing as subspans under the parent fetch/update span
-    for (const [sourceName, durationMs] of Object.entries(
-      durationByDataSource,
-    )) {
-      this.#emitTrace(
-        TRACE_DATA_SOURCE_TIMING,
-        {
-          source: sourceName,
-          duration_ms: durationMs,
-          chain_count: request.chainIds.length,
-          account_count: request.accountsWithSupportedChains.length,
-        },
-        {
-          controller: 'AssetsController',
-          // String tag so Spans widgets can group by `source`.
-          source: sourceName,
-        },
-        parentContext,
-      );
+    // Unlock/first-init only — later polls and subscription updates would spam Sentry.
+    if (emitTraces) {
+      // Emit per-source timing as subspans under the parent fetch/update span
+      for (const [sourceName, durationMs] of Object.entries(
+        durationByDataSource,
+      )) {
+        this.#emitTrace(
+          TRACE_DATA_SOURCE_TIMING,
+          {
+            source: sourceName,
+            duration_ms: durationMs,
+            chain_count: request.chainIds.length,
+            account_count: request.accountsWithSupportedChains.length,
+          },
+          {
+            controller: 'AssetsController',
+            // String tag so Spans widgets can group by `source`.
+            source: sourceName,
+          },
+          parentContext,
+        );
+      }
     }
 
     // Failed middlewares: Issues (optional) + perf/Dashboard spans
@@ -1714,20 +1719,22 @@ export class AssetsController extends BaseController<
       } catch {
         // Never let telemetry throw.
       }
-      this.#emitTrace(
-        TRACE_DATA_SOURCE_ERROR,
-        {
-          failed_sources: failedSources,
-          error_count: middlewareErrors.length,
-          chain_count: request.chainIds.length,
-        },
-        {
-          controller: 'AssetsController',
-          severity: 'error',
-          error_type: assetsError.name,
-        },
-        parentContext,
-      );
+      if (emitTraces) {
+        this.#emitTrace(
+          TRACE_DATA_SOURCE_ERROR,
+          {
+            failed_sources: failedSources,
+            error_count: middlewareErrors.length,
+            chain_count: request.chainIds.length,
+          },
+          {
+            controller: 'AssetsController',
+            severity: 'error',
+            error_type: assetsError.name,
+          },
+          parentContext,
+        );
+      }
     }
 
     return { response: result.response, durationByDataSource };
@@ -1765,154 +1772,175 @@ export class AssetsController extends BaseController<
     }
 
     if (options?.forceUpdate) {
-      await this.#withTrace(
-        TRACE_FETCH_PIPELINE,
-        {
-          chain_count: chainIds.length,
-          account_count: accounts.length,
-          basic_functionality: this.#isBasicFunctionality(),
-        },
-        async (parentContext) => {
-          const startTime = performance.now();
-          const request = this.#buildDataRequest(accounts, chainIds, {
-            assetTypes,
-            dataTypes,
-            customAssets: customAssets.length > 0 ? customAssets : undefined,
-            forceUpdate: true,
-            assetsForPriceUpdate: options?.assetsForPriceUpdate,
-          });
-          // Fast pipeline: accountsApi + stakedBalance → detection → token + price.
-          // Snap and RPC are excluded here due to their latency (snap triggers account
-          // creation, RPC is slow on many chains). Results are committed to state
-          // immediately so the UI can display balances without waiting for them.
-          //
-          // Fast/slow pipelines use merge so partial API snapshots cannot wipe
-          // tokens missing from the response (e.g. USDC when only native balance
-          // is returned). Balances present in the response are still refreshed.
-          const fastSources = this.#isBasicFunctionality()
-            ? [
-                createParallelBalanceMiddleware([
-                  this.#accountsApiDataSource,
-                  this.#stakedBalanceDataSource,
-                ]),
-                // Graduation must run BEFORE the RPC fallback so it only sees
-                // AccountsApi/Websocket balances. RPC intentionally carries
-                // custom assets and must never trigger graduation.
-                this.#customAssetGraduationMiddleware,
-                this.#rpcFallbackMiddleware,
-                this.#detectionMiddleware,
-                createParallelMiddleware([
-                  this.#tokenDataSource,
-                  this.#priceDataSource,
-                ]),
-              ]
-            : [this.#stakedBalanceDataSource, this.#detectionMiddleware];
-          const { response, durationByDataSource } =
-            await this.#executeMiddlewares(
-              fastSources,
-              request,
-              {},
-              parentContext,
-            );
-          await this.#updateState({
-            ...response,
-            updateMode: 'merge',
-            replaceCoveredChainBalances: true,
-          });
+      // Pipeline spans only on unlock/first-init fetch; later forceUpdates skip
+      // tracing so polling does not flood Sentry.
+      const shouldTrace = !this.#firstInitFetchReported;
 
-          // Background pipeline: snap and RPC run in parallel after the fast path
-          // commits to state. Their balances are merged together before detection.
-          // Token + price enrichment matches the pre-split behavior: only when basic
-          // functionality is on (RPC-only mode must not call token/price APIs).
-          // Own parent span so timings nest instead of becoming extra root traces
-          // after the fast-path parent has ended.
-          const slowPipelineChainIds = this.#getSlowPipelineChainIds(
-            chainIds,
-            response,
-          );
-
-          if (slowPipelineChainIds.length > 0) {
-            const slowSources = this.#isBasicFunctionality()
-              ? [this.#snapDataSource, this.#rpcDataSource]
-              : [this.#rpcDataSource];
-
-            const slowRequest = { ...request, chainIds: slowPipelineChainIds };
-
-            this.#withTrace(
-              TRACE_BACKGROUND_FETCH,
-              {
-                chain_count: slowPipelineChainIds.length,
-                account_count: accounts.length,
-              },
-              async (slowParentContext) => {
-                const { response: slowResponse } =
-                  await this.#executeMiddlewares(
-                    [
-                      createParallelBalanceMiddleware(slowSources),
-                      this.#detectionMiddleware,
-                      ...(this.#isBasicFunctionality()
-                        ? [
-                            createParallelMiddleware([
-                              this.#tokenDataSource,
-                              this.#priceDataSource,
-                            ]),
-                          ]
-                        : []),
-                    ],
-                    slowRequest,
-                    {},
-                    slowParentContext,
-                  );
-                await this.#updateState({
-                  ...slowResponse,
-                  updateMode: 'merge',
-                });
-              },
-            ).catch((error) => log('Background pipeline failed', { error }));
-          }
-
-          const durationMs = performance.now() - startTime;
-
-          // Summary fields for Assets Health (nested under the parent span so
-          // they do not create additional root transactions).
-          this.#emitTrace(
-            TRACE_FULL_FETCH,
-            {
-              duration_ms: durationMs,
-              chain_count: chainIds.length,
-              account_count: accounts.length,
-              basic_functionality: this.#isBasicFunctionality(),
-              asset_count: response.assetsBalance
-                ? Object.values(response.assetsBalance).reduce(
-                    (sum, acct) => sum + Object.keys(acct).length,
-                    0,
-                  )
-                : 0,
-              price_count: response.assetsPrice
-                ? Object.keys(response.assetsPrice).length
-                : 0,
-              ...durationByDataSource,
-            },
-            { controller: 'AssetsController' },
+      const runFullFetch = async (parentContext?: TraceContext) => {
+        const startTime = performance.now();
+        const request = this.#buildDataRequest(accounts, chainIds, {
+          assetTypes,
+          dataTypes,
+          customAssets: customAssets.length > 0 ? customAssets : undefined,
+          forceUpdate: true,
+          assetsForPriceUpdate: options?.assetsForPriceUpdate,
+        });
+        // Fast pipeline: accountsApi + stakedBalance → detection → token + price.
+        // Snap and RPC are excluded here due to their latency (snap triggers account
+        // creation, RPC is slow on many chains). Results are committed to state
+        // immediately so the UI can display balances without waiting for them.
+        //
+        // Fast/slow pipelines use merge so partial API snapshots cannot wipe
+        // tokens missing from the response (e.g. USDC when only native balance
+        // is returned). Balances present in the response are still refreshed.
+        const fastSources = this.#isBasicFunctionality()
+          ? [
+              createParallelBalanceMiddleware([
+                this.#accountsApiDataSource,
+                this.#stakedBalanceDataSource,
+              ]),
+              // Graduation must run BEFORE the RPC fallback so it only sees
+              // AccountsApi/Websocket balances. RPC intentionally carries
+              // custom assets and must never trigger graduation.
+              this.#customAssetGraduationMiddleware,
+              this.#rpcFallbackMiddleware,
+              this.#detectionMiddleware,
+              createParallelMiddleware([
+                this.#tokenDataSource,
+                this.#priceDataSource,
+              ]),
+            ]
+          : [this.#stakedBalanceDataSource, this.#detectionMiddleware];
+        const { response, durationByDataSource } =
+          await this.#executeMiddlewares(
+            fastSources,
+            request,
+            {},
             parentContext,
+            shouldTrace,
           );
+        await this.#updateState({
+          ...response,
+          updateMode: 'merge',
+          replaceCoveredChainBalances: true,
+        });
 
-          if (!this.#firstInitFetchReported) {
-            this.#emitTrace(
-              TRACE_FIRST_INIT_FETCH,
-              {
-                duration_ms: durationMs,
-                chain_ids: JSON.stringify(chainIds),
-                ...durationByDataSource,
-              },
-              { controller: 'AssetsController' },
-              parentContext,
+        // Background pipeline: snap and RPC run in parallel after the fast path
+        // commits to state. Their balances are merged together before detection.
+        // Token + price enrichment matches the pre-split behavior: only when basic
+        // functionality is on (RPC-only mode must not call token/price APIs).
+        // Own parent span so timings nest instead of becoming extra root traces
+        // after the fast-path parent has ended.
+        const slowPipelineChainIds = this.#getSlowPipelineChainIds(
+          chainIds,
+          response,
+        );
+
+        if (slowPipelineChainIds.length > 0) {
+          const slowSources = this.#isBasicFunctionality()
+            ? [this.#snapDataSource, this.#rpcDataSource]
+            : [this.#rpcDataSource];
+
+          const slowRequest = { ...request, chainIds: slowPipelineChainIds };
+
+          const runBackground = async (slowParentContext?: TraceContext) => {
+            const { response: slowResponse } = await this.#executeMiddlewares(
+              [
+                createParallelBalanceMiddleware(slowSources),
+                this.#detectionMiddleware,
+                ...(this.#isBasicFunctionality()
+                  ? [
+                      createParallelMiddleware([
+                        this.#tokenDataSource,
+                        this.#priceDataSource,
+                      ]),
+                    ]
+                  : []),
+              ],
+              slowRequest,
+              {},
+              slowParentContext,
+              shouldTrace,
             );
-            // Mark after emitting so a concurrent path cannot skip this report.
-            this.#firstInitFetchReported = true;
-          }
-        },
-      );
+            await this.#updateState({
+              ...slowResponse,
+              updateMode: 'merge',
+            });
+          };
+
+          const backgroundPromise = shouldTrace
+            ? this.#withTrace(
+                TRACE_BACKGROUND_FETCH,
+                {
+                  chain_count: slowPipelineChainIds.length,
+                  account_count: accounts.length,
+                },
+                runBackground,
+              )
+            : runBackground(undefined);
+
+          backgroundPromise.catch((error) =>
+            log('Background pipeline failed', { error }),
+          );
+        }
+
+        if (!shouldTrace) {
+          return;
+        }
+
+        const durationMs = performance.now() - startTime;
+
+        // Summary fields for Assets Health (nested under the parent span so
+        // they do not create additional root transactions).
+        this.#emitTrace(
+          TRACE_FULL_FETCH,
+          {
+            duration_ms: durationMs,
+            chain_count: chainIds.length,
+            account_count: accounts.length,
+            basic_functionality: this.#isBasicFunctionality(),
+            asset_count: response.assetsBalance
+              ? Object.values(response.assetsBalance).reduce(
+                  (sum, acct) => sum + Object.keys(acct).length,
+                  0,
+                )
+              : 0,
+            price_count: response.assetsPrice
+              ? Object.keys(response.assetsPrice).length
+              : 0,
+            ...durationByDataSource,
+          },
+          { controller: 'AssetsController' },
+          parentContext,
+        );
+
+        this.#emitTrace(
+          TRACE_FIRST_INIT_FETCH,
+          {
+            duration_ms: durationMs,
+            chain_ids: JSON.stringify(chainIds),
+            ...durationByDataSource,
+          },
+          { controller: 'AssetsController' },
+          parentContext,
+        );
+        // Mark after emitting so a concurrent path cannot skip this report.
+        this.#firstInitFetchReported = true;
+      };
+
+      if (shouldTrace) {
+        await this.#withTrace(
+          TRACE_FETCH_PIPELINE,
+          {
+            chain_count: chainIds.length,
+            account_count: accounts.length,
+            basic_functionality: this.#isBasicFunctionality(),
+          },
+          runFullFetch,
+        );
+      } else {
+        await runFullFetch(undefined);
+      }
     }
 
     const result = this.#getAssetsFromState(accounts, chainIds, assetTypes);
@@ -3837,89 +3865,103 @@ export class AssetsController extends BaseController<
       hasPrice: Boolean(response.assetsPrice),
     });
 
-    await this.#withTrace(
-      TRACE_UPDATE_PARENT,
-      {
-        source: sourceId,
-        has_balance: Boolean(response.assetsBalance),
-        has_price: Boolean(response.assetsPrice),
-        balance_account_count: response.assetsBalance
-          ? Object.keys(response.assetsBalance).length
-          : 0,
-      },
-      async (parentContext) => {
-        const updateStart = performance.now();
+    // Enrichment spans only before unlock/first-init fetch completes.
+    const shouldTrace = !this.#firstInitFetchReported;
 
-        const resolvedRequest: DataRequest = request ?? {
-          accountsWithSupportedChains: [],
-          chainIds: [],
-          dataTypes: ['balance', 'metadata', 'price'],
-        };
+    const runUpdate = async (parentContext?: TraceContext) => {
+      const updateStart = performance.now();
 
-        // RPC-only mode (basic functionality off): never run token/price APIs. Strip
-        // those data types so downstream middleware cannot treat them as requested.
-        const pipelineRequest: DataRequest = this.#isBasicFunctionality()
-          ? resolvedRequest
-          : {
-              ...resolvedRequest,
-              dataTypes: resolvedRequest.dataTypes.filter(
-                (dt) => dt !== 'metadata' && dt !== 'price',
-              ),
-            };
+      const resolvedRequest: DataRequest = request ?? {
+        accountsWithSupportedChains: [],
+        chainIds: [],
+        dataTypes: ['balance', 'metadata', 'price'],
+      };
 
-        // Graduate custom assets only when AccountsAPI / Websocket reports them.
-        // RPC already fetches custom assets on purpose, and Snap handles non-EVM
-        // chains the rule does not apply to, so skip the middleware for those.
-        const shouldGraduateCustomAssets =
-          sourceId === 'AccountsApiDataSource' ||
-          sourceId === 'BackendWebsocketDataSource' ||
-          sourceId === 'AccountActivityService';
+      // RPC-only mode (basic functionality off): never run token/price APIs. Strip
+      // those data types so downstream middleware cannot treat them as requested.
+      const pipelineRequest: DataRequest = this.#isBasicFunctionality()
+        ? resolvedRequest
+        : {
+            ...resolvedRequest,
+            dataTypes: resolvedRequest.dataTypes.filter(
+              (dt) => dt !== 'metadata' && dt !== 'price',
+            ),
+          };
 
-        const enrichmentSources: AssetsDataSource[] = [
-          ...(shouldGraduateCustomAssets
-            ? [this.#customAssetGraduationMiddleware]
-            : []),
-          this.#detectionMiddleware,
-        ];
-        if (this.#isBasicFunctionality()) {
-          enrichmentSources.push(
-            createParallelMiddleware([
-              this.#tokenDataSource,
-              this.#priceDataSource,
-            ]),
-          );
-        }
+      // Graduate custom assets only when AccountsAPI / Websocket reports them.
+      // RPC already fetches custom assets on purpose, and Snap handles non-EVM
+      // chains the rule does not apply to, so skip the middleware for those.
+      const shouldGraduateCustomAssets =
+        sourceId === 'AccountsApiDataSource' ||
+        sourceId === 'BackendWebsocketDataSource' ||
+        sourceId === 'AccountActivityService';
 
-        const { response: enrichedResponse } = await this.#executeMiddlewares(
-          enrichmentSources,
-          pipelineRequest,
-          response,
-          parentContext,
+      const enrichmentSources: AssetsDataSource[] = [
+        ...(shouldGraduateCustomAssets
+          ? [this.#customAssetGraduationMiddleware]
+          : []),
+        this.#detectionMiddleware,
+      ];
+      if (this.#isBasicFunctionality()) {
+        enrichmentSources.push(
+          createParallelMiddleware([
+            this.#tokenDataSource,
+            this.#priceDataSource,
+          ]),
         );
+      }
 
-        await this.#updateState({
-          ...enrichedResponse,
-          replaceCoveredChainBalances: response.replaceCoveredChainBalances,
-        });
+      const { response: enrichedResponse } = await this.#executeMiddlewares(
+        enrichmentSources,
+        pipelineRequest,
+        response,
+        parentContext,
+        shouldTrace,
+      );
 
-        // Summary fields for Assets Health (nested under the parent span).
-        this.#emitTrace(
-          TRACE_UPDATE_PIPELINE,
-          {
-            source: sourceId,
-            duration_ms: performance.now() - updateStart,
-            has_balance: Boolean(response.assetsBalance),
-            has_price: Boolean(response.assetsPrice),
-            has_metadata: Boolean(enrichedResponse.assetsInfo),
-            balance_account_count: response.assetsBalance
-              ? Object.keys(response.assetsBalance).length
-              : 0,
-          },
-          { controller: 'AssetsController' },
-          parentContext,
-        );
-      },
-    );
+      await this.#updateState({
+        ...enrichedResponse,
+        replaceCoveredChainBalances: response.replaceCoveredChainBalances,
+      });
+
+      if (!shouldTrace) {
+        return;
+      }
+
+      // Summary fields for Assets Health (nested under the parent span).
+      this.#emitTrace(
+        TRACE_UPDATE_PIPELINE,
+        {
+          source: sourceId,
+          duration_ms: performance.now() - updateStart,
+          has_balance: Boolean(response.assetsBalance),
+          has_price: Boolean(response.assetsPrice),
+          has_metadata: Boolean(enrichedResponse.assetsInfo),
+          balance_account_count: response.assetsBalance
+            ? Object.keys(response.assetsBalance).length
+            : 0,
+        },
+        { controller: 'AssetsController' },
+        parentContext,
+      );
+    };
+
+    if (shouldTrace) {
+      await this.#withTrace(
+        TRACE_UPDATE_PARENT,
+        {
+          source: sourceId,
+          has_balance: Boolean(response.assetsBalance),
+          has_price: Boolean(response.assetsPrice),
+          balance_account_count: response.assetsBalance
+            ? Object.keys(response.assetsBalance).length
+            : 0,
+        },
+        runUpdate,
+      );
+    } else {
+      await runUpdate(undefined);
+    }
   }
 
   // ============================================================================

--- a/packages/assets-controller/src/AssetsController.ts
+++ b/packages/assets-controller/src/AssetsController.ts
@@ -211,10 +211,14 @@ const DEFAULT_POLLING_INTERVAL_MS = 30_000;
 // ============================================================================
 const TRACE_FIRST_INIT_FETCH = 'AssetsControllerFirstInitFetch';
 const TRACE_FULL_FETCH = 'AssetsFullFetch';
+/** Parent span that nests per-source timings; dashboard charts {@link TRACE_FULL_FETCH}. */
+const TRACE_FETCH_PIPELINE = 'AssetsFetchPipeline';
 const TRACE_BACKGROUND_FETCH = 'AssetsBackgroundFetch';
 const TRACE_DATA_SOURCE_TIMING = 'AssetsDataSourceTiming';
 const TRACE_DATA_SOURCE_ERROR = 'AssetsDataSourceError';
 const TRACE_UPDATE_PIPELINE = 'AssetsUpdatePipeline';
+/** Parent span that nests update enrichment; dashboard charts {@link TRACE_UPDATE_PIPELINE}. */
+const TRACE_UPDATE_PARENT = 'AssetsUpdateEnrichment';
 const TRACE_SUBSCRIPTION_ERROR = 'AssetsSubscriptionError';
 const TRACE_STATE_SIZE = 'AssetsStateSize';
 
@@ -670,9 +674,9 @@ export class AssetsController extends BaseController<
    * Pass `parentContext` to record a Sentry **subspan** instead of a new root transaction
    * (avoids rate-limiting when many timings fire per fetch).
    *
-   * After the cold-start fetch has been reported, only nested spans (with
-   * `parentContext`) and always-on traces are emitted — subsequent fetches/updates
-   * do not create new Sentry transactions.
+   * When `data.duration_ms` is set, it is also copied to tags (so MetaMask's Sentry
+   * adapter records a `duration_ms` measurement for Spans dashboard widgets) and
+   * `startTime` is backdated so `span.duration` matches the measured work.
    *
    * @param name - Trace / span name visible in Sentry.
    * @param data - Key-value pairs attached as span data.
@@ -690,29 +694,46 @@ export class AssetsController extends BaseController<
     if (!this.#trace) {
       return;
     }
-    // Cold-start only: skip root spans after the first init fetch. Nested
-    // subspans (parentContext set) and error/state-size traces still allowed.
-    if (
-      this.#firstInitFetchReported &&
-      parentContext === undefined &&
-      name !== TRACE_SUBSCRIPTION_ERROR &&
-      name !== TRACE_STATE_SIZE
-    ) {
-      return;
+
+    const durationMs =
+      typeof data.duration_ms === 'number' ? data.duration_ms : undefined;
+
+    // Numeric `data` fields become tags so MetaMask's Sentry adapter records
+    // them as measurements (dashboard fields like `tags[duration_ms,number]` /
+    // `measurements.duration_ms`). String data stays attributes-only unless
+    // callers put them in `tags` (e.g. `source` for group-by).
+    const numericFromData: Record<string, number> = {};
+    for (const [key, value] of Object.entries(data)) {
+      if (typeof value === 'number') {
+        numericFromData[key] = value;
+      }
     }
-    this.#trace({ name, data, tags, parentContext }, () => undefined)?.catch(
-      () => {
-        // Telemetry failure must not break.
+    const requestTags = {
+      ...tags,
+      ...numericFromData,
+    };
+    const startTime =
+      durationMs === undefined
+        ? undefined
+        : performance.timeOrigin + performance.now() - durationMs;
+
+    this.#trace(
+      {
+        name,
+        data,
+        tags: requestTags,
+        parentContext,
+        ...(startTime === undefined ? {} : { startTime }),
       },
-    );
+      () => undefined,
+    )?.catch(() => {
+      // Telemetry failure must not break.
+    });
   }
 
   /**
    * Run work inside a parent Sentry span and pass its context so callers can
    * emit nested subspans via {@link #emitTrace}.
-   *
-   * Only wraps work on cold start (before the first init fetch is reported).
-   * Later calls still run `fn`, but without creating a Sentry parent span.
    *
    * @param name - Parent span name.
    * @param data - Key-value pairs attached as span data.
@@ -728,7 +749,7 @@ export class AssetsController extends BaseController<
       controller: 'AssetsController',
     },
   ): Promise<Result> {
-    if (!this.#trace || this.#firstInitFetchReported) {
+    if (!this.#trace) {
       return fn(undefined);
     }
     return await this.#trace({ name, data, tags }, (parentContext) =>
@@ -780,6 +801,8 @@ export class AssetsController extends BaseController<
     this.#emitTrace(TRACE_STATE_SIZE, {
       balance_entries: balanceEntries,
       balance_accounts: Object.keys(balances).length,
+      // `asset_count` matches the Assets Health dashboard widget field name.
+      asset_count: uniqueAssets.size,
       unique_asset_count: uniqueAssets.size,
       network_count: uniqueNetworks.size,
       metadata_entries: Object.keys(assetsInfo).length,
@@ -1638,7 +1661,11 @@ export class AssetsController extends BaseController<
           chain_count: request.chainIds.length,
           account_count: request.accountsWithSupportedChains.length,
         },
-        { controller: 'AssetsController' },
+        {
+          controller: 'AssetsController',
+          // String tag so Spans widgets can group by `source`.
+          source: sourceName,
+        },
         parentContext,
       );
     }
@@ -1708,7 +1735,7 @@ export class AssetsController extends BaseController<
 
     if (options?.forceUpdate) {
       await this.#withTrace(
-        TRACE_FULL_FETCH,
+        TRACE_FETCH_PIPELINE,
         {
           chain_count: chainIds.length,
           account_count: accounts.length,
@@ -1850,7 +1877,7 @@ export class AssetsController extends BaseController<
               { controller: 'AssetsController' },
               parentContext,
             );
-            // Mark after emitting so the first-init span itself is not gated.
+            // Mark after emitting so a concurrent path cannot skip this report.
             this.#firstInitFetchReported = true;
           }
         },
@@ -3780,7 +3807,7 @@ export class AssetsController extends BaseController<
     });
 
     await this.#withTrace(
-      TRACE_UPDATE_PIPELINE,
+      TRACE_UPDATE_PARENT,
       {
         source: sourceId,
         has_balance: Boolean(response.assetsBalance),

--- a/packages/assets-controller/src/AssetsController.ts
+++ b/packages/assets-controller/src/AssetsController.ts
@@ -154,6 +154,7 @@ import type {
   TransactionPayLegacyFormat,
 } from './utils/index.js';
 import { processAccountActivityBalanceUpdates } from './utils/processAccountActivityBalanceUpdates.js';
+import { emitTrace, withTrace } from './utils/trace.js';
 
 const NATIVE_ASSETS_QUERY_KEY = ['nativeAssets'];
 
@@ -670,125 +671,6 @@ export class AssetsController extends BaseController<
   #stateSizeReported = false;
 
   /**
-   * Fire-and-forget trace helper. Swallows errors so telemetry never breaks the controller.
-   * Pass `parentContext` to record a Sentry **subspan** instead of a new root transaction
-   * (avoids rate-limiting when many timings fire per fetch).
-   *
-   * When `data.duration_ms` is set, it is also copied to tags (so MetaMask's Sentry
-   * adapter records a `duration_ms` measurement for Spans dashboard widgets) and
-   * `startTime` is backdated so `span.duration` matches the measured work.
-   *
-   * @param name - Trace / span name visible in Sentry.
-   * @param data - Key-value pairs attached as span data.
-   * @param tags - Key-value pairs used for Sentry filtering.
-   * @param parentContext - Optional parent span context for nesting as a subspan.
-   */
-  #emitTrace(
-    name: string,
-    data: Record<string, number | string | boolean>,
-    tags: Record<string, number | string | boolean> = {
-      controller: 'AssetsController',
-    },
-    parentContext?: TraceContext,
-  ): void {
-    if (!this.#trace) {
-      return;
-    }
-
-    const durationMs =
-      typeof data.duration_ms === 'number' ? data.duration_ms : undefined;
-
-    // Numeric `data` fields become tags so MetaMask's Sentry adapter records
-    // them as measurements (dashboard fields like `tags[duration_ms,number]` /
-    // `measurements.duration_ms`). String data stays attributes-only unless
-    // callers put them in `tags` (e.g. `source` for group-by).
-    const numericFromData: Record<string, number> = {};
-    for (const [key, value] of Object.entries(data)) {
-      if (typeof value === 'number') {
-        numericFromData[key] = value;
-      }
-    }
-    const requestTags = {
-      ...tags,
-      ...numericFromData,
-    };
-    const startTime =
-      durationMs === undefined
-        ? undefined
-        : performance.timeOrigin + performance.now() - durationMs;
-
-    this.#trace(
-      {
-        name,
-        data,
-        tags: requestTags,
-        parentContext,
-        ...(startTime === undefined ? {} : { startTime }),
-      },
-      () => undefined,
-    )?.catch(() => {
-      // Telemetry failure must not break.
-    });
-  }
-
-  /**
-   * Run work inside a parent Sentry span and pass its context so callers can
-   * emit nested subspans via {@link #emitTrace}.
-   *
-   * Telemetry failures are swallowed (same contract as {@link #emitTrace}): a
-   * rejected `#trace` promise must not fail balance fetches or enrichment.
-   * Errors thrown by `fn` still propagate. If `#trace` never runs `fn`, work
-   * falls back to running without a parent context.
-   *
-   * @param name - Parent span name.
-   * @param data - Key-value pairs attached as span data.
-   * @param fn - Work to run; receives the parent span context.
-   * @param tags - Key-value pairs used for Sentry filtering.
-   * @returns The result of `fn`.
-   */
-  async #withTrace<Result>(
-    name: string,
-    data: Record<string, number | string | boolean>,
-    fn: (parentContext?: TraceContext) => Promise<Result>,
-    tags: Record<string, number | string | boolean> = {
-      controller: 'AssetsController',
-    },
-  ): Promise<Result> {
-    if (!this.#trace) {
-      return fn(undefined);
-    }
-
-    let workResult:
-      | { ok: true; value: Result }
-      | { ok: false; error: unknown }
-      | undefined;
-
-    try {
-      await this.#trace({ name, data, tags }, async (parentContext) => {
-        try {
-          const value = await fn(parentContext);
-          workResult = { ok: true, value };
-          return value;
-        } catch (error) {
-          workResult = { ok: false, error };
-          throw error;
-        }
-      });
-    } catch {
-      // Telemetry failure must not break — unless the work itself failed.
-    }
-
-    if (workResult === undefined) {
-      // `#trace` failed before invoking `fn` (or never called it).
-      return fn(undefined);
-    }
-    if (workResult.ok) {
-      return workResult.value;
-    }
-    throw workResult.error;
-  }
-
-  /**
    * Emit a state-size trace once on app start (first state update after unlock).
    */
   #emitStateSizeTrace(): void {
@@ -829,16 +711,20 @@ export class AssetsController extends BaseController<
       }
     }
 
-    this.#emitTrace(TRACE_STATE_SIZE, {
-      balance_entries: balanceEntries,
-      balance_accounts: Object.keys(balances).length,
-      // `asset_count` matches the Assets Health dashboard widget field name.
-      asset_count: uniqueAssets.size,
-      unique_asset_count: uniqueAssets.size,
-      network_count: uniqueNetworks.size,
-      metadata_entries: Object.keys(assetsInfo).length,
-      price_entries: Object.keys(assetsPrice).length,
-      custom_asset_entries: customAssetEntries,
+    emitTrace({
+      name: TRACE_STATE_SIZE,
+      trace: this.#trace,
+      data: {
+        balance_entries: balanceEntries,
+        balance_accounts: Object.keys(balances).length,
+        // `asset_count` matches the Assets Health dashboard widget field name.
+        asset_count: uniqueAssets.size,
+        unique_asset_count: uniqueAssets.size,
+        network_count: uniqueNetworks.size,
+        metadata_entries: Object.keys(assetsInfo).length,
+        price_entries: Object.keys(assetsPrice).length,
+        custom_asset_entries: customAssetEntries,
+      },
     });
   }
 
@@ -1602,23 +1488,32 @@ export class AssetsController extends BaseController<
    * Execute middlewares with request/response context.
    * Returns response and exclusive duration per source (sum ≈ wall time).
    *
-   * @param sources - Data sources or middlewares with getName() and assetsMiddleware (executed in order).
-   * @param request - The data request.
-   * @param initialResponse - Optional initial response (for enriching existing data).
-   * @param parentContext - Optional parent Sentry span; per-source timings nest under it.
-   * @param emitTraces - When true, emit timing/error spans (unlock/first-init only).
+   * @param params - Middleware execution options.
+   * @param params.sources - Data sources or middlewares with getName() and assetsMiddleware.
+   * @param params.request - The data request.
+   * @param params.initialResponse - Optional initial response (for enriching existing data).
+   * @param params.parentContext - Optional parent Sentry span; per-source timings nest under it.
+   * @param params.trace - Optional trace callback; omit after unlock/first-init to skip spans.
    * @returns Response and durationByDataSource (exclusive ms per source name).
    */
-  async #executeMiddlewares(
-    sources: AssetsDataSource[],
-    request: DataRequest,
-    initialResponse: DataResponse = {},
-    parentContext?: TraceContext,
-    emitTraces = false,
-  ): Promise<{
+  async #executeMiddlewares(params: {
+    sources: AssetsDataSource[];
+    request: DataRequest;
+    initialResponse?: DataResponse;
+    parentContext?: TraceContext;
+    /** Omit after unlock/first-init so timing spans are not emitted. */
+    trace?: TraceCallback;
+  }): Promise<{
     response: DataResponse;
     durationByDataSource: Record<string, number>;
   }> {
+    const {
+      sources,
+      request,
+      initialResponse = {},
+      parentContext,
+      trace,
+    } = params;
     const names = sources.map((source) => source.getName());
     const middlewares = sources.map((source) => source.assetsMiddleware);
     const inclusive: number[] = [];
@@ -1684,28 +1579,27 @@ export class AssetsController extends BaseController<
       }
     }
 
-    // Unlock/first-init only — later polls and subscription updates would spam Sentry.
-    if (emitTraces) {
-      // Emit per-source timing as subspans under the parent fetch/update span
-      for (const [sourceName, durationMs] of Object.entries(
-        durationByDataSource,
-      )) {
-        this.#emitTrace(
-          TRACE_DATA_SOURCE_TIMING,
-          {
-            source: sourceName,
-            duration_ms: durationMs,
-            chain_count: request.chainIds.length,
-            account_count: request.accountsWithSupportedChains.length,
-          },
-          {
-            controller: 'AssetsController',
-            // String tag so Spans widgets can group by `source`.
-            source: sourceName,
-          },
-          parentContext,
-        );
-      }
+    // Emit per-source timing as subspans under the parent fetch/update span
+    // (no-op when `trace` is omitted — unlock/first-init only).
+    for (const [sourceName, durationMs] of Object.entries(
+      durationByDataSource,
+    )) {
+      emitTrace({
+        name: TRACE_DATA_SOURCE_TIMING,
+        trace,
+        data: {
+          source: sourceName,
+          duration_ms: durationMs,
+          chain_count: request.chainIds.length,
+          account_count: request.accountsWithSupportedChains.length,
+        },
+        tags: {
+          controller: 'AssetsController',
+          // String tag so Spans widgets can group by `source`.
+          source: sourceName,
+        },
+        parentContext,
+      });
     }
 
     // Failed middlewares: Issues (optional) + perf/Dashboard spans
@@ -1721,22 +1615,21 @@ export class AssetsController extends BaseController<
       } catch {
         // Never let telemetry throw.
       }
-      if (emitTraces) {
-        this.#emitTrace(
-          TRACE_DATA_SOURCE_ERROR,
-          {
-            failed_sources: failedSources,
-            error_count: middlewareErrors.length,
-            chain_count: request.chainIds.length,
-          },
-          {
-            controller: 'AssetsController',
-            severity: 'error',
-            error_type: assetsError.name,
-          },
-          parentContext,
-        );
-      }
+      emitTrace({
+        name: TRACE_DATA_SOURCE_ERROR,
+        trace,
+        data: {
+          failed_sources: failedSources,
+          error_count: middlewareErrors.length,
+          chain_count: request.chainIds.length,
+        },
+        tags: {
+          controller: 'AssetsController',
+          severity: 'error',
+          error_type: assetsError.name,
+        },
+        parentContext,
+      });
     }
 
     return { response: result.response, durationByDataSource };
@@ -1774,84 +1667,136 @@ export class AssetsController extends BaseController<
     }
 
     if (options?.forceUpdate) {
-      // Pipeline spans only on unlock/first-init fetch; later forceUpdates skip
-      // tracing so polling does not flood Sentry.
-      const shouldTrace = !this.#firstInitFetchReported;
+      // Pipeline spans only on unlock/first-init fetch; later forceUpdates pass
+      // `undefined` so `emitTrace` / `withTrace` no-op without call-site if/else.
+      const pipelineTrace = this.#firstInitFetchReported
+        ? undefined
+        : this.#trace;
 
-      const runFullFetch = async (
-        parentContext?: TraceContext,
-      ): Promise<void> => {
-        const startTime = performance.now();
-        const request = this.#buildDataRequest(accounts, chainIds, {
-          assetTypes,
-          dataTypes,
-          customAssets: customAssets.length > 0 ? customAssets : undefined,
-          forceUpdate: true,
-          assetsForPriceUpdate: options?.assetsForPriceUpdate,
-        });
-        // Fast pipeline: accountsApi + stakedBalance → detection → token + price.
-        // Snap and RPC are excluded here due to their latency (snap triggers account
-        // creation, RPC is slow on many chains). Results are committed to state
-        // immediately so the UI can display balances without waiting for them.
-        //
-        // Fast/slow pipelines use merge so partial API snapshots cannot wipe
-        // tokens missing from the response (e.g. USDC when only native balance
-        // is returned). Balances present in the response are still refreshed.
-        const fastSources = this.#isBasicFunctionality()
-          ? [
-              createParallelBalanceMiddleware([
-                this.#accountsApiDataSource,
-                this.#stakedBalanceDataSource,
-              ]),
-              // Graduation must run BEFORE the RPC fallback so it only sees
-              // AccountsApi/Websocket balances. RPC intentionally carries
-              // custom assets and must never trigger graduation.
-              this.#customAssetGraduationMiddleware,
-              this.#rpcFallbackMiddleware,
-              this.#detectionMiddleware,
-              createParallelMiddleware([
-                this.#tokenDataSource,
-                this.#priceDataSource,
-              ]),
-            ]
-          : [this.#stakedBalanceDataSource, this.#detectionMiddleware];
-        const { response, durationByDataSource } =
-          await this.#executeMiddlewares(
-            fastSources,
+      const request = this.#buildDataRequest(accounts, chainIds, {
+        assetTypes,
+        dataTypes,
+        customAssets: customAssets.length > 0 ? customAssets : undefined,
+        forceUpdate: true,
+        assetsForPriceUpdate: options?.assetsForPriceUpdate,
+      });
+
+      // Fast pipeline: accountsApi + stakedBalance → detection → token + price.
+      // Snap and RPC are excluded here due to their latency (snap triggers account
+      // creation, RPC is slow on many chains). Results are committed to state
+      // immediately so the UI can display balances without waiting for them.
+      //
+      // Fast/slow pipelines use merge so partial API snapshots cannot wipe
+      // tokens missing from the response (e.g. USDC when only native balance
+      // is returned). Balances present in the response are still refreshed.
+      const fastSources = this.#isBasicFunctionality()
+        ? [
+            createParallelBalanceMiddleware([
+              this.#accountsApiDataSource,
+              this.#stakedBalanceDataSource,
+            ]),
+            // Graduation must run BEFORE the RPC fallback so it only sees
+            // AccountsApi/Websocket balances. RPC intentionally carries
+            // custom assets and must never trigger graduation.
+            this.#customAssetGraduationMiddleware,
+            this.#rpcFallbackMiddleware,
+            this.#detectionMiddleware,
+            createParallelMiddleware([
+              this.#tokenDataSource,
+              this.#priceDataSource,
+            ]),
+          ]
+        : [this.#stakedBalanceDataSource, this.#detectionMiddleware];
+
+      const { response } = await withTrace({
+        name: TRACE_FETCH_PIPELINE,
+        trace: pipelineTrace,
+        data: {
+          chain_count: chainIds.length,
+          account_count: accounts.length,
+          basic_functionality: this.#isBasicFunctionality(),
+        },
+        fn: async (parentContext) => {
+          const startTime = performance.now();
+          const result = await this.#executeMiddlewares({
+            sources: fastSources,
             request,
-            {},
             parentContext,
-            shouldTrace,
-          );
-        await this.#updateState({
-          ...response,
-          updateMode: 'merge',
-          replaceCoveredChainBalances: true,
-        });
+            trace: pipelineTrace,
+          });
+          await this.#updateState({
+            ...result.response,
+            updateMode: 'merge',
+            replaceCoveredChainBalances: true,
+          });
 
-        // Background pipeline: snap and RPC run in parallel after the fast path
-        // commits to state. Their balances are merged together before detection.
-        // Token + price enrichment matches the pre-split behavior: only when basic
-        // functionality is on (RPC-only mode must not call token/price APIs).
-        // Own parent span so timings nest instead of becoming extra root traces
-        // after the fast-path parent has ended.
-        const slowPipelineChainIds = this.#getSlowPipelineChainIds(
-          chainIds,
-          response,
-        );
+          const durationMs = performance.now() - startTime;
 
-        if (slowPipelineChainIds.length > 0) {
-          const slowSources = this.#isBasicFunctionality()
-            ? [this.#snapDataSource, this.#rpcDataSource]
-            : [this.#rpcDataSource];
+          // Summary fields for Assets Health (nested under the parent span).
+          emitTrace({
+            name: TRACE_FULL_FETCH,
+            trace: pipelineTrace,
+            data: {
+              duration_ms: durationMs,
+              chain_count: chainIds.length,
+              account_count: accounts.length,
+              basic_functionality: this.#isBasicFunctionality(),
+              asset_count: result.response.assetsBalance
+                ? Object.values(result.response.assetsBalance).reduce(
+                    (sum, acct) => sum + Object.keys(acct).length,
+                    0,
+                  )
+                : 0,
+              price_count: result.response.assetsPrice
+                ? Object.keys(result.response.assetsPrice).length
+                : 0,
+              ...result.durationByDataSource,
+            },
+            parentContext,
+          });
 
-          const slowRequest = { ...request, chainIds: slowPipelineChainIds };
+          emitTrace({
+            name: TRACE_FIRST_INIT_FETCH,
+            trace: pipelineTrace,
+            data: {
+              duration_ms: durationMs,
+              chain_ids: JSON.stringify(chainIds),
+              ...result.durationByDataSource,
+            },
+            parentContext,
+          });
 
-          const runBackground = async (
-            slowParentContext?: TraceContext,
-          ): Promise<void> => {
-            const { response: slowResponse } = await this.#executeMiddlewares(
-              [
+          return result;
+        },
+      });
+
+      // Mark after the unlock/first forceUpdate so later polls skip pipeline spans.
+      this.#firstInitFetchReported = true;
+
+      // Background (slow) lane — flattened sibling of the fast lane (not nested
+      // inside its withTrace callback). Still fire-and-forget so UI is not blocked.
+      const slowPipelineChainIds = this.#getSlowPipelineChainIds(
+        chainIds,
+        response,
+      );
+
+      if (slowPipelineChainIds.length > 0) {
+        const slowSources = this.#isBasicFunctionality()
+          ? [this.#snapDataSource, this.#rpcDataSource]
+          : [this.#rpcDataSource];
+
+        const slowRequest = { ...request, chainIds: slowPipelineChainIds };
+
+        withTrace({
+          name: TRACE_BACKGROUND_FETCH,
+          trace: pipelineTrace,
+          data: {
+            chain_count: slowPipelineChainIds.length,
+            account_count: accounts.length,
+          },
+          fn: async (slowParentContext) => {
+            const { response: slowResponse } = await this.#executeMiddlewares({
+              sources: [
                 createParallelBalanceMiddleware(slowSources),
                 this.#detectionMiddleware,
                 ...(this.#isBasicFunctionality()
@@ -1863,89 +1808,16 @@ export class AssetsController extends BaseController<
                     ]
                   : []),
               ],
-              slowRequest,
-              {},
-              slowParentContext,
-              shouldTrace,
-            );
+              request: slowRequest,
+              parentContext: slowParentContext,
+              trace: pipelineTrace,
+            });
             await this.#updateState({
               ...slowResponse,
               updateMode: 'merge',
             });
-          };
-
-          const backgroundPromise = shouldTrace
-            ? this.#withTrace(
-                TRACE_BACKGROUND_FETCH,
-                {
-                  chain_count: slowPipelineChainIds.length,
-                  account_count: accounts.length,
-                },
-                runBackground,
-              )
-            : runBackground(undefined);
-
-          backgroundPromise.catch((error) =>
-            log('Background pipeline failed', { error }),
-          );
-        }
-
-        if (!shouldTrace) {
-          return;
-        }
-
-        const durationMs = performance.now() - startTime;
-
-        // Summary fields for Assets Health (nested under the parent span so
-        // they do not create additional root transactions).
-        this.#emitTrace(
-          TRACE_FULL_FETCH,
-          {
-            duration_ms: durationMs,
-            chain_count: chainIds.length,
-            account_count: accounts.length,
-            basic_functionality: this.#isBasicFunctionality(),
-            asset_count: response.assetsBalance
-              ? Object.values(response.assetsBalance).reduce(
-                  (sum, acct) => sum + Object.keys(acct).length,
-                  0,
-                )
-              : 0,
-            price_count: response.assetsPrice
-              ? Object.keys(response.assetsPrice).length
-              : 0,
-            ...durationByDataSource,
           },
-          { controller: 'AssetsController' },
-          parentContext,
-        );
-
-        this.#emitTrace(
-          TRACE_FIRST_INIT_FETCH,
-          {
-            duration_ms: durationMs,
-            chain_ids: JSON.stringify(chainIds),
-            ...durationByDataSource,
-          },
-          { controller: 'AssetsController' },
-          parentContext,
-        );
-        // Mark after emitting so a concurrent path cannot skip this report.
-        this.#firstInitFetchReported = true;
-      };
-
-      if (shouldTrace) {
-        await this.#withTrace(
-          TRACE_FETCH_PIPELINE,
-          {
-            chain_count: chainIds.length,
-            account_count: accounts.length,
-            basic_functionality: this.#isBasicFunctionality(),
-          },
-          runFullFetch,
-        );
-      } else {
-        await runFullFetch(undefined);
+        }).catch((error) => log('Background pipeline failed', { error }));
       }
     }
 
@@ -3472,9 +3344,13 @@ export class AssetsController extends BaseController<
         `[AssetsController] Failed to subscribe to '${sourceId}':`,
         error,
       );
-      this.#emitTrace(TRACE_SUBSCRIPTION_ERROR, {
-        source: sourceId,
-        error_message: String(error),
+      emitTrace({
+        name: TRACE_SUBSCRIPTION_ERROR,
+        trace: this.#trace,
+        data: {
+          source: sourceId,
+          error_message: String(error),
+        },
       });
     });
 
@@ -3872,102 +3748,95 @@ export class AssetsController extends BaseController<
     });
 
     // Enrichment spans only before unlock/first-init fetch completes.
-    const shouldTrace = !this.#firstInitFetchReported;
+    const pipelineTrace = this.#firstInitFetchReported
+      ? undefined
+      : this.#trace;
 
-    const runUpdate = async (parentContext?: TraceContext): Promise<void> => {
-      const updateStart = performance.now();
+    await withTrace({
+      name: TRACE_UPDATE_PARENT,
+      trace: pipelineTrace,
+      data: {
+        source: sourceId,
+        has_balance: Boolean(response.assetsBalance),
+        has_price: Boolean(response.assetsPrice),
+        balance_account_count: response.assetsBalance
+          ? Object.keys(response.assetsBalance).length
+          : 0,
+      },
+      fn: async (parentContext) => {
+        const updateStart = performance.now();
 
-      const resolvedRequest: DataRequest = request ?? {
-        accountsWithSupportedChains: [],
-        chainIds: [],
-        dataTypes: ['balance', 'metadata', 'price'],
-      };
+        const resolvedRequest: DataRequest = request ?? {
+          accountsWithSupportedChains: [],
+          chainIds: [],
+          dataTypes: ['balance', 'metadata', 'price'],
+        };
 
-      // RPC-only mode (basic functionality off): never run token/price APIs. Strip
-      // those data types so downstream middleware cannot treat them as requested.
-      const pipelineRequest: DataRequest = this.#isBasicFunctionality()
-        ? resolvedRequest
-        : {
-            ...resolvedRequest,
-            dataTypes: resolvedRequest.dataTypes.filter(
-              (dt) => dt !== 'metadata' && dt !== 'price',
-            ),
-          };
+        // RPC-only mode (basic functionality off): never run token/price APIs. Strip
+        // those data types so downstream middleware cannot treat them as requested.
+        const pipelineRequest: DataRequest = this.#isBasicFunctionality()
+          ? resolvedRequest
+          : {
+              ...resolvedRequest,
+              dataTypes: resolvedRequest.dataTypes.filter(
+                (dt) => dt !== 'metadata' && dt !== 'price',
+              ),
+            };
 
-      // Graduate custom assets only when AccountsAPI / Websocket reports them.
-      // RPC already fetches custom assets on purpose, and Snap handles non-EVM
-      // chains the rule does not apply to, so skip the middleware for those.
-      const shouldGraduateCustomAssets =
-        sourceId === 'AccountsApiDataSource' ||
-        sourceId === 'BackendWebsocketDataSource' ||
-        sourceId === 'AccountActivityService';
+        // Graduate custom assets only when AccountsAPI / Websocket reports them.
+        // RPC already fetches custom assets on purpose, and Snap handles non-EVM
+        // chains the rule does not apply to, so skip the middleware for those.
+        const shouldGraduateCustomAssets =
+          sourceId === 'AccountsApiDataSource' ||
+          sourceId === 'BackendWebsocketDataSource' ||
+          sourceId === 'AccountActivityService';
 
-      const enrichmentSources: AssetsDataSource[] = [
-        ...(shouldGraduateCustomAssets
-          ? [this.#customAssetGraduationMiddleware]
-          : []),
-        this.#detectionMiddleware,
-      ];
-      if (this.#isBasicFunctionality()) {
-        enrichmentSources.push(
-          createParallelMiddleware([
-            this.#tokenDataSource,
-            this.#priceDataSource,
-          ]),
-        );
-      }
+        const enrichmentSources: AssetsDataSource[] = [
+          ...(shouldGraduateCustomAssets
+            ? [this.#customAssetGraduationMiddleware]
+            : []),
+          this.#detectionMiddleware,
+        ];
+        if (this.#isBasicFunctionality()) {
+          enrichmentSources.push(
+            createParallelMiddleware([
+              this.#tokenDataSource,
+              this.#priceDataSource,
+            ]),
+          );
+        }
 
-      const { response: enrichedResponse } = await this.#executeMiddlewares(
-        enrichmentSources,
-        pipelineRequest,
-        response,
-        parentContext,
-        shouldTrace,
-      );
+        const { response: enrichedResponse } = await this.#executeMiddlewares({
+          sources: enrichmentSources,
+          request: pipelineRequest,
+          initialResponse: response,
+          parentContext,
+          trace: pipelineTrace,
+        });
 
-      await this.#updateState({
-        ...enrichedResponse,
-        replaceCoveredChainBalances: response.replaceCoveredChainBalances,
-      });
+        await this.#updateState({
+          ...enrichedResponse,
+          replaceCoveredChainBalances: response.replaceCoveredChainBalances,
+        });
 
-      if (!shouldTrace) {
-        return;
-      }
-
-      // Summary fields for Assets Health (nested under the parent span).
-      this.#emitTrace(
-        TRACE_UPDATE_PIPELINE,
-        {
-          source: sourceId,
-          duration_ms: performance.now() - updateStart,
-          has_balance: Boolean(response.assetsBalance),
-          has_price: Boolean(response.assetsPrice),
-          has_metadata: Boolean(enrichedResponse.assetsInfo),
-          balance_account_count: response.assetsBalance
-            ? Object.keys(response.assetsBalance).length
-            : 0,
-        },
-        { controller: 'AssetsController' },
-        parentContext,
-      );
-    };
-
-    if (shouldTrace) {
-      await this.#withTrace(
-        TRACE_UPDATE_PARENT,
-        {
-          source: sourceId,
-          has_balance: Boolean(response.assetsBalance),
-          has_price: Boolean(response.assetsPrice),
-          balance_account_count: response.assetsBalance
-            ? Object.keys(response.assetsBalance).length
-            : 0,
-        },
-        runUpdate,
-      );
-    } else {
-      await runUpdate(undefined);
-    }
+        // Summary fields for Assets Health (nested under the parent span).
+        emitTrace({
+          name: TRACE_UPDATE_PIPELINE,
+          trace: pipelineTrace,
+          data: {
+            source: sourceId,
+            duration_ms: performance.now() - updateStart,
+            has_balance: Boolean(response.assetsBalance),
+            has_price: Boolean(response.assetsPrice),
+            has_metadata: Boolean(enrichedResponse.assetsInfo),
+            balance_account_count: response.assetsBalance
+              ? Object.keys(response.assetsBalance).length
+              : 0,
+          },
+          parentContext,
+        });
+      },
+    });
   }
 
   // ============================================================================

--- a/packages/assets-controller/src/AssetsController.ts
+++ b/packages/assets-controller/src/AssetsController.ts
@@ -735,6 +735,11 @@ export class AssetsController extends BaseController<
    * Run work inside a parent Sentry span and pass its context so callers can
    * emit nested subspans via {@link #emitTrace}.
    *
+   * Telemetry failures are swallowed (same contract as {@link #emitTrace}): a
+   * rejected `#trace` promise must not fail balance fetches or enrichment.
+   * Errors thrown by `fn` still propagate. If `#trace` never runs `fn`, work
+   * falls back to running without a parent context.
+   *
    * @param name - Parent span name.
    * @param data - Key-value pairs attached as span data.
    * @param fn - Work to run; receives the parent span context.
@@ -752,9 +757,35 @@ export class AssetsController extends BaseController<
     if (!this.#trace) {
       return fn(undefined);
     }
-    return await this.#trace({ name, data, tags }, (parentContext) =>
-      fn(parentContext),
-    );
+
+    let workResult:
+      | { ok: true; value: Result }
+      | { ok: false; error: unknown }
+      | undefined;
+
+    try {
+      await this.#trace({ name, data, tags }, async (parentContext) => {
+        try {
+          const value = await fn(parentContext);
+          workResult = { ok: true, value };
+          return value;
+        } catch (error) {
+          workResult = { ok: false, error };
+          throw error;
+        }
+      });
+    } catch {
+      // Telemetry failure must not break — unless the work itself failed.
+    }
+
+    if (workResult === undefined) {
+      // `#trace` failed before invoking `fn` (or never called it).
+      return fn(undefined);
+    }
+    if (workResult.ok) {
+      return workResult.value;
+    }
+    throw workResult.error;
   }
 
   /**

--- a/packages/assets-controller/src/selectors/balance.test.ts
+++ b/packages/assets-controller/src/selectors/balance.test.ts
@@ -724,6 +724,31 @@ describe('wallet-balance selectors', () => {
 
       expect(result.totalBalanceInUserCurrency).toBe(0);
     });
+
+    it('emits a single AggregatedBalanceSelector span for all groups', () => {
+      const trace = jest.fn().mockResolvedValue(undefined);
+
+      calculateBalanceForAllWallets(
+        buildState(),
+        accountTreeState,
+        undefined,
+        trace,
+      );
+
+      expect(trace).toHaveBeenCalledTimes(1);
+      expect(trace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'AggregatedBalanceSelector',
+          data: expect.objectContaining({
+            duration_ms: expect.any(Number),
+            wallet_count: 2,
+            group_count: 3,
+          }),
+          tags: { controller: 'AssetsController' },
+        }),
+        expect.any(Function),
+      );
+    });
   });
 
   describe('calculateBalanceChangeForAccountGroup', () => {

--- a/packages/assets-controller/src/selectors/balance.test.ts
+++ b/packages/assets-controller/src/selectors/balance.test.ts
@@ -727,19 +727,21 @@ describe('wallet-balance selectors', () => {
 
     it('emits AggregatedBalanceSelector as a subspan under AggregatedBalance', () => {
       const parentSpan = { id: 'aggregated-balance' };
-      const trace = jest.fn().mockImplementation(
-        async (
-          request: { parentContext?: unknown },
-          fn?: (context?: unknown) => unknown,
-        ) => {
-          if (fn) {
-            return fn(
-              request.parentContext === undefined ? parentSpan : undefined,
-            );
-          }
-          return undefined;
-        },
-      );
+      const trace = jest
+        .fn()
+        .mockImplementation(
+          async (
+            request: { parentContext?: unknown },
+            fn?: (context?: unknown) => unknown,
+          ) => {
+            if (fn) {
+              return fn(
+                request.parentContext === undefined ? parentSpan : undefined,
+              );
+            }
+            return undefined;
+          },
+        );
 
       calculateBalanceForAllWallets(
         buildState(),

--- a/packages/assets-controller/src/selectors/balance.test.ts
+++ b/packages/assets-controller/src/selectors/balance.test.ts
@@ -725,8 +725,21 @@ describe('wallet-balance selectors', () => {
       expect(result.totalBalanceInUserCurrency).toBe(0);
     });
 
-    it('emits a single AggregatedBalanceSelector span for all groups', () => {
-      const trace = jest.fn().mockResolvedValue(undefined);
+    it('emits AggregatedBalanceSelector as a subspan under AggregatedBalance', () => {
+      const parentSpan = { id: 'aggregated-balance' };
+      const trace = jest.fn().mockImplementation(
+        async (
+          request: { parentContext?: unknown },
+          fn?: (context?: unknown) => unknown,
+        ) => {
+          if (fn) {
+            return fn(
+              request.parentContext === undefined ? parentSpan : undefined,
+            );
+          }
+          return undefined;
+        },
+      );
 
       calculateBalanceForAllWallets(
         buildState(),
@@ -735,16 +748,36 @@ describe('wallet-balance selectors', () => {
         trace,
       );
 
-      expect(trace).toHaveBeenCalledTimes(1);
-      expect(trace).toHaveBeenCalledWith(
+      expect(trace).toHaveBeenCalledTimes(2);
+      expect(trace).toHaveBeenNthCalledWith(
+        1,
         expect.objectContaining({
-          name: 'AggregatedBalanceSelector',
+          name: 'AggregatedBalance',
           data: expect.objectContaining({
             duration_ms: expect.any(Number),
             wallet_count: 2,
             group_count: 3,
           }),
-          tags: { controller: 'AssetsController' },
+          tags: expect.objectContaining({
+            controller: 'AssetsController',
+            duration_ms: expect.any(Number),
+          }),
+          startTime: expect.any(Number),
+        }),
+        expect.any(Function),
+      );
+      expect(trace).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          name: 'AggregatedBalanceSelector',
+          parentContext: parentSpan,
+          data: expect.objectContaining({
+            duration_ms: expect.any(Number),
+          }),
+          tags: expect.objectContaining({
+            duration_ms: expect.any(Number),
+          }),
+          startTime: expect.any(Number),
         }),
         expect.any(Function),
       );

--- a/packages/assets-controller/src/selectors/balance.ts
+++ b/packages/assets-controller/src/selectors/balance.ts
@@ -1,6 +1,6 @@
 import type { AccountTreeControllerState } from '@metamask/account-tree-controller';
 import { toHex } from '@metamask/controller-utils';
-import type { TraceCallback } from '@metamask/controller-utils';
+import type { TraceCallback, TraceContext } from '@metamask/controller-utils';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 import type { CaipChainId, Hex } from '@metamask/utils';
 import {
@@ -23,7 +23,65 @@ import type {
 // ============================================================================
 // TRACE NAMES — used in Sentry spans (search these strings in Discover)
 // ============================================================================
+/** Parent span that nests {@link TRACE_AGGREGATED_BALANCE_SELECTOR}. */
+const TRACE_AGGREGATED_BALANCE = 'AggregatedBalance';
 const TRACE_AGGREGATED_BALANCE_SELECTOR = 'AggregatedBalanceSelector';
+
+/**
+ * Emit `AggregatedBalanceSelector` as a **subspan** under an `AggregatedBalance`
+ * parent (via `parentContext`).
+ *
+ * Work is timed outside the callback (selectors are sync), so we backdate
+ * `startTime` and set numeric `duration_ms` on tags — MetaMask's Sentry adapter
+ * promotes numeric tags to measurements, which Spans dashboard widgets chart as
+ * `duration_ms`.
+ *
+ * @param trace - Trace callback from the client.
+ * @param durationMs - Measured compute time in milliseconds.
+ * @param data - Additional span attributes (counts, etc.).
+ */
+function emitAggregatedBalanceSelectorTrace(
+  trace: TraceCallback,
+  durationMs: number,
+  data: Record<string, number | string | boolean>,
+): void {
+  const endTime = performance.timeOrigin + performance.now();
+  const startTime = endTime - durationMs;
+  const spanData = {
+    duration_ms: durationMs,
+    ...data,
+  };
+  const spanTags = {
+    controller: 'AssetsController',
+    duration_ms: durationMs,
+  };
+
+  trace(
+    {
+      name: TRACE_AGGREGATED_BALANCE,
+      data: spanData,
+      tags: spanTags,
+      startTime,
+    },
+    (parentContext?: TraceContext) => {
+      trace(
+        {
+          name: TRACE_AGGREGATED_BALANCE_SELECTOR,
+          data: spanData,
+          tags: spanTags,
+          parentContext,
+          startTime,
+        },
+        () => undefined,
+      ).catch(() => {
+        // Telemetry failure must not break.
+      });
+      return undefined;
+    },
+  ).catch(() => {
+    // Telemetry failure must not break.
+  });
+}
 
 export type EnabledNetworkMap =
   | Record<string, Record<string, boolean>>
@@ -523,20 +581,10 @@ function aggregateBalances(
       const info = getAssetInfo(assetInfoCache, assetId);
       uniqueNetworks.add(info.chainId);
     }
-    trace(
-      {
-        name: TRACE_AGGREGATED_BALANCE_SELECTOR,
-        data: {
-          duration_ms: durationMs,
-          asset_count: merged.size,
-          network_count: uniqueNetworks.size,
-          account_count: accountsToAggregate.length,
-        },
-        tags: { controller: 'AssetsController' },
-      },
-      () => undefined,
-    ).catch(() => {
-      // Telemetry failure must not break.
+    emitAggregatedBalanceSelectorTrace(trace, durationMs, {
+      asset_count: merged.size,
+      network_count: uniqueNetworks.size,
+      account_count: accountsToAggregate.length,
     });
   }
 
@@ -764,20 +812,14 @@ export function calculateBalanceForAllWallets(
   }
 
   if (trace) {
-    trace(
+    emitAggregatedBalanceSelectorTrace(
+      trace,
+      performance.now() - startTime,
       {
-        name: TRACE_AGGREGATED_BALANCE_SELECTOR,
-        data: {
-          duration_ms: performance.now() - startTime,
-          wallet_count: Object.keys(wallets).length,
-          group_count: groupCount,
-        },
-        tags: { controller: 'AssetsController' },
+        wallet_count: Object.keys(wallets).length,
+        group_count: groupCount,
       },
-      () => undefined,
-    ).catch(() => {
-      // Telemetry failure must not break.
-    });
+    );
   }
 
   return { wallets, totalBalanceInUserCurrency, userCurrency };

--- a/packages/assets-controller/src/selectors/balance.ts
+++ b/packages/assets-controller/src/selectors/balance.ts
@@ -812,14 +812,10 @@ export function calculateBalanceForAllWallets(
   }
 
   if (trace) {
-    emitAggregatedBalanceSelectorTrace(
-      trace,
-      performance.now() - startTime,
-      {
-        wallet_count: Object.keys(wallets).length,
-        group_count: groupCount,
-      },
-    );
+    emitAggregatedBalanceSelectorTrace(trace, performance.now() - startTime, {
+      wallet_count: Object.keys(wallets).length,
+      group_count: groupCount,
+    });
   }
 
   return { wallets, totalBalanceInUserCurrency, userCurrency };

--- a/packages/assets-controller/src/selectors/balance.ts
+++ b/packages/assets-controller/src/selectors/balance.ts
@@ -721,9 +721,11 @@ export function calculateBalanceForAllWallets(
   enabledNetworkMap?: EnabledNetworkMap,
   trace?: TraceCallback,
 ): AllWalletsBalance {
+  const startTime = performance.now();
   const userCurrency = getUserCurrency(assetsControllerState);
   const wallets: AllWalletsBalance['wallets'] = {};
   let totalBalanceInUserCurrency = 0;
+  let groupCount = 0;
 
   type WalletWithGroups = { groups?: Record<string, unknown> };
   for (const [walletId, wallet] of Object.entries(
@@ -738,12 +740,14 @@ export function calculateBalanceForAllWallets(
 
     const groups = (wallet as WalletWithGroups)?.groups ?? {};
     for (const groupId of Object.keys(groups)) {
+      groupCount += 1;
       const accountIds = getAccountIdsForGroup(accountTreeState, groupId);
+      // Do not forward `trace` per group — that created one root Sentry span
+      // per account group and hit rate limits. Emit a single span below.
       const { totalBalanceInFiat = 0 } = getAggregatedBalanceForAccountIds(
         assetsControllerState,
         accountIds,
         enabledNetworkMap,
-        trace,
       );
 
       walletBalance.groups[groupId] = {
@@ -757,6 +761,23 @@ export function calculateBalanceForAllWallets(
 
     wallets[walletId] = walletBalance;
     totalBalanceInUserCurrency += walletBalance.totalBalanceInUserCurrency;
+  }
+
+  if (trace) {
+    trace(
+      {
+        name: TRACE_AGGREGATED_BALANCE_SELECTOR,
+        data: {
+          duration_ms: performance.now() - startTime,
+          wallet_count: Object.keys(wallets).length,
+          group_count: groupCount,
+        },
+        tags: { controller: 'AssetsController' },
+      },
+      () => undefined,
+    ).catch(() => {
+      // Telemetry failure must not break.
+    });
   }
 
   return { wallets, totalBalanceInUserCurrency, userCurrency };

--- a/packages/assets-controller/src/selectors/balance.ts
+++ b/packages/assets-controller/src/selectors/balance.ts
@@ -1,6 +1,6 @@
 import type { AccountTreeControllerState } from '@metamask/account-tree-controller';
 import { toHex } from '@metamask/controller-utils';
-import type { TraceCallback, TraceContext } from '@metamask/controller-utils';
+import type { TraceCallback } from '@metamask/controller-utils';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 import type { CaipChainId, Hex } from '@metamask/utils';
 import {
@@ -19,6 +19,7 @@ import type {
   AssetPreferences,
   Caip19AssetId,
 } from '../types.js';
+import { emitTrace, withTrace } from '../utils/trace.js';
 
 // ============================================================================
 // TRACE NAMES — used in Sentry spans (search these strings in Discover)
@@ -32,9 +33,8 @@ const TRACE_AGGREGATED_BALANCE_SELECTOR = 'AggregatedBalanceSelector';
  * parent (via `parentContext`).
  *
  * Work is timed outside the callback (selectors are sync), so we backdate
- * `startTime` and set numeric `duration_ms` on tags — MetaMask's Sentry adapter
- * promotes numeric tags to measurements, which Spans dashboard widgets chart as
- * `duration_ms`.
+ * `startTime` via `duration_ms` — MetaMask's Sentry adapter promotes numeric
+ * tags to measurements, which Spans dashboard widgets chart as `duration_ms`.
  *
  * @param trace - Trace callback from the client.
  * @param durationMs - Measured compute time in milliseconds.
@@ -45,40 +45,24 @@ function emitAggregatedBalanceSelectorTrace(
   durationMs: number,
   data: Record<string, number | string | boolean>,
 ): void {
-  const endTime = performance.timeOrigin + performance.now();
-  const startTime = endTime - durationMs;
   const spanData = {
     duration_ms: durationMs,
     ...data,
   };
-  const spanTags = {
-    controller: 'AssetsController',
-    duration_ms: durationMs,
-  };
 
-  trace(
-    {
-      name: TRACE_AGGREGATED_BALANCE,
-      data: spanData,
-      tags: spanTags,
-      startTime,
-    },
-    (parentContext?: TraceContext) => {
-      trace(
-        {
-          name: TRACE_AGGREGATED_BALANCE_SELECTOR,
-          data: spanData,
-          tags: spanTags,
-          parentContext,
-          startTime,
-        },
-        () => undefined,
-      ).catch(() => {
-        // Telemetry failure must not break.
+  withTrace({
+    name: TRACE_AGGREGATED_BALANCE,
+    trace,
+    data: spanData,
+    fn: async (parentContext) => {
+      emitTrace({
+        name: TRACE_AGGREGATED_BALANCE_SELECTOR,
+        trace,
+        data: spanData,
+        parentContext,
       });
-      return undefined;
     },
-  ).catch(() => {
+  }).catch(() => {
     // Telemetry failure must not break.
   });
 }

--- a/packages/assets-controller/src/utils/trace.test.ts
+++ b/packages/assets-controller/src/utils/trace.test.ts
@@ -1,0 +1,142 @@
+import type { TraceCallback, TraceRequest } from '@metamask/controller-utils';
+
+import { emitTrace, withTrace } from './trace.js';
+
+describe('emitTrace', () => {
+  it('is a no-op when trace is omitted', () => {
+    expect(() =>
+      emitTrace({
+        name: 'TestSpan',
+        data: { duration_ms: 1 },
+      }),
+    ).not.toThrow();
+  });
+
+  it('invokes trace with duration tags and backdated startTime', () => {
+    const trace = jest.fn().mockResolvedValue(undefined);
+
+    emitTrace({
+      name: 'TestSpan',
+      trace: trace as unknown as TraceCallback,
+      data: { duration_ms: 25, chain_count: 2 },
+      parentContext: { id: 'parent' },
+    });
+
+    expect(trace).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'TestSpan',
+        data: { duration_ms: 25, chain_count: 2 },
+        tags: expect.objectContaining({
+          controller: 'AssetsController',
+          duration_ms: 25,
+          chain_count: 2,
+        }),
+        parentContext: { id: 'parent' },
+        startTime: expect.any(Number),
+      }),
+      expect.any(Function),
+    );
+  });
+
+  it('swallows rejected trace promises', () => {
+    const trace = jest.fn().mockRejectedValue(new Error('telemetry failed'));
+
+    expect(() =>
+      emitTrace({
+        name: 'TestSpan',
+        trace: trace as unknown as TraceCallback,
+        data: { ok: true },
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe('withTrace', () => {
+  it('runs fn without parent context when trace is omitted', async () => {
+    const result = await withTrace({
+      name: 'Parent',
+      data: {},
+      fn: async (parentContext) => {
+        expect(parentContext).toBeUndefined();
+        return 'done';
+      },
+    });
+
+    expect(result).toBe('done');
+  });
+
+  it('passes parent context from trace into fn', async () => {
+    const parentSpan = { id: 'parent' };
+    const trace = jest
+      .fn()
+      .mockImplementation(
+        async (_request: TraceRequest, fn?: (context?: unknown) => unknown) =>
+          fn?.(parentSpan),
+      );
+
+    const result = await withTrace({
+      name: 'Parent',
+      trace: trace as unknown as TraceCallback,
+      data: { chain_count: 1 },
+      fn: async (parentContext) => {
+        expect(parentContext).toBe(parentSpan);
+        return 42;
+      },
+    });
+
+    expect(result).toBe(42);
+  });
+
+  it('does not fail when trace rejects after work completes', async () => {
+    const trace = jest
+      .fn()
+      .mockImplementation(
+        async (_request: TraceRequest, fn?: (context?: unknown) => unknown) => {
+          await fn?.({ id: 'parent' });
+          throw new Error('telemetry failed');
+        },
+      );
+
+    expect(
+      await withTrace({
+        name: 'Parent',
+        trace: trace as unknown as TraceCallback,
+        data: {},
+        fn: async () => 'ok',
+      }),
+    ).toBe('ok');
+  });
+
+  it('still runs work when trace rejects before invoking fn', async () => {
+    const trace = jest.fn().mockRejectedValue(new Error('telemetry failed'));
+
+    expect(
+      await withTrace({
+        name: 'Parent',
+        trace: trace as unknown as TraceCallback,
+        data: {},
+        fn: async () => 'fallback',
+      }),
+    ).toBe('fallback');
+  });
+
+  it('propagates errors thrown by fn', async () => {
+    const trace = jest
+      .fn()
+      .mockImplementation(
+        async (_request: TraceRequest, fn?: (context?: unknown) => unknown) =>
+          fn?.({ id: 'parent' }),
+      );
+
+    await expect(
+      withTrace({
+        name: 'Parent',
+        trace: trace as unknown as TraceCallback,
+        data: {},
+        fn: async () => {
+          throw new Error('pipeline failed');
+        },
+      }),
+    ).rejects.toThrow('pipeline failed');
+  });
+});

--- a/packages/assets-controller/src/utils/trace.ts
+++ b/packages/assets-controller/src/utils/trace.ts
@@ -1,0 +1,185 @@
+import type { TraceCallback, TraceContext } from '@metamask/controller-utils';
+
+const DEFAULT_TAGS: Record<string, number | string | boolean> = {
+  controller: 'AssetsController',
+};
+
+export type TraceSpanData = Record<string, number | string | boolean>;
+
+export type EmitTraceParams = {
+  name: string;
+  /** When omitted / undefined, this is a no-op (bake call-site gating here). */
+  trace?: TraceCallback;
+  data: TraceSpanData;
+  tags?: TraceSpanData;
+  parentContext?: TraceContext;
+  /** Override span start; otherwise derived from `data.duration_ms` when present. */
+  startTime?: number;
+};
+
+export type WithTraceParams<Result> = {
+  name: string;
+  /** When omitted / undefined, `fn` runs with no parent context. */
+  trace?: TraceCallback;
+  data: TraceSpanData;
+  fn: (parentContext?: TraceContext) => Promise<Result>;
+  tags?: TraceSpanData;
+  startTime?: number;
+};
+
+/**
+ * Build request tags / startTime for MetaMask's Sentry adapter.
+ * Numeric `data` fields become tags (measurements); `duration_ms` backdates start.
+ *
+ * @param data - Span data attributes.
+ * @param tags - Caller tags.
+ * @param startTime - Optional explicit start override.
+ * @returns tags and optional startTime for the TraceRequest.
+ */
+function buildTraceTiming(
+  data: TraceSpanData,
+  tags: TraceSpanData,
+  startTime?: number,
+): { tags: TraceSpanData; startTime?: number } {
+  const numericFromData: Record<string, number> = {};
+  for (const [key, value] of Object.entries(data)) {
+    if (typeof value === 'number') {
+      numericFromData[key] = value;
+    }
+  }
+  const requestTags = {
+    ...tags,
+    ...numericFromData,
+  };
+
+  if (startTime !== undefined) {
+    return { tags: requestTags, startTime };
+  }
+
+  const durationMs =
+    typeof data.duration_ms === 'number' ? data.duration_ms : undefined;
+  if (durationMs === undefined) {
+    return { tags: requestTags };
+  }
+
+  return {
+    tags: requestTags,
+    startTime: performance.timeOrigin + performance.now() - durationMs,
+  };
+}
+
+/**
+ * Fire-and-forget Sentry span. Swallows errors so telemetry never breaks callers.
+ * Pass `parentContext` to nest as a subspan. Omit `trace` to skip emission.
+ *
+ * @param params - Span configuration.
+ * @param params.name - Trace / span name visible in Sentry.
+ * @param params.trace - Optional client trace callback; omit to no-op.
+ * @param params.data - Key-value pairs attached as span data.
+ * @param params.tags - Key-value pairs used for Sentry filtering.
+ * @param params.parentContext - Optional parent span context for nesting.
+ * @param params.startTime - Optional explicit start; else derived from `duration_ms`.
+ */
+export function emitTrace({
+  name,
+  trace,
+  data,
+  tags = DEFAULT_TAGS,
+  parentContext,
+  startTime: startTimeOverride,
+}: EmitTraceParams): void {
+  if (!trace) {
+    return;
+  }
+
+  const { tags: requestTags, startTime } = buildTraceTiming(
+    data,
+    tags,
+    startTimeOverride,
+  );
+
+  trace(
+    {
+      name,
+      data,
+      tags: requestTags,
+      parentContext,
+      ...(startTime === undefined ? {} : { startTime }),
+    },
+    () => undefined,
+  )?.catch(() => {
+    // Telemetry failure must not break.
+  });
+}
+
+/**
+ * Run work inside a parent Sentry span and pass its context for nested
+ * {@link emitTrace} subspans.
+ *
+ * When `trace` is omitted, runs `fn(undefined)` with no span.
+ * Telemetry failures are swallowed; errors from `fn` still propagate.
+ *
+ * @param params - Parent span config and work callback.
+ * @param params.name - Parent span name.
+ * @param params.trace - Optional client trace callback; omit to skip wrapping.
+ * @param params.data - Key-value pairs attached as span data.
+ * @param params.fn - Work to run; receives the parent span context.
+ * @param params.tags - Key-value pairs used for Sentry filtering.
+ * @param params.startTime - Optional explicit start; else derived from `duration_ms`.
+ * @returns The result of `fn`.
+ */
+export async function withTrace<Result>({
+  name,
+  trace,
+  data,
+  fn,
+  tags = DEFAULT_TAGS,
+  startTime: startTimeOverride,
+}: WithTraceParams<Result>): Promise<Result> {
+  if (!trace) {
+    return fn(undefined);
+  }
+
+  const { tags: requestTags, startTime } = buildTraceTiming(
+    data,
+    tags,
+    startTimeOverride,
+  );
+
+  let workResult:
+    | { ok: true; value: Result }
+    | { ok: false; error: unknown }
+    | undefined;
+
+  try {
+    await trace(
+      {
+        name,
+        data,
+        tags: requestTags,
+        ...(startTime === undefined ? {} : { startTime }),
+      },
+      async (parentContext) => {
+        try {
+          const value = await fn(parentContext);
+          workResult = { ok: true, value };
+          return value;
+        } catch (error) {
+          workResult = { ok: false, error };
+          throw error;
+        }
+      },
+    );
+  } catch {
+    // Telemetry failure must not break — unless the work itself failed.
+  }
+
+  if (workResult === undefined) {
+    // `trace` failed before invoking `fn` (or never called it).
+    return fn(undefined);
+  }
+  if (workResult.ok) {
+    return workResult.value;
+  }
+  throw workResult.error;
+}


### PR DESCRIPTION
Avoid Sentry rate limits by nesting pipeline timings as subspans and emitting them only on the first unlock-session fetch, plus a single AggregatedBalanceSelector span for all wallets.

## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to observability wiring and defensive error handling; asset fetch and state-update behavior is unchanged aside from when spans are emitted.
> 
> **Overview**
> Reduces Sentry span volume and improves Assets Health dashboard fidelity by restructuring how `AssetsController` emits traces.
> 
> **Tracing helpers** — Inline `#emitTrace` is replaced by `utils/trace.ts` (`emitTrace` / `withTrace`). Omitting `trace` no-ops at call sites; numeric span data (especially `duration_ms`) is mirrored into tags and used to backdate `startTime` for p95 charts. `withTrace` treats Sentry/adapter rejections as best-effort so `getAssets` force updates and `handleAssetsUpdate` still complete.
> 
> **Nested spans & session gating** — Fetch and update pipelines wrap work in parent spans (`AssetsFetchPipeline`, `AssetsBackgroundFetch`, `AssetsUpdateEnrichment`); per-source timings and summary spans (`AssetsFullFetch`, `AssetsControllerFirstInitFetch`, `AssetsUpdatePipeline`, etc.) nest via `parentContext`. Fast and background fetch lanes are sibling `withTrace` calls, not nested. Pipeline, data-source, and enrichment spans emit only until the first `forceUpdate` in an unlock session (`#firstInitFetchReported`); later polls, force refreshes, and subscription enrichment skip those spans (reset on lock/`#stop`).
> 
> **Balance selector** — `calculateBalanceForAllWallets` emits one `AggregatedBalance` / `AggregatedBalanceSelector` pair for the full wallet pass instead of a root span per account group.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7001768b52477cb1857fbce6579b6b59900644cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->