### PR TITLE
fix(client-utils): native assetId via slip44 lookup

### DIFF
--- a/packages/client-utils/CHANGELOG.md
+++ b/packages/client-utils/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `@metamask/slip44` dependency for native token symbol lookup ([#9701](https://github.com/MetaMask/core/pull/9701))
+
+### Changed
+
+- Restore native `assetId` on activity tokens and network fees when a symbol is available, using `@metamask/slip44` symbol lookup instead of the removed chain registry ([#9701](https://github.com/MetaMask/core/pull/9701))
+  - Native tokens from indexed value transfers use the transfer symbol
+  - Local native tokens and fees include slip44 `assetId` only when a native symbol is already present on the mapped data
+  - API network fees derive the symbol from native value transfers when present
+  - `assetId` is still omitted when no symbol is available (for example ERC-20-only transactions with no native transfer)
+
 ## [1.4.0]
 
 ### Added

--- a/packages/client-utils/package.json
+++ b/packages/client-utils/package.json
@@ -59,6 +59,7 @@
     "@metamask/controller-utils": "^12.3.0",
     "@metamask/core-backend": "^8.0.0",
     "@metamask/keyring-api": "^23.7.0",
+    "@metamask/slip44": "^4.3.0",
     "@metamask/transaction-controller": "^69.3.0",
     "@metamask/utils": "^11.11.0"
   },

--- a/packages/client-utils/src/mappers/README.md
+++ b/packages/client-utils/src/mappers/README.md
@@ -66,7 +66,8 @@ The Accounts API classifies each transaction with a `transactionCategory`. The m
 Notes:
 
 - Backend API improvements are ongoing
-- Native / fee tokens may omit `assetId` and instead set `assetType: 'native'` so clients can resolve icons from chain metadata
+- Native tokens and network fees include slip44 `assetId` when a symbol is available (for example from an indexed native value transfer)
+- When no symbol is available, mappers still set `assetType: 'native'` but omit `assetId` — clients should resolve icons from chain metadata
 
 ---
 

--- a/packages/client-utils/src/mappers/api-transaction-mapper.test.ts
+++ b/packages/client-utils/src/mappers/api-transaction-mapper.test.ts
@@ -100,6 +100,7 @@ describe('mapApiTransaction', () => {
           direction: 'out',
           symbol: 'MATIC',
           assetType: 'native',
+          assetId: 'eip155:137/slip44:966',
         },
       },
     });
@@ -225,6 +226,7 @@ describe('mapApiTransaction', () => {
           direction: 'in',
           symbol: 'ETH',
           assetType: 'native',
+          assetId: 'eip155:59144/slip44:60',
         },
       },
     });
@@ -257,7 +259,18 @@ describe('mapApiTransaction', () => {
           direction: 'in',
           symbol: 'ETH',
           assetType: 'native',
+          assetId: 'eip155:59144/slip44:60',
         },
+        fees: [
+          {
+            type: 'base',
+            amount: '11794061214463',
+            decimals: 18,
+            assetType: 'native',
+            symbol: 'ETH',
+            assetId: 'eip155:59144/slip44:60',
+          },
+        ],
       },
     });
   });
@@ -282,6 +295,8 @@ describe('mapApiTransaction', () => {
         paymentToken: {
           direction: 'in',
           symbol: 'ETH',
+          assetType: 'native',
+          assetId: 'eip155:1/slip44:60',
         },
       },
     });
@@ -354,6 +369,8 @@ describe('mapApiTransaction', () => {
         paymentToken: {
           direction: 'out',
           symbol: 'ETH',
+          assetType: 'native',
+          assetId: 'eip155:1/slip44:60',
         },
       },
     });
@@ -525,6 +542,7 @@ describe('mapApiTransaction', () => {
           direction: 'out',
           symbol: 'ETH',
           assetType: 'native',
+          assetId: 'eip155:1/slip44:60',
         },
       },
     });
@@ -551,6 +569,8 @@ describe('mapApiTransaction', () => {
           direction: 'out',
           symbol: 'ETH',
           amount: '1000000000000',
+          assetType: 'native',
+          assetId: 'eip155:1/slip44:60',
         },
         destinationToken: {
           direction: 'in',
@@ -579,6 +599,7 @@ describe('mapApiTransaction', () => {
           direction: 'out',
           symbol: 'ETH',
           assetType: 'native',
+          assetId: 'eip155:1/slip44:60',
         },
         destinationToken: {
           amount: '1000000000000',
@@ -658,6 +679,7 @@ describe('mapApiTransaction', () => {
           direction: 'in',
           symbol: 'ETH',
           assetType: 'native',
+          assetId: 'eip155:1/slip44:60',
         },
       },
     });

--- a/packages/client-utils/src/mappers/helpers/caip.test.ts
+++ b/packages/client-utils/src/mappers/helpers/caip.test.ts
@@ -1,4 +1,8 @@
-import { formatAddressToAssetId, formatChainIdToCaip } from './caip.js';
+import {
+  formatAddressToAssetId,
+  formatChainIdToCaip,
+  resolveNativeAssetId,
+} from './caip.js';
 
 describe('caip helpers', () => {
   describe('formatChainIdToCaip', () => {
@@ -78,6 +82,35 @@ describe('caip helpers', () => {
           '0xzzzz',
         ),
       ).toBeUndefined();
+    });
+  });
+
+  describe('resolveNativeAssetId', () => {
+    it('resolves ETH via slip44', () => {
+      expect(resolveNativeAssetId('eip155:1', 'ETH')).toBe(
+        'eip155:1/slip44:60',
+      );
+    });
+
+    it('resolves POL via the MATIC slip44 entry', () => {
+      expect(resolveNativeAssetId('eip155:137', 'POL')).toBe(
+        'eip155:137/slip44:966',
+      );
+    });
+
+    it('returns undefined without a symbol', () => {
+      expect(resolveNativeAssetId('eip155:8453', undefined)).toBeUndefined();
+      expect(resolveNativeAssetId('eip155:4663', undefined)).toBeUndefined();
+    });
+
+    it('returns undefined for unknown symbols', () => {
+      expect(
+        resolveNativeAssetId('solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp', 'NOPE'),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined when the chain id cannot be normalized', () => {
+      expect(resolveNativeAssetId('0xzzzz', 'ETH')).toBeUndefined();
     });
   });
 });

--- a/packages/client-utils/src/mappers/helpers/caip.ts
+++ b/packages/client-utils/src/mappers/helpers/caip.ts
@@ -1,4 +1,6 @@
 import { toChecksumHexAddress } from '@metamask/controller-utils';
+// @ts-expect-error: No type definitions for '@metamask/slip44'
+import slip44 from '@metamask/slip44';
 import type { CaipAssetType, CaipChainId, Hex } from '@metamask/utils';
 import {
   isCaipAssetType,
@@ -8,6 +10,32 @@ import {
 } from '@metamask/utils';
 
 import { nativeTokenAddress } from '../constants.js';
+
+const slip44CoinTypeBySymbol = ((): Map<string, string> => {
+  const coinTypeBySymbol = new Map<string, string>();
+
+  for (const [coinType, entry] of Object.entries(
+    slip44 as Record<string, { symbol: string }>,
+  )) {
+    const normalizedSymbol = entry.symbol.toUpperCase();
+
+    if (!coinTypeBySymbol.has(normalizedSymbol)) {
+      coinTypeBySymbol.set(normalizedSymbol, coinType);
+    }
+  }
+
+  const maticCoinType = coinTypeBySymbol.get('MATIC');
+
+  if (maticCoinType) {
+    coinTypeBySymbol.set('POL', maticCoinType);
+  }
+
+  return coinTypeBySymbol;
+})();
+
+function slip44CoinTypeForSymbol(symbol: string): string | undefined {
+  return slip44CoinTypeBySymbol.get(symbol.toUpperCase());
+}
 
 /**
  * Normalizes a hex, decimal, numeric, or CAIP chain id to its CAIP-2 form.
@@ -38,6 +66,31 @@ export function formatChainIdToCaip(
 
   const reference = Number(chainId);
   return Number.isNaN(reference) ? undefined : `eip155:${reference}`;
+}
+
+export function resolveNativeAssetId(
+  chainId: string | number | undefined,
+  symbol: string | undefined,
+): CaipAssetType | undefined {
+  if (chainId === undefined || !symbol) {
+    return undefined;
+  }
+
+  const caipChainId = formatChainIdToCaip(chainId);
+
+  if (!caipChainId) {
+    return undefined;
+  }
+
+  const coinType = slip44CoinTypeForSymbol(symbol);
+
+  if (!coinType) {
+    return undefined;
+  }
+
+  const { namespace, reference } = parseCaipChainId(caipChainId);
+
+  return toCaipAssetType(namespace, reference, 'slip44', coinType);
 }
 
 function isNativeAddress(address: string): boolean {

--- a/packages/client-utils/src/mappers/helpers/transactions.test.ts
+++ b/packages/client-utils/src/mappers/helpers/transactions.test.ts
@@ -144,7 +144,7 @@ describe('transaction helpers', () => {
       });
     });
 
-    it('marks native transfers with type native and no assetId', () => {
+    it('marks native transfers with type native and assetId', () => {
       expect(
         getTokenAmountFromTransfer(
           {
@@ -164,6 +164,7 @@ describe('transaction helpers', () => {
         symbol: 'POL',
         decimals: 18,
         assetType: 'native',
+        assetId: 'eip155:137/slip44:966',
       });
     });
 
@@ -284,6 +285,31 @@ describe('transaction helpers', () => {
       ]);
     });
 
+    it('returns native fee assetId when nativeAssetSymbol is on the group', () => {
+      expect(
+        getLocalTransactionFees({
+          nativeAssetSymbol: 'ETH',
+          primaryTransaction: {
+            chainId: '0x1',
+            txParams: {},
+            txReceipt: {
+              gasUsed: '0x1',
+              effectiveGasPrice: '0x2',
+            },
+          },
+        } as Parameters<typeof getLocalTransactionFees>[0]),
+      ).toStrictEqual([
+        {
+          type: 'base',
+          amount: '2',
+          decimals: 18,
+          assetType: 'native',
+          symbol: 'ETH',
+          assetId: 'eip155:1/slip44:60',
+        },
+      ]);
+    });
+
     it('returns undefined when gas fields are missing', () => {
       expect(
         getLocalTransactionFees({
@@ -294,12 +320,28 @@ describe('transaction helpers', () => {
         } as Parameters<typeof getLocalTransactionFees>[0]),
       ).toBeUndefined();
     });
+
+    it('returns undefined when the chain id cannot be normalized', () => {
+      expect(
+        getLocalTransactionFees({
+          primaryTransaction: {
+            chainId: '0xzzzz',
+            txParams: {},
+            txReceipt: {
+              gasUsed: '0x1',
+              effectiveGasPrice: '0x2',
+            },
+          },
+        } as Parameters<typeof getLocalTransactionFees>[0]),
+      ).toBeUndefined();
+    });
   });
 
   describe('getFees', () => {
     it('returns network fees with amount and decimals only', () => {
       expect(
         getFees({
+          chainId: 1,
           gasUsed: '0x2',
           effectiveGasPrice: '0x3',
         } as Parameters<typeof getFees>[0]),
@@ -311,6 +353,47 @@ describe('transaction helpers', () => {
           assetType: 'native',
         },
       ]);
+    });
+
+    it('returns native fee assetId from native value transfers', () => {
+      expect(
+        getFees({
+          chainId: 59144,
+          gasUsed: 341413,
+          effectiveGasPrice: '34544851',
+          valueTransfers: [
+            {
+              from: '0xa',
+              to: '0xb',
+              amount: '1',
+              decimal: 18,
+              contractAddress: '0x0',
+              symbol: 'ETH',
+              name: 'Ether',
+              transferType: 'internal',
+            },
+          ],
+        } as Parameters<typeof getFees>[0]),
+      ).toStrictEqual([
+        {
+          type: 'base',
+          amount: String(341413n * 34544851n),
+          decimals: 18,
+          assetType: 'native',
+          symbol: 'ETH',
+          assetId: 'eip155:59144/slip44:60',
+        },
+      ]);
+    });
+
+    it('returns undefined when the chain id cannot be normalized', () => {
+      expect(
+        getFees({
+          chainId: '0xzzzz',
+          gasUsed: '0x2',
+          effectiveGasPrice: '0x3',
+        } as Parameters<typeof getFees>[0]),
+      ).toBeUndefined();
     });
   });
 

--- a/packages/client-utils/src/mappers/helpers/transactions.ts
+++ b/packages/client-utils/src/mappers/helpers/transactions.ts
@@ -18,7 +18,11 @@ import type {
   TokenAmount,
   ValueTransfer,
 } from '../../types.js';
-import { formatAddressToAssetId } from './caip.js';
+import {
+  formatAddressToAssetId,
+  formatChainIdToCaip,
+  resolveNativeAssetId,
+} from './caip.js';
 import { getKnownTokenMetadata } from './token-metadata.js';
 
 // Adds optional `isSmartTransaction` to `TransactionMeta`.
@@ -48,12 +52,20 @@ function toNetworkFeeAmount(
   }
 }
 
-function buildBaseNetworkFee(amount: string): Fee {
+function buildBaseNetworkFee(
+  amount: string,
+  chainId: CaipChainId,
+  symbol?: string,
+): Fee {
+  const assetId = resolveNativeAssetId(chainId, symbol);
+
   return {
     type: 'base',
     amount,
     decimals: nativeTokenDecimals,
     assetType: 'native',
+    ...(symbol ? { symbol } : {}),
+    ...(assetId ? { assetId } : {}),
   };
 }
 
@@ -79,15 +91,44 @@ function getAssetTypeFromTransferType(
   return undefined;
 }
 
+function getNativeSymbolFromValueTransfers(
+  valueTransfers: V1TransactionByHashResponse['valueTransfers'],
+): string | undefined {
+  for (const transfer of valueTransfers ?? []) {
+    const transferType = transfer.transferType?.toLowerCase();
+
+    if (
+      (transferType === 'normal' || transferType === 'internal') &&
+      transfer.symbol
+    ) {
+      return transfer.symbol;
+    }
+  }
+
+  return undefined;
+}
+
 function getNetworkFee(
   transaction: V1TransactionByHashResponse,
 ): Fee | undefined {
+  const chainId = formatChainIdToCaip(transaction.chainId);
+
+  if (!chainId) {
+    return undefined;
+  }
+
   const amount = toNetworkFeeAmount(
     transaction.gasUsed,
     transaction.effectiveGasPrice,
   );
 
-  return amount ? buildBaseNetworkFee(amount) : undefined;
+  if (!amount) {
+    return undefined;
+  }
+
+  const symbol = getNativeSymbolFromValueTransfers(transaction.valueTransfers);
+
+  return buildBaseNetworkFee(amount, chainId, symbol);
 }
 
 export function getFees(
@@ -99,16 +140,28 @@ export function getFees(
 }
 
 export function getLocalTransactionFees(
-  transactionGroup: Pick<TransactionGroup, 'primaryTransaction'>,
+  transactionGroup: Pick<TransactionGroup, 'primaryTransaction'> & {
+    nativeAssetSymbol?: string;
+  },
 ): Fee[] | undefined {
-  const { primaryTransaction } = transactionGroup;
+  const { primaryTransaction, nativeAssetSymbol } = transactionGroup;
+  const chainId = formatChainIdToCaip(primaryTransaction.chainId);
+
+  if (!chainId) {
+    return undefined;
+  }
+
   const amount = toNetworkFeeAmount(
     primaryTransaction.txReceipt?.gasUsed,
     primaryTransaction.txReceipt?.effectiveGasPrice ??
       primaryTransaction.txParams?.gasPrice,
   );
 
-  return amount ? [buildBaseNetworkFee(amount)] : undefined;
+  if (!amount) {
+    return undefined;
+  }
+
+  return [buildBaseNetworkFee(amount, chainId, nativeAssetSymbol)];
 }
 
 const inProgressTransactionStatuses = [
@@ -341,14 +394,16 @@ export function getTokenAmountFromTransfer(
     return undefined;
   }
 
-  const assetId =
-    transfer && !isNftTransfer
-      ? resolveAssetId(chainId, transfer.contractAddress)
-      : undefined;
-
   const hasTransferAmount =
     !isNftTransfer && amount !== null && amount !== undefined;
   const assetType = getAssetTypeFromTransferType(transferType);
+
+  let assetId: string | undefined;
+  if (assetType === 'native') {
+    assetId = resolveNativeAssetId(chainId, symbol);
+  } else if (transfer && !isNftTransfer) {
+    assetId = resolveAssetId(chainId, transfer.contractAddress);
+  }
 
   return {
     direction,

--- a/packages/client-utils/src/mappers/local-transaction-mapper.test.ts
+++ b/packages/client-utils/src/mappers/local-transaction-mapper.test.ts
@@ -139,6 +139,7 @@ describe('mapLocalTransaction', () => {
           direction: 'out',
           symbol: 'ETH',
           assetType: 'native',
+          assetId: 'eip155:1338/slip44:60',
         },
       },
     });
@@ -333,7 +334,7 @@ describe('mapLocalTransaction', () => {
       },
     });
   });
-  it('maps an incoming native transfer without nativeAssetSymbol to a Receive with native assetType but no symbol', () => {
+  it('maps an incoming native transfer without nativeAssetSymbol to a Receive with native assetType only', () => {
     const item = mapLocalTransaction(
       localTransactionFixtures.mapInputs.mapsAnIncomingNativeTransferTo,
     );
@@ -347,7 +348,7 @@ describe('mapLocalTransaction', () => {
       },
     });
     expect(
-      item.type === 'receive' ? item.data.token?.symbol : 'unset',
+      item.type === 'receive' ? item.data.token?.assetId : 'unset',
     ).toBeUndefined();
   });
   it('maps an mUSD conversion to a Convert activity', () => {

--- a/packages/client-utils/src/mappers/local-transaction-mapper.ts
+++ b/packages/client-utils/src/mappers/local-transaction-mapper.ts
@@ -12,7 +12,10 @@ import {
   withdrawMethodIds,
   wrapMethodIds,
 } from './constants.js';
-import { formatAddressToAssetId } from './helpers/caip.js';
+import {
+  formatAddressToAssetId,
+  resolveNativeAssetId,
+} from './helpers/caip.js';
 import { getKnownTokenMetadata } from './helpers/token-metadata.js';
 import {
   getLocalTransactionFees,
@@ -39,9 +42,14 @@ export function mapLocalTransaction(
     fees?: Fee[];
   },
 ): ActivityItem {
+  const { initialTransaction, primaryTransaction } = transactionGroup;
+  const chainId = toCaipChainId(
+    KnownCaipNamespace.Eip155,
+    Number.parseInt(initialTransaction.chainId, 16).toString(),
+  );
+  const nativeSymbol = transactionGroup.nativeAssetSymbol;
   const fees =
     transactionGroup.fees ?? getLocalTransactionFees(transactionGroup);
-  const { initialTransaction, primaryTransaction } = transactionGroup;
   const {
     transferInformation,
     type: transactionType,
@@ -64,11 +72,6 @@ export function mapLocalTransaction(
   const tokenContractAddress = isPermit2Approve
     ? undefined
     : (transferInformation?.contractAddress ?? (to || undefined));
-  const chainId = toCaipChainId(
-    KnownCaipNamespace.Eip155,
-    Number.parseInt(initialTransaction.chainId, 16).toString(),
-  );
-  const nativeSymbol = transactionGroup.nativeAssetSymbol;
 
   const getNativeToken = (
     transaction: TransactionGroup['initialTransaction'],
@@ -88,12 +91,15 @@ export function mapLocalTransaction(
       return undefined;
     }
 
+    const assetId = resolveNativeAssetId(chainId, nativeSymbol);
+
     return {
       direction,
       assetType: 'native',
       decimals: evmNativeDecimals,
       ...(amount ? { amount } : {}),
       ...(nativeSymbol === undefined ? {} : { symbol: nativeSymbol }),
+      ...(assetId ? { assetId } : {}),
     };
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6460,6 +6460,7 @@ __metadata:
     "@metamask/controller-utils": "npm:^12.3.0"
     "@metamask/core-backend": "npm:^8.0.0"
     "@metamask/keyring-api": "npm:^23.7.0"
+    "@metamask/slip44": "npm:^4.3.0"
     "@metamask/transaction-controller": "npm:^69.3.0"
     "@metamask/utils": "npm:^11.11.0"
     "@ts-bridge/cli": "npm:^0.6.4"


### PR DESCRIPTION
## Explanation

After #9671 removed the hardcoded nativeAssetsByCaipChainId list, clients are left to resolve native tokens for certain activity types where the API has not provided metadata. 

This PR restores native `assetId`s using the `@metamask/slip44` package.

## References

- Follow-up to #9671
- Extension consumer will bump `@metamask/client-utils` after publish

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

Made with [Cursor](https://cursor.com)