### PR TITLE
fix(profile-sync-controller): tag SRPs only in wallet context

### DIFF
--- a/packages/profile-sync-controller/CHANGELOG.md
+++ b/packages/profile-sync-controller/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Tag `/srp/login` with SRP slot and social provider metadata ([#9741](https://github.com/MetaMask/core/pull/9741))
-  - Append `primary` | `secondary` to `raw_message` (`metamask:<nonce>:<pubkey>:<tag>`; `primary` for the first HD entropy source). Include `metametrics.identifier_type` (`SRP` | `GOOGLE` | `APPLE` | `TELEGRAM`; social vault primary maps from `SeedlessOnboardingController.state.authConnection`).
+- **BREAKING:** Tag `/srp/login` with SRP slot and social provider metadata ([#9741](https://github.com/MetaMask/core/pull/9741), [#XXX](https://github.com/MetaMask/core/pull/XXX))
+  - Append `primary` | `secondary` to `raw_message` (`metamask:<nonce>:<pubkey>:<tag>`; `primary` for the first HD entropy source). Leave `raw_message` untagged when `getLoginTag` is not provided. Include `metametrics.identifier_type` (`SRP` | `GOOGLE` | `APPLE` | `TELEGRAM`; social vault primary maps from `SeedlessOnboardingController.state.authConnection`).
 
 ## [28.3.0]
 

--- a/packages/profile-sync-controller/CHANGELOG.md
+++ b/packages/profile-sync-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Tag `/srp/login` with SRP slot and social provider metadata ([#9741](https://github.com/MetaMask/core/pull/9741), [#XXX](https://github.com/MetaMask/core/pull/XXX))
+- **BREAKING:** Tag `/srp/login` with SRP slot and social provider metadata ([#9741](https://github.com/MetaMask/core/pull/9741), [#9776](https://github.com/MetaMask/core/pull/9776))
   - Append `primary` | `secondary` to `raw_message` (`metamask:<nonce>:<pubkey>:<tag>`; `primary` for the first HD entropy source). Leave `raw_message` untagged when `getLoginTag` is not provided. Include `metametrics.identifier_type` (`SRP` | `GOOGLE` | `APPLE` | `TELEGRAM`; social vault primary maps from `SeedlessOnboardingController.state.authConnection`).
 
 ## [28.3.0]

--- a/packages/profile-sync-controller/src/sdk/authentication-jwt-bearer/flow-srp.test.ts
+++ b/packages/profile-sync-controller/src/sdk/authentication-jwt-bearer/flow-srp.test.ts
@@ -684,7 +684,7 @@ describe('SRPJwtBearerAuth login tag', () => {
     });
   });
 
-  it('defaults to primary when getLoginTag is omitted', async () => {
+  it('leaves raw_message untagged when getLoginTag is omitted', async () => {
     const auth = new SRPJwtBearerAuth(config, {
       storage: {
         getLoginResponse: async (): Promise<LoginResponse | null> => null,
@@ -699,7 +699,7 @@ describe('SRPJwtBearerAuth login tag', () => {
     await auth.getAccessToken();
 
     expect(mockAuthenticate).toHaveBeenCalledWith(
-      'metamask:nonce-1:pubkey-1:primary',
+      'metamask:nonce-1:pubkey-1',
       'signature-1',
       AuthType.SRP,
       Env.DEV,
@@ -735,7 +735,7 @@ describe('SRPJwtBearerAuth login tag', () => {
     );
   });
 
-  it('forwards getLoginIdentifierType to authenticate', async () => {
+  it('forwards getLoginIdentifierType without tagging when getLoginTag is omitted', async () => {
     const getLoginIdentifierType = jest.fn().mockResolvedValue('GOOGLE');
     const auth = new SRPJwtBearerAuth(config, {
       storage: {
@@ -753,7 +753,7 @@ describe('SRPJwtBearerAuth login tag', () => {
 
     expect(getLoginIdentifierType).toHaveBeenCalledWith('entropy-primary');
     expect(mockAuthenticate).toHaveBeenCalledWith(
-      'metamask:nonce-1:pubkey-1:primary',
+      'metamask:nonce-1:pubkey-1',
       'signature-1',
       AuthType.SRP,
       Env.DEV,

--- a/packages/profile-sync-controller/src/sdk/authentication-jwt-bearer/flow-srp.ts
+++ b/packages/profile-sync-controller/src/sdk/authentication-jwt-bearer/flow-srp.ts
@@ -420,7 +420,9 @@ export class SRPJwtBearerAuth implements IBaseAuth {
     nonce: string,
     publicKey: string,
     tag?: SrpLoginTag,
-  ): `metamask:${string}:${string}` | `metamask:${string}:${string}:${SrpLoginTag}` {
+  ):
+    | `metamask:${string}:${string}`
+    | `metamask:${string}:${string}:${SrpLoginTag}` {
     if (tag) {
       return `metamask:${nonce}:${publicKey}:${tag}` as const;
     }

--- a/packages/profile-sync-controller/src/sdk/authentication-jwt-bearer/flow-srp.ts
+++ b/packages/profile-sync-controller/src/sdk/authentication-jwt-bearer/flow-srp.ts
@@ -38,8 +38,8 @@ type JwtBearerAuth_SRP_Options = {
   storage: AuthStorageOptions;
   signing?: AuthSigningOptions;
   /**
-   * Resolves the login tag for a given entropy source. Defaults to
-   * `'primary'` when omitted (SDK / EIP-6963 consumers).
+   * Resolves the login tag for a given entropy source.
+   * When omitted, `raw_message` stays untagged (`metamask:<nonce>:<pubkey>`).
    */
   getLoginTag?: (entropySourceId?: string) => Promise<SrpLoginTag>;
   /**
@@ -295,7 +295,9 @@ export class SRPJwtBearerAuth implements IBaseAuth {
     const publicKey = await this.getIdentifier(entropySourceId);
     const nonceRes = await getNonce(publicKey, this.#config.env);
 
-    const tag = (await this.#getLoginTag?.(entropySourceId)) ?? 'primary';
+    // Tag only when the wallet supplies getLoginTag. SDK callers keep the
+    // legacy 3-part message rather than guessing `primary`.
+    const tag = await this.#getLoginTag?.(entropySourceId);
     const identifierType =
       (await this.#getLoginIdentifierType?.(entropySourceId)) ?? 'SRP';
     const rawMessage = this.#createSrpLoginRawMessage(
@@ -417,8 +419,11 @@ export class SRPJwtBearerAuth implements IBaseAuth {
   #createSrpLoginRawMessage(
     nonce: string,
     publicKey: string,
-    tag: SrpLoginTag,
-  ): `metamask:${string}:${string}:${SrpLoginTag}` {
-    return `metamask:${nonce}:${publicKey}:${tag}` as const;
+    tag?: SrpLoginTag,
+  ): `metamask:${string}:${string}` | `metamask:${string}:${string}:${SrpLoginTag}` {
+    if (tag) {
+      return `metamask:${nonce}:${publicKey}:${tag}` as const;
+    }
+    return `metamask:${nonce}:${publicKey}` as const;
   }
 }


### PR DESCRIPTION
## Explanation

This PR makes it so we don't wrongfully tag SRPs when `getLoginTag` is not provided (outside-of-wallet, SDK consumers).

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Alters the signed login payload for SDK consumers versus the prior default `:primary` tag, which can affect server-side auth expectations until consumers adopt wallet-style tagging.
> 
> **Overview**
> **SRP `/srp/login` signing** no longer appends `:primary` when `getLoginTag` is omitted. SDK and EIP-6963 callers keep the legacy **`metamask:<nonce>:<pubkey>`** `raw_message`; wallets that pass **`getLoginTag`** still get **`metamask:<nonce>:<pubkey>:primary|secondary`**.
> 
> `#performLogin` only resolves a tag via the optional callback, and **`#createSrpLoginRawMessage`** builds a 3- or 4-part string accordingly. **`getLoginIdentifierType`** (e.g. `GOOGLE`) is unchanged and can still be sent without a tag. The unreleased **CHANGELOG** documents this as a breaking adjustment to the earlier tagging work ([#9776]).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de23dc9e8dc1b9f7cf80e5d1f0517a3d390a7815. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->