### PR TITLE
feat: persist pay `strategy` in `TransactionController` `metamaskPay` metadata

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Export `getEffectiveRecipient` utility that returns the actual recipient of a transaction, decoding it from calldata for ERC-20/ERC-721/ERC-1155 token transfer methods where `txParams.to` is the token contract ([#9699](https://github.com/MetaMask/core/pull/9699))
+- Add optional `strategy` field to `MetamaskPayMetadata` to persist the MetaMask Pay strategy used to fund the transaction ([#9733](https://github.com/MetaMask/core/pull/9733))
 
 ## [69.3.0]
 

--- a/packages/transaction-controller/src/types.ts
+++ b/packages/transaction-controller/src/types.ts
@@ -2176,6 +2176,9 @@ export type MetamaskPayMetadata = {
   /** Source chain transaction hash if no local transaction. */
   sourceHash?: Hex;
 
+  /** Pay strategy used to fund the transaction (e.g. "relay", "fiat"). */
+  strategy?: string;
+
   /** Total amount of target token provided in fiat currency. */
   targetFiat?: string;
 

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `atomic` field on `TransactionConfig` / `TransactionData` for a generic non-atomic post-Relay flow: when `atomic` is `false`, Relay bridges to an internally derived recipient (`getPaymentOverrideData` recipient for post-quote flows, otherwise the transaction's own `from`) and the second leg is submitted separately after completion, replacing the removed `relay-post-ma-vault` module ([#9497](https://github.com/MetaMask/core/pull/9497))
+- Persist the quote strategy in the transaction's `metamaskPay.strategy` metadata so clients can derive pay metrics after `transactionData` is gone (e.g. after a restart) ([#9733](https://github.com/MetaMask/core/pull/9733))
 
 ### Changed
 

--- a/packages/transaction-pay-controller/src/utils/quotes.test.ts
+++ b/packages/transaction-pay-controller/src/utils/quotes.test.ts
@@ -908,11 +908,25 @@ describe('Quotes Utils', () => {
           bridgeFeeFiat: TOTALS_MOCK.fees.provider.usd,
           chainId: TRANSACTION_DATA_MOCK.paymentToken?.chainId,
           networkFeeFiat: TOTALS_MOCK.fees.sourceNetwork.estimate.usd,
+          strategy: TransactionPayStrategy.Across,
           targetFiat: TOTALS_MOCK.targetAmount.usd,
           tokenAddress: TRANSACTION_DATA_MOCK.paymentToken?.address,
           totalFiat: TOTALS_MOCK.total.usd,
         },
       });
+    });
+
+    it('does not persist strategy in metadata when there are no executable quotes', async () => {
+      getQuotesMock.mockResolvedValue([
+        { ...QUOTE_MOCK, strategy: TransactionPayStrategy.None },
+      ]);
+
+      await run();
+
+      const transactionMetaMock = {} as TransactionMeta;
+      updateTransactionMock.mock.calls[0][1](transactionMetaMock);
+
+      expect(transactionMetaMock.metamaskPay?.strategy).toBeUndefined();
     });
 
     it('updates metrics in metadata for fiat payment with no payment token', async () => {
@@ -932,6 +946,7 @@ describe('Quotes Utils', () => {
           bridgeFeeFiat: TOTALS_MOCK.fees.provider.usd,
           chainId: undefined,
           networkFeeFiat: TOTALS_MOCK.fees.sourceNetwork.estimate.usd,
+          strategy: TransactionPayStrategy.Across,
           targetFiat: TOTALS_MOCK.targetAmount.usd,
           tokenAddress: undefined,
           totalFiat: TOTALS_MOCK.total.usd,

--- a/packages/transaction-pay-controller/src/utils/quotes.ts
+++ b/packages/transaction-pay-controller/src/utils/quotes.ts
@@ -184,6 +184,7 @@ export async function updateQuotes(
       isPostQuote,
       messenger: messenger as never,
       paymentToken,
+      strategy: executableQuotes[0]?.strategy,
       totals,
       transactionId,
     });
@@ -222,6 +223,7 @@ export async function updateQuotes(
  * @param request.messenger - Messenger instance.
  * @param request.paymentToken - Payment token (source for standard flows, destination for post-quote).
  * @param request.selectedFiatPayment - Selected fiat payment method ID.
+ * @param request.strategy - Strategy of the executable quotes.
  * @param request.totals - Calculated totals.
  * @param request.transactionId - ID of the transaction to sync.
  */
@@ -232,6 +234,7 @@ function syncTransaction({
   messenger,
   paymentToken,
   selectedFiatPayment,
+  strategy,
   totals,
   transactionId,
 }: {
@@ -241,6 +244,7 @@ function syncTransaction({
   isPostQuote?: boolean;
   messenger: TransactionPayControllerMessenger;
   paymentToken: TransactionPaymentToken | undefined;
+  strategy?: TransactionPayStrategy;
   totals: TransactionPayTotals;
   transactionId: string;
 }): void {
@@ -278,6 +282,7 @@ function syncTransaction({
         chainId: paymentToken?.chainId,
         isPostQuote,
         networkFeeFiat: totals.fees.sourceNetwork.estimate.usd,
+        strategy,
         targetFiat: totals.targetAmount.usd,
         tokenAddress: paymentToken?.address,
         totalFiat: totals.total.usd,


### PR DESCRIPTION
## Explanation

`TransactionPayController.transactionData` (including quotes and their strategy) is not persisted, but `transactionMeta.metamaskPay` is. When a MetaMask Pay transaction finalizes after the transaction data is gone (e.g. the app restarted mid-flight), clients cannot report which pay strategy funded the transaction — mobile currently has to assume `relay` for all non-fiat backfills in its metrics builder (see MetaMask/metamask-mobile#34111).

This PR persists the strategy at the same point the rest of the pay metadata is synced:

- **`@metamask/transaction-controller`**: adds an optional `strategy?: string` field to `MetamaskPayMetadata`.
- **`@metamask/transaction-pay-controller`**: `syncTransaction` (called from `updateQuotes`) now writes the first executable quote's strategy to `tx.metamaskPay.strategy`. No-op quotes are already filtered out, so a direct route persists no strategy (consistent with `mm_pay_strategy` metrics semantics, which only count real quotes).

Non-breaking: the field is optional and additive.

## References

- Consumer follow-up for MetaMask/metamask-mobile#34111 (replaces the temporary `relay` assumption in the `mm_pay_strategy` metrics backfill once adopted)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional metadata and quote-sync wiring only; no auth, signing, or transaction lifecycle changes.
> 
> **Overview**
> Adds an optional **`strategy`** field on persisted **`metamaskPay`** metadata so clients can tell which MetaMask Pay funding route was used after in-memory pay quote data is gone (e.g. after restart).
> 
> **`@metamask/transaction-controller`** extends **`MetamaskPayMetadata`** with **`strategy?: string`**. **`@metamask/transaction-pay-controller`** passes the first **executable** quote’s strategy from **`updateQuotes`** into **`syncTransaction`**, which writes it alongside existing fiat totals when pay metadata is synced. Direct / no-op routes (**`TransactionPayStrategy.None`**) still count as no executable quotes, so **`strategy`** stays unset, matching existing pay-metrics semantics. Tests cover successful persistence and the no-quote case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71afa7ea50e3681c8830a4ea75b8344fe28f6610. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->