### PR TITLE
ci: fix changelog validation on release PRs in update-changelogs workflow

### DIFF
--- a/.github/workflows/update-changelogs.yml
+++ b/.github/workflows/update-changelogs.yml
@@ -183,9 +183,10 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
           MERGE_BASE: ${{ needs.is-release.outputs.merge-base }}
-          # This job checks out the merge-base commit directly (a detached SHA),
-          # so there is no `origin/main` ref for validate-changelog.sh to resolve
-          # the merge base against. Point it at the merge-base SHA we already have.
+          # This job's checkout fetches only the merge-base commit by SHA
+          # (depth 1) and never fetches main, so there is no `origin/main` ref
+          # for validate-changelog.sh to resolve the merge base against.
+          # Point it at the merge-base SHA we already have.
           CHANGELOG_BASE_REF: ${{ needs.is-release.outputs.merge-base }}
         run: |
           yarn changelog:validate --checkDeps --fix --currentPr "$PR_NUMBER" --fromRef "$MERGE_BASE"

--- a/.github/workflows/update-changelogs.yml
+++ b/.github/workflows/update-changelogs.yml
@@ -183,6 +183,10 @@ jobs:
         env:
           PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
           MERGE_BASE: ${{ needs.is-release.outputs.merge-base }}
+          # This job checks out the merge-base commit directly (a detached SHA),
+          # so there is no `origin/main` ref for validate-changelog.sh to resolve
+          # the merge base against. Point it at the merge-base SHA we already have.
+          CHANGELOG_BASE_REF: ${{ needs.is-release.outputs.merge-base }}
         run: |
           yarn changelog:validate --checkDeps --fix --currentPr "$PR_NUMBER" --fromRef "$MERGE_BASE"
         shell: bash


### PR DESCRIPTION
## Explanation

The `Update changelogs` workflow fails on every release PR ([example run](https://github.com/MetaMask/core/actions/runs/30549544705)) with:

```
Could not find a common ancestor between HEAD and "origin/main".
```

`validate-changelog.sh` runs `git merge-base origin/main HEAD` on release branches, but the `update-changelogs` job checks out a detached merge-base SHA and never fetches `main`, so there is no `origin/main` ref to resolve against. This shallow-checkout case was flagged in review of #9602 and fixed there with `fetch-depth: 0`, but only on the Validate changelog job. This workflow uses the same script and was missed.

The fix sets `CHANGELOG_BASE_REF` to the merge-base SHA the workflow already has (`MERGE_BASE`), so the script resolves against a commit that exists in the checkout. This is the override #9602 added for exactly this case.

## References

- Introduced by: #9602
- Failing run: https://github.com/MetaMask/core/actions/runs/30549544705

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate (n/a, workflow-only change)
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate (inline comment)
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md) (n/a, internal CI workflow, not consumer facing)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only env wiring for an existing script override; no runtime or consumer-facing code changes.
> 
> **Overview**
> Fixes **Update changelogs** failing on release PRs when `validate-changelog.sh` cannot resolve `origin/main` because the job checks out only the merge-base SHA (shallow) and never fetches `main`.
> 
> The **Ensure required dependency bump entries** step now sets **`CHANGELOG_BASE_REF`** to the merge-base SHA already provided by **`needs.is-release.outputs.merge-base`**, matching the override added in #9602 for the same shallow-checkout case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 187a1e475b1cee24aade0a517689068e4417418f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->