### PR TITLE
refactor(money-account-controller)!: remove `eth_signTransaction` from money accounts

### DIFF
--- a/packages/money-account-controller/CHANGELOG.md
+++ b/packages/money-account-controller/CHANGELOG.md
@@ -11,12 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **BREAKING:** Remove `eth_signTransaction` account method ([#9763](https://github.com/MetaMask/core/pull/9763))
   - Money accounts were not supposed to sign transaction, the support has been removed from the keyring.
+- Bump `@metamask/eth-money-keyring` from `^2.0.4` to `^3.0.1` ([#9763](https://github.com/MetaMask/core/pull/9763))
 - Bump `@metamask/utils` from `^11.9.0` to `^11.11.0` ([#9074](https://github.com/MetaMask/core/pull/9074))
 - Bump `@metamask/keyring-controller` from `^27.0.0` to `^27.1.0` ([#9129](https://github.com/MetaMask/core/pull/9129))
 - Bump `@metamask/accounts-controller` from `^39.0.1` to `^39.0.6` ([#9218](https://github.com/MetaMask/core/pull/9218), [#9231](https://github.com/MetaMask/core/pull/9231), [#9349](https://github.com/MetaMask/core/pull/9349), [#9470](https://github.com/MetaMask/core/pull/9470), [#9735](https://github.com/MetaMask/core/pull/9735))
 - Bump `@metamask/keyring-api` from `^23.1.0` to `^23.7.0` ([#9249](https://github.com/MetaMask/core/pull/9249), [#9390](https://github.com/MetaMask/core/pull/9390), [#9676](https://github.com/MetaMask/core/pull/9676))
 - Bump `@metamask/messenger` from `^1.2.0` to `^2.0.0` ([#9392](https://github.com/MetaMask/core/pull/9392))
-- Bump `@metamask/eth-money-keyring` from `^2.0.4` to `^3.0.1` ([#9763](https://github.com/MetaMask/core/pull/9763))
 
 ## [0.3.3]
 

--- a/packages/money-account-controller/CHANGELOG.md
+++ b/packages/money-account-controller/CHANGELOG.md
@@ -9,11 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING:** Remove `eth_signTransaction` account method ([#9763](https://github.com/MetaMask/core/pull/9763))
+  - Money accounts were not supposed to sign transaction, the support has been removed from the keyring.
 - Bump `@metamask/utils` from `^11.9.0` to `^11.11.0` ([#9074](https://github.com/MetaMask/core/pull/9074))
 - Bump `@metamask/keyring-controller` from `^27.0.0` to `^27.1.0` ([#9129](https://github.com/MetaMask/core/pull/9129))
 - Bump `@metamask/accounts-controller` from `^39.0.1` to `^39.0.6` ([#9218](https://github.com/MetaMask/core/pull/9218), [#9231](https://github.com/MetaMask/core/pull/9231), [#9349](https://github.com/MetaMask/core/pull/9349), [#9470](https://github.com/MetaMask/core/pull/9470), [#9735](https://github.com/MetaMask/core/pull/9735))
 - Bump `@metamask/keyring-api` from `^23.1.0` to `^23.7.0` ([#9249](https://github.com/MetaMask/core/pull/9249), [#9390](https://github.com/MetaMask/core/pull/9390), [#9676](https://github.com/MetaMask/core/pull/9676))
 - Bump `@metamask/messenger` from `^1.2.0` to `^2.0.0` ([#9392](https://github.com/MetaMask/core/pull/9392))
+- Bump `@metamask/eth-money-keyring` from `^2.0.4` to `^3.0.1` ([#9763](https://github.com/MetaMask/core/pull/9763))
 
 ## [0.3.3]
 

--- a/packages/money-account-controller/package.json
+++ b/packages/money-account-controller/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@metamask/accounts-controller": "^39.0.6",
     "@metamask/base-controller": "^9.1.0",
-    "@metamask/eth-money-keyring": "^2.0.4",
+    "@metamask/eth-money-keyring": "^3.0.1",
     "@metamask/keyring-api": "^23.7.0",
     "@metamask/keyring-controller": "^27.1.0",
     "@metamask/messenger": "^2.0.0",

--- a/packages/money-account-controller/src/MoneyAccountController.test.ts
+++ b/packages/money-account-controller/src/MoneyAccountController.test.ts
@@ -41,7 +41,6 @@ const MOCK_MONEY_ACCOUNT: MoneyAccount = {
     exportable: false,
   },
   methods: [
-    'eth_signTransaction',
     'personal_sign',
     'eth_signTypedData_v1',
     'eth_signTypedData_v3',
@@ -64,7 +63,6 @@ const MOCK_MONEY_ACCOUNT_2: MoneyAccount = {
     exportable: false,
   },
   methods: [
-    'eth_signTransaction',
     'personal_sign',
     'eth_signTypedData_v1',
     'eth_signTypedData_v3',
@@ -295,10 +293,7 @@ describe('MoneyAccountController', () => {
             derivationPath: "m/44'/4392018'/0'/0",
           },
         },
-        methods: expect.arrayContaining([
-          'personal_sign',
-          'eth_signTransaction',
-        ]),
+        methods: expect.arrayContaining(['personal_sign']),
       });
       expect(typeof account.id).toBe('string');
     });

--- a/packages/money-account-controller/src/MoneyAccountController.ts
+++ b/packages/money-account-controller/src/MoneyAccountController.ts
@@ -210,7 +210,6 @@ export class MoneyAccountController extends BaseController<
         exportable: false,
       },
       methods: [
-        EthMethod.SignTransaction,
         EthMethod.PersonalSign,
         EthMethod.SignTypedDataV1,
         EthMethod.SignTypedDataV3,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7004,22 +7004,22 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/eth-hd-keyring@npm:^14.1.1":
-  version: 14.1.1
-  resolution: "@metamask/eth-hd-keyring@npm:14.1.1"
+"@metamask/eth-hd-keyring@npm:^14.1.1, @metamask/eth-hd-keyring@npm:^14.1.2":
+  version: 14.1.2
+  resolution: "@metamask/eth-hd-keyring@npm:14.1.2"
   dependencies:
     "@ethereumjs/tx": "npm:^5.4.0"
     "@ethereumjs/util": "npm:^9.1.0"
     "@metamask/eth-sig-util": "npm:^8.2.0"
     "@metamask/key-tree": "npm:^10.0.2"
-    "@metamask/keyring-api": "npm:^23.1.0"
-    "@metamask/keyring-sdk": "npm:^2.0.2"
-    "@metamask/keyring-utils": "npm:^3.2.0"
+    "@metamask/keyring-api": "npm:^23.6.0"
+    "@metamask/keyring-sdk": "npm:^2.3.0"
+    "@metamask/keyring-utils": "npm:^4.0.0"
     "@metamask/scure-bip39": "npm:^2.1.1"
-    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/superstruct": "npm:^3.4.1"
     "@metamask/utils": "npm:^11.11.0"
     ethereum-cryptography: "npm:^2.2.1"
-  checksum: 10/f711742682a77990310272013523595822e29bfb61980828d1460ab8af888d7c344bb50f04d2611d801d63438e31532d3d66698c595b4fd3ad512b02056b7234
+  checksum: 10/077d6aacc674903d737948dfb5a3215e912e73afabad14429614ca643269150604b8ded8cbd48601f99b532c07e51c8d6b1036bad304a21a5b2ded3ea7d06c02
   languageName: node
   linkType: hard
 
@@ -7112,16 +7112,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/eth-money-keyring@npm:^2.0.4":
-  version: 2.0.4
-  resolution: "@metamask/eth-money-keyring@npm:2.0.4"
+"@metamask/eth-money-keyring@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@metamask/eth-money-keyring@npm:3.0.1"
   dependencies:
-    "@metamask/eth-hd-keyring": "npm:^14.1.1"
-    "@metamask/keyring-api": "npm:^23.1.0"
-    "@metamask/keyring-utils": "npm:^3.2.0"
-    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/eth-hd-keyring": "npm:^14.1.2"
+    "@metamask/keyring-api": "npm:^23.6.0"
+    "@metamask/keyring-sdk": "npm:^2.3.0"
+    "@metamask/keyring-utils": "npm:^4.0.0"
+    "@metamask/superstruct": "npm:^3.4.1"
     async-mutex: "npm:^0.5.0"
-  checksum: 10/2e3941355be1750c433cf8106235df1b0785becc47c0c87dfabbe7ed43006fa5d303bca70a1d5a308c0d0b281b75468440ab5c8883d70e12fa3923a5ccba3dd1
+  checksum: 10/98307e38e51d7efcb7bcb485ef9771de8ad31fc83ec681da60112df714d1c999ec59ef7eb3709317d3a4d7edb3226370226b8db0aad9d5c1e12e0575d196d8bc
   languageName: node
   linkType: hard
 
@@ -7532,7 +7533,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-api@npm:^23.1.0, @metamask/keyring-api@npm:^23.2.0, @metamask/keyring-api@npm:^23.5.0, @metamask/keyring-api@npm:^23.6.0, @metamask/keyring-api@npm:^23.7.0":
+"@metamask/keyring-api@npm:^23.1.0, @metamask/keyring-api@npm:^23.5.0, @metamask/keyring-api@npm:^23.6.0, @metamask/keyring-api@npm:^23.7.0":
   version: 23.7.0
   resolution: "@metamask/keyring-api@npm:23.7.0"
   dependencies:
@@ -7609,21 +7610,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-sdk@npm:^2.0.2, @metamask/keyring-sdk@npm:^2.2.0":
-  version: 2.2.0
-  resolution: "@metamask/keyring-sdk@npm:2.2.0"
+"@metamask/keyring-sdk@npm:^2.0.2, @metamask/keyring-sdk@npm:^2.2.0, @metamask/keyring-sdk@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "@metamask/keyring-sdk@npm:2.3.0"
   dependencies:
     "@ethereumjs/tx": "npm:^5.4.0"
     "@metamask/eth-sig-util": "npm:^8.2.0"
-    "@metamask/keyring-api": "npm:^23.2.0"
-    "@metamask/keyring-utils": "npm:^3.3.1"
+    "@metamask/keyring-api": "npm:^23.6.0"
+    "@metamask/keyring-utils": "npm:^4.0.0"
     "@metamask/scure-bip39": "npm:^2.1.1"
-    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/superstruct": "npm:^3.4.1"
     "@metamask/utils": "npm:^11.11.0"
     async-mutex: "npm:^0.5.0"
     ethereum-cryptography: "npm:^2.2.1"
     uuid: "npm:^9.0.1"
-  checksum: 10/5cb7f2496f0fc95e85eb97932b69da9c02c232e2310b5f390bfc7c56996bf8516d15db54260e68288f6d6f5604bfacc19b4b82b9b28b7f794a3ab5ee9a1f10d1
+  checksum: 10/38402f3834e0e364e1b17fe30ff64c1a050549239e204260081ddd0fc9228e9632d586819c551f91793d78207fb33f81e06ec3ac24537d511e8b5f1fabe57d21
   languageName: node
   linkType: hard
 
@@ -7659,7 +7660,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-utils@npm:^3.2.0, @metamask/keyring-utils@npm:^3.3.1":
+"@metamask/keyring-utils@npm:^3.3.1":
   version: 3.3.1
   resolution: "@metamask/keyring-utils@npm:3.3.1"
   dependencies:
@@ -7883,7 +7884,7 @@ __metadata:
     "@metamask/accounts-controller": "npm:^39.0.6"
     "@metamask/auto-changelog": "npm:^6.1.0"
     "@metamask/base-controller": "npm:^9.1.0"
-    "@metamask/eth-money-keyring": "npm:^2.0.4"
+    "@metamask/eth-money-keyring": "npm:^3.0.1"
     "@metamask/keyring-api": "npm:^23.7.0"
     "@metamask/keyring-controller": "npm:^27.1.0"
     "@metamask/keyring-utils": "npm:^3.3.1"


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

The `eth-money-keyring@3.0.0` has removed its support for `eth_signTransaction`, so we now also remove the account's method to reflect the right account's method support.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

PR that will remove the existing method through a migration:
- https://github.com/MetaMask/metamask-mobile/pull/34191

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking API change for account method metadata; consumers that assumed `eth_signTransaction` on money accounts need migrations (e.g. mobile PR referenced), but behavior aligns with keyring and reduces incorrect signing expectations.
> 
> **Overview**
> **Breaking:** Newly created money accounts no longer advertise `eth_signTransaction`, matching `@metamask/eth-money-keyring` v3 (transaction signing was never intended for these accounts).
> 
> `MoneyAccountController` drops `EthMethod.SignTransaction` from the `methods` list on account creation; tests and mocks are updated accordingly. The package bumps `@metamask/eth-money-keyring` from `^2.0.4` to `^3.0.1`, with lockfile updates for related keyring packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9363f8655383b052bfc210c72995d943a23659be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->