### PR TITLE
A couple of fixes for tsconfig linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lint:dependencies": "knip --config knip.config.mts --dependencies && yarn dedupe --check",
     "lint:dependencies:fix": "knip --config knip.config.mts --dependencies && yarn dedupe",
     "lint:eslint": "yarn build:only-clean && NODE_OPTIONS='--max-old-space-size=8192' yarn eslint",
-    "lint:fix": "yarn lint:eslint --fix --prune-suppressions && echo && yarn lint:misc --write && yarn constraints --fix && yarn lint:dependencies:fix && yarn messenger-action-types:generate && yarn readme-content:update && yarn codeowners:generate",
+    "lint:fix": "yarn lint:eslint --fix --prune-suppressions && echo && yarn lint:misc --write && yarn constraints --fix && yarn lint:dependencies:fix && yarn messenger-action-types:generate && yarn readme-content:update && yarn lint:tsconfigs:fix:all && yarn codeowners:generate",
     "lint:misc": "oxfmt --ignore-path .gitignore",
     "lint:misc:check": "yarn lint:misc --check",
     "lint:teams": "tsx scripts/lint-teams-json.ts",

--- a/scripts/lint-tsconfigs/lint-package-tsconfigs.mts
+++ b/scripts/lint-tsconfigs/lint-package-tsconfigs.mts
@@ -1,5 +1,3 @@
-import * as path from 'path';
-
 import type {
   PackageManifest,
   TsconfigLintMetaReport,
@@ -53,13 +51,12 @@ export async function lintPackageTsconfigs({
   const lintReport = await lintPackageLintOnlyTsconfigs({
     packageRoot,
     repoRoot,
-    manifest,
     workspaces,
     expectedPackageNames,
     shouldFix,
   });
 
-  return devAndBuildReport.didPass && lintReport.didPass;
+  return devAndBuildReport.didPass && (!lintReport || lintReport.didPass);
 }
 
 /**
@@ -88,7 +85,7 @@ export async function lintPackageDevAndBuildOnlyTsconfigs({
   expectedPackageNames: Set<string>;
   shouldFix: boolean;
 }): Promise<TsconfigLintMetaReport> {
-  const devAndBuildTsconfigs = await Promise.all([
+  const devAndBuildOnlyTsconfigs = await Promise.all([
     readTsconfig(packageRoot, 'tsconfig.json'),
     readTsconfig(packageRoot, 'tsconfig.build.json'),
   ]);
@@ -100,12 +97,12 @@ export async function lintPackageDevAndBuildOnlyTsconfigs({
   const report = shouldFix
     ? await ensureTsconfigsUpdated({
         workspaces: expectedWorkspaces,
-        tsconfigs: devAndBuildTsconfigs,
+        tsconfigs: devAndBuildOnlyTsconfigs,
         repoRoot,
         currentWorkspaceRoot: packageRoot,
       })
     : await lintTsconfigs({
-        tsconfigs: devAndBuildTsconfigs,
+        tsconfigs: devAndBuildOnlyTsconfigs,
         expectedPackageNames,
         workspaces,
         repoRoot,
@@ -124,7 +121,6 @@ export async function lintPackageDevAndBuildOnlyTsconfigs({
  * @param options - The options object.
  * @param options.packageRoot - The root directory of the package.
  * @param options.repoRoot - The root directory of the repository.
- * @param options.manifest - Contents of the package's `package.json` file.
  * @param options.workspaces - The workspaces in the repository.
  * @param options.expectedPackageNames - Workspace dependencies to reference.
  * @param options.shouldFix - Whether to automatically fix issues.
@@ -133,55 +129,49 @@ export async function lintPackageDevAndBuildOnlyTsconfigs({
 export async function lintPackageLintOnlyTsconfigs({
   packageRoot,
   repoRoot,
-  manifest,
   workspaces,
   expectedPackageNames,
   shouldFix,
 }: {
   packageRoot: string;
   repoRoot: string;
-  manifest: PackageManifest;
   workspaces: Workspaces;
   expectedPackageNames: Set<string>;
   shouldFix: boolean;
-}): Promise<TsconfigLintMetaReport> {
+}): Promise<TsconfigLintMetaReport | undefined> {
   const expectedWorkspaces = getSortedWorkspaces({
     packageNames: expectedPackageNames,
     workspaces,
   });
-  const lintWorkspaces = await filterWorkspacesWithTsconfig({
-    workspaces: expectedWorkspaces,
-    repoRoot,
-    fileName: 'tsconfig.lint.json',
-  });
-  // This allows us to increase linting for the whole repo incrementally.
-  const packageLintWorkspaces = await filterWorkspacesWithTsconfig({
-    workspaces: [
-      {
-        name: manifest.name,
-        location: path.relative(repoRoot, packageRoot),
-      },
-    ],
-    repoRoot,
-    fileName: 'tsconfig.lint.json',
-  });
-  const lintTsconfigsToCheck =
-    packageLintWorkspaces.length === 0
-      ? []
-      : [await readTsconfig(packageRoot, 'tsconfig.lint.json')];
+
+  // Only lint `tsconfig.lint.json` for packages that have this file.
+  // (We assume that if a package has a `tsconfig.lint.json` file, that package
+  // has also been added to the root `tsconfig.lint.json`.)
+  // Filtering the workspaces here allows us to increase typechecking for
+  // packages within this monorepo.
+  let lintOnlyTsconfig;
+  try {
+    lintOnlyTsconfig = await readTsconfig(packageRoot, 'tsconfig.lint.json');
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message.includes('Could not read file')
+    ) {
+      return undefined;
+    }
+    throw error;
+  }
 
   const report = shouldFix
     ? await ensureTsconfigsUpdated({
-        workspaces: lintWorkspaces,
-        tsconfigs: lintTsconfigsToCheck,
+        workspaces: expectedWorkspaces,
+        tsconfigs: [lintOnlyTsconfig],
         repoRoot,
         currentWorkspaceRoot: packageRoot,
       })
     : await lintTsconfigs({
-        tsconfigs: lintTsconfigsToCheck,
-        expectedPackageNames: new Set(
-          lintWorkspaces.map((workspace) => workspace.name),
-        ),
+        tsconfigs: [lintOnlyTsconfig],
+        expectedPackageNames,
         workspaces,
         repoRoot,
         currentWorkspaceRoot: packageRoot,


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

- Fix per-package tsconfig validation
  - Per-package lint-specific tsconfigs were only required to reference internal dependencies that had a `tsconfig.lint.json`, not the full set of internal dependencies. This means that as we add support for linting tsconfigs for more packages, their `tsconfig.lint.json` files may not be fully synced with `tsconfig.json`.
- Hook `lint:tsconfig:fix:all` into `lint:fix`

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them
