### PR TITLE
refactor(seedless-onboarding-controller): keep accessToken out of the vault

### DIFF
--- a/packages/seedless-onboarding-controller/CHANGELOG.md
+++ b/packages/seedless-onboarding-controller/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Stop storing `accessToken` in the seedless vault. The access token is kept in memory only and is refreshed from `refreshToken` when missing or near expiry, including while the vault is locked.
-- `getIsUserAuthenticated` no longer requires `accessToken` in state; a present `revokeToken` plus social-auth details is sufficient.
-- `rotateRefreshToken` now revokes the previous refresh token immediately after a successful rotation. The old pair is queued in `pendingToBeRevokedTokens` only if revocation fails.
+- Stop storing `accessToken` in the seedless vault. The access token is kept in memory only and is refreshed from `refreshToken` when missing or near expiry, including while the vault is locked. ([#9890](https://github.com/MetaMask/core/pull/9890))
+- `getIsUserAuthenticated` no longer requires `accessToken` in state; a present `revokeToken` plus social-auth details is sufficient. ([#9890](https://github.com/MetaMask/core/pull/9890))
+- `rotateRefreshToken` now revokes the previous refresh token immediately after a successful rotation. The old pair is queued in `pendingToBeRevokedTokens` only if revocation fails. ([#9890](https://github.com/MetaMask/core/pull/9890))
 - Bump `@metamask/keyring-controller` from `^27.1.0` to `^27.1.1` ([#9791](https://github.com/MetaMask/core/pull/9791))
 
 ## [10.1.1]

--- a/packages/seedless-onboarding-controller/CHANGELOG.md
+++ b/packages/seedless-onboarding-controller/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Stop storing `accessToken` in the seedless vault. The access token is kept in memory only and is refreshed from `refreshToken` when missing or near expiry, including while the vault is locked.
+- `getIsUserAuthenticated` no longer requires `accessToken` in state; a present `revokeToken` plus social-auth details is sufficient.
+- `rotateRefreshToken` now revokes the previous refresh token immediately after a successful rotation. The old pair is queued in `pendingToBeRevokedTokens` only if revocation fails.
 - Bump `@metamask/keyring-controller` from `^27.1.0` to `^27.1.1` ([#9791](https://github.com/MetaMask/core/pull/9791))
 
 ## [10.1.1]

--- a/packages/seedless-onboarding-controller/src/SeedlessOnboardingController-method-action-types.ts
+++ b/packages/seedless-onboarding-controller/src/SeedlessOnboardingController-method-action-types.ts
@@ -172,7 +172,11 @@ export type SeedlessOnboardingControllerSubmitPasswordAction = {
 };
 
 /**
- * Set the controller to locked state, and deallocate the secrets (vault encryption key and salt).
+ * Set the controller to locked state, and deallocate vault secrets
+ * (`vaultEncryptionKey`, `vaultEncryptionSalt`, and `revokeToken`).
+ *
+ * The access token is left in memory (`persist: false`) so profile-sync
+ * calls can still refresh or reuse it while the vault is locked.
  *
  * When the controller is locked, the user will not be able to perform any operations on the controller/vault.
  *
@@ -228,11 +232,8 @@ export type SeedlessOnboardingControllerCheckIsPasswordOutdatedAction = {
 /**
  * Check if the user is authenticated with the seedless onboarding flow by checking the token values in the state.
  *
- * This method will check the `accessToken` and `revokeToken` in the state, besides the social login authentication details.
- * If both are present, the user is authenticated.
- * If either is missing, the user is not authenticated.
- *
- * This method is useful when we want to check if the state has valid authenticated user details to perform vault creations.
+ * This method checks the social login authentication details and that a
+ * `revokeToken` is present (required to persist a vault).
  *
  * @returns True if the user is authenticated, false otherwise.
  */
@@ -288,7 +289,9 @@ export type SeedlessOnboardingControllerRefreshAuthTokensAction = {
 
 /**
  * Rotate the refresh token — fetch a new refresh/revoke token pair from the
- * auth service and persist the new revoke token in the vault.
+ * auth service, persist the new revoke token in the vault, and revoke the
+ * previous refresh token. If revocation fails, the old pair is queued for
+ * `revokePendingRefreshTokens` to retry.
  *
  * This method should be called after a successful JWT refresh.
  *
@@ -348,9 +351,8 @@ export type SeedlessOnboardingControllerCheckMetadataAccessTokenExpiredAction =
 
 /**
  * Check if the current access token should be refreshed.
- * Returns true when the token is expired or when less than 10% of its
+ * Returns true when the token is missing, expired, or when less than 10% of its
  * lifetime remains (proactive refresh).
- * When the vault is locked, the access token is not accessible, so we return false.
  *
  * @returns True if the access token should be refreshed, false otherwise.
  */

--- a/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.test.ts
+++ b/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.test.ts
@@ -536,7 +536,7 @@ async function mockCreateToprfKeyAndBackupSeedPhrase<
  * @param authKeyPair - The authentication key pair.
  * @param MOCK_PASSWORD - The mock password.
  * @param mockRevokeToken - The revoke token.
- * @param mockAccessToken - The access token.
+ * @param mockAccessToken - The access token kept in test helper state (not stored in the vault).
  *
  * @returns The mock vault data.
  */
@@ -567,7 +567,6 @@ async function createMockVault(
       pk: bytesToBase64(authKeyPair.pk),
     }),
     revokeToken: mockRevokeToken,
-    accessToken: mockAccessToken,
   });
 
   const { vault: encryptedMockVault, exportedKeyString } =
@@ -1032,6 +1031,34 @@ describe('SeedlessOnboardingController', () => {
       );
     });
 
+    it('should authenticate without a revokeToken', async () => {
+      await withController(
+        async ({ controller, toprfClient, baseMessenger }) => {
+          jest.spyOn(toprfClient, 'authenticate').mockResolvedValue({
+            nodeAuthTokens: MOCK_NODE_AUTH_TOKENS,
+            isNewUser: true,
+          });
+
+          await baseMessenger.call(
+            'SeedlessOnboardingController:authenticate',
+            {
+              idTokens,
+              authConnectionId,
+              userId,
+              authConnection,
+              socialLoginEmail,
+              refreshToken,
+              accessToken,
+              metadataAccessToken,
+            },
+          );
+
+          expect(controller.state.revokeToken).toBeUndefined();
+          expect(controller.state.accessToken).toBe(accessToken);
+        },
+      );
+    });
+
     it('should throw an error if the authentication fails', async () => {
       const JSONRPC_ERROR = {
         jsonrpc: '2.0',
@@ -1282,12 +1309,12 @@ describe('SeedlessOnboardingController', () => {
       );
     });
 
-    it('should return false if the user is not authenticated (accessToken is missing)', async () => {
+    it('should return true if the user is authenticated even when accessToken is missing', async () => {
       await withController(
         {
           state: getMockInitialControllerState({
             withMockAuthenticatedUser: true,
-            withoutMockAccessToken: true, // missing accessToken
+            withoutMockAccessToken: true, // accessToken is RAM-only and not required
           }),
         },
         async ({ baseMessenger }) => {
@@ -1295,7 +1322,7 @@ describe('SeedlessOnboardingController', () => {
             await baseMessenger.call(
               'SeedlessOnboardingController:getIsUserAuthenticated',
             ),
-          ).toBe(false);
+          ).toBe(true);
         },
       );
     });
@@ -1402,7 +1429,7 @@ describe('SeedlessOnboardingController', () => {
       );
     });
 
-    it('should store accessToken in the vault during backup creation', async () => {
+    it('should store revokeToken in the vault during backup creation and omit accessToken', async () => {
       await withController(
         {
           state: getMockInitialControllerState({
@@ -1425,14 +1452,13 @@ describe('SeedlessOnboardingController', () => {
           // Verify the vault was created
           expect(controller.state.vault).toBeDefined();
 
-          // Decrypt the vault and verify accessToken is stored
           const decryptedVaultData = await encryptor.decrypt(
             MOCK_PASSWORD,
             controller.state.vault as string,
           );
           const parsedVaultData = JSON.parse(decryptedVaultData as string);
 
-          expect(parsedVaultData.accessToken).toBe(accessToken);
+          expect(parsedVaultData.accessToken).toBeUndefined();
           expect(parsedVaultData.revokeToken).toBe(revokeToken);
           expect(parsedVaultData.toprfEncryptionKey).toBeDefined();
           expect(parsedVaultData.toprfPwEncryptionKey).toBeDefined();
@@ -5603,7 +5629,6 @@ describe('SeedlessOnboardingController', () => {
               pk: bytesToBase64(newAuthKeyPair.pk),
             }),
             revokeToken: controller.state.revokeToken,
-            accessToken: controller.state.accessToken,
           });
           expect(encryptorSpy).toHaveBeenCalledWith(
             GLOBAL_PASSWORD,
@@ -5620,7 +5645,7 @@ describe('SeedlessOnboardingController', () => {
       );
     });
 
-    it('should persist the latest accessToken when state token is newer than vault token', async () => {
+    it('should keep a refreshed accessToken in state and omit it from the vault', async () => {
       const futureExp = Math.floor(Date.now() / 1000) + 3600; // 1 hour from now
       const newerAccessToken = createMockJWTToken({ exp: futureExp }); // refreshed accessToken
       const b64EncKey = bytesToBase64(initialEncryptedSeedlessEncryptionKey);
@@ -5729,7 +5754,6 @@ describe('SeedlessOnboardingController', () => {
               pk: bytesToBase64(newAuthKeyPair.pk),
             }),
             revokeToken: controller.state.revokeToken,
-            accessToken: newerAccessToken,
           });
           expect(encryptorSpy).toHaveBeenCalledWith(
             GLOBAL_PASSWORD,
@@ -5901,7 +5925,7 @@ describe('SeedlessOnboardingController', () => {
     const MOCK_PASSWORD = 'mock-password';
     const NEW_MOCK_PASSWORD = 'new-mock-password';
 
-    it('should skip access token check when vault is locked', async () => {
+    it('should refresh when the access token is expired even if the vault is locked', async () => {
       await withController(
         {
           state: getMockInitialControllerState({
@@ -5909,17 +5933,23 @@ describe('SeedlessOnboardingController', () => {
             withMockAuthPubKey: true,
           }),
         },
-        async ({ controller, toprfClient, baseMessenger }) => {
-          // Ensure the controller is locked
+        async ({
+          controller,
+          toprfClient,
+          mockRefreshJWTToken,
+          baseMessenger,
+        }) => {
           await baseMessenger.call('SeedlessOnboardingController:setLocked');
 
-          // Mock fetchAuthPubKey to return a valid response
           jest.spyOn(toprfClient, 'fetchAuthPubKey').mockResolvedValue({
             authPubKey: base64ToBytes(MOCK_AUTH_PUB_KEY),
             keyIndex: 1,
           });
+          jest.spyOn(toprfClient, 'authenticate').mockResolvedValue({
+            nodeAuthTokens: MOCK_NODE_AUTH_TOKENS,
+            isNewUser: false,
+          });
 
-          // Mock the token expiration checks
           jest
             .spyOn(controller, 'checkNodeAuthTokenExpired')
             .mockReturnValue(false);
@@ -5930,13 +5960,18 @@ describe('SeedlessOnboardingController', () => {
             .spyOn(controller, 'checkAccessTokenExpired')
             .mockReturnValue(true);
 
-          // This should not trigger token refresh since access token check is skipped when locked
+          mockRefreshJWTToken.mockResolvedValueOnce({
+            idTokens: ['newIdToken'],
+            accessToken,
+            metadataAccessToken,
+          });
+
           await baseMessenger.call(
             'SeedlessOnboardingController:checkIsPasswordOutdated',
           );
 
-          // Verify that refreshAuthTokens was not called
-          expect(controller.checkAccessTokenExpired).not.toHaveBeenCalled();
+          expect(controller.checkAccessTokenExpired).toHaveBeenCalled();
+          expect(mockRefreshJWTToken).toHaveBeenCalled();
         },
       );
     });
@@ -6474,7 +6509,6 @@ describe('SeedlessOnboardingController', () => {
                 pk: bytesToBase64(newAuthKeyPair.pk),
               }),
               revokeToken: controller.state.revokeToken,
-              accessToken: controller.state.accessToken,
             });
             expect(encryptorSpy).toHaveBeenCalledWith(
               GLOBAL_PASSWORD,
@@ -7238,7 +7272,7 @@ describe('SeedlessOnboardingController', () => {
         );
       });
 
-      it('should throw error when vaultEncryptionKey or vaultEncryptionSalt is missing while vault is unlocked', async () => {
+      it('should refresh JWTs even if rotation cannot update the vault', async () => {
         await withController(
           {
             state: getMockInitialControllerState({
@@ -7254,39 +7288,37 @@ describe('SeedlessOnboardingController', () => {
             mockRefreshJWTToken,
             baseMessenger,
           }) => {
-            // Unlock the vault first
             await baseMessenger.call(
               'SeedlessOnboardingController:submitPassword',
               MOCK_PASSWORD,
             );
 
-            // Mock refreshJWTToken to return new tokens
             mockRefreshJWTToken.mockResolvedValueOnce({
               idTokens: ['newIdToken'],
               accessToken: 'new-access-token',
               metadataAccessToken: 'new-metadata-access-token',
             });
 
-            // Mock authenticate for token refresh
             jest.spyOn(toprfClient, 'authenticate').mockResolvedValue({
               nodeAuthTokens: MOCK_NODE_AUTH_TOKENS,
               isNewUser: false,
             });
 
-            // Clear vaultEncryptionKey from state after unlocking
+            // Clear vaultEncryptionKey from state after unlocking so rotation
+            // cannot persist the new revoke token. JWT refresh should still succeed.
             // @ts-expect-error Accessing protected method for testing
             controller.update((state) => {
               state.vaultEncryptionKey = undefined;
               state.vaultEncryptionSalt = undefined;
             });
 
-            // Should throw AuthenticationError (which wraps MissingCredentials)
-            await expect(
-              baseMessenger.call(
-                'SeedlessOnboardingController:refreshAuthTokens',
-              ),
-            ).rejects.toThrow(
-              SeedlessOnboardingControllerErrorMessage.AuthenticationError,
+            await baseMessenger.call(
+              'SeedlessOnboardingController:refreshAuthTokens',
+            );
+
+            expect(controller.state.accessToken).toBe('new-access-token');
+            expect(controller.state.metadataAccessToken).toBe(
+              'new-metadata-access-token',
             );
           },
         );
@@ -7564,7 +7596,7 @@ describe('SeedlessOnboardingController', () => {
         );
       });
 
-      it('should queue old refresh token for revocation after successful rotation', async () => {
+      it('should revoke the old refresh token after successful rotation', async () => {
         await withController(
           {
             state: getMockInitialControllerState({
@@ -7578,6 +7610,7 @@ describe('SeedlessOnboardingController', () => {
             controller,
             toprfClient,
             mockRefreshJWTToken,
+            mockRevokeRefreshToken,
             baseMessenger,
           }) => {
             await baseMessenger.call(
@@ -7585,7 +7618,6 @@ describe('SeedlessOnboardingController', () => {
               MOCK_PASSWORD,
             );
 
-            const originalRefreshToken = controller.state.refreshToken;
             const originalRevokeToken = controller.state.revokeToken;
 
             mockRefreshJWTToken.mockResolvedValueOnce({
@@ -7603,16 +7635,13 @@ describe('SeedlessOnboardingController', () => {
               'SeedlessOnboardingController:refreshAuthTokens',
             );
 
-            // After successful rotation the old token pair should be queued
-            // for background revocation.
-            expect(controller.state.pendingToBeRevokedTokens).toStrictEqual(
-              expect.arrayContaining([
-                {
-                  refreshToken: originalRefreshToken,
-                  revokeToken: originalRevokeToken,
-                },
-              ]),
-            );
+            expect(mockRevokeRefreshToken).toHaveBeenCalledWith({
+              connection: controller.state.authConnection,
+              revokeToken: originalRevokeToken,
+            });
+            expect(
+              controller.state.pendingToBeRevokedTokens ?? [],
+            ).toHaveLength(0);
           },
         );
       });
@@ -8197,7 +8226,7 @@ describe('SeedlessOnboardingController', () => {
       );
     });
 
-    it('should return undefined when accessToken is not set', async () => {
+    it('should refresh tokens when accessToken is missing and return the new access token', async () => {
       await withController(
         {
           state: {
@@ -8210,11 +8239,37 @@ describe('SeedlessOnboardingController', () => {
             refreshToken,
           },
         },
-        async ({ baseMessenger }) => {
+        async ({
+          controller,
+          baseMessenger,
+          mockRefreshJWTToken,
+          toprfClient,
+        }) => {
+          jest
+            .spyOn(controller, 'checkAccessTokenExpired')
+            .mockReturnValue(true);
+          jest
+            .spyOn(controller, 'checkNodeAuthTokenExpired')
+            .mockReturnValue(false);
+          jest
+            .spyOn(controller, 'checkMetadataAccessTokenExpired')
+            .mockReturnValue(false);
+
+          mockRefreshJWTToken.mockResolvedValueOnce({
+            idTokens: ['newIdToken'],
+            accessToken,
+            metadataAccessToken: 'mock-metadata-access-token',
+          });
+          jest.spyOn(toprfClient, 'authenticate').mockResolvedValueOnce({
+            nodeAuthTokens: MOCK_NODE_AUTH_TOKENS,
+            isNewUser: false,
+          });
+
           const result = await baseMessenger.call(
             'SeedlessOnboardingController:getAccessToken',
           );
-          expect(result).toBeUndefined();
+          expect(result).toBe(accessToken);
+          expect(mockRefreshJWTToken).toHaveBeenCalled();
         },
       );
     });
@@ -8325,10 +8380,10 @@ describe('SeedlessOnboardingController', () => {
     });
   });
 
-  describe('#getAccessTokenAndRevokeToken', () => {
+  describe('#getRevokeToken', () => {
     const MOCK_PASSWORD = 'mock-password';
 
-    it('should retrieve the access token and revoke token from the vault if it is not available in the state', async () => {
+    it('should retrieve the revoke token from the vault if it is not available in the state', async () => {
       const mockToprfEncryptor = createMockToprfEncryptor();
       const MOCK_ENCRYPTION_KEY =
         mockToprfEncryptor.deriveEncKey(MOCK_PASSWORD);
@@ -8423,12 +8478,12 @@ describe('SeedlessOnboardingController', () => {
       );
     });
 
-    it('should throw error if access token is not available either in the state or the vault', async () => {
+    it('should throw error if revoke token is not available either in the state or the vault', async () => {
       await withController(
         {
           state: getMockInitialControllerState({
             withMockAuthenticatedUser: true,
-            withoutMockAccessToken: true,
+            withoutMockRevokeToken: true,
           }),
         },
         async ({ controller, toprfClient, baseMessenger }) => {
@@ -8461,7 +8516,7 @@ describe('SeedlessOnboardingController', () => {
               MOCK_PASSWORD,
             ),
           ).rejects.toThrow(
-            SeedlessOnboardingControllerErrorMessage.InvalidAccessToken,
+            SeedlessOnboardingControllerErrorMessage.InvalidRevokeToken,
           );
         },
       );
@@ -8517,7 +8572,7 @@ describe('SeedlessOnboardingController', () => {
       );
     });
 
-    it('should update state with new tokens and queue old token for revocation', async () => {
+    it('should update state with new tokens and revoke the old refresh token', async () => {
       const mockToprfEncryptor = createMockToprfEncryptor();
       const MOCK_ENCRYPTION_KEY =
         mockToprfEncryptor.deriveEncKey(MOCK_PASSWORD);
@@ -8543,7 +8598,7 @@ describe('SeedlessOnboardingController', () => {
             vaultEncryptionSalt: mockResult.vaultEncryptionSalt,
           }),
         },
-        async ({ controller, baseMessenger }) => {
+        async ({ controller, mockRevokeRefreshToken, baseMessenger }) => {
           // Unlock vault so #cachedDecryptedVaultData is populated.
           await baseMessenger.call(
             'SeedlessOnboardingController:submitPassword',
@@ -8556,16 +8611,17 @@ describe('SeedlessOnboardingController', () => {
             'SeedlessOnboardingController:rotateRefreshToken',
           );
 
-          // State should be updated with new tokens
           expect(controller.state.refreshToken).toBe('newRefreshToken');
           expect(controller.state.revokeToken).toBe('newRevokeToken');
 
-          // Old token should be queued for revocation
-          expect(controller.state.pendingToBeRevokedTokens).toHaveLength(1);
-          expect(controller.state.pendingToBeRevokedTokens?.[0]).toStrictEqual({
-            refreshToken: originalRefreshToken,
+          expect(mockRevokeRefreshToken).toHaveBeenCalledWith({
+            connection: controller.state.authConnection,
             revokeToken: MOCK_REVOKE_TOKEN,
           });
+          expect(controller.state.pendingToBeRevokedTokens ?? []).toHaveLength(
+            0,
+          );
+          expect(originalRefreshToken).toBe(refreshToken);
         },
       );
     });
@@ -8578,6 +8634,58 @@ describe('SeedlessOnboardingController', () => {
           SeedlessOnboardingControllerErrorMessage.MissingAuthUserInfo,
         );
       });
+    });
+
+    it('should queue old token for revocation when immediate revoke fails', async () => {
+      const mockToprfEncryptor = createMockToprfEncryptor();
+      const MOCK_ENCRYPTION_KEY =
+        mockToprfEncryptor.deriveEncKey(MOCK_PASSWORD);
+      const MOCK_PASSWORD_ENCRYPTION_KEY =
+        mockToprfEncryptor.derivePwEncKey(MOCK_PASSWORD);
+      const MOCK_AUTH_KEY_PAIR =
+        mockToprfEncryptor.deriveAuthKeyPair(MOCK_PASSWORD);
+
+      const mockResult = await createMockVault(
+        MOCK_ENCRYPTION_KEY,
+        MOCK_PASSWORD_ENCRYPTION_KEY,
+        MOCK_AUTH_KEY_PAIR,
+        MOCK_PASSWORD,
+        MOCK_REVOKE_TOKEN,
+      );
+
+      await withController(
+        {
+          state: getMockInitialControllerState({
+            withMockAuthenticatedUser: true,
+            vault: mockResult.encryptedMockVault,
+            vaultEncryptionKey: mockResult.vaultEncryptionKey,
+            vaultEncryptionSalt: mockResult.vaultEncryptionSalt,
+          }),
+        },
+        async ({ controller, mockRevokeRefreshToken, baseMessenger }) => {
+          await baseMessenger.call(
+            'SeedlessOnboardingController:submitPassword',
+            MOCK_PASSWORD,
+          );
+
+          const originalRefreshToken = controller.state.refreshToken;
+          mockRevokeRefreshToken.mockRejectedValueOnce(
+            new Error('Revoke failed'),
+          );
+
+          await baseMessenger.call(
+            'SeedlessOnboardingController:rotateRefreshToken',
+          );
+
+          expect(controller.state.refreshToken).toBe('newRefreshToken');
+          expect(controller.state.pendingToBeRevokedTokens).toStrictEqual([
+            {
+              refreshToken: originalRefreshToken,
+              revokeToken: MOCK_REVOKE_TOKEN,
+            },
+          ]);
+        },
+      );
     });
 
     it('should not update state when renewal returns null tokens', async () => {
@@ -8791,6 +8899,31 @@ describe('SeedlessOnboardingController', () => {
           // The first one was removed in the catch block (line 1911)
           // The second one was removed after successful revocation
           expect(controller.state.pendingToBeRevokedTokens?.length).toBe(1);
+        },
+      );
+    });
+
+    it('should keep pending tokens when every revoke call fails', async () => {
+      await withController(
+        {
+          state: getMockInitialControllerState({
+            withMockAuthenticatedUser: true,
+            pendingToBeRevokedTokens: [
+              {
+                refreshToken: 'old-refresh-token-1',
+                revokeToken: 'old-revoke-token-1',
+              },
+            ],
+          }),
+        },
+        async ({ controller, mockRevokeRefreshToken, baseMessenger }) => {
+          mockRevokeRefreshToken.mockRejectedValue(new Error('Revoke failed'));
+
+          await baseMessenger.call(
+            'SeedlessOnboardingController:revokePendingRefreshTokens',
+          );
+
+          expect(controller.state.pendingToBeRevokedTokens).toHaveLength(1);
         },
       );
     });

--- a/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.ts
+++ b/packages/seedless-onboarding-controller/src/SeedlessOnboardingController.ts
@@ -74,7 +74,6 @@ import type {
   ToprfKeyDeriver,
 } from './types.js';
 import {
-  compareAndGetLatestToken,
   decodeJWTToken,
   decodeNodeAuthToken,
   deserializeVaultData,
@@ -155,8 +154,7 @@ export type SeedlessOnboardingControllerOptions<
   EncryptionKey = encryptionUtils.EncryptionKey,
   SupportedKeyDerivationParams = encryptionUtils.KeyDerivationOptions,
   EncryptionResult extends
-    EncryptionResultConstraint<SupportedKeyDerivationParams> =
-    DefaultEncryptionResult<SupportedKeyDerivationParams>,
+    EncryptionResultConstraint<SupportedKeyDerivationParams> = DefaultEncryptionResult<SupportedKeyDerivationParams>,
 > = {
   messenger: SeedlessOnboardingControllerMessenger;
 
@@ -346,7 +344,8 @@ const seedlessOnboardingMetadata: StateMetadata<SeedlessOnboardingControllerStat
       includeInDebugSnapshot: false,
       usedInUi: false,
     },
-    // stays in vault
+    // RAM-only JWT. Not stored in the vault; refreshed from `refreshToken`
+    // when missing or near expiry, including while the vault is locked.
     accessToken: {
       includeInStateLogs: false,
       persist: false,
@@ -391,8 +390,7 @@ export class SeedlessOnboardingController<
   EncryptionKey = encryptionUtils.EncryptionKey,
   SupportedKeyDerivationOptions = encryptionUtils.KeyDerivationOptions,
   EncryptionResult extends
-    EncryptionResultConstraint<SupportedKeyDerivationOptions> =
-    DefaultEncryptionResult<SupportedKeyDerivationOptions>,
+    EncryptionResultConstraint<SupportedKeyDerivationOptions> = DefaultEncryptionResult<SupportedKeyDerivationOptions>,
 > extends BaseController<
   typeof controllerName,
   SeedlessOnboardingControllerState,
@@ -1097,42 +1095,20 @@ export class SeedlessOnboardingController<
    */
   async submitPassword(password: string): Promise<void> {
     return await this.#withControllerLock(async () => {
-      // get the access token from the state before unlocking, it might be the new token set from the `refreshAuthTokens` method.
-      const { accessToken: accessTokenBeforeUnlock } = this.state;
-
-      const deserializedVaultData = await this.#unlockVaultAndGetVaultData({
+      await this.#unlockVaultAndGetVaultData({
         password,
       });
-
-      const accessTokenFromDecryptedVault = deserializedVaultData.accessToken;
-
-      // Pick the latest access token - the token from state might be newer (from refreshAuthTokens)
-      // than the token stored in the vault.
-      const latestAccessToken = this.#pickLatestAccessToken(
-        accessTokenBeforeUnlock,
-        accessTokenFromDecryptedVault,
-      );
-
-      // update the state and vault with the latest access token `ONLY` if it's different from the current access token in the state.
-      if (latestAccessToken !== accessTokenFromDecryptedVault) {
-        const updatedVaultData = {
-          ...deserializedVaultData,
-          accessToken: latestAccessToken,
-        };
-
-        await this.#updateVault({
-          password,
-          vaultData: updatedVaultData,
-          pwEncKey: deserializedVaultData.toprfPwEncryptionKey,
-        });
-      }
 
       this.#setUnlocked();
     });
   }
 
   /**
-   * Set the controller to locked state, and deallocate the secrets (vault encryption key and salt).
+   * Set the controller to locked state, and deallocate vault secrets
+   * (`vaultEncryptionKey`, `vaultEncryptionSalt`, and `revokeToken`).
+   *
+   * The access token is left in memory (`persist: false`) so profile-sync
+   * calls can still refresh or reuse it while the vault is locked.
    *
    * When the controller is locked, the user will not be able to perform any operations on the controller/vault.
    *
@@ -1144,7 +1120,6 @@ export class SeedlessOnboardingController<
         delete state.vaultEncryptionKey;
         delete state.vaultEncryptionSalt;
         delete state.revokeToken;
-        delete state.accessToken;
       });
 
       this.#cachedDecryptedVaultData = undefined;
@@ -1251,22 +1226,10 @@ export class SeedlessOnboardingController<
       const { pwEncKey } = res;
       const vaultKey = await this.#loadSeedlessEncryptionKey(pwEncKey);
 
-      // accessToken before unlocking vault and flooding the state with values from the decrypted vault
-      // it might be the new token set from the `refreshAuthTokens` method.
-      const { accessToken: accessTokenBeforeUnlock } = this.state;
-
-      // Unlock the controller
-      const decryptedVaultData = await this.#unlockVaultAndGetVaultData({
+      await this.#unlockVaultAndGetVaultData({
         encryptionKey: vaultKey,
       });
       this.#setUnlocked();
-
-      // Pick the latest access token - the token from state might be newer (from refreshAuthTokens)
-      // than the token stored in the vault. The vault will be updated later by syncLatestGlobalPassword.
-      this.#pickLatestAccessToken(
-        accessTokenBeforeUnlock,
-        decryptedVaultData.accessToken,
-      );
     } catch (error) {
       if (this.#isAuthTokenError(error)) {
         throw error;
@@ -1365,18 +1328,15 @@ export class SeedlessOnboardingController<
   /**
    * Check if the user is authenticated with the seedless onboarding flow by checking the token values in the state.
    *
-   * This method will check the `accessToken` and `revokeToken` in the state, besides the social login authentication details.
-   * If both are present, the user is authenticated.
-   * If either is missing, the user is not authenticated.
-   *
-   * This method is useful when we want to check if the state has valid authenticated user details to perform vault creations.
+   * This method checks the social login authentication details and that a
+   * `revokeToken` is present (required to persist a vault).
    *
    * @returns True if the user is authenticated, false otherwise.
    */
   async getIsUserAuthenticated(): Promise<boolean> {
     try {
       this.#assertIsAuthenticatedUser(this.state);
-      return Boolean(this.state.accessToken) && Boolean(this.state.revokeToken);
+      return Boolean(this.state.revokeToken);
     } catch {
       return false;
     }
@@ -1384,39 +1344,6 @@ export class SeedlessOnboardingController<
 
   #setUnlocked(): void {
     this.#isUnlocked = true;
-  }
-
-  /**
-   * Compares two access tokens and picks the latest one based on JWT expiration.
-   * If the tokens are different, the state is updated with the latest token.
-   *
-   * @param tokenBeforeUnlock - The access token from state before unlocking (may have been set by refreshAuthTokens).
-   * @param tokenAfterUnlock - The access token from the decrypted vault after unlocking.
-   * @returns The latest access token, or the token after unlock if no reconciliation was needed.
-   */
-  #pickLatestAccessToken(
-    tokenBeforeUnlock: string | undefined,
-    tokenAfterUnlock: string,
-  ): string {
-    let latestToken = tokenAfterUnlock;
-
-    if (
-      tokenBeforeUnlock &&
-      tokenAfterUnlock &&
-      tokenBeforeUnlock !== tokenAfterUnlock
-    ) {
-      latestToken = compareAndGetLatestToken(
-        tokenBeforeUnlock,
-        tokenAfterUnlock,
-      );
-
-      // Update the access token in the state with the latest access token
-      this.update((state) => {
-        state.accessToken = latestToken;
-      });
-    }
-
-    return latestToken;
   }
 
   /**
@@ -1812,7 +1739,6 @@ export class SeedlessOnboardingController<
    * - toprfEncryptionKey: The decrypted TOPRF encryption key
    * - toprfAuthKeyPair: The decrypted TOPRF authentication key pair
    * - revokeToken: The decrypted revoke token
-   * - accessToken: The decrypted access token
    * @throws {Error} If:
    * - The password is invalid or empty
    * - The vault is not initialized
@@ -1835,7 +1761,6 @@ export class SeedlessOnboardingController<
         state.vaultEncryptionKey = vaultEncryptionKey;
         state.vaultEncryptionSalt = vaultEncryptionSalt;
         state.revokeToken = vaultData.revokeToken;
-        state.accessToken = vaultData.accessToken;
       });
 
       const deserializedVaultData = deserializeVaultData(vaultData);
@@ -2031,15 +1956,13 @@ export class SeedlessOnboardingController<
   }): Promise<void> {
     this.#assertIsAuthenticatedUser(this.state);
 
-    const { accessToken, revokeToken } =
-      await this.#getAccessTokenAndRevokeToken(password);
+    const revokeToken = await this.#getRevokeToken(password);
 
     const vaultData: DeserializedVaultData = {
       toprfAuthKeyPair: rawToprfAuthKeyPair,
       toprfEncryptionKey: rawToprfEncryptionKey,
       toprfPwEncryptionKey: rawToprfPwEncryptionKey,
       revokeToken,
-      accessToken,
     };
 
     await this.#updateVault({
@@ -2162,36 +2085,22 @@ export class SeedlessOnboardingController<
   }
 
   /**
-   * Get the access token and revoke token from the state or the vault.
+   * Get the revoke token from the state or the vault.
    *
    * @param password - The password to decrypt the vault.
-   * @returns The access token and revoke token.
+   * @returns The revoke token.
    */
-  async #getAccessTokenAndRevokeToken(
-    password: string,
-  ): Promise<{ accessToken: string; revokeToken: string }> {
-    let { accessToken, revokeToken } = this.state;
-    // `accessToken` and `revokeToken` are both available in the state, `ONLY` when the wallet (vault) is unlocked
+  async #getRevokeToken(password: string): Promise<string> {
+    let { revokeToken } = this.state;
+    // `revokeToken` is available in the state when the wallet (vault) is unlocked
     // or during the period between the social authentication and the vault creation during the onboarding flow.
-    if (accessToken && revokeToken) {
-      return { accessToken, revokeToken };
+    if (revokeToken) {
+      return revokeToken;
     }
 
-    // if `password` is provided to decrypt the vault, decrypt the vault and get the access token and revoke token from the vault
     if (this.state.vault) {
-      // if the access token or revoke token is not available in the state, decrypt the vault and get the access token and revoke token from the vault
       const { vaultData } = await this.#decryptAndParseVaultData({ password });
-      accessToken = accessToken ?? vaultData.accessToken;
-      revokeToken = revokeToken ?? vaultData.revokeToken;
-    }
-
-    // we should always throw an error if the access token or revoke token is not available
-    // to prevent the caller from using the controller in an invalid state
-
-    if (!accessToken) {
-      throw new Error(
-        SeedlessOnboardingControllerErrorMessage.InvalidAccessToken,
-      );
+      revokeToken = vaultData.revokeToken;
     }
 
     if (!revokeToken) {
@@ -2200,7 +2109,7 @@ export class SeedlessOnboardingController<
       );
     }
 
-    return { accessToken, revokeToken };
+    return revokeToken;
   }
 
   /**
@@ -2423,20 +2332,8 @@ export class SeedlessOnboardingController<
         metadataAccessToken,
       });
 
-      // update the vault with new access token if wallet is unlocked
+      // Rotate the refresh token now that we have vault access.
       if (this.#isUnlocked && this.#cachedDecryptedVaultData) {
-        const updatedVaultData = {
-          ...this.#cachedDecryptedVaultData,
-          accessToken,
-        };
-        const pwEncKey = this.#cachedDecryptedVaultData.toprfPwEncryptionKey;
-
-        await this.#updateVault({
-          vaultData: updatedVaultData,
-          pwEncKey,
-        });
-
-        // Proactively rotate the refresh token now that we have vault access.
         await this.rotateRefreshToken().catch((error) => {
           // Rotation failure is intentionally non-fatal: the JWT refresh
           // itself succeeded and the caller should not be blocked.
@@ -2530,7 +2427,9 @@ export class SeedlessOnboardingController<
 
   /**
    * Rotate the refresh token — fetch a new refresh/revoke token pair from the
-   * auth service and persist the new revoke token in the vault.
+   * auth service, persist the new revoke token in the vault, and revoke the
+   * previous refresh token. If revocation fails, the old pair is queued for
+   * `revokePendingRefreshTokens` to retry.
    *
    * This method should be called after a successful JWT refresh.
    *
@@ -2573,11 +2472,20 @@ export class SeedlessOnboardingController<
         state.refreshToken = newRefreshToken;
       });
 
-      // add the old refresh token to the list to be revoked later when possible
-      this.#addRefreshTokenToRevokeList({
-        refreshToken,
-        revokeToken,
-      });
+      // Revoke the previous refresh token now that the new pair is persisted.
+      // If revocation fails, queue it so `revokePendingRefreshTokens` can retry.
+      try {
+        await this.#revokeRefreshToken({
+          connection: this.state.authConnection,
+          revokeToken,
+        });
+      } catch (error) {
+        log('Error revoking previous refresh token after rotation', error);
+        this.#addRefreshTokenToRevokeList({
+          refreshToken,
+          revokeToken,
+        });
+      }
     }
   }
 
@@ -2762,12 +2670,7 @@ export class SeedlessOnboardingController<
     // proactively check for expired tokens and refresh them if needed
     const isNodeAuthTokenExpired = this.checkNodeAuthTokenExpired();
     const isMetadataAccessTokenExpired = this.checkMetadataAccessTokenExpired();
-    // access token is only accessible when the vault is unlocked
-    // so skip the check if the vault is locked
-    let isAccessTokenExpired = false;
-    if (this.#isUnlocked) {
-      isAccessTokenExpired = this.checkAccessTokenExpired();
-    }
+    const isAccessTokenExpired = this.checkAccessTokenExpired();
 
     return (
       isNodeAuthTokenExpired ||
@@ -2814,9 +2717,8 @@ export class SeedlessOnboardingController<
 
   /**
    * Check if the current access token should be refreshed.
-   * Returns true when the token is expired or when less than 10% of its
+   * Returns true when the token is missing, expired, or when less than 10% of its
    * lifetime remains (proactive refresh).
-   * When the vault is locked, the access token is not accessible, so we return false.
    *
    * @returns True if the access token should be refreshed, false otherwise.
    */

--- a/packages/seedless-onboarding-controller/src/assertions.test.ts
+++ b/packages/seedless-onboarding-controller/src/assertions.test.ts
@@ -52,7 +52,6 @@ describe('assertIsValidVaultData', () => {
     toprfEncryptionKey: 'mock_encryption_key',
     toprfPwEncryptionKey: 'mock_pw_encryption_key',
     toprfAuthKeyPair: 'mock_auth_key_pair',
-    accessToken: 'mock_access_token',
     revokeToken: 'mock_revoke_token',
   });
 
@@ -119,23 +118,22 @@ describe('assertIsValidVaultData', () => {
       }).toThrow(SeedlessOnboardingControllerErrorMessage.InvalidVaultData);
     });
 
-    it('should throw when accessToken is missing or not a string', () => {
+    it('should throw when revokeToken is missing or not a string', () => {
       const invalidData = createValidVaultData();
-      delete (invalidData as Record<string, unknown>).accessToken;
+      delete (invalidData as Record<string, unknown>).revokeToken;
 
       expect(() => {
         assertIsValidVaultData(invalidData);
-      }).toThrow(SeedlessOnboardingControllerErrorMessage.InvalidAccessToken);
+      }).toThrow(SeedlessOnboardingControllerErrorMessage.InvalidRevokeToken);
 
       const invalidData2 = {
         ...createValidVaultData(),
-        revokeToken: 'MOCK_REVOKE_TOKEN',
-        accessToken: 999,
+        revokeToken: 999,
       };
 
       expect(() => {
         assertIsValidVaultData(invalidData2);
-      }).toThrow(SeedlessOnboardingControllerErrorMessage.InvalidAccessToken);
+      }).toThrow(SeedlessOnboardingControllerErrorMessage.InvalidRevokeToken);
     });
   });
 
@@ -157,6 +155,17 @@ describe('assertIsValidVaultData', () => {
 
       expect(() => {
         assertIsValidVaultData(validDataWithExtras);
+      }).not.toThrow();
+    });
+
+    it('should not throw when a legacy vault includes accessToken', () => {
+      const legacyVaultData = {
+        ...createValidVaultData(),
+        accessToken: 'legacy_access_token',
+      };
+
+      expect(() => {
+        assertIsValidVaultData(legacyVaultData);
       }).not.toThrow();
     });
   });

--- a/packages/seedless-onboarding-controller/src/assertions.ts
+++ b/packages/seedless-onboarding-controller/src/assertions.ts
@@ -119,10 +119,4 @@ export function assertIsValidVaultData(
       SeedlessOnboardingControllerErrorMessage.InvalidRevokeToken,
     );
   }
-
-  if (!('accessToken' in value) || typeof value.accessToken !== 'string') {
-    throw new Error(
-      SeedlessOnboardingControllerErrorMessage.InvalidAccessToken,
-    );
-  }
 }

--- a/packages/seedless-onboarding-controller/src/types.ts
+++ b/packages/seedless-onboarding-controller/src/types.ts
@@ -170,6 +170,9 @@ export type SeedlessOnboardingControllerState =
 
       /**
        * The access token used for pairing with profile sync auth service and to access other services.
+       *
+       * Kept in memory only (`persist: false`) and not stored in the vault.
+       * Refreshed from `refreshToken` when missing or near expiry.
        */
       accessToken?: string;
 
@@ -267,16 +270,9 @@ export type VaultData = {
    * The revoke token may no longer be available after a large number of password changes. In this case, re-authentication is advised.
    */
   revokeToken: string;
-  /**
-   * The access token used for pairing with profile sync auth service and to access other services.
-   */
-  accessToken: string;
 };
 
-export type DeserializedVaultData = Pick<
-  VaultData,
-  'accessToken' | 'revokeToken'
-> & {
+export type DeserializedVaultData = Pick<VaultData, 'revokeToken'> & {
   toprfEncryptionKey: Uint8Array;
   toprfPwEncryptionKey: Uint8Array;
   toprfAuthKeyPair: KeyPair;

--- a/packages/seedless-onboarding-controller/src/utils.ts
+++ b/packages/seedless-onboarding-controller/src/utils.ts
@@ -65,7 +65,6 @@ export function serializeVaultData(data: DeserializedVaultData): string {
     toprfPwEncryptionKey,
     toprfAuthKeyPair,
     revokeToken: data.revokeToken,
-    accessToken: data.accessToken,
   });
 }
 


### PR DESCRIPTION
## Summary
- Stop storing the short-lived `accessToken` JWT in the seedless vault. The vault now holds TOPRF keys and `revokeToken` only; `accessToken` stays in memory and is refreshed from `refreshToken` when missing or near expiry, including while locked.
- `rotateRefreshToken` revokes the previous refresh pair immediately after a successful vault write, and only queues it in `pendingToBeRevokedTokens` if revocation fails.
- `getIsUserAuthenticated` no longer requires `accessToken` in state (social-auth details + `revokeToken` are enough for vault creation).

## Test plan
- [ ] `yarn workspace @metamask/seedless-onboarding-controller run test`
- [ ] Unlock / lock / restart: `getAccessToken` still works while locked and after a process restart (missing token triggers refresh)
- [ ] Create backup / change password: vault decrypts and does **not** contain `accessToken`
- [ ] Refresh tokens while unlocked: old refresh token is revoked immediately; pending list stays empty unless revoke fails
- [ ] Existing vaults that still contain `accessToken` continue to unlock (legacy extra field is ignored)


Made with [Cursor](https://cursor.com)