### PR TITLE
fix: defer re-entrant publishes of the same event

### DIFF
--- a/packages/messenger/CHANGELOG.md
+++ b/packages/messenger/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Unlike `delegate`, this method requires all external actions and events to be listed, producing a TypeScript error showing exactly which items are missing.
 - Add `MessengerNamespace` utility type to extract the namespace from a Messenger type ([#8338](https://github.com/MetaMask/core/pull/8338))
 
+### Fixed
+
+- Defer re-entrant publishes of the same event so subscribers no longer receive a stale payload ([#9840](https://github.com/MetaMask/core/pull/9840))
+  - When a subscriber publishes the same event it is currently handling (directly, or indirectly through a delegated messenger), that nested publish is now queued and delivered after the in-progress publish finishes, rather than inline. Previously the in-progress publish would resume afterwards and re-deliver its now-stale payload to the subscribers it had not yet reached.
+
 ## [2.0.0]
 
 ### Added

--- a/packages/messenger/src/Messenger.test.ts
+++ b/packages/messenger/src/Messenger.test.ts
@@ -583,6 +583,113 @@ describe('Messenger', () => {
       expect(handler2.mock.calls).toHaveLength(1);
     });
 
+    it('defers a re-entrant publish of the same event until the current publish finishes', () => {
+      type MessageEvent = { type: 'Fixture:message'; payload: [string] };
+      const messenger = new Messenger<'Fixture', never, MessageEvent>({
+        namespace: 'Fixture',
+      });
+
+      const calls: string[] = [];
+      let republished = false;
+      messenger.subscribe('Fixture:message', (message) => {
+        calls.push(`first:${message}`);
+        if (!republished) {
+          republished = true;
+          messenger.publish('Fixture:message', 'second');
+        }
+      });
+      messenger.subscribe('Fixture:message', (message) => {
+        calls.push(`second:${message}`);
+      });
+
+      messenger.publish('Fixture:message', 'first');
+
+      expect(calls).toStrictEqual([
+        'first:first',
+        'second:first',
+        'first:second',
+        'second:second',
+      ]);
+    });
+
+    it('drains multiple re-entrant publishes of the same event in order', () => {
+      type MessageEvent = { type: 'Fixture:message'; payload: [string] };
+      const messenger = new Messenger<'Fixture', never, MessageEvent>({
+        namespace: 'Fixture',
+      });
+
+      const received: string[] = [];
+      let done = false;
+      messenger.subscribe('Fixture:message', (message) => {
+        received.push(message);
+        if (!done) {
+          done = true;
+          messenger.publish('Fixture:message', 'b');
+          messenger.publish('Fixture:message', 'c');
+        }
+      });
+
+      messenger.publish('Fixture:message', 'a');
+
+      expect(received).toStrictEqual(['a', 'b', 'c']);
+    });
+
+    it('runs a re-entrant publish of a different event inline', () => {
+      type MessageEvent =
+        | { type: 'Fixture:a'; payload: [] }
+        | { type: 'Fixture:b'; payload: [] };
+      const messenger = new Messenger<'Fixture', never, MessageEvent>({
+        namespace: 'Fixture',
+      });
+
+      const calls: string[] = [];
+      messenger.subscribe('Fixture:a', () => {
+        calls.push('a:start');
+        messenger.publish('Fixture:b');
+        calls.push('a:end');
+      });
+      messenger.subscribe('Fixture:b', () => {
+        calls.push('b');
+      });
+
+      messenger.publish('Fixture:a');
+
+      expect(calls).toStrictEqual(['a:start', 'b', 'a:end']);
+    });
+
+    it('defers a re-entrant publish that crosses a delegated messenger', () => {
+      type ExampleEvent = { type: 'Source:event'; payload: [string] };
+      const source = new Messenger<'Source', never, ExampleEvent>({
+        namespace: 'Source',
+      });
+      const delegatee = new Messenger<'Destination', never, ExampleEvent>({
+        namespace: 'Destination',
+      });
+      source.delegate({ messenger: delegatee, events: ['Source:event'] });
+
+      const calls: string[] = [];
+      let republished = false;
+      delegatee.subscribe('Source:event', (message) => {
+        calls.push(`delegatee:${message}`);
+        if (!republished) {
+          republished = true;
+          source.publish('Source:event', 'second');
+        }
+      });
+      source.subscribe('Source:event', (message) => {
+        calls.push(`source:${message}`);
+      });
+
+      source.publish('Source:event', 'first');
+
+      expect(calls).toStrictEqual([
+        'delegatee:first',
+        'source:first',
+        'delegatee:second',
+        'source:second',
+      ]);
+    });
+
     describe('on first state change with an initial payload function registered', () => {
       it('publishes event if selected payload differs', () => {
         const state = {

--- a/packages/messenger/src/Messenger.ts
+++ b/packages/messenger/src/Messenger.ts
@@ -263,6 +263,13 @@ export class Messenger<
   readonly #events = new Map<Event['type'], EventSubscriptionMap<Event>>();
 
   /**
+   * In-progress publishes, keyed by event type. A key is present for the
+   * duration of a publish (so presence means "publishing"); its array collects
+   * re-entrant publishes of that event, drained when the publish finishes.
+   */
+  readonly #deferredPublishes = new Map<Event['type'], (() => void)[]>();
+
+  /**
    * The set of messengers we've delegated events to and their event handlers, by event type.
    */
   readonly #subscriptionDelegationTargets = new Map<
@@ -646,6 +653,37 @@ export class Messenger<
   }
 
   #publish<EventType extends Event['type']>(
+    eventType: EventType,
+    ...payload: ExtractEventPayload<Event, EventType>
+  ): void {
+    // Defer a re-entrant publish of the same event (e.g. a subscriber that
+    // publishes the event it is handling). Delivering it inline would let the
+    // in-progress publish resume and re-deliver its now-stale payload to the
+    // subscribers it had not reached yet.
+    const inProgress = this.#deferredPublishes.get(eventType);
+    if (inProgress) {
+      inProgress.push((): void =>
+        this.#deliverToSubscribers(eventType, ...payload),
+      );
+      return;
+    }
+
+    const deferred: (() => void)[] = [];
+    this.#deferredPublishes.set(eventType, deferred);
+    try {
+      this.#deliverToSubscribers(eventType, ...payload);
+
+      // Drain deferred publishes in order. The array grows as further
+      // re-entrant publishes push onto it; the iterator reads those too.
+      for (const run of deferred) {
+        run();
+      }
+    } finally {
+      this.#deferredPublishes.delete(eventType);
+    }
+  }
+
+  #deliverToSubscribers<EventType extends Event['type']>(
     eventType: EventType,
     ...payload: ExtractEventPayload<Event, EventType>
   ): void {


### PR DESCRIPTION
## Explanation

`Messenger` delivered a re-entrant publish of the same event **inline**. When a subscriber published the event it was currently handling — directly, or indirectly through a delegated messenger (for example a `stateChange` subscriber that calls an action which triggers `update()` on the same controller) — the nested publish ran to completion, and then the in-progress publish **resumed its subscriber loop and re-delivered its now-stale payload** to the subscribers it had not yet reached. A downstream subscriber such as a UI store bridging controller state could therefore end up observing an older payload after a newer one.

This surfaced in the extension as a network filter that stayed on a just-added network even though the enabled-network map had already been restored: the restore's `stateChange` re-entered `publish`, and the stale "switched" payload was the last thing the UI received.

This change makes `#publish` **defer** a publish of an event that is already being published on the same messenger, then **drain** the deferred publishes in order once the in-progress publish finishes. Because the event stays marked as "publishing" while draining, further re-entrant publishes of that event are deferred and drained too. Re-entrant publishes of a *different* event still run inline. The fix covers delegated messengers as well, since delegated publishes funnel through the same `#publish`.

Note this is a small behavioral change: a re-entrant publish of the same event is now delivered after the current publish completes (still synchronously, within the same tick) rather than nested inside it.

## References

- Related to MetaMask/metamask-extension#44142, where this was worked around at the call site (restoring the map outside the `stateChange` publish via `await`).

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core event-delivery ordering for re-entrant same-event publishes across all Messenger consumers; behavior is intentional but could affect code that relied on nested delivery order.
> 
> **Overview**
> Fixes **`Messenger`** so a subscriber that publishes the **same** event while handling it (including via delegation) no longer causes later subscribers to see an **outdated** payload.
> 
> `#publish` now tracks in-flight publishes per event type and **queues** same-event re-entrancy until the current delivery finishes, then drains queued publishes in order. Subscriber iteration moves to **`#deliverToSubscribers`**; re-entrant publishes of **different** events still run inline. Tests and the changelog document the behavior change (deferred delivery is still synchronous in the same tick).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ab366a8be2dd82af255661d247e3618bcbab913. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->