### PR TITLE
fix: patch nock to schedule response delays on global timers

### DIFF
--- a/.yarn/patches/nock-npm-13.5.5-ccb57f0a2f.patch
+++ b/.yarn/patches/nock-npm-13.5.5-ccb57f0a2f.patch
@@ -1,0 +1,51 @@
+diff --git a/lib/common.js b/lib/common.js
+index a6f7f766d03fb7acc9fe2494488685684fa7fe07..1d29b572e18ee94c4a76e593e69cf628f9e18d69 100644
+--- a/lib/common.js
++++ b/lib/common.js
+@@ -612,7 +612,45 @@ const wrapTimer =
+     return id
+   }
+ 
+-const setTimeout = wrapTimer(timers.setTimeout, timeouts)
++/**
++ * PATCH NOTES (https://github.com/MetaMask/core/issues/4428):
++ *
++ * Schedule positive response delays (e.g. from `.delay()`) on the global
++ * `setTimeout`, resolved at call time, instead of the `timers` module
++ * function captured at module load time. Jest/Sinon fake timers replace the
++ * global timer functions but cannot affect the load-time-captured `timers`
++ * module reference, so delayed responses were not controllable by fake
++ * timers and ran in real time.
++ *
++ * Zero-delay scheduling (used for every mocked response) is deliberately
++ * left on the real `timers` module function so that tests which enable fake
++ * timers but do not advance them still receive undelayed mock responses, as
++ * they do today.
++ *
++ * This is a more conservative version of the patch applied in the extension
++ * repository: https://github.com/MetaMask/metamask-extension/pull/24805
++ *
++ * TODO: Remove this patch after updating to `nock@14`, which no longer uses
++ * the `timers` module for response delays.
++ */
++const wrapDelayTimer =
++  (timer, ids) =>
++  (callback, ...timerArgs) => {
++    const cb = (...callbackArgs) => {
++      try {
++        // eslint-disable-next-line n/no-callback-literal
++        callback(...callbackArgs)
++      } finally {
++        ids.delete(id)
++      }
++    }
++    const timerFn = timerArgs[0] > 0 ? globalThis.setTimeout : timer
++    const id = timerFn(cb, ...timerArgs)
++    ids.add(id)
++    return id
++  }
++
++const setTimeout = wrapDelayTimer(timers.setTimeout, timeouts)
+ const setImmediate = wrapTimer(timers.setImmediate, immediates)
+ 
+ function clearTimer(clear, ids) {

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "@nktkas/hyperliquid@npm:^0.33.1": "patch:@nktkas/hyperliquid@npm%3A0.33.1#~/.yarn/patches/@nktkas-hyperliquid-npm-0.33.1-6a541fdd1d.patch",
     "elliptic@6.5.4": "^6.5.7",
     "fast-xml-parser@^4.3.4": "^4.4.1",
+    "nock@npm:^13.3.1": "patch:nock@npm%3A13.5.5#~/.yarn/patches/nock-npm-13.5.5-ccb57f0a2f.patch",
     "ws@7.4.6": "^7.5.10"
   },
   "simple-git-hooks": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -22106,7 +22106,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nock@npm:^13.3.1":
+"nock@npm:13.5.5":
   version: 13.5.5
   resolution: "nock@npm:13.5.5"
   dependencies:
@@ -22114,6 +22114,17 @@ __metadata:
     json-stringify-safe: "npm:^5.0.1"
     propagate: "npm:^2.0.0"
   checksum: 10/c19d7bf9654db056357a22b00127bb5606c1bbdff188a5b6c469825e580e31cd0cb0701bce8dd8b4876dbbd36a145fdb681fd69fd59308d6db4923ce8ab2439e
+  languageName: node
+  linkType: hard
+
+"nock@patch:nock@npm%3A13.5.5#~/.yarn/patches/nock-npm-13.5.5-ccb57f0a2f.patch":
+  version: 13.5.5
+  resolution: "nock@patch:nock@npm%3A13.5.5#~/.yarn/patches/nock-npm-13.5.5-ccb57f0a2f.patch::version=13.5.5&hash=5834ac"
+  dependencies:
+    debug: "npm:^4.1.0"
+    json-stringify-safe: "npm:^5.0.1"
+    propagate: "npm:^2.0.0"
+  checksum: 10/4e8a6eeac8f3997ade78d65234d2489e33aeab144977fc129cf567b5a9010ea959cc32989d923d366f8836adead4e320495d0624a57a93013f993d277a3a4ee1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation

`nock` v13 is not compatible with Jest fake timers: `lib/common.js` does `const timers = require('timers')` and captures `timers.setTimeout` into its timer wrappers at module load time. Jest/Sinon fake timers replace the global timer functions, but they cannot affect the function reference nock captured at load time, so `.delay()`-ed nock responses always run in real time and cannot be advanced with fake timers.

Notably, upgrading to Jest 30 did **not** fix this, contrary to the expectation recorded in #4428 and in the extension's patch notes. Even though `@sinonjs/fake-timers` ≥ 11 can fake the `timers` module, it patches the module's properties at `useFakeTimers()` time — after nock has already captured the original function. I verified this empirically on this repo (Jest 30.4.2, `@sinonjs/fake-timers` 15.4.0, nock 13.5.5): a test awaiting a nock response with a one-hour `.delay()` under fake timers times out despite `jest.advanceTimersByTimeAsync`, because the delay is scheduled on a real timer.

This PR applies the equivalent of the extension's patch (https://github.com/MetaMask/metamask-extension/pull/24805) via the Yarn patch protocol (`.yarn/patches` + a `resolutions` entry, following the existing `@nktkas/hyperliquid` precedent), with one deliberate refinement:

- Positive response delays are scheduled on the **global** `setTimeout`, resolved at call time, so fake timers control them.
- Zero-delay scheduling (nock routes *every* mocked response through `common.setTimeout(respond, 0)`) is left on the real `timers` module function.

The refinement matters because applying the extension patch verbatim breaks existing suites in this repo: 21 test files across ~14 packages use nock together with fake timers, and many await a mocked response before advancing timers. With the verbatim patch, every one of those responses would require explicit timer advancement — e.g. `@metamask/base-data-service`'s suite fails with test timeouts. With this refinement, only actual `.delay()`s become fake-timer-controlled, which is the behavior the issue asks for, and no existing test's expectations change.

The patch can be removed when nock is updated to v14, which no longer uses the `timers` module for response delays.

## Testing

Verified with a scratch test (not committed, mirroring how the extension PR validated the patch) in `@metamask/base-data-service`, using `jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate'] })` per this repo's convention:

1. A request against a nock interceptor with `.delay(ONE_HOUR)` resolves after `jest.advanceTimersByTimeAsync(ONE_HOUR)`.
   - Before this patch: fails with "Exceeded timeout of 10000 ms" (delay runs on a real timer).
   - After this patch: passes in ~0.2s.
2. A request against a no-delay interceptor resolves without advancing fake timers — passes both before and after, demonstrating no behavior change for the common case.

Also ran (all passing with the patch applied):

- `yarn workspace @metamask/base-data-service run test` (fails with test timeouts under the verbatim extension patch; passes with this one)
- `yarn workspace @metamask/ramps-controller run test`
- `yarn constraints`

Not run: the full monorepo test suite.

## References

Fixes #4428

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
  - No changelog entries: this is a development-only change to a root dev dependency; no published package is affected.
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only dependency patch affecting test HTTP mocking; no production runtime or published package behavior changes.
> 
> **Overview**
> Adds a **Yarn patch** for `nock@13.5.5` so HTTP mock **`.delay()`** responses can be driven by Jest/Sinon fake timers instead of real time.
> 
> The patch replaces nock’s load-time `timers.setTimeout` wrapper with `wrapDelayTimer`: **positive** delays schedule on **`globalThis.setTimeout`** at call time; **zero-delay** responses still use the captured `timers` module timer so existing suites that use fake timers without advancing them keep getting immediate mocks.
> 
> Root **`package.json`** pins the patch via **`resolutions`** (same pattern as other patched deps); **`yarn.lock`** records the patched package entry. Intended to be removed when upgrading to **nock v14**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cea9f24e45745826b2614c5794917898d9e73e8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->