### PR TITLE
feat: add robinhood-mainnet URL on smart-transaction-controller

### DIFF
--- a/packages/smart-transactions-controller/CHANGELOG.md
+++ b/packages/smart-transactions-controller/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Add Robinhood mainnet tx-sentinel URL ([#9783](https://github.com/MetaMask/core/pull/9783))
 - Bump `@metamask/transaction-controller` from `^69.4.0` to `^69.5.0` ([#9780](https://github.com/MetaMask/core/pull/9780))
 
 ## [25.0.3]

--- a/packages/smart-transactions-controller/src/constants.ts
+++ b/packages/smart-transactions-controller/src/constants.ts
@@ -9,6 +9,7 @@ export const SENTINEL_API_BASE_URL_MAP: SentinelApiBaseUrlMap = {
   1: 'https://tx-sentinel-ethereum-mainnet.api.cx.metamask.io',
   56: 'https://tx-sentinel-bsc-mainnet.api.cx.metamask.io',
   137: 'https://tx-sentinel-polygon-mainnet.api.cx.metamask.io',
+  4663: 'https://tx-sentinel-robinhood-mainnet.api.cx.metamask.io',
   8453: 'https://tx-sentinel-base-mainnet.api.cx.metamask.io',
   42161: 'https://tx-sentinel-arbitrum-mainnet.api.cx.metamask.io',
   59144: 'https://tx-sentinel-linea-mainnet.api.cx.metamask.io',


### PR DESCRIPTION
NB: this is the simple fix to have STX in the next release 13.43.0 but we need to refactor this to use the URL coming from the flags.

## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single new map entry with no changes to auth, transaction flow, or existing chains; behavior only affects Robinhood mainnet when STX is enabled.
> 
> **Overview**
> Registers **Robinhood mainnet** (chain ID `4663`) in `SENTINEL_API_BASE_URL_MAP` so smart transactions on that network use `https://tx-sentinel-robinhood-mainnet.api.cx.metamask.io` for sentinel calls (e.g. liveness), matching how other supported chains are wired.
> 
> The changelog is updated under **Unreleased**. The PR description notes this is a short-term mapping change to ship STX in 13.43.0, with a follow-up to source sentinel URLs from feature flags instead of a static map.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e6c9c8cd60306a28d38243a5826dca0775cfe9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->