### PR TITLE
Revert "Release 1189.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "1189.0.0",
+  "version": "1188.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {

--- a/packages/logging-controller/CHANGELOG.md
+++ b/packages/logging-controller/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [8.1.0]
-
 ### Added
 
 - Add `expiryTime` constructor argument, by default logs are pruned after 7 days ([#9839](https://github.com/MetaMask/core/pull/9839))
@@ -85,8 +83,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bump `@metamask/base-controller` from `^7.0.2` to `^8.0.0` ([#5079](https://github.com/MetaMask/core/pull/5079), [#5305](https://github.com/MetaMask/core/pull/5305))
-- Bump `@metamask/controller-utils` from `^11.4.4` to `^11.5.0` ([#5135](https://github.com/MetaMask/core/pull/5135), [#5272](https://github.com/MetaMask/core/pull/5272))
+- Bump `@metamask/base-controller` from `^7.0.2` to `^8.0.0` ([#5079](https://github.com/MetaMask/core/pull/5079)), ([#5305](https://github.com/MetaMask/core/pull/5305))
+- Bump `@metamask/controller-utils` from `^11.4.4` to `^11.5.0` ([#5135](https://github.com/MetaMask/core/pull/5135)), ([#5272](https://github.com/MetaMask/core/pull/5272))
 
 ## [6.0.3]
 
@@ -113,7 +111,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     ["Are the Types Wrong?"](https://arethetypeswrong.github.io/) tool as
     ["masquerading as CJS"](https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/FalseCJS.md).
     All of the ATTW checks now pass.
-- Remove chunk files. ([#4648](https://github.com/MetaMask/core/pull/4648))
+- Remove chunk files ([#4648](https://github.com/MetaMask/core/pull/4648)).
   - Previously, the build tool we used to generate JavaScript files extracted
     common code to "chunk" files. While this was intended to make this package
     more tree-shakeable, it also made debugging more difficult for our
@@ -232,8 +230,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial Release
   - Add logging controller ([#1089](https://github.com/MetaMask/core.git/pull/1089))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/logging-controller@8.1.0...HEAD
-[8.1.0]: https://github.com/MetaMask/core/compare/@metamask/logging-controller@8.0.2...@metamask/logging-controller@8.1.0
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/logging-controller@8.0.2...HEAD
 [8.0.2]: https://github.com/MetaMask/core/compare/@metamask/logging-controller@8.0.1...@metamask/logging-controller@8.0.2
 [8.0.1]: https://github.com/MetaMask/core/compare/@metamask/logging-controller@8.0.0...@metamask/logging-controller@8.0.1
 [8.0.0]: https://github.com/MetaMask/core/compare/@metamask/logging-controller@7.0.1...@metamask/logging-controller@8.0.0

--- a/packages/logging-controller/package.json
+++ b/packages/logging-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/logging-controller",
-  "version": "8.1.0",
+  "version": "8.0.2",
   "description": "Manages logging data to assist users and support staff",
   "keywords": [
     "Ethereum",

--- a/packages/signature-controller/CHANGELOG.md
+++ b/packages/signature-controller/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/network-controller` from `^35.0.0` to `^35.0.1` ([#9758](https://github.com/MetaMask/core/pull/9758))
 - Bump `@metamask/accounts-controller` from `^39.0.6` to `^39.1.0` ([#9791](https://github.com/MetaMask/core/pull/9791), [#9807](https://github.com/MetaMask/core/pull/9807))
 - Bump `@metamask/keyring-controller` from `^27.1.0` to `^27.1.1` ([#9791](https://github.com/MetaMask/core/pull/9791))
-- Bump `@metamask/logging-controller` from `^8.0.2` to `^8.1.0` ([#9841](https://github.com/MetaMask/core/pull/9841))
 
 ## [39.2.9]
 

--- a/packages/signature-controller/package.json
+++ b/packages/signature-controller/package.json
@@ -62,7 +62,7 @@
     "@metamask/eth-sig-util": "^8.2.0",
     "@metamask/gator-permissions-controller": "^5.0.1",
     "@metamask/keyring-controller": "^27.1.1",
-    "@metamask/logging-controller": "^8.1.0",
+    "@metamask/logging-controller": "^8.0.2",
     "@metamask/messenger": "^2.0.0",
     "@metamask/network-controller": "^35.0.1",
     "@metamask/utils": "^11.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7715,7 +7715,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/logging-controller@npm:^8.1.0, @metamask/logging-controller@workspace:packages/logging-controller":
+"@metamask/logging-controller@npm:^8.0.2, @metamask/logging-controller@workspace:packages/logging-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/logging-controller@workspace:packages/logging-controller"
   dependencies:
@@ -8946,7 +8946,7 @@ __metadata:
     "@metamask/eth-sig-util": "npm:^8.2.0"
     "@metamask/gator-permissions-controller": "npm:^5.0.1"
     "@metamask/keyring-controller": "npm:^27.1.1"
-    "@metamask/logging-controller": "npm:^8.1.0"
+    "@metamask/logging-controller": "npm:^8.0.2"
     "@metamask/messenger": "npm:^2.0.0"
     "@metamask/network-controller": "npm:^35.0.1"
     "@metamask/utils": "npm:^11.11.0"


### PR DESCRIPTION
Reverts MetaMask/core#9841

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only revert with no runtime or API behavior changes in this PR.
> 
> **Overview**
> Reverts **Release 1189.0.0** (`#9841`), restoring pre-release package versions without removing the underlying unreleased `logging-controller` work.
> 
> Rolls the monorepo back to `1188.0.0` and `@metamask/logging-controller` from `8.1.0` to `8.0.2`. Updates `signature-controller` and `yarn.lock` to depend on `^8.0.2` again, and moves the `8.1.0` changelog entries (including `expiryTime`) back under **Unreleased**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f9a7c40a7aa509ed3e1f739f4734ac9e6b95747. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->