### PR TITLE
feat(logging-controller): Add expiration to logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,7 +427,6 @@ linkStyle default opacity:0.5
   keyring_controller --> controller_utils;
   keyring_controller --> messenger;
   logging_controller --> base_controller;
-  logging_controller --> controller_utils;
   logging_controller --> messenger;
   message_manager --> base_controller;
   message_manager --> controller_utils;

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1141,17 +1141,11 @@
   "packages/logging-controller/src/LoggingController.test.ts": {
     "@typescript-eslint/explicit-function-return-type": {
       "count": 1
-    },
-    "import-x/namespace": {
-      "count": 1
     }
   },
   "packages/logging-controller/src/LoggingController.ts": {
     "@typescript-eslint/explicit-function-return-type": {
       "count": 2
-    },
-    "no-restricted-syntax": {
-      "count": 1
     }
   },
   "packages/message-manager/src/AbstractMessageManager.test.ts": {

--- a/packages/logging-controller/CHANGELOG.md
+++ b/packages/logging-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `expiryTime` constructor argument, by default logs are pruned after 7 days ([#9839](https://github.com/MetaMask/core/pull/9839))
+
 ### Changed
 
 - Bump `@metamask/controller-utils` from `^12.0.0` to `^12.3.0` ([#8774](https://github.com/MetaMask/core/pull/8774), [#9058](https://github.com/MetaMask/core/pull/9058), [#9083](https://github.com/MetaMask/core/pull/9083), [#9218](https://github.com/MetaMask/core/pull/9218))

--- a/packages/logging-controller/package.json
+++ b/packages/logging-controller/package.json
@@ -56,8 +56,8 @@
   },
   "dependencies": {
     "@metamask/base-controller": "^9.1.0",
-    "@metamask/controller-utils": "^12.3.0",
     "@metamask/messenger": "^2.0.0",
+    "@metamask/utils": "^11.11.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/packages/logging-controller/src/LoggingController.test.ts
+++ b/packages/logging-controller/src/LoggingController.test.ts
@@ -5,7 +5,7 @@ import type {
   MessengerEvents,
   MockAnyNamespace,
 } from '@metamask/messenger';
-import * as uuid from 'uuid';
+import { Duration, inMilliseconds } from '@metamask/utils';
 
 import type { LoggingControllerMessenger } from './LoggingController.js';
 import { LoggingController } from './LoggingController.js';
@@ -119,13 +119,32 @@ describe('LoggingController', () => {
     });
   });
 
-  it('action: LoggingController:add prevents possible collision of ids', async () => {
+  it('removes expired logs', () => {
     const rootMessenger = getRootMessenger();
     const messenger = getLoggingControllerMessenger(rootMessenger);
-    const uuidV1Spy = jest.spyOn(uuid, 'v1');
 
     const controller = new LoggingController({
       messenger,
+      state: {
+        logs: {
+          'foo': {
+            id: 'foo',
+            timestamp: Date.now() - inMilliseconds(14, Duration.Day),
+            log: {
+              type: LogType.GenericLog,
+              data: 'bar',
+            }
+          },
+          'baz': {
+            id: 'baz',
+            timestamp: Date.now() - inMilliseconds(1, Duration.Day),
+            log: {
+              type: LogType.GenericLog,
+              data: 'qux',
+            }
+          }
+        }
+      }
     });
 
     expect(
@@ -134,39 +153,17 @@ describe('LoggingController', () => {
         data: `Generic log`,
       }),
     ).toBeUndefined();
-
-    const { id } = Object.values(controller.state.logs)[0];
-
-    uuidV1Spy.mockReturnValueOnce(id);
-
-    expect(
-      rootMessenger.call('LoggingController:add', {
-        type: LogType.GenericLog,
-        data: `Generic log 2`,
-      }),
-    ).toBeUndefined();
     const logs = Object.values(controller.state.logs);
     expect(logs).toHaveLength(2);
-    expect(logs).toContainEqual({
-      timestamp: expect.any(Number),
-      id,
-      log: expect.objectContaining({
-        type: LogType.GenericLog,
-        data: 'Generic log',
-      }),
-    });
-
     expect(logs).toContainEqual({
       timestamp: expect.any(Number),
       id: expect.any(String),
       log: expect.objectContaining({
         type: LogType.GenericLog,
-        data: 'Generic log 2',
+        data: 'Generic log',
       }),
     });
-
-    expect(uuidV1Spy).toHaveBeenCalledTimes(3);
-  });
+  })
 
   it('internal method: clear', async () => {
     const rootMessenger = getRootMessenger();

--- a/packages/logging-controller/src/LoggingController.test.ts
+++ b/packages/logging-controller/src/LoggingController.test.ts
@@ -127,24 +127,24 @@ describe('LoggingController', () => {
       messenger,
       state: {
         logs: {
-          'foo': {
+          foo: {
             id: 'foo',
             timestamp: Date.now() - inMilliseconds(14, Duration.Day),
             log: {
               type: LogType.GenericLog,
               data: 'bar',
-            }
+            },
           },
-          'baz': {
+          baz: {
             id: 'baz',
             timestamp: Date.now() - inMilliseconds(1, Duration.Day),
             log: {
               type: LogType.GenericLog,
               data: 'qux',
-            }
-          }
-        }
-      }
+            },
+          },
+        },
+      },
     });
 
     expect(
@@ -163,7 +163,7 @@ describe('LoggingController', () => {
         data: 'Generic log',
       }),
     });
-  })
+  });
 
   it('internal method: clear', async () => {
     const rootMessenger = getRootMessenger();

--- a/packages/logging-controller/src/LoggingController.ts
+++ b/packages/logging-controller/src/LoggingController.ts
@@ -80,8 +80,7 @@ export class LoggingController extends BaseController<
   LoggingControllerState,
   LoggingControllerMessenger
 > {
-
-  #expiryTime: number;
+  readonly #expiryTime: number;
 
   /**
    * Creates a LoggingController instance.

--- a/packages/logging-controller/src/LoggingController.ts
+++ b/packages/logging-controller/src/LoggingController.ts
@@ -5,7 +5,8 @@ import type {
 } from '@metamask/base-controller';
 import { BaseController } from '@metamask/base-controller';
 import type { Messenger } from '@metamask/messenger';
-import { v1 as random } from 'uuid';
+import { Duration, inMilliseconds } from '@metamask/utils';
+import { v4 as uuid } from 'uuid';
 
 import type { LoggingControllerMethodActions } from './LoggingController-method-action-types.js';
 import type { Log } from './logTypes/index.js';
@@ -79,19 +80,25 @@ export class LoggingController extends BaseController<
   LoggingControllerState,
   LoggingControllerMessenger
 > {
+
+  #expiryTime: number;
+
   /**
    * Creates a LoggingController instance.
    *
    * @param options - Constructor options
    * @param options.messenger - An instance of the Messenger
    * @param options.state - Initial state to set on this controller.
+   * @param options.expiryTime - The number of milliseconds before we consider a log entry expired.
    */
   constructor({
     messenger,
     state,
+    expiryTime = inMilliseconds(7, Duration.Day),
   }: {
     messenger: LoggingControllerMessenger;
     state?: Partial<LoggingControllerState>;
+    expiryTime?: number;
   }) {
     super({
       name,
@@ -103,27 +110,12 @@ export class LoggingController extends BaseController<
       },
     });
 
+    this.#expiryTime = expiryTime;
+
     this.messenger.registerMethodActionHandlers(
       this,
       MESSENGER_EXPOSED_METHODS,
     );
-  }
-
-  /**
-   * Method to generate a randomId and ensures no collision with existing ids.
-   *
-   * We may want to end up using a hashing mechanism to make ids deterministic
-   * by the *data* passed in, and then make each key an array of logs that
-   * match that id.
-   *
-   * @returns unique id
-   */
-  #generateId(): string {
-    let id = random();
-    while (id in this.state.logs) {
-      id = random();
-    }
-    return id;
   }
 
   /**
@@ -133,12 +125,19 @@ export class LoggingController extends BaseController<
    */
   add(log: Log) {
     const newLog: LogEntry = {
-      id: this.#generateId(),
+      id: uuid(),
       timestamp: Date.now(),
       log,
     };
 
+    const expiry = Date.now() - this.#expiryTime;
+
     this.update((state) => {
+      for (const [id, entry] of Object.entries(state.logs)) {
+        if (entry.timestamp < expiry) {
+          delete state.logs[id];
+        }
+      }
       state.logs[newLog.id] = newLog;
     });
   }

--- a/packages/logging-controller/tsconfig.build.json
+++ b/packages/logging-controller/tsconfig.build.json
@@ -7,7 +7,7 @@
   },
   "references": [
     { "path": "../base-controller/tsconfig.build.json" },
-    { "path": "../messenger/tsconfig.build.json" },
+    { "path": "../messenger/tsconfig.build.json" }
   ],
   "include": ["../../types", "./src"]
 }

--- a/packages/logging-controller/tsconfig.build.json
+++ b/packages/logging-controller/tsconfig.build.json
@@ -8,7 +8,6 @@
   "references": [
     { "path": "../base-controller/tsconfig.build.json" },
     { "path": "../messenger/tsconfig.build.json" },
-    { "path": "../controller-utils/tsconfig.build.json" }
   ],
   "include": ["../../types", "./src"]
 }

--- a/packages/logging-controller/tsconfig.json
+++ b/packages/logging-controller/tsconfig.json
@@ -3,9 +3,6 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    { "path": "../base-controller" },
-    { "path": "../messenger" },
-  ],
+  "references": [{ "path": "../base-controller" }, { "path": "../messenger" }],
   "include": ["../../types", "./src"]
 }

--- a/packages/logging-controller/tsconfig.json
+++ b/packages/logging-controller/tsconfig.json
@@ -6,7 +6,6 @@
   "references": [
     { "path": "../base-controller" },
     { "path": "../messenger" },
-    { "path": "../controller-utils" }
   ],
   "include": ["../../types", "./src"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7721,8 +7721,8 @@ __metadata:
   dependencies:
     "@metamask/auto-changelog": "npm:^6.1.0"
     "@metamask/base-controller": "npm:^9.1.0"
-    "@metamask/controller-utils": "npm:^12.3.0"
     "@metamask/messenger": "npm:^2.0.0"
+    "@metamask/utils": "npm:^11.11.0"
     "@ts-bridge/cli": "npm:^0.6.4"
     "@types/jest": "npm:^30.0.0"
     deepmerge: "npm:^4.2.2"


### PR DESCRIPTION
## Explanation

Add `expiryTime` constructor argument to `LoggingController`, it defaults to 7 days.

When adding a new log entry, we iterate through the existing logs and discard any that were logged before the expiry cutoff.

Additionally simplifies the controller by using UUID v4, not checking for conflicts and removing an unused dependency on `controller-utils`.

## References

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes persisted log retention by auto-deleting old entries on `add`, which can remove historical support/debug data. Scope is limited to `LoggingController` and the new constructor option is backward-compatible.
> 
> **Overview**
> Adds an optional `expiryTime` constructor argument to `LoggingController` (default **7 days**). On each `add`, expired entries are removed before the new log is stored, so persisted logs no longer grow indefinitely.
> 
> Also simplifies ID generation by switching from UUID v1 with collision retries to UUID v4, and drops the unused `@metamask/controller-utils` dependency in favor of `@metamask/utils` for duration helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e0a54e931657607c8b468e3add54f247b3bddf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->