### PR TITLE
Release/1158.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "1156.0.0",
+  "version": "1158.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {

--- a/packages/client-utils/CHANGELOG.md
+++ b/packages/client-utils/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.1]
+
 ### Added
 
 - Add `@metamask/slip44` dependency for native token symbol lookup ([#9701](https://github.com/MetaMask/core/pull/9701))
@@ -85,7 +87,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/transaction-controller` from `^68.2.2` to `^68.3.0` ([#9421](https://github.com/MetaMask/core/pull/9421))
 - Bump `@metamask/keyring-api` from `^23.3.0` to `^23.5.0` ([#9390](https://github.com/MetaMask/core/pull/9390))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/client-utils@1.4.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/client-utils@1.4.1...HEAD
+[1.4.1]: https://github.com/MetaMask/core/compare/@metamask/client-utils@1.4.0...@metamask/client-utils@1.4.1
 [1.4.0]: https://github.com/MetaMask/core/compare/@metamask/client-utils@1.3.1...@metamask/client-utils@1.4.0
 [1.3.1]: https://github.com/MetaMask/core/compare/@metamask/client-utils@1.3.0...@metamask/client-utils@1.3.1
 [1.3.0]: https://github.com/MetaMask/core/compare/@metamask/client-utils@1.2.1...@metamask/client-utils@1.3.0

--- a/packages/client-utils/CHANGELOG.md
+++ b/packages/client-utils/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.4.1]
+## [1.5.0]
 
 ### Added
 
@@ -87,8 +87,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/transaction-controller` from `^68.2.2` to `^68.3.0` ([#9421](https://github.com/MetaMask/core/pull/9421))
 - Bump `@metamask/keyring-api` from `^23.3.0` to `^23.5.0` ([#9390](https://github.com/MetaMask/core/pull/9390))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/client-utils@1.4.1...HEAD
-[1.4.1]: https://github.com/MetaMask/core/compare/@metamask/client-utils@1.4.0...@metamask/client-utils@1.4.1
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/client-utils@1.5.0...HEAD
+[1.5.0]: https://github.com/MetaMask/core/compare/@metamask/client-utils@1.4.0...@metamask/client-utils@1.5.0
 [1.4.0]: https://github.com/MetaMask/core/compare/@metamask/client-utils@1.3.1...@metamask/client-utils@1.4.0
 [1.3.1]: https://github.com/MetaMask/core/compare/@metamask/client-utils@1.3.0...@metamask/client-utils@1.3.1
 [1.3.0]: https://github.com/MetaMask/core/compare/@metamask/client-utils@1.2.1...@metamask/client-utils@1.3.0

--- a/packages/client-utils/package.json
+++ b/packages/client-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/client-utils",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Shared functions and utilities used across MetaMask clients (extension and mobile)",
   "keywords": [
     "Ethereum",

--- a/packages/client-utils/package.json
+++ b/packages/client-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/client-utils",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Shared functions and utilities used across MetaMask clients (extension and mobile)",
   "keywords": [
     "Ethereum",


### PR DESCRIPTION
## Explanation

Releases `@metamask/client-utils@1.5.0`.

Restores native `assetId` on activity tokens and network fees when a symbol is available, using `@metamask/slip44` symbol lookup ([#9701](https://github.com/MetaMask/core/pull/9701)).

Minor bump for the new `@metamask/slip44` runtime dependency.

**Blocked on:** [#9702](https://github.com/MetaMask/core/pull/9702) — remove `DO-NOT-MERGE` after that release merges.

## References

- Follow-up release for [#9701](https://github.com/MetaMask/core/pull/9701)

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only changes; functional risk depends on already-merged #9701 code, not new logic in this diff.
> 
> **Overview**
> **Monorepo release `1158.0.0`** that cuts **`@metamask/client-utils@1.5.0`**. The diff only updates version fields and changelog metadata—no application code in this PR.
> 
> The **1.5.0** changelog (now under a fixed `[1.5.0]` section with compare links) documents what ships with that tag: a new **`@metamask/slip44`** dependency and restored native **`assetId`** on activity tokens and network fees when a symbol is available, instead of the removed chain registry (from [#9701](https://github.com/MetaMask/core/pull/9701)).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22ef3d4c2d83db9a2990afd47ca2571ca2a8dc8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->