### PR TITLE
chore: disable persistence for legacy assets controllers

### DIFF
--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Set `persist: false` on state metadata for legacy assets controllers so their state is no longer written to disk (`TokensController`, `CurrencyRateController`, `TokenRatesController`, `TokenBalancesController`, `AccountTrackerController`, `MultichainAssetsController`, `MultichainAssetsRatesController`, `MultichainBalancesController`)
 - Bump `@metamask/core-backend` from `^9.0.0` to `^9.1.0` ([#10138](https://github.com/MetaMask/core/pull/10138))
 - Bump `@metamask/phishing-controller` from `^17.4.0` to `^17.4.1` ([#10080](https://github.com/MetaMask/core/pull/10080))
 - Bump `@metamask/remote-feature-flag-controller` from `^6.0.0` to `^6.1.1` ([#9980](https://github.com/MetaMask/core/pull/9980), [#10129](https://github.com/MetaMask/core/pull/10129))

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Set `persist: false` on state metadata for legacy assets controllers so their state is no longer written to disk (`TokensController`, `CurrencyRateController`, `TokenRatesController`, `TokenBalancesController`, `AccountTrackerController`, `MultichainAssetsController`, `MultichainAssetsRatesController`, `MultichainBalancesController`)
+- Set `persist: false` on state metadata for legacy assets controllers so their state is no longer written to disk (`TokensController`, `CurrencyRateController`, `TokenRatesController`, `TokenBalancesController`, `AccountTrackerController`, `MultichainAssetsController`, `MultichainAssetsRatesController`, `MultichainBalancesController`) ([#9842](https://github.com/MetaMask/core/pull/9842))
 - Bump `@metamask/core-backend` from `^9.0.0` to `^9.1.0` ([#10138](https://github.com/MetaMask/core/pull/10138))
 - Bump `@metamask/phishing-controller` from `^17.4.0` to `^17.4.1` ([#10080](https://github.com/MetaMask/core/pull/10080))
 - Bump `@metamask/remote-feature-flag-controller` from `^6.0.0` to `^6.1.1` ([#9980](https://github.com/MetaMask/core/pull/9980), [#10129](https://github.com/MetaMask/core/pull/10129))

--- a/packages/assets-controllers/src/AccountTrackerController.test.ts
+++ b/packages/assets-controllers/src/AccountTrackerController.test.ts
@@ -2042,13 +2042,7 @@ describe('AccountTrackerController', () => {
             controller.metadata,
             'persist',
           ),
-        ).toMatchInlineSnapshot(`
-          {
-            "accountsByChainId": {
-              "0x1": {},
-            },
-          }
-        `);
+        ).toMatchInlineSnapshot(`{}`);
       });
     });
 

--- a/packages/assets-controllers/src/AccountTrackerController.ts
+++ b/packages/assets-controllers/src/AccountTrackerController.ts
@@ -153,7 +153,7 @@ export type AccountTrackerControllerState = {
 const accountTrackerMetadata: StateMetadata<AccountTrackerControllerState> = {
   accountsByChainId: {
     includeInStateLogs: false,
-    persist: true,
+    persist: false,
     includeInDebugSnapshot: false,
     usedInUi: true,
   },

--- a/packages/assets-controllers/src/CurrencyRateController.test.ts
+++ b/packages/assets-controllers/src/CurrencyRateController.test.ts
@@ -2326,18 +2326,7 @@ describe('CurrencyRateController', () => {
           controller.metadata,
           'persist',
         ),
-      ).toMatchInlineSnapshot(`
-        {
-          "currencyRates": {
-            "ETH": {
-              "conversionDate": 0,
-              "conversionRate": 0,
-              "usdConversionRate": null,
-            },
-          },
-          "currentCurrency": "usd",
-        }
-      `);
+      ).toMatchInlineSnapshot(`{}`);
     });
 
     it('exposes expected state to UI', () => {

--- a/packages/assets-controllers/src/CurrencyRateController.ts
+++ b/packages/assets-controllers/src/CurrencyRateController.ts
@@ -80,13 +80,13 @@ export type CurrencyRateMessenger = Messenger<
 const metadata: StateMetadata<CurrencyRateState> = {
   currentCurrency: {
     includeInStateLogs: true,
-    persist: true,
+    persist: false,
     includeInDebugSnapshot: true,
     usedInUi: true,
   },
   currencyRates: {
     includeInStateLogs: true,
-    persist: true,
+    persist: false,
     includeInDebugSnapshot: true,
     usedInUi: true,
   },

--- a/packages/assets-controllers/src/MultichainAssetsController/MultichainAssetsController.test.ts
+++ b/packages/assets-controllers/src/MultichainAssetsController/MultichainAssetsController.test.ts
@@ -2212,13 +2212,7 @@ describe('MultichainAssetsController', () => {
           controller.metadata,
           'persist',
         ),
-      ).toMatchInlineSnapshot(`
-        {
-          "accountsAssets": {},
-          "allIgnoredAssets": {},
-          "assetsMetadata": {},
-        }
-      `);
+      ).toMatchInlineSnapshot(`{}`);
     });
 
     it('exposes expected state to UI', () => {

--- a/packages/assets-controllers/src/MultichainAssetsController/MultichainAssetsController.ts
+++ b/packages/assets-controllers/src/MultichainAssetsController/MultichainAssetsController.ts
@@ -159,19 +159,19 @@ const assetsControllerMetadata: StateMetadata<MultichainAssetsControllerState> =
   {
     assetsMetadata: {
       includeInStateLogs: false,
-      persist: true,
+      persist: false,
       includeInDebugSnapshot: false,
       usedInUi: true,
     },
     accountsAssets: {
       includeInStateLogs: false,
-      persist: true,
+      persist: false,
       includeInDebugSnapshot: false,
       usedInUi: true,
     },
     allIgnoredAssets: {
       includeInStateLogs: false,
-      persist: true,
+      persist: false,
       includeInDebugSnapshot: false,
       usedInUi: true,
     },

--- a/packages/assets-controllers/src/MultichainAssetsRatesController/MultichainAssetsRatesController.test.ts
+++ b/packages/assets-controllers/src/MultichainAssetsRatesController/MultichainAssetsRatesController.test.ts
@@ -1613,11 +1613,7 @@ describe('MultichainAssetsRatesController', () => {
           controller.metadata,
           'persist',
         ),
-      ).toMatchInlineSnapshot(`
-        {
-          "conversionRates": {},
-        }
-      `);
+      ).toMatchInlineSnapshot(`{}`);
     });
 
     it('exposes expected state to UI', () => {

--- a/packages/assets-controllers/src/MultichainAssetsRatesController/MultichainAssetsRatesController.ts
+++ b/packages/assets-controllers/src/MultichainAssetsRatesController/MultichainAssetsRatesController.ts
@@ -153,7 +153,7 @@ export type MultichainAssetsRatesPollingInput = {
 const metadata: StateMetadata<MultichainAssetsRatesControllerState> = {
   conversionRates: {
     includeInStateLogs: false,
-    persist: true,
+    persist: false,
     includeInDebugSnapshot: true,
     usedInUi: true,
   },

--- a/packages/assets-controllers/src/MultichainBalancesController/MultichainBalancesController.test.ts
+++ b/packages/assets-controllers/src/MultichainBalancesController/MultichainBalancesController.test.ts
@@ -1040,11 +1040,7 @@ describe('MultichainBalancesController', () => {
           controller.metadata,
           'persist',
         ),
-      ).toMatchInlineSnapshot(`
-        {
-          "balances": {},
-        }
-      `);
+      ).toMatchInlineSnapshot(`{}`);
     });
 
     it('exposes expected state to UI', () => {

--- a/packages/assets-controllers/src/MultichainBalancesController/MultichainBalancesController.ts
+++ b/packages/assets-controllers/src/MultichainBalancesController/MultichainBalancesController.ts
@@ -126,7 +126,7 @@ const balancesControllerMetadata: StateMetadata<MultichainBalancesControllerStat
   {
     balances: {
       includeInStateLogs: false,
-      persist: true,
+      persist: false,
       includeInDebugSnapshot: false,
       usedInUi: true,
     },

--- a/packages/assets-controllers/src/TokenBalancesController.test.ts
+++ b/packages/assets-controllers/src/TokenBalancesController.test.ts
@@ -6345,11 +6345,7 @@ describe('TokenBalancesController', () => {
           controller.metadata,
           'persist',
         ),
-      ).toMatchInlineSnapshot(`
-        {
-          "tokenBalances": {},
-        }
-      `);
+      ).toMatchInlineSnapshot(`{}`);
     });
 
     it('exposes expected state to UI', () => {

--- a/packages/assets-controllers/src/TokenBalancesController.ts
+++ b/packages/assets-controllers/src/TokenBalancesController.ts
@@ -129,7 +129,7 @@ export function mergeUpdateBalancesOptions(
 const metadata: StateMetadata<TokenBalancesControllerState> = {
   tokenBalances: {
     includeInStateLogs: false,
-    persist: true,
+    persist: false,
     includeInDebugSnapshot: false,
     usedInUi: true,
   },

--- a/packages/assets-controllers/src/TokenRatesController.test.ts
+++ b/packages/assets-controllers/src/TokenRatesController.test.ts
@@ -1407,11 +1407,7 @@ describe('TokenRatesController', () => {
             controller.metadata,
             'persist',
           ),
-        ).toMatchInlineSnapshot(`
-          {
-            "marketData": {},
-          }
-        `);
+        ).toMatchInlineSnapshot(`{}`);
       });
     });
 

--- a/packages/assets-controllers/src/TokenRatesController.ts
+++ b/packages/assets-controllers/src/TokenRatesController.ts
@@ -161,7 +161,7 @@ export type TokenRatesControllerMessenger = Messenger<
 const tokenRatesControllerMetadata: StateMetadata<TokenRatesControllerState> = {
   marketData: {
     includeInStateLogs: false,
-    persist: true,
+    persist: false,
     includeInDebugSnapshot: false,
     usedInUi: true,
   },

--- a/packages/assets-controllers/src/TokensController.test.ts
+++ b/packages/assets-controllers/src/TokensController.test.ts
@@ -4025,13 +4025,7 @@ describe('TokensController', () => {
             controller.metadata,
             'persist',
           ),
-        ).toMatchInlineSnapshot(`
-          {
-            "allDetectedTokens": {},
-            "allIgnoredTokens": {},
-            "allTokens": {},
-          }
-        `);
+        ).toMatchInlineSnapshot(`{}`);
       });
     });
 

--- a/packages/assets-controllers/src/TokensController.ts
+++ b/packages/assets-controllers/src/TokensController.ts
@@ -110,19 +110,19 @@ export type TokensControllerState = {
 const metadata: StateMetadata<TokensControllerState> = {
   allTokens: {
     includeInStateLogs: false,
-    persist: true,
+    persist: false,
     includeInDebugSnapshot: false,
     usedInUi: true,
   },
   allIgnoredTokens: {
     includeInStateLogs: false,
-    persist: true,
+    persist: false,
     includeInDebugSnapshot: false,
     usedInUi: true,
   },
   allDetectedTokens: {
     includeInStateLogs: false,
-    persist: true,
+    persist: false,
     includeInDebugSnapshot: false,
     usedInUi: true,
   },


### PR DESCRIPTION
Stop writing Tokens, CurrencyRate, TokenRates, TokenBalances, AccountTracker, and Multichain assets/rates/balances controller state to disk so clients can rely on AssetsController instead.

## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Disabling on-disk persistence changes how cached balances, tokens, and rates survive restarts until clients rely on AssetsController and refetch logic.
> 
> **Overview**
> Legacy assets-related controllers no longer mark any state fields for disk persistence: **`persist` is set to `false`** on metadata for `TokensController`, `CurrencyRateController`, `TokenRatesController`, `TokenBalancesController`, `AccountTrackerController`, and the multichain assets, rates, and balances controllers.
> 
> Runtime behavior and **UI exposure (`usedInUi`) are unchanged**—only what gets written to persistent storage. Tests that assert persisted state via `deriveStateFromMetadata(..., 'persist')` now expect an **empty object** instead of controller-specific snapshots. The **assets-controllers changelog** documents the change under Unreleased.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b9a4f373148d0860a8f461117cd69d1a4544a6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->