### PR TITLE
feat: add Eden (chain 714) to assets-controllers spot price support

### DIFF
--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add Eden (`714`/`0x2ca`) to `SPOT_PRICES_SUPPORT_INFO` in `codefi-v2.ts`, pricing its native TIA at the zero-address ([#9874](https://github.com/MetaMask/core/pull/9874))
+
 ### Changed
 
 - Bump `@metamask/transaction-controller` from `^69.5.0` to `^69.5.2` ([#9798](https://github.com/MetaMask/core/pull/9798), [#9823](https://github.com/MetaMask/core/pull/9823))

--- a/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
+++ b/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
@@ -275,6 +275,7 @@ export const SPOT_PRICES_SUPPORT_INFO = {
   '0x144': 'eip155:324/slip44:60', // zkSync Era Mainnet (Ethereum L2) - Native symbol: ETH
   '0x150': 'eip155:336/slip44:809', // Shiden - Native symbol: SDN
   '0x169': 'eip155:361/slip44:589', // Theta Mainnet - Native symbol: TFUEL
+  '0x2ca': 'eip155:714/erc20:0x0000000000000000000000000000000000000000', // Eden - Native symbol: TIA (Celestia)
   '0x2eb': 'eip155:747/slip44:539', // Flow evm - Native symbol: Flow
   '0x3dc': 'eip155:988/erc20:0x0000000000000000000000000000000000000000', // Stable - Native symbol: USDT0
   '0x3e7': 'eip155:999/slip44:2457', // HyperEVM - Native symbol: HYPE


### PR DESCRIPTION
## Explanation

Eden (`eip155:714`, hex `0x2ca`) is an EVM chain that settles gas in TIA and is not indexed by CoinGecko as an asset platform. Without an entry in `SPOT_PRICES_SUPPORT_INFO`, assets-controllers cannot resolve a spot price for its native asset.

This PR adds the Eden entry, pricing native TIA at the zero-address:

```ts
'0x2ca': 'eip155:714/erc20:0x0000000000000000000000000000000000000000', // Eden - Native symbol: TIA (Celestia)
```

This follows the pattern established for Forma (#8873): TIA has no SLIP-44 coin type, so the native asset is addressed at the zero-address rather than an invented `slip44` reference. Price API support for this asset id ships in consensys-vertical-apps/va-mmcx-price-api#697; the Price API resolves it from the CoinGecko `celestia` coin through a chain-keyed native-asset registry, so Forma and Eden are priced independently.

Chain id verified against the live RPC: `eth_chainId` on `rpc.eden.gateway.fm` returns `0x2ca`.

## References

* Related to consensys-vertical-apps/va-mmcx-price-api#697
* Related to #8873

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single additive registry entry and changelog note; no auth, data migration, or pricing logic changes beyond enabling one more chain.
> 
> **Overview**
> Adds **Eden** (`0x2ca` / chain `714`) to `SPOT_PRICES_SUPPORT_INFO` in `codefi-v2.ts` so assets-controllers can request spot prices for that network through the Codefi v2 price service.
> 
> Native gas is modeled as **TIA** via the zero-address CAIP-19 id (`eip155:714/erc20:0x0…`), matching chains like Forma where there is no SLIP-44 coin type. The new key also flows into `SUPPORTED_CHAIN_IDS` derived from that map. The package **changelog** documents the addition under Unreleased.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fcccaf44d6ce640406ce555d99df6603f6ae905. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->