### PR TITLE
Release 1159.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "1158.0.0",
+  "version": "1159.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {

--- a/packages/money-account-utils/CHANGELOG.md
+++ b/packages/money-account-utils/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0]
+
 ### Added
 
 - Add mUSD token constants and guards, ported from MetaMask Mobile ([#9397](https://github.com/MetaMask/core/pull/9397))
@@ -14,4 +16,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Guards: `isMusdToken`, `isMusdTokenOnChain`, `isMusdOnMoneyAccountChain`
 - Add `getTokenDisplaySymbol`, ported from MetaMask Mobile, which canonicalises the registry symbol of the mUSD token to its branded casing (`MUSD` → `mUSD`) and passes all other symbols through unchanged ([#9397](https://github.com/MetaMask/core/pull/9397))
 
-[Unreleased]: https://github.com/MetaMask/core/
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/money-account-utils@1.0.0...HEAD
+[1.0.0]: https://github.com/MetaMask/core/releases/tag/@metamask/money-account-utils@1.0.0

--- a/packages/money-account-utils/package.json
+++ b/packages/money-account-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/money-account-utils",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "description": "Shared money account utilities: activity parsing, classification, and mUSD constants",
   "keywords": [
     "Ethereum",


### PR DESCRIPTION
Releases `@metamask/money-account-utils@1.0.0`.

Initial release of the shared money account utilities package: mUSD token
constants and guards, and `getTokenDisplaySymbol`.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only version and changelog changes with no runtime code diffs in this PR.
> 
> **Overview**
> **Monorepo release 1159.0.0** that publishes **`@metamask/money-account-utils` at `1.0.0`** (from `0.0.0`).
> 
> The root `@metamask/core-monorepo` version moves **1158.0.0 → 1159.0.0**. The package **CHANGELOG** is finalized with a **`[1.0.0]`** section and updated compare/release links; **no application or library source files** are modified in this diff—only versioning and changelog metadata for the initial public release described in the PR body (mUSD utilities landed in prior work).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a558709e2f3a7cafcac941c1e1ebc5fe0a35e74b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->