### PR TITLE
fix(eth-block-tracker): promote @metamask/json-rpc-engine to a production dependency

### DIFF
--- a/packages/eth-block-tracker/CHANGELOG.md
+++ b/packages/eth-block-tracker/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Promote `@metamask/json-rpc-engine` from a dev dependency to a production dependency, so the `ContextConstraint` and `MiddlewareContext` types it contributes to `PollingBlockTracker`'s public declaration files resolve for downstream consumers ([#6864](https://github.com/MetaMask/core/issues/6864))
 - Deduplicate concurrent `checkForLatestBlock()` calls so they share a single ongoing request and resolve to the same promise, instead of each issuing its own `eth_blockNumber` request ([#7905](https://github.com/MetaMask/core/pull/7905))
 
 ## [15.0.1]

--- a/packages/eth-block-tracker/package.json
+++ b/packages/eth-block-tracker/package.json
@@ -56,13 +56,13 @@
   },
   "dependencies": {
     "@metamask/eth-json-rpc-provider": "^6.0.1",
+    "@metamask/json-rpc-engine": "^10.5.0",
     "@metamask/safe-event-emitter": "^3.0.0",
     "@metamask/utils": "^11.11.0",
     "json-rpc-random-id": "^1.0.1"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^6.1.0",
-    "@metamask/json-rpc-engine": "^10.5.0",
     "@ts-bridge/cli": "^0.6.4",
     "@types/jest": "^30.0.0",
     "@types/json-rpc-random-id": "^1.0.1",

--- a/packages/eth-block-tracker/src/dependencies.test.ts
+++ b/packages/eth-block-tracker/src/dependencies.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+describe('@metamask/eth-block-tracker package manifest', () => {
+  it('declares @metamask/json-rpc-engine as a production dependency', () => {
+    // `PollingBlockTracker.ts` imports the `ContextConstraint` and
+    // `MiddlewareContext` types from `@metamask/json-rpc-engine/v2` with a
+    // type-only import. Those types leak into the published declaration files
+    // through `PollingBlockTrackerOptions` and the `PollingBlockTracker` class
+    // generic, so consumers need `@metamask/json-rpc-engine` resolvable when
+    // type-checking against this package. It must therefore be a production
+    // dependency rather than only a devDependency.
+    //
+    // Regression test for https://github.com/MetaMask/core/issues/6864
+    const packageJsonPath = resolve(__dirname, '..', 'package.json');
+    const { dependencies } = JSON.parse(
+      readFileSync(packageJsonPath, 'utf8'),
+    ) as { dependencies: Record<string, string> };
+
+    expect(dependencies['@metamask/json-rpc-engine']).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #6864

`@metamask/json-rpc-engine` is only declared as a `devDependency` of `@metamask/eth-block-tracker`, but `PollingBlockTracker.ts` imports the `ContextConstraint` and `MiddlewareContext` types from `@metamask/json-rpc-engine/v2` with a type-only import. Those types appear in the published declaration files through `PollingBlockTrackerOptions` and the `PollingBlockTracker` class generic, so downstream consumers that type-check against the published package need `@metamask/json-rpc-engine` resolvable. Today the resolution happens to work because `@metamask/json-rpc-engine` is pulled in transitively through `@metamask/eth-json-rpc-provider`; declaring it only as a dev dependency makes the dependency graph correct by accident rather than by contract.

## Changes

- `packages/eth-block-tracker/package.json`: promote `@metamask/json-rpc-engine` from `devDependencies` to `dependencies`. The range is unchanged (`^10.5.0`), matching the version the source imports and the version `@metamask/eth-json-rpc-provider` already requires.
- `packages/eth-block-tracker/src/dependencies.test.ts`: add a regression test asserting `@metamask/json-rpc-engine` is declared as a production dependency. It fails on `main` and passes with this change.
- `packages/eth-block-tracker/CHANGELOG.md`: add an `[Unreleased]` `Fixed` entry.

## Test plan

```sh
cd packages/eth-block-tracker
NODE_OPTIONS=--experimental-vm-modules yarn exec jest src/dependencies.test.ts --coverage=false --silent=false
```

- Fails on `main`: `Expected: not undefined, Received: undefined`.
- Passes once `@metamask/json-rpc-engine` is declared in `dependencies`.

No `yarn.lock` change is needed: the lockfile records workspace dependency sets as a union, so moving a dependency between the `dependencies`/`devDependencies` sections does not alter the resolution metadata for `@metamask/eth-block-tracker`.

## Notes

- The `[Unreleased]` changelog entry currently links to the issue; it can be updated to this PR's number once assigned.
- Separate, unrelated change: this author has an open PR in the same repo for a different subsystem (`assets-controllers`, NFT ownership restore).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency classification fix with no runtime behavior change; only ensures types already used in public declarations are correctly declared.
> 
> **Overview**
> Promotes `@metamask/json-rpc-engine` from a **devDependency** to a **production dependency** so types that leak into `PollingBlockTracker`'s published declarations resolve for consumers.
> 
> `PollingBlockTracker` type-only-imports `ContextConstraint` and `MiddlewareContext`, which appear in public `.d.ts` files via `PollingBlockTrackerOptions` and the class generic. Declaring the package only as a dev dependency left resolution dependent on a transitive install. Adds a regression test that asserts the production dependency is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bfe741c53a0491e71707ddecd838cbaadbe882f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->