### PR TITLE
feat(account-tree-controller): add export support

### DIFF
--- a/packages/account-tree-controller/package.json
+++ b/packages/account-tree-controller/package.json
@@ -73,6 +73,7 @@
   "devDependencies": {
     "@metamask/account-api": "^2.0.0",
     "@metamask/auto-changelog": "^6.1.0",
+    "@metamask/eth-hd-keyring": "^15.0.0",
     "@metamask/providers": "^22.1.0",
     "@ts-bridge/cli": "^0.6.4",
     "@types/jest": "^30.0.0",

--- a/packages/account-tree-controller/src/state/export.test.ts
+++ b/packages/account-tree-controller/src/state/export.test.ts
@@ -1,0 +1,709 @@
+import {
+  AccountWalletType,
+  toAccountGroupId,
+  toMultichainAccountGroupId,
+  toAccountWalletId,
+} from '@metamask/account-api';
+import { AccountGroupType } from '@metamask/account-api';
+import { KeyringTypes } from '@metamask/keyring-controller';
+import { SnapId } from '@metamask/snaps-sdk';
+
+import type {
+  AccountTreeControllerMessenger,
+  AccountTreeControllerState,
+} from '../types.js';
+import type { ExportContext } from './export.js';
+import {
+  exportState,
+  isMnemonicWalletObject,
+  isPrivateKeyWalletObject,
+} from './export.js';
+import {
+  AccountWalletMnemonicGroupEntry,
+  AccountWalletPayloadType,
+  AccountWalletPrivateKeyEncoding,
+  toGroupPayloadId,
+  toWalletPayloadId,
+} from './payload.js';
+
+const MOCK_PRIVATE_KEY_PAYLOAD_ID = toWalletPayloadId(
+  AccountWalletPayloadType.PrivateKey,
+);
+
+const MOCK_HD_WALLET_ID = toAccountWalletId(
+  AccountWalletType.Entropy,
+  'mock-entropy-id',
+);
+const MOCK_HD_GROUP_ID = toMultichainAccountGroupId(MOCK_HD_WALLET_ID, 0);
+const MOCK_PRIVATE_KEY_WALLET_ID = toAccountWalletId(
+  AccountWalletType.Keyring,
+  KeyringTypes.simple,
+);
+const MOCK_PRIVATE_KEY_GROUP_ID = toAccountGroupId(
+  MOCK_PRIVATE_KEY_WALLET_ID,
+  '0xabc',
+);
+
+const MOCK_HD_WALLET_STATE: AccountTreeControllerState['accountTree']['wallets'] =
+  {
+    [MOCK_HD_WALLET_ID]: {
+      id: MOCK_HD_WALLET_ID,
+      type: AccountWalletType.Entropy,
+      status: 'ready',
+      groups: {
+        [MOCK_HD_GROUP_ID]: {
+          id: MOCK_HD_GROUP_ID,
+          type: AccountGroupType.MultichainAccount,
+          accounts: ['account-1'],
+          metadata: {
+            name: 'Account 1',
+            entropy: { groupIndex: 0 },
+            pinned: false,
+            hidden: false,
+            lastSelected: 0,
+          },
+        },
+      },
+      metadata: {
+        name: 'Wallet 1',
+        entropy: { id: 'mock-entropy-id' },
+      },
+    },
+  };
+
+const MOCK_PRIVATE_KEY_WALLET_STATE: AccountTreeControllerState['accountTree']['wallets'] =
+  {
+    [MOCK_PRIVATE_KEY_WALLET_ID]: {
+      id: MOCK_PRIVATE_KEY_WALLET_ID,
+      type: AccountWalletType.Keyring,
+      status: 'ready',
+      groups: {
+        [MOCK_PRIVATE_KEY_GROUP_ID]: {
+          id: MOCK_PRIVATE_KEY_GROUP_ID,
+          type: AccountGroupType.SingleAccount,
+          accounts: ['account-pk-1'],
+          metadata: {
+            name: 'Imported 1',
+            pinned: false,
+            hidden: false,
+            lastSelected: 0,
+          },
+        },
+      },
+      metadata: {
+        name: 'Imported Accounts',
+        keyring: { type: KeyringTypes.simple },
+      },
+    },
+  };
+
+/**
+ * Creates an ExportContext with individual jest mocks per action so tests can
+ * configure them with `.mockReturnValue` / `.mockImplementation`.
+ *
+ * @param options - Setup options.
+ * @param options.wallets - Initial wallet state.
+ * @param options.isUnlocked - Whether the vault reports as unlocked (default: true).
+ * @returns context, mocks (per-action jest.fn()s), and the raw messenger mock.
+ */
+function setup({
+  wallets = {} as AccountTreeControllerState['accountTree']['wallets'],
+  isUnlocked = true,
+}: {
+  wallets?: AccountTreeControllerState['accountTree']['wallets'];
+  isUnlocked?: boolean;
+} = {}): {
+  context: ExportContext;
+  /* eslint-disable @typescript-eslint/naming-convention */
+  mocks: {
+    KeyringController: {
+      getState: jest.Mock;
+      withKeyringV2Unsafe: jest.Mock;
+      withKeyringV2: jest.Mock;
+    };
+    AccountsController: { getAccount: jest.Mock };
+  };
+  /* eslint-enable @typescript-eslint/naming-convention */
+  messenger: AccountTreeControllerMessenger;
+} {
+  const mocks = {
+    KeyringController: {
+      getState: jest.fn().mockReturnValue({ isUnlocked, keyrings: [] }),
+      withKeyringV2Unsafe: jest.fn(),
+      withKeyringV2: jest.fn(),
+    },
+    AccountsController: {
+      getAccount: jest.fn(),
+    },
+  };
+
+  const messenger = {
+    call: jest.fn().mockImplementation((action: string, ...args: unknown[]) => {
+      switch (action) {
+        case 'KeyringController:getState':
+          return mocks.KeyringController.getState();
+        case 'KeyringController:withKeyringV2Unsafe':
+          return mocks.KeyringController.withKeyringV2Unsafe(...args);
+        case 'KeyringController:withKeyringV2':
+          return mocks.KeyringController.withKeyringV2(...args);
+        case 'AccountsController:getAccount':
+          return mocks.AccountsController.getAccount(...args);
+        default:
+          return undefined;
+      }
+    }),
+  } as unknown as AccountTreeControllerMessenger;
+
+  const state: AccountTreeControllerState = {
+    accountTree: { wallets },
+    selectedAccountGroup: '',
+    isAccountTreeSyncingInProgress: false,
+    hasAccountTreeSyncingSyncedAtLeastOnce: false,
+    accountGroupsMetadata: {},
+    accountWalletsMetadata: {},
+  };
+
+  const context: ExportContext = {
+    getState: () => state,
+    messenger,
+  };
+
+  return { context, mocks, messenger };
+}
+
+function makeHdKeyringHandler(
+  entropySourceId: string,
+  mnemonic: Uint8Array | null = null,
+): jest.Mock {
+  return jest
+    .fn()
+    .mockImplementation(
+      async (
+        _selector: unknown,
+        callback: (ctx: { keyring: unknown }) => unknown,
+      ) =>
+        callback({
+          keyring: {
+            toEntropySourceId: async () => entropySourceId,
+            mnemonic,
+          },
+        }),
+    );
+}
+
+function makePrivateKeyExportHandler(
+  result: { privateKey: string; encoding: string } | undefined,
+): jest.Mock {
+  return jest
+    .fn()
+    .mockImplementation(
+      async (
+        _selector: unknown,
+        callback: (ctx: { keyring: unknown }) => unknown,
+      ) =>
+        callback({
+          keyring: {
+            exportAccount: async () => result,
+          },
+        }),
+    );
+}
+
+describe('isMnemonicWalletObject', () => {
+  it('returns true for an entropy wallet', () => {
+    expect(
+      isMnemonicWalletObject(MOCK_HD_WALLET_STATE[MOCK_HD_WALLET_ID]),
+    ).toBe(true);
+  });
+
+  it('returns false for a keyring wallet', () => {
+    expect(
+      isMnemonicWalletObject(
+        MOCK_PRIVATE_KEY_WALLET_STATE[MOCK_PRIVATE_KEY_WALLET_ID],
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('isPrivateKeyWalletObject', () => {
+  it('returns true for a simple-keyring wallet', () => {
+    expect(
+      isPrivateKeyWalletObject(
+        MOCK_PRIVATE_KEY_WALLET_STATE[MOCK_PRIVATE_KEY_WALLET_ID],
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for an entropy wallet', () => {
+    expect(
+      isPrivateKeyWalletObject(MOCK_HD_WALLET_STATE[MOCK_HD_WALLET_ID]),
+    ).toBe(false);
+  });
+
+  it('returns false for a non-simple keyring wallet (e.g. ledger)', () => {
+    const ledgerWalletId = toAccountWalletId(
+      AccountWalletType.Keyring,
+      KeyringTypes.ledger,
+    );
+    const ledgerGroupId = toAccountGroupId(ledgerWalletId, '0xhw');
+    const ledgerWallet: AccountTreeControllerState['accountTree']['wallets'][string] =
+      {
+        id: ledgerWalletId,
+        type: AccountWalletType.Keyring,
+        status: 'ready',
+        groups: {
+          [ledgerGroupId]: {
+            id: ledgerGroupId,
+            type: AccountGroupType.SingleAccount,
+            accounts: ['account-hw-1'],
+            metadata: {
+              name: 'Ledger 1',
+              pinned: false,
+              hidden: false,
+              lastSelected: 0,
+            },
+          },
+        },
+        metadata: { name: 'Ledger', keyring: { type: KeyringTypes.ledger } },
+      };
+    expect(isPrivateKeyWalletObject(ledgerWallet)).toBe(false);
+  });
+});
+
+describe('exportState', () => {
+  describe('vault locking', () => {
+    it('throws when includeSecrets is true and the vault is locked', async () => {
+      const { context } = setup({ isUnlocked: false });
+      await expect(
+        exportState(context, { includeSecrets: true }),
+      ).rejects.toThrow(
+        'Cannot include secrets in export when vault is locked',
+      );
+    });
+
+    it('does not throw when includeSecrets is false and vault is locked', async () => {
+      const { context } = setup({ isUnlocked: false });
+      expect(await exportState(context)).toBeDefined();
+    });
+  });
+
+  describe('with no wallets', () => {
+    it('returns an empty snapshot', async () => {
+      const { context } = setup();
+      const snapshot = await exportState(context);
+      expect(snapshot.serialize().wallets).toHaveLength(0);
+    });
+  });
+
+  describe('with an HD wallet', () => {
+    it('exports the wallet without secrets by default', async () => {
+      const { context, mocks } = setup({ wallets: MOCK_HD_WALLET_STATE });
+      // encodeMnemonic uses Uint16Array internally -- must be even-length.
+      mocks.KeyringController.withKeyringV2Unsafe = makeHdKeyringHandler(
+        'stable-entropy-id',
+        new Uint8Array([1, 2, 3, 4]),
+      );
+
+      const snapshot = await exportState(context);
+      const wallet = snapshot.serialize().wallets[0];
+
+      expect(wallet?.id).toBe(toWalletPayloadId('stable-entropy-id'));
+      expect(wallet?.type).toBe(AccountWalletPayloadType.Mnemonic);
+      expect(wallet?.metadata.name).toBe('Wallet 1');
+      expect((wallet as { value?: string }).value).toBeUndefined();
+    });
+
+    it('exports the wallet with the mnemonic when includeSecrets is true', async () => {
+      const { context, mocks } = setup({ wallets: MOCK_HD_WALLET_STATE });
+      mocks.KeyringController.withKeyringV2Unsafe = makeHdKeyringHandler(
+        'stable-entropy-id',
+        new Uint8Array([1, 2, 3, 4]),
+      );
+
+      const snapshot = await exportState(context, { includeSecrets: true });
+      const wallet = snapshot.serialize().wallets[0] as { value?: string };
+
+      expect(Array.isArray(wallet.value)).toBe(true);
+    });
+
+    it('throws when includeSecrets is true but mnemonic is unavailable', async () => {
+      const { context, mocks } = setup({ wallets: MOCK_HD_WALLET_STATE });
+      // mnemonic: null -> includeMnemonic will be false -> throws after export.
+      mocks.KeyringController.withKeyringV2Unsafe = makeHdKeyringHandler(
+        'stable-entropy-id',
+        null,
+      );
+
+      await expect(
+        exportState(context, { includeSecrets: true }),
+      ).rejects.toThrow('Failed to export mnemonic');
+    });
+
+    it('populates the idMap with wallet and group local↔payload ID pairs', async () => {
+      const { context, mocks } = setup({ wallets: MOCK_HD_WALLET_STATE });
+      mocks.KeyringController.withKeyringV2Unsafe =
+        makeHdKeyringHandler('stable-entropy-id');
+
+      const snapshot = await exportState(context);
+
+      expect(snapshot.toLocalId(toWalletPayloadId('stable-entropy-id'))).toBe(
+        MOCK_HD_WALLET_ID,
+      );
+      expect(
+        snapshot.toLocalId(
+          toGroupPayloadId(toWalletPayloadId('stable-entropy-id'), 0),
+        ),
+      ).toBe(MOCK_HD_GROUP_ID);
+      expect(snapshot.toPayloadId(MOCK_HD_WALLET_ID)).toBe(
+        toWalletPayloadId('stable-entropy-id'),
+      );
+      expect(snapshot.toPayloadId(MOCK_HD_GROUP_ID)).toBe(
+        toGroupPayloadId(toWalletPayloadId('stable-entropy-id'), 0),
+      );
+    });
+
+    it('exports groups sorted by groupIndex regardless of insertion order', async () => {
+      const group0Id = toMultichainAccountGroupId(MOCK_HD_WALLET_ID, 0);
+      const group1Id = toMultichainAccountGroupId(MOCK_HD_WALLET_ID, 1);
+      const group2Id = toMultichainAccountGroupId(MOCK_HD_WALLET_ID, 2);
+
+      // Insert groups in reverse order so Object.values() returns them as [2, 1, 0].
+      const walletsWithReversedGroups: AccountTreeControllerState['accountTree']['wallets'] =
+        {
+          [MOCK_HD_WALLET_ID]: {
+            id: MOCK_HD_WALLET_ID,
+            type: AccountWalletType.Entropy,
+            status: 'ready',
+            groups: {
+              [group2Id]: {
+                id: group2Id,
+                type: AccountGroupType.MultichainAccount,
+                accounts: ['account-3'],
+                metadata: {
+                  name: 'Account 3',
+                  entropy: { groupIndex: 2 },
+                  pinned: false,
+                  hidden: false,
+                  lastSelected: 0,
+                },
+              },
+              [group1Id]: {
+                id: group1Id,
+                type: AccountGroupType.MultichainAccount,
+                accounts: ['account-2'],
+                metadata: {
+                  name: 'Account 2',
+                  entropy: { groupIndex: 1 },
+                  pinned: false,
+                  hidden: false,
+                  lastSelected: 0,
+                },
+              },
+              [group0Id]: {
+                id: group0Id,
+                type: AccountGroupType.MultichainAccount,
+                accounts: ['account-1'],
+                metadata: {
+                  name: 'Account 1',
+                  entropy: { groupIndex: 0 },
+                  pinned: false,
+                  hidden: false,
+                  lastSelected: 0,
+                },
+              },
+            },
+            metadata: { name: 'Wallet 1', entropy: { id: 'mock-entropy-id' } },
+          },
+        };
+
+      const { context, mocks } = setup({ wallets: walletsWithReversedGroups });
+      mocks.KeyringController.withKeyringV2Unsafe =
+        makeHdKeyringHandler('stable-entropy-id');
+
+      const snapshot = await exportState(context);
+      const groups = snapshot.serialize().wallets[0]
+        ?.groups as AccountWalletMnemonicGroupEntry[];
+
+      expect(groups?.map((group) => group.groupIndex)).toStrictEqual([0, 1, 2]);
+    });
+
+    it('skips snap and hardware wallets', async () => {
+      const snapWalletId = toAccountWalletId(
+        AccountWalletType.Snap,
+        'local:mock-snap',
+      );
+      const ledgerWalletId = toAccountWalletId(
+        AccountWalletType.Keyring,
+        KeyringTypes.ledger,
+      );
+      const snapGroupId = toAccountGroupId(snapWalletId, '0xsnap');
+      const ledgerGroupId = toAccountGroupId(ledgerWalletId, '0xhw');
+
+      const mixedWallets: AccountTreeControllerState['accountTree']['wallets'] =
+        {
+          [snapWalletId]: {
+            id: snapWalletId,
+            type: AccountWalletType.Snap,
+            status: 'ready',
+            groups: {
+              [snapGroupId]: {
+                id: snapGroupId,
+                type: AccountGroupType.SingleAccount,
+                accounts: ['snap-account-1'],
+                metadata: {
+                  name: 'Snap 1',
+                  pinned: false,
+                  hidden: false,
+                  lastSelected: 0,
+                },
+              },
+            },
+            metadata: {
+              name: 'Snap Wallet',
+              snap: { id: 'local:mock-snap' as SnapId },
+            },
+          },
+          [ledgerWalletId]: {
+            id: ledgerWalletId,
+            type: AccountWalletType.Keyring,
+            status: 'ready',
+            groups: {
+              [ledgerGroupId]: {
+                id: ledgerGroupId,
+                type: AccountGroupType.SingleAccount,
+                accounts: ['hw-account-1'],
+                metadata: {
+                  name: 'Ledger 1',
+                  pinned: false,
+                  hidden: false,
+                  lastSelected: 0,
+                },
+              },
+            },
+            metadata: {
+              name: 'Ledger',
+              keyring: { type: KeyringTypes.ledger },
+            },
+          },
+        };
+
+      const { context } = setup({ wallets: mixedWallets });
+      const snapshot = await exportState(context);
+      expect(snapshot.serialize().wallets).toHaveLength(0);
+    });
+  });
+
+  describe('with a private-key wallet', () => {
+    it('exports the wallet without secrets', async () => {
+      const { context, mocks } = setup({
+        wallets: MOCK_PRIVATE_KEY_WALLET_STATE,
+      });
+      mocks.AccountsController.getAccount.mockReturnValue({
+        id: 'account-pk-1',
+        address: '0xabc',
+      });
+
+      const snapshot = await exportState(context);
+      const payload = snapshot.serialize();
+
+      expect(payload.wallets).toHaveLength(1);
+      const wallet = payload.wallets[0];
+      expect(wallet?.id).toBe(MOCK_PRIVATE_KEY_PAYLOAD_ID);
+      expect(wallet?.type).toBe(AccountWalletPayloadType.PrivateKey);
+      expect(wallet?.groups).toHaveLength(1);
+      expect(wallet?.groups[0]?.id).toBe(
+        toGroupPayloadId(MOCK_PRIVATE_KEY_PAYLOAD_ID, '0xabc'),
+      );
+      expect((wallet?.groups[0] as { value?: unknown })?.value).toBeUndefined();
+    });
+
+    it('exports the wallet with secrets when includeSecrets is true', async () => {
+      const { context, mocks } = setup({
+        wallets: MOCK_PRIVATE_KEY_WALLET_STATE,
+      });
+      mocks.AccountsController.getAccount.mockReturnValue({
+        id: 'account-pk-1',
+        address: '0xabc',
+      });
+      mocks.KeyringController.withKeyringV2 = makePrivateKeyExportHandler({
+        privateKey: '0xdeadbeef',
+        encoding: AccountWalletPrivateKeyEncoding.Hexadecimal,
+      });
+
+      const snapshot = await exportState(context, { includeSecrets: true });
+      const group = snapshot.serialize().wallets[0]?.groups[0] as {
+        value?: { privateKey: number[]; encoding: string; type: string };
+      };
+
+      expect(group.value?.privateKey).toStrictEqual(
+        Array.from(new TextEncoder().encode('0xdeadbeef')),
+      );
+      expect(group.value?.encoding).toBe(
+        AccountWalletPrivateKeyEncoding.Hexadecimal,
+      );
+      expect(group.value?.type).toBe('eip155:eoa');
+    });
+
+    it('throws when includeSecrets is true but keyring does not support exportAccount', async () => {
+      const { context, mocks } = setup({
+        wallets: MOCK_PRIVATE_KEY_WALLET_STATE,
+      });
+      mocks.AccountsController.getAccount.mockReturnValue({
+        id: 'account-pk-1',
+        address: '0xabc',
+      });
+      mocks.KeyringController.withKeyringV2.mockImplementation(
+        async (
+          _selector: unknown,
+          callback: (ctx: { keyring: unknown }) => unknown,
+        ) => callback({ keyring: {} }), // No exportAccount method.
+      );
+
+      await expect(
+        exportState(context, { includeSecrets: true }),
+      ).rejects.toThrow('does not support exportAccount');
+    });
+
+    it('throws when includeSecrets is true but the exported value is absent', async () => {
+      const { context, mocks } = setup({
+        wallets: MOCK_PRIVATE_KEY_WALLET_STATE,
+      });
+      mocks.AccountsController.getAccount.mockReturnValue({
+        id: 'account-pk-1',
+        address: '0xabc',
+      });
+      mocks.KeyringController.withKeyringV2 =
+        makePrivateKeyExportHandler(undefined);
+
+      await expect(
+        exportState(context, { includeSecrets: true }),
+      ).rejects.toThrow('Failed to export private key');
+    });
+
+    it('skips groups whose first account cannot be found', async () => {
+      const { context, mocks } = setup({
+        wallets: MOCK_PRIVATE_KEY_WALLET_STATE,
+      });
+      mocks.AccountsController.getAccount.mockReturnValue(undefined);
+
+      const snapshot = await exportState(context);
+      expect(snapshot.serialize().wallets[0]?.groups).toHaveLength(0);
+    });
+
+    it('skips groups with no accounts', async () => {
+      const emptyGroupWalletId = toAccountWalletId(
+        AccountWalletType.Keyring,
+        KeyringTypes.simple,
+      );
+      const emptyGroupId = toAccountGroupId(emptyGroupWalletId, '0xempty');
+      const wallets: AccountTreeControllerState['accountTree']['wallets'] = {
+        [emptyGroupWalletId]: {
+          id: emptyGroupWalletId,
+          type: AccountWalletType.Keyring,
+          status: 'ready',
+          groups: {
+            [emptyGroupId]: {
+              id: emptyGroupId,
+              type: AccountGroupType.SingleAccount,
+              // @ts-expect-error -- deliberately empty for the test
+              accounts: [],
+              metadata: {
+                name: 'Empty',
+                pinned: false,
+                hidden: false,
+                lastSelected: 0,
+              },
+            },
+          },
+          metadata: {
+            name: 'Imported Accounts',
+            keyring: { type: KeyringTypes.simple },
+          },
+        },
+      };
+
+      const { context } = setup({ wallets });
+      const snapshot = await exportState(context);
+      expect(snapshot.serialize().wallets[0]?.groups).toHaveLength(0);
+    });
+
+    it('populates the idMap with private-key wallet and group pairs', async () => {
+      const { context, mocks } = setup({
+        wallets: MOCK_PRIVATE_KEY_WALLET_STATE,
+      });
+      mocks.AccountsController.getAccount.mockReturnValue({
+        id: 'account-pk-1',
+        address: '0xabc',
+      });
+
+      const snapshot = await exportState(context);
+
+      expect(snapshot.toLocalId(MOCK_PRIVATE_KEY_PAYLOAD_ID)).toBe(
+        MOCK_PRIVATE_KEY_WALLET_ID,
+      );
+      expect(
+        snapshot.toLocalId(
+          toGroupPayloadId(MOCK_PRIVATE_KEY_PAYLOAD_ID, '0xabc'),
+        ),
+      ).toBe(MOCK_PRIVATE_KEY_GROUP_ID);
+    });
+
+    it('merges multiple simple-keyring wallets into one private-key payload entry', async () => {
+      const secondPkWalletId =
+        'keyring:simple:legacy' as typeof MOCK_PRIVATE_KEY_WALLET_ID;
+      const secondPkGroupId = toAccountGroupId(secondPkWalletId, '0xdef');
+
+      const wallets: AccountTreeControllerState['accountTree']['wallets'] = {
+        ...MOCK_PRIVATE_KEY_WALLET_STATE,
+        [secondPkWalletId]: {
+          id: secondPkWalletId,
+          type: AccountWalletType.Keyring,
+          status: 'ready',
+          groups: {
+            [secondPkGroupId]: {
+              id: secondPkGroupId,
+              type: AccountGroupType.SingleAccount,
+              accounts: ['account-pk-2'],
+              metadata: {
+                name: 'Imported 2',
+                pinned: false,
+                hidden: false,
+                lastSelected: 0,
+              },
+            },
+          },
+          metadata: {
+            name: 'Imported Accounts 2',
+            keyring: { type: KeyringTypes.simple },
+          },
+        },
+      };
+
+      const { context, mocks } = setup({ wallets });
+      mocks.AccountsController.getAccount.mockImplementation((accountId) => {
+        if (accountId === 'account-pk-1') {
+          return { id: 'account-pk-1', address: '0xabc' };
+        }
+        if (accountId === 'account-pk-2') {
+          return { id: 'account-pk-2', address: '0xdef' };
+        }
+        return undefined;
+      });
+
+      const snapshot = await exportState(context);
+      const payload = snapshot.serialize();
+
+      expect(payload.wallets).toHaveLength(1);
+      expect(payload.wallets[0]?.type).toBe(
+        AccountWalletPayloadType.PrivateKey,
+      );
+      expect(payload.wallets[0]?.groups).toHaveLength(2);
+      expect(payload.wallets[0]?.groups.map((group) => group.id)).toStrictEqual(
+        [
+          toGroupPayloadId(MOCK_PRIVATE_KEY_PAYLOAD_ID, '0xabc'),
+          toGroupPayloadId(MOCK_PRIVATE_KEY_PAYLOAD_ID, '0xdef'),
+        ],
+      );
+    });
+  });
+});

--- a/packages/account-tree-controller/src/state/export.test.ts
+++ b/packages/account-tree-controller/src/state/export.test.ts
@@ -428,6 +428,55 @@ describe('exportState', () => {
       expect(groups?.map((group) => group.groupIndex)).toStrictEqual([0, 1, 2]);
     });
 
+    it('throws when mnemonic groups have a gap after sorting', async () => {
+      const group0Id = toMultichainAccountGroupId(MOCK_HD_WALLET_ID, 0);
+      const group2Id = toMultichainAccountGroupId(MOCK_HD_WALLET_ID, 2);
+
+      const walletsWithGap: AccountTreeControllerState['accountTree']['wallets'] =
+        {
+          [MOCK_HD_WALLET_ID]: {
+            id: MOCK_HD_WALLET_ID,
+            type: AccountWalletType.Entropy,
+            status: 'ready',
+            groups: {
+              [group0Id]: {
+                id: group0Id,
+                type: AccountGroupType.MultichainAccount,
+                accounts: ['account-1'],
+                metadata: {
+                  name: 'Account 1',
+                  entropy: { groupIndex: 0 },
+                  pinned: false,
+                  hidden: false,
+                  lastSelected: 0,
+                },
+              },
+              [group2Id]: {
+                id: group2Id,
+                type: AccountGroupType.MultichainAccount,
+                accounts: ['account-3'],
+                metadata: {
+                  name: 'Account 3',
+                  entropy: { groupIndex: 2 },
+                  pinned: false,
+                  hidden: false,
+                  lastSelected: 0,
+                },
+              },
+            },
+            metadata: { name: 'Wallet 1', entropy: { id: 'mock-entropy-id' } },
+          },
+        };
+
+      const { context, mocks } = setup({ wallets: walletsWithGap });
+      mocks.KeyringController.withKeyringV2Unsafe =
+        makeHdKeyringHandler('stable-entropy-id');
+
+      await expect(exportState(context)).rejects.toThrow(
+        'Found non-contiguous groups in mnemonic wallet',
+      );
+    });
+
     it('skips snap and hardware wallets', async () => {
       const snapWalletId = toAccountWalletId(
         AccountWalletType.Snap,

--- a/packages/account-tree-controller/src/state/export.test.ts
+++ b/packages/account-tree-controller/src/state/export.test.ts
@@ -273,18 +273,18 @@ describe('isPrivateKeyWalletObject', () => {
 
 describe('exportState', () => {
   describe('vault locking', () => {
-    it('throws when includeSecrets is true and the vault is locked', async () => {
+    it('throws when the vault is locked', async () => {
       const { context } = setup({ isUnlocked: false });
-      await expect(
-        exportState(context, { includeSecrets: true }),
-      ).rejects.toThrow(
-        'Cannot include secrets in export when vault is locked',
+      await expect(exportState(context)).rejects.toThrow(
+        'Cannot export account tree when vault is locked',
       );
     });
 
-    it('does not throw when includeSecrets is false and vault is locked', async () => {
+    it('throws when the vault is locked even without includeSecrets', async () => {
       const { context } = setup({ isUnlocked: false });
-      expect(await exportState(context)).toBeDefined();
+      await expect(
+        exportState(context, { includeSecrets: false }),
+      ).rejects.toThrow('Cannot export account tree when vault is locked');
     });
   });
 

--- a/packages/account-tree-controller/src/state/export.test.ts
+++ b/packages/account-tree-controller/src/state/export.test.ts
@@ -7,6 +7,7 @@ import {
 import { AccountGroupType } from '@metamask/account-api';
 import { KeyringTypes } from '@metamask/keyring-controller';
 import { SnapId } from '@metamask/snaps-sdk';
+import { InternalAccount } from '@metamask/snaps-utils';
 
 import type {
   AccountTreeControllerMessenger,
@@ -81,7 +82,7 @@ const MOCK_PRIVATE_KEY_WALLET_STATE: AccountTreeControllerState['accountTree']['
         [MOCK_PRIVATE_KEY_GROUP_ID]: {
           id: MOCK_PRIVATE_KEY_GROUP_ID,
           type: AccountGroupType.SingleAccount,
-          accounts: ['account-pk-1'],
+          accounts: ['account-private-key-1'],
           metadata: {
             name: 'Imported 1',
             pinned: false,
@@ -499,7 +500,7 @@ describe('exportState', () => {
         wallets: MOCK_PRIVATE_KEY_WALLET_STATE,
       });
       mocks.AccountsController.getAccount.mockReturnValue({
-        id: 'account-pk-1',
+        id: 'account-private-key-1',
         address: '0xabc',
       });
 
@@ -522,7 +523,7 @@ describe('exportState', () => {
         wallets: MOCK_PRIVATE_KEY_WALLET_STATE,
       });
       mocks.AccountsController.getAccount.mockReturnValue({
-        id: 'account-pk-1',
+        id: 'account-private-key-1',
         address: '0xabc',
       });
       mocks.KeyringController.withKeyringV2 = makePrivateKeyExportHandler({
@@ -549,7 +550,7 @@ describe('exportState', () => {
         wallets: MOCK_PRIVATE_KEY_WALLET_STATE,
       });
       mocks.AccountsController.getAccount.mockReturnValue({
-        id: 'account-pk-1',
+        id: 'account-private-key-1',
         address: '0xabc',
       });
       mocks.KeyringController.withKeyringV2.mockImplementation(
@@ -569,7 +570,7 @@ describe('exportState', () => {
         wallets: MOCK_PRIVATE_KEY_WALLET_STATE,
       });
       mocks.AccountsController.getAccount.mockReturnValue({
-        id: 'account-pk-1',
+        id: 'account-private-key-1',
         address: '0xabc',
       });
       mocks.KeyringController.withKeyringV2 =
@@ -632,7 +633,7 @@ describe('exportState', () => {
         wallets: MOCK_PRIVATE_KEY_WALLET_STATE,
       });
       mocks.AccountsController.getAccount.mockReturnValue({
-        id: 'account-pk-1',
+        id: 'account-private-key-1',
         address: '0xabc',
       });
 
@@ -649,21 +650,24 @@ describe('exportState', () => {
     });
 
     it('merges multiple simple-keyring wallets into one private-key payload entry', async () => {
-      const secondPkWalletId =
+      const secondPrivateKeyWalletId =
         'keyring:simple:legacy' as typeof MOCK_PRIVATE_KEY_WALLET_ID;
-      const secondPkGroupId = toAccountGroupId(secondPkWalletId, '0xdef');
+      const secondPrivateKeyGroupId = toAccountGroupId(
+        secondPrivateKeyWalletId,
+        '0xdef',
+      );
 
       const wallets: AccountTreeControllerState['accountTree']['wallets'] = {
         ...MOCK_PRIVATE_KEY_WALLET_STATE,
-        [secondPkWalletId]: {
-          id: secondPkWalletId,
+        [secondPrivateKeyWalletId]: {
+          id: secondPrivateKeyWalletId,
           type: AccountWalletType.Keyring,
           status: 'ready',
           groups: {
-            [secondPkGroupId]: {
-              id: secondPkGroupId,
+            [secondPrivateKeyGroupId]: {
+              id: secondPrivateKeyGroupId,
               type: AccountGroupType.SingleAccount,
-              accounts: ['account-pk-2'],
+              accounts: ['account-private-key-2'],
               metadata: {
                 name: 'Imported 2',
                 pinned: false,
@@ -680,15 +684,17 @@ describe('exportState', () => {
       };
 
       const { context, mocks } = setup({ wallets });
-      mocks.AccountsController.getAccount.mockImplementation((accountId) => {
-        if (accountId === 'account-pk-1') {
-          return { id: 'account-pk-1', address: '0xabc' };
-        }
-        if (accountId === 'account-pk-2') {
-          return { id: 'account-pk-2', address: '0xdef' };
-        }
-        return undefined;
-      });
+      mocks.AccountsController.getAccount.mockImplementation(
+        (accountId: InternalAccount['id']) => {
+          if (accountId === 'account-private-key-1') {
+            return { id: 'account-private-key-1', address: '0xabc' };
+          }
+          if (accountId === 'account-private-key-2') {
+            return { id: 'account-private-key-2', address: '0xdef' };
+          }
+          return undefined;
+        },
+      );
 
       const snapshot = await exportState(context);
       const payload = snapshot.serialize();

--- a/packages/account-tree-controller/src/state/export.ts
+++ b/packages/account-tree-controller/src/state/export.ts
@@ -143,7 +143,15 @@ async function exportMnemonicWalletObject(
     (group, otherGroup) => group.groupIndex - otherGroup.groupIndex,
   );
 
-  // This should never happen, but we check just in case.
+  // Defensive check: group indices must be contiguous starting at 0. This should never happen
+  // in practice since groups are only ever appended, but guards against future regressions
+  // producing a payload that silently fails validation on import.
+  for (let i = 0; i < wallet.groups.length; i++) {
+    if (wallet.groups[i]?.groupIndex !== i) {
+      throw new Error('Found non-contiguous groups in mnemonic wallet');
+    }
+  }
+
   if (includeSecrets) {
     if (mnemonic === undefined) {
       throw new Error(`Failed to export mnemonic for wallet ${wallet.id}`);

--- a/packages/account-tree-controller/src/state/export.ts
+++ b/packages/account-tree-controller/src/state/export.ts
@@ -1,0 +1,318 @@
+import { AccountWalletType } from '@metamask/account-api';
+import { HdKeyring } from '@metamask/eth-hd-keyring/v2';
+import { EthAccountType } from '@metamask/keyring-api';
+import { PrivateKeyExportedAccount } from '@metamask/keyring-api/v2';
+import { KeyringTypes } from '@metamask/keyring-controller';
+
+import type {
+  AccountTreeControllerMessenger,
+  AccountTreeControllerState,
+} from '../types.js';
+import type { AccountWalletObject } from '../wallet.js';
+import {
+  AccountWalletEntropyObject,
+  AccountWalletKeyringObject,
+} from '../wallet.js';
+import { IdMap } from './id-map.js';
+import type {
+  AccountTreeWalletEntry,
+  AccountWalletMnemonicGroupEntry,
+  AccountWalletMnemonicPayload,
+  AccountWalletPrivateKeyGroupEntry,
+  AccountWalletPrivateKeyPayload,
+  ExportStateOptions,
+} from './payload.js';
+import {
+  AccountWalletPayloadType,
+  AccountWalletPrivateKeyEncoding,
+  toWalletPayloadId,
+  toGroupPayloadId,
+} from './payload.js';
+import { AccountTreeSnapshot } from './snapshot.js';
+import { encodeBytes } from './utils.js';
+
+/**
+ * Returns `true` if `wallet` is an HD entropy wallet ({@link AccountWalletEntropyObject}).
+ *
+ * @param wallet - The wallet object to test.
+ * @returns Type predicate narrowing to {@link AccountWalletEntropyObject}.
+ */
+export function isMnemonicWalletObject(
+  wallet: AccountWalletObject,
+): wallet is AccountWalletEntropyObject {
+  return wallet.type === AccountWalletType.Entropy;
+}
+
+/**
+ * Returns `true` if `wallet` is an imported private-key wallet
+ * ({@link AccountWalletKeyringObject} with keyring type {@link KeyringTypes.simple}).
+ *
+ * @param wallet - The wallet object to test.
+ * @returns Type predicate narrowing to {@link AccountWalletKeyringObject}.
+ */
+export function isPrivateKeyWalletObject(
+  wallet: AccountWalletObject,
+): wallet is AccountWalletKeyringObject {
+  return (
+    wallet.type === AccountWalletType.Keyring &&
+    wallet.metadata.keyring.type === KeyringTypes.simple
+  );
+}
+
+/** Context required by {@link exportState}. */
+export type ExportContext = {
+  getState: () => AccountTreeControllerState;
+  messenger: AccountTreeControllerMessenger;
+};
+
+/**
+ * Exports a single entropy (HD) wallet object as an {@link AccountWalletMnemonicPayload}.
+ *
+ * Calls `KeyringController:withKeyringV2Unsafe` to derive the stable entropy source ID
+ * via {@link HdKeyring.toEntropySourceId} and, when `includeSecrets` is `true`, to read
+ * the raw mnemonic bytes.
+ *
+ * @param context - Export context.
+ * @param walletObj - The local entropy wallet to export.
+ * @param includeSecrets - When `true`, the BIP-39 mnemonic is included in the payload.
+ * @param idMap - ID map to populate with local↔payload ID pairs for this wallet and its groups.
+ * @returns The mnemonic wallet payload entry.
+ * @throws If `includeSecrets` is `true` but the mnemonic cannot be read from the keyring.
+ */
+async function exportMnemonicWalletObject(
+  context: ExportContext,
+  walletObj: AccountWalletEntropyObject,
+  includeSecrets: boolean,
+  idMap: IdMap,
+): Promise<AccountWalletMnemonicPayload> {
+  const result = await context.messenger.call(
+    'KeyringController:withKeyringV2Unsafe',
+    // The local wallet entropy ID is the keyring ID.
+    { id: walletObj.metadata.entropy.id },
+    async ({ keyring }) => {
+      const hdKeyring = keyring as HdKeyring;
+      const includeMnemonic =
+        includeSecrets &&
+        hdKeyring.mnemonic !== null &&
+        hdKeyring.mnemonic !== undefined;
+
+      return {
+        // Compute the stable entropy source ID from the keyring's mnemonic (BIP-39 seed).
+        entropySourceId: await hdKeyring.toEntropySourceId(),
+        // No need to include the mnemonic here if we're not exporting secrets.
+        mnemonic: includeMnemonic ? hdKeyring.mnemonic : undefined,
+      };
+    },
+  );
+  const { entropySourceId, mnemonic } = result as {
+    entropySourceId: string;
+    mnemonic?: Uint8Array;
+  };
+
+  // We use the stable entropy source ID as the payload wallet ID, rather than the local wallet ID, to
+  // ensure that the exported snapshot is stable across different installations and sessions.
+  const wallet: AccountWalletMnemonicPayload = {
+    type: AccountWalletPayloadType.Mnemonic,
+    id: toWalletPayloadId(entropySourceId),
+    metadata: { name: walletObj.metadata.name },
+    groups: [],
+  };
+
+  idMap.add(walletObj.id, wallet.id);
+
+  for (const groupObj of Object.values(walletObj.groups)) {
+    const { groupIndex } = groupObj.metadata.entropy;
+
+    const group: AccountWalletMnemonicGroupEntry = {
+      id: toGroupPayloadId(wallet.id, groupIndex),
+      groupIndex,
+      metadata: {
+        name: groupObj.metadata.name,
+        pinned: groupObj.metadata.pinned,
+        hidden: groupObj.metadata.hidden,
+      },
+    };
+
+    idMap.add(groupObj.id, group.id);
+
+    wallet.groups.push(group);
+  }
+
+  // Sort the groups by their `groupIndex` to ensure a stable order in the exported payload.
+  wallet.groups.sort(
+    (group, otherGroup) => group.groupIndex - otherGroup.groupIndex,
+  );
+
+  // This should never happen, but we check just in case.
+  if (includeSecrets) {
+    if (mnemonic === undefined) {
+      throw new Error(`Failed to export mnemonic for wallet ${wallet.id}`);
+    }
+
+    wallet.value = encodeBytes(mnemonic);
+  }
+
+  return wallet;
+}
+
+/**
+ * Exports a single simple-keyring wallet object as an {@link AccountWalletPrivateKeyPayload}.
+ *
+ * All groups from the wallet are merged into the `'private-key'` singleton payload entry.
+ * When `includeSecrets` is `true`, each group's private key is exported via
+ * `KeyringController:withKeyringV2`.
+ *
+ * @param context - Export context.
+ * @param walletObj - The local simple-keyring wallet to export.
+ * @param includeSecrets - When `true`, private keys are included in the payload.
+ * @param idMap - ID map to populate with local↔payload ID pairs for this wallet and its groups.
+ * @returns The private-key wallet payload entry.
+ * @throws If `includeSecrets` is `true` but a private key cannot be exported for an account.
+ */
+async function exportPrivateKeyWalletObject(
+  context: ExportContext,
+  walletObj: AccountWalletKeyringObject,
+  includeSecrets: boolean,
+  idMap: IdMap,
+): Promise<AccountWalletPrivateKeyPayload> {
+  // We use a singleton wallet ID for private keys.
+  const wallet: AccountWalletPrivateKeyPayload = {
+    type: AccountWalletPayloadType.PrivateKey,
+    id: toWalletPayloadId(AccountWalletPayloadType.PrivateKey),
+    metadata: { name: walletObj.metadata.name },
+    groups: [],
+  };
+
+  for (const groupObj of Object.values(walletObj.groups)) {
+    const accountId = groupObj.accounts[0];
+    if (!accountId) {
+      continue;
+    }
+    const account = context.messenger.call(
+      'AccountsController:getAccount',
+      accountId,
+    );
+    if (!account) {
+      continue;
+    }
+
+    const { address } = account;
+
+    let exported: PrivateKeyExportedAccount | undefined;
+    if (includeSecrets) {
+      const result = await context.messenger.call(
+        'KeyringController:withKeyringV2',
+        { address },
+        async ({ keyring }) => {
+          if (!keyring.exportAccount) {
+            throw new Error(
+              `Keyring for account ${accountId} does not support exportAccount`,
+            );
+          }
+
+          return keyring.exportAccount(accountId, {
+            type: 'private-key',
+            encoding: AccountWalletPrivateKeyEncoding.Hexadecimal,
+          });
+        },
+      );
+
+      exported = result as PrivateKeyExportedAccount;
+    }
+
+    const group: AccountWalletPrivateKeyGroupEntry = {
+      id: toGroupPayloadId(wallet.id, address),
+      metadata: {
+        name: groupObj.metadata.name,
+        pinned: groupObj.metadata.pinned,
+        hidden: groupObj.metadata.hidden,
+      },
+    };
+
+    if (includeSecrets) {
+      if (!exported) {
+        throw new Error(
+          `Failed to export private key for account ${accountId}`,
+        );
+      }
+      group.value = {
+        privateKey: encodeBytes(new TextEncoder().encode(exported.privateKey)),
+        encoding: exported.encoding,
+        type: EthAccountType.Eoa,
+      };
+    }
+
+    idMap.add(groupObj.id, group.id);
+
+    wallet.groups.push(group);
+  }
+
+  return wallet;
+}
+
+/**
+ * Builds an {@link AccountTreeSnapshot} from the current controller state.
+ *
+ * Iterates over all wallets in the tree:
+ * - {@link AccountWalletType.Entropy} (HD) wallets -> `'mnemonic'` payload entries.
+ * - {@link AccountWalletType.Keyring} wallets of type `simple` -> `'private-key'` payload entries.
+ * - Snap wallets and hardware keyrings are skipped in v1.
+ *
+ * @param context - Export context providing state and messenger access.
+ * @param options - Export options.
+ * @returns A promise that resolves to the built snapshot.
+ * @throws If `options.includeSecrets` is `true` and the vault is locked.
+ */
+export async function exportState(
+  context: ExportContext,
+  options: ExportStateOptions = {},
+): Promise<AccountTreeSnapshot> {
+  const state = context.getState();
+
+  const includeSecrets = options.includeSecrets ?? false;
+  const { isUnlocked } = context.messenger.call('KeyringController:getState');
+  if (includeSecrets && !isUnlocked) {
+    throw new Error('Cannot include secrets in export when vault is locked');
+  }
+
+  const idMap = new IdMap();
+  const entries: AccountTreeWalletEntry[] = [];
+  let privateKeyWallet: AccountWalletPrivateKeyPayload | undefined;
+
+  for (const walletObj of Object.values(state.accountTree.wallets)) {
+    if (isMnemonicWalletObject(walletObj)) {
+      entries.push(
+        await exportMnemonicWalletObject(
+          context,
+          walletObj,
+          includeSecrets,
+          idMap,
+        ),
+      );
+    } else if (isPrivateKeyWalletObject(walletObj)) {
+      const exported = await exportPrivateKeyWalletObject(
+        context,
+        walletObj,
+        includeSecrets,
+        idMap,
+      );
+
+      if (privateKeyWallet) {
+        privateKeyWallet.groups.push(...exported.groups);
+      } else {
+        privateKeyWallet = exported;
+
+        // Register only once, since all private keys are exported into the same wallet entry.
+        idMap.add(walletObj.id, exported.id);
+      }
+    } else {
+      // AccountWalletType.Snap and hardware keyrings: skipped for now.
+    }
+  }
+
+  if (privateKeyWallet) {
+    entries.push(privateKeyWallet);
+  }
+
+  return new AccountTreeSnapshot(entries, idMap);
+}

--- a/packages/account-tree-controller/src/state/export.ts
+++ b/packages/account-tree-controller/src/state/export.ts
@@ -261,7 +261,7 @@ async function exportPrivateKeyWalletObject(
  * @param context - Export context providing state and messenger access.
  * @param options - Export options.
  * @returns A promise that resolves to the built snapshot.
- * @throws If `options.includeSecrets` is `true` and the vault is locked.
+ * @throws If the vault is locked.
  */
 export async function exportState(
   context: ExportContext,
@@ -271,8 +271,8 @@ export async function exportState(
 
   const includeSecrets = options.includeSecrets ?? false;
   const { isUnlocked } = context.messenger.call('KeyringController:getState');
-  if (includeSecrets && !isUnlocked) {
-    throw new Error('Cannot include secrets in export when vault is locked');
+  if (!isUnlocked) {
+    throw new Error('Cannot export account tree when vault is locked');
   }
 
   const idMap = new IdMap();

--- a/packages/account-tree-controller/src/state/payload.ts
+++ b/packages/account-tree-controller/src/state/payload.ts
@@ -210,7 +210,7 @@ export function toGroupPayloadId(
 
 /** Options accepted by {@link AccountTreeController.exportState}. */
 export type ExportStateOptions = {
-  /** When `true`, secrets (mnemonic / private keys) are included. Requires the vault to be unlocked. */
+  /** When `true`, secrets (mnemonic / private keys) are included in the export. */
   includeSecrets?: boolean;
 };
 

--- a/packages/account-tree-controller/src/types.ts
+++ b/packages/account-tree-controller/src/types.ts
@@ -14,7 +14,11 @@ import type {
   ControllerStateChangeEvent,
 } from '@metamask/base-controller';
 import type { TraceCallback } from '@metamask/controller-utils';
-import type { KeyringControllerGetStateAction } from '@metamask/keyring-controller';
+import type {
+  KeyringControllerGetStateAction,
+  KeyringControllerWithKeyringV2Action,
+  KeyringControllerWithKeyringV2UnsafeAction,
+} from '@metamask/keyring-controller';
 import type { Messenger } from '@metamask/messenger';
 import type {
   MultichainAccountServiceCreateMultichainAccountGroupAction,
@@ -94,7 +98,9 @@ export type AllowedActions =
   | UserStorageController.UserStorageControllerPerformBatchSetStorageAction
   | AuthenticationController.AuthenticationControllerGetSessionProfileAction
   | MultichainAccountServiceCreateMultichainAccountGroupAction
-  | MultichainAccountServiceCreateMultichainAccountGroupsAction;
+  | MultichainAccountServiceCreateMultichainAccountGroupsAction
+  | KeyringControllerWithKeyringV2Action
+  | KeyringControllerWithKeyringV2UnsafeAction;
 
 export type AccountTreeControllerActions =
   | AccountTreeControllerGetStateAction

--- a/yarn.lock
+++ b/yarn.lock
@@ -5743,6 +5743,7 @@ __metadata:
     "@metamask/accounts-controller": "npm:^39.1.0"
     "@metamask/auto-changelog": "npm:^6.1.0"
     "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/eth-hd-keyring": "npm:^15.0.0"
     "@metamask/keyring-api": "npm:^24.0.0"
     "@metamask/keyring-controller": "npm:^27.1.1"
     "@metamask/messenger": "npm:^2.0.0"


### PR DESCRIPTION
## Explanation

Add the export functions for the import/export feature of the account-tree.

## References

- https://github.com/MetaMask/core/pull/9663

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches mnemonic and private-key export via keyring APIs; mishandling could leak secrets or produce bad import payloads, though behavior is gated on an unlocked vault and covered by tests.
> 
> **Overview**
> Adds **`exportState`** in `account-tree-controller` to build an **`AccountTreeSnapshot`** from live account-tree state for the import/export feature.
> 
> Export maps **HD (entropy) wallets** to mnemonic payload entries (stable wallet IDs from `HdKeyring.toEntropySourceId`, groups sorted by `groupIndex` with a contiguous-index guard) and **simple-keyring imported wallets** into a single **`private-key`** payload, merging multiple local simple wallets into one entry. **Snap and hardware wallets are omitted** in this v1 path. Optional **`includeSecrets`** pulls mnemonics via `KeyringController:withKeyringV2Unsafe` and private keys via `withKeyringV2` / `exportAccount`; **any export fails if the vault is locked**, including metadata-only exports.
> 
> Messenger types now allow the keyring `withKeyringV2` actions; **`@metamask/eth-hd-keyring`** is added as a dev dependency for tests. A large **`export.test.ts`** suite covers locking, secrets, ID mapping, edge cases, and wallet-type filtering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 479c6d800b18bcf5920f69e89a8e5b8a33ee17a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->