### PR TITLE
feat(transaction-controller): extend isSimulationEnabled to include transaction

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `@metamask/core-backend` from `^8.1.1` to `^8.1.2` ([#9886](https://github.com/MetaMask/core/pull/9886))
+- Extend `isSimulationEnabled` option to accept an optional `TransactionMeta` argument, enabling callback consumers to inspect the relevant transaction ([#9800](https://github.com/MetaMask/core/pull/9800))
 
 ## [69.5.2]
 

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Extend `isSimulationEnabled` option to accept an optional `TransactionMeta` argument, enabling callback consumers to inspect the relevant transaction ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
+- Extend `isSimulationEnabled` option to accept an optional `TransactionMeta` argument, enabling callback consumers to inspect the relevant transaction ([#9800](https://github.com/MetaMask/core/pull/9800))
 
 ## [69.5.1]
 

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Extend `isSimulationEnabled` option to accept an optional `TransactionMeta` argument, enabling callback consumers to inspect the relevant transaction ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
+
 ## [69.5.1]
 
 ### Changed

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -2662,6 +2662,30 @@ describe('TransactionController', () => {
         });
       });
 
+      it('passes the transaction meta to the isSimulationEnabled callback', async () => {
+        const isSimulationEnabled = jest.fn().mockReturnValue(true);
+
+        const { controller } = setupController({
+          options: { isSimulationEnabled },
+        });
+
+        const { transactionMeta } = await controller.addTransaction(
+          {
+            from: ACCOUNT_MOCK,
+            to: ACCOUNT_MOCK,
+          },
+          {
+            networkClientId: NETWORK_CLIENT_ID_MOCK,
+          },
+        );
+
+        await flushPromises();
+
+        expect(isSimulationEnabled).toHaveBeenCalledWith(
+          expect.objectContaining({ id: transactionMeta.id }),
+        );
+      });
+
       it('unless approval not required', async () => {
         getBalanceChangesMock.mockResolvedValueOnce({
           simulationData: SIMULATION_DATA_RESULT_MOCK,

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -2711,6 +2711,30 @@ describe('TransactionController', () => {
         });
       });
 
+      it('passes the transaction meta to the isSimulationEnabled callback', async () => {
+        const isSimulationEnabled = jest.fn().mockReturnValue(true);
+
+        const { controller } = setupController({
+          options: { isSimulationEnabled },
+        });
+
+        const { transactionMeta } = await controller.addTransaction(
+          {
+            from: ACCOUNT_MOCK,
+            to: ACCOUNT_MOCK,
+          },
+          {
+            networkClientId: NETWORK_CLIENT_ID_MOCK,
+          },
+        );
+
+        await flushPromises();
+
+        expect(isSimulationEnabled).toHaveBeenCalledWith(
+          expect.objectContaining({ id: transactionMeta.id }),
+        );
+      });
+
       it('unless approval not required', async () => {
         getBalanceChangesMock.mockResolvedValueOnce({
           simulationData: SIMULATION_DATA_RESULT_MOCK,

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -843,7 +843,7 @@ export class TransactionController extends BaseController<
       ((): Promise<boolean> => Promise.resolve(false));
     this.#isFirstTimeInteractionEnabled =
       isFirstTimeInteractionEnabled ?? ((): boolean => true);
-    this.#isSimulationEnabled = isSimulationEnabled ?? ((_txMeta?: TransactionMeta): boolean => true);
+    this.#isSimulationEnabled = isSimulationEnabled ?? ((): boolean => true);
     this.#isSwapsDisabled = disableSwaps ?? false;
     this.#isTimeoutEnabled = isTimeoutEnabled ?? ((): boolean => true);
     this.#publicKeyEIP7702 = publicKeyEIP7702;

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -374,7 +374,7 @@ export type TransactionControllerOptions = {
   isFirstTimeInteractionEnabled?: () => boolean;
 
   /** Whether new transactions will be automatically simulated. */
-  isSimulationEnabled?: () => boolean;
+  isSimulationEnabled?: (transactionMeta?: TransactionMeta) => boolean;
 
   /** Whether timeout checking is enabled for a transaction. */
   isTimeoutEnabled?: (transactionMeta: TransactionMeta) => boolean;
@@ -750,7 +750,7 @@ export class TransactionController extends BaseController<
 
   readonly #isFirstTimeInteractionEnabled: () => boolean;
 
-  readonly #isSimulationEnabled: () => boolean;
+  readonly #isSimulationEnabled: (transactionMeta?: TransactionMeta) => boolean;
 
   readonly #isSwapsDisabled: boolean;
 
@@ -843,7 +843,7 @@ export class TransactionController extends BaseController<
       ((): Promise<boolean> => Promise.resolve(false));
     this.#isFirstTimeInteractionEnabled =
       isFirstTimeInteractionEnabled ?? ((): boolean => true);
-    this.#isSimulationEnabled = isSimulationEnabled ?? ((): boolean => true);
+    this.#isSimulationEnabled = isSimulationEnabled ?? ((_txMeta?: TransactionMeta): boolean => true);
     this.#isSwapsDisabled = disableSwaps ?? false;
     this.#isTimeoutEnabled = isTimeoutEnabled ?? ((): boolean => true);
     this.#publicKeyEIP7702 = publicKeyEIP7702;
@@ -4039,7 +4039,7 @@ export class TransactionController extends BaseController<
         validateTxParams(transactionMeta.txParams);
       }
 
-      if (!skipResimulateCheck && this.#isSimulationEnabled()) {
+      if (!skipResimulateCheck && this.#isSimulationEnabled(transactionMeta)) {
         resimulateResponse = shouldResimulate(
           originalTransactionMeta,
           transactionMeta,
@@ -4109,7 +4109,7 @@ export class TransactionController extends BaseController<
     this.#simulationRequestTokens.set(transactionId, simulationRequestToken);
 
     try {
-      const isSimulationEnabled = this.#isSimulationEnabled();
+      const isSimulationEnabled = this.#isSimulationEnabled(transactionMeta);
       const isBalanceChangesSkipped =
         this.#isBalanceChangesSkipped(transactionMeta);
 
@@ -4327,7 +4327,7 @@ export class TransactionController extends BaseController<
 
     await updateGas({
       isCustomNetwork,
-      isSimulationEnabled: this.#isSimulationEnabled(),
+      isSimulationEnabled: this.#isSimulationEnabled(transactionMeta),
       getSimulationConfig: this.#getSimulationConfig,
       messenger: this.messenger,
       txMeta: transactionMeta,

--- a/packages/transaction-controller/src/utils/batch.ts
+++ b/packages/transaction-controller/src/utils/batch.ts
@@ -85,7 +85,7 @@ type AddTransactionBatchRequest = {
   ) => PendingTransactionTracker;
   getSimulationConfig: GetSimulationConfig;
   getTransaction: (id: string) => TransactionMeta;
-  isSimulationEnabled: () => boolean;
+  isSimulationEnabled: (transactionMeta?: TransactionMeta) => boolean;
   messenger: TransactionControllerMessenger;
   publishBatchHook?: PublishBatchHook;
   publishTransaction: (transactionMeta: TransactionMeta) => Promise<Hex>;


### PR DESCRIPTION
## Explanation

The `isSimulationEnabled` constructor option on `TransactionController` previously had the type `() => boolean`, giving consumers no visibility into which transaction triggered the check. This made it impossible to implement per-transaction simulation policies (e.g. skip simulation for certain transaction types, origins, or chain IDs).

This change updates the callback signature to `(transactionMeta?: TransactionMeta) => boolean`. The argument is optional so the change is backward-compatible — existing consumers that pass `() => boolean` continue to compile without modification. All three call sites that have a `TransactionMeta` in scope (`#updateTransactionInternal`, `#updateSimulationData`, `#updateGasEstimate`) now forward the meta; the two remaining call sites (`estimateGas`, `estimateGasBuffered`) and the batch utility pass no argument, which is valid given the optional typing.

The matching `isSimulationEnabled` member of `AddTransactionBatchRequest` in `batch.ts` is updated to the same signature.

## References

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible optional callback signature with localized call-site updates; behavior unchanged unless consumers opt into per-transaction logic.
> 
> **Overview**
> Extends the **`isSimulationEnabled`** constructor option (and the matching **`AddTransactionBatchRequest`** field in `batch.ts`) from `() => boolean` to **`(transactionMeta?: TransactionMeta) => boolean`**, so hosts can turn simulation on or off per transaction (e.g. by type, origin, or chain).
> 
> Where **`TransactionMeta`** is in scope, the controller now passes it into the callback for **resimulation checks**, **simulation data updates**, and **gas estimate updates**. Paths that lack a specific meta (e.g. some estimate helpers) still call the callback with no argument; existing `() => boolean` implementations remain valid because the parameter is optional.
> 
> Adds a test that **`addTransaction`** invokes **`isSimulationEnabled`** with the new transaction’s meta, and documents the change in the package changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7585e3ab863b53f2eef1c5c4dcb8814e6668b72b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->