### PR TITLE
fix(transaction-controller): Skip resimulation check when failing incomplete transactions at boot

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Skip resimulation check when failing incomplete transactions at startup, preventing a crash when `isSimulationEnabled` depends on controllers not yet registered ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
+- Skip resimulation check when failing incomplete transactions at startup, preventing a crash when `isSimulationEnabled` depends on controllers not yet registered ([#9821](https://github.com/MetaMask/core/pull/9821))
 
 ### Changed
 

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,13 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Skip resimulation check when failing incomplete transactions at startup, preventing a crash when `isSimulationEnabled` depends on controllers not yet registered ([#9821](https://github.com/MetaMask/core/pull/9821))
-
 ### Changed
 
 - Bump `@metamask/accounts-controller` from `^39.0.7` to `^39.1.0` ([#9807](https://github.com/MetaMask/core/pull/9807))
+
+### Fixed
+
+- Skip resimulation check when failing incomplete transactions at startup, preventing a crash when `isSimulationEnabled` depends on controllers not yet registered ([#9821](https://github.com/MetaMask/core/pull/9821))
 
 ## [69.5.1]
 

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Skip resimulation check when failing incomplete transactions at startup, preventing a crash when `isSimulationEnabled` depends on controllers not yet registered ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
+
 ### Changed
 
 - Bump `@metamask/accounts-controller` from `^39.0.7` to `^39.1.0` ([#9807](https://github.com/MetaMask/core/pull/9807))

--- a/packages/transaction-controller/src/TransactionController.test.ts
+++ b/packages/transaction-controller/src/TransactionController.test.ts
@@ -1275,6 +1275,55 @@ describe('TransactionController', () => {
       );
     });
 
+    it('fails signed transactions even when isSimulationEnabled throws', async () => {
+      const mockTransactionMeta = {
+        from: ACCOUNT_MOCK,
+        txParams: {
+          from: ACCOUNT_MOCK,
+          to: ACCOUNT_2_MOCK,
+        },
+      };
+
+      const mockedTransactions = [
+        {
+          id: '111',
+          chainId: toHex(5),
+          status: TransactionStatus.signed,
+          ...mockTransactionMeta,
+        },
+        {
+          id: '222',
+          chainId: toHex(1),
+          status: TransactionStatus.approved,
+          ...mockTransactionMeta,
+        },
+      ];
+
+      const mockedControllerState = {
+        transactions: mockedTransactions,
+        methodData: {},
+        lastFetchedBlockNumbers: {},
+      };
+
+      const { controller } = setupController({
+        options: {
+          isSimulationEnabled: () => {
+            throw new Error('Handler not registered');
+          },
+          // TODO: Replace `any` with type
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          state: mockedControllerState as any,
+        },
+      });
+
+      await flushPromises();
+
+      const { transactions } = controller.state;
+
+      expect(transactions[0].status).toBe(TransactionStatus.failed);
+      expect(transactions[1].status).toBe(TransactionStatus.failed);
+    });
+
     it('removes unapproved transactions', async () => {
       const mockTransactionMeta = {
         from: ACCOUNT_MOCK,

--- a/packages/transaction-controller/src/TransactionController.ts
+++ b/packages/transaction-controller/src/TransactionController.ts
@@ -4388,6 +4388,7 @@ export class TransactionController extends BaseController<
         {
           transactionId: transactionMeta.id,
           skipValidation: true,
+          skipResimulateCheck: true,
         },
         (draftTransactionMeta) => {
           draftTransactionMeta.status = TransactionStatus.failed;


### PR DESCRIPTION
## Explanation

When `TransactionController` is constructed, `#onBootCleanup()` runs `#failIncompleteTransactions()` to transition any `signed` or `approved` transactions to `failed`. This calls `#failTransaction()`, which internally calls `#updateTransactionInternal()`.

The problem is that `#updateTransactionInternal()` calls `this.#isSimulationEnabled()` for its resimulation check. In mobile, the `isSimulationEnabled` callback calls `PreferencesController:getState` via the messenger — but this is a **controller initialization order problem**: `TransactionController` is constructed inside `Wallet` during `Engine.init`, and at that point `PreferencesController` has not yet registered its action handler on the root messenger. The `PreferencesController` is a mobile-only controller that does not exist in the `@metamask/wallet` package, so the Wallet has no way to guarantee its availability during `TransactionController` construction.

This causes `#failTransaction` to throw, and the catch block creates a fallback `TransactionMeta` with `status: failed` but **never writes it back to state**. The transaction remains `signed` in persisted state permanently, surviving every app restart.

The fix adds `skipResimulateCheck: true` to the `#updateTransactionInternal` call inside `#failTransaction`. There is no reason to check whether a transaction needs resimulation when the intent is to mark it as failed.

## References

- Discovered via MetaMask Mobile: a `batch` transaction on Arbitrum (`0xa4b1`) stuck in `signed` status indefinitely across app restarts

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to the failure update path at boot with a targeted test; no API or simulation behavior changes for normal transaction flows.
> 
> **Overview**
> Fixes startup cleanup so **signed/approved** transactions left over from a prior session are reliably marked **failed** instead of staying stuck in **signed**.
> 
> `#failTransaction` now passes **`skipResimulateCheck: true`** into `#updateTransactionInternal`, so boot-time failure no longer runs the resimulation path that calls **`isSimulationEnabled`**. That avoids throws when the callback depends on controllers (e.g. mobile `PreferencesController`) that are not registered yet during `TransactionController` construction—previously the error could prevent the failed status from being persisted.
> 
> Adds a regression test where **`isSimulationEnabled` throws** and both **signed** and **approved** txs still end up **failed**, plus an **Unreleased** changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0935188e0c25792072f243a7e6750e804e0bce9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->