### PR TITLE
fix: widen `isSafeDynamicKey` parameter type to `PropertyKey`

### DIFF
--- a/packages/controller-utils/CHANGELOG.md
+++ b/packages/controller-utils/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add optional `startTime` to `TraceRequest` to allow backdating a span's start time ([#9315](https://github.com/MetaMask/core/pull/9315))
 
+### Changed
+
+- Widen `isSafeDynamicKey` parameter type from `string` to `PropertyKey` ([#9774](https://github.com/MetaMask/core/pull/9774))
+  - `number` and `symbol` keys are now considered safe and return `true`; previously any non-string input returned `false`
+
 ### Deprecated
 
 - Deprecate `createServicePolicy` and related symbols ([#9418](https://github.com/MetaMask/core/pull/9418))

--- a/packages/controller-utils/src/util.test.ts
+++ b/packages/controller-utils/src/util.test.ts
@@ -33,8 +33,15 @@ describe('util', () => {
     for (const badKey of util.PROTOTYPE_POLLUTION_BLOCKLIST) {
       expect(util.isSafeDynamicKey(badKey)).toBe(false);
     }
-    // @ts-expect-error - ensure that non-string input return false.
+    expect(util.isSafeDynamicKey(0)).toBe(true);
+    expect(util.isSafeDynamicKey(123)).toBe(true);
+    expect(util.isSafeDynamicKey(Number.NaN)).toBe(true);
+    expect(util.isSafeDynamicKey(Symbol('__proto__'))).toBe(true);
+    expect(util.isSafeDynamicKey(Symbol.iterator)).toBe(true);
+    // @ts-expect-error - ensure that non-`PropertyKey` input returns false.
     expect(util.isSafeDynamicKey(null)).toBe(false);
+    // @ts-expect-error - ensure that non-`PropertyKey` input returns false.
+    expect(util.isSafeDynamicKey(undefined)).toBe(false);
   });
   it('isSafeChainId', () => {
     expect(util.isSafeChainId(util.toHex(MAX_SAFE_CHAIN_ID + 1))).toBe(false);

--- a/packages/controller-utils/src/util.ts
+++ b/packages/controller-utils/src/util.ts
@@ -31,14 +31,21 @@ export const PROTOTYPE_POLLUTION_BLOCKLIST = [
  * Checks whether a dynamic property key could be used in
  * a [prototype pollution attack](https://portswigger.net/web-security/prototype-pollution).
  *
+ * String keys are compared against the {@link PROTOTYPE_POLLUTION_BLOCKLIST}.
+ * Number and symbol keys are always considered safe: number keys are coerced
+ * to numeric strings, which can never collide with the blocklist, and symbol
+ * keys cannot alias the string-keyed `Object.prototype` properties.
+ *
  * @param key - The dynamic key to validate.
  * @returns Whether the given dynamic key is safe to use.
  */
-export function isSafeDynamicKey(key: string): boolean {
-  return (
-    typeof key === 'string' &&
-    !PROTOTYPE_POLLUTION_BLOCKLIST.some((blockedKey) => key === blockedKey)
-  );
+export function isSafeDynamicKey(key: PropertyKey): boolean {
+  if (typeof key === 'string') {
+    return !PROTOTYPE_POLLUTION_BLOCKLIST.some(
+      (blockedKey) => key === blockedKey,
+    );
+  }
+  return typeof key === 'number' || typeof key === 'symbol';
 }
 
 /**


### PR DESCRIPTION
## Explanation

`isSafeDynamicKey` in `@metamask/controller-utils` only accepts `string` keys and returns `false` for any non-string input. This means valid dynamic keys of type `number` (e.g. array indices such as `currentIndex` in `SmartTransactionsController`, the case that motivated the ticket) or `symbol` cannot be validated without a lossy `String()` conversion.

Neither number nor symbol keys can be used for a prototype pollution attack via the blocklisted keys:

- number keys are coerced to canonical numeric strings when used as property keys, which can never collide with `'__proto__'`, `'constructor'`, or `'prototype'`;
- symbol keys cannot alias the string-keyed `Object.prototype` properties.

This PR widens the parameter type to `PropertyKey` (`string | number | symbol`). Behavior:

- `string` keys: unchanged — checked against `PROTOTYPE_POLLUTION_BLOCKLIST`.
- `number` / `symbol` keys: now return `true` (previously `false`).
- Non-`PropertyKey` runtime values passed from untyped code (e.g. `null`, `undefined`): still return `false`, preserving the existing defensive behavior.

The change is backwards compatible for all existing (string-typed) callers.

Note: the tracking issue lives in the `MetaMask/utils` repo, but the function itself lives here in `@metamask/controller-utils` (added in #4041), so this PR targets `core`.

## References

Fixes MetaMask/utils#200

* Context: https://github.com/MetaMask/smart-transactions-controller/pull/397#discussion_r1526612364 (maintainer noted `isSafeDynamicKey` should handle all `PropertyKey` subtypes so number indices can be validated without string conversion)
* Related to #4041

## Testing

- `yarn workspace @metamask/controller-utils run jest --no-coverage` — 6 suites, 186 tests passed
- `yarn workspace @metamask/controller-utils run test` (with coverage) — passed
- `yarn workspace @metamask/controller-utils run build` — passed
- `yarn eslint` on the changed files — clean
- Added test coverage for all three `PropertyKey` subtypes (blocklisted and safe strings, number keys incl. `NaN`, symbol keys incl. `Symbol('__proto__')`) plus `null`/`undefined` returning `false`

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, intentional behavior change in a prototype-pollution helper; string semantics are unchanged and the new number/symbol paths are documented as non-polluting.
> 
> **Overview**
> **`isSafeDynamicKey`** in `@metamask/controller-utils` now accepts **`PropertyKey`** (`string | number | symbol`) instead of only `string`, so callers can validate numeric indices and symbol keys without coercing to strings.
> 
> String keys still use **`PROTOTYPE_POLLUTION_BLOCKLIST`** as before. **Number** and **symbol** keys now return **`true`** (they were **`false`** for any non-string). **`null`** / **`undefined`** still return **`false`**. JSDoc explains why number/symbol keys are treated as safe; tests and the package changelog are updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2034caab9f87cade29897bdbaa2366b0d14297f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->