### PR TITLE
feat(AssetsController): add offhours to token rwa data types

### DIFF
--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `offhours` field to `TokenRwaData` and `RwaTokenData` types to support off-hours RWA trading windows ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
+- Add `offhours` field to `TokenRwaData` and `RwaTokenData` types to support off-hours RWA trading windows ([#9792](https://github.com/MetaMask/core/pull/9792))
   - `offhours.nextOpen`: ISO-8601 datetime when the next off-hours window opens
   - `offhours.nextClose`: ISO-8601 datetime when the next off-hours window closes
   - Field is only present when the asset's source reports off-hours tradability; absence means off-hours trading is not supported

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `offhours` field to `TokenRwaData` and `RwaTokenData` types to support off-hours RWA trading windows ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
+  - `offhours.nextOpen`: ISO-8601 datetime when the next off-hours window opens
+  - `offhours.nextClose`: ISO-8601 datetime when the next off-hours window closes
+  - Field is only present when the asset's source reports off-hours tradability; absence means off-hours trading is not supported
 ### Changed
 
 - Bump `@metamask/account-tree-controller` from `^7.6.0` to `^7.6.1` ([#9791](https://github.com/MetaMask/core/pull/9791))

--- a/packages/assets-controllers/src/token-service.test.ts
+++ b/packages/assets-controllers/src/token-service.test.ts
@@ -2003,6 +2003,47 @@ describe('Token service', () => {
       expect(result).toStrictEqual(sampleRwasResponse);
     });
 
+    it('passes through offhours field when present in the response', async () => {
+      const responseWithOffhours = {
+        ...sampleRwasResponse,
+        data: [
+          {
+            ...sampleRwasResponse.data[0],
+            rwaData: {
+              ...sampleRwasResponse.data[0].rwaData,
+              offhours: {
+                nextOpen: '2026-08-08T00:05:00Z',
+                nextClose: '2026-08-09T23:55:00Z',
+              },
+            },
+          },
+        ],
+      };
+
+      nock(TOKEN_END_POINT_API)
+        .get('/v1/rwas?limit=100')
+        .reply(200, responseWithOffhours)
+        .persist();
+
+      const result = await fetchRwas();
+
+      expect(result.data[0].rwaData.offhours).toStrictEqual({
+        nextOpen: '2026-08-08T00:05:00Z',
+        nextClose: '2026-08-09T23:55:00Z',
+      });
+    });
+
+    it('returns rwaData without offhours field when asset does not support off-hours trading', async () => {
+      nock(TOKEN_END_POINT_API)
+        .get('/v1/rwas?limit=100')
+        .reply(200, sampleRwasResponse)
+        .persist();
+
+      const result = await fetchRwas();
+
+      expect(result.data[0].rwaData.offhours).toBeUndefined();
+    });
+
     it('throws if the fetch fails', async () => {
       nock(TOKEN_END_POINT_API).get('/v1/rwas?limit=100').reply(500);
 

--- a/packages/assets-controllers/src/token-service.ts
+++ b/packages/assets-controllers/src/token-service.ts
@@ -380,13 +380,6 @@ export type TokenRwaData = {
     start?: string;
     end?: string;
   };
-  /**
-   * Off-hours trading window. Present only when the asset's source reports
-   * off-hours tradability (i.e. tradableSessions contains "offhours").
-   * When absent, off-hours trading is not supported for this asset.
-   * nextOpen: when the off-hours window next opens (ISO-8601)
-   * nextClose: when the off-hours window next closes (ISO-8601)
-   */
   offhours?: {
     nextOpen?: string;
     nextClose?: string;
@@ -412,13 +405,6 @@ export type RwaTokenData = {
   industry: string[];
   market?: RwaMarket;
   nextPause?: Record<string, unknown>;
-  /**
-   * Off-hours trading window. Present only when the asset's source reports
-   * off-hours tradability (i.e. tradableSessions contains "offhours").
-   * When absent, off-hours trading is not supported for this asset.
-   * nextOpen: when the off-hours window next opens (ISO-8601)
-   * nextClose: when the off-hours window next closes (ISO-8601)
-   */
   offhours?: {
     nextOpen?: string;
     nextClose?: string;

--- a/packages/assets-controllers/src/token-service.ts
+++ b/packages/assets-controllers/src/token-service.ts
@@ -380,6 +380,17 @@ export type TokenRwaData = {
     start?: string;
     end?: string;
   };
+  /**
+   * Off-hours trading window. Present only when the asset's source reports
+   * off-hours tradability (i.e. tradableSessions contains "offhours").
+   * When absent, off-hours trading is not supported for this asset.
+   * nextOpen: when the off-hours window next opens (ISO-8601)
+   * nextClose: when the off-hours window next closes (ISO-8601)
+   */
+  offhours?: {
+    nextOpen?: string;
+    nextClose?: string;
+  };
   ticker?: string;
   instrumentType?: string;
 };
@@ -401,6 +412,17 @@ export type RwaTokenData = {
   industry: string[];
   market?: RwaMarket;
   nextPause?: Record<string, unknown>;
+  /**
+   * Off-hours trading window. Present only when the asset's source reports
+   * off-hours tradability (i.e. tradableSessions contains "offhours").
+   * When absent, off-hours trading is not supported for this asset.
+   * nextOpen: when the off-hours window next opens (ISO-8601)
+   * nextClose: when the off-hours window next closes (ISO-8601)
+   */
+  offhours?: {
+    nextOpen?: string;
+    nextClose?: string;
+  };
   sharesOutstanding?: number;
   restrictedCountries?: string[];
   updatedAt?: string;


### PR DESCRIPTION
## Explanation

This adds offhours to token rwa data types

   Off-hours trading window. Present only when the asset's source reports
   off-hours tradability (i.e. tradableSessions contains "offhours").
   When absent, off-hours trading is not supported for this asset.
   nextOpen: when the off-hours window next opens (ISO-8601)
   nextClose: when the off-hours window next closes (ISO-8601)
   
## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Related to [#455](https://consensyssoftware.atlassian.net/browse/BETR-455)

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional type fields and tests only; no fetch or business-logic changes beyond typing API responses.
> 
> **Overview**
> Adds an optional **`offhours`** block (`nextOpen` / `nextClose`, ISO-8601) to **`TokenRwaData`** and **`RwaTokenData`** so RWA payloads from the token API can describe off-hours trading windows separately from regular **`market`** hours.
> 
> **`fetchRwas`** behavior is unchanged aside from typing—the new field is passed through when the API includes it and stays absent when off-hours trading is not supported. Tests cover both cases; the changelog documents the shape for consumers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5587769378b82179a2c7618c4299ec42e8325d2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->