### PR TITLE
docs(analytics-controller): note geolocation resolves at most once per session

### DIFF
--- a/packages/analytics-controller/src/AnalyticsController.ts
+++ b/packages/analytics-controller/src/AnalyticsController.ts
@@ -589,6 +589,11 @@ export class AnalyticsController extends BaseController<
    * location is never requested before they consent to analytics (for example,
    * during onboarding).
    *
+   * Resolution runs at most once per controller session: the settled promise
+   * is retained, so the outcome — including a failure (see
+   * {@link #resolveLocationContext}) — is not retried, and events are delivered
+   * without location for the rest of the session.
+   *
    * @returns The geolocation resolution promise, or `undefined` when no
    * resolution is warranted.
    */


### PR DESCRIPTION
## Explanation

Follow-up to #9728. A reviewer [noted](https://github.com/MetaMask/core/pull/9728#discussion_r3688657867) that the at-most-once resolution behavior of `#maybeResolveLocation` is easy to overlook, since `#resolveLocationContext` swallows its own errors (the shared promise resolves rather than rejects, and the `#locationResolvePromise !== undefined` guard then blocks any retry).

This adds a JSDoc paragraph to `#maybeResolveLocation` making the behavior explicit: a failed resolution is not retried, and events are delivered without location for the rest of the session.

## References

- Follow-up to #9728
- Addresses [review comment](https://github.com/MetaMask/core/pull/9728#discussion_r3688657867) by @NicolasMassart

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> JSDoc-only change with no behavioral impact.
> 
> **Overview**
> Adds a JSDoc paragraph on **`#maybeResolveLocation`** so reviewers and maintainers can see behavior that was easy to miss: geolocation resolution runs **at most once per controller session**, the settled promise is kept (including after **`#resolveLocationContext`** swallows errors), failures are **not retried**, and analytics events go out **without location** for the rest of the session.
> 
> No runtime or test changes—documentation only, following review on #9728.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46c2c80400aebaf18ab11ec0ec8eddfe153f28aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->