### PR TITLE
fix: prohibit retroactive subscriptions to published events

### DIFF
--- a/packages/messenger/CHANGELOG.md
+++ b/packages/messenger/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Unlike `delegate`, this method requires all external actions and events to be listed, producing a TypeScript error showing exactly which items are missing.
 - Add `MessengerNamespace` utility type to extract the namespace from a Messenger type ([#8338](https://github.com/MetaMask/core/pull/8338))
 
+### Fixed
+
+- Prohibit retroactive delivery of published events: a handler subscribed while an event is being published no longer receives the in-flight event ([#9773](https://github.com/MetaMask/core/pull/9773))
+  - The subscriber collection is now snapshotted before it is iterated during publish, so only handlers registered at the time the event was published are called, matching the behavior of `EventEmitter`. Consequently, a handler unsubscribed while an event is being published still receives the in-flight event.
+
 ## [2.0.0]
 
 ### Added

--- a/packages/messenger/src/Messenger.test.ts
+++ b/packages/messenger/src/Messenger.test.ts
@@ -583,6 +583,64 @@ describe('Messenger', () => {
       expect(handler2.mock.calls).toHaveLength(1);
     });
 
+    it('does not publish event to subscriber that was added during publish', () => {
+      type MessageEvent = { type: 'Fixture:message'; payload: [string] };
+      const messenger = new Messenger<'Fixture', never, MessageEvent>({
+        namespace: 'Fixture',
+      });
+
+      const addedDuringPublishHandler = jest.fn();
+      const handler = jest.fn(() => {
+        messenger.subscribe('Fixture:message', addedDuringPublishHandler);
+      });
+      messenger.subscribe('Fixture:message', handler);
+      messenger.publish('Fixture:message', 'hello');
+
+      expect(handler.mock.calls).toHaveLength(1);
+      expect(addedDuringPublishHandler).not.toHaveBeenCalled();
+    });
+
+    it('publishes subsequent event to subscriber that was added during publish of an earlier event', () => {
+      type MessageEvent = { type: 'Fixture:message'; payload: [string] };
+      const messenger = new Messenger<'Fixture', never, MessageEvent>({
+        namespace: 'Fixture',
+      });
+
+      const addedDuringPublishHandler = jest.fn();
+      const handler = jest.fn(() => {
+        messenger.subscribe('Fixture:message', addedDuringPublishHandler);
+      });
+      messenger.subscribe('Fixture:message', handler);
+      messenger.publish('Fixture:message', 'hello');
+      messenger.unsubscribe('Fixture:message', handler);
+      messenger.publish('Fixture:message', 'there');
+
+      expect(addedDuringPublishHandler).toHaveBeenCalledWith('there');
+      expect(addedDuringPublishHandler.mock.calls).toHaveLength(1);
+    });
+
+    it('publishes event to subscriber that was removed during publish of the same event', () => {
+      type MessageEvent = { type: 'Fixture:message'; payload: [string] };
+      const messenger = new Messenger<'Fixture', never, MessageEvent>({
+        namespace: 'Fixture',
+      });
+
+      const removedDuringPublishHandler = jest.fn();
+      const handler = jest.fn(() => {
+        messenger.unsubscribe('Fixture:message', removedDuringPublishHandler);
+      });
+      messenger.subscribe('Fixture:message', handler);
+      messenger.subscribe('Fixture:message', removedDuringPublishHandler);
+      messenger.publish('Fixture:message', 'hello');
+
+      expect(removedDuringPublishHandler).toHaveBeenCalledWith('hello');
+      expect(removedDuringPublishHandler.mock.calls).toHaveLength(1);
+
+      messenger.publish('Fixture:message', 'there');
+
+      expect(removedDuringPublishHandler.mock.calls).toHaveLength(1);
+    });
+
     describe('on first state change with an initial payload function registered', () => {
       it('publishes event if selected payload differs', () => {
         const state = {

--- a/packages/messenger/src/Messenger.ts
+++ b/packages/messenger/src/Messenger.ts
@@ -652,7 +652,12 @@ export class Messenger<
     const subscribers = this.#events.get(eventType);
 
     if (subscribers) {
-      for (const [handler, { selector }] of subscribers.entries()) {
+      // The subscriber collection is snapshotted before iterating so that
+      // mutating it during publish (e.g. a handler subscribing or
+      // unsubscribing) does not affect which handlers are called for this
+      // event. Only the handlers registered at the time the event was
+      // published are called, matching the behavior of `EventEmitter`.
+      for (const [handler, { selector }] of [...subscribers.entries()]) {
         try {
           if (selector) {
             const previousValue = this.#eventPayloadCache.get(handler);


### PR DESCRIPTION
## Explanation

When the messenger publishes an event, it iterates over the live subscriber `Map` via `entries()`. Because the iterator reflects mutations made while it is being consumed, a handler that calls `subscribe` for the same event *during* publication causes the newly added handler to be invoked with the in-flight event, even though it was not registered when the event was published.

This differs from typical event systems (such as Node's `EventEmitter`, which snapshots its listener array before emitting), and it has caused real-world bugs — e.g. a React render loop on mobile where a subscription handler mutated a hook dependency that re-triggered the subscription, causing the retroactively added handler to run immediately and crash the app.

This PR snapshots the subscriber collection before iterating in `Messenger.#publish`, so that only handlers registered at the time the event was published are called:

- A handler added during publication no longer receives the in-flight event (it receives subsequent events as expected).
- A handler removed during publication still receives the in-flight event (and none after), consistent with `EventEmitter`'s `removeListener` semantics: "removeListener() will remove, at most, one instance of a listener... this will not remove them from emit() in progress".

Both paths through `#publish` are covered, since the public `publish` method and the internal delegated publish share the same implementation.

Regression tests are added for all three behaviors above. All three failed against the previous implementation.

## References

Fixes #4700

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core event-dispatch semantics across MetaMask core; behavior shifts for code that relied on live-map iteration, but aligns with EventEmitter and fixes real re-entrancy bugs.
> 
> **Overview**
> Fixes **retroactive event delivery** in `@metamask/messenger`: handlers that `subscribe` while an event is being published no longer receive that in-flight publish.
> 
> `Messenger.#publish` now iterates over a **snapshot** of the subscriber map (`[...subscribers.entries()]`) instead of the live `Map` iterator, so subscribe/unsubscribe during dispatch only affects **later** publishes. Handlers removed mid-publish still run for the current event (aligned with Node `EventEmitter`).
> 
> Regression tests cover subscribe-during-publish, unsubscribe-during-publish, and later delivery after a mid-publish subscribe. The unreleased changelog documents the fix (Fixes #4700).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a6fd948c7025b13643128a2c671a7322f3ed304. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->