### PR TITLE
fix: correct defi types from api

### DIFF
--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/keyring-api` from `^23.5.0` to `^23.7.0` ([#9676](https://github.com/MetaMask/core/pull/9676))
 
+### Fixed
+
+- Treat `loan` (not `lending`) as the DeFi liability position type in `DEFI_POSITION_LIABILITY_TYPES`, matching corrected Accounts API v6 position types ([#9683](https://github.com/MetaMask/core/pull/9683))
+
 ## [110.0.0]
 
 ### Added

--- a/packages/assets-controllers/src/DeFiPositionsController/group-defi-positions-v6.test.ts
+++ b/packages/assets-controllers/src/DeFiPositionsController/group-defi-positions-v6.test.ts
@@ -266,7 +266,7 @@ describe('groupDeFiPositionsV6', () => {
     expect(group.sections[2].positions[0].marketValue).toBe(5);
   });
 
-  it('subtracts lending positions from the protocol market value', () => {
+  it('subtracts loan positions from the protocol market value', () => {
     const response = buildResponse([
       {
         accountId: 'account-1',
@@ -296,7 +296,7 @@ describe('groupDeFiPositionsV6', () => {
             metadata: {
               ...AAVE_METADATA,
               productName: 'Aave V3 Borrow',
-              positionType: 'lending',
+              positionType: 'loan',
             },
           },
         ],
@@ -308,7 +308,7 @@ describe('groupDeFiPositionsV6', () => {
     expect(group.marketValue).toBe(1500);
     expect(group.sections[0].positions[0].marketValue).toBe(2000);
     expect(group.sections[1].positions[0].marketValue).toBe(500);
-    expect(group.sections[1].positions[0].positionType).toBe('lending');
+    expect(group.sections[1].positions[0].positionType).toBe('loan');
   });
 
   it('creates separate detail sections per productName under one protocolId', () => {
@@ -340,7 +340,7 @@ describe('groupDeFiPositionsV6', () => {
             metadata: {
               ...AAVE_METADATA,
               productName: 'Aave V3 Borrow',
-              positionType: 'lending',
+              positionType: 'loan',
             },
           },
         ],
@@ -365,7 +365,7 @@ describe('groupDeFiPositionsV6', () => {
         positions: [
           expect.objectContaining({
             symbol: 'USDC',
-            positionType: 'lending',
+            positionType: 'loan',
           }),
         ],
       },
@@ -407,7 +407,7 @@ describe('groupDeFiPositionsV6', () => {
             price: '2000',
             metadata: {
               ...AAVE_METADATA,
-              positionType: 'rewards',
+              positionType: 'reward',
             },
           },
         ],

--- a/packages/assets-controllers/src/DeFiPositionsController/group-defi-positions-v6.ts
+++ b/packages/assets-controllers/src/DeFiPositionsController/group-defi-positions-v6.ts
@@ -37,7 +37,7 @@ export type DeFiPositionType = V6DeFiPositionType;
  * protocol group's aggregated `marketValue`.
  */
 export const DEFI_POSITION_LIABILITY_TYPES: ReadonlySet<DeFiPositionType> =
-  new Set<DeFiPositionType>(['lending']);
+  new Set<DeFiPositionType>(['loan']);
 
 /**
  * An icon-group entry shown next to a protocol in the DeFi tab list.

--- a/packages/core-backend/CHANGELOG.md
+++ b/packages/core-backend/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Align `V6_DEFI_POSITION_TYPES` (and inferred `V6DeFiPositionType`) with Accounts API / Zerion wallet fungible position types: `deposit`, `loan`, `locked`, `staked`, `reward`, `wallet`, `investment` ([#9683](https://github.com/MetaMask/core/pull/9683))
+- **BREAKING:** Align `V6_DEFI_POSITION_TYPES` (and inferred `V6DeFiPositionType`) with Accounts API / Zerion wallet fungible position types: `deposit`, `loan`, `locked`, `staked`, `reward`, `wallet`, `investment` ([#9683](https://github.com/MetaMask/core/pull/9683))
 
 ## [7.0.0]
 

--- a/packages/core-backend/CHANGELOG.md
+++ b/packages/core-backend/CHANGELOG.md
@@ -10,8 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Align `V6_DEFI_POSITION_TYPES` (and inferred `V6DeFiPositionType`) with Accounts API / Zerion wallet fungible position types: `deposit`, `loan`, `locked`, `staked`, `reward`, `wallet`, `investment` ([#9683](https://github.com/MetaMask/core/pull/9683))
-  - Removes incorrect values such as `lending`, `yield`, `liquidity_pool`, `leveraged_farming`, `nft_staked`, `farming`, `vesting`, and `rewards`
-  - Consumers that switch on or compare `positionType` must update to the corrected set
 
 ## [7.0.0]
 

--- a/packages/core-backend/CHANGELOG.md
+++ b/packages/core-backend/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Align `V6_DEFI_POSITION_TYPES` (and inferred `V6DeFiPositionType`) with Accounts API / Zerion wallet fungible position types: `deposit`, `loan`, `locked`, `staked`, `reward`, `wallet`, `investment` ([#9683](https://github.com/MetaMask/core/pull/9683))
+  - Removes incorrect values such as `lending`, `yield`, `liquidity_pool`, `leveraged_farming`, `nft_staked`, `farming`, `vesting`, and `rewards`
+  - Consumers that switch on or compare `positionType` must update to the corrected set
+
 ## [7.0.0]
 
 ### Added

--- a/packages/core-backend/src/api/accounts/types.ts
+++ b/packages/core-backend/src/api/accounts/types.ts
@@ -78,8 +78,6 @@ export const V6_DEFI_POSITION_TYPES = [
   'investment',
 ] as const;
 
-// deposit, loan, locked, staked, reward, wallet, investment
-
 /**
  * The specific module or functionality within a DeFi protocol where a position
  * is held.

--- a/packages/core-backend/src/api/accounts/types.ts
+++ b/packages/core-backend/src/api/accounts/types.ts
@@ -66,21 +66,19 @@ export type V6VsCurrency = string;
 /**
  * Possible `positionType` values on DeFi rows in the v6 balances response.
  * Categorizes the protocol module where the position is held.
+ * Link here: https://developers.zerion.io/api-reference/wallets/get-wallet-fungible-positions#parameter-filter-position-types
  */
 export const V6_DEFI_POSITION_TYPES = [
   'deposit',
-  'lending',
-  'yield',
-  'liquidity_pool',
-  'staked',
-  'leveraged_farming',
-  'nft_staked',
-  'farming',
+  'loan',
   'locked',
-  'vesting',
-  'rewards',
+  'staked',
+  'reward',
+  'wallet',
   'investment',
 ] as const;
+
+// deposit, loan, locked, staked, reward, wallet, investment
 
 /**
  * The specific module or functionality within a DeFi protocol where a position


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

`V6_DEFI_POSITION_TYPES` in `@metamask/core-backend` did not match the Accounts API / Zerion wallet fungible position `position_types` filter values, so typed DeFi rows and downstream grouping could disagree with real API data.

This PR updates the allowed position types to: `deposit`, `loan`, `locked`, `staked`, `reward`, `wallet`, `investment`. In `@metamask/assets-controllers`, `DEFI_POSITION_LIABILITY_TYPES` is updated from `lending` to `loan` so liability market-value handling stays aligned with the corrected type.

Tested locally in both extension and mobile. 

<img width="828" height="556" alt="image" src="https://github.com/user-attachments/assets/4a4bde02-47a0-432c-9acb-88d65f0c9e56" />


## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Related to https://consensyssoftware.atlassian.net/browse/ASSETS-3800

## Checklist

- [X] I've updated the test suite for new or updated code as appropriate
- [X] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [X] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking type changes in `@metamask/core-backend` can fail compile-time checks for consumers using removed position types; incorrect liability handling before this fix could have mis-stated DeFi totals.
> 
> **Overview**
> **Aligns v6 DeFi `positionType` values with the Accounts API / Zerion fungible position types** so typed API rows and client grouping match live responses.
> 
> In `@metamask/core-backend`, `V6_DEFI_POSITION_TYPES` (and `V6DeFiPositionType`) is replaced with `deposit`, `loan`, `locked`, `staked`, `reward`, `wallet`, and `investment`, dropping the previous set (e.g. `lending`, `yield`, `liquidity_pool`, `rewards`). A Zerion API doc link is added on the constant.
> 
> In `@metamask/assets-controllers`, `DEFI_POSITION_LIABILITY_TYPES` now treats **`loan`** (not `lending`) as the liability type when subtracting borrow exposure from protocol `marketValue`. Tests for v6 grouping are updated for `loan` and `reward` position types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3eee31ba0f60779f88c417cf5d9045ad07c2f1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->