### PR TITLE
Release/1161.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "1160.0.0",
+  "version": "1161.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {

--- a/packages/money-account-balance-service/CHANGELOG.md
+++ b/packages/money-account-balance-service/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.0]
+
+### Uncategorized
+
+- refactor: add `.js` import extensions to Earn packages ([#9625](https://github.com/MetaMask/core/pull/9625))
+- chore: migrate Jest from v29 to v30 ([#7905](https://github.com/MetaMask/core/pull/7905))
+
 ### Changed
 
 - Convert all Veda vault APR values returned by `getVaultApy` to compounded APY using daily compounding before exposing them to consumers. ([#9684](https://github.com/MetaMask/core/pull/9684))
@@ -125,7 +132,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Compute mUSD-equivalent value of vault share holdings (`getMusdEquivalentValue`)
   - Fetch vault APY from the Veda performance REST API (`getVaultApy`)
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/money-account-balance-service@2.3.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/money-account-balance-service@2.4.0...HEAD
+[2.4.0]: https://github.com/MetaMask/core/compare/@metamask/money-account-balance-service@2.3.0...@metamask/money-account-balance-service@2.4.0
 [2.3.0]: https://github.com/MetaMask/core/compare/@metamask/money-account-balance-service@2.2.0...@metamask/money-account-balance-service@2.3.0
 [2.2.0]: https://github.com/MetaMask/core/compare/@metamask/money-account-balance-service@2.1.2...@metamask/money-account-balance-service@2.2.0
 [2.1.2]: https://github.com/MetaMask/core/compare/@metamask/money-account-balance-service@2.1.1...@metamask/money-account-balance-service@2.1.2

--- a/packages/money-account-balance-service/CHANGELOG.md
+++ b/packages/money-account-balance-service/CHANGELOG.md
@@ -9,16 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.4.0]
 
-### Uncategorized
-
-- refactor: add `.js` import extensions to Earn packages ([#9625](https://github.com/MetaMask/core/pull/9625))
-- chore: migrate Jest from v29 to v30 ([#7905](https://github.com/MetaMask/core/pull/7905))
-
 ### Changed
 
 - Convert all Veda vault APR values returned by `getVaultApy` to compounded APY using daily compounding before exposing them to consumers. ([#9684](https://github.com/MetaMask/core/pull/9684))
 - Bump `@metamask/money-account-api-data-service` from `^0.3.0` to `^0.4.0` ([#9677](https://github.com/MetaMask/core/pull/9677))
 - Bump `@metamask/money-account-api-data-service` from `^0.2.0` to `^0.3.0` ([#9592](https://github.com/MetaMask/core/pull/9592))
+- refactor: add `.js` import extensions to Earn packages ([#9625](https://github.com/MetaMask/core/pull/9625))
+- chore: migrate Jest from v29 to v30 ([#7905](https://github.com/MetaMask/core/pull/7905))
 
 ## [2.3.0]
 

--- a/packages/money-account-balance-service/package.json
+++ b/packages/money-account-balance-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/money-account-balance-service",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Data service for fetching Money account balances, exchange rates, and vault APY",
   "keywords": [
     "Ethereum",


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only release with no runtime code changes in the diff.
> 
> **Overview**
> This is a **release cut** that bumps the root monorepo from `1160.0.0` to **`1161.0.0`** and publishes **`@metamask/money-account-balance-service@2.4.0`** (from `2.3.0`).
> 
> The package changelog is finalized for **2.4.0**: entries move out of `[Unreleased]` into the new section, and compare links are updated. There is **no application source change** in this diff—only version metadata and changelog documentation for work already merged (notably **`getVaultApy`** now exposing **daily-compounded APY** instead of raw APR, dependency bumps, Earn `.js` import extensions, and Jest 30).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 366aba7d1bdf203182f3b8f71658c4558408e239. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->