### PR TITLE
fix(accounts-controller): guard undefined scopes in multichain listing

### DIFF
--- a/packages/accounts-controller/CHANGELOG.md
+++ b/packages/accounts-controller/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/utils` from `^11.11.0` to `^11.12.0` ([#10076](https://github.com/MetaMask/core/pull/10076))
 
+### Fixed
+
+- Prevent `listMultichainAccounts` from throwing a `TypeError` when an internal account has an undefined `scopes` field ([#41962](https://github.com/MetaMask/metamask-extension/issues/41962))
+
 ## [39.1.1]
 
 ### Changed

--- a/packages/accounts-controller/src/AccountsController.test.ts
+++ b/packages/accounts-controller/src/AccountsController.test.ts
@@ -3958,6 +3958,47 @@ describe('AccountsController', () => {
         accountsController.listMultichainAccounts(invalidCaip2),
       ).toThrow(`Invalid CAIP-2 chain ID: ${invalidCaip2}`);
     });
+
+    it('does not throw when an account has an undefined `scopes` field and excludes it from chain-filtered results', () => {
+      // Regression test: a legacy or partially-migrated internal account can be
+      // persisted without a `scopes` field (its runtime value is `undefined`),
+      // even though the type declares it required. Filtering by a chain ID must
+      // not throw for such an account; it declares no scopes, so it matches no
+      // chain and is simply excluded.
+      const mockAccountWithoutScopes = {
+        ...createMockInternalAccount({
+          id: 'mock-account-without-scopes-id',
+          address: '0x9999999999999999999999999999999999999999',
+          name: 'Legacy Account',
+        }),
+        scopes: undefined,
+      } as unknown as InternalAccount;
+
+      const { accountsController } = setupAccountsController({
+        initialState: {
+          internalAccounts: {
+            accounts: {
+              [mockAccount.id]: mockAccount,
+              [mockAccountWithoutScopes.id]: mockAccountWithoutScopes,
+            },
+            selectedAccount: mockAccount.id,
+          },
+          accountIdByAddress: {
+            [mockAccount.address]: mockAccount.id,
+            [mockAccountWithoutScopes.address]: mockAccountWithoutScopes.id,
+          },
+        },
+      });
+
+      expect(() =>
+        accountsController.listMultichainAccounts(BtcScope.Mainnet),
+      ).not.toThrow();
+      // The well-formed account is still returned for its scope; the account
+      // with undefined `scopes` is excluded rather than throwing.
+      expect(
+        accountsController.listMultichainAccounts(EthScope.Eoa),
+      ).toStrictEqual([mockAccount]);
+    });
   });
 
   describe('setSelectedAccount', () => {

--- a/packages/accounts-controller/src/AccountsController.ts
+++ b/packages/accounts-controller/src/AccountsController.ts
@@ -420,8 +420,12 @@ export class AccountsController extends BaseController<
       throw new Error(`Invalid CAIP-2 chain ID: ${String(chainId)}`);
     }
 
-    return accounts.filter((account) =>
-      isScopeEqualToAny(chainId, account.scopes),
+    return accounts.filter(
+      (account) =>
+        // A legacy or partially-migrated account can be persisted without a
+        // `scopes` field, so guard against a non-array value before matching.
+        Array.isArray(account.scopes) &&
+        isScopeEqualToAny(chainId, account.scopes),
     );
   }
 


### PR DESCRIPTION
## Summary

Adds a guard for undefined `scopes` when listing multichain accounts in the accounts controller flow.

## Why

Undefined scope payloads can surface in edge cases and currently trigger avoidable runtime failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow defensive change to multichain account filtering; only excludes malformed legacy accounts from chain-scoped lists.
> 
> **Overview**
> Fixes a **runtime `TypeError`** when `listMultichainAccounts` is called with a CAIP-2 chain ID while persisted state includes internal accounts whose `scopes` is missing (`undefined`), which can happen for legacy or partially migrated accounts.
> 
> Chain filtering now requires `Array.isArray(account.scopes)` before calling `isScopeEqualToAny`; accounts without valid scopes are **omitted** from filtered results instead of crashing. Unfiltered listing (no `chainId`) is unchanged.
> 
> A regression test and changelog entry document the fix (metamask-extension [#41962](https://github.com/MetaMask/metamask-extension/issues/41962)).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6f12e2b8fbea7c34d0c096ba2ef6d561d643b42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->