### PR TITLE
fix(transaction-pay-controller): read stableTokens feature flag instead of stable-tokens

### DIFF
--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Read the `stableTokens` remote feature flag in `getStablecoins` instead of `stable-tokens`
+- Read the `stableTokens` remote feature flag in `getStablecoins` instead of `stable-tokens` ([#9885](https://github.com/MetaMask/core/pull/9885))
 
 ## [26.3.0]
 

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/assets-controller` from `^13.1.2` to `^13.1.3` ([#9873](https://github.com/MetaMask/core/pull/9873))
 - Bump `@metamask/transaction-controller` from `^69.5.1` to `^69.5.2` ([#9823](https://github.com/MetaMask/core/pull/9823))
 
+### Fixed
+
+- Read the `stableTokens` remote feature flag in `getStablecoins` instead of `stable-tokens`
+
 ## [26.3.0]
 
 ### Added

--- a/packages/transaction-pay-controller/src/utils/feature-flags.test.ts
+++ b/packages/transaction-pay-controller/src/utils/feature-flags.test.ts
@@ -2067,7 +2067,7 @@ describe('Feature Flags Utils', () => {
       );
     });
 
-    it('returns flag value when stable-tokens is a valid object', () => {
+    it('returns flag value when stableTokens is a valid object', () => {
       const flagValue = {
         '0x1': ['0xaaa', '0xbbb'],
         '0xa4b1': ['0xccc'],
@@ -2076,7 +2076,7 @@ describe('Feature Flags Utils', () => {
       getRemoteFeatureFlagControllerStateMock.mockReturnValue({
         ...getDefaultRemoteFeatureFlagControllerState(),
         remoteFeatureFlags: {
-          'stable-tokens': flagValue,
+          stableTokens: flagValue,
         },
       });
 
@@ -2087,7 +2087,7 @@ describe('Feature Flags Utils', () => {
       getRemoteFeatureFlagControllerStateMock.mockReturnValue({
         ...getDefaultRemoteFeatureFlagControllerState(),
         remoteFeatureFlags: {
-          'stable-tokens': {
+          stableTokens: {
             '0xA4B1': ['0xAf88d065e77c8cC2239327C5EDb3A432268e5831'],
           },
         },
@@ -2103,7 +2103,7 @@ describe('Feature Flags Utils', () => {
       getRemoteFeatureFlagControllerStateMock.mockReturnValue({
         ...getDefaultRemoteFeatureFlagControllerState(),
         remoteFeatureFlags: {
-          'stable-tokens': {
+          stableTokens: {
             '0x1': ['0xaaa'],
             '0xa4b1': 'not-an-array',
           },
@@ -2118,7 +2118,7 @@ describe('Feature Flags Utils', () => {
       getRemoteFeatureFlagControllerStateMock.mockReturnValue({
         ...getDefaultRemoteFeatureFlagControllerState(),
         remoteFeatureFlags: {
-          'stable-tokens': ['not', 'an', 'object'],
+          stableTokens: ['not', 'an', 'object'],
         },
       });
 
@@ -2130,7 +2130,7 @@ describe('Feature Flags Utils', () => {
       getRemoteFeatureFlagControllerStateMock.mockReturnValue({
         ...getDefaultRemoteFeatureFlagControllerState(),
         remoteFeatureFlags: {
-          'stable-tokens': true,
+          stableTokens: true,
         },
       });
 

--- a/packages/transaction-pay-controller/src/utils/feature-flags.ts
+++ b/packages/transaction-pay-controller/src/utils/feature-flags.ts
@@ -535,7 +535,7 @@ export function getFeatureFlags(
 }
 
 /**
- * Get the stablecoins map from the `stable-tokens` feature flag.
+ * Get the stablecoins map from the `stableTokens` feature flag.
  * Falls back to the hardcoded {@link STABLECOINS} constant when the flag is
  * absent or not a valid object.
  *
@@ -546,7 +546,7 @@ export function getStablecoins(
   messenger: TransactionPayControllerMessenger,
 ): Record<Hex, Hex[]> {
   const state = messenger.call('RemoteFeatureFlagController:getState');
-  const flag = state.remoteFeatureFlags?.['stable-tokens'];
+  const flag = state.remoteFeatureFlags?.stableTokens;
 
   if (flag && typeof flag === 'object' && !Array.isArray(flag)) {
     const raw = flag as Record<string, string[]>;


### PR DESCRIPTION
## Explanation

`getStablecoins` reads the remote stablecoin map used by Relay quotes and token fiat-rate logic, falling back to the hardcoded `STABLECOINS` constant when the flag is absent or invalid.

The reader currently looks up `stable-tokens`, but the LaunchDarkly flag is named `stableTokens`. Because those keys never match, the remote list is ignored and the hardcoded fallback is always used. This change reads `stableTokens` instead so the remotely configured map is applied. Fallback behavior for a missing or malformed flag is unchanged.

## References

- Related to https://consensyssoftware.atlassian.net/browse/CONF-1798

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

[CONF-1671]: https://consensyssoftware.atlassian.net/browse/CONF-1671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-key bugfix in feature-flag lookup with unchanged fallback semantics; main effect is enabling remote stablecoin lists that were previously ignored.
> 
> **Overview**
> **`getStablecoins`** now reads the LaunchDarkly remote flag **`stableTokens`** instead of **`stable-tokens`**, so the configured per-chain stablecoin map is actually used for Relay quotes and token fiat-rate logic.
> 
> Because the old key never matched the real flag name, **`getStablecoins`** always fell back to the hardcoded **`STABLECOINS`** list. Invalid or missing flag behavior is unchanged. Tests and the changelog were updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 717b39dacecb335915dc557d531f1a84cba10d75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->