### PR TITLE
feat: MUSD-1207 convert Veda APR values to compounded APY

### DIFF
--- a/packages/money-account-balance-service/CHANGELOG.md
+++ b/packages/money-account-balance-service/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Convert all Veda vault APR values returned by `getVaultApy` to compounded APY using daily compounding before exposing them to consumers.
+- Convert all Veda vault APR values returned by `getVaultApy` to compounded APY using daily compounding before exposing them to consumers. ([#9684](https://github.com/MetaMask/core/pull/9684))
 - Bump `@metamask/money-account-api-data-service` from `^0.3.0` to `^0.4.0` ([#9677](https://github.com/MetaMask/core/pull/9677))
 - Bump `@metamask/money-account-api-data-service` from `^0.2.0` to `^0.3.0` ([#9592](https://github.com/MetaMask/core/pull/9592))
 

--- a/packages/money-account-balance-service/CHANGELOG.md
+++ b/packages/money-account-balance-service/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Convert all Veda vault APR values returned by `getVaultApy` to compounded APY using daily compounding before exposing them to consumers.
 - Bump `@metamask/money-account-api-data-service` from `^0.3.0` to `^0.4.0` ([#9677](https://github.com/MetaMask/core/pull/9677))
 - Bump `@metamask/money-account-api-data-service` from `^0.2.0` to `^0.3.0` ([#9592](https://github.com/MetaMask/core/pull/9592))
 

--- a/packages/money-account-balance-service/src/money-account-balance-service-method-action-types.ts
+++ b/packages/money-account-balance-service/src/money-account-balance-service-method-action-types.ts
@@ -93,8 +93,10 @@ export type MoneyAccountBalanceServiceGetMusdEquivalentValueAction = {
 
 /**
  * Fetches the vault's APY and fee breakdown from the Veda performance REST API.
+ * APR values in the response are converted to APY using daily
+ * compounding before the normalized response is returned.
  *
- * @returns The normalized vault APY response.
+ * @returns The normalized vault APY response with compounded APY values.
  * @throws {@link VaultConfigNotAvailableError} if vault config has not been loaded.
  */
 export type MoneyAccountBalanceServiceGetVaultApyAction = {

--- a/packages/money-account-balance-service/src/money-account-balance-service.test.ts
+++ b/packages/money-account-balance-service/src/money-account-balance-service.test.ts
@@ -119,20 +119,20 @@ const MOCK_VAULT_APY_RAW_RESPONSE = {
 
 const MOCK_VAULT_APY_NORMALIZED = {
   aggregationPeriod: '7 days',
-  apy: 0.055,
+  apy: 0.05653623699373145,
   chainAllocation: { arbitrum: 1.0 },
   fees: 0.005,
   globalApyBreakdown: {
     fee: 0.005,
-    maturityApy: 0.03,
-    realApy: 0.05,
+    maturityApy: 0.030453263600551006,
+    realApy: 0.05126749646744733,
   },
   performanceFees: 0.001,
   realApyBreakdown: [
     {
       allocation: 1.0,
-      apy: 0.055,
-      apyNet: 0.05,
+      apy: 0.05653623699373145,
+      apyNet: 0.05126749646744733,
       chain: 'arbitrum',
       protocol: 'aave',
     },
@@ -2191,6 +2191,11 @@ describe('MoneyAccountBalanceService', () => {
 
       expect(result.apy).toBe(0);
       expect(result.fees).toBe(0);
+      expect(result.globalApyBreakdown).toStrictEqual({
+        fee: 0,
+        maturityApy: 0,
+        realApy: 0,
+      });
       expect(result.timestamp).toBe('Fri, 10 Apr 2026 22:05:54 GMT');
       expect(result.realApyBreakdown).toStrictEqual([]);
     });
@@ -2213,7 +2218,7 @@ describe('MoneyAccountBalanceService', () => {
 
       expect(result).toStrictEqual({
         aggregationPeriod: undefined,
-        apy: 0.03,
+        apy: 0.030453263600551006,
         chainAllocation: undefined,
         fees: undefined,
         globalApyBreakdown: undefined,

--- a/packages/money-account-balance-service/src/money-account-balance-service.ts
+++ b/packages/money-account-balance-service/src/money-account-balance-service.ts
@@ -1101,8 +1101,10 @@ export class MoneyAccountBalanceService extends BaseDataService<
 
   /**
    * Fetches the vault's APY and fee breakdown from the Veda performance REST API.
+   * APR values in the response are converted to APY using daily
+   * compounding before the normalized response is returned.
    *
-   * @returns The normalized vault APY response.
+   * @returns The normalized vault APY response with compounded APY values.
    * @throws {@link VaultConfigNotAvailableError} if vault config has not been loaded.
    */
   async getVaultApy(): Promise<NormalizedVaultApyResponse> {

--- a/packages/money-account-balance-service/src/requestNormalization.ts
+++ b/packages/money-account-balance-service/src/requestNormalization.ts
@@ -2,10 +2,11 @@ import { Infer } from '@metamask/superstruct';
 
 import type { NormalizedVaultApyResponse } from './response.types';
 import { VaultApyRawResponseStruct } from './structs.js';
+import { convertAprToApy } from './utils.js';
 
 /**
  * Normalizes the raw response from the Veda performance API into the expected
- * format.
+ * format and converts all APR values to compounded APY values.
  *
  * @param rawResponse - The raw response from the Veda performance API.
  * @returns The normalized response.
@@ -17,21 +18,23 @@ export function normalizeVaultApyResponse(
 
   return {
     aggregationPeriod: response.aggregation_period,
-    apy: response.apy,
+    apy: convertAprToApy(response.apy),
     chainAllocation: response.chain_allocation,
     fees: response.fees,
     globalApyBreakdown: response.global_apy_breakdown
       ? {
           fee: response.global_apy_breakdown.fee,
-          maturityApy: response.global_apy_breakdown.maturity_apy,
-          realApy: response.global_apy_breakdown.real_apy,
+          maturityApy: convertAprToApy(
+            response.global_apy_breakdown.maturity_apy,
+          ),
+          realApy: convertAprToApy(response.global_apy_breakdown.real_apy),
         }
       : undefined,
     performanceFees: response.performance_fees,
     realApyBreakdown: response.real_apy_breakdown?.map((item) => ({
       allocation: item.allocation,
-      apy: item.apy,
-      apyNet: item.apy_net,
+      apy: convertAprToApy(item.apy),
+      apyNet: convertAprToApy(item.apy_net),
       chain: item.chain,
       protocol: item.protocol,
     })),

--- a/packages/money-account-balance-service/src/response.types.ts
+++ b/packages/money-account-balance-service/src/response.types.ts
@@ -35,7 +35,9 @@ export type CanonicalMoneyAccountBalanceResponse =
 
 /**
  * Response from {@link MoneyAccountBalanceService.getVaultApy}.
- * All APY / fee values are decimals (multiply by 100 for percentage).
+ * APY and fee values are decimals (multiply by 100 for percentage).
+ * Veda's APY values are actually APR (labeled incorrectly). They are converted APY using daily compounding
+ * (see {@link convertAprToApy}) before this response is returned.
  *
  * Only `apy` and `timestamp` are guaranteed to be present — all other fields
  * are optional because the Veda API omits them when the vault has no activity.

--- a/packages/money-account-balance-service/src/structs.ts
+++ b/packages/money-account-balance-service/src/structs.ts
@@ -26,13 +26,15 @@ export const VaultConfigStruct = type({
 });
 
 /**
- * Superstruct schema for {@link NormalizedVaultApyResponse}.
+ * Superstruct schema for the raw Veda vault performance response.
  *
  * Uses `type()` (loose validation) so that unknown fields returned by the
  * Veda API do not cause validation failures.
  *
- * Only `apy` and `timestamp` are required — all other fields are optional
- * because the Veda API omits some fields when the vault has no activity.
+ * APY fields are APR values despite their API names. They are converted to
+ * compounded APY values by {@link normalizeVaultApyResponse}. Only `apy` and
+ * `timestamp` are required — all other fields are optional because the Veda
+ * API omits some fields when the vault has no activity.
  */
 export const VaultApyRawResponseStruct = type({
   Response: type({

--- a/packages/money-account-balance-service/src/utils.test.ts
+++ b/packages/money-account-balance-service/src/utils.test.ts
@@ -1,0 +1,15 @@
+import { convertAprToApy } from './utils.js';
+
+describe('convertAprToApy', () => {
+  it('returns undefined when APR is undefined', () => {
+    expect(convertAprToApy(undefined)).toBeUndefined();
+  });
+
+  it('returns zero when APR is zero', () => {
+    expect(convertAprToApy(0)).toBe(0);
+  });
+
+  it('converts APR to APY using daily compounding', () => {
+    expect(convertAprToApy(0.05)).toBeCloseTo(0.05126749646744733, 15);
+  });
+});

--- a/packages/money-account-balance-service/src/utils.ts
+++ b/packages/money-account-balance-service/src/utils.ts
@@ -1,0 +1,19 @@
+const DAYS_PER_YEAR = 365;
+
+export function convertAprToApy(apr: undefined): undefined;
+export function convertAprToApy(apr: number): number;
+export function convertAprToApy(apr: number | undefined): number | undefined;
+
+/**
+ * Converts a decimal APR to a decimal APY using daily compounding.
+ *
+ * @param apr - The APR as a decimal.
+ * @returns The compounded APY, or undefined when APR is undefined.
+ */
+export function convertAprToApy(apr: number | undefined): number | undefined {
+  if (apr === undefined || apr === 0) {
+    return apr;
+  }
+
+  return (1 + apr / DAYS_PER_YEAR) ** DAYS_PER_YEAR - 1;
+}


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Veda labels its linear annualized yield as APY, which underreports the compounded yield shown to Money account users. Convert all Veda vault APR fields to daily compounded APY.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->
Fixes: [MUSD-1207: [Feature] APY display – Convert APR to compounded APY in MetaMask UI](https://consensyssoftware.atlassian.net/browse/MUSD-1207)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes numeric yield values exposed to UI and downstream consumers of `getVaultApy`, which can affect displayed rates and any logic keyed on prior APR-like values.
> 
> **Overview**
> **Vault APY from `getVaultApy` is now daily-compounded APY**, not the linear APR values Veda returns under “APY” field names.
> 
> A new `convertAprToApy` helper applies `(1 + apr/365)^365 - 1` during `normalizeVaultApyResponse`, covering top-level `apy`, `globalApyBreakdown` (`maturityApy`, `realApy`), and each `realApyBreakdown` entry (`apy`, `apyNet`). **Fees are unchanged.** Docs and types note that raw Veda fields are APR and that consumers receive compounded decimals.
> 
> Tests and changelog are updated to match the new numbers (e.g. 5% APR → ~5.13% APY).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a13c518074db262412f230e1eda6da66bc309d96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->