### PR TITLE
fix(eth-json-rpc-middleware): validate typed-data keys on eth_signTypedData_v3

### DIFF
--- a/packages/eth-json-rpc-middleware/src/wallet.test.ts
+++ b/packages/eth-json-rpc-middleware/src/wallet.test.ts
@@ -659,6 +659,42 @@ describe('wallet', () => {
         '0x68dc980608bceb5f99f691e62c32caccaee05317309015e9454eba1a14c3cd4505d1dd098b8339801239c9bcaac3c4df95569dcf307108b92f68711379be14d81c',
       );
     });
+
+    it('should throw if message data contains extraneous keys', async () => {
+      const getAccounts = async (): Promise<string[]> => testAddresses.slice();
+      const processTypedMessageV3 = async (): Promise<string> => testMsgSig;
+      const engine = JsonRpcEngineV2.create({
+        middleware: [
+          createWalletMiddleware({ getAccounts, processTypedMessageV3 }),
+        ],
+      });
+
+      const message = {
+        types: {
+          EIP712Domain: [
+            { name: 'name', type: 'string' },
+            { name: 'version', type: 'string' },
+            { name: 'chainId', type: 'uint256' },
+            { name: 'verifyingContract', type: 'address' },
+          ],
+        },
+        primaryType: 'EIP712Domain',
+        domain: {
+          verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+        },
+        message: {},
+        extraKey: 'unexpected',
+      };
+
+      const payload = {
+        method: 'eth_signTypedData_v3',
+        params: [testAddresses[0], JSON.stringify(message)],
+      };
+
+      await expect(
+        engine.handle(...createHandleParams(payload)),
+      ).rejects.toThrow('Invalid input.');
+    });
   });
 
   describe('signTypedDataV4', () => {

--- a/packages/eth-json-rpc-middleware/src/wallet.ts
+++ b/packages/eth-json-rpc-middleware/src/wallet.ts
@@ -371,6 +371,7 @@ export function createWalletMiddleware({
 
     const address = await validateAndNormalizeKeyholder(params[0], context);
     const message = normalizeTypedMessage(params[1]);
+    validateTypedMessageKeys(message);
     validatePrimaryType(message);
     validateVerifyingContract(message);
     validateTypedDataForPrototypePollution(message);


### PR DESCRIPTION
## Summary
- `eth_signTypedData_v4` already calls `validateTypedMessageKeys` after normalize; `eth_signTypedData_v3` skipped it.
- Add the same check so V3 rejects EIP-712 payloads with extraneous top-level keys before `processTypedMessageV3`.
- Mirror the existing V4 unit test for extraneous keys on the V3 path.

## Test plan
- [x] Added `should throw if message data contains extraneous keys` under `signTypedDataV3`
- [ ] CI: `@metamask/eth-json-rpc-middleware` jest suite


Made with [Cursor](https://cursor.com)