### PR TITLE
feat: add srcTxHash to QuoteStatusManager reportFinalized method

### DIFF
--- a/packages/bridge-status-controller/CHANGELOG.md
+++ b/packages/bridge-status-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Populate `srcTxHash` in the `QuoteStatusUpdateError` when a finalization is reported for a transaction that has no tracked quote-status entry, so the error details identify the source transaction alongside `txMetaId` and `srcChainId` ([#9671](https://github.com/MetaMask/core/pull/9671))
+
 ## [74.5.0]
 
 ### Changed

--- a/packages/bridge-status-controller/CHANGELOG.md
+++ b/packages/bridge-status-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Populate `srcTxHash` in the `QuoteStatusUpdateError` when a finalization is reported for a transaction that has no tracked quote-status entry, so the error details identify the source transaction alongside `txMetaId` and `srcChainId` ([#9671](https://github.com/MetaMask/core/pull/9671))
+- Populate `srcTxHash` in the `QuoteStatusUpdateError` when a finalization is reported for a transaction that has no tracked quote-status entry, so the error details identify the source transaction alongside `txMetaId` and `srcChainId` ([#9673](https://github.com/MetaMask/core/pull/9673))
 
 ## [74.5.0]
 

--- a/packages/bridge-status-controller/src/bridge-status-controller.ts
+++ b/packages/bridge-status-controller/src/bridge-status-controller.ts
@@ -376,6 +376,7 @@ export class BridgeStatusController extends StaticIntervalPollingController<Brid
         txMeta.id,
         false,
         txMeta.chainId,
+        txMeta.hash,
       );
     }
 
@@ -433,7 +434,12 @@ export class BridgeStatusController extends StaticIntervalPollingController<Brid
       ) {
         this.#reportSubmittedOnce(historyKey, txMeta.hash, txMeta.id);
       }
-      this.#quoteStatusManager.reportFinalised(txMeta.id, true, txMeta.chainId);
+      this.#quoteStatusManager.reportFinalised(
+        txMeta.id,
+        true,
+        txMeta.chainId,
+        txMeta.hash,
+      );
       this.#trackUnifiedSwapBridgeEvent(
         UnifiedSwapBridgeEventName.Completed,
         historyKey,
@@ -920,10 +926,12 @@ export class BridgeStatusController extends StaticIntervalPollingController<Brid
     // Report finalization as a failure here, this is the only place that
     // permanently ends polling, so it's the correct and non-duplicative point
     // to emit the final status.
+    const historyItem = this.state.txHistory[bridgeTxMetaId];
     this.#quoteStatusManager.reportFinalised(
       bridgeTxMetaId,
       false,
-      this.state.txHistory[bridgeTxMetaId]?.quote.srcChainId,
+      historyItem?.quote.srcChainId,
+      historyItem?.status.srcChain.txHash,
     );
     this.#deleteHistoryItem(bridgeTxMetaId);
   };
@@ -1085,6 +1093,7 @@ export class BridgeStatusController extends StaticIntervalPollingController<Brid
           bridgeTxMetaId,
           status.status === StatusTypes.COMPLETE,
           historyItem.quote.srcChainId,
+          settlementTxHash,
         );
 
         if (status.status === StatusTypes.COMPLETE) {
@@ -1312,17 +1321,21 @@ export class BridgeStatusController extends StaticIntervalPollingController<Brid
             this.#startPollingForTxId(payload.historyKey);
             break;
 
-          case SubmitStep.PublishCompletedEvent:
+          case SubmitStep.PublishCompletedEvent: {
+            const completedHistoryItem =
+              this.state.txHistory[payload.historyKey];
             this.#quoteStatusManager.reportFinalised(
               payload.historyKey,
               true,
-              this.state.txHistory[payload.historyKey]?.quote.srcChainId,
+              completedHistoryItem?.quote.srcChainId,
+              completedHistoryItem?.status.srcChain.txHash,
             );
             this.#trackUnifiedSwapBridgeEvent(
               UnifiedSwapBridgeEventName.Completed,
               payload.historyKey,
             );
             break;
+          }
 
           /* c8 ignore start */
           default:

--- a/packages/bridge-status-controller/src/quote-status-manager/quotes-status-manager.test.ts
+++ b/packages/bridge-status-controller/src/quote-status-manager/quotes-status-manager.test.ts
@@ -668,7 +668,7 @@ describe('QuoteStatusUpdateManager', () => {
     it('surfaces an error when the entry is not found', () => {
       const { manager, onError } = createManager();
 
-      manager.reportFinalised('tx-missing', true, 'eip155:1');
+      manager.reportFinalised('tx-missing', true, 'eip155:1', '0xabc');
 
       expect(onError).toHaveBeenCalledTimes(1);
       expect(onError.mock.calls[0][0].message).toBe(
@@ -678,6 +678,7 @@ describe('QuoteStatusUpdateManager', () => {
         quoteId: '',
         txMetaId: 'tx-missing',
         srcChainId: 'eip155:1',
+        srcTxHash: '0xabc',
       });
     });
 

--- a/packages/bridge-status-controller/src/quote-status-manager/quotes-status-manager.ts
+++ b/packages/bridge-status-controller/src/quote-status-manager/quotes-status-manager.ts
@@ -165,7 +165,6 @@ export class QuoteStatusManager {
 
     const entries = this.#quoteStatusEntryStore.getAllByTxMetaId(txMetaId);
 
-    console.log('dwfwfw', { quoteId: '', txMetaId, srcChainId, srcTxHash })
     if (entries.length === 0) {
       this.#onError?.(
         new QuoteStatusUpdateError(

--- a/packages/bridge-status-controller/src/quote-status-manager/quotes-status-manager.ts
+++ b/packages/bridge-status-controller/src/quote-status-manager/quotes-status-manager.ts
@@ -150,11 +150,14 @@ export class QuoteStatusManager {
    * @param success - Whether the transaction finalized successfully.
    * @param srcChainId - Optional source-chain id, forwarded to error reporting
    * to aid debugging when no matching entry is found.
+   * @param srcTxHash - Optional source-chain transaction hash, forwarded to
+   * error reporting to aid debugging when no matching entry is found.
    */
   reportFinalised(
     txMetaId: string,
     success: boolean,
     srcChainId?: string | number,
+    srcTxHash?: string,
   ): void {
     if (!this.#isEnabled?.()) {
       return;
@@ -162,11 +165,12 @@ export class QuoteStatusManager {
 
     const entries = this.#quoteStatusEntryStore.getAllByTxMetaId(txMetaId);
 
+    console.log('dwfwfw', { quoteId: '', txMetaId, srcChainId, srcTxHash })
     if (entries.length === 0) {
       this.#onError?.(
         new QuoteStatusUpdateError(
           'reporting finalization status but entry was not found',
-          { quoteId: '', txMetaId, srcChainId },
+          { quoteId: '', txMetaId, srcChainId, srcTxHash },
         ),
       );
       return;
@@ -311,12 +315,22 @@ export class QuoteStatusManager {
       }
 
       if (txMeta.status === TransactionStatus.confirmed) {
-        this.reportFinalised(entry.txMetaId, true, entry.srcChainId);
+        this.reportFinalised(
+          entry.txMetaId,
+          true,
+          entry.srcChainId,
+          entry.srcTxHash,
+        );
       } else if (
         txMeta.status === TransactionStatus.failed ||
         txMeta.status === TransactionStatus.dropped
       ) {
-        this.reportFinalised(entry.txMetaId, false, entry.srcChainId);
+        this.reportFinalised(
+          entry.txMetaId,
+          false,
+          entry.srcChainId,
+          entry.srcTxHash,
+        );
       }
     }
   }
@@ -514,8 +528,8 @@ export class QuoteStatusManager {
       );
       return Boolean(
         live &&
-        live.status.state === sentStatus &&
-        live.acknowledgedState !== sentStatus,
+          live.status.state === sentStatus &&
+          live.acknowledgedState !== sentStatus,
       );
     };
 

--- a/packages/bridge-status-controller/src/quote-status-manager/quotes-status-manager.ts
+++ b/packages/bridge-status-controller/src/quote-status-manager/quotes-status-manager.ts
@@ -527,8 +527,8 @@ export class QuoteStatusManager {
       );
       return Boolean(
         live &&
-          live.status.state === sentStatus &&
-          live.acknowledgedState !== sentStatus,
+        live.status.state === sentStatus &&
+        live.acknowledgedState !== sentStatus,
       );
     };
 


### PR DESCRIPTION
## Explanation

`QuoteStatusManager.reportFinalised` surfaces a `QuoteStatusUpdateError` through the
`onError` callback when it is asked to finalize a `txMetaId` that has no tracked
quote-status entry. Those reports carried only an empty `quoteId`, the `txMetaId`, and
`srcChainId`, so when one lands in Sentry there is nothing tying it to the on-chain
source transaction — which is exactly what you need to tell whether the entry was never
created, was created under a different source hash, or had already been evicted by TTL.
`QuoteStatusUpdateErrorDetails` has carried an optional `srcTxHash` field since #9596,
but nothing on the finalization path populated it.

This adds an optional `srcTxHash` parameter to `reportFinalised`, forwards it into the
error details, and supplies it from every caller:

| Caller | Source of the hash |
| --- | --- |
| `#onTransactionFailed` | `txMeta.hash` |
| `#onTransactionConfirmed` (swap branch) | `txMeta.hash` |
| `#handleOldHistoryItem` (polling permanently ends) | history item's `status.srcChain.txHash` |
| `#fetchBridgeTxStatus` (final status) | the `settlementTxHash` already computed for `#reportSubmittedOnce` |
| `SubmitStep.PublishCompletedEvent` | history item's `status.srcChain.txHash` |
| `QuoteStatusManager.init()` reconciliation (both calls) | `entry.srcTxHash` |

Things that may not be obvious:

- The two `init()` call sites cannot actually reach the missing-entry branch, since that
  loop iterates entries that are by definition in the store. They pass `srcTxHash` purely
  so every call site is consistent.
- In `#handleOldHistoryItem` and `SubmitStep.PublishCompletedEvent` the `txHistory` lookup
  is hoisted into a local rather than indexing state twice; the latter case is now wrapped
  in braces because it declares a `const`.
- This is not a breaking change: `QuoteStatusManager` is not exported from
  `src/index.ts`, and the new parameter is optional.
- One unrelated re-indent of an existing boolean expression inside `#processEntry`'s
  `retry()` closure, so the file passes the Prettier check.

## References

https://consensyssoftware.atlassian.net/browse/SWAPS-4841

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional parameter and richer error metadata only; no change to successful finalization or backend sync behavior.
> 
> **Overview**
> **Quote status finalization errors** now include the source transaction hash when `reportFinalised` cannot find a tracked entry, so Sentry reports tie failures to the on-chain source tx (not just `txMetaId` and `srcChainId`).
> 
> `QuoteStatusManager.reportFinalised` gains an optional `srcTxHash` argument that is forwarded into `QuoteStatusUpdateError` details. **Bridge status controller** call sites pass the hash from the relevant context (`txMeta.hash`, bridge history `status.srcChain.txHash`, or `settlementTxHash`); startup reconciliation passes `entry.srcTxHash`. Tests and the package changelog are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44397942891bbf9700cd508257053f00d56ef873. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->