### PR TITLE
chore(seedless-onboarding-controller): add `Telegram` to `AuthConnection`

### DIFF
--- a/packages/seedless-onboarding-controller/CHANGELOG.md
+++ b/packages/seedless-onboarding-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `AuthConnection.Telegram` (`'telegram'`) to align with client social-login providers that already persist this value on `state.authConnection` ([#XXX](https://github.com/MetaMask/core/pull/XXX))
+- Add `AuthConnection.Telegram` (`'telegram'`) to align with client social-login providers that already persist this value on `state.authConnection` ([#9737](https://github.com/MetaMask/core/pull/9737))
 
 ## [10.1.0]
 

--- a/packages/seedless-onboarding-controller/CHANGELOG.md
+++ b/packages/seedless-onboarding-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `AuthConnection.Telegram` (`'telegram'`) to align with client social-login providers that already persist this value on `state.authConnection` ([#XXX](https://github.com/MetaMask/core/pull/XXX))
+
 ## [10.1.0]
 
 ### Added

--- a/packages/seedless-onboarding-controller/src/constants.ts
+++ b/packages/seedless-onboarding-controller/src/constants.ts
@@ -13,6 +13,7 @@ export enum Web3AuthNetwork {
 export enum AuthConnection {
   Google = 'google',
   Apple = 'apple',
+  Telegram = 'telegram',
 }
 
 export enum SecretType {


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Enum-only additive change with no auth or runtime behavior changes in this PR.
> 
> **Overview**
> Adds **`AuthConnection.Telegram`** (`'telegram'`) to the social-login provider enum in `@metamask/seedless-onboarding-controller`, matching clients that already store Telegram on **`state.authConnection`**.
> 
> The **[Unreleased]** changelog entry documents the addition; no controller logic or API signatures change beyond the expanded enum.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca2b27a9271b808d443e5c2e558904784cf90e23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->