### PR TITLE
fix: fall back to zero-address for native tokens without slip44

### DIFF
--- a/packages/client-utils/CHANGELOG.md
+++ b/packages/client-utils/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Fall back to a zero-address ERC-20 CAIP-19 asset id (`eip155:<chainId>/erc20:0x000…000`) in `resolveNativeAssetId` and `getNativeAsset` when an EVM native has no SLIP-44 coin type (previously `undefined`)
+  - `resolveNativeAssetId` no longer requires a `symbol` on EVM chains for this fallback
+  - Non-EVM chains still return `undefined` when no slip44 entry is found
 - Bump `@metamask/transaction-controller` from `^69.5.0` to `^69.5.2` ([#9798](https://github.com/MetaMask/core/pull/9798), [#9823](https://github.com/MetaMask/core/pull/9823))
 
 ## [2.0.1]

--- a/packages/client-utils/CHANGELOG.md
+++ b/packages/client-utils/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fall back to a zero-address ERC-20 CAIP-19 asset id (`eip155:<chainId>/erc20:0x000…000`) in `resolveNativeAssetId` and `getNativeAsset` when an EVM native has no SLIP-44 coin type (previously `undefined`) ([#9833](https://github.com/MetaMask/core/pull/9833))
-  - `resolveNativeAssetId` no longer requires a `symbol` on EVM chains for this fallback
+  - `resolveNativeAssetId` consults chainlist via `getNativeAsset` before that fallback so symbol-less calls stay aligned with `getNativeAsset`
   - Non-EVM chains still return `undefined` when no slip44 entry is found
 - Bump `@metamask/transaction-controller` from `^69.5.0` to `^69.5.2` ([#9798](https://github.com/MetaMask/core/pull/9798), [#9823](https://github.com/MetaMask/core/pull/9823))
 

--- a/packages/client-utils/CHANGELOG.md
+++ b/packages/client-utils/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Fall back to a zero-address ERC-20 CAIP-19 asset id (`eip155:<chainId>/erc20:0x000…000`) in `resolveNativeAssetId` and `getNativeAsset` when an EVM native has no SLIP-44 coin type (previously `undefined`)
+- Fall back to a zero-address ERC-20 CAIP-19 asset id (`eip155:<chainId>/erc20:0x000…000`) in `resolveNativeAssetId` and `getNativeAsset` when an EVM native has no SLIP-44 coin type (previously `undefined`) ([#9833](https://github.com/MetaMask/core/pull/9833))
   - `resolveNativeAssetId` no longer requires a `symbol` on EVM chains for this fallback
   - Non-EVM chains still return `undefined` when no slip44 entry is found
 - Bump `@metamask/transaction-controller` from `^69.5.0` to `^69.5.2` ([#9798](https://github.com/MetaMask/core/pull/9798), [#9823](https://github.com/MetaMask/core/pull/9823))

--- a/packages/client-utils/src/mappers/helpers/caip.test.ts
+++ b/packages/client-utils/src/mappers/helpers/caip.test.ts
@@ -111,18 +111,35 @@ describe('caip helpers', () => {
       );
     });
 
-    it('falls back to the zero-address erc20 form on eip155 chains without a symbol', () => {
+    it('uses chainlist via getNativeAsset when symbol is missing but the chain has slip44', () => {
+      mockGetChainById.mockReturnValue({
+        slip44: 60,
+        nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+      } as ReturnType<typeof getChainById>);
+
       expect(resolveNativeAssetId('eip155:8453', undefined)).toBe(
-        'eip155:8453/erc20:0x0000000000000000000000000000000000000000',
-      );
-      expect(resolveNativeAssetId('eip155:4663', undefined)).toBe(
-        'eip155:4663/erc20:0x0000000000000000000000000000000000000000',
+        'eip155:8453/slip44:60',
       );
     });
 
-    it('falls back to the zero-address erc20 form on eip155 chains when the symbol has no slip44', () => {
+    it('falls back to the zero-address erc20 form when symbol and chainlist both miss slip44', () => {
+      mockGetChainById.mockReturnValue({
+        nativeCurrency: { name: 'Chiliz', symbol: 'CHZ', decimals: 18 },
+      } as ReturnType<typeof getChainById>);
+
       expect(resolveNativeAssetId('eip155:88888', 'CHZ')).toBe(
         'eip155:88888/erc20:0x0000000000000000000000000000000000000000',
+      );
+      expect(resolveNativeAssetId('eip155:88888', undefined)).toBe(
+        'eip155:88888/erc20:0x0000000000000000000000000000000000000000',
+      );
+    });
+
+    it('falls back to the zero-address erc20 form when the chain is absent from chainlist', () => {
+      mockGetChainById.mockReturnValue(undefined);
+
+      expect(resolveNativeAssetId('eip155:4663', undefined)).toBe(
+        'eip155:4663/erc20:0x0000000000000000000000000000000000000000',
       );
     });
 

--- a/packages/client-utils/src/mappers/helpers/caip.test.ts
+++ b/packages/client-utils/src/mappers/helpers/caip.test.ts
@@ -141,6 +141,11 @@ describe('caip helpers', () => {
     it('returns undefined when the chain id cannot be normalized', () => {
       expect(resolveNativeAssetId('0xzzzz', 'ETH')).toBeUndefined();
     });
+
+    it('returns undefined when chain id is missing', () => {
+      expect(resolveNativeAssetId(undefined, 'ETH')).toBeUndefined();
+      expect(resolveNativeAssetId(undefined, undefined)).toBeUndefined();
+    });
   });
 
   describe('getNativeAsset', () => {

--- a/packages/client-utils/src/mappers/helpers/caip.test.ts
+++ b/packages/client-utils/src/mappers/helpers/caip.test.ts
@@ -111,14 +111,30 @@ describe('caip helpers', () => {
       );
     });
 
-    it('returns undefined without a symbol', () => {
-      expect(resolveNativeAssetId('eip155:8453', undefined)).toBeUndefined();
-      expect(resolveNativeAssetId('eip155:4663', undefined)).toBeUndefined();
+    it('falls back to the zero-address erc20 form on eip155 chains without a symbol', () => {
+      expect(resolveNativeAssetId('eip155:8453', undefined)).toBe(
+        'eip155:8453/erc20:0x0000000000000000000000000000000000000000',
+      );
+      expect(resolveNativeAssetId('eip155:4663', undefined)).toBe(
+        'eip155:4663/erc20:0x0000000000000000000000000000000000000000',
+      );
     });
 
-    it('returns undefined for unknown symbols', () => {
+    it('falls back to the zero-address erc20 form on eip155 chains when the symbol has no slip44', () => {
+      expect(resolveNativeAssetId('eip155:88888', 'CHZ')).toBe(
+        'eip155:88888/erc20:0x0000000000000000000000000000000000000000',
+      );
+    });
+
+    it('returns undefined for non-eip155 chains without a slip44 hit', () => {
       expect(
         resolveNativeAssetId('solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp', 'NOPE'),
+      ).toBeUndefined();
+      expect(
+        resolveNativeAssetId(
+          'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+          undefined,
+        ),
       ).toBeUndefined();
     });
 
@@ -214,16 +230,21 @@ describe('caip helpers', () => {
       });
     });
 
-    it('returns undefined when slip44 and symbol lookup both fail', () => {
+    it('falls back to the zero-address erc20 assetId when slip44 and symbol lookup both fail', () => {
       mockGetChainById.mockReturnValue({
         nativeCurrency: {
-          name: 'Unknown',
-          symbol: 'NOTACOIN',
+          name: 'Chiliz',
+          symbol: 'CHZ',
           decimals: 18,
         },
       } as ReturnType<typeof getChainById>);
 
-      expect(getNativeAsset('eip155:1088')).toBeUndefined();
+      expect(getNativeAsset('eip155:88888')).toStrictEqual({
+        symbol: 'CHZ',
+        decimals: 18,
+        assetId:
+          'eip155:88888/erc20:0x0000000000000000000000000000000000000000',
+      });
     });
   });
 });

--- a/packages/client-utils/src/mappers/helpers/caip.test.ts
+++ b/packages/client-utils/src/mappers/helpers/caip.test.ts
@@ -111,7 +111,7 @@ describe('caip helpers', () => {
       );
     });
 
-    it('uses chainlist via getNativeAsset when symbol is missing but the chain has slip44', () => {
+    it('resolves when symbol is missing but the chain has slip44', () => {
       mockGetChainById.mockReturnValue({
         slip44: 60,
         nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },

--- a/packages/client-utils/src/mappers/helpers/caip.ts
+++ b/packages/client-utils/src/mappers/helpers/caip.ts
@@ -73,7 +73,7 @@ export function resolveNativeAssetId(
   chainId: string | number | undefined,
   symbol: string | undefined,
 ): CaipAssetType | undefined {
-  if (chainId === undefined || !symbol) {
+  if (chainId === undefined) {
     return undefined;
   }
 
@@ -83,21 +83,26 @@ export function resolveNativeAssetId(
     return undefined;
   }
 
-  const assetReference = getCoinType(symbol);
+  const { namespace, reference } = parseCaipChainId(caipChainId);
+  const assetReference = symbol ? getCoinType(symbol) : undefined;
 
-  if (!assetReference) {
-    return undefined;
+  if (assetReference) {
+    return toCaipAssetType(namespace, reference, 'slip44', assetReference);
   }
 
-  const { namespace, reference } = parseCaipChainId(caipChainId);
+  if (namespace === KnownCaipNamespace.Eip155) {
+    return toCaipAssetType(namespace, reference, 'erc20', nativeTokenAddress);
+  }
 
-  return toCaipAssetType(namespace, reference, 'slip44', assetReference);
+  return undefined;
 }
 
 /**
- * Resolves EVM native symbol, decimals, and slip44 asset id for a chain.
+ * Resolves EVM native symbol, decimals, and CAIP asset id for a chain.
  * Prefers eth-chainlist slip44 except testnet coin type 1, then falls back to
- * `@metamask/slip44` by native symbol.
+ * `@metamask/slip44` by native symbol. When both slip44 sources miss, falls
+ * back to the zero-address ERC-20 CAIP form (`erc20:0x000…000`) so chains with
+ * no assigned coin type (e.g. Chiliz) still get an asset id.
  *
  * @param chainId - CAIP-2 chain id (eip155 only).
  * @returns Native asset metadata, or undefined when it cannot be resolved.
@@ -130,14 +135,14 @@ export function getNativeAsset(chainId: CaipChainId):
       ? String(slip44)
       : getCoinType(nativeCurrency.symbol);
 
-  if (!assetReference) {
-    return undefined;
-  }
+  const assetId = assetReference
+    ? toCaipAssetType(namespace, reference, 'slip44', assetReference)
+    : toCaipAssetType(namespace, reference, 'erc20', nativeTokenAddress);
 
   return {
     symbol: nativeCurrency.symbol,
     decimals: nativeCurrency.decimals ?? nativeTokenDecimals,
-    assetId: toCaipAssetType(namespace, reference, 'slip44', assetReference),
+    assetId,
   };
 }
 

--- a/packages/client-utils/src/mappers/helpers/caip.ts
+++ b/packages/client-utils/src/mappers/helpers/caip.ts
@@ -90,7 +90,13 @@ export function resolveNativeAssetId(
   }
 
   if (namespace === KnownCaipNamespace.Eip155) {
-    return toCaipAssetType(namespace, reference, 'erc20', nativeTokenAddress);
+    // Prefer chainlist (same source as getNativeAsset) before the zero-address
+    // form so fee/token on one activity don't diverge when symbol is missing
+    // or has no slip44 entry.
+    return (
+      getNativeAsset(caipChainId)?.assetId ??
+      toCaipAssetType(namespace, reference, 'erc20', nativeTokenAddress)
+    );
   }
 
   return undefined;

--- a/packages/client-utils/src/mappers/helpers/caip.ts
+++ b/packages/client-utils/src/mappers/helpers/caip.ts
@@ -26,16 +26,15 @@ const slip44BySymbol = ((): Map<string, string> => {
     }
   }
 
-  const maticCoinType = coinTypeBySymbol.get('MATIC');
-  if (maticCoinType && !coinTypeBySymbol.has('POL')) {
-    coinTypeBySymbol.set('POL', maticCoinType);
-  }
-
   return coinTypeBySymbol;
 })();
 
 function getCoinType(symbol: string): string | undefined {
-  return slip44BySymbol.get(symbol.toUpperCase());
+  const normalizedSymbol = symbol.toUpperCase();
+  return (
+    slip44BySymbol.get(normalizedSymbol) ??
+    (normalizedSymbol === 'POL' ? slip44BySymbol.get('MATIC') : undefined)
+  );
 }
 
 /**

--- a/packages/client-utils/src/mappers/helpers/caip.ts
+++ b/packages/client-utils/src/mappers/helpers/caip.ts
@@ -90,9 +90,6 @@ export function resolveNativeAssetId(
   }
 
   if (namespace === KnownCaipNamespace.Eip155) {
-    // Prefer chainlist (same source as getNativeAsset) before the zero-address
-    // form so fee/token on one activity don't diverge when symbol is missing
-    // or has no slip44 entry.
     return (
       getNativeAsset(caipChainId)?.assetId ??
       toCaipAssetType(namespace, reference, 'erc20', nativeTokenAddress)
@@ -105,9 +102,7 @@ export function resolveNativeAssetId(
 /**
  * Resolves EVM native symbol, decimals, and CAIP asset id for a chain.
  * Prefers eth-chainlist slip44 except testnet coin type 1, then falls back to
- * `@metamask/slip44` by native symbol. When both slip44 sources miss, falls
- * back to the zero-address ERC-20 CAIP form (`erc20:0x000…000`) so chains with
- * no assigned coin type (e.g. Chiliz) still get an asset id.
+ * `@metamask/slip44` by native symbol.
  *
  * @param chainId - CAIP-2 chain id (eip155 only).
  * @returns Native asset metadata, or undefined when it cannot be resolved.

--- a/packages/client-utils/src/mappers/helpers/transactions.test.ts
+++ b/packages/client-utils/src/mappers/helpers/transactions.test.ts
@@ -353,7 +353,7 @@ describe('transaction helpers', () => {
       ]);
     });
 
-    it('keeps the nativeAssetSymbol on fees when it cannot be mapped to an assetId', () => {
+    it('falls back to the zero-address native assetId when the chain is unknown and the symbol has no slip44', () => {
       expect(
         getLocalTransactionFees({
           nativeAssetSymbol: 'NOTACOIN',
@@ -373,6 +373,8 @@ describe('transaction helpers', () => {
           decimals: 18,
           assetType: 'native',
           symbol: 'NOTACOIN',
+          assetId:
+            'eip155:999999991/erc20:0x0000000000000000000000000000000000000000',
         },
       ]);
     });

--- a/packages/client-utils/src/mappers/local-transaction-mapper.test.ts
+++ b/packages/client-utils/src/mappers/local-transaction-mapper.test.ts
@@ -41,7 +41,7 @@ describe('mapLocalTransaction', () => {
       },
     });
   });
-  it('maps a native send on an unknown chain without a ticker to a Send with amount, no symbol, and a zero-address native assetId', () => {
+  it('maps a native send on an unknown chain without a ticker to a Send with amount and a zero-address native assetId', () => {
     const item = mapLocalTransaction(
       localTransactionFixtures.mapInputs.mapsANativeSendOnAn,
     );
@@ -337,7 +337,7 @@ describe('mapLocalTransaction', () => {
       },
     });
   });
-  it('maps an incoming native transfer without nativeAssetSymbol to a Receive with the chainlist native assetId', () => {
+  it('maps an incoming native transfer without nativeAssetSymbol to a Receive with the native assetId', () => {
     const item = mapLocalTransaction(
       localTransactionFixtures.mapInputs.mapsAnIncomingNativeTransferTo,
     );
@@ -623,7 +623,7 @@ describe('mapLocalTransaction', () => {
       data: { from },
     });
   });
-  it('maps a WETH9 deposit contract interaction to a Wrap activity with a native source amount, no symbol, and the chainlist native assetId when nativeAssetSymbol is omitted', () => {
+  it('maps a WETH9 deposit contract interaction to a Wrap activity with a native source amount and the native assetId when nativeAssetSymbol is omitted', () => {
     const item = mapLocalTransaction(
       localTransactionFixtures.mapInputs.mapsAWeth9DepositContractInteraction,
     );

--- a/packages/client-utils/src/mappers/local-transaction-mapper.test.ts
+++ b/packages/client-utils/src/mappers/local-transaction-mapper.test.ts
@@ -36,11 +36,12 @@ describe('mapLocalTransaction', () => {
           decimals: 18,
           direction: 'out',
           assetType: 'native',
+          assetId: 'eip155:1/erc20:0x0000000000000000000000000000000000000000',
         },
       },
     });
   });
-  it('maps a native send on an unknown chain without a ticker to a Send with amount but no symbol', () => {
+  it('maps a native send on an unknown chain without a ticker to a Send with amount, no symbol, and a zero-address native assetId', () => {
     const item = mapLocalTransaction(
       localTransactionFixtures.mapInputs.mapsANativeSendOnAn,
     );
@@ -58,6 +59,8 @@ describe('mapLocalTransaction', () => {
           decimals: 18,
           direction: 'out',
           assetType: 'native',
+          assetId:
+            'eip155:1338/erc20:0x0000000000000000000000000000000000000000',
         },
       },
     });
@@ -334,7 +337,7 @@ describe('mapLocalTransaction', () => {
       },
     });
   });
-  it('maps an incoming native transfer without nativeAssetSymbol to a Receive with native assetType only', () => {
+  it('maps an incoming native transfer without nativeAssetSymbol to a Receive with the zero-address native assetId', () => {
     const item = mapLocalTransaction(
       localTransactionFixtures.mapInputs.mapsAnIncomingNativeTransferTo,
     );
@@ -347,9 +350,9 @@ describe('mapLocalTransaction', () => {
         },
       },
     });
-    expect(
-      item.type === 'receive' ? item.data.token?.assetId : 'unset',
-    ).toBeUndefined();
+    expect(item.type === 'receive' ? item.data.token?.assetId : 'unset').toBe(
+      'eip155:1/erc20:0x0000000000000000000000000000000000000000',
+    );
   });
   it('maps an mUSD conversion to a Convert activity', () => {
     const item = mapLocalTransaction(
@@ -620,7 +623,7 @@ describe('mapLocalTransaction', () => {
       data: { from },
     });
   });
-  it('maps a WETH9 deposit contract interaction to a Wrap activity with a native source amount but no symbol when nativeAssetSymbol is omitted', () => {
+  it('maps a WETH9 deposit contract interaction to a Wrap activity with a native source amount, no symbol, and a zero-address native assetId when nativeAssetSymbol is omitted', () => {
     const item = mapLocalTransaction(
       localTransactionFixtures.mapInputs.mapsAWeth9DepositContractInteraction,
     );
@@ -637,6 +640,7 @@ describe('mapLocalTransaction', () => {
           decimals: 18,
           direction: 'out',
           assetType: 'native',
+          assetId: 'eip155:1/erc20:0x0000000000000000000000000000000000000000',
         },
         destinationToken: {
           amount: '0x3782dace9d900000',
@@ -710,7 +714,7 @@ describe('mapLocalTransaction', () => {
       },
     });
   });
-  it('maps a native value contract interaction with amount but no symbol when nativeAssetSymbol is omitted', () => {
+  it('maps a native value contract interaction with amount, no symbol, and a zero-address native assetId when nativeAssetSymbol is omitted', () => {
     const item = mapLocalTransaction(
       localTransactionFixtures.mapInputs.mapsANativeValueContractInteraction,
     );
@@ -728,6 +732,7 @@ describe('mapLocalTransaction', () => {
           decimals: 18,
           direction: 'out',
           assetType: 'native',
+          assetId: 'eip155:1/erc20:0x0000000000000000000000000000000000000000',
         },
         methodId: '0xd0e30db0',
       },

--- a/packages/client-utils/src/mappers/local-transaction-mapper.test.ts
+++ b/packages/client-utils/src/mappers/local-transaction-mapper.test.ts
@@ -36,7 +36,7 @@ describe('mapLocalTransaction', () => {
           decimals: 18,
           direction: 'out',
           assetType: 'native',
-          assetId: 'eip155:1/erc20:0x0000000000000000000000000000000000000000',
+          assetId: 'eip155:1/slip44:60',
         },
       },
     });
@@ -337,7 +337,7 @@ describe('mapLocalTransaction', () => {
       },
     });
   });
-  it('maps an incoming native transfer without nativeAssetSymbol to a Receive with the zero-address native assetId', () => {
+  it('maps an incoming native transfer without nativeAssetSymbol to a Receive with the chainlist native assetId', () => {
     const item = mapLocalTransaction(
       localTransactionFixtures.mapInputs.mapsAnIncomingNativeTransferTo,
     );
@@ -351,7 +351,7 @@ describe('mapLocalTransaction', () => {
       },
     });
     expect(item.type === 'receive' ? item.data.token?.assetId : 'unset').toBe(
-      'eip155:1/erc20:0x0000000000000000000000000000000000000000',
+      'eip155:1/slip44:60',
     );
   });
   it('maps an mUSD conversion to a Convert activity', () => {
@@ -623,7 +623,7 @@ describe('mapLocalTransaction', () => {
       data: { from },
     });
   });
-  it('maps a WETH9 deposit contract interaction to a Wrap activity with a native source amount, no symbol, and a zero-address native assetId when nativeAssetSymbol is omitted', () => {
+  it('maps a WETH9 deposit contract interaction to a Wrap activity with a native source amount, no symbol, and the chainlist native assetId when nativeAssetSymbol is omitted', () => {
     const item = mapLocalTransaction(
       localTransactionFixtures.mapInputs.mapsAWeth9DepositContractInteraction,
     );
@@ -640,7 +640,7 @@ describe('mapLocalTransaction', () => {
           decimals: 18,
           direction: 'out',
           assetType: 'native',
-          assetId: 'eip155:1/erc20:0x0000000000000000000000000000000000000000',
+          assetId: 'eip155:1/slip44:60',
         },
         destinationToken: {
           amount: '0x3782dace9d900000',
@@ -714,7 +714,7 @@ describe('mapLocalTransaction', () => {
       },
     });
   });
-  it('maps a native value contract interaction with amount, no symbol, and a zero-address native assetId when nativeAssetSymbol is omitted', () => {
+  it('maps a native value contract interaction with amount, no symbol, and the chainlist native assetId when nativeAssetSymbol is omitted', () => {
     const item = mapLocalTransaction(
       localTransactionFixtures.mapInputs.mapsANativeValueContractInteraction,
     );
@@ -732,7 +732,7 @@ describe('mapLocalTransaction', () => {
           decimals: 18,
           direction: 'out',
           assetType: 'native',
-          assetId: 'eip155:1/erc20:0x0000000000000000000000000000000000000000',
+          assetId: 'eip155:1/slip44:60',
         },
         methodId: '0xd0e30db0',
       },


### PR DESCRIPTION
## Explanation

EVM native tokens without a slip44 mapping (e.g. Chiliz) left `assetId` undefined.

Fall back to the zero-address ERC-20 CAIP-19 form (`eip155:<chainId>/erc20:0x000…000`) so clients can resolve based still based on assetId by deriving the chain id.

## References

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


Made with [Cursor](https://cursor.com)