### PR TITLE
feat: point ARC USDC to the registered slip44:5042 asset ID

### DIFF
--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Point Arc's native USDC to the registered `slip44:5042` asset ID instead of the `erc20:0x0000...` placeholder ([#9796](https://github.com/MetaMask/core/pull/9796))
+
 ### Changed
 
 - Bump `@metamask/accounts-controller` from `^39.0.6` to `^39.0.7` ([#9791](https://github.com/MetaMask/core/pull/9791))

--- a/packages/bridge-controller/src/constants/tokens.ts
+++ b/packages/bridge-controller/src/constants/tokens.ts
@@ -208,7 +208,7 @@ const ROBINHOOD_SWAPS_TOKEN_OBJECT = {
 const ARC_SWAPS_TOKEN_OBJECT = {
   symbol: 'USDC',
   name: 'USDC',
-  address: '0x0000000000000000000000000000000000000000',
+  address: DEFAULT_TOKEN_ADDRESS,
   decimals: 18,
   iconUrl: '',
 } as const;
@@ -264,6 +264,5 @@ export const SYMBOL_TO_SLIP44_MAP: Record<
   XLM: 'slip44:148',
   MON: 'slip44:268435779',
   HYPE: 'slip44:2457',
-  // It won't be displayed - hidden on UI client side
-  USDC: 'erc20:0x0000000000000000000000000000000000000000',
+  USDC: 'slip44:5042',
 };


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Constants-only change for Arc swap/bridge token metadata; low impact unless consumers relied on the old erc20 placeholder asset ID.
> 
> **Overview**
> Arc’s native **USDC** is now identified with the registered **`slip44:5042`** asset ID instead of the **`erc20:0x0000…`** placeholder in `SYMBOL_TO_SLIP44_MAP`, so native-asset CAIP IDs built for Arc match the token API and other multichain asset registries.
> 
> `ARC_SWAPS_TOKEN_OBJECT` now uses **`DEFAULT_TOKEN_ADDRESS`** for its `address` field (same zero address, shared constant). Changelog updated under Unreleased.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 100edb5c97fa842c989b47a6a15a322a269e79d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->