### PR TITLE
fix(assets-controller): force default-track Arc's native USDC

### DIFF
--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix Arc native USDC never appearing until the account receives its first deposit, by default-tracking the native asset id (`eip155:5042/slip44:5042`) instead of the `0x3600...` ERC20 identity so `assetsInfo` metadata is seeded up front ([#PR_NUMBER](https://github.com/MetaMask/core/pull/PR_NUMBER))
+- Fix Arc native USDC never appearing until the account receives its first deposit, by default-tracking the native asset id (`eip155:5042/slip44:5042`) instead of the `0x3600...` ERC20 identity so `assetsInfo` metadata is seeded up front ([#9869](https://github.com/MetaMask/core/pull/9869))
 
 ## [13.1.2]
 

--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/transaction-controller` from `^69.5.1` to `^69.5.2` ([#9823](https://github.com/MetaMask/core/pull/9823))
 
+### Fixed
+
+- Fix Arc native USDC never appearing until the account receives its first deposit, by default-tracking the native asset id (`eip155:5042/slip44:5042`) instead of the `0x3600...` ERC20 identity so `assetsInfo` metadata is seeded up front ([#PR_NUMBER](https://github.com/MetaMask/core/pull/PR_NUMBER))
+
 ## [13.1.2]
 
 ### Changed

--- a/packages/assets-controller/src/defaults.ts
+++ b/packages/assets-controller/src/defaults.ts
@@ -32,23 +32,8 @@ const MUSD_METADATA: FungibleAssetMetadata = {
 };
 
 /**
- * Hardcoded metadata for native USDC on Arc (5042/0x13b2).
- *
- * Arc's native gas token is USDC. It's a default tracked asset (see
- * `DEFAULT_TRACKED_ASSETS_BY_CHAIN` below) so `#ensureDefaultTrackedAssetsSeeded`
- * writes both a zero `assetsBalance` entry and this `assetsInfo` metadata up
- * front. That explicit metadata seed is required because it can never arrive
- * from a live poll: Arc's Accounts-API balance fetch always succeeds, which
- * marks the chain "handled" and skips the RPC fallback path that would
- * otherwise be the only place writing `type: 'native'` for this id. Without
- * a metadata entry here, the zero-balance native row that
- * `#ensureNativeBalancesDefaultZero` seeds for every chain has no
- * `type: 'native'` to be recognized by, and is silently dropped by clients
- * that gate rendering on it (e.g. metamask-mobile's `assets-migration.ts`).
- *
- * The `0x3600...` ERC20 interface for USDC on Arc is no longer tracked here
- * — it's not a valid representation to default-track anymore now that the
- * native id carries its own metadata directly.
+ * Arc's native USDC also exists as its own ERC20 (`0x3600...`); Accounts API
+ * resolves that identity without ever seeding native `assetsInfo` metadata.
  */
 const ARC_NATIVE_ASSET_ID = 'eip155:5042/slip44:5042';
 

--- a/packages/assets-controller/src/defaults.ts
+++ b/packages/assets-controller/src/defaults.ts
@@ -32,20 +32,31 @@ const MUSD_METADATA: FungibleAssetMetadata = {
 };
 
 /**
- * Harcoded metadata for USDC on Arc (5042/0x13b2).
- * USDC exists as both native (18 decimals) and ERC20 (6 decimals).
- * We choose to force-hide the native version to avoid double listing using
- * `CHAIN_IDS_WITH_NO_NATIVE_TOKEN`.
- * In the meantime, the code below force-shows USDC the ERC20 token.
+ * Hardcoded metadata for native USDC on Arc (5042/0x13b2).
+ *
+ * Arc's native gas token is USDC. It's a default tracked asset (see
+ * `DEFAULT_TRACKED_ASSETS_BY_CHAIN` below) so `#ensureDefaultTrackedAssetsSeeded`
+ * writes both a zero `assetsBalance` entry and this `assetsInfo` metadata up
+ * front. That explicit metadata seed is required because it can never arrive
+ * from a live poll: Arc's Accounts-API balance fetch always succeeds, which
+ * marks the chain "handled" and skips the RPC fallback path that would
+ * otherwise be the only place writing `type: 'native'` for this id. Without
+ * a metadata entry here, the zero-balance native row that
+ * `#ensureNativeBalancesDefaultZero` seeds for every chain has no
+ * `type: 'native'` to be recognized by, and is silently dropped by clients
+ * that gate rendering on it (e.g. metamask-mobile's `assets-migration.ts`).
+ *
+ * The `0x3600...` ERC20 interface for USDC on Arc is no longer tracked here
+ * — it's not a valid representation to default-track anymore now that the
+ * native id carries its own metadata directly.
  */
-const USDC_ON_ARC_ASSET_ID =
-  'eip155:5042/erc20:0x3600000000000000000000000000000000000000';
+const ARC_NATIVE_ASSET_ID = 'eip155:5042/slip44:5042';
 
-const USDC_ON_ARC_METADATA: FungibleAssetMetadata = {
-  type: 'erc20',
+const ARC_NATIVE_METADATA: FungibleAssetMetadata = {
+  type: 'native',
   symbol: 'USDC',
   name: 'USDC',
-  decimals: 6,
+  decimals: 18,
 };
 
 /**
@@ -76,7 +87,7 @@ export const DEFAULT_TRACKED_ASSETS_BY_CHAIN: ReadonlyMap<
   ['eip155:1' as ChainId, [musdAssetId('eip155:1' as ChainId)]],
   ['eip155:59144' as ChainId, [musdAssetId('eip155:59144' as ChainId)]],
   ['eip155:143' as ChainId, [musdAssetId('eip155:143' as ChainId)]],
-  ['eip155:5042' as ChainId, [USDC_ON_ARC_ASSET_ID]],
+  ['eip155:5042' as ChainId, [ARC_NATIVE_ASSET_ID]],
 ]);
 
 /**
@@ -97,7 +108,7 @@ export const DEFAULT_ASSET_METADATA: ReadonlyMap<string, AssetMetadata> =
     [musdAssetId('eip155:1' as ChainId), MUSD_METADATA],
     [musdAssetId('eip155:59144' as ChainId), MUSD_METADATA],
     [musdAssetId('eip155:143' as ChainId), MUSD_METADATA],
-    [USDC_ON_ARC_ASSET_ID, USDC_ON_ARC_METADATA],
+    [ARC_NATIVE_ASSET_ID, ARC_NATIVE_METADATA],
   ]);
 
 /**


### PR DESCRIPTION

For fresh SRP, when adding Arc, no `USDC` (native) entry shows at all, until balance gets different from `0`.
I couldn't find the root cause of the issue - only happening for Arc - but found that `default.ts` contains instructions that pre-dates the decision of showing USDC native (instead of ERC20) on Arc.
Re-using the same maps, we can force-show USDC native, overriding the still-nonunderstood behavior that led it to disappear.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/51525125-c61d-4413-a7f7-debd51bacc5f" />


Default-track the native id (`eip155:5042/slip44:5042`) instead of the `0x3600...` ERC20 identity, which is no longer a valid representation to track here.
As a result, `USDC` native on Arc is forced to be always shown in user's asset list, even when they own `0` USDC.

## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows to default-tracked asset IDs and metadata for Arc only; no auth, pipeline, or API contract changes.
> 
> **Overview**
> Fixes **Arc native USDC missing from the asset list** until the wallet receives a non-zero balance by changing how Arc default-tracked assets are registered in `defaults.ts`.
> 
> For `eip155:5042`, the default tracked id is now **`eip155:5042/slip44:5042`** (native USDC) instead of the **`0x3600…` ERC-20** CAIP-19 id. Pre-seeded metadata is updated to **`type: 'native'`** with **18 decimals**, so `buildDefaultAssetsInfo` / default seeding populate `assetsInfo` (and zero balances) as soon as Arc is enabled—matching the decision to surface native USDC rather than the duplicate ERC-20 representation.
> 
> The **Unreleased** changelog documents the user-visible fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7474961e695a35280a7562f7ba5c8b07c0741ef7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->