### PR TITLE
feat: wire `PreferencesController` to `ConfigRegistryController`

### DIFF
--- a/packages/config-registry-controller/src/config-registry-api-service/types.ts
+++ b/packages/config-registry-controller/src/config-registry-api-service/types.ts
@@ -70,6 +70,7 @@ export const RegistryNetworkConfigSchema = type({
   blockExplorerUrls: BlockExplorerUrlsSchema,
   config: ChainConfigSchema,
   contracts: optional(NetworkContractsSchema),
+  supportsEtherscanApi: optional(boolean()),
 });
 
 /**

--- a/packages/preferences-controller/jest.config.js
+++ b/packages/preferences-controller/jest.config.js
@@ -17,7 +17,7 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 90,
+      branches: 91.66,
       functions: 100,
       lines: 100,
       statements: 100,

--- a/packages/preferences-controller/package.json
+++ b/packages/preferences-controller/package.json
@@ -56,6 +56,7 @@
   },
   "dependencies": {
     "@metamask/base-controller": "^9.1.0",
+    "@metamask/config-registry-controller": "^2.0.1",
     "@metamask/messenger": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/preferences-controller/src/PreferencesController.test.ts
+++ b/packages/preferences-controller/src/PreferencesController.test.ts
@@ -161,6 +161,28 @@ describe('PreferencesController', () => {
     expect(controller.state.showIncomingTransactions['0x1']).toBe(false);
   });
 
+  it('should set showIncomingTransactions to true when the chain supports Etherscan API (via config-registry)', () => {
+    const {
+      controller,
+      rootMessenger,
+      mockConfigRegistryControllerGetNetworkConfigByCaip2ChainId,
+    } = setupPreferencesController();
+    mockConfigRegistryControllerGetNetworkConfigByCaip2ChainId.mockReturnValue({
+      supportsEtherscanApi: true,
+    });
+
+    rootMessenger.call(
+      'PreferencesController:setEnableNetworkIncomingTransactions',
+      '0x9999',
+      true,
+    );
+
+    expect(controller.state.showIncomingTransactions['0x9999']).toBe(true);
+    expect(
+      mockConfigRegistryControllerGetNetworkConfigByCaip2ChainId,
+    ).toHaveBeenCalledWith('eip155:0x9999');
+  });
+
   it('should set smartTransactionsOptInStatus', () => {
     const { controller, rootMessenger } = setupPreferencesController();
     rootMessenger.call(
@@ -528,7 +550,20 @@ function setupPreferencesController({
 }: {
   options?: Partial<ConstructorParameters<typeof PreferencesController>[0]>;
   messenger?: RootMessenger;
-} = {}): { controller: PreferencesController; rootMessenger: RootMessenger } {
+} = {}): {
+  controller: PreferencesController;
+  rootMessenger: RootMessenger;
+  mockConfigRegistryControllerGetNetworkConfigByCaip2ChainId: jest.Mock;
+} {
+  const mockConfigRegistryControllerGetNetworkConfigByCaip2ChainId = jest
+    .fn()
+    .mockReturnValue({});
+
+  messenger.registerActionHandler(
+    'ConfigRegistryController:getNetworkConfigByCaip2ChainId',
+    mockConfigRegistryControllerGetNetworkConfigByCaip2ChainId,
+  );
+
   const preferencesControllerMessenger = new Messenger<
     'PreferencesController',
     AllPreferencesControllerActions,
@@ -541,7 +576,7 @@ function setupPreferencesController({
 
   messenger.delegate({
     messenger: preferencesControllerMessenger,
-    actions: [],
+    actions: ['ConfigRegistryController:getNetworkConfigByCaip2ChainId'],
   });
 
   const controller = new PreferencesController({
@@ -549,5 +584,9 @@ function setupPreferencesController({
     ...options,
   });
 
-  return { controller, rootMessenger: messenger };
+  return {
+    controller,
+    rootMessenger: messenger,
+    mockConfigRegistryControllerGetNetworkConfigByCaip2ChainId,
+  };
 }

--- a/packages/preferences-controller/src/PreferencesController.ts
+++ b/packages/preferences-controller/src/PreferencesController.ts
@@ -3,10 +3,17 @@ import type {
   ControllerStateChangeEvent,
   ControllerGetStateAction,
 } from '@metamask/base-controller';
+import type { ConfigRegistryControllerGetNetworkConfigByCaip2ChainIdAction } from '@metamask/config-registry-controller';
 import type { Messenger } from '@metamask/messenger';
 
 import { ETHERSCAN_SUPPORTED_CHAIN_IDS } from './constants.js';
 import type { PreferencesControllerMethodActions } from './PreferencesController-method-action-types.js';
+import {
+  Hex,
+  KnownCaipNamespace,
+  parseCaipChainId,
+  toCaipChainId,
+} from '@metamask/utils';
 
 /**
  * A type union of the name for each chain that is supported by Etherscan or
@@ -59,9 +66,7 @@ export type PreferencesState = {
   /**
    * Controls whether incoming transactions are enabled, per-chain (for Etherscan-supported chains)
    */
-  showIncomingTransactions: {
-    [chainId in EtherscanSupportedHexChainId]: boolean;
-  };
+  showIncomingTransactions: Record<Hex, boolean>;
   /**
    * Controls whether test networks are shown in the wallet
    */
@@ -267,11 +272,14 @@ export type PreferencesControllerActions =
   | PreferencesControllerGetStateAction
   | PreferencesControllerMethodActions;
 
+export type AllowedActions =
+  ConfigRegistryControllerGetNetworkConfigByCaip2ChainIdAction;
+
 export type PreferencesControllerEvents = PreferencesControllerStateChangeEvent;
 
 export type PreferencesControllerMessenger = Messenger<
   typeof name,
-  PreferencesControllerActions,
+  PreferencesControllerActions | AllowedActions,
   PreferencesControllerEvents
 >;
 
@@ -487,10 +495,19 @@ export class PreferencesController extends BaseController<
    * @param isIncomingTransactionNetworkEnable - true to enable incoming transactions
    */
   setEnableNetworkIncomingTransactions(
-    chainId: EtherscanSupportedHexChainId,
+    chainId: Hex,
     isIncomingTransactionNetworkEnable: boolean,
   ): void {
-    if (Object.values(ETHERSCAN_SUPPORTED_CHAIN_IDS).includes(chainId)) {
+    const isEtherscanSupportedChain =
+      this.messenger.call(
+        'ConfigRegistryController:getNetworkConfigByCaip2ChainId',
+        toCaipChainId(KnownCaipNamespace.Eip155, chainId),
+      )?.supportsEtherscanApi ??
+      Object.values(ETHERSCAN_SUPPORTED_CHAIN_IDS).includes(
+        chainId as EtherscanSupportedHexChainId,
+      );
+
+    if (isEtherscanSupportedChain) {
       this.update((state) => {
         state.showIncomingTransactions = {
           ...this.state.showIncomingTransactions,

--- a/packages/preferences-controller/tsconfig.build.json
+++ b/packages/preferences-controller/tsconfig.build.json
@@ -10,6 +10,9 @@
       "path": "../base-controller/tsconfig.build.json"
     },
     {
+      "path": "../config-registry-controller/tsconfig.build.json"
+    },
+    {
       "path": "../messenger/tsconfig.build.json"
     }
   ],

--- a/packages/preferences-controller/tsconfig.json
+++ b/packages/preferences-controller/tsconfig.json
@@ -8,6 +8,9 @@
       "path": "../base-controller"
     },
     {
+      "path": "../config-registry-controller"
+    },
+    {
       "path": "../messenger"
     }
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -8551,6 +8551,7 @@ __metadata:
   dependencies:
     "@metamask/auto-changelog": "npm:^6.1.0"
     "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/config-registry-controller": "npm:^2.0.1"
     "@metamask/messenger": "npm:^2.0.0"
     "@metamask/utils": "npm:^11.11.0"
     "@ts-bridge/cli": "npm:^0.6.4"


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->
`PreferencesController` is being wired to `config-registry-controller` to consume remote network configurations to establish whether a chain is supported by Etherscan API

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->
* Fixes https://consensyssoftware.atlassian.net/browse/WPN-1563

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them
