### PR TITLE
fix: strip leading zero digits from value in eth_estimateGas requests

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/accounts-controller` from `^39.0.6` to `^39.0.7` ([#9791](https://github.com/MetaMask/core/pull/9791))
 
+### Fixed
+
+- Strip leading zero digits from `value` in `eth_estimateGas` requests, so gas estimation no longer fails on RPC nodes that reject non-canonical hex quantities such as `0x00` (e.g. Go's `hexutil` parsing)
+
 ## [69.5.0]
 
 ### Added

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Strip leading zero digits from `value` in `eth_estimateGas` requests, so gas estimation no longer fails on RPC nodes that reject non-canonical hex quantities such as `0x00` (e.g. Go's `hexutil` parsing)
+- Strip leading zero digits from `value` in `eth_estimateGas` requests, so gas estimation no longer fails on RPC nodes that reject non-canonical hex quantities such as `0x00` (e.g. Go's `hexutil` parsing) ([#9797](https://github.com/MetaMask/core/pull/9797))
 
 ## [69.5.0]
 

--- a/packages/transaction-controller/src/utils/gas.test.ts
+++ b/packages/transaction-controller/src/utils/gas.test.ts
@@ -870,35 +870,48 @@ describe('gas', () => {
       });
     });
 
-    it('normalizes value in estimate request', async () => {
-      mockQuery({
-        getBlockByNumberResponse: { gasLimit: toHex(BLOCK_GAS_LIMIT_MOCK) },
-        estimateGasResponse: toHex(GAS_MOCK),
-      });
+    it.each<[string, string | undefined, string]>([
+      ['undefined', undefined, '0x0'],
+      ['zero with leading zero digits', '0x00', '0x0'],
+      [
+        'a quantity with leading zero digits',
+        '0x0de0b6b3a7640000',
+        '0xde0b6b3a7640000',
+      ],
+      ['an already canonical quantity', '0x1', '0x1'],
+      ['not a strict hex string', '123', '123'],
+    ])(
+      'normalizes value in estimate request when value is %s',
+      async (_case, value, expectedValue) => {
+        mockQuery({
+          getBlockByNumberResponse: { gasLimit: toHex(BLOCK_GAS_LIMIT_MOCK) },
+          estimateGasResponse: toHex(GAS_MOCK),
+        });
 
-      await estimateGas({
-        networkClientId: NETWORK_CLIENT_ID_MOCK,
-        isSimulationEnabled: false,
-        getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
-        messenger: MESSENGER_MOCK,
-        txParams: {
-          ...TRANSACTION_META_MOCK.txParams,
-          value: undefined,
-        },
-      });
-
-      expect(rpcRequestMock).toHaveBeenCalledWith({
-        messenger: MESSENGER_MOCK,
-        networkClientId: NETWORK_CLIENT_ID_MOCK,
-        method: 'eth_estimateGas',
-        params: [
-          {
+        await estimateGas({
+          networkClientId: NETWORK_CLIENT_ID_MOCK,
+          isSimulationEnabled: false,
+          getSimulationConfig: GET_SIMULATION_CONFIG_MOCK,
+          messenger: MESSENGER_MOCK,
+          txParams: {
             ...TRANSACTION_META_MOCK.txParams,
-            value: '0x0',
+            value,
           },
-        ],
-      });
-    });
+        });
+
+        expect(rpcRequestMock).toHaveBeenCalledWith({
+          messenger: MESSENGER_MOCK,
+          networkClientId: NETWORK_CLIENT_ID_MOCK,
+          method: 'eth_estimateGas',
+          params: [
+            {
+              ...TRANSACTION_META_MOCK.txParams,
+              value: expectedValue,
+            },
+          ],
+        });
+      },
+    );
 
     it('normalizes authorization list in estimate request', async () => {
       mockQuery({

--- a/packages/transaction-controller/src/utils/gas.test.ts
+++ b/packages/transaction-controller/src/utils/gas.test.ts
@@ -870,8 +870,9 @@ describe('gas', () => {
       });
     });
 
-    it.each<[string, string | undefined, string]>([
+    it.each<[string, string | null | undefined, string]>([
       ['undefined', undefined, '0x0'],
+      ['null', null, '0x0'],
       ['zero with leading zero digits', '0x00', '0x0'],
       [
         'a quantity with leading zero digits',
@@ -895,7 +896,7 @@ describe('gas', () => {
           messenger: MESSENGER_MOCK,
           txParams: {
             ...TRANSACTION_META_MOCK.txParams,
-            value,
+            value: value as string | undefined,
           },
         });
 

--- a/packages/transaction-controller/src/utils/gas.ts
+++ b/packages/transaction-controller/src/utils/gas.ts
@@ -6,7 +6,12 @@ import {
 } from '@metamask/controller-utils';
 import type { NetworkClientId } from '@metamask/network-controller';
 import type { Hex, Json } from '@metamask/utils';
-import { add0x, createModuleLogger, remove0x } from '@metamask/utils';
+import {
+  add0x,
+  createModuleLogger,
+  isStrictHexString,
+  remove0x,
+} from '@metamask/utils';
 import { BigNumber } from 'bignumber.js';
 
 import { simulateTransactions } from '../api/simulation-api.js';
@@ -161,7 +166,7 @@ export async function estimateGas({
   log('Estimation fallback values', fallback);
 
   request.data = data ? add0x(data) : data;
-  request.value = value ?? '0x0';
+  request.value = normalizeValue(value);
 
   request.authorizationList = normalizeAuthorizationList(
     request.authorizationList,
@@ -779,6 +784,28 @@ function normalizeAuthorizationList(
     s: authorization.s ?? DUMMY_AUTHORIZATION_SIGNATURE,
     yParity: authorization.yParity ?? '0x1',
   }));
+}
+
+/**
+ * Normalize the value to a canonical hex quantity with no leading zero digits.
+ * Some RPC nodes (e.g. Go's `hexutil`) reject quantities such as `0x00` or
+ * `0x0de0b6b3a7640000`, failing gas estimation entirely.
+ *
+ * @param value - The transaction value to normalize.
+ * @returns The normalized transaction value.
+ */
+function normalizeValue(value: string | undefined): string {
+  if (value === undefined) {
+    return '0x0';
+  }
+
+  if (!isStrictHexString(value)) {
+    return value;
+  }
+
+  const stripped = remove0x(value).replace(/^0+/u, '');
+
+  return stripped.length === 0 ? '0x0' : add0x(stripped);
 }
 
 /**

--- a/packages/transaction-controller/src/utils/gas.ts
+++ b/packages/transaction-controller/src/utils/gas.ts
@@ -795,15 +795,13 @@ function normalizeAuthorizationList(
  * @returns The normalized transaction value.
  */
 function normalizeValue(value: string | undefined): string {
-  if (value === undefined) {
-    return '0x0';
+  const valueOrDefault = value ?? '0x0';
+
+  if (!isStrictHexString(valueOrDefault)) {
+    return valueOrDefault;
   }
 
-  if (!isStrictHexString(value)) {
-    return value;
-  }
-
-  const stripped = remove0x(value).replace(/^0+/u, '');
+  const stripped = remove0x(valueOrDefault).replace(/^0+/u, '');
 
   return stripped.length === 0 ? '0x0' : add0x(stripped);
 }


### PR DESCRIPTION
## Explanation

Some RPC nodes strictly parse hex quantities (Go's `hexutil`) and reject `eth_estimateGas` requests when the transaction `value` contains leading zero digits, e.g. `0x00` or `0x0de0b6b3a7640000`:

```
json: cannot unmarshal hex number with leading zero digits into Go struct field TransactionArgs.value of type *hexutil.Big
```

Dapp libraries commonly pad hex to an even byte length (e.g. ethers v6 `toBeHex(0)` returns `0x00`), so dapp-provided values can hit this on strict chains. When the estimate call fails, the controller silently falls back to a percentage of the block gas limit, which can exceed a chain's per-transaction gas cap and cause every submission to fail.

This change normalizes `value` in the `eth_estimateGas` request built by `estimateGas()`:

- Strips leading zero digits from strict hex strings (`0x00` → `0x0`, `0x0de0b6b3a7640000` → `0xde0b6b3a7640000`).
- Keeps the existing nullish default (`0x0`).
- Leaves non-hex input untouched so it still fails into the fallback path as before.

`data` is intentionally not touched — it is bytes, not a quantity, so leading zeros are semantic there.

## References

- Related to CONF-1740
- Same failure mode as #4897, which fixed the `gas` field by removing computed fields from the estimate request; `value` cannot be removed, so it is normalized instead

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to gas-estimate request shaping with explicit tests; no auth or submission-path changes.
> 
> **Overview**
> Fixes gas estimation failures on RPC nodes that reject non-canonical hex **quantities** in `eth_estimateGas` (e.g. Go `hexutil` rejecting `0x00` or `0x0de0b6b3a7640000`), which often comes from dapp libraries padding `value` to even byte length.
> 
> **`estimateGas()`** now runs transaction `value` through a new **`normalizeValue`** helper before the RPC call: nullish still becomes `0x0`, strict hex strings lose leading zero digits, and non-hex input is left unchanged so existing error/fallback behavior is preserved. **`data`** is unchanged (byte data, not a quantity).
> 
> Tests cover the value matrix; the changelog documents the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f8142279be1ddc65ee07e8563c099d942ccad5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->