### PR TITLE
feat(perps): add PREVIOUS_LEVERAGE to Perps analytics event properties

### DIFF
--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `PERPS_EVENT_PROPERTY.PREVIOUS_LEVERAGE` (`previous_leverage`) for Perp UI Interaction `leverage_changed` events so clients can import the Segment property key from `@metamask/perps-controller` instead of a local interim constant
+
 ## [12.0.0]
 
 ### Added

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `PERPS_EVENT_PROPERTY.PREVIOUS_LEVERAGE` (`previous_leverage`) for Perp UI Interaction `leverage_changed` events so clients can import the Segment property key from `@metamask/perps-controller` instead of a local interim constant
+- Add `PERPS_EVENT_PROPERTY.PREVIOUS_LEVERAGE` (`previous_leverage`) for Perp UI Interaction `leverage_changed` events so clients can import the Segment property key from `@metamask/perps-controller` instead of a local interim constant ([#9881](https://github.com/MetaMask/core/pull/9881))
 
 ## [12.0.0]
 

--- a/packages/perps-controller/src/constants/eventNames.ts
+++ b/packages/perps-controller/src/constants/eventNames.ts
@@ -18,6 +18,8 @@ export const PERPS_EVENT_PROPERTY = {
   // Trade properties
   LEVERAGE: 'leverage',
   LEVERAGE_USED: 'leverage_used',
+  // Perp UI Interaction `leverage_changed`: prior leverage before the user change
+  PREVIOUS_LEVERAGE: 'previous_leverage',
   ORDER_SIZE: 'order_size',
   MARGIN_USED: 'margin_used',
   ORDER_TYPE: 'order_type', // lowercase per dashboard
@@ -442,6 +444,10 @@ export const PERPS_EVENT_VALUE = {
     ORDER_TYPE_SELECTED: 'order_type_selected',
     /** @deprecated Use LEVERAGE_CHANGED instead for clarity */
     SETTING_CHANGED: 'setting_changed',
+    /**
+     * Perp UI Interaction `leverage_changed`. Properties include `leverage`
+     * and `previous_leverage`.
+     */
     LEVERAGE_CHANGED: 'leverage_changed',
     TUTORIAL_STARTED: 'tutorial_started',
     TUTORIAL_COMPLETED: 'tutorial_completed',

--- a/packages/perps-controller/tests/src/constants/eventNames.test.ts
+++ b/packages/perps-controller/tests/src/constants/eventNames.test.ts
@@ -5,6 +5,12 @@ import {
 import { PerpsAnalyticsEvent } from '../../../src/types/index.js';
 
 describe('PERPS_EVENT_PROPERTY', () => {
+  describe('PREVIOUS_LEVERAGE', () => {
+    it('exports PREVIOUS_LEVERAGE as previous_leverage', () => {
+      expect(PERPS_EVENT_PROPERTY.PREVIOUS_LEVERAGE).toBe('previous_leverage');
+    });
+  });
+
   describe('advanced chart analytics property keys', () => {
     it('exports CHART_LIBRARY key', () => {
       expect(PERPS_EVENT_PROPERTY.CHART_LIBRARY).toBe('chart_library');


### PR DESCRIPTION
## Explanation

Perp UI Interaction `leverage_changed` events need a Segment property `previous_leverage`. Clients import keys from `PERPS_EVENT_PROPERTY` in `@metamask/perps-controller`; that object had `LEVERAGE`, `LEVERAGE_USED`, and `DEFAULT_LEVERAGE` but not `PREVIOUS_LEVERAGE`. Mobile TAT-3743 currently ships an interim local constant so payloads are not unknown camelCase `previousLeverage`.

This change adds `PERPS_EVENT_PROPERTY.PREVIOUS_LEVERAGE` (`previous_leverage`) next to the other leverage keys, documents it on Perp UI Interaction `leverage_changed` in the MetaMetrics reference (`eventNames.ts`), and records it in the Unreleased changelog so the next published `@metamask/perps-controller` version includes the key. `PERPS_EVENT_PROPERTY` is already a package-root export; no new export path is required. This is additive and non-breaking.

Validation: targeted Jest on `eventNames.test.ts` (63 passing), changelog validate, changed-file ESLint/oxfmt, and a headless recipe that imports the constant and asserts strict equality.

## References

- https://consensyssoftware.atlassian.net/browse/TAT-3767
- Relates to TAT-3743 (Mobile interim `PERPS_ANALYTICS_PREVIOUS_LEVERAGE`). After this package is published, Mobile should bump `@metamask/perps-controller` and drop that interim constant.
- No Extension follow-up: Extension does not emit this property.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them — not applicable: additive `as const` key, same pattern as `PERPS_MODE` / `ROE_SIGN`

## **Screenshots/Recordings**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive analytics constant and documentation only; no runtime trading, auth, or persistence behavior changes.
> 
> **Overview**
> Adds **`PERPS_EVENT_PROPERTY.PREVIOUS_LEVERAGE`** (`previous_leverage`) so Perp UI Interaction **`leverage_changed`** events can send the prior leverage using the shared `@metamask/perps-controller` contract instead of client-local constants.
> 
> Documents the property on **`LEVERAGE_CHANGED`** in `eventNames.ts`, records it under **Unreleased** in the package changelog, and adds a Jest assertion that the key exports as `previous_leverage`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddf75bddbd22ccc73eebeb99ce83f727a9f08962. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->