### PR TITLE
docs(assets-controllers): add spot-prices example URL for dev verification

### DIFF
--- a/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
+++ b/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
@@ -243,10 +243,10 @@ const chainIdToNativeTokenAddress: Record<Hex, Hex> = {
 export const getNativeTokenAddress = (chainId: Hex): Hex =>
   chainIdToNativeTokenAddress[chainId] ?? ZERO_ADDRESS;
 
-// Source: https://github.com/consensys-vertical-apps/va-mmcx-price-api/blob/main/src/constants/slip44.ts
 // Price API v3/spot-prices chains only — verify support before adding:
+// Source: https://github.com/consensys-vertical-apps/va-mmcx-price-api/blob/main/src/constants/slip44.ts
 // https://price.api.cx.metamask.io/v2/supportedNetworks
-// https://price.api.cx.metamask.io/v3/spot-prices?assetIds=eip155:5042/erc20:0x3600000000000000000000000000000000000000&vsCurrency=usd&includeMarketData=true&cacheOnly=false
+// https://price.api.cx.metamask.io/v3/spot-prices?assetIds=<CAIP-ASSET-ID>&vsCurrency=usd
 // Include chain name + native symbol. Keep sorted by chain ID.
 export const SPOT_PRICES_SUPPORT_INFO = {
   '0x1': 'eip155:1/slip44:60', // Ethereum Mainnet - Native symbol: ETH

--- a/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
+++ b/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
@@ -246,6 +246,7 @@ export const getNativeTokenAddress = (chainId: Hex): Hex =>
 // Source: https://github.com/consensys-vertical-apps/va-mmcx-price-api/blob/main/src/constants/slip44.ts
 // This list is ONLY for chains that are supported by the Price API v3/spot-prices endpoint.
 // Please check that endpoint returns a price for the given assetId before including it in this list.
+// Example: https://price.api.cx.metamask.io/v3/spot-prices?assetIds=eip155:5042/erc20:0x3600000000000000000000000000000000000000&vsCurrency=usd&includeMarketData=true&cacheOnly=false
 // Please include a comment with the name of the chain and the native symbol.
 // Please keep the list sorted by chain ID.
 export const SPOT_PRICES_SUPPORT_INFO = {

--- a/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
+++ b/packages/assets-controllers/src/token-prices-service/codefi-v2.ts
@@ -244,11 +244,10 @@ export const getNativeTokenAddress = (chainId: Hex): Hex =>
   chainIdToNativeTokenAddress[chainId] ?? ZERO_ADDRESS;
 
 // Source: https://github.com/consensys-vertical-apps/va-mmcx-price-api/blob/main/src/constants/slip44.ts
-// This list is ONLY for chains that are supported by the Price API v3/spot-prices endpoint.
-// Please check that endpoint returns a price for the given assetId before including it in this list.
-// Example: https://price.api.cx.metamask.io/v3/spot-prices?assetIds=eip155:5042/erc20:0x3600000000000000000000000000000000000000&vsCurrency=usd&includeMarketData=true&cacheOnly=false
-// Please include a comment with the name of the chain and the native symbol.
-// Please keep the list sorted by chain ID.
+// Price API v3/spot-prices chains only — verify support before adding:
+// https://price.api.cx.metamask.io/v2/supportedNetworks
+// https://price.api.cx.metamask.io/v3/spot-prices?assetIds=eip155:5042/erc20:0x3600000000000000000000000000000000000000&vsCurrency=usd&includeMarketData=true&cacheOnly=false
+// Include chain name + native symbol. Keep sorted by chain ID.
 export const SPOT_PRICES_SUPPORT_INFO = {
   '0x1': 'eip155:1/slip44:60', // Ethereum Mainnet - Native symbol: ETH
   '0xa': 'eip155:10/slip44:60', // OP Mainnet - Native symbol: ETH


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Restructures verification comments above `SPOT_PRICES_SUPPORT_INFO` in `codefi-v2.ts`:

```
// Price API v3/spot-prices chains only — verify support before adding:
// Source: https://github.com/consensys-vertical-apps/va-mmcx-price-api/blob/main/src/constants/slip44.ts
// https://price.api.cx.metamask.io/v2/supportedNetworks
// https://price.api.cx.metamask.io/v3/spot-prices?assetIds=<CAIP-ASSET-ID>&vsCurrency=usd
// Include chain name + native symbol. Keep sorted by chain ID.
```

Developers can check network support and confirm a specific `assetId` returns a price before adding a new chain entry.

## Checklist

- [x] Comment-only change; no changelog needed
- [x] No functional or test changes required
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e6184d20-1b90-40fc-a42e-1a9d3d1c7706?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6184d20-1b90-40fc-a42e-1a9d3d1c7706&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

