### PR TITLE
fix(transaction-controller): refresh gas tokens for enforced simulations

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Refresh gas fee token quotes independently of balance changes for enforced-simulation transactions, and prevent stale simulation responses from overwriting newer transaction state.
+- Refresh gas fee token quotes independently of balance changes for enforced-simulation transactions, and prevent stale simulation responses from overwriting newer transaction state. ([#9757](https://github.com/MetaMask/core/pull/9757))
 
 ## [69.4.0]
 

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/network-controller` from `^35.0.0` to `^35.0.1` ([#9758](https://github.com/MetaMask/core/pull/9758))
 
+### Fixed
+
+- Refresh gas fee token quotes independently of balance changes for enforced-simulation transactions, and prevent stale simulation responses from overwriting newer transaction state.
+
 ## [69.4.0]
 
 ### Added

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -44,7 +44,7 @@ import * as uuidModule from 'uuid';
 
 import { FakeBlockTracker } from '../../../tests/fake-block-tracker.js';
 import { FakeProvider } from '../../../tests/fake-provider.js';
-import { flushPromises } from '../../../tests/helpers.js';
+import { flushPromises, jestAdvanceTime } from '../../../tests/helpers.js';
 import {
   buildCustomNetworkClientConfiguration,
   buildMockFindNetworkClientIdByChainId,
@@ -62,7 +62,10 @@ import {
 import { MethodDataHelper } from './helpers/MethodDataHelper.js';
 import { MultichainTrackingHelper } from './helpers/MultichainTrackingHelper.js';
 import { PendingTransactionTracker } from './helpers/PendingTransactionTracker.js';
-import { shouldResimulate } from './helpers/ResimulateHelper.js';
+import {
+  RESIMULATE_INTERVAL_MS,
+  shouldResimulate,
+} from './helpers/ResimulateHelper.js';
 import { ExtraTransactionsPublishHook } from './hooks/ExtraTransactionsPublishHook.js';
 import type {
   MethodData,
@@ -413,6 +416,7 @@ const METHOD_DATA_MOCK: MethodData = {
 describe('TransactionController', () => {
   afterEach(() => {
     jest.restoreAllMocks();
+    jest.useRealTimers();
   });
 
   const uuidModuleMock = jest.mocked(uuidModule);
@@ -2151,35 +2155,210 @@ describe('TransactionController', () => {
       });
     });
 
-    it('skips simulation when containerTypes includes EnforcedSimulations', async () => {
-      const { controller } = setupController();
+    describe('with enforced simulations', () => {
+      const wrappedParams = {
+        data: '0xabcdef',
+        to: ACCOUNT_2_MOCK,
+        value: '0x123',
+      };
+      const refreshedGasFeeToken = {
+        ...GAS_FEE_TOKEN_MOCK,
+        amount: '0x10',
+      };
 
-      const { transactionMeta } = await controller.addTransaction(
-        {
-          from: ACCOUNT_MOCK,
-          to: ACCOUNT_MOCK,
-        },
-        {
-          networkClientId: NETWORK_CLIENT_ID_MOCK,
-        },
-      );
+      it('skips balance changes but refreshes gas fee tokens using the wrapped transaction', async () => {
+        getGasFeeTokensMock.mockResolvedValueOnce({
+          gasFeeTokens: [refreshedGasFeeToken],
+          isGasFeeSponsored: false,
+        });
+        shouldResimulateMock.mockReturnValueOnce({
+          blockTime: 123,
+          resimulate: true,
+        });
+        const originalGasUsed = '0x5208';
+        const transactionMeta = {
+          ...TRANSACTION_META_MOCK,
+          gasFeeTokens: [GAS_FEE_TOKEN_MOCK],
+          gasUsed: originalGasUsed,
+          isGasFeeSponsored: true,
+          selectedGasFeeToken: GAS_FEE_TOKEN_MOCK.tokenAddress,
+          simulationData: SIMULATION_DATA_RESULT_MOCK,
+          status: TransactionStatus.unapproved as const,
+        };
+        const { controller } = setupController({
+          options: {
+            state: { transactions: [transactionMeta] },
+          },
+          updateToInitialState: true,
+        });
 
-      await flushPromises();
+        await controller.updateEditableParams(transactionMeta.id, {
+          ...wrappedParams,
+          containerTypes: [TransactionContainerType.EnforcedSimulations],
+        });
+        await flushPromises();
 
-      expect(getBalanceChangesMock).toHaveBeenCalledTimes(1);
-
-      shouldResimulateMock.mockReturnValue({
-        blockTime: 123,
-        resimulate: true,
+        expect(getBalanceChangesMock).not.toHaveBeenCalled();
+        expect(getGasFeeTokensMock).toHaveBeenCalledTimes(1);
+        expect(getGasFeeTokensMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            transactionMeta: expect.objectContaining({
+              containerTypes: [TransactionContainerType.EnforcedSimulations],
+              txParams: expect.objectContaining(wrappedParams),
+            }),
+          }),
+        );
+        expect(controller.state.transactions[0]).toMatchObject({
+          gasFeeTokens: [refreshedGasFeeToken],
+          gasUsed: originalGasUsed,
+          isExternalSign: true,
+          isGasFeeSponsored: true,
+          selectedGasFeeToken: GAS_FEE_TOKEN_MOCK.tokenAddress,
+          simulationData: SIMULATION_DATA_RESULT_MOCK,
+        });
       });
 
-      await controller.updateEditableParams(transactionMeta.id, {
-        containerTypes: [TransactionContainerType.EnforcedSimulations],
+      it('keeps the selected token during periodic simulation updates', async () => {
+        jest.useFakeTimers();
+        getGasFeeTokensMock.mockResolvedValue({
+          gasFeeTokens: [refreshedGasFeeToken],
+          isGasFeeSponsored: false,
+        });
+        const transactionMeta = {
+          ...TRANSACTION_META_MOCK,
+          containerTypes: [TransactionContainerType.EnforcedSimulations],
+          gasFeeTokens: [GAS_FEE_TOKEN_MOCK],
+          isActive: true,
+          selectedGasFeeToken: GAS_FEE_TOKEN_MOCK.tokenAddress,
+          status: TransactionStatus.unapproved as const,
+          txParams: {
+            ...TRANSACTION_META_MOCK.txParams,
+            ...wrappedParams,
+          },
+        };
+        const { controller } = setupController({
+          options: {
+            state: { transactions: [transactionMeta] },
+          },
+          updateToInitialState: true,
+        });
+
+        await jestAdvanceTime({ duration: RESIMULATE_INTERVAL_MS });
+
+        expect(getBalanceChangesMock).not.toHaveBeenCalled();
+        expect(getGasFeeTokensMock).toHaveBeenCalledTimes(1);
+        expect(controller.state.transactions[0]).toMatchObject({
+          gasFeeTokens: [refreshedGasFeeToken],
+          selectedGasFeeToken: GAS_FEE_TOKEN_MOCK.tokenAddress,
+        });
+
+        jest.useRealTimers();
       });
 
-      await flushPromises();
+      it('replaces existing tokens with an empty response without clearing the selection', async () => {
+        getGasFeeTokensMock.mockResolvedValueOnce({
+          gasFeeTokens: [],
+          isGasFeeSponsored: false,
+        });
+        shouldResimulateMock.mockReturnValueOnce({
+          blockTime: 123,
+          resimulate: true,
+        });
+        const transactionMeta = {
+          ...TRANSACTION_META_MOCK,
+          containerTypes: [TransactionContainerType.EnforcedSimulations],
+          gasFeeTokens: [GAS_FEE_TOKEN_MOCK],
+          gasUsed: '0x5208',
+          selectedGasFeeToken: GAS_FEE_TOKEN_MOCK.tokenAddress,
+          status: TransactionStatus.unapproved as const,
+        };
+        const { controller } = setupController({
+          options: {
+            state: { transactions: [transactionMeta] },
+          },
+          updateToInitialState: true,
+        });
 
-      expect(getBalanceChangesMock).toHaveBeenCalledTimes(1);
+        await controller.updateEditableParams(transactionMeta.id, {
+          data: wrappedParams.data,
+        });
+        await flushPromises();
+
+        expect(getGasFeeTokensMock).toHaveBeenCalledTimes(1);
+        expect(controller.state.transactions[0]).toMatchObject({
+          gasFeeTokens: [],
+          gasUsed: transactionMeta.gasUsed,
+          selectedGasFeeToken: GAS_FEE_TOKEN_MOCK.tokenAddress,
+        });
+      });
+
+      it('does not apply an older in-flight simulation response after wrapping', async () => {
+        const staleBalanceChanges =
+          createDeferredPromise<
+            Awaited<ReturnType<typeof getBalanceChanges>>
+          >();
+        const staleGasFeeToken = {
+          ...GAS_FEE_TOKEN_MOCK,
+          amount: '0x20',
+        };
+        getBalanceChangesMock.mockReturnValueOnce(staleBalanceChanges.promise);
+        getGasFeeTokensMock.mockImplementation(async ({ transactionMeta }) => {
+          const isWrapped = transactionMeta.containerTypes?.includes(
+            TransactionContainerType.EnforcedSimulations,
+          );
+
+          return {
+            gasFeeTokens: [isWrapped ? refreshedGasFeeToken : staleGasFeeToken],
+            isGasFeeSponsored: false,
+          };
+        });
+        shouldResimulateMock.mockReturnValue({
+          blockTime: 123,
+          resimulate: true,
+        });
+        const transactionMeta = {
+          ...TRANSACTION_META_MOCK,
+          gasFeeTokens: [GAS_FEE_TOKEN_MOCK],
+          gasUsed: '0x100',
+          status: TransactionStatus.unapproved as const,
+        };
+        const { controller } = setupController({
+          options: {
+            state: { transactions: [transactionMeta] },
+          },
+          updateToInitialState: true,
+        });
+
+        await controller.updateEditableParams(transactionMeta.id, {
+          data: '0x1111',
+        });
+        await controller.updateEditableParams(transactionMeta.id, {
+          ...wrappedParams,
+          containerTypes: [TransactionContainerType.EnforcedSimulations],
+        });
+        await flushPromises();
+
+        expect(controller.state.transactions[0].gasFeeTokens).toStrictEqual([
+          refreshedGasFeeToken,
+        ]);
+
+        staleBalanceChanges.resolve({
+          gasUsed: '0x200',
+          simulationData: {
+            ...SIMULATION_DATA_RESULT_MOCK,
+            tokenBalanceChanges: [],
+          },
+        });
+        await flushPromises();
+
+        expect(getGasFeeTokensMock).toHaveBeenCalledTimes(2);
+        expect(controller.state.transactions[0]).toMatchObject({
+          containerTypes: [TransactionContainerType.EnforcedSimulations],
+          gasFeeTokens: [refreshedGasFeeToken],
+          gasUsed: transactionMeta.gasUsed,
+          txParams: expect.objectContaining(wrappedParams),
+        });
+      });
     });
 
     describe('with beforeSign hook', () => {
@@ -2317,6 +2496,86 @@ describe('TransactionController', () => {
         await flushPromises();
 
         expect(controller.state.transactions[0].gasUsed).toBe(testGasUsed);
+      });
+
+      it('does not apply an older in-flight result after a newer simulation', async () => {
+        const staleBalanceChanges =
+          createDeferredPromise<
+            Awaited<ReturnType<typeof getBalanceChanges>>
+          >();
+        const freshBalanceChanges =
+          createDeferredPromise<
+            Awaited<ReturnType<typeof getBalanceChanges>>
+          >();
+        const staleGasFeeToken = {
+          ...GAS_FEE_TOKEN_MOCK,
+          amount: '0x20',
+        };
+        const freshGasFeeToken = {
+          ...GAS_FEE_TOKEN_MOCK,
+          amount: '0x30',
+        };
+        const freshSimulationData = {
+          ...SIMULATION_DATA_RESULT_MOCK,
+          tokenBalanceChanges: [],
+        };
+        const freshSimulationRevert = { message: 'Fresh revert' };
+        getBalanceChangesMock
+          .mockReturnValueOnce(staleBalanceChanges.promise)
+          .mockReturnValueOnce(freshBalanceChanges.promise);
+        getGasFeeTokensMock.mockImplementation(async ({ transactionMeta }) => {
+          const isFresh = transactionMeta.txParams.data === '0x2222';
+
+          return {
+            gasFeeTokens: [isFresh ? freshGasFeeToken : staleGasFeeToken],
+            isGasFeeSponsored: isFresh,
+          };
+        });
+        shouldResimulateMock.mockReturnValue({
+          blockTime: 123,
+          resimulate: true,
+        });
+        const transactionMeta = {
+          ...TRANSACTION_META_MOCK,
+          status: TransactionStatus.unapproved as const,
+        };
+        const { controller } = setupController({
+          options: {
+            state: { transactions: [transactionMeta] },
+          },
+          updateToInitialState: true,
+        });
+
+        await controller.updateEditableParams(transactionMeta.id, {
+          data: '0x1111',
+        });
+        await controller.updateEditableParams(transactionMeta.id, {
+          data: '0x2222',
+        });
+
+        freshBalanceChanges.resolve({
+          gasUsed: '0x300',
+          simulationData: freshSimulationData,
+          simulationRevert: freshSimulationRevert,
+        });
+        await flushPromises();
+
+        staleBalanceChanges.resolve({
+          gasUsed: '0x200',
+          simulationData: SIMULATION_DATA_RESULT_MOCK,
+          simulationRevert: { message: 'Stale revert' },
+        });
+        await flushPromises();
+
+        expect(controller.state.transactions[0]).toMatchObject({
+          gasFeeTokens: [freshGasFeeToken],
+          gasUsed: '0x300',
+          isExternalSign: true,
+          isGasFeeSponsored: true,
+          revert: { simulation: freshSimulationRevert },
+          simulationData: freshSimulationData,
+          txParams: expect.objectContaining({ data: '0x2222' }),
+        });
       });
 
       it('with getSimulationConfig', async () => {

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -775,6 +775,8 @@ export class TransactionController extends BaseController<
 
   readonly #skipSimulationTransactionIds: Set<string> = new Set();
 
+  readonly #simulationRequestTokens: Map<string, symbol> = new Map();
+
   readonly #testGasFeeFlows: boolean;
 
   readonly #trace: TraceCallback;
@@ -4103,92 +4105,115 @@ export class TransactionController extends BaseController<
     let isGasFeeSponsored = false;
     let simulationRevert: Revert | undefined;
 
-    const isBalanceChangesSkipped =
-      this.#isBalanceChangesSkipped(transactionMeta);
+    const simulationRequestToken = Symbol(transactionId);
+    this.#simulationRequestTokens.set(transactionId, simulationRequestToken);
 
-    if (this.#isSimulationEnabled() && !isBalanceChangesSkipped) {
-      const balanceChangesResult = await this.#trace(
-        { name: 'Simulate', parentContext: traceContext },
-        () =>
-          getBalanceChanges({
-            blockTime,
-            chainId,
-            messenger: this.messenger,
-            networkClientId,
-            getSimulationConfig: (url, opts) => {
-              return this.#getSimulationConfig(url, {
-                txMeta: transactionMeta,
-                ...opts,
-              });
-            },
-            nestedTransactions,
-            txParams,
-          }),
-      );
-      simulationData = balanceChangesResult.simulationData;
-      gasUsed = balanceChangesResult.gasUsed;
-      simulationRevert = balanceChangesResult.simulationRevert;
+    try {
+      const isSimulationEnabled = this.#isSimulationEnabled();
+      const isBalanceChangesSkipped =
+        this.#isBalanceChangesSkipped(transactionMeta);
 
-      if (
-        blockTime &&
-        prevSimulationData &&
-        hasSimulationDataChanged(prevSimulationData, simulationData)
-      ) {
-        simulationData = {
-          ...simulationData,
-          isUpdatedAfterSecurityCheck: true,
-        };
+      if (isSimulationEnabled && !isBalanceChangesSkipped) {
+        const balanceChangesResult = await this.#trace(
+          { name: 'Simulate', parentContext: traceContext },
+          () =>
+            getBalanceChanges({
+              blockTime,
+              chainId,
+              messenger: this.messenger,
+              networkClientId,
+              getSimulationConfig: (url, opts) => {
+                return this.#getSimulationConfig(url, {
+                  txMeta: transactionMeta,
+                  ...opts,
+                });
+              },
+              nestedTransactions,
+              txParams,
+            }),
+        );
+        simulationData = balanceChangesResult.simulationData;
+        gasUsed = balanceChangesResult.gasUsed;
+        simulationRevert = balanceChangesResult.simulationRevert;
+
+        if (
+          blockTime &&
+          prevSimulationData &&
+          hasSimulationDataChanged(prevSimulationData, simulationData)
+        ) {
+          simulationData = {
+            ...simulationData,
+            isUpdatedAfterSecurityCheck: true,
+          };
+        }
       }
 
-      const gasFeeTokensResponse = await this.#getGasFeeTokens(transactionMeta);
+      if (isSimulationEnabled) {
+        const gasFeeTokensResponse =
+          await this.#getGasFeeTokens(transactionMeta);
 
-      gasFeeTokens = gasFeeTokensResponse?.gasFeeTokens ?? [];
-      isGasFeeSponsored = gasFeeTokensResponse?.isGasFeeSponsored ?? false;
-    }
+        gasFeeTokens = gasFeeTokensResponse?.gasFeeTokens ?? [];
+        isGasFeeSponsored = gasFeeTokensResponse?.isGasFeeSponsored ?? false;
+      }
 
-    const latestTransactionMeta = this.#getTransaction(transactionId);
+      if (
+        this.#simulationRequestTokens.get(transactionId) !==
+        simulationRequestToken
+      ) {
+        log('Ignoring stale simulation data', transactionId);
+        return;
+      }
 
-    /* istanbul ignore if */
-    if (!latestTransactionMeta) {
-      log(
-        'Cannot update simulation data as transaction not found',
-        transactionId,
-        simulationData,
+      const latestTransactionMeta = this.#getTransaction(transactionId);
+
+      /* istanbul ignore if */
+      if (!latestTransactionMeta) {
+        log(
+          'Cannot update simulation data as transaction not found',
+          transactionId,
+          simulationData,
+        );
+
+        return;
+      }
+
+      const updatedTransactionMeta = this.#updateTransactionInternal(
+        {
+          transactionId,
+          skipResimulateCheck: Boolean(blockTime),
+        },
+        (txMeta) => {
+          txMeta.gasFeeTokens = gasFeeTokens;
+          txMeta.isGasFeeSponsored =
+            txMeta.isGasFeeSponsored ?? isGasFeeSponsored;
+
+          if (txMeta.isGasFeeSponsored) {
+            txMeta.isExternalSign = true;
+          }
+
+          if (!this.#isBalanceChangesSkipped(txMeta)) {
+            txMeta.gasUsed = gasUsed;
+            txMeta.simulationData = simulationData;
+
+            if (simulationRevert) {
+              txMeta.revert = {
+                ...txMeta.revert,
+                simulation: simulationRevert,
+              };
+            }
+          }
+        },
       );
 
-      return;
+      log('Updated simulation data', transactionId, updatedTransactionMeta);
+    } finally {
+      if (
+        this.#simulationRequestTokens.get(transactionId) ===
+        simulationRequestToken
+      ) {
+        this.#simulationRequestTokens.delete(transactionId);
+      }
     }
-
-    const updatedTransactionMeta = this.#updateTransactionInternal(
-      {
-        transactionId,
-        skipResimulateCheck: Boolean(blockTime),
-      },
-      (txMeta) => {
-        txMeta.gasFeeTokens = gasFeeTokens;
-        txMeta.isGasFeeSponsored =
-          txMeta.isGasFeeSponsored ?? isGasFeeSponsored;
-
-        if (txMeta.isGasFeeSponsored) {
-          txMeta.isExternalSign = true;
-        }
-
-        txMeta.gasUsed = gasUsed;
-
-        if (!this.#isBalanceChangesSkipped(txMeta)) {
-          txMeta.simulationData = simulationData;
-
-          if (simulationRevert) {
-            txMeta.revert = {
-              ...txMeta.revert,
-              simulation: simulationRevert,
-            };
-          }
-        }
-      },
-    );
-
-    log('Updated simulation data', transactionId, updatedTransactionMeta);
   }
 
   #onGasFeePollerTransactionUpdate({

--- a/packages/transaction-controller/src/helpers/ResimulateHelper.test.ts
+++ b/packages/transaction-controller/src/helpers/ResimulateHelper.test.ts
@@ -9,7 +9,11 @@ import type {
   SimulationData,
   SimulationTokenBalanceChange,
 } from '../types.js';
-import { TransactionStatus, SimulationTokenStandard } from '../types.js';
+import {
+  TransactionContainerType,
+  TransactionStatus,
+  SimulationTokenStandard,
+} from '../types.js';
 import { getPercentageChange } from '../utils/utils.js';
 import {
   ResimulateHelper,
@@ -321,6 +325,35 @@ describe('Resimulate Utils', () => {
         expect(result).toStrictEqual({
           blockTime: undefined,
           resimulate: false,
+        });
+      });
+    });
+
+    describe('Enforced simulations', () => {
+      it('resimulates when enforced simulations are applied', () => {
+        const result = shouldResimulate(TRANSACTION_META_MOCK, {
+          ...TRANSACTION_META_MOCK,
+          containerTypes: [TransactionContainerType.EnforcedSimulations],
+        });
+
+        expect(result).toStrictEqual({
+          blockTime: undefined,
+          resimulate: true,
+        });
+      });
+
+      it('resimulates when enforced simulations are removed', () => {
+        const result = shouldResimulate(
+          {
+            ...TRANSACTION_META_MOCK,
+            containerTypes: [TransactionContainerType.EnforcedSimulations],
+          },
+          TRANSACTION_META_MOCK,
+        );
+
+        expect(result).toStrictEqual({
+          blockTime: undefined,
+          resimulate: true,
         });
       });
     });

--- a/packages/transaction-controller/src/helpers/ResimulateHelper.ts
+++ b/packages/transaction-controller/src/helpers/ResimulateHelper.ts
@@ -4,7 +4,7 @@ import { BN } from 'bn.js';
 import { isEqual } from 'lodash';
 
 import { createModuleLogger, projectLogger } from '../logger.js';
-import { TransactionStatus } from '../types.js';
+import { TransactionContainerType, TransactionStatus } from '../types.js';
 import type {
   SimulationBalanceChange,
   SimulationData,
@@ -166,13 +166,24 @@ export function shouldResimulate(
     newTransactionMeta,
   );
 
+  const enforcedSimulationsUpdated =
+    originalTransactionMeta.containerTypes?.includes(
+      TransactionContainerType.EnforcedSimulations,
+    ) !==
+    newTransactionMeta.containerTypes?.includes(
+      TransactionContainerType.EnforcedSimulations,
+    );
+
   const valueAndNativeBalanceMismatch = hasValueAndNativeBalanceMismatch(
     originalTransactionMeta,
     newTransactionMeta,
   );
 
   const resimulate =
-    parametersUpdated || securityAlert || valueAndNativeBalanceMismatch;
+    parametersUpdated ||
+    securityAlert ||
+    enforcedSimulationsUpdated ||
+    valueAndNativeBalanceMismatch;
 
   let blockTime: number | undefined;
 
@@ -187,6 +198,7 @@ export function shouldResimulate(
       blockTime,
       parametersUpdated,
       securityAlert,
+      enforcedSimulationsUpdated,
       valueAndNativeBalanceMismatch,
     });
   }


### PR DESCRIPTION
## Explanation

When a transaction is wrapped with `TransactionContainerType.EnforcedSimulations`, TransactionController intentionally skips the normal balance-change simulation so that the enforced/original balance changes remain authoritative.

Gas-fee-token retrieval was coupled to that same skip condition. `#updateSimulationData` initialized `gasFeeTokens` to an empty array, skipped both balance simulation and token retrieval, and then wrote the empty array to transaction state. The periodic resimulation loop repeated this roughly every three seconds, removing the gas-fee-token picker and invalidating the visible quote. An older pre-wrap simulation could also finish later and temporarily overwrite state with a stale quote based on the unwrapped transaction.

This PR separates the two concerns:

- Balance changes and their associated `gasUsed` remain untouched for enforced-simulation transactions.
- Gas-fee-token quotes are refreshed independently using the current wrapped transaction metadata.
- Empty or unsupported quote responses retain the existing behavior of replacing the available token list without clearing the selected token field.
- Existing sponsorship and external-sign semantics are preserved.
- Per-transaction request tokens make simulation updates latest-request-wins, preventing older in-flight results from overwriting newer transaction state. Conditional `finally` cleanup also handles rejected requests without deleting a newer request token.
- Applying or removing the enforced-simulation container now triggers resimulation even when `to`, `value`, and `data` are unchanged.

Focused tests cover wrapped quote inputs, preserved balance simulation and `gasUsed`, sponsorship, periodic refreshes, empty responses, container-only transitions, and out-of-order async responses.

### Validation

- `yarn workspace @metamask/transaction-controller run jest --no-coverage src/TransactionController.test.ts src/helpers/ResimulateHelper.test.ts --runInBand`
- `yarn exec eslint packages/transaction-controller/src/TransactionController.ts packages/transaction-controller/src/TransactionController.test.ts packages/transaction-controller/src/helpers/ResimulateHelper.ts packages/transaction-controller/src/helpers/ResimulateHelper.test.ts`
- `yarn lint:tsc --pretty false`
- `yarn workspace @metamask/transaction-controller run build`
- `yarn workspace @metamask/transaction-controller run changelog:validate`
- Linked the local package into the extension investigation worktree and verified a single local TransactionController copy resolves. Manual UI confirmation remains pending.

## References

- Affected extension dependency: `@metamask/transaction-controller@69.3.0`
- Tagged controller source: https://github.com/MetaMask/core/blob/%40metamask/transaction-controller%4069.3.0/packages/transaction-controller/src/TransactionController.ts

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes unapproved-transaction simulation and gas-fee-token state during confirmation; incorrect behavior could affect quotes or UI, but scope is limited and well covered by new tests.
> 
> **Overview**
> Fixes **enforced-simulation** transactions (`TransactionContainerType.EnforcedSimulations`) where gas-fee-token quotes were cleared because token fetching was tied to the same path that skips balance-change simulation.
> 
> `#updateSimulationData` now **always** refreshes `gasFeeTokens` when simulation is enabled, while still skipping balance simulation, `gasUsed`, and `simulationData` updates when balance changes are skipped. Applying simulation results only writes balance-related fields when balance changes are not skipped.
> 
> Adds **per-transaction simulation request tokens** so only the latest in-flight simulation update can commit state; older responses are dropped. `shouldResimulate` also treats adding or removing the enforced-simulation container as a reason to resimulate even if `to`/`value`/`data` are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08c3d3c3f80f487e53e874f45cea3364ed640f1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->