### PR TITLE
fix(perps): ensure SDK clients before provider metadata read

### DIFF
--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -65,6 +65,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prevent `CLIENT_NOT_INITIALIZED` errors during cold-start and reconnection by awaiting in-flight initialization in trading action methods (`placeOrder`, `editOrder`, `cancelOrder`, `closePosition`, `deposit`, `withdraw`, etc.) ([#9032](https://github.com/MetaMask/core/pull/9032))
 - Fix compound error string (`CLIENT_NOT_INITIALIZED: <reason>`) breaking i18n translation lookup — now always throws the plain `CLIENT_NOT_INITIALIZED` code ([#9032](https://github.com/MetaMask/core/pull/9032))
 - Recreate all four SDK clients (including `ExchangeClient` and HTTP `InfoClient`) during WebSocket reconnection so `isInitialized()` returns `true` after reconnect ([#9032](https://github.com/MetaMask/core/pull/9032))
+- Bring the HyperLiquid SDK clients up before the provider's first asset-metadata read, so a trading action taken during cold start or after a disconnect waits for the clients instead of failing with `CLIENT_NOT_INITIALIZED` ([#9841](https://github.com/MetaMask/core/pull/9841))
+  - `placeOrder` resolves asset info before it ensures trading readiness, so waiting for controller initialization alone was not enough: the metadata read still hit an uninitialized `InfoClient` and the order failed. Warm reads are unaffected — the cached path returns before the client check.
 
 ## [11.0.0]
 

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -65,7 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prevent `CLIENT_NOT_INITIALIZED` errors during cold-start and reconnection by awaiting in-flight initialization in trading action methods (`placeOrder`, `editOrder`, `cancelOrder`, `closePosition`, `deposit`, `withdraw`, etc.) ([#9032](https://github.com/MetaMask/core/pull/9032))
 - Fix compound error string (`CLIENT_NOT_INITIALIZED: <reason>`) breaking i18n translation lookup — now always throws the plain `CLIENT_NOT_INITIALIZED` code ([#9032](https://github.com/MetaMask/core/pull/9032))
 - Recreate all four SDK clients (including `ExchangeClient` and HTTP `InfoClient`) during WebSocket reconnection so `isInitialized()` returns `true` after reconnect ([#9032](https://github.com/MetaMask/core/pull/9032))
-- Bring the HyperLiquid SDK clients up before the provider's first asset-metadata read, so a trading action taken during cold start or after a disconnect waits for the clients instead of failing with `CLIENT_NOT_INITIALIZED` ([#9841](https://github.com/MetaMask/core/pull/9841))
+- Bring the HyperLiquid SDK clients up before the provider's first asset-metadata read, so a trading action taken during cold start or after a disconnect waits for the clients instead of failing with `CLIENT_NOT_INITIALIZED` ([#9865](https://github.com/MetaMask/core/pull/9865))
   - `placeOrder` resolves asset info before it ensures trading readiness, so waiting for controller initialization alone was not enough: the metadata read still hit an uninitialized `InfoClient` and the order failed. Warm reads are unaffected — the cached path returns before the client check.
 
 ## [11.0.0]

--- a/packages/perps-controller/src/providers/HyperLiquidProvider.ts
+++ b/packages/perps-controller/src/providers/HyperLiquidProvider.ts
@@ -2028,7 +2028,13 @@ export class HyperLiquidProvider implements PerpsProvider {
       }
     }
 
-    // Cache miss or skipCache=true - fetch from API
+    // Cache miss or skipCache=true - fetch from API.
+    // Bring the SDK clients up first. This is the first client touch on the
+    // write path — placeOrder resolves asset info before it ensures trading
+    // readiness — so without it a cold start or a post-disconnect action fails
+    // with CLIENT_NOT_INITIALIZED instead of waiting for the clients it needs.
+    // Idempotent, and a warm cache hit returns above without reaching here.
+    await this.#ensureClientsInitialized();
     const infoClient = this.#clientService.getInfoClient();
     // Pass dex only for HIP-3 DEXs; omit for main DEX (empty string).
     // Testnet API returns null when dex="" is explicitly sent.

--- a/packages/perps-controller/tests/src/providers/HyperLiquidProvider.trading.test.ts
+++ b/packages/perps-controller/tests/src/providers/HyperLiquidProvider.trading.test.ts
@@ -535,6 +535,37 @@ describe('HyperLiquidProvider', () => {
     });
   });
   describe('Trading Operations', () => {
+    it('brings the SDK clients up before reading asset metadata', async () => {
+      // Reproduces the cold-start / post-disconnect failure: placeOrder resolves
+      // asset info (an InfoClient read) before it ensures trading readiness, so
+      // an order taken while the clients are still down used to fail with
+      // CLIENT_NOT_INITIALIZED instead of waiting for them.
+      let clientsUp = false;
+      const infoClient = mockClientService.getInfoClient();
+      mockClientService.initialize.mockImplementation(async () => {
+        clientsUp = true;
+      });
+      mockClientService.getInfoClient.mockImplementation(() => {
+        if (!clientsUp) {
+          throw new Error(PERPS_ERROR_CODES.CLIENT_NOT_INITIALIZED);
+        }
+        return infoClient;
+      });
+
+      const orderParams: OrderParams = {
+        symbol: 'BTC',
+        isBuy: true,
+        size: '0.1',
+        orderType: 'market',
+        currentPrice: 50000,
+      };
+
+      const result = await provider.placeOrder(orderParams);
+
+      expect(result.success).toBe(true);
+      expect(mockClientService.initialize).toHaveBeenCalled();
+    });
+
     it('places a market order successfully', async () => {
       const orderParams: OrderParams = {
         symbol: 'BTC',


### PR DESCRIPTION
## Explanation

Stacked on #9032 — merge that first, this targets its branch.

#9032 makes trading actions wait for an in-flight `PerpsController.init()` instead of failing immediately. Running that branch against HyperLiquid testnet shows the wait works but the action still fails: it now reaches `HyperLiquidProvider.placeOrder`, which resolves asset info **before** it ensures trading readiness. That path calls `#getCachedMeta` → `#clientService.getInfoClient()` → `ensureInitialized()`, which throws `CLIENT_NOT_INITIALIZED` while the SDK clients are still down. `#ensureReadyForTrading()` (and with it `#ensureClientsInitialized()`) only runs later in `placeOrder`.

So on #9032 alone the caller stops getting a thrown error and starts getting `{ success: false, error: 'CLIENT_NOT_INITIALIZED' }` — same failure, quieter.

This adds the missing ensure on the cache-miss path of `#getCachedMeta`, which is the first client touch on the write path. It is idempotent, and a warm cache hit returns before it, so an initialized provider does no extra work. All 12 `#getCachedMeta` callers benefit.

## Proof

Real `PerpsController` on HyperLiquid **testnet** (headless core adapter: real messenger wiring, fixture signer, real transports). Scenario: `disconnect()` → start `init()` without awaiting → `placeOrder` immediately. Order is a resting limit 50% below market (never fills), cancelled by the rig.

| Build | Cold-start result |
| --- | --- |
| `main` | rejects, thrown `CLIENT_NOT_INITIALIZED` |
| #9032 alone | resolves `{ success: false, error: 'CLIENT_NOT_INITIALIZED' }` |
| #9032 + this change | **order placed** (`57799146376`), cancelled |

Executable recipe (`perps-cold-start-order.recipe.json`, core adapter): asserts `verdict: ORDER_PLACED` and `error: null` from the rig. **Fails** on #9032 alone (`cold-start-order.stdout does not contain "verdict": "ORDER_PLACED"`), **passes** with this change. Recipe and rig live in the perps recipe library rather than this repo; happy to share both.

Unit guard: `HyperLiquidProvider.trading.test.ts` — "brings the SDK clients up before reading asset metadata" makes the mocked `getInfoClient` throw `CLIENT_NOT_INITIALIZED` until `initialize()` runs, then asserts `placeOrder` succeeds. Red before the change, green after.

## Validation

- `jest tests/src/providers` — 14 suites, 667 passed, 0 failed
- `eslint` on both changed files — clean
- `changelog:validate` — clean

## References

* Builds on #9032

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow, idempotent initialization guard on an existing metadata fetch path; warm-cache behavior unchanged and covered by a focused unit test.
> 
> **Overview**
> **Fixes a remaining cold-start / post-disconnect `CLIENT_NOT_INITIALIZED` path** on HyperLiquid trading after controller init waits (#9032): `placeOrder` still resolves asset info (via `#getCachedMeta` → `InfoClient`) **before** `#ensureReadyForTrading`, so the first metadata fetch could throw or return `{ success: false, error: 'CLIENT_NOT_INITIALIZED' }` while clients were still down.
> 
> On **cache miss** (or `skipCache`), `#getCachedMeta` now **`await`s `#ensureClientsInitialized()`** before `getInfoClient()`. That call is idempotent; **warm cache hits** return earlier and do not add work.
> 
> Adds a **unit test** that mocks `getInfoClient` to fail until `initialize()` runs, and documents the fix in **CHANGELOG**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32e3a60bb836712824935f029e98c699d14dc260. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->