### PR TITLE
feat(core-backend): add debouncer system notifications in AccountActivity

### DIFF
--- a/packages/core-backend/CHANGELOG.md
+++ b/packages/core-backend/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `AccountActivityService` now debounces chain status updates instead of publishing one event per notification ([#9700](https://github.com/MetaMask/core/pull/9700))
+
 ## [8.0.0]
 
 ### Fixed

--- a/packages/core-backend/src/ws/AccountActivityService.test.ts
+++ b/packages/core-backend/src/ws/AccountActivityService.test.ts
@@ -482,50 +482,355 @@ describe('AccountActivityService', () => {
       });
 
       it('should track chains as up and down based on system notifications', async () => {
-        await withService(async ({ messenger, mocks }) => {
-          const statusChangedEventListener = jest.fn();
-          messenger.subscribe(
-            'AccountActivityService:statusChanged',
-            statusChangedEventListener,
-          );
-          const systemCallback = getSystemNotificationCallback(mocks);
+        jest.useFakeTimers();
+        // Remove the random jitter so the debounce delay is exactly the base
+        // window; jitter is covered separately below.
+        jest.spyOn(Math, 'random').mockReturnValue(0);
+        try {
+          await withService(async ({ messenger, mocks }) => {
+            const statusChangedEventListener = jest.fn();
+            messenger.subscribe(
+              'AccountActivityService:statusChanged',
+              statusChangedEventListener,
+            );
+            const systemCallback = getSystemNotificationCallback(mocks);
 
-          // Simulate chains coming up
-          const timestamp1 = 1760344704595;
-          systemCallback({
-            event: 'system-notification',
-            channel: 'system-notifications.v1.account-activity.v1',
-            data: {
+            // Simulate chains coming up
+            systemCallback({
+              event: 'system-notification',
+              channel: 'system-notifications.v1.account-activity.v1',
+              data: {
+                chainIds: ['eip155:1', 'eip155:137'],
+                status: 'up',
+              },
+              timestamp: 1760344704595,
+            });
+
+            jest.advanceTimersByTime(1000);
+
+            expect(statusChangedEventListener).toHaveBeenCalledWith({
               chainIds: ['eip155:1', 'eip155:137'],
               status: 'up',
-            },
-            timestamp: timestamp1,
-          });
+            });
 
-          expect(statusChangedEventListener).toHaveBeenCalledWith({
-            chainIds: ['eip155:1', 'eip155:137'],
-            status: 'up',
-            timestamp: timestamp1,
-          });
+            // Simulate one chain going down
+            systemCallback({
+              event: 'system-notification',
+              channel: 'system-notifications.v1.account-activity.v1',
+              data: {
+                chainIds: ['eip155:137'],
+                status: 'down',
+              },
+              timestamp: 1760344704696,
+            });
 
-          // Simulate one chain going down
-          const timestamp2 = 1760344704696;
-          systemCallback({
-            event: 'system-notification',
-            channel: 'system-notifications.v1.account-activity.v1',
-            data: {
+            jest.advanceTimersByTime(1000);
+
+            expect(statusChangedEventListener).toHaveBeenCalledWith({
               chainIds: ['eip155:137'],
               status: 'down',
-            },
-            timestamp: timestamp2,
+            });
           });
+        } finally {
+          jest.useRealTimers();
+        }
+      });
 
-          expect(statusChangedEventListener).toHaveBeenCalledWith({
-            chainIds: ['eip155:137'],
-            status: 'down',
-            timestamp: timestamp2,
+      it('accumulates notifications and publishes one batched event per status after the debounce window', async () => {
+        jest.useFakeTimers();
+        // Remove the random jitter so the debounce delay is exactly the base
+        // window; jitter is covered separately below.
+        jest.spyOn(Math, 'random').mockReturnValue(0);
+        try {
+          await withService(async ({ messenger, mocks }) => {
+            const statusChangedEventListener = jest.fn();
+            messenger.subscribe(
+              'AccountActivityService:statusChanged',
+              statusChangedEventListener,
+            );
+            const systemCallback = getSystemNotificationCallback(mocks);
+
+            // Burst of notifications within the debounce window
+            systemCallback({
+              event: 'system-notification',
+              channel: 'system-notifications.v1.account-activity.v1',
+              data: { chainIds: ['eip155:1', 'eip155:137'], status: 'up' },
+              timestamp: 1000,
+            });
+            systemCallback({
+              event: 'system-notification',
+              channel: 'system-notifications.v1.account-activity.v1',
+              data: { chainIds: ['eip155:56'], status: 'up' },
+              timestamp: 2000,
+            });
+            // eip155:137 flips to down before the window elapses
+            systemCallback({
+              event: 'system-notification',
+              channel: 'system-notifications.v1.account-activity.v1',
+              data: { chainIds: ['eip155:137'], status: 'down' },
+              timestamp: 3000,
+            });
+
+            // Nothing published yet - still within the debounce window
+            expect(statusChangedEventListener).not.toHaveBeenCalled();
+
+            jest.advanceTimersByTime(1000);
+
+            // One batched 'up' event and one batched 'down' event.
+            expect(statusChangedEventListener).toHaveBeenCalledTimes(2);
+            expect(statusChangedEventListener).toHaveBeenCalledWith({
+              chainIds: ['eip155:1', 'eip155:56'],
+              status: 'up',
+            });
+            expect(statusChangedEventListener).toHaveBeenCalledWith({
+              chainIds: ['eip155:137'],
+              status: 'down',
+            });
           });
-        });
+        } finally {
+          jest.useRealTimers();
+        }
+      });
+
+      it('resets the debounce timer on each notification', async () => {
+        jest.useFakeTimers();
+        // Remove the random jitter so the debounce delay is exactly the base
+        // window; jitter is covered separately below.
+        jest.spyOn(Math, 'random').mockReturnValue(0);
+        try {
+          await withService(async ({ messenger, mocks }) => {
+            const statusChangedEventListener = jest.fn();
+            messenger.subscribe(
+              'AccountActivityService:statusChanged',
+              statusChangedEventListener,
+            );
+            const systemCallback = getSystemNotificationCallback(mocks);
+
+            systemCallback({
+              event: 'system-notification',
+              channel: 'system-notifications.v1.account-activity.v1',
+              data: { chainIds: ['eip155:1'], status: 'up' },
+              timestamp: 1000,
+            });
+
+            // A second notification part-way through the window resets the
+            // timer, pushing the flush back another full window.
+            jest.advanceTimersByTime(500);
+            systemCallback({
+              event: 'system-notification',
+              channel: 'system-notifications.v1.account-activity.v1',
+              data: { chainIds: ['eip155:137'], status: 'up' },
+              timestamp: 1500,
+            });
+
+            // 1000ms after the first notification, but only 500ms after the
+            // second: not flushed yet because the timer was reset.
+            jest.advanceTimersByTime(500);
+            expect(statusChangedEventListener).not.toHaveBeenCalled();
+
+            // A full window after the last notification flushes both chains.
+            jest.advanceTimersByTime(500);
+            expect(statusChangedEventListener).toHaveBeenCalledTimes(1);
+            expect(statusChangedEventListener).toHaveBeenCalledWith({
+              chainIds: ['eip155:1', 'eip155:137'],
+              status: 'up',
+            });
+          });
+        } finally {
+          jest.useRealTimers();
+        }
+      });
+
+      it('adds random jitter on top of the debounce window before publishing', async () => {
+        jest.useFakeTimers();
+        // Mid-range jitter: 1000ms debounce + 0.5 * 1000ms jitter = 1500ms.
+        jest.spyOn(Math, 'random').mockReturnValue(0.5);
+        try {
+          await withService(async ({ messenger, mocks }) => {
+            const statusChangedEventListener = jest.fn();
+            messenger.subscribe(
+              'AccountActivityService:statusChanged',
+              statusChangedEventListener,
+            );
+            const systemCallback = getSystemNotificationCallback(mocks);
+
+            systemCallback({
+              event: 'system-notification',
+              channel: 'system-notifications.v1.account-activity.v1',
+              data: { chainIds: ['eip155:1'], status: 'up' },
+              timestamp: 1000,
+            });
+
+            // Not yet flushed at the base debounce window: jitter delays it.
+            jest.advanceTimersByTime(1000);
+            expect(statusChangedEventListener).not.toHaveBeenCalled();
+
+            // Flushed once the jittered delay elapses.
+            jest.advanceTimersByTime(500);
+            expect(statusChangedEventListener).toHaveBeenCalledTimes(1);
+            expect(statusChangedEventListener).toHaveBeenCalledWith({
+              chainIds: ['eip155:1'],
+              status: 'up',
+            });
+          });
+        } finally {
+          jest.useRealTimers();
+        }
+      });
+
+      it('drops buffered status changes when the WebSocket disconnects before the window elapses', async () => {
+        jest.useFakeTimers();
+        // Remove the random jitter so the debounce delay is exactly the base
+        // window; jitter is covered separately below.
+        jest.spyOn(Math, 'random').mockReturnValue(0);
+        try {
+          await withService(async ({ messenger, rootMessenger, mocks }) => {
+            const statusChangedEventListener = jest.fn();
+            messenger.subscribe(
+              'AccountActivityService:statusChanged',
+              statusChangedEventListener,
+            );
+            mocks.getAccountsFromSelectedAccountGroup.mockReturnValue([]);
+            const systemCallback = getSystemNotificationCallback(mocks);
+
+            systemCallback({
+              event: 'system-notification',
+              channel: 'system-notifications.v1.account-activity.v1',
+              data: { chainIds: ['eip155:1', 'eip155:137'], status: 'up' },
+              timestamp: 1000,
+            });
+
+            // Disconnect before the debounce window elapses.
+            rootMessenger.publish(
+              'BackendWebSocketService:connectionStateChanged',
+              {
+                state: WebSocketState.DISCONNECTED,
+                url: 'ws://test',
+                reconnectAttempts: 0,
+                timeout: 10000,
+                reconnectDelay: 500,
+                maxReconnectDelay: 5000,
+                requestTimeout: 30000,
+              },
+            );
+
+            // The buffered 'up' event is dropped; only the 'down' flush for
+            // the tracked chains is published.
+            expect(statusChangedEventListener).toHaveBeenCalledTimes(1);
+            expect(statusChangedEventListener).toHaveBeenCalledWith({
+              chainIds: ['eip155:1', 'eip155:137'],
+              status: 'down',
+              timestamp: expect.any(Number),
+            });
+
+            // Advancing past the window must not emit the stale 'up' event.
+            jest.advanceTimersByTime(1000);
+            expect(statusChangedEventListener).toHaveBeenCalledTimes(1);
+          });
+        } finally {
+          jest.useRealTimers();
+        }
+      });
+
+      it('publishes down on disconnect for chains whose buffered down was still pending', async () => {
+        jest.useFakeTimers();
+        // Remove the random jitter so the debounce delay is exactly the base
+        // window; jitter is covered separately below.
+        jest.spyOn(Math, 'random').mockReturnValue(0);
+        try {
+          await withService(async ({ messenger, rootMessenger, mocks }) => {
+            const statusChangedEventListener = jest.fn();
+            messenger.subscribe(
+              'AccountActivityService:statusChanged',
+              statusChangedEventListener,
+            );
+            mocks.getAccountsFromSelectedAccountGroup.mockReturnValue([]);
+            const systemCallback = getSystemNotificationCallback(mocks);
+
+            // Both chains come up and the window elapses, so consumers have
+            // been told they are up.
+            systemCallback({
+              event: 'system-notification',
+              channel: 'system-notifications.v1.account-activity.v1',
+              data: { chainIds: ['eip155:1', 'eip155:137'], status: 'up' },
+              timestamp: 1000,
+            });
+            jest.advanceTimersByTime(1000);
+            expect(statusChangedEventListener).toHaveBeenCalledWith({
+              chainIds: ['eip155:1', 'eip155:137'],
+              status: 'up',
+            });
+
+            // eip155:137 goes down, but the WebSocket disconnects before the
+            // debounce window elapses.
+            systemCallback({
+              event: 'system-notification',
+              channel: 'system-notifications.v1.account-activity.v1',
+              data: { chainIds: ['eip155:137'], status: 'down' },
+              timestamp: 2000,
+            });
+            rootMessenger.publish(
+              'BackendWebSocketService:connectionStateChanged',
+              {
+                state: WebSocketState.DISCONNECTED,
+                url: 'ws://test',
+                reconnectAttempts: 0,
+                timeout: 10000,
+                reconnectDelay: 500,
+                maxReconnectDelay: 5000,
+                requestTimeout: 30000,
+              },
+            );
+
+            // The disconnect flush must include the chain whose buffered
+            // 'down' was still pending, not just the chains still tracked
+            // as up.
+            expect(statusChangedEventListener).toHaveBeenCalledTimes(2);
+            expect(statusChangedEventListener).toHaveBeenLastCalledWith({
+              chainIds: ['eip155:1', 'eip155:137'],
+              status: 'down',
+              timestamp: expect.any(Number),
+            });
+
+            // Advancing past the window must not emit anything further.
+            jest.advanceTimersByTime(1000);
+            expect(statusChangedEventListener).toHaveBeenCalledTimes(2);
+          });
+        } finally {
+          jest.useRealTimers();
+        }
+      });
+
+      it('cancels a pending debounced flush when the service is destroyed', async () => {
+        jest.useFakeTimers();
+        // Remove the random jitter so the debounce delay is exactly the base
+        // window; jitter is covered separately below.
+        jest.spyOn(Math, 'random').mockReturnValue(0);
+        try {
+          await withService(async ({ service, messenger, mocks }) => {
+            const statusChangedEventListener = jest.fn();
+            messenger.subscribe(
+              'AccountActivityService:statusChanged',
+              statusChangedEventListener,
+            );
+            const systemCallback = getSystemNotificationCallback(mocks);
+
+            systemCallback({
+              event: 'system-notification',
+              channel: 'system-notifications.v1.account-activity.v1',
+              data: { chainIds: ['eip155:1'], status: 'up' },
+              timestamp: 1000,
+            });
+
+            // Destroying before the window elapses cancels the pending flush.
+            service.destroy();
+
+            jest.advanceTimersByTime(1000);
+            expect(statusChangedEventListener).not.toHaveBeenCalled();
+          });
+        } finally {
+          jest.useRealTimers();
+        }
       });
     });
 

--- a/packages/core-backend/src/ws/AccountActivityService.ts
+++ b/packages/core-backend/src/ws/AccountActivityService.ts
@@ -57,6 +57,17 @@ const MESSENGER_EXPOSED_METHODS = [] as const;
 
 const SUBSCRIPTION_NAMESPACE = 'account-activity.v1';
 
+// Window (in ms) over which consecutive system notifications are accumulated
+// before a single batched `statusChanged` event is published. Coalescing bursts
+// of chain up/down notifications avoids flooding consumers.
+const STATUS_CHANGE_DEBOUNCE_MS = 1000;
+
+// Maximum random jitter (in ms) added to the debounce window before publishing.
+// Spreading the publish across a random delay prevents many clients reacting to
+// the same system notification from publishing in lockstep (a thundering herd
+// on downstream consumers).
+const STATUS_CHANGE_JITTER_MS = 1000;
+
 // EVM subscriptions are always enabled.
 const ALWAYS_SUPPORTED_CHAIN_PREFIXES = ['eip155'] as const;
 
@@ -220,6 +231,17 @@ export class AccountActivityService {
 
   // Track chains that are currently up (based on system notifications)
   readonly #chainsUp: Set<string> = new Set();
+
+  // Debouncing for rapid status changes: buffers the latest status per chain
+  // and coalesces bursts of system notifications into fewer downstream
+  // `statusChanged` events.
+  readonly #statusChangeDebouncer: {
+    timer: NodeJS.Timeout | null;
+    pendingChanges: Map<string, 'up' | 'down'>;
+  } = {
+    timer: null,
+    pendingChanges: new Map(),
+  };
 
   // =============================================================================
   // Constructor and Initialization
@@ -421,7 +443,6 @@ export class AccountActivityService {
    */
   #handleSystemNotification(notification: ServerNotificationMessage): void {
     const data = notification.data as SystemNotificationData;
-    const { timestamp } = notification;
 
     // Validate required fields
     if (!data.chainIds || !Array.isArray(data.chainIds) || !data.status) {
@@ -430,7 +451,6 @@ export class AccountActivityService {
       );
     }
 
-    // Track chain status
     if (data.status === 'up') {
       for (const chainId of data.chainIds) {
         this.#chainsUp.add(chainId);
@@ -441,21 +461,65 @@ export class AccountActivityService {
       }
     }
 
-    // Publish status change directly (delta update)
-    this.#messenger.publish(`AccountActivityService:statusChanged`, {
-      chainIds: data.chainIds,
-      status: data.status,
-      timestamp,
-    });
+    for (const chainId of data.chainIds) {
+      this.#statusChangeDebouncer.pendingChanges.set(chainId, data.status);
+    }
 
-    log(
-      `WebSocket status change - Published tracked chains as ${data.status}`,
-      {
-        count: data.chainIds.length,
-        chains: data.chainIds,
-        status: data.status,
-      },
+    if (this.#statusChangeDebouncer.timer) {
+      clearTimeout(this.#statusChangeDebouncer.timer);
+    }
+
+    // Debounce window plus a random jitter, so clients reacting to the same
+    // system notification don't publish in lockstep.
+    const delay =
+      STATUS_CHANGE_DEBOUNCE_MS + Math.random() * STATUS_CHANGE_JITTER_MS;
+
+    this.#statusChangeDebouncer.timer = setTimeout(() => {
+      this.#processAccumulatedStatusChanges();
+    }, delay);
+
+    log(`WebSocket status change - Buffered chains as ${data.status}`, {
+      count: data.chainIds.length,
+      chains: data.chainIds,
+      status: data.status,
+    });
+  }
+
+  /**
+   * Publish the buffered status changes as batched `statusChanged` events, one
+   * per status (`up`/`down`), then reset the buffer and timer.
+   */
+  #processAccumulatedStatusChanges(): void {
+    const changes = Array.from(
+      this.#statusChangeDebouncer.pendingChanges.entries(),
     );
+    this.#statusChangeDebouncer.pendingChanges.clear();
+    this.#statusChangeDebouncer.timer = null;
+
+    // Group buffered chains by their latest status. A chain can only appear in
+    // one group because the buffer keeps a single entry per chain.
+    const grouped: Record<'up' | 'down', string[]> = { up: [], down: [] };
+    for (const [chainId, status] of changes) {
+      grouped[status].push(chainId);
+    }
+
+    for (const status of ['up', 'down'] as const) {
+      const chainIds = grouped[status];
+      if (chainIds.length === 0) {
+        continue;
+      }
+
+      this.#messenger.publish(`AccountActivityService:statusChanged`, {
+        chainIds,
+        status,
+      });
+
+      log(`WebSocket status change - Published batched chains as ${status}`, {
+        count: chainIds.length,
+        chains: chainIds,
+        status,
+      });
+    }
   }
 
   /**
@@ -473,19 +537,28 @@ export class AccountActivityService {
       // The system notification will automatically provide the list of chains that are up
       await this.#subscribeToSelectedAccount();
     } else if (state === WebSocketState.DISCONNECTED) {
-      // On disconnect, flush all tracked chains as down
-      const chainsToMarkDown = Array.from(this.#chainsUp);
+      if (this.#statusChangeDebouncer.timer) {
+        clearTimeout(this.#statusChangeDebouncer.timer);
+        this.#statusChangeDebouncer.timer = null;
+      }
 
-      if (chainsToMarkDown.length > 0) {
+      const chainsToMarkDown = new Set(this.#chainsUp);
+      for (const chainId of this.#statusChangeDebouncer.pendingChanges.keys()) {
+        chainsToMarkDown.add(chainId);
+      }
+      this.#statusChangeDebouncer.pendingChanges.clear();
+
+      if (chainsToMarkDown.size > 0) {
+        const chainIds = Array.from(chainsToMarkDown);
         this.#messenger.publish(`AccountActivityService:statusChanged`, {
-          chainIds: chainsToMarkDown,
+          chainIds,
           status: 'down',
           timestamp: Date.now(),
         });
 
         log('WebSocket disconnection - Published tracked chains as down', {
-          count: chainsToMarkDown.length,
-          chains: chainsToMarkDown,
+          count: chainIds.length,
+          chains: chainIds,
         });
 
         // Clear the tracking set since all chains are now down
@@ -628,6 +701,12 @@ export class AccountActivityService {
    * Optimized for fast cleanup during service destruction or mobile app termination
    */
   destroy(): void {
+    // Cancel any pending batched status-change flush
+    if (this.#statusChangeDebouncer.timer) {
+      clearTimeout(this.#statusChangeDebouncer.timer);
+      this.#statusChangeDebouncer.timer = null;
+    }
+
     // Clean up system notification callback
     this.#messenger.call(
       'BackendWebSocketService:removeChannelCallback',


### PR DESCRIPTION

## Explanation

Without Debouncer: https://www.loom.com/share/e96ef8f592254e9baaad15e86e823fa4

With Debouncer: https://www.loom.com/share/eddb747eb72b4a6eb8e880e9a942ac12

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes real-time chain status signaling timing and payload shape (no timestamp on debounced events), which downstream polling/UI may depend on; disconnect and batching logic adds behavioral edge cases.
> 
> **Overview**
> **`AccountActivityService`** no longer publishes `AccountActivityService:statusChanged` on every WebSocket system notification. Bursts are buffered for **1s** (plus up to **1s** random jitter), the timer resets on each new notification, and flush emits **one event per status** with merged `chainIds` (latest status wins per chain).
> 
> Debounced publishes **omit `timestamp`**; disconnect-driven `down` events still include `timestamp`. On **disconnect**, pending debounced work is cleared and affected chains (including buffered pending changes) are published as `down`. **`destroy()`** cancels any pending flush.
> 
> Tests use fake timers and cover batching, timer reset, jitter, disconnect, and destroy behavior. Changelog updated under Unreleased.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f329124b1cd14c7ed915beb266f817ccc03a7282. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->