### PR TITLE
feat(account-tree-controller): add `:{initialized,uninitialized}` events

### DIFF
--- a/packages/account-tree-controller/CHANGELOG.md
+++ b/packages/account-tree-controller/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `AccountTreeController:initialized` event, emitted at the end of `init()` when the account tree is fully built and ready to consume ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
+- Add `AccountTreeController:uninitialized` event, emitted at the end of `clearState()` when the account tree has been torn down ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
+
 ### Changed
 
 - Bump `@metamask/accounts-controller` from `^39.0.7` to `^39.1.0` ([#9807](https://github.com/MetaMask/core/pull/9807))

--- a/packages/account-tree-controller/CHANGELOG.md
+++ b/packages/account-tree-controller/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `AccountTreeController:initialized` event, emitted at the end of `init()` when the account tree is fully built and ready to consume ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
-- Add `AccountTreeController:uninitialized` event, emitted at the end of `clearState()` when the account tree has been torn down ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
+- Add `AccountTreeController:initialized` event, emitted at the end of `init()` when the account tree is fully built and ready to consume ([#9880](https://github.com/MetaMask/core/pull/9880))
+- Add `AccountTreeController:uninitialized` event, emitted at the end of `clearState()` when the account tree has been torn down ([#9880](https://github.com/MetaMask/core/pull/9880))
 
 ### Changed
 

--- a/packages/account-tree-controller/src/AccountTreeController.test.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.test.ts
@@ -5360,6 +5360,100 @@ describe('AccountTreeController', () => {
       expect(updatedListener).toHaveBeenCalledWith(expectedGroup);
       expect(expectedGroup.metadata.hidden).toBe(true);
     });
+
+    it('emits initialized after init() completes', () => {
+      const { controller, messenger } = setup({
+        accounts: [MOCK_HD_ACCOUNT_1],
+        keyrings: [MOCK_HD_KEYRING_1],
+      });
+
+      const initializedListener = jest.fn();
+      messenger.subscribe(
+        'AccountTreeController:initialized',
+        initializedListener,
+      );
+
+      controller.init();
+
+      expect(initializedListener).toHaveBeenCalledTimes(1);
+      expect(initializedListener).toHaveBeenCalledWith(controller.state);
+    });
+
+    it('emits initialized again after reinit()', () => {
+      const { controller, messenger } = setup({
+        accounts: [MOCK_HD_ACCOUNT_1],
+        keyrings: [MOCK_HD_KEYRING_1],
+      });
+
+      const initializedListener = jest.fn();
+      messenger.subscribe(
+        'AccountTreeController:initialized',
+        initializedListener,
+      );
+
+      controller.init();
+      jest.clearAllMocks();
+
+      controller.reinit();
+
+      expect(initializedListener).toHaveBeenCalledTimes(1);
+      expect(initializedListener).toHaveBeenCalledWith(controller.state);
+    });
+
+    it('does NOT emit initialized during clearState()', () => {
+      const { controller, messenger } = setup({
+        accounts: [MOCK_HD_ACCOUNT_1],
+        keyrings: [MOCK_HD_KEYRING_1],
+      });
+
+      controller.init();
+
+      const initializedListener = jest.fn();
+      messenger.subscribe(
+        'AccountTreeController:initialized',
+        initializedListener,
+      );
+
+      controller.clearState();
+
+      expect(initializedListener).not.toHaveBeenCalled();
+    });
+
+    it('emits uninitialized after clearState()', () => {
+      const { controller, messenger } = setup({
+        accounts: [MOCK_HD_ACCOUNT_1],
+        keyrings: [MOCK_HD_KEYRING_1],
+      });
+
+      controller.init();
+
+      const uninitializedListener = jest.fn();
+      messenger.subscribe(
+        'AccountTreeController:uninitialized',
+        uninitializedListener,
+      );
+
+      controller.clearState();
+
+      expect(uninitializedListener).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT emit uninitialized during init()', () => {
+      const { controller, messenger } = setup({
+        accounts: [MOCK_HD_ACCOUNT_1],
+        keyrings: [MOCK_HD_KEYRING_1],
+      });
+
+      const uninitializedListener = jest.fn();
+      messenger.subscribe(
+        'AccountTreeController:uninitialized',
+        uninitializedListener,
+      );
+
+      controller.init();
+
+      expect(uninitializedListener).not.toHaveBeenCalled();
+    });
   });
 
   describe('syncWithUserStorage', () => {

--- a/packages/account-tree-controller/src/AccountTreeController.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.ts
@@ -434,8 +434,9 @@ export class AccountTreeController extends BaseController<
       previousSelectedAccountGroup,
     );
 
-    log('Initialized!');
     this.#initialized = true;
+    log('Initialized!');
+    this.messenger.publish(`${controllerName}:initialized`, this.state);
   }
 
   /**
@@ -1837,6 +1838,7 @@ export class AccountTreeController extends BaseController<
 
     // So we know we have to call `init` again.
     this.#initialized = false;
+    this.messenger.publish(`${controllerName}:uninitialized`);
   }
 
   /**

--- a/packages/account-tree-controller/src/index.ts
+++ b/packages/account-tree-controller/src/index.ts
@@ -17,6 +17,8 @@ export type {
   AccountTreeControllerAccountGroupCreatedEvent,
   AccountTreeControllerAccountGroupUpdatedEvent,
   AccountTreeControllerAccountGroupRemovedEvent,
+  AccountTreeControllerInitializedEvent,
+  AccountTreeControllerUninitializedEvent,
   AccountTreeControllerEvents,
   AccountTreeControllerMessenger,
 } from './types.js';

--- a/packages/account-tree-controller/src/types.ts
+++ b/packages/account-tree-controller/src/types.ts
@@ -159,6 +159,27 @@ export type AccountTreeControllerAccountGroupRemovedEvent = {
   payload: [AccountGroupId];
 };
 
+/**
+ * Represents the `AccountTreeController:initialized` event.
+ * This event is emitted when the account tree has been fully built and is
+ * ready to consume. It carries the full controller state at the moment of
+ * initialization so that consumers do not need an extra `getState()` call.
+ */
+export type AccountTreeControllerInitializedEvent = {
+  type: `${typeof controllerName}:initialized`;
+  payload: [AccountTreeControllerState];
+};
+
+/**
+ * Represents the `AccountTreeController:uninitialized` event.
+ * This event is emitted when the account tree has been torn down via
+ * `clearState()`, symmetric to `initialized`.
+ */
+export type AccountTreeControllerUninitializedEvent = {
+  type: `${typeof controllerName}:uninitialized`;
+  payload: [];
+};
+
 export type AllowedEvents =
   | AccountsControllerAccountsAddedEvent
   | AccountsControllerAccountsRemovedEvent
@@ -172,7 +193,9 @@ export type AccountTreeControllerEvents =
   | AccountTreeControllerSelectedAccountGroupChangeEvent
   | AccountTreeControllerAccountGroupCreatedEvent
   | AccountTreeControllerAccountGroupUpdatedEvent
-  | AccountTreeControllerAccountGroupRemovedEvent;
+  | AccountTreeControllerAccountGroupRemovedEvent
+  | AccountTreeControllerInitializedEvent
+  | AccountTreeControllerUninitializedEvent;
 
 export type AccountTreeControllerMessenger = Messenger<
   typeof controllerName,


### PR DESCRIPTION
## Explanation

Adding those events so consumers can rely on this instead of `:stateChange` during the `init` phase that can trigger multiple times.

The `:uninitialized` one is to have a symmetric event that can be used for any kind of teardown.

## References

N/A

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, opt-in messenger events with no change to existing init/clearState behavior beyond one extra publish at the end of each path.
> 
> **Overview**
> Adds **lifecycle messenger events** so consumers can wait for a ready account tree without inferring readiness from repeated `:stateChange` during `init`.
> 
> **`AccountTreeController:initialized`** is published at the end of `init()` (and therefore after `reinit()`), with the full controller state as payload so listeners can bootstrap without a separate `getState()`. **`AccountTreeController:uninitialized`** is published at the end of `clearState()` with an empty payload, for symmetric teardown handling (e.g. wallet reset).
> 
> New event types are wired into `AccountTreeControllerEvents` and exported from the package index; unit tests assert emission timing (including that `initialized` does not fire on `clearState` and `uninitialized` does not fire on `init`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f9d4bc114d57119fa6a13ff7a7b6109983b7963. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->