### PR TITLE
chore: update `@tanstack/query-core` to v5 in remaining packages

### DIFF
--- a/packages/base-data-service/package.json
+++ b/packages/base-data-service/package.json
@@ -59,7 +59,7 @@
     "@metamask/messenger": "^2.0.0",
     "@metamask/storage-service": "^1.0.2",
     "@metamask/utils": "^11.11.0",
-    "@tanstack/query-core": "^4.43.0",
+    "@tanstack/query-core": "^5.62.16",
     "cockatiel": "^3.1.2",
     "fast-deep-equal": "^3.1.3",
     "lodash": "^4.17.21"

--- a/packages/chomp-api-service/package.json
+++ b/packages/chomp-api-service/package.json
@@ -58,7 +58,7 @@
     "@metamask/messenger": "^2.0.0",
     "@metamask/superstruct": "^3.1.0",
     "@metamask/utils": "^11.11.0",
-    "@tanstack/query-core": "^4.43.0"
+    "@tanstack/query-core": "^5.62.16"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^6.1.0",

--- a/packages/money-account-api-data-service/package.json
+++ b/packages/money-account-api-data-service/package.json
@@ -60,7 +60,7 @@
     "@metamask/messenger": "^2.0.0",
     "@metamask/superstruct": "^3.1.0",
     "@metamask/utils": "^11.11.0",
-    "@tanstack/query-core": "^4.43.0"
+    "@tanstack/query-core": "^5.62.16"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^6.1.0",

--- a/packages/sample-controllers/package.json
+++ b/packages/sample-controllers/package.json
@@ -61,7 +61,7 @@
     "@metamask/network-controller": "^34.0.0",
     "@metamask/superstruct": "^3.1.0",
     "@metamask/utils": "^11.11.0",
-    "@tanstack/query-core": "^4.43.0"
+    "@tanstack/query-core": "^5.62.16"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^6.1.0",

--- a/packages/sentinel-api-service/package.json
+++ b/packages/sentinel-api-service/package.json
@@ -60,7 +60,7 @@
     "@metamask/messenger": "^2.0.0",
     "@metamask/superstruct": "^3.1.0",
     "@metamask/utils": "^11.11.0",
-    "@tanstack/query-core": "^4.43.0"
+    "@tanstack/query-core": "^5.62.16"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^6.1.0",

--- a/packages/wallet-framework-docs/package.json
+++ b/packages/wallet-framework-docs/package.json
@@ -42,7 +42,7 @@
     "@metamask/messenger": "^2.0.0",
     "@metamask/superstruct": "^3.1.0",
     "@metamask/utils": "^11.11.0",
-    "@tanstack/query-core": "^4.43.0"
+    "@tanstack/query-core": "^5.62.16"
   },
   "devDependencies": {
     "@docusaurus/core": "^3.10.1",

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -23,9 +23,7 @@ const { inspect } = require('util');
  * Only intended as temporary measures to faciliate upgrades and releases.
  * This should trend towards empty.
  */
-const ALLOWED_INCONSISTENT_DEPENDENCIES = {
-  '@tanstack/query-core': ['^4.43.0'],
-};
+const ALLOWED_INCONSISTENT_DEPENDENCIES = {};
 
 /**
  * These packages are allowed as peer dependencies without requiring installation as

--- a/yarn.lock
+++ b/yarn.lock
@@ -6149,7 +6149,7 @@ __metadata:
     "@metamask/messenger": "npm:^2.0.0"
     "@metamask/storage-service": "npm:^1.0.2"
     "@metamask/utils": "npm:^11.11.0"
-    "@tanstack/query-core": "npm:^4.43.0"
+    "@tanstack/query-core": "npm:^5.62.16"
     "@ts-bridge/cli": "npm:^0.6.4"
     "@types/jest": "npm:^30.0.0"
     "@types/lodash": "npm:^4.14.191"
@@ -6332,7 +6332,7 @@ __metadata:
     "@metamask/messenger": "npm:^2.0.0"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^11.11.0"
-    "@tanstack/query-core": "npm:^4.43.0"
+    "@tanstack/query-core": "npm:^5.62.16"
     "@ts-bridge/cli": "npm:^0.6.4"
     "@types/jest": "npm:^30.0.0"
     deepmerge: "npm:^4.2.2"
@@ -7767,7 +7767,7 @@ __metadata:
     "@metamask/messenger": "npm:^2.0.0"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^11.11.0"
-    "@tanstack/query-core": "npm:^4.43.0"
+    "@tanstack/query-core": "npm:^5.62.16"
     "@ts-bridge/cli": "npm:^0.6.4"
     "@types/jest": "npm:^30.0.0"
     deepmerge: "npm:^4.2.2"
@@ -8687,7 +8687,7 @@ __metadata:
     "@metamask/network-controller": "npm:^34.0.0"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^11.11.0"
-    "@tanstack/query-core": "npm:^4.43.0"
+    "@tanstack/query-core": "npm:^5.62.16"
     "@ts-bridge/cli": "npm:^0.6.4"
     "@types/jest": "npm:^30.0.0"
     deepmerge: "npm:^4.2.2"
@@ -8783,7 +8783,7 @@ __metadata:
     "@metamask/messenger": "npm:^2.0.0"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^11.11.0"
-    "@tanstack/query-core": "npm:^4.43.0"
+    "@tanstack/query-core": "npm:^5.62.16"
     "@ts-bridge/cli": "npm:^0.6.4"
     "@types/jest": "npm:^30.0.0"
     deepmerge: "npm:^4.2.2"
@@ -9415,7 +9415,7 @@ __metadata:
     "@metamask/messenger": "npm:^2.0.0"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^11.11.0"
-    "@tanstack/query-core": "npm:^4.43.0"
+    "@tanstack/query-core": "npm:^5.62.16"
     "@types/jest": "npm:^30.0.0"
     "@types/react": "npm:^19.0.0"
     deepmerge: "npm:^4.2.2"
@@ -11302,13 +11302,6 @@ __metadata:
   version: 5.101.2
   resolution: "@tanstack/query-core@npm:5.101.2"
   checksum: 10/567af5e3c21628745a08c1a5054d838597bc620dcbbeabe20cdd6ccffdcca85a8d38128f6e80829b6e04d10f79ca793a7dd8fddc8a3d6bef10c2d580ae214c7d
-  languageName: node
-  linkType: hard
-
-"@tanstack/query-core@npm:^4.43.0":
-  version: 4.43.0
-  resolution: "@tanstack/query-core@npm:4.43.0"
-  checksum: 10/c2a5a151c7adaea8311e01a643255f31946ae3164a71567ba80048242821ae14043f13f5516b695baebe5ea7e4b2cf717fd60908a929d18a5c5125fee925ff67
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation

A recent PR updated this package to v5 in one package (#9563). This PR updates to v5 in all remaining packages.

## References

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them
