### PR TITLE
feat(transaction-pay-controller): enable relay validation per transaction type

### DIFF
--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Support an object form for the `payStrategies.relay.validationEnabled` feature flag (in `confirmations_pay_extended`), allowing per-`TransactionType` overrides via `{ enabled: boolean; transactionTypes?: { [type]?: boolean } }` while remaining backwards compatible with the boolean form ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
+- Support an object form for the `payStrategies.relay.validationEnabled` feature flag (in `confirmations_pay_extended`), allowing per-`TransactionType` overrides via `{ enabled: boolean; transactionTypes?: { [type]?: boolean } }` while remaining backwards compatible with the boolean form ([#9888](https://github.com/MetaMask/core/pull/9888))
 - Bump `@metamask/assets-controller` from `^13.1.2` to `^13.1.4` ([#9873](https://github.com/MetaMask/core/pull/9873), [#9886](https://github.com/MetaMask/core/pull/9886))
 - Bump `@metamask/transaction-controller` from `^69.5.1` to `^69.5.2` ([#9823](https://github.com/MetaMask/core/pull/9823))
 - Bump `@metamask/assets-controllers` from `^111.1.0` to `^111.1.1` ([#9886](https://github.com/MetaMask/core/pull/9886))

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING:** The `payStrategies.relay.validationEnabled` feature flag (in `confirmations_pay_extended`) is now an object `{ default?: boolean; transactionTypes?: { [type in TransactionType]?: boolean } }` instead of a boolean, adding per-`TransactionType` overrides that match nested transactions ([#9888](https://github.com/MetaMask/core/pull/9888))
+
 ### Fixed
 
 - Fix quote simulation for Polymarket Predict withdrawals ([#9891](https://github.com/MetaMask/core/pull/9891))
@@ -15,10 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** The `payStrategies.relay.validationEnabled` feature flag (in `confirmations_pay_extended`) is now an object instead of a boolean ([#9888](https://github.com/MetaMask/core/pull/9888))
-  - The shape is `{ default?: boolean; transactionTypes?: { [type in TransactionType]?: boolean } }`, where `default` toggles validation for all transaction types (omitted = `false`) and a matching `transactionTypes[type]` entry overrides `default` for that specific transaction type.
-  - The previous boolean form is no longer supported; a boolean value of `true` must now be expressed as `{ default: true }`.
-  - Exposes a new `RelayValidationEnabledConfig` type describing the flag shape.
 - Bump `@metamask/assets-controller` from `^13.1.2` to `^13.1.4` ([#9873](https://github.com/MetaMask/core/pull/9873), [#9886](https://github.com/MetaMask/core/pull/9886))
 - Bump `@metamask/transaction-controller` from `^69.5.1` to `^69.5.2` ([#9823](https://github.com/MetaMask/core/pull/9823))
 - Bump `@metamask/assets-controllers` from `^111.1.0` to `^111.1.1` ([#9886](https://github.com/MetaMask/core/pull/9886))

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Support an object form for the `payStrategies.relay.validationEnabled` feature flag (in `confirmations_pay_extended`), allowing per-`TransactionType` overrides via `{ enabled: boolean; transactionTypes?: { [type]?: boolean } }` while remaining backwards compatible with the boolean form ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
 - Bump `@metamask/assets-controller` from `^13.1.2` to `^13.1.4` ([#9873](https://github.com/MetaMask/core/pull/9873), [#9886](https://github.com/MetaMask/core/pull/9886))
 - Bump `@metamask/transaction-controller` from `^69.5.1` to `^69.5.2` ([#9823](https://github.com/MetaMask/core/pull/9823))
 - Bump `@metamask/assets-controllers` from `^111.1.0` to `^111.1.1` ([#9886](https://github.com/MetaMask/core/pull/9886))

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -15,7 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Support an object form for the `payStrategies.relay.validationEnabled` feature flag (in `confirmations_pay_extended`), allowing per-`TransactionType` overrides via `{ enabled: boolean; transactionTypes?: { [type]?: boolean } }` while remaining backwards compatible with the boolean form ([#9888](https://github.com/MetaMask/core/pull/9888))
+- **BREAKING:** The `payStrategies.relay.validationEnabled` feature flag (in `confirmations_pay_extended`) is now an object instead of a boolean ([#9888](https://github.com/MetaMask/core/pull/9888))
+  - The shape is `{ default?: boolean; transactionTypes?: { [type in TransactionType]?: boolean } }`, where `default` toggles validation for all transaction types (omitted = `false`) and a matching `transactionTypes[type]` entry overrides `default` for that specific transaction type.
+  - The previous boolean form is no longer supported; a boolean value of `true` must now be expressed as `{ default: true }`.
+  - Exposes a new `RelayValidationEnabledConfig` type describing the flag shape.
 - Bump `@metamask/assets-controller` from `^13.1.2` to `^13.1.4` ([#9873](https://github.com/MetaMask/core/pull/9873), [#9886](https://github.com/MetaMask/core/pull/9886))
 - Bump `@metamask/transaction-controller` from `^69.5.1` to `^69.5.2` ([#9823](https://github.com/MetaMask/core/pull/9823))
 - Bump `@metamask/assets-controllers` from `^111.1.0` to `^111.1.1` ([#9886](https://github.com/MetaMask/core/pull/9886))

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-validation.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-validation.test.ts
@@ -972,4 +972,59 @@ describe('validateRelayQuotes', () => {
     expect(getRelaySubmitCallsMock).not.toHaveBeenCalled();
     expect(validateQuoteExecutionMock).not.toHaveBeenCalled();
   });
+
+  it('skips validation when object form per-type override is false', async () => {
+    getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+      ...getDefaultRemoteFeatureFlagControllerState(),
+      remoteFeatureFlags: {
+        confirmations_pay_extended: {
+          payStrategies: {
+            relay: {
+              validationEnabled: {
+                enabled: true,
+                transactionTypes: { simpleSend: false },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    await validateRelayQuotes({
+      messenger,
+      quotes: [buildQuote()],
+      transaction: { ...TRANSACTION_MOCK, type: 'simpleSend' as never },
+    });
+
+    expect(getRelaySubmitCallsMock).not.toHaveBeenCalled();
+    expect(validateQuoteExecutionMock).not.toHaveBeenCalled();
+  });
+
+  it('runs validation when object form per-type override is true and enabled is false', async () => {
+    getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+      ...getDefaultRemoteFeatureFlagControllerState(),
+      remoteFeatureFlags: {
+        confirmations_pay_extended: {
+          payStrategies: {
+            relay: {
+              validationEnabled: {
+                enabled: false,
+                transactionTypes: { simpleSend: true },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    getRelaySubmitCallsMock.mockResolvedValue({ calls: [] });
+
+    await validateRelayQuotes({
+      messenger,
+      quotes: [buildQuote()],
+      transaction: { ...TRANSACTION_MOCK, type: 'simpleSend' as never },
+    });
+
+    expect(validateQuoteExecutionMock).toHaveBeenCalled();
+  });
 });

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-validation.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-validation.test.ts
@@ -149,7 +149,7 @@ describe('validateRelayQuotes', () => {
       ...getDefaultRemoteFeatureFlagControllerState(),
       remoteFeatureFlags: {
         confirmations_pay_extended: {
-          payStrategies: { relay: { validationEnabled: true } },
+          payStrategies: { relay: { validationEnabled: { default: true } } },
         },
       },
     });
@@ -587,7 +587,9 @@ describe('validateRelayQuotes', () => {
           ...getDefaultRemoteFeatureFlagControllerState(),
           remoteFeatureFlags: {
             confirmations_pay_extended: {
-              payStrategies: { relay: { validationEnabled: true } },
+              payStrategies: {
+                relay: { validationEnabled: { default: true } },
+              },
             },
             confirmations_eip_7702: {
               contracts: {
@@ -973,7 +975,7 @@ describe('validateRelayQuotes', () => {
     expect(validateQuoteExecutionMock).not.toHaveBeenCalled();
   });
 
-  it('skips validation when object form per-type override is false', async () => {
+  it('skips validation when per-type override is false', async () => {
     getRemoteFeatureFlagControllerStateMock.mockReturnValue({
       ...getDefaultRemoteFeatureFlagControllerState(),
       remoteFeatureFlags: {
@@ -981,7 +983,7 @@ describe('validateRelayQuotes', () => {
           payStrategies: {
             relay: {
               validationEnabled: {
-                enabled: true,
+                default: true,
                 transactionTypes: { simpleSend: false },
               },
             },
@@ -1000,7 +1002,7 @@ describe('validateRelayQuotes', () => {
     expect(validateQuoteExecutionMock).not.toHaveBeenCalled();
   });
 
-  it('runs validation when object form per-type override is true and enabled is false', async () => {
+  it('runs validation when per-type override is true and default is false', async () => {
     getRemoteFeatureFlagControllerStateMock.mockReturnValue({
       ...getDefaultRemoteFeatureFlagControllerState(),
       remoteFeatureFlags: {
@@ -1008,7 +1010,7 @@ describe('validateRelayQuotes', () => {
           payStrategies: {
             relay: {
               validationEnabled: {
-                enabled: false,
+                default: false,
                 transactionTypes: { simpleSend: true },
               },
             },

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-validation.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-validation.ts
@@ -43,7 +43,7 @@ export type ValidateRelayQuotesRequest = {
 export async function validateRelayQuotes(
   request: ValidateRelayQuotesRequest,
 ): Promise<void> {
-  if (!isRelayValidationEnabled(request.messenger)) {
+  if (!isRelayValidationEnabled(request.messenger, request.transaction.type)) {
     return;
   }
 

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-validation.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-validation.ts
@@ -43,7 +43,7 @@ export type ValidateRelayQuotesRequest = {
 export async function validateRelayQuotes(
   request: ValidateRelayQuotesRequest,
 ): Promise<void> {
-  if (!isRelayValidationEnabled(request.messenger, request.transaction.type)) {
+  if (!isRelayValidationEnabled(request.messenger, request.transaction)) {
     return;
   }
 

--- a/packages/transaction-pay-controller/src/utils/feature-flags.test.ts
+++ b/packages/transaction-pay-controller/src/utils/feature-flags.test.ts
@@ -655,7 +655,7 @@ describe('Feature Flags Utils', () => {
         expect(isRelayValidationEnabled(messenger)).toBe(false);
       });
 
-      it('per-type override true beats enabled=false', () => {
+      it('returns true when per-type override is true and enabled is false', () => {
         getRemoteFeatureFlagControllerStateMock.mockReturnValue({
           ...getDefaultRemoteFeatureFlagControllerState(),
           remoteFeatureFlags: {
@@ -678,7 +678,7 @@ describe('Feature Flags Utils', () => {
         ).toBe(true);
       });
 
-      it('per-type override false beats enabled=true', () => {
+      it('returns false when per-type override is false and enabled is true', () => {
         getRemoteFeatureFlagControllerStateMock.mockReturnValue({
           ...getDefaultRemoteFeatureFlagControllerState(),
           remoteFeatureFlags: {
@@ -701,7 +701,7 @@ describe('Feature Flags Utils', () => {
         ).toBe(false);
       });
 
-      it('falls back to enabled for unspecified txType', () => {
+      it('returns enabled value for a txType with no per-type override', () => {
         getRemoteFeatureFlagControllerStateMock.mockReturnValue({
           ...getDefaultRemoteFeatureFlagControllerState(),
           remoteFeatureFlags: {
@@ -724,7 +724,7 @@ describe('Feature Flags Utils', () => {
         ).toBe(true);
       });
 
-      it('ignores transactionTypes when transactionType is undefined', () => {
+      it('returns enabled value when no transactionType is provided', () => {
         getRemoteFeatureFlagControllerStateMock.mockReturnValue({
           ...getDefaultRemoteFeatureFlagControllerState(),
           remoteFeatureFlags: {
@@ -745,7 +745,7 @@ describe('Feature Flags Utils', () => {
         expect(isRelayValidationEnabled(messenger)).toBe(true);
       });
 
-      it('defaults to false when object has no enabled', () => {
+      it('returns false when object has no enabled field', () => {
         getRemoteFeatureFlagControllerStateMock.mockReturnValue({
           ...getDefaultRemoteFeatureFlagControllerState(),
           remoteFeatureFlags: {

--- a/packages/transaction-pay-controller/src/utils/feature-flags.test.ts
+++ b/packages/transaction-pay-controller/src/utils/feature-flags.test.ts
@@ -1,4 +1,5 @@
 import { TransactionType } from '@metamask/transaction-controller';
+import type { TransactionMeta } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 
 import { getDefaultRemoteFeatureFlagControllerState } from '../../../remote-feature-flag-controller/src/remote-feature-flag-controller.js';
@@ -663,7 +664,9 @@ describe('Feature Flags Utils', () => {
         },
       });
       expect(
-        isRelayValidationEnabled(messenger, TransactionType.perpsDeposit),
+        isRelayValidationEnabled(messenger, {
+          type: TransactionType.perpsDeposit,
+        } as TransactionMeta),
       ).toBe(true);
     });
 
@@ -686,7 +689,9 @@ describe('Feature Flags Utils', () => {
         },
       });
       expect(
-        isRelayValidationEnabled(messenger, TransactionType.perpsDeposit),
+        isRelayValidationEnabled(messenger, {
+          type: TransactionType.perpsDeposit,
+        } as TransactionMeta),
       ).toBe(false);
     });
 
@@ -709,11 +714,13 @@ describe('Feature Flags Utils', () => {
         },
       });
       expect(
-        isRelayValidationEnabled(messenger, TransactionType.simpleSend),
+        isRelayValidationEnabled(messenger, {
+          type: TransactionType.simpleSend,
+        } as TransactionMeta),
       ).toBe(true);
     });
 
-    it('returns default value when no transactionType is provided', () => {
+    it('returns default value when no transaction is provided', () => {
       getRemoteFeatureFlagControllerStateMock.mockReturnValue({
         ...getDefaultRemoteFeatureFlagControllerState(),
         remoteFeatureFlags: {
@@ -732,6 +739,32 @@ describe('Feature Flags Utils', () => {
         },
       });
       expect(isRelayValidationEnabled(messenger)).toBe(true);
+    });
+
+    it('applies a per-type override matched via a nested transaction type', () => {
+      getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+        ...getDefaultRemoteFeatureFlagControllerState(),
+        remoteFeatureFlags: {
+          confirmations_pay_extended: {
+            payStrategies: {
+              relay: {
+                validationEnabled: {
+                  default: false,
+                  transactionTypes: {
+                    [TransactionType.perpsDeposit]: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+      expect(
+        isRelayValidationEnabled(messenger, {
+          type: TransactionType.simpleSend,
+          nestedTransactions: [{ type: TransactionType.perpsDeposit }],
+        } as TransactionMeta),
+      ).toBe(true);
     });
   });
 

--- a/packages/transaction-pay-controller/src/utils/feature-flags.test.ts
+++ b/packages/transaction-pay-controller/src/utils/feature-flags.test.ts
@@ -602,163 +602,136 @@ describe('Feature Flags Utils', () => {
       expect(isRelayValidationEnabled(messenger)).toBe(false);
     });
 
-    it('returns true when validationEnabled is true', () => {
+    it('returns true when default is true', () => {
       getRemoteFeatureFlagControllerStateMock.mockReturnValue({
         ...getDefaultRemoteFeatureFlagControllerState(),
         remoteFeatureFlags: {
           confirmations_pay_extended: {
-            payStrategies: { relay: { validationEnabled: true } },
+            payStrategies: {
+              relay: { validationEnabled: { default: true } },
+            },
           },
         },
       });
       expect(isRelayValidationEnabled(messenger)).toBe(true);
     });
 
-    it('returns false when validationEnabled is false', () => {
+    it('returns false when default is false', () => {
       getRemoteFeatureFlagControllerStateMock.mockReturnValue({
         ...getDefaultRemoteFeatureFlagControllerState(),
         remoteFeatureFlags: {
           confirmations_pay_extended: {
-            payStrategies: { relay: { validationEnabled: false } },
+            payStrategies: {
+              relay: { validationEnabled: { default: false } },
+            },
           },
         },
       });
       expect(isRelayValidationEnabled(messenger)).toBe(false);
     });
 
-    describe('object form', () => {
-      it('returns enabled when no transactionTypes set', () => {
-        getRemoteFeatureFlagControllerStateMock.mockReturnValue({
-          ...getDefaultRemoteFeatureFlagControllerState(),
-          remoteFeatureFlags: {
-            confirmations_pay_extended: {
-              payStrategies: {
-                relay: { validationEnabled: { enabled: true } },
-              },
+    it('returns false when default is omitted', () => {
+      getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+        ...getDefaultRemoteFeatureFlagControllerState(),
+        remoteFeatureFlags: {
+          confirmations_pay_extended: {
+            payStrategies: {
+              relay: { validationEnabled: {} },
             },
           },
-        });
-        expect(isRelayValidationEnabled(messenger)).toBe(true);
+        },
       });
+      expect(isRelayValidationEnabled(messenger)).toBe(false);
+    });
 
-      it('returns enabled=false when no transactionTypes set', () => {
-        getRemoteFeatureFlagControllerStateMock.mockReturnValue({
-          ...getDefaultRemoteFeatureFlagControllerState(),
-          remoteFeatureFlags: {
-            confirmations_pay_extended: {
-              payStrategies: {
-                relay: { validationEnabled: { enabled: false } },
-              },
-            },
-          },
-        });
-        expect(isRelayValidationEnabled(messenger)).toBe(false);
-      });
-
-      it('returns true when per-type override is true and enabled is false', () => {
-        getRemoteFeatureFlagControllerStateMock.mockReturnValue({
-          ...getDefaultRemoteFeatureFlagControllerState(),
-          remoteFeatureFlags: {
-            confirmations_pay_extended: {
-              payStrategies: {
-                relay: {
-                  validationEnabled: {
-                    enabled: false,
-                    transactionTypes: {
-                      [TransactionType.perpsDeposit]: true,
-                    },
+    it('returns true when per-type override is true and default is false', () => {
+      getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+        ...getDefaultRemoteFeatureFlagControllerState(),
+        remoteFeatureFlags: {
+          confirmations_pay_extended: {
+            payStrategies: {
+              relay: {
+                validationEnabled: {
+                  default: false,
+                  transactionTypes: {
+                    [TransactionType.perpsDeposit]: true,
                   },
                 },
               },
             },
           },
-        });
-        expect(
-          isRelayValidationEnabled(messenger, TransactionType.perpsDeposit),
-        ).toBe(true);
+        },
       });
+      expect(
+        isRelayValidationEnabled(messenger, TransactionType.perpsDeposit),
+      ).toBe(true);
+    });
 
-      it('returns false when per-type override is false and enabled is true', () => {
-        getRemoteFeatureFlagControllerStateMock.mockReturnValue({
-          ...getDefaultRemoteFeatureFlagControllerState(),
-          remoteFeatureFlags: {
-            confirmations_pay_extended: {
-              payStrategies: {
-                relay: {
-                  validationEnabled: {
-                    enabled: true,
-                    transactionTypes: {
-                      [TransactionType.perpsDeposit]: false,
-                    },
+    it('returns false when per-type override is false and default is true', () => {
+      getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+        ...getDefaultRemoteFeatureFlagControllerState(),
+        remoteFeatureFlags: {
+          confirmations_pay_extended: {
+            payStrategies: {
+              relay: {
+                validationEnabled: {
+                  default: true,
+                  transactionTypes: {
+                    [TransactionType.perpsDeposit]: false,
                   },
                 },
               },
             },
           },
-        });
-        expect(
-          isRelayValidationEnabled(messenger, TransactionType.perpsDeposit),
-        ).toBe(false);
+        },
       });
+      expect(
+        isRelayValidationEnabled(messenger, TransactionType.perpsDeposit),
+      ).toBe(false);
+    });
 
-      it('returns enabled value for a txType with no per-type override', () => {
-        getRemoteFeatureFlagControllerStateMock.mockReturnValue({
-          ...getDefaultRemoteFeatureFlagControllerState(),
-          remoteFeatureFlags: {
-            confirmations_pay_extended: {
-              payStrategies: {
-                relay: {
-                  validationEnabled: {
-                    enabled: true,
-                    transactionTypes: {
-                      [TransactionType.perpsDeposit]: false,
-                    },
+    it('returns default value for a txType with no per-type override', () => {
+      getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+        ...getDefaultRemoteFeatureFlagControllerState(),
+        remoteFeatureFlags: {
+          confirmations_pay_extended: {
+            payStrategies: {
+              relay: {
+                validationEnabled: {
+                  default: true,
+                  transactionTypes: {
+                    [TransactionType.perpsDeposit]: false,
                   },
                 },
               },
             },
           },
-        });
-        expect(
-          isRelayValidationEnabled(messenger, TransactionType.simpleSend),
-        ).toBe(true);
+        },
       });
+      expect(
+        isRelayValidationEnabled(messenger, TransactionType.simpleSend),
+      ).toBe(true);
+    });
 
-      it('returns enabled value when no transactionType is provided', () => {
-        getRemoteFeatureFlagControllerStateMock.mockReturnValue({
-          ...getDefaultRemoteFeatureFlagControllerState(),
-          remoteFeatureFlags: {
-            confirmations_pay_extended: {
-              payStrategies: {
-                relay: {
-                  validationEnabled: {
-                    enabled: true,
-                    transactionTypes: {
-                      [TransactionType.perpsDeposit]: false,
-                    },
+    it('returns default value when no transactionType is provided', () => {
+      getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+        ...getDefaultRemoteFeatureFlagControllerState(),
+        remoteFeatureFlags: {
+          confirmations_pay_extended: {
+            payStrategies: {
+              relay: {
+                validationEnabled: {
+                  default: true,
+                  transactionTypes: {
+                    [TransactionType.perpsDeposit]: false,
                   },
                 },
               },
             },
           },
-        });
-        expect(isRelayValidationEnabled(messenger)).toBe(true);
+        },
       });
-
-      it('returns false when object has no enabled field', () => {
-        getRemoteFeatureFlagControllerStateMock.mockReturnValue({
-          ...getDefaultRemoteFeatureFlagControllerState(),
-          remoteFeatureFlags: {
-            confirmations_pay_extended: {
-              payStrategies: {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                relay: { validationEnabled: {} as any },
-              },
-            },
-          },
-        });
-        expect(isRelayValidationEnabled(messenger)).toBe(false);
-      });
+      expect(isRelayValidationEnabled(messenger)).toBe(true);
     });
   });
 

--- a/packages/transaction-pay-controller/src/utils/feature-flags.test.ts
+++ b/packages/transaction-pay-controller/src/utils/feature-flags.test.ts
@@ -625,6 +625,141 @@ describe('Feature Flags Utils', () => {
       });
       expect(isRelayValidationEnabled(messenger)).toBe(false);
     });
+
+    describe('object form', () => {
+      it('returns enabled when no transactionTypes set', () => {
+        getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+          ...getDefaultRemoteFeatureFlagControllerState(),
+          remoteFeatureFlags: {
+            confirmations_pay_extended: {
+              payStrategies: {
+                relay: { validationEnabled: { enabled: true } },
+              },
+            },
+          },
+        });
+        expect(isRelayValidationEnabled(messenger)).toBe(true);
+      });
+
+      it('returns enabled=false when no transactionTypes set', () => {
+        getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+          ...getDefaultRemoteFeatureFlagControllerState(),
+          remoteFeatureFlags: {
+            confirmations_pay_extended: {
+              payStrategies: {
+                relay: { validationEnabled: { enabled: false } },
+              },
+            },
+          },
+        });
+        expect(isRelayValidationEnabled(messenger)).toBe(false);
+      });
+
+      it('per-type override true beats enabled=false', () => {
+        getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+          ...getDefaultRemoteFeatureFlagControllerState(),
+          remoteFeatureFlags: {
+            confirmations_pay_extended: {
+              payStrategies: {
+                relay: {
+                  validationEnabled: {
+                    enabled: false,
+                    transactionTypes: {
+                      [TransactionType.perpsDeposit]: true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        });
+        expect(
+          isRelayValidationEnabled(messenger, TransactionType.perpsDeposit),
+        ).toBe(true);
+      });
+
+      it('per-type override false beats enabled=true', () => {
+        getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+          ...getDefaultRemoteFeatureFlagControllerState(),
+          remoteFeatureFlags: {
+            confirmations_pay_extended: {
+              payStrategies: {
+                relay: {
+                  validationEnabled: {
+                    enabled: true,
+                    transactionTypes: {
+                      [TransactionType.perpsDeposit]: false,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        });
+        expect(
+          isRelayValidationEnabled(messenger, TransactionType.perpsDeposit),
+        ).toBe(false);
+      });
+
+      it('falls back to enabled for unspecified txType', () => {
+        getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+          ...getDefaultRemoteFeatureFlagControllerState(),
+          remoteFeatureFlags: {
+            confirmations_pay_extended: {
+              payStrategies: {
+                relay: {
+                  validationEnabled: {
+                    enabled: true,
+                    transactionTypes: {
+                      [TransactionType.perpsDeposit]: false,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        });
+        expect(
+          isRelayValidationEnabled(messenger, TransactionType.simpleSend),
+        ).toBe(true);
+      });
+
+      it('ignores transactionTypes when transactionType is undefined', () => {
+        getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+          ...getDefaultRemoteFeatureFlagControllerState(),
+          remoteFeatureFlags: {
+            confirmations_pay_extended: {
+              payStrategies: {
+                relay: {
+                  validationEnabled: {
+                    enabled: true,
+                    transactionTypes: {
+                      [TransactionType.perpsDeposit]: false,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        });
+        expect(isRelayValidationEnabled(messenger)).toBe(true);
+      });
+
+      it('defaults to false when object has no enabled', () => {
+        getRemoteFeatureFlagControllerStateMock.mockReturnValue({
+          ...getDefaultRemoteFeatureFlagControllerState(),
+          remoteFeatureFlags: {
+            confirmations_pay_extended: {
+              payStrategies: {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                relay: { validationEnabled: {} as any },
+              },
+            },
+          },
+        });
+        expect(isRelayValidationEnabled(messenger)).toBe(false);
+      });
+    });
   });
 
   describe('isChainExcludedFromInfura', () => {

--- a/packages/transaction-pay-controller/src/utils/feature-flags.ts
+++ b/packages/transaction-pay-controller/src/utils/feature-flags.ts
@@ -681,6 +681,7 @@ export function isRelayValidationEnabled(
       ? undefined
       : validationEnabled.transactionTypes?.[transactionType];
 
+  // `?? false`: malformed config may omit `enabled` despite the type requiring it
   return typeOverride ?? validationEnabled.enabled ?? false;
 }
 

--- a/packages/transaction-pay-controller/src/utils/feature-flags.ts
+++ b/packages/transaction-pay-controller/src/utils/feature-flags.ts
@@ -1,4 +1,8 @@
-import type { TransactionType } from '@metamask/transaction-controller';
+import { hasTransactionType } from '@metamask/transaction-controller';
+import type {
+  TransactionMeta,
+  TransactionType,
+} from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 import { createModuleLogger } from '@metamask/utils';
 import { BigNumber } from 'bignumber.js';
@@ -642,25 +646,25 @@ export function isRelayExecuteEnabled(
 }
 
 /**
- * Whether Relay quote validation is enabled for a given transaction type.
+ * Whether Relay quote validation is enabled for a given transaction.
  *
  * Acts as an emergency kill switch: when disabled (default), Relay quotes are
  * surfaced without being simulated/validated.
  *
  * Configured via the `payStrategies.relay.validationEnabled` flag, an object
  * `{ default?: boolean; transactionTypes?: { [type]?: boolean } }`:
- * `default` is the base toggle applied to all transaction types (omitted =
- * `false`); a matching `transactionTypes[txType]` entry overrides `default` for
- * that specific transaction type.
+ * `default` is the base toggle applied to all transactions (omitted = `false`);
+ * a matching `transactionTypes[type]` entry overrides `default` when the
+ * transaction, or any of its nested transactions, has that type.
  *
  * @param messenger - Controller messenger.
- * @param transactionType - Optional transaction type. When provided, a per-type
- * override takes precedence over `default`.
+ * @param transaction - Transaction being validated. Its top-level and nested
+ * types are matched against the `transactionTypes` overrides.
  * @returns True if Relay quote validation is enabled.
  */
 export function isRelayValidationEnabled(
   messenger: TransactionPayControllerMessenger,
-  transactionType?: TransactionType,
+  transaction?: TransactionMeta,
 ): boolean {
   const state = messenger.call('RemoteFeatureFlagController:getState');
   const featureFlags =
@@ -671,14 +675,18 @@ export function isRelayValidationEnabled(
   const validationEnabled =
     featureFlags.payStrategies?.relay?.validationEnabled;
 
-  // A per-type override wins over the global `default` toggle.
-  const typeOverride =
-    transactionType === undefined
-      ? undefined
-      : validationEnabled?.transactionTypes?.[transactionType];
+  const transactionTypes = validationEnabled?.transactionTypes ?? {};
+
+  // A per-type override wins over the global `default` toggle. An override
+  // matches when the transaction, or any nested transaction, has that type.
+  for (const [type, enabled] of Object.entries(transactionTypes)) {
+    if (hasTransactionType(transaction, [type as TransactionType])) {
+      return enabled;
+    }
+  }
 
   // `?? false`: `default` is optional, so an omitted config disables validation.
-  return typeOverride ?? validationEnabled?.default ?? false;
+  return validationEnabled?.default ?? false;
 }
 
 /**

--- a/packages/transaction-pay-controller/src/utils/feature-flags.ts
+++ b/packages/transaction-pay-controller/src/utils/feature-flags.ts
@@ -187,7 +187,7 @@ export type PayStrategiesConfigRaw = {
 };
 
 export type RelayValidationEnabledConfig = {
-  enabled: boolean;
+  default?: boolean;
   transactionTypes?: Partial<Record<TransactionType, boolean>>;
 };
 
@@ -196,7 +196,7 @@ type FeatureFlagsExtendedRaw = {
   payStrategies?: {
     relay?: {
       gaslessEnabled?: boolean;
-      validationEnabled?: boolean | RelayValidationEnabledConfig;
+      validationEnabled?: RelayValidationEnabledConfig;
     };
     server?: {
       enabled?: boolean;
@@ -647,15 +647,15 @@ export function isRelayExecuteEnabled(
  * Acts as an emergency kill switch: when disabled (default), Relay quotes are
  * surfaced without being simulated/validated.
  *
- * Accepts two forms for the `payStrategies.relay.validationEnabled` flag:
- * - **Boolean** (backwards compatible): behaves exactly as before.
- * - **Object** `{ enabled: boolean; transactionTypes?: { [type]?: boolean } }`:
- *   `enabled` mirrors the old boolean toggle; a matching `transactionTypes[txType]`
- *   entry overrides `enabled` for that specific transaction type.
+ * Configured via the `payStrategies.relay.validationEnabled` flag, an object
+ * `{ default?: boolean; transactionTypes?: { [type]?: boolean } }`:
+ * `default` is the base toggle applied to all transaction types (omitted =
+ * `false`); a matching `transactionTypes[txType]` entry overrides `default` for
+ * that specific transaction type.
  *
  * @param messenger - Controller messenger.
- * @param transactionType - Optional transaction type. When provided and the
- * object form is used, a per-type override takes precedence over `enabled`.
+ * @param transactionType - Optional transaction type. When provided, a per-type
+ * override takes precedence over `default`.
  * @returns True if Relay quote validation is enabled.
  */
 export function isRelayValidationEnabled(
@@ -671,19 +671,14 @@ export function isRelayValidationEnabled(
   const validationEnabled =
     featureFlags.payStrategies?.relay?.validationEnabled;
 
-  // Backwards compatibility: boolean or undefined behaves exactly as before.
-  if (typeof validationEnabled !== 'object' || validationEnabled === null) {
-    return validationEnabled ?? false;
-  }
-
-  // Object form: per-type override wins over the global `enabled` toggle.
+  // A per-type override wins over the global `default` toggle.
   const typeOverride =
     transactionType === undefined
       ? undefined
-      : validationEnabled.transactionTypes?.[transactionType];
+      : validationEnabled?.transactionTypes?.[transactionType];
 
-  // `?? false`: malformed config may omit `enabled` despite the type requiring it
-  return typeOverride ?? validationEnabled.enabled ?? false;
+  // `?? false`: `default` is optional, so an omitted config disables validation.
+  return typeOverride ?? validationEnabled?.default ?? false;
 }
 
 /**

--- a/packages/transaction-pay-controller/src/utils/feature-flags.ts
+++ b/packages/transaction-pay-controller/src/utils/feature-flags.ts
@@ -668,7 +668,8 @@ export function isRelayValidationEnabled(
       | FeatureFlagsExtendedRaw
       | undefined) ?? {};
 
-  const validationEnabled = featureFlags.payStrategies?.relay?.validationEnabled;
+  const validationEnabled =
+    featureFlags.payStrategies?.relay?.validationEnabled;
 
   // Backwards compatibility: boolean or undefined behaves exactly as before.
   if (typeof validationEnabled !== 'object' || validationEnabled === null) {

--- a/packages/transaction-pay-controller/src/utils/feature-flags.ts
+++ b/packages/transaction-pay-controller/src/utils/feature-flags.ts
@@ -186,12 +186,17 @@ export type PayStrategiesConfigRaw = {
   };
 };
 
+export type RelayValidationEnabledConfig = {
+  enabled: boolean;
+  transactionTypes?: Partial<Record<TransactionType, boolean>>;
+};
+
 type FeatureFlagsExtendedRaw = {
   excludeChainIdsFromInfura?: Hex[];
   payStrategies?: {
     relay?: {
       gaslessEnabled?: boolean;
-      validationEnabled?: boolean;
+      validationEnabled?: boolean | RelayValidationEnabledConfig;
     };
     server?: {
       enabled?: boolean;
@@ -637,23 +642,46 @@ export function isRelayExecuteEnabled(
 }
 
 /**
- * Whether Relay quote validation is enabled.
+ * Whether Relay quote validation is enabled for a given transaction type.
  *
  * Acts as an emergency kill switch: when disabled (default), Relay quotes are
  * surfaced without being simulated/validated.
  *
+ * Accepts two forms for the `payStrategies.relay.validationEnabled` flag:
+ * - **Boolean** (backwards compatible): behaves exactly as before.
+ * - **Object** `{ enabled: boolean; transactionTypes?: { [type]?: boolean } }`:
+ *   `enabled` mirrors the old boolean toggle; a matching `transactionTypes[txType]`
+ *   entry overrides `enabled` for that specific transaction type.
+ *
  * @param messenger - Controller messenger.
+ * @param transactionType - Optional transaction type. When provided and the
+ * object form is used, a per-type override takes precedence over `enabled`.
  * @returns True if Relay quote validation is enabled.
  */
 export function isRelayValidationEnabled(
   messenger: TransactionPayControllerMessenger,
+  transactionType?: TransactionType,
 ): boolean {
   const state = messenger.call('RemoteFeatureFlagController:getState');
   const featureFlags =
     (state.remoteFeatureFlags?.confirmations_pay_extended as
       | FeatureFlagsExtendedRaw
       | undefined) ?? {};
-  return featureFlags.payStrategies?.relay?.validationEnabled ?? false;
+
+  const validationEnabled = featureFlags.payStrategies?.relay?.validationEnabled;
+
+  // Backwards compatibility: boolean or undefined behaves exactly as before.
+  if (typeof validationEnabled !== 'object' || validationEnabled === null) {
+    return validationEnabled ?? false;
+  }
+
+  // Object form: per-type override wins over the global `enabled` toggle.
+  const typeOverride =
+    transactionType === undefined
+      ? undefined
+      : validationEnabled.transactionTypes?.[transactionType];
+
+  return typeOverride ?? validationEnabled.enabled ?? false;
 }
 
 /**


### PR DESCRIPTION
## Explanation

The `payStrategies.relay.validationEnabled` flag (in the `confirmations_pay_extended` remote feature flag) was a plain boolean, so Relay quote validation could only be toggled globally — there was no way to enable or disable it per transaction type.

This PR replaces the boolean with an object-only schema:

```ts
validationEnabled: {
  default?: boolean;                                             // base toggle for all types (omitted = false)
  transactionTypes?: Partial<Record<TransactionType, boolean>>;  // per-type overrides
}
```

- `default` is the base toggle applied to every transaction type. When omitted, validation is off.
- A matching `transactionTypes[txType]` entry overrides `default` for that specific type (using `??`, so an explicit `false` override correctly beats a `true` default).

Because the `confirmations_pay_extended` flag is versioned, the boolean form is dropped rather than kept for backwards compatibility — this is a **breaking change** to the flag shape (`true` is now expressed as `{ default: true }`).

The resolver `isRelayValidationEnabled` gains an optional `transactionType` parameter, and the single call site in `relay-validation.ts` passes `request.transaction.type`. A new `RelayValidationEnabledConfig` type describes the flag shape.

## References

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking remote flag shape requires LaunchDarkly/client updates; behavior only affects whether Relay quotes are simulated, but misconfiguration could disable validation broadly or for specific types.
> 
> **Overview**
> **Breaking change:** `confirmations_pay_extended.payStrategies.relay.validationEnabled` is no longer a boolean. It must be `{ default?: boolean; transactionTypes?: Partial<Record<TransactionType, boolean>> }` (e.g. `{ default: true }` instead of `true`).
> 
> `isRelayValidationEnabled` now takes an optional `TransactionMeta` and resolves the toggle from `default`, with per-`TransactionType` entries in `transactionTypes` overriding when the top-level or **nested** transaction type matches (`hasTransactionType`). `validateRelayQuotes` passes `request.transaction` into that check so simulation can be turned on or off per flow without a global flag flip.
> 
> Tests and the changelog document the new shape and override behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9082f3584288abfc5b087398200dfcee52e2084d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->