### PR TITLE
fix(transaction-pay-controller): keep quote on insufficient-source-balance relay validation error

### DIFF
--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -40,7 +40,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix Relay quote validation simulation to exclude a zero `gas` value from the simulated transaction and to simulate single-step quotes as a single transaction instead of an EIP-7702 batch ([#9723](https://github.com/MetaMask/core/pull/9723))
+- Fix Relay quote validation simulation to exclude a zero `gas` value from the simulated transaction ([#9723](https://github.com/MetaMask/core/pull/9723))
+- Always include an EIP-7702 authorization in the Relay quote validation batch simulation so a not-yet-upgraded account is simulated as delegated, using the quote authorization address when present and otherwise the configured EIP-7702 upgrade contract for the chain ([#9723](https://github.com/MetaMask/core/pull/9723))
+- Surface the revert return data as `Custom Error - <return>` when a Sentinel simulation reverts with `execution reverted` and non-empty return data, falling back to `Reverted - Unknown Error` when the return data is empty, instead of the implied `execution reverted` message ([#9723](https://github.com/MetaMask/core/pull/9723))
 
 ## [26.0.1]
 

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix Relay quote validation ([#9723](https://github.com/MetaMask/core/pull/9723))
+  - Keep the quote when validation fails with reason `insufficient-source-balance`, while still surfacing `quoteError`; all other validation-failure reasons continue to remove the quote.
+  - Exclude a zero `gas` value from the simulated transaction.
+  - Always include an EIP-7702 authorization in the batch simulation so a not-yet-upgraded account is simulated as delegated, using the quote authorization address when present and otherwise the configured EIP-7702 upgrade contract for the chain.
+  - Surface the revert return data as `Custom Error - <return>` when a Sentinel simulation reverts with `execution reverted` and non-empty return data, falling back to `Reverted - Unknown Error` when the return data is empty, instead of the implied `execution reverted` message.
+
 ## [26.1.1]
 
 ### Changed

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -38,6 +38,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/ramps-controller` from `^18.0.0` to `^18.0.1` ([#9735](https://github.com/MetaMask/core/pull/9735))
 - Bump `@metamask/remote-feature-flag-controller` from `^4.2.2` to `^5.0.0` ([#9735](https://github.com/MetaMask/core/pull/9735))
 
+### Fixed
+
+- Fix Relay quote validation simulation to exclude a zero `gas` value from the simulated transaction and to simulate single-step quotes as a single transaction instead of an EIP-7702 batch ([#9723](https://github.com/MetaMask/core/pull/9723))
+
 ## [26.0.1]
 
 ### Changed

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -40,9 +40,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix Relay quote validation simulation to exclude a zero `gas` value from the simulated transaction ([#9723](https://github.com/MetaMask/core/pull/9723))
-- Always include an EIP-7702 authorization in the Relay quote validation batch simulation so a not-yet-upgraded account is simulated as delegated, using the quote authorization address when present and otherwise the configured EIP-7702 upgrade contract for the chain ([#9723](https://github.com/MetaMask/core/pull/9723))
-- Surface the revert return data as `Custom Error - <return>` when a Sentinel simulation reverts with `execution reverted` and non-empty return data, falling back to `Reverted - Unknown Error` when the return data is empty, instead of the implied `execution reverted` message ([#9723](https://github.com/MetaMask/core/pull/9723))
+- Fix Relay quote validation simulation ([#9723](https://github.com/MetaMask/core/pull/9723))
+  - Exclude a zero `gas` value from the simulated transaction.
+  - Always include an EIP-7702 authorization in the batch simulation so a not-yet-upgraded account is simulated as delegated, using the quote authorization address when present and otherwise the configured EIP-7702 upgrade contract for the chain.
+  - Surface the revert return data as `Custom Error - <return>` when a Sentinel simulation reverts with `execution reverted` and non-empty return data, falling back to `Reverted - Unknown Error` when the return data is empty, instead of the implied `execution reverted` message.
 
 ## [26.0.1]
 

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -38,13 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/ramps-controller` from `^18.0.0` to `^18.0.1` ([#9735](https://github.com/MetaMask/core/pull/9735))
 - Bump `@metamask/remote-feature-flag-controller` from `^4.2.2` to `^5.0.0` ([#9735](https://github.com/MetaMask/core/pull/9735))
 
-### Fixed
-
-- Fix Relay quote validation simulation ([#9723](https://github.com/MetaMask/core/pull/9723))
-  - Exclude a zero `gas` value from the simulated transaction.
-  - Always include an EIP-7702 authorization in the batch simulation so a not-yet-upgraded account is simulated as delegated, using the quote authorization address when present and otherwise the configured EIP-7702 upgrade contract for the chain.
-  - Surface the revert return data as `Custom Error - <return>` when a Sentinel simulation reverts with `execution reverted` and non-empty return data, falling back to `Reverted - Unknown Error` when the return data is empty, instead of the implied `execution reverted` message.
-
 ## [26.0.1]
 
 ### Changed

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-validation.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-validation.test.ts
@@ -213,6 +213,29 @@ describe('validateRelayQuotes', () => {
     });
   });
 
+  it('attaches the entire quote batch (not just the failing quote) when insufficient-source-balance is thrown', async () => {
+    const quoteError = new QuoteError({
+      message: 'Insufficient source balance for quote',
+      reason: 'insufficient-source-balance',
+    });
+
+    // Only the first quote triggers the error; the second has not yet been validated.
+    validateQuoteExecutionMock
+      .mockRejectedValueOnce(quoteError)
+      .mockResolvedValue(undefined);
+
+    const quote1 = buildQuote();
+    const quote2 = buildQuote();
+
+    const thrownError = await validateRelayQuotes({
+      messenger,
+      quotes: [quote1, quote2],
+      transaction: TRANSACTION_MOCK,
+    }).catch((caughtError: unknown) => caughtError);
+
+    expect((thrownError as QuoteError).quotes).toStrictEqual([quote1, quote2]);
+  });
+
   it('throws QuoteError without quotes for non-insufficient-source-balance reason', async () => {
     const quoteError = new QuoteError({
       message: 'Quote simulation failed',

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-validation.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-validation.test.ts
@@ -331,6 +331,31 @@ describe('validateRelayQuotes', () => {
           }),
         );
       });
+
+      it('omits gas from normal simulation when gas is zero', async () => {
+        getRelaySubmitCallsMock.mockResolvedValue({
+          calls: [
+            {
+              data: '0xdata' as Hex,
+              from: FROM_MOCK,
+              gas: '0x0' as Hex,
+              to: '0xto' as Hex,
+              value: '0x0' as Hex,
+            },
+          ],
+        });
+        const quote = buildQuote({}, {
+          metamask: { gasLimits: [], is7702: false, isExecute: false },
+        } as Partial<RelayQuote>);
+        await validateRelayQuotes({
+          messenger,
+          quotes: [quote],
+          transaction: TRANSACTION_MOCK,
+        });
+        const simulationTx =
+          validateQuoteExecutionMock.mock.calls[0][0].simulation.transactions[0];
+        expect(simulationTx).not.toHaveProperty('gas');
+      });
     });
 
     describe('7702 batch simulation (is7702 true, no executeRequest)', () => {
@@ -340,6 +365,12 @@ describe('validateRelayQuotes', () => {
             data: '0xdata' as Hex,
             from: FROM_MOCK,
             to: '0xdest' as Hex,
+            value: '0x4d2' as Hex,
+          },
+          {
+            data: '0xdata2' as Hex,
+            from: FROM_MOCK,
+            to: '0xdest2' as Hex,
             value: '0x4d2' as Hex,
           },
         ];
@@ -382,6 +413,12 @@ describe('validateRelayQuotes', () => {
             to: '0xdest' as Hex,
             value: '0x4d2' as Hex,
           },
+          {
+            data: '0xdata2' as Hex,
+            from: FROM_MOCK,
+            to: '0xdest2' as Hex,
+            value: '0x4d2' as Hex,
+          },
         ];
 
         getRelaySubmitCallsMock.mockResolvedValue({ calls });
@@ -414,6 +451,12 @@ describe('validateRelayQuotes', () => {
             data: '0xdata' as Hex,
             from: FROM_MOCK,
             to: '0xdest' as Hex,
+            value: '0x4d2' as Hex,
+          },
+          {
+            data: '0xdata2' as Hex,
+            from: FROM_MOCK,
+            to: '0xdest2' as Hex,
             value: '0x4d2' as Hex,
           },
         ];
@@ -463,6 +506,12 @@ describe('validateRelayQuotes', () => {
             to: '0xdest' as Hex,
             value: '0x4d2' as Hex,
           },
+          {
+            data: '0xdata2' as Hex,
+            from: FROM_MOCK,
+            to: '0xdest2' as Hex,
+            value: '0x4d2' as Hex,
+          },
         ];
 
         getRelaySubmitCallsMock.mockResolvedValue({ calls });
@@ -499,6 +548,12 @@ describe('validateRelayQuotes', () => {
             to: '0xdest' as Hex,
             value: '0x4d2' as Hex,
           },
+          {
+            data: '0xdata2' as Hex,
+            from: FROM_MOCK,
+            to: '0xdest2' as Hex,
+            value: '0x4d2' as Hex,
+          },
         ];
 
         getRelaySubmitCallsMock.mockResolvedValue({ calls });
@@ -532,6 +587,65 @@ describe('validateRelayQuotes', () => {
             }),
           }),
         );
+      });
+
+      it('omits gas from 7702 batch simulation when gasLimits[0] is zero', async () => {
+        getRelaySubmitCallsMock.mockResolvedValue({
+          calls: [
+            {
+              data: '0xcall1' as Hex,
+              from: FROM_MOCK,
+              gas: '0x5208' as Hex,
+              to: '0xdest1' as Hex,
+              value: '0x0' as Hex,
+            },
+            {
+              data: '0xcall2' as Hex,
+              from: FROM_MOCK,
+              gas: '0x5208' as Hex,
+              to: '0xdest2' as Hex,
+              value: '0x0' as Hex,
+            },
+          ],
+        });
+        const quote = buildQuote({}, {
+          metamask: { gasLimits: [0], is7702: true, isExecute: false },
+        } as Partial<RelayQuote>);
+        await validateRelayQuotes({
+          messenger,
+          quotes: [quote],
+          transaction: TRANSACTION_MOCK,
+        });
+        const batchTx =
+          validateQuoteExecutionMock.mock.calls[0][0].simulation.transactions[0];
+        expect(batchTx).not.toHaveProperty('gas');
+      });
+
+      it('uses single (non-batch) simulation when is7702 is true but there is only one call', async () => {
+        getRelaySubmitCallsMock.mockResolvedValue({
+          calls: [
+            {
+              data: '0xcall1data' as Hex,
+              from: FROM_MOCK,
+              gas: '0x5208' as Hex,
+              to: '0xcall1to' as Hex,
+              value: '0x0' as Hex,
+            },
+          ],
+        });
+        const quote = buildQuote({}, {
+          metamask: { gasLimits: [21000], is7702: true, isExecute: false },
+        } as Partial<RelayQuote>);
+        await validateRelayQuotes({
+          messenger,
+          quotes: [quote],
+          transaction: TRANSACTION_MOCK,
+        });
+        expect(generateEIP7702BatchTransactionMock).not.toHaveBeenCalled();
+        const simulationTx =
+          validateQuoteExecutionMock.mock.calls[0][0].simulation.transactions[0];
+        expect(simulationTx.data).toBe('0xcall1data');
+        expect(simulationTx.to).toBe('0xcall1to');
       });
     });
 

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-validation.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-validation.test.ts
@@ -368,12 +368,6 @@ describe('validateRelayQuotes', () => {
             to: '0xdest' as Hex,
             value: '0x4d2' as Hex,
           },
-          {
-            data: '0xdata2' as Hex,
-            from: FROM_MOCK,
-            to: '0xdest2' as Hex,
-            value: '0x4d2' as Hex,
-          },
         ];
 
         getRelaySubmitCallsMock.mockResolvedValue({ calls });
@@ -414,12 +408,6 @@ describe('validateRelayQuotes', () => {
             to: '0xdest' as Hex,
             value: '0x4d2' as Hex,
           },
-          {
-            data: '0xdata2' as Hex,
-            from: FROM_MOCK,
-            to: '0xdest2' as Hex,
-            value: '0x4d2' as Hex,
-          },
         ];
 
         getRelaySubmitCallsMock.mockResolvedValue({ calls });
@@ -452,12 +440,6 @@ describe('validateRelayQuotes', () => {
             data: '0xdata' as Hex,
             from: FROM_MOCK,
             to: '0xdest' as Hex,
-            value: '0x4d2' as Hex,
-          },
-          {
-            data: '0xdata2' as Hex,
-            from: FROM_MOCK,
-            to: '0xdest2' as Hex,
             value: '0x4d2' as Hex,
           },
         ];
@@ -499,7 +481,23 @@ describe('validateRelayQuotes', () => {
         );
       });
 
-      it('omits authorizationList on transaction when authorizationList is absent', async () => {
+      it('includes authorizationList from the EIP-7702 upgrade contract when the quote has no authorizationList', async () => {
+        getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+          ...getDefaultRemoteFeatureFlagControllerState(),
+          remoteFeatureFlags: {
+            confirmations_pay_extended: {
+              payStrategies: { relay: { validationEnabled: true } },
+            },
+            confirmations_eip_7702: {
+              contracts: {
+                [CHAIN_ID_MOCK]: [
+                  { address: '0xdelegator' as Hex, signature: '0xsig' as Hex },
+                ],
+              },
+            },
+          },
+        });
+
         const calls = [
           {
             data: '0xdata' as Hex,
@@ -507,10 +505,42 @@ describe('validateRelayQuotes', () => {
             to: '0xdest' as Hex,
             value: '0x4d2' as Hex,
           },
+        ];
+
+        getRelaySubmitCallsMock.mockResolvedValue({ calls });
+
+        const quote = buildQuote({}, {
+          metamask: { gasLimits: [21000], is7702: true, isExecute: false },
+          request: {},
+        } as Partial<RelayQuote>);
+
+        await validateRelayQuotes({
+          messenger,
+          quotes: [quote],
+          transaction: TRANSACTION_MOCK,
+        });
+
+        expect(validateQuoteExecutionMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            simulation: expect.objectContaining({
+              transactions: [
+                expect.objectContaining({
+                  authorizationList: [
+                    { address: '0xdelegator', from: FROM_MOCK },
+                  ],
+                }),
+              ],
+            }),
+          }),
+        );
+      });
+
+      it('omits authorizationList when neither the quote nor the upgrade contract provide an address', async () => {
+        const calls = [
           {
-            data: '0xdata2' as Hex,
+            data: '0xdata' as Hex,
             from: FROM_MOCK,
-            to: '0xdest2' as Hex,
+            to: '0xdest' as Hex,
             value: '0x4d2' as Hex,
           },
         ];
@@ -547,12 +577,6 @@ describe('validateRelayQuotes', () => {
             data: '0xdata' as Hex,
             from: FROM_MOCK,
             to: '0xdest' as Hex,
-            value: '0x4d2' as Hex,
-          },
-          {
-            data: '0xdata2' as Hex,
-            from: FROM_MOCK,
-            to: '0xdest2' as Hex,
             value: '0x4d2' as Hex,
           },
         ];
@@ -600,13 +624,6 @@ describe('validateRelayQuotes', () => {
               to: '0xdest1' as Hex,
               value: '0x0' as Hex,
             },
-            {
-              data: '0xcall2' as Hex,
-              from: FROM_MOCK,
-              gas: '0x5208' as Hex,
-              to: '0xdest2' as Hex,
-              value: '0x0' as Hex,
-            },
           ],
         });
         const quote = buildQuote({}, {
@@ -621,34 +638,6 @@ describe('validateRelayQuotes', () => {
           validateQuoteExecutionMock.mock.calls[0][0].simulation
             .transactions[0];
         expect(batchTx).not.toHaveProperty('gas');
-      });
-
-      it('uses single (non-batch) simulation when is7702 is true but there is only one call', async () => {
-        getRelaySubmitCallsMock.mockResolvedValue({
-          calls: [
-            {
-              data: '0xcall1data' as Hex,
-              from: FROM_MOCK,
-              gas: '0x5208' as Hex,
-              to: '0xcall1to' as Hex,
-              value: '0x0' as Hex,
-            },
-          ],
-        });
-        const quote = buildQuote({}, {
-          metamask: { gasLimits: [21000], is7702: true, isExecute: false },
-        } as Partial<RelayQuote>);
-        await validateRelayQuotes({
-          messenger,
-          quotes: [quote],
-          transaction: TRANSACTION_MOCK,
-        });
-        expect(generateEIP7702BatchTransactionMock).not.toHaveBeenCalled();
-        const simulationTx =
-          validateQuoteExecutionMock.mock.calls[0][0].simulation
-            .transactions[0];
-        expect(simulationTx.data).toBe('0xcall1data');
-        expect(simulationTx.to).toBe('0xcall1to');
       });
     });
 

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-validation.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-validation.test.ts
@@ -188,7 +188,7 @@ describe('validateRelayQuotes', () => {
     });
   });
 
-  it('passes through existing QuoteError unchanged', async () => {
+  it('re-wraps insufficient-source-balance QuoteError with request.quotes attached', async () => {
     const quoteError = new QuoteError({
       message: 'Insufficient source balance for quote',
       reason: 'insufficient-source-balance',
@@ -209,7 +209,34 @@ describe('validateRelayQuotes', () => {
         message: 'Insufficient source balance for quote',
         reason: 'insufficient-source-balance',
       },
+      quotes: [quote],
     });
+  });
+
+  it('throws QuoteError without quotes for non-insufficient-source-balance reason', async () => {
+    const quoteError = new QuoteError({
+      message: 'Quote simulation failed',
+      reason: 'simulation-failed',
+      detail: ['revert'],
+    });
+
+    validateQuoteExecutionMock.mockRejectedValue(quoteError);
+
+    const quote = buildQuote();
+
+    const thrownError = await validateRelayQuotes({
+      messenger,
+      quotes: [quote],
+      transaction: TRANSACTION_MOCK,
+    }).catch((caughtError: unknown) => caughtError);
+
+    expect(thrownError).toMatchObject({
+      info: {
+        message: 'Quote simulation failed',
+        reason: 'simulation-failed',
+      },
+    });
+    expect((thrownError as QuoteError).quotes).toBeUndefined();
   });
 
   it('validates multiple quotes sequentially', async () => {

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-validation.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-validation.test.ts
@@ -353,7 +353,8 @@ describe('validateRelayQuotes', () => {
           transaction: TRANSACTION_MOCK,
         });
         const simulationTx =
-          validateQuoteExecutionMock.mock.calls[0][0].simulation.transactions[0];
+          validateQuoteExecutionMock.mock.calls[0][0].simulation
+            .transactions[0];
         expect(simulationTx).not.toHaveProperty('gas');
       });
     });
@@ -617,7 +618,8 @@ describe('validateRelayQuotes', () => {
           transaction: TRANSACTION_MOCK,
         });
         const batchTx =
-          validateQuoteExecutionMock.mock.calls[0][0].simulation.transactions[0];
+          validateQuoteExecutionMock.mock.calls[0][0].simulation
+            .transactions[0];
         expect(batchTx).not.toHaveProperty('gas');
       });
 
@@ -643,7 +645,8 @@ describe('validateRelayQuotes', () => {
         });
         expect(generateEIP7702BatchTransactionMock).not.toHaveBeenCalled();
         const simulationTx =
-          validateQuoteExecutionMock.mock.calls[0][0].simulation.transactions[0];
+          validateQuoteExecutionMock.mock.calls[0][0].simulation
+            .transactions[0];
         expect(simulationTx.data).toBe('0xcall1data');
         expect(simulationTx.to).toBe('0xcall1to');
       });

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-validation.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-validation.ts
@@ -76,7 +76,16 @@ export async function validateRelayQuotes(
       if (request.signal?.aborted) {
         throw error;
       }
-      throw toQuoteError(error);
+      const quoteError = toQuoteError(error);
+      if (quoteError.info.reason === 'insufficient-source-balance') {
+        // Backwards compatibility: keep the quote(s) visible to clients even
+        // though validation failed, while still surfacing the error.
+        throw new QuoteError(
+          quoteError.info,
+          request.quotes as TransactionPayQuote<unknown>[],
+        );
+      }
+      throw quoteError;
     }
   }
 }

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-validation.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-validation.ts
@@ -121,7 +121,7 @@ function buildRelayValidationSimulation(
     log('Building execute simulation', context);
     return buildRelayExecuteSimulation(quote, executeRequest);
   }
-  if (quote.original.metamask.is7702) {
+  if (quote.original.metamask.is7702 && calls.length > 1) {
     log('Building 7702 batch simulation', context);
     return buildRelay7702BatchSimulation(quote, calls);
   }
@@ -183,7 +183,7 @@ function buildRelay7702BatchSimulation(
         ...(authList ? { authorizationList: authList } : {}),
         data: batchTx.data,
         from,
-        ...(gas === undefined ? {} : { gas: toHex(gas) }),
+        ...(gas === undefined || gas === 0 ? {} : { gas: toHex(gas) }),
         to: batchTx.to as Hex,
         value: '0x0',
       },
@@ -195,14 +195,17 @@ function buildRelayNormalSimulation(
   calls: TransactionParams[],
 ): QuoteSimulation {
   return {
-    transactions: calls.map((params) => ({
-      data: params.data as Hex | undefined,
-      from: params.from as Hex,
-      gas: params.gas as Hex | undefined,
-      maxFeePerGas: params.maxFeePerGas as Hex | undefined,
-      maxPriorityFeePerGas: params.maxPriorityFeePerGas as Hex | undefined,
-      to: params.to as Hex | undefined,
-      value: params.value as Hex,
-    })),
+    transactions: calls.map((params) => {
+      const gas = params.gas as Hex | undefined;
+      return {
+        data: params.data as Hex | undefined,
+        from: params.from as Hex,
+        ...(gas === undefined || new BigNumber(gas).isZero() ? {} : { gas }),
+        maxFeePerGas: params.maxFeePerGas as Hex | undefined,
+        maxPriorityFeePerGas: params.maxPriorityFeePerGas as Hex | undefined,
+        to: params.to as Hex | undefined,
+        value: params.value as Hex,
+      };
+    }),
   };
 }

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-validation.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-validation.ts
@@ -78,8 +78,9 @@ export async function validateRelayQuotes(
       }
       const quoteError = toQuoteError(error);
       if (quoteError.info.reason === 'insufficient-source-balance') {
-        // Backwards compatibility: keep the quote(s) visible to clients even
-        // though validation failed, while still surfacing the error.
+        // Backwards compatibility: keep the entire quote batch (including
+        // quotes that may have passed or not yet been validated) so that
+        // clients can still show quote details alongside the balance error.
         throw new QuoteError(
           quoteError.info,
           request.quotes as TransactionPayQuote<unknown>[],

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-validation.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-validation.ts
@@ -13,7 +13,10 @@ import type {
   TransactionPayControllerMessenger,
   TransactionPayQuote,
 } from '../../types.js';
-import { isRelayValidationEnabled } from '../../utils/feature-flags.js';
+import {
+  getEIP7702UpgradeContractAddress,
+  isRelayValidationEnabled,
+} from '../../utils/feature-flags.js';
 import {
   validateQuoteExecution,
   QuoteError,
@@ -67,6 +70,7 @@ export async function validateRelayQuotes(
         quote,
         signal: request.signal,
         simulation: buildRelayValidationSimulation(
+          request.messenger,
           quote,
           calls,
           executeRequest,
@@ -110,6 +114,7 @@ function toQuoteError(error: unknown): QuoteError {
 }
 
 function buildRelayValidationSimulation(
+  messenger: TransactionPayControllerMessenger,
   quote: TransactionPayQuote<RelayQuote>,
   calls: TransactionParams[],
   executeRequest?: Omit<RelayExecuteRequest, 'metamask'>,
@@ -121,9 +126,9 @@ function buildRelayValidationSimulation(
     log('Building execute simulation', context);
     return buildRelayExecuteSimulation(quote, executeRequest);
   }
-  if (quote.original.metamask.is7702 && calls.length > 1) {
+  if (quote.original.metamask.is7702) {
     log('Building 7702 batch simulation', context);
-    return buildRelay7702BatchSimulation(quote, calls);
+    return buildRelay7702BatchSimulation(messenger, quote, calls);
   }
   log('Building normal simulation', context);
   return buildRelayNormalSimulation(calls);
@@ -155,10 +160,11 @@ function buildRelayExecuteSimulation(
 }
 
 function buildRelay7702BatchSimulation(
+  messenger: TransactionPayControllerMessenger,
   quote: TransactionPayQuote<RelayQuote>,
   calls: TransactionParams[],
 ): QuoteSimulation {
-  const { from } = quote.request;
+  const { from, sourceChainId } = quote.request;
   const gas = quote.original.metamask.gasLimits[0];
 
   const batchTx = generateEIP7702BatchTransaction(
@@ -170,17 +176,22 @@ function buildRelay7702BatchSimulation(
     })),
   );
 
-  const authList = quote.original.request.authorizationList?.length
-    ? quote.original.request.authorizationList.map((auth) => ({
-        address: auth.address,
-        from,
-      }))
-    : undefined;
+  // The batch call is an ERC-7821 `execute` on the sender's own account, so the
+  // account must appear upgraded for the simulation to succeed. The quote does
+  // not always carry an authorization, and there is no fast way to check the
+  // live upgrade state, so an authorization is always included: the delegator
+  // address comes from the quote when present, otherwise from the configured
+  // EIP-7702 upgrade contract for the chain.
+  const address =
+    quote.original.request.authorizationList?.[0]?.address ??
+    getEIP7702UpgradeContractAddress(messenger, sourceChainId);
+
+  const authorizationList = address ? [{ address, from }] : undefined;
 
   return {
     transactions: [
       {
-        ...(authList ? { authorizationList: authList } : {}),
+        ...(authorizationList ? { authorizationList } : {}),
         data: batchTx.data,
         from,
         ...(gas === undefined || gas === 0 ? {} : { gas: toHex(gas) }),

--- a/packages/transaction-pay-controller/src/utils/feature-flags.test.ts
+++ b/packages/transaction-pay-controller/src/utils/feature-flags.test.ts
@@ -519,9 +519,9 @@ describe('Feature Flags Utils', () => {
         },
       });
 
-      expect(
-        getEIP7702UpgradeContractAddress(messenger, '0xaabb' as Hex),
-      ).toBe(CONTRACT_ADDRESS_MOCK);
+      expect(getEIP7702UpgradeContractAddress(messenger, '0xaabb' as Hex)).toBe(
+        CONTRACT_ADDRESS_MOCK,
+      );
     });
 
     it('returns undefined when the chain has no contracts', () => {

--- a/packages/transaction-pay-controller/src/utils/feature-flags.test.ts
+++ b/packages/transaction-pay-controller/src/utils/feature-flags.test.ts
@@ -34,6 +34,7 @@ import {
   getStablecoins,
   isChainExcludedFromInfura,
   isEIP7702Chain,
+  getEIP7702UpgradeContractAddress,
   isRelayExecuteEnabled,
   isRelayValidationEnabled,
   getFeatureFlags,
@@ -472,6 +473,87 @@ describe('Feature Flags Utils', () => {
       });
 
       expect(isEIP7702Chain(messenger, CHAIN_ID_MOCK)).toBe(false);
+    });
+  });
+
+  describe('getEIP7702UpgradeContractAddress', () => {
+    const CONTRACT_ADDRESS_MOCK = '0xdelegator' as Hex;
+
+    it('returns undefined when no feature flags are set', () => {
+      expect(
+        getEIP7702UpgradeContractAddress(messenger, CHAIN_ID_MOCK),
+      ).toBeUndefined();
+    });
+
+    it('returns the first contract address for the chain', () => {
+      getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+        ...getDefaultRemoteFeatureFlagControllerState(),
+        remoteFeatureFlags: {
+          confirmations_eip_7702: {
+            contracts: {
+              [CHAIN_ID_MOCK]: [
+                { address: CONTRACT_ADDRESS_MOCK, signature: '0xsig' as Hex },
+                { address: '0xsecond' as Hex, signature: '0xsig2' as Hex },
+              ],
+            },
+          },
+        },
+      });
+
+      expect(getEIP7702UpgradeContractAddress(messenger, CHAIN_ID_MOCK)).toBe(
+        CONTRACT_ADDRESS_MOCK,
+      );
+    });
+
+    it('matches the chain ID case-insensitively', () => {
+      getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+        ...getDefaultRemoteFeatureFlagControllerState(),
+        remoteFeatureFlags: {
+          confirmations_eip_7702: {
+            contracts: {
+              ['0xAABB' as Hex]: [
+                { address: CONTRACT_ADDRESS_MOCK, signature: '0xsig' as Hex },
+              ],
+            },
+          },
+        },
+      });
+
+      expect(
+        getEIP7702UpgradeContractAddress(messenger, '0xaabb' as Hex),
+      ).toBe(CONTRACT_ADDRESS_MOCK);
+    });
+
+    it('returns undefined when the chain has no contracts', () => {
+      getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+        ...getDefaultRemoteFeatureFlagControllerState(),
+        remoteFeatureFlags: {
+          confirmations_eip_7702: {
+            contracts: {
+              [CHAIN_ID_DIFFERENT_MOCK]: [
+                { address: CONTRACT_ADDRESS_MOCK, signature: '0xsig' as Hex },
+              ],
+            },
+          },
+        },
+      });
+
+      expect(
+        getEIP7702UpgradeContractAddress(messenger, CHAIN_ID_MOCK),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined when contracts is undefined', () => {
+      getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+        ...getDefaultRemoteFeatureFlagControllerState(),
+        remoteFeatureFlags: {
+          confirmations_eip_7702: {},
+        },
+      });
+
+      expect(
+        getEIP7702UpgradeContractAddress(messenger, CHAIN_ID_MOCK),
+      ).toBeUndefined();
     });
   });
 

--- a/packages/transaction-pay-controller/src/utils/feature-flags.ts
+++ b/packages/transaction-pay-controller/src/utils/feature-flags.ts
@@ -202,6 +202,11 @@ type FeatureFlagsExtendedRaw = {
   };
 };
 
+type EIP7702FeatureFlag = {
+  contracts?: Record<Hex, { address: Hex; signature: Hex }[]>;
+  supportedChains?: Hex[];
+};
+
 export type PayStrategiesConfig = {
   across: AcrossConfig;
   server: {
@@ -1105,7 +1110,7 @@ export function isEIP7702Chain(
 ): boolean {
   const state = messenger.call('RemoteFeatureFlagController:getState');
   const eip7702Flags = state.remoteFeatureFlags.confirmations_eip_7702 as
-    | { supportedChains?: Hex[] }
+    | EIP7702FeatureFlag
     | undefined;
 
   const supportedChains = eip7702Flags?.supportedChains ?? [];
@@ -1113,4 +1118,26 @@ export function isEIP7702Chain(
   return supportedChains.some(
     (supported) => supported.toLowerCase() === chainId.toLowerCase(),
   );
+}
+
+/**
+ * Get the EIP-7702 upgrade contract address for a chain from the
+ * `confirmations_eip_7702.contracts` feature flag, if any.
+ *
+ * @param messenger - Controller messenger.
+ * @param chainId - Chain ID to resolve the upgrade contract for.
+ * @returns The upgrade contract address, or `undefined` when none is set.
+ */
+export function getEIP7702UpgradeContractAddress(
+  messenger: TransactionPayControllerMessenger,
+  chainId: Hex,
+): Hex | undefined {
+  const state = messenger.call('RemoteFeatureFlagController:getState');
+  const eip7702Flags = state.remoteFeatureFlags.confirmations_eip_7702 as
+    | EIP7702FeatureFlag
+    | undefined;
+
+  const contracts = getCaseInsensitive(eip7702Flags?.contracts, chainId);
+
+  return contracts?.[0]?.address;
 }

--- a/packages/transaction-pay-controller/src/utils/quotes.test.ts
+++ b/packages/transaction-pay-controller/src/utils/quotes.test.ts
@@ -365,6 +365,69 @@ describe('Quotes Utils', () => {
       });
     });
 
+    it('keeps quotes and sets quoteError when strategy throws QuoteError with reason insufficient-source-balance and attached quotes', async () => {
+      const attachedQuote = {
+        ...QUOTE_MOCK,
+        strategy: TransactionPayStrategy.Relay,
+      } as TransactionPayQuote<Json>;
+      const error = new QuoteError(
+        {
+          message: 'Insufficient source balance for quote',
+          reason: 'insufficient-source-balance',
+          detail: ['Required: 1 USDC', 'Current: 0.5 USDC'],
+        },
+        [attachedQuote],
+      );
+      getQuotesMock.mockRejectedValue(error);
+
+      await run();
+
+      const transactionDataMock = {} as Record<string, unknown>;
+      updateTransactionDataMock.mock.calls.map((call) =>
+        call[1](transactionDataMock),
+      );
+
+      expect(transactionDataMock).toMatchObject({
+        quotes: [attachedQuote],
+        quoteError: {
+          message: 'Insufficient source balance for quote',
+          reason: 'insufficient-source-balance',
+          detail: ['Required: 1 USDC', 'Current: 0.5 USDC'],
+        },
+      });
+    });
+
+    it('drops quotes and sets quoteError when strategy throws QuoteError with non-insufficient-source-balance reason and attached quotes', async () => {
+      const attachedQuote = {
+        ...QUOTE_MOCK,
+        strategy: TransactionPayStrategy.Relay,
+      } as TransactionPayQuote<Json>;
+      const error = new QuoteError(
+        {
+          message: 'Quote simulation failed',
+          reason: 'simulation-failed',
+          detail: ['revert'],
+        },
+        [attachedQuote],
+      );
+      getQuotesMock.mockRejectedValue(error);
+
+      await run();
+
+      const transactionDataMock = {} as Record<string, unknown>;
+      updateTransactionDataMock.mock.calls.map((call) =>
+        call[1](transactionDataMock),
+      );
+
+      expect(transactionDataMock).toMatchObject({
+        quotes: [],
+        quoteError: {
+          message: 'Quote simulation failed',
+          reason: 'simulation-failed',
+        },
+      });
+    });
+
     it('clears quotes in state if strategy throws', async () => {
       getQuotesMock.mockRejectedValue(new Error('Strategy error'));
 

--- a/packages/transaction-pay-controller/src/utils/quotes.ts
+++ b/packages/transaction-pay-controller/src/utils/quotes.ts
@@ -191,7 +191,7 @@ export async function updateQuotes(
 
     updateTransactionData(transactionId, (data) => {
       data.quotes = quotes as never;
-      data.quoteError = quotes.length ? undefined : error;
+      data.quoteError = error;
       data.quotesLastUpdated = Date.now();
       data.totals = totals;
     });
@@ -758,6 +758,22 @@ async function getQuotes(
       error ??= isQuoteError(caughtError)
         ? caughtError.info
         : { message: (caughtError as Error).message, reason: 'no-quotes' };
+
+      if (
+        isQuoteError(caughtError) &&
+        caughtError.info.reason === 'insufficient-source-balance' &&
+        caughtError.quotes?.length
+      ) {
+        log('Keeping quotes despite insufficient source balance', {
+          strategy: name,
+          transactionId,
+        });
+        return {
+          batchTransactions: [],
+          error: caughtError.info,
+          quotes: caughtError.quotes as TransactionPayQuote<Json>[],
+        };
+      }
 
       log('Strategy failed, trying next', {
         error: caughtError,

--- a/packages/transaction-pay-controller/src/utils/simulation.test.ts
+++ b/packages/transaction-pay-controller/src/utils/simulation.test.ts
@@ -111,6 +111,91 @@ describe('simulateQuoteTransactions', () => {
         message: 'tx2 route error',
       });
     });
+
+    it('throws a custom error with the return data when execution reverted with return data', async () => {
+      messengerMock.simulateTransactionsMock.mockResolvedValue({
+        transactions: [{ error: 'execution reverted', return: '0xdeadbeef' }],
+      } as unknown as SentinelSimulationResponse);
+
+      await expect(
+        simulateQuoteTransactions(buildRequest()),
+      ).rejects.toMatchObject({
+        name: 'TransactionPaySimulationError',
+        message: 'Custom Error - 0xdeadbeef',
+      });
+    });
+
+    it('throws an unknown reverted error when execution reverted with empty return data', async () => {
+      messengerMock.simulateTransactionsMock.mockResolvedValue({
+        transactions: [{ error: 'execution reverted', return: '0x' }],
+      } as unknown as SentinelSimulationResponse);
+
+      await expect(
+        simulateQuoteTransactions(buildRequest()),
+      ).rejects.toMatchObject({
+        name: 'TransactionPaySimulationError',
+        message: 'Reverted - Unknown Error',
+      });
+    });
+
+    it('throws an unknown reverted error when execution reverted with no return data', async () => {
+      messengerMock.simulateTransactionsMock.mockResolvedValue({
+        transactions: [{ error: 'execution reverted' }],
+      } as unknown as SentinelSimulationResponse);
+
+      await expect(
+        simulateQuoteTransactions(buildRequest()),
+      ).rejects.toMatchObject({
+        name: 'TransactionPaySimulationError',
+        message: 'Reverted - Unknown Error',
+      });
+    });
+
+    it('throws the original error unchanged for non-reverted errors even with return data', async () => {
+      messengerMock.simulateTransactionsMock.mockResolvedValue({
+        transactions: [{ error: 'tx route error', return: '0xdeadbeef' }],
+      } as unknown as SentinelSimulationResponse);
+
+      await expect(
+        simulateQuoteTransactions(buildRequest()),
+      ).rejects.toMatchObject({
+        name: 'TransactionPaySimulationError',
+        message: 'tx route error',
+      });
+    });
+
+    it('strips the execution reverted prefix and surfaces the reason when a message follows', async () => {
+      messengerMock.simulateTransactionsMock.mockResolvedValue({
+        transactions: [
+          { error: 'execution reverted: insufficient allowance' },
+        ],
+      } as unknown as SentinelSimulationResponse);
+
+      await expect(
+        simulateQuoteTransactions(buildRequest()),
+      ).rejects.toMatchObject({
+        name: 'TransactionPaySimulationError',
+        message: 'insufficient allowance',
+      });
+    });
+
+    it('prefers the reason over return data when execution reverted has both', async () => {
+      messengerMock.simulateTransactionsMock.mockResolvedValue({
+        transactions: [
+          {
+            error: 'execution reverted: insufficient allowance',
+            return: '0xdeadbeef',
+          },
+        ],
+      } as unknown as SentinelSimulationResponse);
+
+      await expect(
+        simulateQuoteTransactions(buildRequest()),
+      ).rejects.toMatchObject({
+        name: 'TransactionPaySimulationError',
+        message: 'insufficient allowance',
+      });
+    });
   });
 
   describe('Sentinel call', () => {

--- a/packages/transaction-pay-controller/src/utils/simulation.test.ts
+++ b/packages/transaction-pay-controller/src/utils/simulation.test.ts
@@ -166,9 +166,7 @@ describe('simulateQuoteTransactions', () => {
 
     it('strips the execution reverted prefix and surfaces the reason when a message follows', async () => {
       messengerMock.simulateTransactionsMock.mockResolvedValue({
-        transactions: [
-          { error: 'execution reverted: insufficient allowance' },
-        ],
+        transactions: [{ error: 'execution reverted: insufficient allowance' }],
       } as unknown as SentinelSimulationResponse);
 
       await expect(

--- a/packages/transaction-pay-controller/src/utils/simulation.ts
+++ b/packages/transaction-pay-controller/src/utils/simulation.ts
@@ -14,6 +14,13 @@ export type { SentinelSimulationTransaction };
 
 const log = createModuleLogger(projectLogger, 'simulation');
 
+/**
+ * The generic revert message returned by Sentinel when a transaction reverts
+ * without a decoded reason. The `execution reverted` text is implied, so it is
+ * replaced with the revert return data (if any) when surfaced to consumers.
+ */
+const EXECUTION_REVERTED_ERROR = 'execution reverted';
+
 export type SimulationTransaction = SentinelSimulationTransaction;
 
 export type SimulationRequest = {
@@ -65,9 +72,52 @@ export async function simulateQuoteTransactions(
 
   for (const responseTransaction of responseTransactions) {
     if (responseTransaction.error) {
-      throw new TransactionPaySimulationError(responseTransaction.error);
+      throw new TransactionPaySimulationError(
+        getResponseErrorMessage(responseTransaction),
+      );
     }
   }
+}
+
+/**
+ * Build a user-facing error message from a reverted simulation response
+ * transaction.
+ *
+ * The implied `execution reverted` prefix is always stripped. When a specific
+ * reason follows the prefix (for example `execution reverted: insufficient
+ * allowance`), that reason is surfaced directly. When the message is only
+ * `execution reverted`, the revert return data is used instead: non-empty
+ * return data becomes `Custom Error - <return>`, while an empty return
+ * (`0x`) becomes `Reverted - Unknown Error`. Any error that does not start
+ * with the prefix is returned unchanged.
+ *
+ * @param responseTransaction - The reverted simulation response transaction.
+ * @returns The error message to throw.
+ */
+function getResponseErrorMessage(
+  responseTransaction: SentinelSimulationResponseTransaction,
+): string {
+  const { error, return: returnData } = responseTransaction;
+  const message = error as string;
+
+  if (!message.startsWith(EXECUTION_REVERTED_ERROR)) {
+    return message;
+  }
+
+  const reason = message
+    .slice(EXECUTION_REVERTED_ERROR.length)
+    .replace(/^:\s*/u, '')
+    .trim();
+
+  if (reason.length) {
+    return reason;
+  }
+
+  if (returnData && returnData !== '0x') {
+    return `Custom Error - ${returnData}`;
+  }
+
+  return 'Reverted - Unknown Error';
 }
 
 function getErrorMessage(error: unknown): string {

--- a/packages/transaction-pay-controller/src/utils/validation.test.ts
+++ b/packages/transaction-pay-controller/src/utils/validation.test.ts
@@ -393,6 +393,21 @@ describe('validateQuoteExecution', () => {
   });
 });
 
+describe('QuoteError', () => {
+  it('stores quotes when provided as second argument', () => {
+    const info = { message: 'test', reason: 'simulation-failed' as const };
+    const quotes = [{ strategy: 'relay' }] as never;
+    const error = new QuoteError(info, quotes);
+    expect(error.quotes).toBe(quotes);
+  });
+
+  it('leaves quotes undefined when not provided', () => {
+    const info = { message: 'test', reason: 'simulation-failed' as const };
+    const error = new QuoteError(info);
+    expect(error.quotes).toBeUndefined();
+  });
+});
+
 describe('isQuoteError', () => {
   it('returns true for a QuoteError instance', () => {
     const error = new QuoteError({

--- a/packages/transaction-pay-controller/src/utils/validation.ts
+++ b/packages/transaction-pay-controller/src/utils/validation.ts
@@ -40,10 +40,13 @@ export type QuoteExecutionRequest = {
 export class QuoteError extends Error {
   readonly info: QuoteErrorInfo;
 
-  constructor(info: QuoteErrorInfo) {
+  readonly quotes?: TransactionPayQuote<unknown>[];
+
+  constructor(info: QuoteErrorInfo, quotes?: TransactionPayQuote<unknown>[]) {
     super(info.message);
     this.name = 'QuoteError';
     this.info = info;
+    this.quotes = quotes;
   }
 }
 


### PR DESCRIPTION
## Explanation

This PR bundles several independent fixes to Relay quote validation and simulation in the pay controller:

- **Keep the quote on `insufficient-source-balance`.** Validation previously dropped all quotes regardless of failure reason. For `insufficient-source-balance` the quote is valid — the user simply lacks the balance to execute it right now — so the quote is now kept in state (with `quoteError` still set so the client can surface the balance error). All other failure reasons continue to drop the quotes as before. Mechanism: `QuoteError` gains an optional `quotes` field; `relay-validation.ts` attaches `request.quotes` when re-throwing for this reason; the `getQuotes` catch block returns those attached quotes early; and the state-persist line always writes `error`.

- **Always include an EIP-7702 authorization in the batch validation simulation.** The batch call is an ERC-7821 `execute` on the sender's own account, so the account must appear upgraded for the simulation to succeed. The quote does not always carry an authorization and there is no fast way to check the live upgrade state, so an authorization is now always included: the delegator address comes from the quote when present, otherwise from the configured EIP-7702 upgrade contract for the chain (new `getEIP7702UpgradeContractAddress` feature-flag util reading `confirmations_eip_7702.contracts`).

- **Exclude a zero `gas` value from the simulated transaction.** Both the 7702 batch and normal simulation builders now omit `gas` when it is zero, instead of passing `0x0` to the simulation.

- **Improve reverted Sentinel simulation error messages.** The implied `execution reverted` prefix is stripped; when a reason follows it is surfaced directly; otherwise non-empty revert return data becomes `Custom Error - <return>` and empty return data becomes `Reverted - Unknown Error`.

## References

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes quote state on validation errors and alters EIP-7702 simulation inputs, which affects pay UX and whether validation passes; scope is limited to relay validation/simulation with broad test coverage.
> 
> **Overview**
> Fixes Relay quote validation and Sentinel simulation behavior in the pay controller.
> 
> **Insufficient balance:** When validation fails with `insufficient-source-balance`, quotes stay in `transactionData` while `quoteError` is still set. `QuoteError` can carry an optional `quotes` array; relay validation re-throws with the full batch attached, and the quote fetch path returns those quotes instead of clearing them. Other failure reasons still drop quotes.
> 
> **EIP-7702 batch simulation:** 7702 batch validation always includes an `authorizationList` so undelegated accounts simulate as upgraded—quote auth when present, otherwise `getEIP7702UpgradeContractAddress` from `confirmations_eip_7702.contracts`.
> 
> **Simulation payloads:** Normal and 7702 batch builders omit `gas` when it is zero (`0x0` / `gasLimits[0] === 0`).
> 
> **Sentinel errors:** Generic `execution reverted` messages are normalized: strip the prefix, prefer an explicit reason after the colon, else show `Custom Error - <return>` or `Reverted - Unknown Error`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bea9b04bae0f2cb0de0f6bf10148b0ea8a8e690. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->