### PR TITLE
feat(social-controllers): add the position-lifecycle stage of a trade

### DIFF
--- a/packages/social-controllers/CHANGELOG.md
+++ b/packages/social-controllers/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add optional `action` to `Trade` and optional `isOpen` to `Position`, plus the `TradeAction` type ([#9793](https://github.com/MetaMask/core/pull/9793))
+- Add optional `action` to `Trade` and optional `isOpen` to `Position`, plus the `TradeAction` type ([#9871](https://github.com/MetaMask/core/pull/9871))
   - `action` is the fill's position-lifecycle stage (`opened` / `added` / `reduced` / `closed`), computed by the social-api. Unlike `intent`, it separates a partial exit from a full close.
   - Both are optional so responses from a social-api deployment that predates them still validate.
 

--- a/packages/social-controllers/CHANGELOG.md
+++ b/packages/social-controllers/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add optional `action` to `Trade` and optional `isOpen` to `Position`, plus the `TradeAction` type ([#9793](https://github.com/MetaMask/core/pull/9793))
+  - `action` is the fill's position-lifecycle stage (`opened` / `added` / `reduced` / `closed`), computed by the social-api. Unlike `intent`, it separates a partial exit from a full close.
+  - Both are optional so responses from a social-api deployment that predates them still validate.
+
 ## [2.7.2]
 
 ### Changed

--- a/packages/social-controllers/src/SocialService.test.ts
+++ b/packages/social-controllers/src/SocialService.test.ts
@@ -634,6 +634,79 @@ describe('SocialService', () => {
       expect(result.positions[0].trades[0].classification).toBeNull();
     });
 
+    it('passes the position lifecycle fields through', async () => {
+      const position = {
+        ...mockPosition,
+        isOpen: true,
+        trades: [{ ...mockTrade, action: 'added' }],
+      };
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            positions: [position],
+            pagination: { hasMore: false },
+          }),
+      });
+
+      const service = createService();
+      const result = await service.fetchOpenPositions({
+        addressOrId: '0x1234',
+      });
+
+      expect(result.positions[0].isOpen).toBe(true);
+      expect(result.positions[0].trades[0].action).toBe('added');
+    });
+
+    // The social-api ships independently of this package, so a response from a
+    // deployment that predates `action`/`isOpen` must still validate — clients
+    // fall back to deriving the stage from the trade history.
+    it('accepts a position without the lifecycle fields', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            positions: [mockPosition],
+            pagination: { hasMore: false },
+          }),
+      });
+
+      const service = createService();
+      const result = await service.fetchOpenPositions({
+        addressOrId: '0x1234',
+      });
+
+      expect(result.positions[0].isOpen).toBeUndefined();
+      expect(result.positions[0].trades[0].action).toBeUndefined();
+    });
+
+    it('rejects an unknown trade action', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            positions: [
+              {
+                ...mockPosition,
+                trades: [{ ...mockTrade, action: 'flipped' }],
+              },
+            ],
+            pagination: { hasMore: false },
+          }),
+      });
+
+      const service = createService();
+
+      await expect(
+        service.fetchOpenPositions({ addressOrId: '0x1234' }),
+      ).rejects.toThrow(
+        SocialServiceErrorMessage.FETCH_OPEN_POSITIONS_INVALID_RESPONSE,
+      );
+    });
+
     it('rejects an invalid perpPositionType', async () => {
       mockFetch.mockResolvedValue({
         ok: true,

--- a/packages/social-controllers/src/SocialService.ts
+++ b/packages/social-controllers/src/SocialService.ts
@@ -70,6 +70,7 @@ const PositionStruct = structType({
   tokenAddress: string(),
   chain: string(),
   positionAmount: number(),
+  isOpen: optional(boolean()),
   boughtUsd: number(),
   soldUsd: number(),
   realizedPnl: number(),

--- a/packages/social-controllers/src/index.ts
+++ b/packages/social-controllers/src/index.ts
@@ -68,6 +68,7 @@ export type {
   SocialControllerState,
   SocialHandles,
   Trade,
+  TradeAction,
   TraderProfile,
   TraderProfileResponse,
   TraderStats,

--- a/packages/social-controllers/src/social-types.ts
+++ b/packages/social-controllers/src/social-types.ts
@@ -36,9 +36,26 @@ export type SocialHandles = {
   lens?: string | null;
 };
 
+/**
+ * Where a fill sits in its position's lifecycle.
+ *
+ * Deliberately asset-agnostic so the classification is computed once, upstream:
+ * clients render `opened / added / reduced / closed` for perps and
+ * `bought / bought more / sold some / sold all` for spot from the same value.
+ *
+ * Distinct from `intent`, which only says whether the fill grew or shrank the
+ * position — `intent: 'exit'` covers both a partial trim and a full close.
+ */
+export type TradeAction = 'opened' | 'added' | 'reduced' | 'closed';
+
 export const TradeStruct = structType({
   direction: enums(['buy', 'sell']),
   intent: enums(['enter', 'exit']),
+  /**
+   * Lifecycle stage of this fill. Absent on responses from a social-api that
+   * predates the field, so treat it as a hint and keep a client-side fallback.
+   */
+  action: optional(enums(['opened', 'added', 'reduced', 'closed'])),
   category: optional(string()),
   /** High-level trade classification. `null` when Clicker does not classify. */
   classification: optional(
@@ -160,6 +177,13 @@ export type Position = {
   tokenAddress: string;
   chain: string;
   positionAmount: number;
+  /**
+   * Whether the position still carries exposure. Clicker's own verdict, which
+   * beats a `positionAmount === 0` check: it survives precision dust and
+   * distinguishes "no position" from "a position of size ~0". Absent on
+   * responses from a social-api that predates the field.
+   */
+  isOpen?: boolean;
   boughtUsd: number;
   soldUsd: number;
   realizedPnl: number;


### PR DESCRIPTION
## Explanation

A trading position moves through four events: it is **opened**, **added to**, **reduced**, and **closed**. `Trade['intent']` only distinguishes two of them — `exit` covers both a partial trim and a full close — so a consumer cannot tell a trader who sold 10% of a position from one who sold out. In MetaMask Mobile's social feed that surfaced as a real defect: both announced "closed", and the row switched to realized P&L on the strength of the same wrong boolean.

The social-api already had the information to settle this (it classifies each fill server-side, using a per-position `isOpen` flag), but nothing in this package's types carried it. This PR adds the two fields that do:

- **`Trade['action']`** — `'opened' | 'added' | 'reduced' | 'closed'`, the fill's stage in its position's lifecycle. Deliberately asset-agnostic: a client may render only a direction for spot tokens while still needing the full value, because it is what decides whether a row shows realized or current P&L.
- **`Position['isOpen']`** — the API's own open/closed verdict. Stronger than a `positionAmount === 0` check: it survives precision dust, and it distinguishes "no position" from "a position of size ~0". Perpetuals in particular retain a non-zero `positionAmount` after closing, so size alone cannot answer the question.

`TradeAction` is exported for consumers that branch on the value.

**Both fields are optional, so this is not a breaking change.** The social-api deploys independently of this package, so a response from a deployment that predates the fields must still validate — `SocialService` uses superstruct's permissive `type()`, and there is now a test pinning that a payload without them is accepted. Clients keep a local fallback that derives the stage from trade history for exactly this window.

## References

- Jira: [TSA-988](https://consensyssoftware.atlassian.net/browse/TSA-988)
- Producer: `va-mmcx-social-api` PR adding `TradeDto.action` and `PositionDto.isOpen`
- Consumer: MetaMask Mobile PR rendering the four stages in the social feed and position views

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[TSA-988]: https://consensyssoftware.atlassian.net/browse/TSA-988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible optional schema and type additions with tests; no changes to auth, networking, or breaking API contracts.
> 
> **Overview**
> Adds optional **`Trade.action`** (`opened` / `added` / `reduced` / `closed`) and **`Position.isOpen`** so clients can tell partial exits from full closes and use the API’s open/closed verdict instead of inferring from `intent` or `positionAmount`. **`TradeAction`** is exported for consumers.
> 
> Response validation (`TradeStruct`, `PositionStruct`) accepts these fields when present and still validates older social-api payloads without them. Tests cover passthrough, backward compatibility, and rejection of unknown `action` values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 857b0a4e227e75159501f9e021c771bb9a6e1288. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->