### PR TITLE
fix: restore isCurrentlyOwned when re-adding an NFT

### DIFF
--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Correct Somnia (`5031`/`0x13a7`)'s `SPOT_PRICES_SUPPORT_INFO` entry in `codefi-v2.ts` from the invented `slip44:111115031` placeholder to `slip44:5031`, now that Somnia has a real SLIP-44 registry entry ([#9811](https://github.com/MetaMask/core/pull/9811))
+- Fix `addNft` and `addNftVerifyOwnership` not restoring `isCurrentlyOwned` when re-adding an NFT that was previously flagged as not currently owned, which left re-acquired NFTs permanently hidden in the UI ([#9787](https://github.com/MetaMask/core/issues/9787))
 
 ## [111.1.0]
 

--- a/packages/assets-controllers/src/NftController.test.ts
+++ b/packages/assets-controllers/src/NftController.test.ts
@@ -3483,6 +3483,53 @@ describe('NftController', () => {
         tokenURI,
       });
     });
+
+    it('should restore isCurrentlyOwned when re-adding an NFT that was previously flagged as not currently owned', async () => {
+      const tokenURI = 'https://url/';
+      const mockGetERC721TokenURI = jest.fn().mockResolvedValue(tokenURI);
+      const { nftController } = setupController({
+        getERC721TokenURI: mockGetERC721TokenURI,
+        options: {
+          state: {
+            allNfts: {
+              [OWNER_ACCOUNT.address]: {
+                [ChainId.mainnet]: [
+                  {
+                    address: '0x01',
+                    chainId: convertHexToDecimal(ChainId.mainnet),
+                    description: 'description',
+                    image: 'url',
+                    name: 'name',
+                    tokenId: '1234',
+                    standard: ERC721,
+                    favorite: false,
+                    isCurrentlyOwned: false,
+                    tokenURI,
+                  },
+                ],
+              },
+            },
+          },
+        },
+      });
+
+      jest.spyOn(nftController, 'isNftOwner').mockResolvedValue(true);
+
+      nock('https://url')
+        .get('/')
+        .reply(200, {
+          name: 'name',
+          image: 'url',
+          description: 'description',
+        })
+        .persist();
+      await nftController.addNftVerifyOwnership('0x01', '1234', 'mainnet');
+
+      expect(
+        nftController.state.allNfts[OWNER_ACCOUNT.address][ChainId.mainnet][0]
+          .isCurrentlyOwned,
+      ).toBe(true);
+    });
   });
 
   describe('removeNft', () => {

--- a/packages/assets-controllers/src/NftController.ts
+++ b/packages/assets-controllers/src/NftController.ts
@@ -951,6 +951,13 @@ export class NftController extends BaseController<
               allNftsForUserPerChain[chainId][indexToUpdate] = {
                 ...existingEntry,
                 ...nftMetadata,
+                // Ownership is re-confirmed on the manual import path
+                // (Source.Custom reaches this code only after ownership has
+                // been verified on-chain), so restore the flag instead of
+                // preserving a stale `isCurrentlyOwned: false`.
+                ...(source === Source.Custom
+                  ? { isCurrentlyOwned: true }
+                  : {}),
               };
             }
           } else {


### PR DESCRIPTION
## Description

Fixes #9787

When an NFT leaves a wallet and is later re-acquired, the manual import path
reports success but the NFT stays invisible. `#addMultipleNfts` refreshes an
existing state entry with `{ ...existingEntry, ...nftMetadata }`, and because
`nftMetadata` never carries `isCurrentlyOwned`, the stale `isCurrentlyOwned:
false` written earlier by `checkAndUpdateSingleNftOwnershipStatus` survives the
merge.

Ownership is already proven on the manual import path: `addNftVerifyOwnership`
throws unless the user owns the token on-chain, and `addNft`/`addNfts` default
to `Source.Custom` when invoked for manual imports. This PR restores
`isCurrentlyOwned: true` when refreshing an existing entry on the
`Source.Custom` path, so re-acquired NFTs reappear. Other sources (autodetection
`Source.Detected`, dapp-suggested `Source.Dapp`) are untouched.

## Changes

- `packages/assets-controllers/src/NftController.ts`: restore `isCurrentlyOwned`
  to `true` in `#addMultipleNfts` when `source === Source.Custom`.
- `packages/assets-controllers/src/NftController.test.ts`: add a regression test
  that re-adds a previously-unowned NFT via `addNftVerifyOwnership` and asserts
  `isCurrentlyOwned` flips back to `true`.
- `packages/assets-controllers/CHANGELOG.md`: add `[Unreleased]` `Fixed` entry.

## Test plan

```sh
cd packages/assets-controllers
NODE_OPTIONS=--experimental-vm-modules yarn jest src/NftController.test.ts src/NftDetectionController.test.ts --coverage=false
```

- New regression test fails on `main` (`Expected: true, Received: false`) and
  passes with the fix.
- `NftController.test.ts`: 117 passed, 4 snapshots.
- `NftDetectionController.test.ts`: 20 passed.
- `eslint` clean on changed files; `changelog:validate` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow fix to manual NFT import merge logic with a targeted regression test; no auth, security, or broad behavioral changes outside Custom source updates.
> 
> **Overview**
> Fixes re-acquired NFTs staying hidden after a successful manual import when state still had **`isCurrentlyOwned: false`** from an earlier ownership check.
> 
> In **`#addMultipleNfts`**, updating an existing entry now sets **`isCurrentlyOwned: true`** when **`source === Source.Custom`** (manual import / **`addNftVerifyOwnership`**), instead of leaving the stale flag from the spread merge. Autodetection and dapp-suggested sources are unchanged.
> 
> Adds a regression test for **`addNftVerifyOwnership`** and an **`[Unreleased]`** changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13aba0e396fd2b645051bfe745bc64988ffa0875. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->