### PR TITLE
fix: ignore underpriced saved gas fee preferences

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The `userFeeLevel` for such transactions is set to `medium` instead of `dappSuggested`, so the values are kept updated while the transaction is unapproved.
   - The original dapp-suggested values remain available via `dappSuggestedGasFees` on the transaction metadata.
   - Disabled by default.
+- Ignore underpriced saved (advanced) gas fee preferences in favour of the wallet's suggested estimates ([#YYYY](https://github.com/MetaMask/core/pull/YYYY))
+  - If the new `replaceUnderpricedSavedGasFees` feature flag is enabled for the chain, saved custom fees with a `maxBaseFee` below the current low estimate are ignored and the suggested medium values are used instead, as they are unlikely to result in inclusion in a block before fee values change.
+  - Level-based saved preferences track current estimates and are never ignored.
+  - The `userFeeLevel` for such transactions is set to `medium` instead of `custom`, so the values are kept updated while the transaction is unapproved.
+  - Disabled by default.
 
 ## [69.3.0]
 

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The `userFeeLevel` for such transactions is set to `medium` instead of `dappSuggested`, so the values are kept updated while the transaction is unapproved.
   - The original dapp-suggested values remain available via `dappSuggestedGasFees` on the transaction metadata.
   - Disabled by default.
-- Ignore underpriced saved (advanced) gas fee preferences in favour of the wallet's suggested estimates ([#YYYY](https://github.com/MetaMask/core/pull/YYYY))
+- Ignore underpriced saved (advanced) gas fee preferences in favour of the wallet's suggested estimates ([#9705](https://github.com/MetaMask/core/pull/9705))
   - If the new `replaceUnderpricedSavedGasFees` feature flag is enabled for the chain, saved custom fees with a `maxBaseFee` below the current low estimate are ignored and the suggested medium values are used instead, as they are unlikely to result in inclusion in a block before fee values change.
   - Level-based saved preferences track current estimates and are never ignored.
   - The `userFeeLevel` for such transactions is set to `medium` instead of `custom`, so the values are kept updated while the transaction is unapproved.

--- a/packages/transaction-controller/src/utils/feature-flags.ts
+++ b/packages/transaction-controller/src/utils/feature-flags.ts
@@ -205,6 +205,27 @@ export type TransactionControllerFeatureFlags = {
        */
       default?: boolean;
     };
+
+    /**
+     * Replacement of underpriced saved (advanced) gas fee preferences.
+     * If enabled, saved custom fees with a `maxBaseFee` below the current low
+     * estimate are ignored in favour of the wallet's suggested fees, as they
+     * are unlikely to be included in a block before fee values change.
+     * Level-based saved preferences track current estimates and are never
+     * ignored.
+     */
+    replaceUnderpricedSavedGasFees?: {
+      /** Enablement on a per-chain basis. */
+      perChainConfig?: {
+        [chainId: Hex]: boolean;
+      };
+
+      /**
+       * Default enablement.
+       * This value is used when no specific value is found for a chain ID.
+       */
+      default?: boolean;
+    };
   };
 };
 
@@ -504,6 +525,30 @@ export function getReplaceUnderpricedDappGasFeesEnabled(
   return (
     replaceUnderpricedDappGasFeesFlags?.perChainConfig?.[chainId] ??
     replaceUnderpricedDappGasFeesFlags?.default ??
+    false
+  );
+}
+
+/**
+ * Retrieves whether underpriced saved (advanced) gas fee preferences should be
+ * ignored in favour of the wallet's suggested fees.
+ *
+ * @param chainId - The chain ID.
+ * @param messenger - The controller messenger instance.
+ * @returns Whether the replacement is enabled.
+ */
+export function getReplaceUnderpricedSavedGasFeesEnabled(
+  chainId: Hex,
+  messenger: TransactionControllerMessenger,
+): boolean {
+  const featureFlags = getFeatureFlags(messenger);
+
+  const replaceUnderpricedSavedGasFeesFlags =
+    featureFlags?.[FeatureFlag.Transactions]?.replaceUnderpricedSavedGasFees;
+
+  return (
+    replaceUnderpricedSavedGasFeesFlags?.perChainConfig?.[chainId] ??
+    replaceUnderpricedSavedGasFeesFlags?.default ??
     false
   );
 }

--- a/packages/transaction-controller/src/utils/gas-fees.test.ts
+++ b/packages/transaction-controller/src/utils/gas-fees.test.ts
@@ -8,7 +8,10 @@ import {
   TransactionType,
   UserFeeLevel,
 } from '../types.js';
-import { getReplaceUnderpricedDappGasFeesEnabled } from './feature-flags.js';
+import {
+  getReplaceUnderpricedDappGasFeesEnabled,
+  getReplaceUnderpricedSavedGasFeesEnabled,
+} from './feature-flags.js';
 import type { UpdateGasFeesRequest } from './gas-fees.js';
 import { gweiDecimalToWeiDecimal, updateGasFees } from './gas-fees.js';
 import { rpcRequest } from './provider.js';
@@ -106,6 +109,9 @@ describe('gas-fees', () => {
   const rpcRequestMock = jest.mocked(rpcRequest);
   const getReplaceUnderpricedDappGasFeesEnabledMock = jest.mocked(
     getReplaceUnderpricedDappGasFeesEnabled,
+  );
+  const getReplaceUnderpricedSavedGasFeesEnabledMock = jest.mocked(
+    getReplaceUnderpricedSavedGasFeesEnabled,
   );
   let gasFeeFlowMock: jest.Mocked<GasFeeFlow>;
 
@@ -860,6 +866,98 @@ describe('gas-fees', () => {
         );
         expect(updateGasFeeRequest.txMeta.userFeeLevel).toBe(
           UserFeeLevel.DAPP_SUGGESTED,
+        );
+      });
+    });
+
+    describe('replaces underpriced saved gas fees', () => {
+      beforeEach(() => {
+        getReplaceUnderpricedSavedGasFeesEnabledMock.mockReturnValue(true);
+        mockGasFeeFlowMockResponse(FLOW_RESPONSE_FEE_MARKET_MOCK);
+      });
+
+      it('with suggested medium values if saved maxBaseFee below low estimate', async () => {
+        updateGasFeeRequest.getSavedGasFees.mockReturnValueOnce({
+          maxBaseFee: String(GAS_LOW_MOCK - 1),
+          priorityFee: '1',
+        });
+
+        await updateGasFees(updateGasFeeRequest);
+
+        expect(updateGasFeeRequest.txMeta.txParams.maxFeePerGas).toBe(
+          GAS_HEX_WEI_MOCK,
+        );
+        expect(updateGasFeeRequest.txMeta.txParams.maxPriorityFeePerGas).toBe(
+          GAS_HEX_WEI_MOCK,
+        );
+        expect(updateGasFeeRequest.txMeta.userFeeLevel).toBe(
+          UserFeeLevel.MEDIUM,
+        );
+      });
+
+      it('unless saved maxBaseFee is at or above low estimate', async () => {
+        updateGasFeeRequest.getSavedGasFees.mockReturnValueOnce({
+          maxBaseFee: String(GAS_LOW_MOCK),
+          priorityFee: '1',
+        });
+
+        await updateGasFees(updateGasFeeRequest);
+
+        expect(updateGasFeeRequest.txMeta.txParams.maxFeePerGas).toBe(
+          GAS_LOW_HEX_WEI_MOCK,
+        );
+        expect(updateGasFeeRequest.txMeta.userFeeLevel).toBe(
+          UserFeeLevel.CUSTOM,
+        );
+      });
+
+      it('unless saved preference is level-based', async () => {
+        updateGasFeeRequest.getSavedGasFees.mockReturnValueOnce({
+          level: GasFeeEstimateLevel.Low,
+        });
+
+        await updateGasFees(updateGasFeeRequest);
+
+        expect(updateGasFeeRequest.txMeta.txParams.maxFeePerGas).toBe(
+          GAS_LOW_HEX_WEI_MOCK,
+        );
+        expect(updateGasFeeRequest.txMeta.userFeeLevel).toBe(
+          GasFeeEstimateLevel.Low,
+        );
+      });
+
+      it('unless feature flag is disabled', async () => {
+        getReplaceUnderpricedSavedGasFeesEnabledMock.mockReturnValue(false);
+        updateGasFeeRequest.getSavedGasFees.mockReturnValueOnce({
+          maxBaseFee: String(GAS_LOW_MOCK - 1),
+          priorityFee: '1',
+        });
+
+        await updateGasFees(updateGasFeeRequest);
+
+        expect(updateGasFeeRequest.txMeta.txParams.maxFeePerGas).toBe(
+          UNDERPRICED_GAS_HEX_WEI_MOCK,
+        );
+        expect(updateGasFeeRequest.txMeta.userFeeLevel).toBe(
+          UserFeeLevel.CUSTOM,
+        );
+      });
+
+      it('unless estimates are unavailable', async () => {
+        gasFeeFlowMock.getGasFees.mockRejectedValue(new Error('TestError'));
+        rpcRequestMock.mockResolvedValue(GAS_HEX_WEI_MOCK);
+        updateGasFeeRequest.getSavedGasFees.mockReturnValueOnce({
+          maxBaseFee: String(GAS_LOW_MOCK - 1),
+          priorityFee: '1',
+        });
+
+        await updateGasFees(updateGasFeeRequest);
+
+        expect(updateGasFeeRequest.txMeta.txParams.maxFeePerGas).toBe(
+          UNDERPRICED_GAS_HEX_WEI_MOCK,
+        );
+        expect(updateGasFeeRequest.txMeta.userFeeLevel).toBe(
+          UserFeeLevel.CUSTOM,
         );
       });
     });

--- a/packages/transaction-controller/src/utils/gas-fees.ts
+++ b/packages/transaction-controller/src/utils/gas-fees.ts
@@ -21,7 +21,10 @@ import {
   TransactionType,
   UserFeeLevel,
 } from '../types.js';
-import { getReplaceUnderpricedDappGasFeesEnabled } from './feature-flags.js';
+import {
+  getReplaceUnderpricedDappGasFeesEnabled,
+  getReplaceUnderpricedSavedGasFeesEnabled,
+} from './feature-flags.js';
 import { getGasFeeFlow } from './gas-flow.js';
 import { rpcRequest } from './provider.js';
 import { SWAP_TRANSACTION_TYPES } from './swaps.js';
@@ -85,7 +88,7 @@ export async function updateGasFees(
       txMeta.type as TransactionType,
     );
 
-  const savedGasFees =
+  let savedGasFees =
     shouldIgnoreSavedGasFees || hasInitialGasFeeParams(initialParams)
       ? undefined
       : request.getSavedGasFees(txMeta);
@@ -96,6 +99,17 @@ export async function updateGasFees(
   });
 
   log('Suggested gas fees', suggestedGasFees);
+
+  if (
+    shouldIgnoreUnderpricedSavedGasFees(savedGasFees, suggestedGasFees, request)
+  ) {
+    log(
+      'Ignoring saved custom gas fees below low estimate',
+      savedGasFees?.maxBaseFee,
+      suggestedGasFees.low?.maxFeePerGas,
+    );
+    savedGasFees = undefined;
+  }
 
   const getGasFeeRequest: GetGasFeeRequest = {
     ...request,
@@ -155,6 +169,53 @@ export function gweiDecimalToWeiDecimal(gweiDecimal: string | number): string {
   const weiValue = Number(gweiDecimal) * 1e9;
 
   return weiValue.toString().split('.')[0];
+}
+
+/**
+ * Determine whether saved (advanced) gas fee preferences should be ignored in
+ * favour of the suggested gas fees, as the saved custom `maxBaseFee` is below
+ * the current low estimate and hence unlikely to result in timely inclusion in
+ * a block. Level-based saved preferences track current estimates and are never
+ * ignored.
+ *
+ * @param savedGasFees - The saved gas fee preferences.
+ * @param suggestedGasFees - The suggested gas fees.
+ * @param request - The request object.
+ * @returns Whether the saved gas fee preferences should be ignored.
+ */
+function shouldIgnoreUnderpricedSavedGasFees(
+  savedGasFees: SavedGasFees | undefined,
+  suggestedGasFees: SuggestedGasFees,
+  request: UpdateGasFeesRequest,
+): boolean {
+  const { eip1559, messenger, txMeta } = request;
+
+  if (
+    !eip1559 ||
+    !savedGasFees?.maxBaseFee ||
+    !getReplaceUnderpricedSavedGasFeesEnabled(txMeta.chainId, messenger)
+  ) {
+    return false;
+  }
+
+  const lowMaxFeePerGas = suggestedGasFees.low?.maxFeePerGas;
+
+  const hasReplacement =
+    Boolean(suggestedGasFees.maxFeePerGas) &&
+    Boolean(suggestedGasFees.maxPriorityFeePerGas);
+
+  if (!lowMaxFeePerGas || !hasReplacement) {
+    return false;
+  }
+
+  try {
+    return (
+      BigInt(gweiDecimalToWeiHex(savedGasFees.maxBaseFee)) <
+      BigInt(lowMaxFeePerGas)
+    );
+  } catch {
+    return false;
+  }
 }
 
 /**


### PR DESCRIPTION
> [!NOTE]
> **Draft — there is a product decision to make here** (see "The product decision" below). The mechanics are ready for review; the behavior on gate-fire (silently replace vs. replace + alert vs. warn-only) needs a product call before this leaves draft.

## Explanation

Companion to #9704, which replaces underpriced **dapp-suggested** fees. This PR applies the same staleness gate to the other unguarded fee source: **saved (advanced) gas fee preferences**.

A saved *custom* preference is a static `maxBaseFee` captured at some point in the past. Network conditions move; the preference doesn't. Once the base fee rises past the saved value, every transaction priced from it is unlikely to be included before fee conditions change further, and typically ends up stuck as pending until timeout mechanisms mark it failed — with no actionable feedback. Unlike the dapp case, nothing else guards this source: #9704 deliberately excludes `savedGasFees`, and `hasInitialGasFeeParams` only protects transactions that carry explicit fee params (saved fees apply precisely when they don't).

This is increasingly relevant: clients are expanding saved-preference usage (e.g. per-account custom gas settings persisted from the confirmation flow, and #9682 extending saved fees to wallet-initiated transfers), which grows the surface a stale value can underprice.

**Behavior** (flag-gated, disabled by default):

- After suggested fees are fetched, if the saved preference has a custom `maxBaseFee` below the current **low** estimate, the saved preference is ignored for this transaction and the suggested (medium) values are used instead.
- **Level-based saved preferences (`low`/`medium`/`high`) are never touched** — they track current estimates by construction and are the recommended shape for persistent preferences.
- `userFeeLevel` becomes `medium` instead of `custom`, which also opts the transaction into `GasFeePoller` refresh while unapproved.
- Fail-open: flag off, non-EIP-1559, no low estimate, or no full replacement available → saved preference applies unchanged.
- No fetch-path changes needed: transactions eligible for saved fees carry no fee params, so estimates (including the low level) are already fetched.

## The product decision

Overriding a value the *user* saved is a stronger intervention than overriding a dapp's computed value, and there are three defensible behaviors when the gate fires:

1. **Silently use suggested fees** (this PR's current behavior) — best transaction outcome, least transparency.
2. **Use suggested fees + surface an alert** ("your saved gas setting is below current network fees; using market estimate") — same outcome, user learns their preference is stale.
3. **Keep the saved value + warn only** — maximum autonomy, transaction remains likely to strand.

An argument that we should intervene (option 1 or 2) rather than defer entirely to the saved value: **saved preferences already do not grant full autonomy.** The controller already ignores them for swaps and bridges (`SAVED_GAS_FEES_IGNORED_TRANSACTION_TYPES`, #9401/#9682) — explicitly because a saved fee could underprice aggregator-priced transactions — and already yields them to explicit fee params (`hasInitialGasFeeParams`, #8993). The established principle is that saved preferences apply *where they can work* and yield *where they would predictably break the transaction*. A custom `maxBaseFee` below the current low estimate is the clearest possible instance of "would predictably break the transaction" — extending the same principle to it is consistent, not a new precedent.

The same known edge case as #9704 applies (fee bump vs. max-spend arithmetic); see the balance-clamp proposal there — it covers both gates.

## References

- Companion: #9704
- Prior art for saved-fee exclusions: #9401, #9682, #8993

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them
