### PR TITLE
fix: populate QuotesReceived usd_amount_source property

### DIFF
--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Populate QuotesReceived event's `usd_amount_source` property
+- Populate QuotesReceived event's `usd_amount_source` property ([#9828](https://github.com/MetaMask/core/pull/9828))
 
 ## [79.0.1]
 

--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/assets-controllers` from `^111.0.0` to `^111.1.0` ([#9793](https://github.com/MetaMask/core/pull/9793))
 - Bump `@metamask/assets-controller` from `^13.1.1` to `^13.1.2` ([#9813](https://github.com/MetaMask/core/pull/9813))
 
+### Fixed
+
+- Populate QuotesReceived event's `usd_amount_source` property
+
 ## [79.0.1]
 
 ### Changed

--- a/packages/bridge-controller/src/utils/metrics/properties.test.ts
+++ b/packages/bridge-controller/src/utils/metrics/properties.test.ts
@@ -438,6 +438,7 @@ describe('properties', () => {
           "quoted_time_minutes": 1,
           "token_symbol_destination": "USDC",
           "token_symbol_source": "ETH",
+          "usd_amount_source": 0,
           "usd_balance_source": 0,
           "usd_quoted_gas": 0,
           "usd_quoted_return": 0,

--- a/packages/bridge-controller/src/utils/metrics/properties.ts
+++ b/packages/bridge-controller/src/utils/metrics/properties.ts
@@ -178,6 +178,7 @@ export const getQuotesReceivedProperties = (
     usd_quoted_gas: Number(activeQuote?.quote?.feeData?.network?.[0]?.usd ?? 0),
     usd_quoted_return: Number(activeQuote?.quote?.dest?.usd ?? 0),
     usd_balance_source: usdBalanceSource ?? 0,
+    usd_amount_source: Number(activeQuote?.quote?.src?.usd ?? 0),
     best_quote_provider: recommendedQuote
       ? formatProviderLabel(recommendedQuote.quote)
       : provider,

--- a/packages/bridge-controller/src/utils/metrics/types.ts
+++ b/packages/bridge-controller/src/utils/metrics/types.ts
@@ -231,6 +231,7 @@ type RequiredEventContextFromClientBase = {
       can_submit: QuoteFetchData['can_submit'];
       usd_balance_source?: number;
       has_sufficient_gas_for_quote?: boolean | null;
+      usd_amount_source: number;
     };
   [UnifiedSwapBridgeEventName.QuotesError]: Pick<
     RequestMetadata,

--- a/packages/bridge-status-controller/CHANGELOG.md
+++ b/packages/bridge-status-controller/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Include `usd_amount_source` value in QuotesReceived MixPanel event properties ([#9828](https://github.com/MetaMask/core/pull/9828))
 - Include quote's `slippage` value in post-submission MixPanel event properties ([#9786](https://github.com/MetaMask/core/pull/9786))
 
 ## [75.0.0]

--- a/packages/bridge-status-controller/src/__snapshots__/bridge-status-controller.test.ts.snap
+++ b/packages/bridge-status-controller/src/__snapshots__/bridge-status-controller.test.ts.snap
@@ -1287,6 +1287,7 @@ exports[`BridgeStatusController submitTx: EVM bridge should handle smart transac
       "quoted_time_minutes": 0.25,
       "token_symbol_destination": "ETH",
       "token_symbol_source": "ETH",
+      "usd_amount_source": 1.01,
       "usd_balance_source": 0,
       "usd_quoted_gas": 2.5778,
       "usd_quoted_return": 0.134214,


### PR DESCRIPTION
## Explanation

Adds `usd_amount_source` property to event payload

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Fixes https://consensyssoftware.atlassian.net/browse/SWAPS-4857

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only change to event payload properties; no auth, transaction, or data-handling logic is affected.
> 
> **Overview**
> Fixes the **QuotesReceived** MixPanel event so it includes the missing `usd_amount_source` property.
> 
> `getQuotesReceivedProperties` now sets `usd_amount_source` from the active quote's source USD value (`quote.src.usd`), and the event type requires that field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc6c2e214a385ccdc24d6a4e6503c10baacd3104. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->