### PR TITLE
fix(transaction-controller): scope saved gas exclusions to swaps and bridges

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Apply saved gas fee preferences to wallet-initiated transfers while continuing to ignore them for swaps and bridge transactions.
+
 ### Changed
 
 - Bump `@metamask/gas-fee-controller` from `^26.2.4` to `^26.3.0` ([#9629](https://github.com/MetaMask/core/pull/9629))

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,13 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Apply saved gas fee preferences to wallet-initiated transfers while continuing to ignore them for swaps and bridge transactions ([#9682](https://github.com/MetaMask/core/pull/9682)).
-
 ### Changed
 
 - Bump `@metamask/gas-fee-controller` from `^26.2.4` to `^26.3.0` ([#9629](https://github.com/MetaMask/core/pull/9629))
+
+### Fixed
+
+- Apply saved gas fee preferences to wallet-initiated transfers while continuing to ignore them for swaps and bridge transactions ([#9682](https://github.com/MetaMask/core/pull/9682)).
 
 ## [69.2.1]
 

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Apply saved gas fee preferences to wallet-initiated transfers while continuing to ignore them for swaps and bridge transactions ([#9682](https://github.com/MetaMask/core/pull/9682)).
+
 ### Changed
 
 - Bump `@metamask/gas-fee-controller` from `^26.2.4` to `^26.3.0` ([#9629](https://github.com/MetaMask/core/pull/9629))

--- a/packages/transaction-controller/src/utils/gas-fees.test.ts
+++ b/packages/transaction-controller/src/utils/gas-fees.test.ts
@@ -169,9 +169,31 @@ describe('gas-fees', () => {
         );
       });
 
-      it('are ignored for internal transactions (e.g. swaps and bridges)', async () => {
+      it('are applied for internal wallet transactions', async () => {
+        updateGasFeeRequest.txMeta.isInternal = true;
+        updateGasFeeRequest.txMeta.type = TransactionType.simpleSend;
+        updateGasFeeRequest.getSavedGasFees.mockReturnValueOnce(
+          SAVED_GAS_FEES_MOCK,
+        );
+
+        await updateGasFees(updateGasFeeRequest);
+
+        expect(updateGasFeeRequest.getSavedGasFees).toHaveBeenCalledTimes(1);
+        expect(updateGasFeeRequest.txMeta.txParams.maxFeePerGas).toBe(
+          '0x1ca35f0e00', // 123 gwei
+        );
+      });
+
+      it.each([
+        TransactionType.swap,
+        TransactionType.swapAndSend,
+        TransactionType.swapApproval,
+        TransactionType.bridge,
+        TransactionType.bridgeApproval,
+      ])('are ignored for %s transactions', async (type) => {
         mockGasFeeFlowMockResponse(FLOW_RESPONSE_FEE_MARKET_MOCK);
         updateGasFeeRequest.txMeta.isInternal = true;
+        updateGasFeeRequest.txMeta.type = type;
         updateGasFeeRequest.getSavedGasFees.mockReturnValueOnce(
           SAVED_GAS_FEES_MOCK,
         );

--- a/packages/transaction-controller/src/utils/gas-fees.ts
+++ b/packages/transaction-controller/src/utils/gas-fees.ts
@@ -17,9 +17,11 @@ import type {
 import {
   GasFeeEstimateLevel,
   GasFeeEstimateType,
+  TransactionType,
   UserFeeLevel,
 } from '../types.js';
 import { getGasFeeFlow } from './gas-flow.js';
+import { SWAP_TRANSACTION_TYPES } from './swaps.js';
 import { rpcRequest } from './provider.js';
 
 export type UpdateGasFeesRequest = {
@@ -57,6 +59,12 @@ type SuggestedGasFees = {
 
 const log = createModuleLogger(projectLogger, 'gas-fees');
 
+const SAVED_GAS_FEES_IGNORED_TRANSACTION_TYPES = [
+  ...SWAP_TRANSACTION_TYPES,
+  TransactionType.bridge,
+  TransactionType.bridgeApproval,
+];
+
 /**
  * Update the gas fee properties of the provided transaction meta.
  *
@@ -68,12 +76,13 @@ export async function updateGasFees(
   const { txMeta } = request;
   const initialParams = { ...txMeta.txParams };
 
-  // User-saved (advanced) gas fees only apply to dApp transactions. Internal
-  // transactions (e.g. swaps and bridges) have their fees dictated by the
-  // aggregator or relay, so applying saved gas fees could underprice them and
-  // cause them to fail or get stuck.
+  const shouldIgnoreSavedGasFees =
+    SAVED_GAS_FEES_IGNORED_TRANSACTION_TYPES.includes(
+      txMeta.type as TransactionType,
+    );
+
   const savedGasFees =
-    txMeta.isInternal || hasInitialGasFeeParams(initialParams)
+    shouldIgnoreSavedGasFees || hasInitialGasFeeParams(initialParams)
       ? undefined
       : request.getSavedGasFees(txMeta);
 

--- a/packages/transaction-controller/src/utils/gas-fees.ts
+++ b/packages/transaction-controller/src/utils/gas-fees.ts
@@ -21,8 +21,8 @@ import {
   UserFeeLevel,
 } from '../types.js';
 import { getGasFeeFlow } from './gas-flow.js';
-import { SWAP_TRANSACTION_TYPES } from './swaps.js';
 import { rpcRequest } from './provider.js';
+import { SWAP_TRANSACTION_TYPES } from './swaps.js';
 
 export type UpdateGasFeesRequest = {
   eip1559: boolean;


### PR DESCRIPTION
## Summary

Saved gas preferences were excluded from every transaction with `isInternal: true`. This also excluded wallet-initiated transfers, which are marked internal by the extension API even though they should use saved gas settings.

This changes the exclusion to a dedicated transaction-type list containing swaps and bridge transactions. Wallet transfers can now apply saved gas preferences while swaps and bridges remain protected from underpriced saved fees.

## Related PRs

- MetaMask/core#9401
- MetaMask/metamask-extension#43317

## Testing

- `yarn jest --config packages/transaction-controller/jest.config.js --runInBand packages/transaction-controller/src/utils/gas-fees.test.ts --coverage=false`
- Added coverage for internal wallet transactions and swap/bridge exclusions.

## Changelog

Added an Unreleased changelog entry for `@metamask/transaction-controller`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which transactions receive saved gas fees at submit time; wallet sends gain user prefs while swap/bridge behavior stays guarded, but any misclassified `type` could get the wrong fee path.
> 
> **Overview**
> **Saved gas preferences** were skipped for every transaction with `isInternal: true`, which incorrectly blocked wallet-initiated transfers (often marked internal) from using the user’s advanced gas settings.
> 
> `updateGasFees` now ignores saved gas only for **swap and bridge** transaction types (`SWAP_TRANSACTION_TYPES`, `bridge`, `bridgeApproval`) instead of all internal transactions. Internal `simpleSend` transfers can apply saved fees again; aggregator/relay-driven swaps and bridges still avoid user-saved fees that could underprice them.
> 
> Tests cover internal wallet sends applying saved gas and parameterized cases for swap/bridge types still ignoring them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61d407435e6ada2aae13a8edd82db770f01e3313. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->