### PR TITLE
fix(assets-controller): exempt user-initiated activity from spam filtering

### DIFF
--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -72,6 +72,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **BREAKING:** Remove `BackendWebsocketDataSource` and its factory/types (`BackendWebsocketDataSource`, `createBackendWebsocketDataSource`, `BackendWebsocketDataSourceOptions`, `BackendWebsocketDataSourceState`). Real-time balance updates and per-chain status are now consumed from `AccountActivityService` via `AccountActivityDataSource`, which manages the WebSocket connection and subscriptions. Consumers no longer need to delegate `BackendWebSocketService` actions/events to the `AssetsController` messenger ([#9517](https://github.com/MetaMask/core/pull/9517))
 
+### Fixed
+
+- Exempt assets acquired through user-initiated activity from occurrence-floor / Blockaid spam filtering while keeping the filter for passive discovery (auto-detection, airdrops):
+  - `AccountActivityDataSource` inspects websocket transfers and lists assets on a new `DataResponse.userInteractedAssets` field when the account sent funds in the same transaction (e.g. a swap), so swap outputs always show even for brand-new tokens below the floor
+  - `TokenDataSource` bypasses spam filtering for `userInteractedAssets` (like custom assets); incoming-only websocket updates (spam airdrops) remain subject to the occurrence floor
+  - Filtered-out spam is now also removed from stub `assetsInfo` on the response, and balance deletions match asset IDs case-insensitively
+
 ## [11.3.1]
 
 ### Changed

--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/network-enablement-controller` from `^6.0.2` to `^6.0.3` ([#9791](https://github.com/MetaMask/core/pull/9791))
 - Bump `@metamask/assets-controllers` from `^111.0.0` to `^111.1.0` ([#9793](https://github.com/MetaMask/core/pull/9793))
 
+### Fixed
+
+- Exempt assets acquired through user-initiated activity from occurrence-floor / Blockaid spam filtering while keeping the filter for passive discovery (auto-detection, airdrops) ([#9768](https://github.com/MetaMask/core/pull/9768)):
+  - `AccountActivityDataSource` inspects websocket transfers and lists assets on a new `DataResponse.userInteractedAssets` field when the account sent funds in the same transaction (e.g. a swap), so swap outputs always show even for brand-new tokens below the floor
+  - `TokenDataSource` bypasses spam filtering for `userInteractedAssets` (like custom assets); incoming-only websocket updates (spam airdrops) remain subject to the occurrence floor
+  - Filtered-out spam is now also removed from stub `assetsInfo` on the response, and balance deletions match asset IDs case-insensitively
+
 ## [13.1.1]
 
 ### Changed
@@ -71,13 +78,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - **BREAKING:** Remove `BackendWebsocketDataSource` and its factory/types (`BackendWebsocketDataSource`, `createBackendWebsocketDataSource`, `BackendWebsocketDataSourceOptions`, `BackendWebsocketDataSourceState`). Real-time balance updates and per-chain status are now consumed from `AccountActivityService` via `AccountActivityDataSource`, which manages the WebSocket connection and subscriptions. Consumers no longer need to delegate `BackendWebSocketService` actions/events to the `AssetsController` messenger ([#9517](https://github.com/MetaMask/core/pull/9517))
-
-### Fixed
-
-- Exempt assets acquired through user-initiated activity from occurrence-floor / Blockaid spam filtering while keeping the filter for passive discovery (auto-detection, airdrops) ([#9768](https://github.com/MetaMask/core/pull/9768)):
-  - `AccountActivityDataSource` inspects websocket transfers and lists assets on a new `DataResponse.userInteractedAssets` field when the account sent funds in the same transaction (e.g. a swap), so swap outputs always show even for brand-new tokens below the floor
-  - `TokenDataSource` bypasses spam filtering for `userInteractedAssets` (like custom assets); incoming-only websocket updates (spam airdrops) remain subject to the occurrence floor
-  - Filtered-out spam is now also removed from stub `assetsInfo` on the response, and balance deletions match asset IDs case-insensitively
 
 ## [11.3.1]
 

--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -74,7 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Exempt assets acquired through user-initiated activity from occurrence-floor / Blockaid spam filtering while keeping the filter for passive discovery (auto-detection, airdrops):
+- Exempt assets acquired through user-initiated activity from occurrence-floor / Blockaid spam filtering while keeping the filter for passive discovery (auto-detection, airdrops) ([#9768](https://github.com/MetaMask/core/pull/9768)):
   - `AccountActivityDataSource` inspects websocket transfers and lists assets on a new `DataResponse.userInteractedAssets` field when the account sent funds in the same transaction (e.g. a swap), so swap outputs always show even for brand-new tokens below the floor
   - `TokenDataSource` bypasses spam filtering for `userInteractedAssets` (like custom assets); incoming-only websocket updates (spam airdrops) remain subject to the occurrence floor
   - Filtered-out spam is now also removed from stub `assetsInfo` on the response, and balance deletions match asset IDs case-insensitively

--- a/packages/assets-controller/src/data-sources/AccountActivityDataSource.test.ts
+++ b/packages/assets-controller/src/data-sources/AccountActivityDataSource.test.ts
@@ -354,6 +354,138 @@ describe('AccountActivityDataSource', () => {
       cleanup();
     });
 
+    it('marks assets as userInteractedAssets when the account sent funds in the message', async () => {
+      // Swap: the account pays USDC and receives NEWTOKEN in the same tx.
+      // Both assets must be exempt from spam filtering downstream.
+      const paidAsset =
+        'eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48' as Caip19AssetId;
+      const receivedAsset =
+        'eip155:1/erc20:0x1111111111111111111111111111111111111111' as Caip19AssetId;
+      const account = createMockAccount();
+      const { onAssetsUpdate, triggerBalanceUpdated, cleanup } = setup({
+        groupAccounts: [account],
+        getAssetType: () => 'erc20',
+      });
+
+      triggerBalanceUpdated({
+        address: EVM_ADDRESS,
+        chain: CHAIN_MAINNET,
+        updates: [
+          createBalanceUpdate({
+            asset: { type: paidAsset, unit: 'USDC', decimals: 6 },
+            postBalance: { amount: '0' },
+            transfers: [
+              { from: EVM_ADDRESS, to: '0xpool', amount: '1000000' },
+            ],
+          }),
+          createBalanceUpdate({
+            asset: { type: receivedAsset, unit: 'NEW', decimals: 18 },
+            postBalance: { amount: '1000000000000000000' },
+            transfers: [
+              { from: '0xpool', to: EVM_ADDRESS, amount: '1000000000000000000' },
+            ],
+          }),
+        ],
+      });
+
+      await Promise.resolve();
+
+      expect(onAssetsUpdate).toHaveBeenCalledTimes(1);
+      const [response] = onAssetsUpdate.mock.calls[0];
+      expect(response.userInteractedAssets).toStrictEqual([
+        paidAsset,
+        receivedAsset,
+      ]);
+
+      cleanup();
+    });
+
+    it('does not mark userInteractedAssets for incoming-only transfers (airdrops)', async () => {
+      const airdroppedAsset =
+        'eip155:1/erc20:0x2222222222222222222222222222222222222222' as Caip19AssetId;
+      const account = createMockAccount();
+      const { onAssetsUpdate, triggerBalanceUpdated, cleanup } = setup({
+        groupAccounts: [account],
+        getAssetType: () => 'erc20',
+      });
+
+      triggerBalanceUpdated({
+        address: EVM_ADDRESS,
+        chain: CHAIN_MAINNET,
+        updates: [
+          createBalanceUpdate({
+            asset: { type: airdroppedAsset, unit: 'SPAM', decimals: 18 },
+            postBalance: { amount: '1000000000000000000' },
+            transfers: [
+              {
+                from: '0x9999999999999999999999999999999999999999',
+                to: EVM_ADDRESS,
+                amount: '1000000000000000000',
+              },
+            ],
+          }),
+        ],
+      });
+
+      await Promise.resolve();
+
+      expect(onAssetsUpdate).toHaveBeenCalledTimes(1);
+      const [response] = onAssetsUpdate.mock.calls[0];
+      expect(response.userInteractedAssets).toBeUndefined();
+      expect(response.assetsBalance[account.id][airdroppedAsset]).toBeDefined();
+
+      cleanup();
+    });
+
+    it('seeds stub assetsInfo for erc20 tokens from websocket updates', async () => {
+      const erc20Asset =
+        'eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48' as Caip19AssetId;
+      const account = createMockAccount();
+      const { onAssetsUpdate, triggerBalanceUpdated, cleanup } = setup({
+        groupAccounts: [account],
+        getAssetType: () => 'erc20',
+      });
+
+      triggerBalanceUpdated({
+        address: EVM_ADDRESS,
+        chain: CHAIN_MAINNET,
+        updates: [
+          createBalanceUpdate({
+            asset: {
+              type: erc20Asset,
+              unit: 'USDC',
+              decimals: 6,
+            },
+            postBalance: { amount: '1000000' },
+          }),
+        ],
+      });
+
+      await Promise.resolve();
+
+      expect(onAssetsUpdate).toHaveBeenCalledTimes(1);
+      const [response] = onAssetsUpdate.mock.calls[0];
+      // eslint-disable-next-line jest/prefer-strict-equal
+      expect(response).toEqual({
+        updateMode: 'merge',
+        assetsBalance: {
+          [account.id]: {
+            [erc20Asset]: { amount: '1' },
+          },
+        },
+        assetsInfo: {
+          [erc20Asset]: {
+            type: 'erc20',
+            symbol: 'USDC',
+            name: 'USDC',
+            decimals: 6,
+          },
+        },
+      });
+
+      cleanup();
+    });
+
     it.each([
       ['address is empty', { address: '' }],
       ['chain is empty', { chain: '' }],

--- a/packages/assets-controller/src/data-sources/AccountActivityDataSource.test.ts
+++ b/packages/assets-controller/src/data-sources/AccountActivityDataSource.test.ts
@@ -374,15 +374,17 @@ describe('AccountActivityDataSource', () => {
           createBalanceUpdate({
             asset: { type: paidAsset, unit: 'USDC', decimals: 6 },
             postBalance: { amount: '0' },
-            transfers: [
-              { from: EVM_ADDRESS, to: '0xpool', amount: '1000000' },
-            ],
+            transfers: [{ from: EVM_ADDRESS, to: '0xpool', amount: '1000000' }],
           }),
           createBalanceUpdate({
             asset: { type: receivedAsset, unit: 'NEW', decimals: 18 },
             postBalance: { amount: '1000000000000000000' },
             transfers: [
-              { from: '0xpool', to: EVM_ADDRESS, amount: '1000000000000000000' },
+              {
+                from: '0xpool',
+                to: EVM_ADDRESS,
+                amount: '1000000000000000000',
+              },
             ],
           }),
         ],

--- a/packages/assets-controller/src/data-sources/AccountActivityDataSource.ts
+++ b/packages/assets-controller/src/data-sources/AccountActivityDataSource.ts
@@ -33,17 +33,47 @@ const log = createModuleLogger(projectLogger, CONTROLLER_NAME);
 // ============================================================================
 
 /**
+ * Whether the account actively sent funds in this activity message — i.e. the
+ * update was caused by a transaction the user participated in (swap, payment)
+ * rather than a passive incoming transfer (airdrop, unsolicited spam send).
+ *
+ * @param updates - Balance updates from account-activity websocket payload.
+ * @param address - The account address the message is for.
+ * @returns True when any transfer in the message has the account as sender.
+ */
+function isUserInitiatedActivity(
+  updates: BalanceUpdate[],
+  address: string,
+): boolean {
+  const addressLower = address.toLowerCase();
+  return updates.some((update) =>
+    update.transfers?.some(
+      (transfer) => transfer.from?.toLowerCase() === addressLower,
+    ),
+  );
+}
+
+/**
  * Convert AccountActivityMessage balance updates into a {@link DataResponse}
  * for AssetsController.
  *
+ * When the message is user-initiated (the account sent funds in the same
+ * transaction — see {@link isUserInitiatedActivity}), its assets are listed
+ * on `userInteractedAssets` so TokenDataSource exempts them from
+ * occurrence-floor / Blockaid spam filtering (a swap output chosen by the
+ * user must always show, even for a brand-new token). Passive incoming
+ * transfers get no exemption, so spam airdrops are still filtered.
+ *
  * @param updates - Balance updates from account-activity websocket payload.
  * @param accountId - Internal account UUID.
+ * @param address - The account address the message is for.
  * @param getAssetType - Resolver for asset metadata type.
  * @returns DataResponse with merge mode when balances are present.
  */
 function processAccountActivityBalanceUpdates(
   updates: BalanceUpdate[],
   accountId: string,
+  address: string,
   getAssetType: (assetId: Caip19AssetId) => 'native' | 'erc20' | 'spl',
 ): DataResponse {
   const assetsBalance = Object.create(null) as Record<
@@ -93,9 +123,13 @@ function processAccountActivityBalanceUpdates(
   }
 
   const response: DataResponse = { updateMode: 'merge' };
-  if (Object.keys(assetsBalance[accountId]).length > 0) {
+  const assetIds = Object.keys(assetsBalance[accountId]) as Caip19AssetId[];
+  if (assetIds.length > 0) {
     response.assetsBalance = assetsBalance;
     response.assetsInfo = assetsMetadata;
+    if (isUserInitiatedActivity(updates, address)) {
+      response.userInteractedAssets = assetIds;
+    }
   }
 
   return response;
@@ -285,6 +319,7 @@ export class AccountActivityDataSource extends AbstractDataSource<
       const response = processAccountActivityBalanceUpdates(
         updates,
         account.id,
+        address,
         (assetId) => this.#getAssetType(assetId),
       );
 

--- a/packages/assets-controller/src/data-sources/TokenDataSource.test.ts
+++ b/packages/assets-controller/src/data-sources/TokenDataSource.test.ts
@@ -403,9 +403,7 @@ describe('TokenDataSource', () => {
     const { controller } = setupController({
       messenger: createTestMessenger(),
       supportedNetworks: ['eip155:1'],
-      assetsResponse: [
-        createMockAssetResponse(spamLower, { occurrences: 1 }),
-      ],
+      assetsResponse: [createMockAssetResponse(spamLower, { occurrences: 1 })],
       suggestedOccurrenceFloors: { '1': 3 },
     });
 

--- a/packages/assets-controller/src/data-sources/TokenDataSource.test.ts
+++ b/packages/assets-controller/src/data-sources/TokenDataSource.test.ts
@@ -392,6 +392,61 @@ describe('TokenDataSource', () => {
     );
   });
 
+  it('middleware strips stub assetsInfo and case-mismatched balances for filtered spam', async () => {
+    // Websocket stubs may leave assetsInfo without image, and balance keys may
+    // differ in address casing from the Token API assetId.
+    const spamChecksum =
+      'eip155:1/erc20:0x2222222222222222222222222222222222222222' as Caip19AssetId;
+    const spamLower =
+      'eip155:1/erc20:0x2222222222222222222222222222222222222222' as Caip19AssetId;
+
+    const { controller } = setupController({
+      messenger: createTestMessenger(),
+      supportedNetworks: ['eip155:1'],
+      assetsResponse: [
+        createMockAssetResponse(spamLower, { occurrences: 1 }),
+      ],
+      suggestedOccurrenceFloors: { '1': 3 },
+    });
+
+    const next = jest.fn().mockResolvedValue(undefined);
+    const context = createMiddlewareContext({
+      response: {
+        detectedAssets: {
+          'mock-account-id': [spamChecksum],
+        },
+        assetsBalance: {
+          'mock-account-id': {
+            [spamChecksum]: { amount: '50' },
+          },
+        },
+        assetsInfo: {
+          [spamChecksum]: {
+            type: 'erc20',
+            name: 'SPAM',
+            symbol: 'SPAM',
+            decimals: 18,
+          },
+        },
+      },
+    });
+
+    await controller.assetsMiddleware(context, next);
+
+    expect(context.response.assetsInfo?.[spamChecksum]).toBeUndefined();
+    expect(context.response.assetsInfo?.[spamLower]).toBeUndefined();
+    expect(
+      (
+        context.response.assetsBalance?.['mock-account-id'] as
+          | Record<string, unknown>
+          | undefined
+      )?.[spamChecksum],
+    ).toBeUndefined();
+    expect(context.response.detectedAssets?.['mock-account-id']).not.toContain(
+      spamChecksum,
+    );
+  });
+
   it('middleware skips assets with existing metadata containing image in response', async () => {
     const { controller, apiClient } = setupController({
       messenger: createTestMessenger(),
@@ -971,6 +1026,114 @@ describe('TokenDataSource', () => {
     );
     expect(context.response.detectedAssets?.['mock-account-id']).not.toContain(
       spamAsset,
+    );
+  });
+
+  it('middleware removes stub assetsInfo and case-mismatched balances for filtered spam', async () => {
+    // Websocket may leave a stub assetsInfo entry and a differently-cased
+    // balance key; filtering must clear both so spam cannot linger in state.
+    const spamAssetChecksummed =
+      'eip155:1/erc20:0x1111111111111111111111111111111111111111' as Caip19AssetId;
+    const spamAssetLower =
+      'eip155:1/erc20:0x1111111111111111111111111111111111111111' as Caip19AssetId;
+
+    const { controller } = setupController({
+      messenger: createTestMessenger(),
+      supportedNetworks: ['eip155:1'],
+      assetsResponse: [
+        createMockAssetResponse(spamAssetLower, { occurrences: 1 }),
+      ],
+      suggestedOccurrenceFloors: { '1': 3 },
+    });
+
+    const next = jest.fn().mockResolvedValue(undefined);
+    const context = createMiddlewareContext({
+      response: {
+        detectedAssets: {
+          'mock-account-id': [spamAssetChecksummed],
+        },
+        assetsBalance: {
+          'mock-account-id': {
+            [spamAssetChecksummed]: { amount: '50' },
+          },
+        },
+        assetsInfo: {
+          [spamAssetChecksummed]: {
+            type: 'erc20',
+            symbol: 'SPAM',
+            name: 'SPAM',
+            decimals: 18,
+          },
+        },
+      },
+    });
+
+    await controller.assetsMiddleware(context, next);
+
+    expect(context.response.assetsInfo?.[spamAssetChecksummed]).toBeUndefined();
+    expect(
+      (
+        context.response.assetsBalance?.['mock-account-id'] as
+          | Record<string, unknown>
+          | undefined
+      )?.[spamAssetChecksummed],
+    ).toBeUndefined();
+    expect(context.response.detectedAssets?.['mock-account-id']).not.toContain(
+      spamAssetChecksummed,
+    );
+  });
+
+  it('middleware skips occurrence filter for user-interacted assets (e.g. swap outputs)', async () => {
+    // Assets on response.userInteractedAssets were acquired through
+    // user-initiated activity and must keep balance and metadata even when
+    // below the occurrence floor (passive detection still filters).
+    const lowOccurrenceAsset =
+      'eip155:1/erc20:0x1111111111111111111111111111111111111111' as Caip19AssetId;
+
+    const { controller } = setupController({
+      messenger: createTestMessenger(),
+      supportedNetworks: ['eip155:1'],
+      assetsResponse: [
+        createMockAssetResponse(lowOccurrenceAsset, { occurrences: 1 }),
+      ],
+      suggestedOccurrenceFloors: { '1': 3 },
+    });
+
+    const next = jest.fn().mockResolvedValue(undefined);
+    const context = createMiddlewareContext({
+      response: {
+        userInteractedAssets: [lowOccurrenceAsset],
+        detectedAssets: {
+          'mock-account-id': [lowOccurrenceAsset],
+        },
+        assetsBalance: {
+          'mock-account-id': {
+            [lowOccurrenceAsset]: { amount: '50' },
+          },
+        },
+        assetsInfo: {
+          [lowOccurrenceAsset]: {
+            type: 'erc20',
+            symbol: 'SWAP',
+            name: 'SWAP',
+            decimals: 18,
+          },
+        },
+      },
+    });
+
+    await controller.assetsMiddleware(context, next);
+
+    expect(context.response.assetsInfo?.[lowOccurrenceAsset]).toBeDefined();
+    expect(
+      (
+        context.response.assetsBalance?.['mock-account-id'] as
+          | Record<string, unknown>
+          | undefined
+      )?.[lowOccurrenceAsset],
+    ).toBeDefined();
+    expect(context.response.detectedAssets?.['mock-account-id']).toContain(
+      lowOccurrenceAsset,
     );
   });
 

--- a/packages/assets-controller/src/data-sources/TokenDataSource.ts
+++ b/packages/assets-controller/src/data-sources/TokenDataSource.ts
@@ -358,9 +358,16 @@ export class TokenDataSource {
    * 4. Calls next() at the end to continue the middleware chain
    *
    * Spam filtering (EVM occurrence floors / non-EVM Blockaid) applies only to
-   * newly `detectedAssets`. Balance-only heals — assets already present in
-   * `assetsBalance` but missing `assetsInfo`, which DetectionMiddleware skips —
-   * are enriched without being filtered out of balances.
+   * newly `detectedAssets` from passive discovery (auto-detection, airdrops).
+   * It is skipped when:
+   * - the asset is a balance-only heal (already in `assetsBalance`, Detection skipped),
+   * - the asset is a user-imported custom asset, or
+   * - the asset is listed on `response.userInteractedAssets` — acquired through
+   *   user-initiated activity (e.g. a swap output), so it must always show.
+   *
+   * Filtered-out detected assets are removed from `assetsBalance`,
+   * `detectedAssets`, and any stub `assetsInfo` already on the response so spam
+   * cannot linger in state.
    *
    * @returns The middleware function for the assets pipeline.
    */
@@ -385,6 +392,14 @@ export class TokenDataSource {
         Object.values(customAssets ?? {})
           .flat()
           .map((id) => id.toLowerCase()),
+      );
+
+      // Assets acquired through user-initiated on-chain activity (the user
+      // sent funds in the same transaction, e.g. swap outputs reported by the
+      // account-activity websocket). Exempt from spam filtering like custom
+      // assets — the user chose to acquire them.
+      const userInteractedAssetIds = new Set<string>(
+        (response.userInteractedAssets ?? []).map((id) => id.toLowerCase()),
       );
 
       // Always include native asset IDs from NetworkEnablementController
@@ -526,11 +541,13 @@ export class TokenDataSource {
         // can import whatever they want and we must keep their metadata even
         // if the API has fewer aggregator hits than the floor.
         // Balance-only heals also bypass — see `balanceHealAssetIds` below.
+        // User-initiated acquisitions bypass — see `userInteractedAssetIds`.
         const allowedEvmIds = new Set(
           evmErc20Ids.filter(
             (id) =>
               customAssetIds.has(id.toLowerCase()) ||
               balanceHealAssetIds.has(id.toLowerCase()) ||
+              userInteractedAssetIds.has(id.toLowerCase()) ||
               (occurrencesByAssetId.get(id) ?? 0) >=
                 getOccurrenceFloorForAsset(id, suggestedOccurrenceFloors) ||
               id.includes(`/erc20:${MUSD_ADDRESS_LOWERCASE}`),
@@ -538,17 +555,19 @@ export class TokenDataSource {
         );
 
         // Non-EVM: Blockaid bulk scan.
-        // Custom assets and balance-only heals bypass Blockaid filtering.
+        // Custom assets, balance-only heals, and user-initiated acquisitions bypass.
         const nonEvmToScan = nonEvmTokenIds.filter(
           (id) =>
             !customAssetIds.has(id.toLowerCase()) &&
-            !balanceHealAssetIds.has(id.toLowerCase()),
+            !balanceHealAssetIds.has(id.toLowerCase()) &&
+            !userInteractedAssetIds.has(id.toLowerCase()),
         );
         const allowedNonEvmIds = new Set([
           ...nonEvmTokenIds.filter(
             (id) =>
               customAssetIds.has(id.toLowerCase()) ||
-              balanceHealAssetIds.has(id.toLowerCase()),
+              balanceHealAssetIds.has(id.toLowerCase()) ||
+              userInteractedAssetIds.has(id.toLowerCase()),
           ),
           ...(await this.#filterBlockaidSpamTokens(nonEvmToScan)),
         ]);
@@ -572,10 +591,12 @@ export class TokenDataSource {
         response.assetsInfo ??= {};
 
         const filteredOutAssets = new Set<string>();
+        const filteredOutAssetsLower = new Set<string>();
 
         for (const assetData of metadataResponse) {
           if (!allowedAssetIds.has(assetData.assetId)) {
             filteredOutAssets.add(assetData.assetId);
+            filteredOutAssetsLower.add(assetData.assetId.toLowerCase());
             continue;
           }
 
@@ -592,8 +613,20 @@ export class TokenDataSource {
             for (const accountBalances of Object.values(
               response.assetsBalance,
             )) {
-              for (const assetId of filteredOutAssets) {
-                delete (accountBalances as Record<string, unknown>)[assetId];
+              for (const assetId of Object.keys(
+                accountBalances as Record<string, unknown>,
+              )) {
+                if (filteredOutAssetsLower.has(assetId.toLowerCase())) {
+                  delete (accountBalances as Record<string, unknown>)[assetId];
+                }
+              }
+            }
+          }
+
+          if (response.assetsInfo) {
+            for (const assetId of Object.keys(response.assetsInfo)) {
+              if (filteredOutAssetsLower.has(assetId.toLowerCase())) {
+                delete response.assetsInfo[assetId as Caip19AssetId];
               }
             }
           }
@@ -603,7 +636,7 @@ export class TokenDataSource {
               response.detectedAssets,
             )) {
               response.detectedAssets[accountId] = assetIds.filter(
-                (id) => !filteredOutAssets.has(id),
+                (id) => !filteredOutAssetsLower.has(id.toLowerCase()),
               );
             }
           }

--- a/packages/assets-controller/src/types.ts
+++ b/packages/assets-controller/src/types.ts
@@ -380,6 +380,15 @@ export type DataResponse = {
    * without switching to `updateMode: 'full'`.
    */
   replaceCoveredChainBalances?: boolean;
+  /**
+   * Assets acquired through user-initiated on-chain activity — the user sent
+   * funds in the same transaction (e.g. swap outputs from account-activity
+   * websocket updates). TokenDataSource exempts these from occurrence-floor /
+   * Blockaid spam filtering, like custom assets. Passive incoming transfers
+   * (airdrops) are never listed here and remain subject to spam filtering.
+   * Pipeline-only metadata: not persisted to state.
+   */
+  userInteractedAssets?: Caip19AssetId[];
 };
 
 /**


### PR DESCRIPTION
Occurrence-floor / Blockaid spam filtering now applies only to passively discovered tokens (auto-detection, incoming-only websocket transfers such as airdrops). Assets acquired through user-initiated activity — the account sent funds in the same transaction, e.g. swap outputs — are listed on a new DataResponse.userInteractedAssets field by AccountActivityDataSource and bypass the filter in TokenDataSource, so they always show even when below the per-chain occurrence floor.

Filtered-out spam is now also stripped from stub assetsInfo on the response, and balance deletions match asset IDs case-insensitively.

## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them
