### PR TITLE
feat(analytics-controller): resolve geolocation only after opt-in

### DIFF
--- a/packages/analytics-controller/CHANGELOG.md
+++ b/packages/analytics-controller/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **BREAKING:** Optionally enrich non-anonymous track, identify, and view payloads with the user's `country_code`, `region`, and `timezone` under `context.location`, gated behind the new `isGeolocationEnabled` constructor option (default `false`) ([#9691](https://github.com/MetaMask/core/pull/9691))
-  - `AnalyticsController.init` is now asynchronous and returns a `Promise<void>`, so await it before tracking events
-  - When `isGeolocationEnabled` is `true`, the geolocation is resolved during `init` via `GeolocationController:getGeolocationData`, which compositions must register and initialize before `AnalyticsController` (otherwise enrichment is skipped for the session)
+  - `AnalyticsController.init` and `AnalyticsController.optIn` are now asynchronous and return a `Promise<void>`, so await them before tracking events
+  - When enabled, geolocation is resolved via `GeolocationController:getGeolocationData` (which compositions must register) only after the user opts in, so location is never requested before they consent to analytics; queued pre-consent events are then enriched on replay (anonymous payloads excluded)
   - Adds `@metamask/geolocation-controller` `^0.1.3` as a dependency
 - Bump `@metamask/messenger` from `^1.2.0` to `^2.0.0` ([#9392](https://github.com/MetaMask/core/pull/9392))
 

--- a/packages/analytics-controller/CHANGELOG.md
+++ b/packages/analytics-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Optionally enrich non-anonymous track, identify, and view payloads with the user's `country_code`, `region`, and `timezone` under `context.location`, gated behind the new `isGeolocationEnabled` constructor option (default `false`) ([#9691](https://github.com/MetaMask/core/pull/9691))
+- **BREAKING:** Optionally enrich non-anonymous track, identify, and view payloads with the user's `country_code`, `region`, and `timezone` under `context.location`, gated behind the new `isGeolocationEnabled` constructor option (default `false`) ([#9691](https://github.com/MetaMask/core/pull/9691), [#9728](https://github.com/MetaMask/core/pull/9728))
   - `AnalyticsController.init` and `AnalyticsController.optIn` are now asynchronous and return a `Promise<void>`, so await them before tracking events
   - When enabled, geolocation is resolved via `GeolocationController:getGeolocationData` (which compositions must register) only after the user opts in, so location is never requested before they consent to analytics; queued pre-consent events are then enriched on replay (anonymous payloads excluded)
   - Adds `@metamask/geolocation-controller` `^0.1.3` as a dependency

--- a/packages/analytics-controller/src/AnalyticsController-method-action-types.ts
+++ b/packages/analytics-controller/src/AnalyticsController-method-action-types.ts
@@ -46,6 +46,12 @@ export type AnalyticsControllerTrackViewAction = {
  *
  * Records that a consent decision has been made and replays any events that
  * were queued while the user was undecided.
+ *
+ * When geolocation enrichment is enabled, geolocation is resolved here (once
+ * the user has consented) and awaited before the queued events are replayed,
+ * so those events are enriched with the resolved location as they are sent.
+ *
+ * @returns A promise that resolves once opt-in processing has completed.
  */
 export type AnalyticsControllerOptInAction = {
   type: `AnalyticsController:optIn`;

--- a/packages/analytics-controller/src/AnalyticsController.test.ts
+++ b/packages/analytics-controller/src/AnalyticsController.test.ts
@@ -1726,7 +1726,10 @@ describe('AnalyticsController', () => {
       });
     });
 
-    it('replays pre-consent events with the location context captured at track time', async () => {
+    it('defers geolocation to opt-in, then enriches replayed pre-consent events and later events', async () => {
+      const geolocationHandler = jest.fn(() =>
+        Promise.resolve(buildGeolocationData(fullGeolocation)),
+      );
       const mockAdapter = createMockAdapter();
       const { controller } = await setupController({
         state: {
@@ -1736,20 +1739,101 @@ describe('AnalyticsController', () => {
         },
         platformAdapter: mockAdapter,
         isPreConsentQueueEnabled: true,
-        geolocation: fullGeolocation,
+        isGeolocationEnabled: true,
+        geolocationHandler,
       });
 
-      controller.trackEvent(createTestEvent('test_event'));
+      // While undecided, the event is queued and geolocation is not requested.
+      controller.trackEvent(createTestEvent('preconsent_event'));
       expect(mockAdapter.track).not.toHaveBeenCalled();
+      expect(geolocationHandler).not.toHaveBeenCalled();
 
-      controller.optIn();
+      // optIn resolves geolocation (awaited) before replaying the queue.
+      await controller.optIn();
+      expect(geolocationHandler).toHaveBeenCalledTimes(1);
 
+      // The replayed pre-consent event is enriched with the location resolved
+      // on opt-in.
       expect(mockAdapter.track).toHaveBeenCalledWith(
-        'test_event',
+        'preconsent_event',
         undefined,
         { location: fullLocationContext },
         expect.any(Object),
       );
+
+      // Events tracked after opt-in are enriched too.
+      controller.trackEvent(createTestEvent('postconsent_event'));
+      expect(mockAdapter.track).toHaveBeenLastCalledWith(
+        'postconsent_event',
+        undefined,
+        { location: fullLocationContext },
+      );
+    });
+
+    it('does not enrich an anonymous pre-consent payload on replay', async () => {
+      const mockAdapter = createMockAdapter();
+      const { controller } = await setupController({
+        state: {
+          optedIn: false,
+          consentDecisionMade: false,
+          analyticsId,
+        },
+        platformAdapter: mockAdapter,
+        isPreConsentQueueEnabled: true,
+        isAnonymousEventsFeatureEnabled: true,
+        isGeolocationEnabled: true,
+        geolocation: fullGeolocation,
+      });
+
+      controller.trackEvent(
+        createTestEvent(
+          'test_event',
+          { prop: 'value' },
+          { sensitive_prop: 'sensitive value' },
+        ),
+      );
+
+      await controller.optIn();
+
+      // The identified payload is enriched...
+      expect(mockAdapter.track).toHaveBeenCalledWith(
+        'test_event',
+        { prop: 'value' },
+        { location: fullLocationContext },
+        expect.any(Object),
+      );
+      // ...but the anonymous payload carries no location.
+      expect(mockAdapter.track).toHaveBeenCalledWith(
+        'test_event',
+        {
+          prop: 'value',
+          sensitive_prop: 'sensitive value',
+          anonymous: true,
+        },
+        undefined,
+        expect.any(Object),
+      );
+    });
+
+    it('does not resolve geolocation at init when the user is not opted in', async () => {
+      const geolocationHandler = jest.fn(() =>
+        Promise.resolve(buildGeolocationData(fullGeolocation)),
+      );
+      const mockAdapter = createMockAdapter();
+      await setupController({
+        state: {
+          optedIn: false,
+          consentDecisionMade: true,
+          analyticsId,
+        },
+        platformAdapter: mockAdapter,
+        isGeolocationEnabled: true,
+        geolocationHandler,
+      });
+
+      // init awaits geolocation resolution, so if it were going to request
+      // location it would have by now.
+      expect(geolocationHandler).not.toHaveBeenCalled();
     });
   });
 
@@ -2393,7 +2477,7 @@ describe('AnalyticsController', () => {
         },
       });
 
-      controller.optIn();
+      await controller.optIn();
 
       expect(controller.state.optedIn).toBe(true);
       expect(controller.state.consentDecisionMade).toBe(true);
@@ -2499,7 +2583,7 @@ describe('AnalyticsController', () => {
 
       expect(controller.state.preConsentEventQueue).toStrictEqual({});
 
-      controller.optIn();
+      await controller.optIn();
 
       expect(controller.state.optedIn).toBe(true);
       expect(mockAdapter.track).not.toHaveBeenCalled();
@@ -2516,7 +2600,7 @@ describe('AnalyticsController', () => {
         isPreConsentQueueEnabled: true,
       });
 
-      controller.optIn();
+      await controller.optIn();
 
       expect(controller.state.optedIn).toBe(true);
       expect(controller.state.consentDecisionMade).toBe(true);
@@ -2545,7 +2629,7 @@ describe('AnalyticsController', () => {
       const { controller, mockAdapter } =
         await setupControllerWithQueuedEvent();
 
-      controller.optIn();
+      await controller.optIn();
 
       expect(controller.state.optedIn).toBe(true);
       expect(controller.state.consentDecisionMade).toBe(true);
@@ -2575,7 +2659,7 @@ describe('AnalyticsController', () => {
       // Held in the pre-consent queue, not yet in the delivery queue.
       expect(controller.state.eventQueue ?? {}).toStrictEqual({});
 
-      controller.optIn();
+      await controller.optIn();
 
       // The pre-consent queue is drained and the event is now tracked for
       // delivery (the mock adapter never acks, so it remains in eventQueue).
@@ -2707,7 +2791,7 @@ describe('AnalyticsController', () => {
         Object.values(controller.state.preConsentEventQueue ?? {}),
       ).toHaveLength(2);
 
-      controller.optIn();
+      await controller.optIn();
 
       expect(mockAdapter.track).toHaveBeenCalledTimes(2);
       expect(mockAdapter.track).toHaveBeenCalledWith(
@@ -2751,7 +2835,7 @@ describe('AnalyticsController', () => {
         isPreConsentQueueEnabled: true,
       });
 
-      controller.optIn();
+      await controller.optIn();
 
       // Only the valid entry is replayed; every malformed entry is dropped.
       expect(mockAdapter.track).toHaveBeenCalledTimes(1);

--- a/packages/analytics-controller/src/AnalyticsController.test.ts
+++ b/packages/analytics-controller/src/AnalyticsController.test.ts
@@ -1835,6 +1835,49 @@ describe('AnalyticsController', () => {
       // location it would have by now.
       expect(geolocationHandler).not.toHaveBeenCalled();
     });
+
+    it('does not replay pre-consent events if consent is reset while geolocation resolves', async () => {
+      let resolveGeolocation: (data: GeolocationData) => void = () => undefined;
+      const geolocationHandler = jest.fn(
+        () =>
+          new Promise<GeolocationData>((resolve) => {
+            resolveGeolocation = resolve;
+          }),
+      );
+      const mockAdapter = createMockAdapter();
+      const { controller } = await setupController({
+        state: {
+          optedIn: false,
+          consentDecisionMade: false,
+          analyticsId,
+        },
+        platformAdapter: mockAdapter,
+        isPreConsentQueueEnabled: true,
+        isGeolocationEnabled: true,
+        geolocationHandler,
+      });
+
+      controller.trackEvent(createTestEvent('preconsent_event'));
+      expect(mockAdapter.track).not.toHaveBeenCalled();
+
+      // Opt in, but leave geolocation resolving (do not await yet).
+      const optInPromise = controller.optIn();
+      expect(geolocationHandler).toHaveBeenCalledTimes(1);
+
+      // The user resets their consent decision before geolocation resolves.
+      controller.resetConsentDecision();
+
+      // Geolocation resolves and optIn finishes reconciling.
+      resolveGeolocation(buildGeolocationData(fullGeolocation));
+      await optInPromise;
+
+      // The pre-consent event is not delivered — the user is undecided again —
+      // and it remains queued for a later decision.
+      expect(mockAdapter.track).not.toHaveBeenCalled();
+      expect(
+        Object.values(controller.state.preConsentEventQueue ?? {}),
+      ).toHaveLength(1);
+    });
   });
 
   describe('event queue persistence', () => {

--- a/packages/analytics-controller/src/AnalyticsController.ts
+++ b/packages/analytics-controller/src/AnalyticsController.ts
@@ -457,6 +457,12 @@ export class AnalyticsController extends BaseController<
    */
   #initPromise: Promise<void> | undefined;
 
+  /**
+   * The in-flight (or settled) geolocation resolution, if any. Its presence
+   * marks that resolution has been started, so it runs at most once.
+   */
+  #locationResolvePromise: Promise<void> | undefined;
+
   #locationContext: AnalyticsLocationContext | undefined;
 
   /**
@@ -506,6 +512,7 @@ export class AnalyticsController extends BaseController<
     this.#isGeolocationEnabled = isGeolocationEnabled;
     this.#platformAdapter = platformAdapter;
     this.#initPromise = undefined;
+    this.#locationResolvePromise = undefined;
 
     this.messenger.registerMethodActionHandlers(
       this,
@@ -524,20 +531,18 @@ export class AnalyticsController extends BaseController<
   }
 
   /**
-   * Initialize the controller by resolving the geolocation used to enrich
-   * events and then calling the platform adapter's onSetupCompleted lifecycle
-   * hook. This method must be called after construction to complete the setup
-   * process.
+   * Initialize the controller by calling the platform adapter's
+   * onSetupCompleted lifecycle hook and replaying any queued events. This
+   * method must be called after construction to complete the setup process.
    *
-   * Geolocation is resolved before any queued event is replayed so that
-   * replayed events carry the same location context as new ones.
-   *
-   * When geolocation enrichment is enabled (`isGeolocationEnabled`), the
-   * `GeolocationController` and its `GeolocationController:getGeolocationData`
-   * action must be registered and initialized *before* this method is called.
-   * Otherwise the resolution fails and events are delivered for the rest of the
-   * session without location (a message is logged, see
-   * {@link #resolveLocationContext}).
+   * When geolocation enrichment is enabled (`isGeolocationEnabled`), geolocation
+   * is resolved only for a user who is already opted in; for undecided or
+   * opted-out users it is deferred until they opt in (see {@link optIn}), so a
+   * user's location is never requested before they consent to analytics. In
+   * either case the `GeolocationController` and its
+   * `GeolocationController:getGeolocationData` action must be registered before
+   * resolution occurs, or enrichment is skipped for the session (a message is
+   * logged, see {@link #resolveLocationContext}).
    *
    * Safe to call more than once: the first call performs initialization and
    * subsequent calls return the same in-flight (or settled) promise.
@@ -558,7 +563,10 @@ export class AnalyticsController extends BaseController<
    * and pre-consent events.
    */
   async #performInit(): Promise<void> {
-    await this.#resolveLocationContext();
+    // Resolve geolocation only when the user is already opted in; for undecided
+    // or opted-out users it is deferred to {@link optIn}. Awaited so that an
+    // already-opted-in session has location available before events replay.
+    await this.#maybeResolveLocation();
 
     // Call onSetupCompleted lifecycle hook after initialization
     // State is already validated, so analyticsId is guaranteed to be a valid UUIDv4
@@ -574,17 +582,29 @@ export class AnalyticsController extends BaseController<
   }
 
   /**
-   * Resolve the location context used to enrich analytics events.
+   * Start resolving the geolocation context if warranted, and return the
+   * in-flight (or settled) resolution so callers can await it. No-op unless
+   * enrichment is enabled, the user is opted in, and a resolution has not
+   * already been started. Deferring resolution until opt-in ensures a user's
+   * location is never requested before they consent to analytics (for example,
+   * during onboarding).
    *
-   * No-op unless geolocation enrichment is enabled. Otherwise geolocation is
-   * best-effort: when the GeolocationController is unavailable or fails to
-   * resolve, events are still delivered, just without location.
+   * @returns The geolocation resolution promise, or `undefined` when no
+   * resolution is warranted.
    */
-  async #resolveLocationContext(): Promise<void> {
-    if (!this.#isGeolocationEnabled) {
-      return;
+  #maybeResolveLocation(): Promise<void> | undefined {
+    if (
+      this.#isGeolocationEnabled &&
+      this.#locationResolvePromise === undefined &&
+      analyticsControllerSelectors.selectEnabled(this.state)
+    ) {
+      this.#locationResolvePromise = this.#resolveLocationContext();
     }
 
+    return this.#locationResolvePromise;
+  }
+
+  async #resolveLocationContext(): Promise<void> {
     try {
       const geolocation = await this.messenger.call(
         'GeolocationController:getGeolocationData',
@@ -592,11 +612,12 @@ export class AnalyticsController extends BaseController<
 
       this.#locationContext = buildLocationContext(geolocation);
     } catch (error) {
-      // A common cause is calling `init()` before the GeolocationController is
-      // registered/initialized. Name it here so the failure is diagnosable,
-      // since enrichment is otherwise skipped silently for the session.
+      // A common cause is the GeolocationController not being registered before
+      // resolution runs (at init for an opted-in user, otherwise at opt-in).
+      // Name it here so the failure is diagnosable, since enrichment is
+      // otherwise skipped silently for the session.
       log(
-        'Failed to resolve geolocation for analytics enrichment; events will be sent without location. Ensure the GeolocationController is registered and initialized before AnalyticsController.init() when geolocation is enabled.',
+        'Failed to resolve geolocation for analytics enrichment; events will be sent without location. Ensure the GeolocationController is registered and initialized before the user opts in when geolocation is enabled.',
         error,
       );
     }
@@ -921,12 +942,41 @@ export class AnalyticsController extends BaseController<
         continue;
       }
 
+      const eventToReplay = this.#enrichPreConsentEvent(queuedEvent);
+
       if (this.#isEventQueuePersistenceEnabled) {
-        this.#enqueueEvent(queuedEvent);
+        this.#enqueueEvent(eventToReplay);
       } else {
-        this.#sendQueuedEvent(queuedEvent);
+        this.#sendQueuedEvent(eventToReplay);
       }
     }
+  }
+
+  /**
+   * Enrich a pre-consent event with the geolocation resolved on opt-in.
+   *
+   * Pre-consent events are captured while geolocation is not yet resolved, so
+   * they are re-enriched here as they replay. Anonymous track payloads are left
+   * untouched, since they must never carry location.
+   *
+   * @param queuedEvent - The queued pre-consent event.
+   * @returns The event with its context enriched, or the event unchanged when
+   * enrichment does not apply.
+   */
+  #enrichPreConsentEvent(
+    queuedEvent: AnalyticsQueuedEvent,
+  ): AnalyticsQueuedEvent {
+    if (
+      queuedEvent.type === 'track' &&
+      queuedEvent.properties?.anonymous === true
+    ) {
+      return queuedEvent;
+    }
+
+    return {
+      ...queuedEvent,
+      context: this.#withLocationContext(queuedEvent.context),
+    };
   }
 
   /**
@@ -1087,12 +1137,22 @@ export class AnalyticsController extends BaseController<
    *
    * Records that a consent decision has been made and replays any events that
    * were queued while the user was undecided.
+   *
+   * When geolocation enrichment is enabled, geolocation is resolved here (once
+   * the user has consented) and awaited before the queued events are replayed,
+   * so those events are enriched with the resolved location as they are sent.
+   *
+   * @returns A promise that resolves once opt-in processing has completed.
    */
-  optIn(): void {
+  async optIn(): Promise<void> {
     this.update((state) => {
       state.optedIn = true;
       state.consentDecisionMade = true;
     });
+
+    // Now that the user has consented, resolve geolocation (once) and wait for
+    // it so the queued pre-consent events can be enriched as they replay.
+    await this.#maybeResolveLocation();
 
     this.#replayPreConsentEvents();
   }

--- a/packages/analytics-controller/src/AnalyticsController.ts
+++ b/packages/analytics-controller/src/AnalyticsController.ts
@@ -973,9 +973,11 @@ export class AnalyticsController extends BaseController<
       return queuedEvent;
     }
 
+    const context = this.#withLocationContext(queuedEvent.context);
+
     return {
       ...queuedEvent,
-      context: this.#withLocationContext(queuedEvent.context),
+      ...(context === undefined ? {} : { context }),
     };
   }
 

--- a/packages/analytics-controller/src/AnalyticsController.ts
+++ b/packages/analytics-controller/src/AnalyticsController.ts
@@ -915,20 +915,13 @@ export class AnalyticsController extends BaseController<
   /**
    * Replay queued pre-consent events through the delivery path.
    *
-   * Called on opt-in, once analytics is enabled. The queue is cleared before
-   * replaying so events cannot be re-queued or replayed twice.
+   * Only called by {@link #reconcilePreConsentEvents}, which guarantees the
+   * pre-consent queue is enabled and that the user is opted in. The queue is
+   * cleared before replaying so events cannot be re-queued or replayed twice.
+   *
+   * @param queue - The pre-consent event queue to replay.
    */
-  #replayPreConsentEvents(): void {
-    if (!this.#isPreConsentQueueEnabled) {
-      return;
-    }
-
-    const queue = this.state.preConsentEventQueue;
-
-    if (!queue) {
-      return;
-    }
-
+  #replayPreConsentEvents(queue: Record<string, Json>): void {
     this.#clearPreConsentEvents();
 
     for (const [messageId, queuedEvent] of Object.entries(queue)) {
@@ -1019,7 +1012,7 @@ export class AnalyticsController extends BaseController<
     }
 
     if (this.state.optedIn) {
-      this.#replayPreConsentEvents();
+      this.#replayPreConsentEvents(queue);
     } else if (this.state.consentDecisionMade) {
       this.#clearPreConsentEvents();
     }
@@ -1156,7 +1149,11 @@ export class AnalyticsController extends BaseController<
     // it so the queued pre-consent events can be enriched as they replay.
     await this.#maybeResolveLocation();
 
-    this.#replayPreConsentEvents();
+    // Reconcile against the current state rather than replaying blindly: the
+    // consent decision may have changed while geolocation was resolving (e.g.
+    // resetConsentDecision ran during the await), and preserved pre-consent
+    // events must not be delivered once the user is no longer opted in.
+    this.#reconcilePreConsentEvents();
   }
 
   /**


### PR DESCRIPTION
## Explanation

Follow-up to #9691, which added geo-enrichment of analytics events. As originally merged, the `AnalyticsController` resolved the user's geolocation during `init` regardless of consent state — so a user's location could be requested before they had opted in to analytics (for example, during onboarding).

This PR gates geolocation resolution behind user consent:

- Resolution now runs **only once the user is opted in**: during `init` for an already-opted-in user, otherwise deferred to `optIn`. A user's location is never requested before they consent to analytics.
- `AnalyticsController.optIn` becomes **async** (returns `Promise<void>`). It resolves and awaits geolocation before replaying queued pre-consent events, so those events are enriched with the resolved location as they replay. Anonymous payloads are excluded, per ADR-0008.
- Resolution is started at most once per session (`#maybeResolveLocation` is idempotent).

`init` was already async (from #9691); `optIn` becoming async is the one new breaking change for consumers, who must now `await` it.

## References

- Follow-up to #9691
- Implements the consent-gating requirement of ADR-0008 (geo-enrichment of Extension/Mobile metric events)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking API change (`optIn` async) plus consent-sensitive geolocation and pre-consent replay timing; behavior is well-tested but integrators must await `optIn` and register GeolocationController before consent.
> 
> **Overview**
> Follow-up to geo-enrichment in **AnalyticsController**: **geolocation is no longer fetched during `init` for undecided or opted-out users**. With `isGeolocationEnabled`, resolution runs only after the user has opted in—on `init` if already opted in, otherwise on **`optIn`**—via a one-shot `#maybeResolveLocation` path.
> 
> **`optIn` is now async** (`Promise<void>`): it awaits geolocation, then calls `#reconcilePreConsentEvents` instead of replaying the pre-consent queue immediately, so events are not sent if consent was reset while location was resolving. Queued pre-consent events get **`context.location` on replay** through `#enrichPreConsentEvent`; anonymous track payloads stay without location.
> 
> The changelog documents the breaking **`await optIn()`** requirement for consumers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8c64625673a25e8b231ed6f68365cfb5b84c759. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->