### PR TITLE
fix(client-utils): require chainId on ramp activity items

### DIFF
--- a/packages/client-utils/CHANGELOG.md
+++ b/packages/client-utils/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.7.0]
-
 ### Changed
 
 - **BREAKING:** Make `chainId` required on `rampBuy` / `rampSell` `ActivityItem` variants, matching every other activity kind. `mapRampsOrder` now returns `null` when no CAIP chain id can be resolved from the order (empty or unparseable `network`, missing `cryptoCurrency.chainId` / `assetId`), instead of emitting an item with an undefined `chainId` ([#9777](https://github.com/MetaMask/core/pull/9777))

--- a/packages/client-utils/CHANGELOG.md
+++ b/packages/client-utils/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING:** Make `chainId` required on `rampBuy` / `rampSell` `ActivityItem` variants, matching every other activity kind. `mapRampsOrder` now returns `null` when no CAIP chain id can be resolved from the order (empty or unparseable `network`, missing `cryptoCurrency.chainId` / `assetId`), instead of emitting an item with an undefined `chainId`.
+
 ## [1.6.0]
 
 ### Added

--- a/packages/client-utils/CHANGELOG.md
+++ b/packages/client-utils/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0]
+
 ### Changed
 
-- **BREAKING:** Make `chainId` required on `rampBuy` / `rampSell` `ActivityItem` variants, matching every other activity kind. `mapRampsOrder` now returns `null` when no CAIP chain id can be resolved from the order (empty or unparseable `network`, missing `cryptoCurrency.chainId` / `assetId`), instead of emitting an item with an undefined `chainId`.
+- **BREAKING:** Make `chainId` required on `rampBuy` / `rampSell` `ActivityItem` variants, matching every other activity kind. `mapRampsOrder` now returns `null` when no CAIP chain id can be resolved from the order (empty or unparseable `network`, missing `cryptoCurrency.chainId` / `assetId`), instead of emitting an item with an undefined `chainId` ([#9777](https://github.com/MetaMask/core/pull/9777))
 
 ## [1.6.0]
 

--- a/packages/client-utils/package.json
+++ b/packages/client-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/client-utils",
-  "version": "1.7.0",
+  "version": "1.6.0",
   "description": "Shared functions and utilities used across MetaMask clients (extension and mobile)",
   "keywords": [
     "Ethereum",

--- a/packages/client-utils/package.json
+++ b/packages/client-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/client-utils",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Shared functions and utilities used across MetaMask clients (extension and mobile)",
   "keywords": [
     "Ethereum",

--- a/packages/client-utils/src/mappers/ramps-order-mapper.test.ts
+++ b/packages/client-utils/src/mappers/ramps-order-mapper.test.ts
@@ -102,14 +102,14 @@ describe('mapRampsOrder', () => {
     expect(item?.status).toBe('pending');
   });
 
-  it('maps a precreated stub order with an empty chain id to an undefined chainId, not eip155:0', () => {
+  it('hides a precreated stub order with an empty chain id instead of mapping eip155:0', () => {
     const item = mapRampsOrder({
       ...baseOrder,
       network: { chainId: '' },
       cryptoCurrency: undefined,
     });
 
-    expect(item?.chainId).toBeUndefined();
+    expect(item).toBeNull();
   });
 
   it('falls through an unparseable network name to cryptoCurrency.chainId', () => {
@@ -139,24 +139,24 @@ describe('mapRampsOrder', () => {
     expect(item?.chainId).toBe('eip155:1');
   });
 
-  it('returns an undefined chainId when cryptoCurrency.assetId has no valid chain segment', () => {
+  it('hides an order when cryptoCurrency.assetId has no valid chain segment', () => {
     const item = mapRampsOrder({
       ...baseOrder,
       network: 'ethereum',
       cryptoCurrency: { assetId: 'not-an-asset-id', symbol: 'ETH' },
     });
 
-    expect(item?.chainId).toBeUndefined();
+    expect(item).toBeNull();
   });
 
-  it('returns an undefined chainId when network is an unparseable name and crypto currency has no chain', () => {
+  it('hides an order when network is an unparseable name and crypto currency has no chain', () => {
     const item = mapRampsOrder({
       ...baseOrder,
       network: 'ethereum',
       cryptoCurrency: undefined,
     });
 
-    expect(item?.chainId).toBeUndefined();
+    expect(item).toBeNull();
   });
 
   it.each(['0x', '0x0000'])(

--- a/packages/client-utils/src/mappers/ramps-order-mapper.ts
+++ b/packages/client-utils/src/mappers/ramps-order-mapper.ts
@@ -143,10 +143,16 @@ function isPlausibleRampTxHash(txHash: string): boolean {
  *
  * @param order - The ramps order to map.
  * @returns The normalized activity item, or `null` if the order's status
- * should not be surfaced in the activity list.
+ * should not be surfaced in the activity list, or if no CAIP chain id can be
+ * resolved from the order.
  */
 export function mapRampsOrder(order: RampsOrderLike): ActivityItem | null {
   if (HIDDEN_STATUSES.has(order.status) || order.excludeFromPurchases) {
+    return null;
+  }
+
+  const chainId = resolveRampsOrderChainId(order);
+  if (!chainId) {
     return null;
   }
 
@@ -183,8 +189,6 @@ export function mapRampsOrder(order: RampsOrderLike): ActivityItem | null {
       symbol: order.fiatCurrency?.symbol,
     },
   ];
-
-  const chainId = resolveRampsOrderChainId(order);
 
   return {
     type: isBuy ? 'rampBuy' : 'rampSell',

--- a/packages/client-utils/src/types.ts
+++ b/packages/client-utils/src/types.ts
@@ -176,34 +176,26 @@ export type ActivityItem =
         transactionProtocol?: string;
       }
     >
-  | (Omit<
-      ActivityData<
-        'rampBuy' | 'rampSell',
-        {
-          from?: string;
-          fiat?: FiatAmount;
-          token?: TokenAmount;
-          fees?: Fee[];
-          provider?: {
-            id?: string;
-            name?: string;
-            orderLink?: string;
-          };
-          statusDescription?: string;
-          paymentDetails?: RampOrderPaymentDetail[];
-          // Stable identifier for orders that may not have a hash yet (e.g. a
-          // ramp order pending fiat settlement, where `hash` is empty until it
-          // settles on-chain). Lives in `data` as a ramp-specific property.
+  | ActivityData<
+      'rampBuy' | 'rampSell',
+      {
+        from?: string;
+        fiat?: FiatAmount;
+        token?: TokenAmount;
+        fees?: Fee[];
+        provider?: {
           id?: string;
-        }
-      >,
-      'chainId'
-    > & {
-      // Precreated stub orders (see `RampsController.addPrecreatedOrder`) may
-      // not have an assigned network yet, so unlike every other activity
-      // kind, a ramp order's chain id isn't guaranteed.
-      chainId?: CaipChainId;
-    });
+          name?: string;
+          orderLink?: string;
+        };
+        statusDescription?: string;
+        paymentDetails?: RampOrderPaymentDetail[];
+        // Stable identifier for orders that may not have a hash yet (e.g. a
+        // ramp order pending fiat settlement, where `hash` is empty until it
+        // settles on-chain). Lives in `data` as a ramp-specific property.
+        id?: string;
+      }
+    >;
 
 // Note: Update core-backend
 export type ValueTransfer = _ValueTransfer & {

--- a/packages/ramps-controller/CHANGELOG.md
+++ b/packages/ramps-controller/CHANGELOG.md
@@ -24,7 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Require a non-empty `chainId` on `addPrecreatedOrder`. Callers must seed the selected token's chain so precreated stubs (and pending flips before API enrichment) always carry a network. Empty or whitespace `chainId` is a no-op, matching empty `orderId` handling. ([#9777](https://github.com/MetaMask/core/pull/9777))
 - **BREAKING:** `RampsController` now calls `RampsService:getDefaultRedirectCallbackUrl` on the widened quote path, so hosts must delegate that action to the controller's messenger. It is included in the exported `RAMPS_CONTROLLER_REQUIRED_SERVICE_ACTIONS` list; hosts that spell out their delegated action list instead of spreading that constant have to add it, or the entire `RampsController:getQuotes` call rejects with a messenger "handler has not been delegated" error (including MM Pay's fiat quote path, which omits `redirectUrl` and relies on widening). ([#9752](https://github.com/MetaMask/core/pull/9752))
   - The action is only called when the `moneyHeadlessAllProviders` widening is in effect and the caller omitted `redirectUrl`. An explicit `redirectUrl` and the native-only path never reach the service.
 

--- a/packages/ramps-controller/CHANGELOG.md
+++ b/packages/ramps-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING:** Require a non-empty `chainId` on `addPrecreatedOrder`. Callers must seed the selected token's chain so precreated stubs (and pending flips before API enrichment) always carry a network. Empty or whitespace `chainId` is a no-op, matching empty `orderId` handling. ([#9777](https://github.com/MetaMask/core/pull/9777))
+
 ## [19.0.0]
 
 ### Added

--- a/packages/ramps-controller/CHANGELOG.md
+++ b/packages/ramps-controller/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING:** Require a non-empty `chainId` on `addPrecreatedOrder`. Callers must seed the selected token's chain so precreated stubs (and pending flips before API enrichment) always carry a network. Empty or whitespace `chainId` is a no-op, matching empty `orderId` handling. ([#9777](https://github.com/MetaMask/core/pull/9777))
 - **BREAKING:** `RampsController` now calls `RampsService:getDefaultRedirectCallbackUrl` on the widened quote path, so hosts must delegate that action to the controller's messenger. It is included in the exported `RAMPS_CONTROLLER_REQUIRED_SERVICE_ACTIONS` list; hosts that spell out their delegated action list instead of spreading that constant have to add it, or the entire `RampsController:getQuotes` call rejects with a messenger "handler has not been delegated" error (including MM Pay's fiat quote path, which omits `redirectUrl` and relies on widening). ([#9752](https://github.com/MetaMask/core/pull/9752))
   - The action is only called when the `moneyHeadlessAllProviders` widening is in effect and the caller omitted `redirectUrl`. An explicit `redirectUrl` and the native-only path never reach the service.
 

--- a/packages/ramps-controller/src/RampsController-method-action-types.ts
+++ b/packages/ramps-controller/src/RampsController-method-action-types.ts
@@ -321,7 +321,7 @@ export type RampsControllerGetBuyWidgetDataAction = {
  * @param params.orderId - Full order ID (e.g. "/providers/paypal/orders/abc123") or order code.
  * @param params.providerCode - Canonical provider code (e.g. "paypal", "transak").
  * @param params.walletAddress - Wallet address for the order.
- * @param params.chainId - Optional chain ID for the order.
+ * @param params.chainId - Chain ID for the order (decimal, hex, or CAIP-2). Must be non-empty.
  */
 export type RampsControllerAddPrecreatedOrderAction = {
   type: `RampsController:addPrecreatedOrder`;

--- a/packages/ramps-controller/src/RampsController.test.ts
+++ b/packages/ramps-controller/src/RampsController.test.ts
@@ -8870,6 +8870,7 @@ describe('RampsController', () => {
         expect(stub?.provider?.id).toBe('paypal');
         expect(stub?.walletAddress).toBe('0xabc');
         expect(stub?.status).toBe(RampsOrderStatus.Precreated);
+        expect(stub?.network).toEqual({ chainId: '1', name: '' });
       });
     });
 
@@ -8879,11 +8880,16 @@ describe('RampsController', () => {
           orderId: 'plain-order-id',
           providerCode: 'transak',
           walletAddress: '0xdef',
+          chainId: 'eip155:1',
         });
 
         expect(controller.state.orders[0]?.providerOrderId).toBe(
           'plain-order-id',
         );
+        expect(controller.state.orders[0]?.network).toEqual({
+          chainId: 'eip155:1',
+          name: '',
+        });
       });
     });
 
@@ -8893,6 +8899,20 @@ describe('RampsController', () => {
           orderId: '/providers/paypal/orders/',
           providerCode: 'paypal',
           walletAddress: '0xabc',
+          chainId: '1',
+        });
+
+        expect(controller.state.orders).toHaveLength(0);
+      });
+    });
+
+    it('skips addOrder when chainId is empty or whitespace', async () => {
+      await withController(({ controller, rootMessenger }) => {
+        rootMessenger.call('RampsController:addPrecreatedOrder', {
+          orderId: '/providers/paypal/orders/abc123',
+          providerCode: 'paypal',
+          walletAddress: '0xabc',
+          chainId: '   ',
         });
 
         expect(controller.state.orders).toHaveLength(0);

--- a/packages/ramps-controller/src/RampsController.test.ts
+++ b/packages/ramps-controller/src/RampsController.test.ts
@@ -8870,7 +8870,7 @@ describe('RampsController', () => {
         expect(stub?.provider?.id).toBe('paypal');
         expect(stub?.walletAddress).toBe('0xabc');
         expect(stub?.status).toBe(RampsOrderStatus.Precreated);
-        expect(stub?.network).toEqual({ chainId: '1', name: '' });
+        expect(stub?.network).toStrictEqual({ chainId: '1', name: '' });
       });
     });
 
@@ -8886,7 +8886,7 @@ describe('RampsController', () => {
         expect(controller.state.orders[0]?.providerOrderId).toBe(
           'plain-order-id',
         );
-        expect(controller.state.orders[0]?.network).toEqual({
+        expect(controller.state.orders[0]?.network).toStrictEqual({
           chainId: 'eip155:1',
           name: '',
         });

--- a/packages/ramps-controller/src/RampsController.ts
+++ b/packages/ramps-controller/src/RampsController.ts
@@ -2618,18 +2618,21 @@ export class RampsController extends BaseController<
    * @param params.orderId - Full order ID (e.g. "/providers/paypal/orders/abc123") or order code.
    * @param params.providerCode - Canonical provider code (e.g. "paypal", "transak").
    * @param params.walletAddress - Wallet address for the order.
-   * @param params.chainId - Optional chain ID for the order.
+   * @param params.chainId - Chain ID for the order (decimal, hex, or CAIP-2). Must be non-empty.
    */
   addPrecreatedOrder(params: {
     orderId: string;
     providerCode: string;
     walletAddress: string;
-    chainId?: string;
+    chainId: string;
   }): void {
     const { orderId, providerCode, walletAddress, chainId } = params;
 
     const orderCode = getInternalOrderCode(orderId);
     if (!orderCode?.trim()) {
+      return;
+    }
+    if (!chainId.trim()) {
       return;
     }
     const stubOrder: RampsOrder = {
@@ -2654,7 +2657,7 @@ export class RampsController extends BaseController<
       providerOrderLink: '',
       totalFeesFiat: 0,
       txHash: '',
-      network: chainId ? { chainId, name: '' } : { chainId: '', name: '' },
+      network: { chainId, name: '' },
       canBeUpdated: true,
       idHasExpired: false,
       excludeFromPurchases: false,


### PR DESCRIPTION
## Explanation

- follow up from https://github.com/MetaMask/core/pull/9650
- `rampBuy` / `rampSell` were the only `ActivityItem` kinds with optional `chainId`, which softens `chainId` across the whole union for TypeScript consumers (notably MetaMask Extension Activity).
- Optional chainId existed for precreated stubs / unparseable provider network strings. Those rows should be hidden instead, matching mobile's local `mapRampOrder` (returns `null` when chain cannot be resolved).

## Changes
- **`@metamask/client-utils`**: Make `chainId` required on ramp activity items; `mapRampsOrder` returns `null` when no CAIP chain can be resolved.
- **`@metamask/ramps-controller`**: Require non-empty `chainId` on `addPrecreatedOrder` so checkout stubs always seed `network` before pending flips.

## Client follow-ups
- Extension: https://github.com/MetaMask/metamask-extension/pull/45143 — uses the `client-utils` preview build; drops Activity `Exclude` / optional-`chainId` safeguards.
- Mobile: https://github.com/MetaMask/metamask-mobile/pull/34246 — uses the `ramps-controller` preview build; requires `chainId` at `addPrecreatedOrder` call sites.

## Manual Testing Steps
1. Run `yarn workspace @metamask/client-utils test --testPathPatterns=ramps-order-mapper --coverage=false`
2. Run `yarn workspace @metamask/ramps-controller test --testPathPatterns=RampsController.test --testNamePattern=addPrecreatedOrder --coverage=false`
3. Confirm mapper still resolves Coinbase-style `network: 'ethereum'` via `cryptoCurrency.chainId` / `assetId`.

## Changelog
Updated `@metamask/client-utils` and `@metamask/ramps-controller` changelogs under Unreleased (BREAKING).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking API changes in two packages require Extension/Mobile upgrades; behavior change hides ramp rows that previously appeared without chain, which is intentional but affects activity lists.
> 
> **Overview**
> **Breaking:** `rampBuy` / `rampSell` `ActivityItem` variants now require `chainId` like every other activity kind, so TypeScript consumers no longer treat `chainId` as optional on the whole union.
> 
> In **`@metamask/client-utils`**, `mapRampsOrder` resolves chain id up front and returns **`null`** when no CAIP-2 id can be derived (empty network, unparseable provider network strings without `cryptoCurrency` fallbacks, invalid `assetId`), instead of emitting rows with missing `chainId`. The ramp types drop the special optional-`chainId` intersection.
> 
> In **`@metamask/ramps-controller`**, `addPrecreatedOrder` requires a **non-empty** `chainId` (decimal, hex, or CAIP-2); whitespace-only values are ignored like invalid `orderId`, and stubs always set `network.chainId` from the caller so pending activity can map before API enrichment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a795eb7f5e61f70e3106bc718b5ce90583805cea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->