### PR TITLE
docs(releasing): clarify major-bump dependents in release PRs

### DIFF
--- a/docs/processes/releasing.md
+++ b/docs/processes/releasing.md
@@ -39,8 +39,7 @@ This option provides a visual interface to streamline the release process:
 
    Common types of dependency issues you might encounter:
    - **Missing dependencies**: If you're releasing Package A that depends on Package B, the UI will prompt you to include Package B
-   - **Breaking change impacts**: If you're releasing Package B with breaking changes, the UI will identify packages that have peer dependencies on Package B that need to be updated
-   - **Major-version dependents**: If Package B is getting a major bump, include impacted dependents in the same release branch and update their version ranges/changelogs in that release PR
+   - **Breaking change impacts**: If you're releasing a package with breaking changes (and therefore bumping the major part of its version), the UI will identify dependents of that package and strongly advise you to also include them in the release
    - **Version incompatibilities**: The UI will flag if your selected version bumps don't follow semantic versioning rules relative to dependent packages
 
    Unlike the manual workflow where you need to repeatedly edit a YAML file, in the interactive mode you can quickly resolve these issues by checking boxes and selecting version bumps directly in the UI.
@@ -108,10 +107,9 @@ If you prefer more direct control over the release process:
    - Confirming that you want to skip certain packages (if you're certain they don't need to be updated)
 
    Common types of dependency issues you might encounter:
-   - **Missing dependencies**: If you're releasing Package A that depends on Package B, the UI will prompt you to include Package B
-   - **Breaking change impacts**: If you're releasing Package B with breaking changes, the UI will identify packages that have peer dependencies on Package B that need to be updated
-   - **Major-version dependents**: If Package B is getting a major bump, include impacted dependents in the same release branch and update their version ranges/changelogs in that release PR
-   - **Version incompatibilities**: The UI will flag if your selected version bumps don't follow semantic versioning rules relative to dependent packages
+   - **Missing dependencies**: If you're releasing Package A that depends on Package B, you will be prompted to include Package B
+   - **Breaking change impacts**: If you're releasing a package with breaking changes (and therefore bumping the major part of its version), you will be asked to include dependents of that package in the release
+   - **Version incompatibilities**: You will receive an error if your selected version bumps don't follow semantic versioning rules relative to dependent packages
 
    To address these issues, you will need to reopen the YAML file, modify it by either adding more packages to the release or omitting packages from the release you think are safe, and then re-running `yarn create-release-branch`. You may need to repeat this step multiple times until you don't see any more errors.
 

--- a/docs/processes/releasing.md
+++ b/docs/processes/releasing.md
@@ -40,6 +40,7 @@ This option provides a visual interface to streamline the release process:
    Common types of dependency issues you might encounter:
    - **Missing dependencies**: If you're releasing Package A that depends on Package B, the UI will prompt you to include Package B
    - **Breaking change impacts**: If you're releasing Package B with breaking changes, the UI will identify packages that have peer dependencies on Package B that need to be updated
+   - **Major-version dependents**: If Package B is getting a major bump, include impacted dependents in the same release branch and update their version ranges/changelogs in that release PR
    - **Version incompatibilities**: The UI will flag if your selected version bumps don't follow semantic versioning rules relative to dependent packages
 
    Unlike the manual workflow where you need to repeatedly edit a YAML file, in the interactive mode you can quickly resolve these issues by checking boxes and selecting version bumps directly in the UI.
@@ -109,6 +110,7 @@ If you prefer more direct control over the release process:
    Common types of dependency issues you might encounter:
    - **Missing dependencies**: If you're releasing Package A that depends on Package B, the UI will prompt you to include Package B
    - **Breaking change impacts**: If you're releasing Package B with breaking changes, the UI will identify packages that have peer dependencies on Package B that need to be updated
+   - **Major-version dependents**: If Package B is getting a major bump, include impacted dependents in the same release branch and update their version ranges/changelogs in that release PR
    - **Version incompatibilities**: The UI will flag if your selected version bumps don't follow semantic versioning rules relative to dependent packages
 
    To address these issues, you will need to reopen the YAML file, modify it by either adding more packages to the release or omitting packages from the release you think are safe, and then re-running `yarn create-release-branch`. You may need to repeat this step multiple times until you don't see any more errors.


### PR DESCRIPTION
## Summary
- clarify in `docs/processes/releasing.md` that when a package gets a major bump, impacted dependents should be included in the same release branch/PR
- add this note in both interactive and manual release workflows where dependency issues are reviewed

## Why
`create-release-branch` already flags dependent packages for breaking changes, but the contributor docs did not explicitly call out that these dependents should be released together.

Closes #8066.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to the release process guide; no runtime, tooling, or release automation behavior changes.
> 
> **Overview**
> Updates **`docs/processes/releasing.md`** so contributors know that a **major version bump** (breaking change) should trigger including **dependent packages** in the same release branch/PR—not only peer-dependent edge cases.
> 
> The **interactive** workflow now says the UI will **strongly advise** including those dependents when resolving dependency issues. The **manual** workflow uses parallel wording (prompt to include dependents) and tightens how **missing dependencies** and **version incompatibilities** are described (errors vs. flags).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5db897c8c2047de7cbfaf9e34ac74c10a393e7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->