### PR TITLE
fix(perps): clear clients when reconnect readiness fails

### DIFF
--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Recreate all four SDK clients (including `ExchangeClient` and HTTP `InfoClient`) during WebSocket reconnection so `isInitialized()` returns `true` after reconnect ([#9032](https://github.com/MetaMask/core/pull/9032))
 - Bring the HyperLiquid SDK clients up before the provider's first asset-metadata read, so a trading action taken during cold start or after a disconnect waits for the clients instead of failing with `CLIENT_NOT_INITIALIZED` ([#9865](https://github.com/MetaMask/core/pull/9865))
   - `placeOrder` resolves asset info before it ensures trading readiness, so waiting for controller initialization alone was not enough: the metadata read still hit an uninitialized `InfoClient` and the order failed. Warm reads are unaffected — the cached path returns before the client check.
+- Clear the SDK clients and transports when a reconnection attempt fails before the WebSocket reports ready, so `isInitialized()` no longer reports a usable session backed by a socket that never opened (PR_PLACEHOLDER)
 
 ## [11.0.0]
 

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -71,7 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Recreate all four SDK clients (including `ExchangeClient` and HTTP `InfoClient`) during WebSocket reconnection so `isInitialized()` returns `true` after reconnect ([#9032](https://github.com/MetaMask/core/pull/9032))
 - Bring the HyperLiquid SDK clients up before the provider's first asset-metadata read, so a trading action taken during cold start or after a disconnect waits for the clients instead of failing with `CLIENT_NOT_INITIALIZED` ([#9865](https://github.com/MetaMask/core/pull/9865))
   - `placeOrder` resolves asset info before it ensures trading readiness, so waiting for controller initialization alone was not enough: the metadata read still hit an uninitialized `InfoClient` and the order failed. Warm reads are unaffected — the cached path returns before the client check.
-- Clear the SDK clients and transports when a reconnection attempt fails before the WebSocket reports ready, so `isInitialized()` no longer reports a usable session backed by a socket that never opened (PR_PLACEHOLDER)
+- Clear the SDK clients and transports when a reconnection attempt fails before the WebSocket reports ready, so `isInitialized()` no longer reports a usable session backed by a socket that never opened ([#9868](https://github.com/MetaMask/core/pull/9868))
 
 ## [11.0.0]
 

--- a/packages/perps-controller/src/services/HyperLiquidClientService.ts
+++ b/packages/perps-controller/src/services/HyperLiquidClientService.ts
@@ -1234,6 +1234,26 @@ export class HyperLiquidClientService {
       this.#updateConnectionState(WebSocketConnectionState.Connected);
       this.#isReconnecting = false;
     } catch {
+      // Drop the half-built session, mirroring initialize()'s cleanup. The
+      // clients are constructed before the transport reports ready, so leaving
+      // them in place would make isInitialized() report a usable session while
+      // the WebSocket never opened, and callers gated on it would issue reads
+      // over a dead socket instead of taking the uninitialized path.
+      this.#subscriptionClient = undefined;
+      this.#infoClient = undefined;
+      this.#infoClientHttp = undefined;
+      this.#exchangeClient = undefined;
+
+      if (this.#wsTransport) {
+        try {
+          this.#wsTransport.close();
+        } catch {
+          // Ignore cleanup errors - transport may already be dead
+        }
+      }
+      this.#wsTransport = undefined;
+      this.#httpTransport = undefined;
+
       // Reset flag before scheduling retry so the next attempt can proceed
       this.#isReconnecting = false;
 

--- a/packages/perps-controller/tests/src/services/HyperLiquidClientService.test.ts
+++ b/packages/perps-controller/tests/src/services/HyperLiquidClientService.test.ts
@@ -1681,6 +1681,29 @@ describe('HyperLiquidClientService', () => {
       expect(freshService.isInitialized()).toBe(false);
     });
 
+    it('reports uninitialized when reconnect readiness fails', async () => {
+      await service.initialize(mockWallet);
+      expect(service.isInitialized()).toBe(true);
+
+      // Clients are constructed before the transport reports ready, so a
+      // rejected ready() must not leave a session that looks usable.
+      mockWsTransportReady.mockRejectedValueOnce(new Error('ws never opened'));
+      await service.reconnect();
+
+      expect(service.isInitialized()).toBe(false);
+      expect(service.getSubscriptionClient()).toBeUndefined();
+    });
+
+    it('reports uninitialized when reconnect readiness fails after a disconnect', async () => {
+      await service.initialize(mockWallet);
+      await service.disconnect();
+
+      mockWsTransportReady.mockRejectedValueOnce(new Error('ws never opened'));
+      await service.reconnect();
+
+      expect(service.isInitialized()).toBe(false);
+    });
+
     it('performDisconnection resets isReconnecting flag', async () => {
       const {
         WebSocketConnectionState,


### PR DESCRIPTION
## Explanation

Addresses the reconnect-readiness finding raised in review on #9032; stacked on that branch.

`#handleConnectionDrop` constructs all four SDK clients *before* `await newWsTransport.ready()`. The catch path left them in place, so a reconnect whose readiness rejected kept `isInitialized()` returning `true`. Callers gated on `isInitialized()` / `ensureInitialized()` then issued WebSocket-backed reads (`getInfoClient`, `getSubscriptionClient`) over a socket that never opened, instead of taking the uninitialized path. Writes were unaffected — `ExchangeClient` runs on the HTTP transport.

This clears the clients and both transports on failure, mirroring the cleanup `initialize()` already performs, before the retry is scheduled. The retry then rebuilds them from scratch as it already did.

## Scope of the regression

Measured with a rejected `ready()` on the reconnect path:

| Scenario | `0837703` (before #9032) | branch tip `322eda6` | with this change |
| --- | --- | --- | --- |
| plain drop after `initialize()` | `isInitialized()` **true** | **true** | **false** |
| after `disconnect()` | `isInitialized()` **false** | **true** | **false** |

So the post-disconnect row is the behaviour change introduced by recreating all four clients on the reconnect path; the plain-drop row was already wrong before and is fixed here too.

## Test

`HyperLiquidClientService.test.ts` gains two cases under the reconnection describe: readiness rejects after a plain `initialize()`, and after a `disconnect()`. Both assert `isInitialized() === false` (the first also asserts `getSubscriptionClient()` is `undefined`). Both fail on the branch without this change (`Received: true`) and pass with it.

## Validation

- `jest tests/src/services tests/src/providers` — 34 suites, 1484 passed, 0 failed
- `eslint` on both changed files — clean

## References

* Stacked on #9032, follows #9865

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches WebSocket reconnection lifecycle in a critical trading client path; behavior change is narrow (fail-closed on failed ready) but affects when reads proceed after a bad reconnect.
> 
> **Overview**
> Fixes a **reconnect** edge case where HyperLiquid SDK clients are built before `WebSocketTransport.ready()` completes. If `ready()` rejects, the catch path used to leave those clients in place, so **`isInitialized()` stayed true** even though the socket never opened—callers gated on initialization could issue WebSocket-backed reads on a dead connection instead of failing closed or retrying.
> 
> On reconnect failure, **`#handleConnectionDrop` now clears all four SDK clients and both transports** (with safe `close()` on the WS transport), matching the cleanup **`initialize()`** already does on failure, before scheduling the existing retry.
> 
> **Tests** cover readiness rejection after a normal `initialize()` and after `disconnect()`; both assert `isInitialized() === false`. Changelog updated under Fixed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4df3413ab137d5bf662341cd26ad58e4cbb6e5ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->