### PR TITLE
fix(transaction-pay-controller): fix quote validation for predict withdraw

### DIFF
--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix quote simulation for Polymarket Predict withdrawals ([#9891](https://github.com/MetaMask/core/pull/9891))
+
 ## [26.3.1]
 
 ### Changed

--- a/packages/transaction-pay-controller/src/strategy/relay/polymarket/withdraw.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/polymarket/withdraw.test.ts
@@ -299,16 +299,19 @@ describe('Polymarket withdraw', () => {
     });
 
     it('returns false when not post-quote', () => {
-      expect(
-        isPredictWithdraw({} as QuoteRequest, withdrawTransaction),
-      ).toBe(false);
+      expect(isPredictWithdraw({} as QuoteRequest, withdrawTransaction)).toBe(
+        false,
+      );
     });
 
     it('returns false when the transaction is not a predict withdraw', () => {
       expect(
-        isPredictWithdraw({ isPostQuote: true } as QuoteRequest, {
-          type: TransactionType.simpleSend,
-        } as TransactionMeta),
+        isPredictWithdraw(
+          { isPostQuote: true } as QuoteRequest,
+          {
+            type: TransactionType.simpleSend,
+          } as TransactionMeta,
+        ),
       ).toBe(false);
     });
   });

--- a/packages/transaction-pay-controller/src/strategy/relay/polymarket/withdraw.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/polymarket/withdraw.test.ts
@@ -1,3 +1,6 @@
+import { Interface } from '@ethersproject/abi';
+import { TransactionType } from '@metamask/transaction-controller';
+import type { TransactionMeta } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 
 import {
@@ -14,6 +17,9 @@ import {
 } from './constants.js';
 import {
   applyPolymarketDepositWalletOverrides,
+  buildPolymarketDepositWalletSimulation,
+  getPredictWithdrawSafeAddress,
+  isPredictWithdraw,
   submitPolymarketWithdraw,
   sweepPolymarketDepositWallet,
 } from './withdraw.js';
@@ -275,6 +281,168 @@ describe('Polymarket withdraw', () => {
         expect(getLiveTokenBalanceMock).toHaveBeenCalledTimes(5);
         expect(polymarketSubmitDepositWalletBatchMock).toHaveBeenCalledTimes(1);
       });
+    });
+  });
+
+  describe('isPredictWithdraw', () => {
+    const withdrawTransaction = {
+      type: TransactionType.predictWithdraw,
+    } as TransactionMeta;
+
+    it('returns true for a post-quote predict withdraw', () => {
+      expect(
+        isPredictWithdraw(
+          { isPostQuote: true } as QuoteRequest,
+          withdrawTransaction,
+        ),
+      ).toBe(true);
+    });
+
+    it('returns false when not post-quote', () => {
+      expect(
+        isPredictWithdraw({} as QuoteRequest, withdrawTransaction),
+      ).toBe(false);
+    });
+
+    it('returns false when the transaction is not a predict withdraw', () => {
+      expect(
+        isPredictWithdraw({ isPostQuote: true } as QuoteRequest, {
+          type: TransactionType.simpleSend,
+        } as TransactionMeta),
+      ).toBe(false);
+    });
+  });
+
+  describe('getPredictWithdrawSafeAddress', () => {
+    const withdrawTransaction = {
+      type: TransactionType.predictWithdraw,
+    } as TransactionMeta;
+    const depositSteps = [
+      { id: 'deposit', kind: 'transaction', items: [] },
+    ] as unknown as RelayQuote['steps'];
+    const swapSteps = [
+      { id: 'swap', kind: 'transaction', items: [] },
+    ] as unknown as RelayQuote['steps'];
+
+    it('returns refundTo for a deposit-style predict withdraw', () => {
+      expect(
+        getPredictWithdrawSafeAddress(
+          { isPostQuote: true, refundTo: DEPOSIT_WALLET_MOCK } as QuoteRequest,
+          depositSteps,
+          withdrawTransaction,
+        ),
+      ).toBe(DEPOSIT_WALLET_MOCK);
+    });
+
+    it('returns undefined for the deposit-wallet variant (handled by its own simulation)', () => {
+      expect(
+        getPredictWithdrawSafeAddress(
+          {
+            isPostQuote: true,
+            refundTo: DEPOSIT_WALLET_MOCK,
+            isPolymarketDepositWallet: true,
+          } as QuoteRequest,
+          depositSteps,
+          withdrawTransaction,
+        ),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined for swap-only routes (no deposit step)', () => {
+      expect(
+        getPredictWithdrawSafeAddress(
+          { isPostQuote: true, refundTo: DEPOSIT_WALLET_MOCK } as QuoteRequest,
+          swapSteps,
+          withdrawTransaction,
+        ),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined when not a predict withdraw', () => {
+      expect(
+        getPredictWithdrawSafeAddress(
+          { isPostQuote: true, refundTo: DEPOSIT_WALLET_MOCK } as QuoteRequest,
+          depositSteps,
+          { type: TransactionType.simpleSend } as TransactionMeta,
+        ),
+      ).toBeUndefined();
+    });
+  });
+
+  describe('buildPolymarketDepositWalletSimulation', () => {
+    const RELAY_DEPOSIT_ADDRESS_MOCK =
+      '0x1234567890123456789012345678901234567890' as Hex;
+
+    it('simulates the real approve + unwrap batch from the deposit wallet', async () => {
+      const simulation = await buildPolymarketDepositWalletSimulation(
+        buildQuote(),
+        EOA_MOCK,
+        messenger,
+      );
+
+      expect(polymarketGetDepositWalletAddressMock).toHaveBeenCalledWith({
+        eoa: EOA_MOCK,
+      });
+      expect(simulation.transactions).toHaveLength(2);
+
+      const [approve, unwrap] = simulation.transactions;
+
+      expect(approve.from).toBe(DEPOSIT_WALLET_MOCK);
+      expect(approve.to).toBe(POLYGON_PUSD_ADDRESS);
+      expect(approve.value).toBe('0x0');
+
+      expect(unwrap.from).toBe(DEPOSIT_WALLET_MOCK);
+      expect(unwrap.to).toBe(POLYMARKET_COLLATERAL_OFFRAMP_POLYGON);
+      expect(unwrap.value).toBe('0x0');
+    });
+
+    it('encodes the approve for the offramp and the amount from the quote', async () => {
+      const simulation = await buildPolymarketDepositWalletSimulation(
+        buildQuote(),
+        EOA_MOCK,
+        messenger,
+      );
+
+      const [approve, unwrap] = simulation.transactions;
+
+      // approve(offramp, 1000000)
+      const approveInterface = new Interface([
+        'function approve(address spender, uint256 amount)',
+      ]);
+      const decodedApprove = approveInterface.decodeFunctionData(
+        'approve',
+        approve.data as Hex,
+      );
+      expect(decodedApprove[0].toLowerCase()).toBe(
+        POLYMARKET_COLLATERAL_OFFRAMP_POLYGON.toLowerCase(),
+      );
+      expect(decodedApprove[1].toString()).toBe(SOURCE_AMOUNT_RAW_MOCK);
+
+      // unwrap(USDC.e, relayDepositAddress, 1000000)
+      const unwrapInterface = new Interface([
+        'function unwrap(address asset, address recipient, uint256 amount)',
+      ]);
+      const decodedUnwrap = unwrapInterface.decodeFunctionData(
+        'unwrap',
+        unwrap.data as Hex,
+      );
+      expect(decodedUnwrap[0].toLowerCase()).toBe(
+        POLYGON_USDCE_ADDRESS.toLowerCase(),
+      );
+      expect(decodedUnwrap[1].toLowerCase()).toBe(
+        RELAY_DEPOSIT_ADDRESS_MOCK.toLowerCase(),
+      );
+      expect(decodedUnwrap[2].toString()).toBe(SOURCE_AMOUNT_RAW_MOCK);
+    });
+
+    it('throws when the Relay quote has no deposit step', async () => {
+      await expect(
+        buildPolymarketDepositWalletSimulation(
+          buildQuote({ steps: [] } as Partial<RelayQuote>),
+          EOA_MOCK,
+          messenger,
+        ),
+      ).rejects.toThrow('Relay quote has no deposit step');
     });
   });
 });

--- a/packages/transaction-pay-controller/src/strategy/relay/polymarket/withdraw.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/polymarket/withdraw.ts
@@ -47,10 +47,6 @@ type RelayQuoteStep = RelayQuote['steps'][number];
  * Whether a quote request + transaction represent a Predict withdraw post-quote
  * flow.
  *
- * Predict withdraws move the user's source token (pUSD) out of a Polymarket
- * smart-contract account (a Safe proxy or a deposit wallet), not the EOA. They
- * are always post-quote flows.
- *
  * @param request - Quote request.
  * @param transaction - Original transaction metadata.
  * @returns True when this is a Predict withdraw post-quote flow.
@@ -66,30 +62,12 @@ export function isPredictWithdraw(
 }
 
 /**
- * Resolve the Polymarket Safe proxy address that holds the source token for a
- * Safe-based Predict withdraw, and that must act as `msg.sender` when estimating
- * gas for the withdraw leg.
+ * Resolve the Polymarket Safe proxy address that must act as `msg.sender` when
+ * estimating gas for the withdraw leg of a Safe-based Predict withdraw.
  *
- * For Safe-based Predict withdraws the source token lives in the Polymarket
- * Safe proxy rather than the EOA, so gas estimation for the deposit-style route
- * must be anchored to the Safe. Its address is carried on the quote request as
- * `refundTo` (written through to the request for the Safe variant). (Quote
- * validation for this legacy variant is skipped entirely; see
- * `shouldSkipValidation` in `relay-validation.ts`.)
- *
- * This does NOT apply to the deposit-wallet variant: there the submitted batch
- * is a hardcoded approve + unwrap sent from the CREATE2 deposit wallet (see
- * {@link buildPolymarketDepositWalletSimulation}), and `request.refundTo` is
- * not the deposit wallet (only the outgoing Relay body carries it). That
- * variant is handled by its own simulation builder, so this returns
- * `undefined` for it.
- *
- * The Safe sender is only used for deposit-style Relay routes (those with a
- * `deposit` step), mirroring the gas-estimation logic in `relay-quotes.ts`.
- * Same-chain swap-only routes go through DEX aggregators that reject contract
- * callers (anti-MEV `msg.sender == tx.origin` checks, ERC777-style callbacks,
- * native wrap/unwrap requiring caller native balance), so those keep the EOA
- * `from` and this returns `undefined`.
+ * Only applies to the Safe variant on deposit-style Relay routes: the source
+ * token lives in the Safe (carried as `request.refundTo`), and swap-only routes
+ * keep the EOA `from` because DEX aggregators reject contract callers.
  *
  * @param request - Quote request.
  * @param steps - Relay quote steps (used to detect a deposit-style route).
@@ -122,24 +100,9 @@ export function getPredictWithdrawSafeAddress(
 }
 
 /**
- * Build the simulation for a Polymarket deposit-wallet Predict withdraw.
- *
- * The deposit-wallet variant does not submit the Relay quote's calldata. That
- * calldata is a placeholder generated because the quote was requested with
- * `useDepositAddress: true`; only the Relay deposit address is extracted from
- * it. The transaction actually broadcast is a hardcoded two-call batch executed
- * by the CREATE2 deposit wallet:
- *
- * 1. `approve(offramp, amount)` on pUSD
- * 2. `unwrap(USDC.e, relayDepositAddress, amount)` on the offramp
- *
- * This mirrors {@link submitPolymarketWithdraw} exactly so validation simulates
- * what is really broadcast. The deposit wallet is resolved via the client
- * callback and used as `from`, so the simulation checks that the deposit wallet
- * holds enough pUSD and that the unwrap succeeds. The client-side execution
- * wrapper (how the deposit wallet batches the two calls on-chain) is opaque to
- * the controller and is intentionally not modelled; the calls themselves only
- * require `msg.sender` to be the deposit wallet.
+ * Build the simulation for a Polymarket deposit-wallet Predict withdraw,
+ * mirroring the approve + unwrap batch broadcast by {@link submitPolymarketWithdraw}
+ * so validation checks the deposit wallet holds enough pUSD.
  *
  * @param quote - Relay quote (source amount + deposit step).
  * @param from - The user EOA that owns the deposit wallet.
@@ -166,40 +129,6 @@ export async function buildPolymarketDepositWalletSimulation(
       value: '0x0',
     })),
   };
-}
-
-/**
- * Build the approve + unwrap batch that moves a deposit wallet's pUSD to the
- * Relay deposit address as USDC.e. Shared by the simulation
- * ({@link buildPolymarketDepositWalletSimulation}) and the real submit
- * ({@link submitPolymarketWithdraw}) so both model the exact same calls:
- *
- * 1. `approve(offramp, amount)` on pUSD
- * 2. `unwrap(USDC.e, relayDepositAddress, amount)` on the offramp
- *
- * @param relayDepositAddress - The Relay deposit address that receives the
- * unwrapped USDC.e.
- * @param amount - The pUSD amount to unwrap.
- * @returns The two `{ target, data }` calls.
- */
-function buildDepositWalletUnwrapCalls(
-  relayDepositAddress: Hex,
-  amount: bigint,
-): { target: Hex; data: Hex }[] {
-  return [
-    {
-      target: POLYGON_PUSD_ADDRESS,
-      data: encodeApprove(POLYMARKET_COLLATERAL_OFFRAMP_POLYGON, amount),
-    },
-    {
-      target: POLYMARKET_COLLATERAL_OFFRAMP_POLYGON,
-      data: encodeUnwrap({
-        asset: POLYGON_USDCE_ADDRESS,
-        recipient: relayDepositAddress,
-        amount,
-      }),
-    },
-  ];
 }
 
 export async function applyPolymarketDepositWalletOverrides(
@@ -439,4 +368,34 @@ function extractRelayDepositAddress(relayQuote: RelayQuote): Hex {
   }
 
   return extractErc20TransferRecipient(depositCallData);
+}
+
+/**
+ * Build the approve + unwrap batch that moves a deposit wallet's pUSD to the
+ * Relay deposit address as USDC.e. Shared by the simulation and the real submit
+ * so both model the exact same calls.
+ *
+ * @param relayDepositAddress - The Relay deposit address that receives the
+ * unwrapped USDC.e.
+ * @param amount - The pUSD amount to unwrap.
+ * @returns The two `{ target, data }` calls.
+ */
+function buildDepositWalletUnwrapCalls(
+  relayDepositAddress: Hex,
+  amount: bigint,
+): { target: Hex; data: Hex }[] {
+  return [
+    {
+      target: POLYGON_PUSD_ADDRESS,
+      data: encodeApprove(POLYMARKET_COLLATERAL_OFFRAMP_POLYGON, amount),
+    },
+    {
+      target: POLYMARKET_COLLATERAL_OFFRAMP_POLYGON,
+      data: encodeUnwrap({
+        asset: POLYGON_USDCE_ADDRESS,
+        recipient: relayDepositAddress,
+        amount,
+      }),
+    },
+  ];
 }

--- a/packages/transaction-pay-controller/src/strategy/relay/polymarket/withdraw.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/polymarket/withdraw.ts
@@ -57,7 +57,7 @@ export function isPredictWithdraw(
 ): boolean {
   return Boolean(
     request.isPostQuote &&
-      hasTransactionType(transaction, [TransactionType.predictWithdraw]),
+    hasTransactionType(transaction, [TransactionType.predictWithdraw]),
   );
 }
 

--- a/packages/transaction-pay-controller/src/strategy/relay/polymarket/withdraw.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/polymarket/withdraw.ts
@@ -1,3 +1,8 @@
+import {
+  TransactionType,
+  hasTransactionType,
+} from '@metamask/transaction-controller';
+import type { TransactionMeta } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 import { createModuleLogger } from '@metamask/utils';
 
@@ -13,6 +18,7 @@ import type {
   TransactionPayQuote,
 } from '../../../types.js';
 import { getLiveTokenBalance } from '../../../utils/token.js';
+import type { QuoteSimulation } from '../../../utils/validation.js';
 import type {
   RelayQuote,
   RelayQuoteRequest,
@@ -34,6 +40,167 @@ import {
 } from './constants.js';
 
 const log = createModuleLogger(projectLogger, 'polymarket-withdraw');
+
+type RelayQuoteStep = RelayQuote['steps'][number];
+
+/**
+ * Whether a quote request + transaction represent a Predict withdraw post-quote
+ * flow.
+ *
+ * Predict withdraws move the user's source token (pUSD) out of a Polymarket
+ * smart-contract account (a Safe proxy or a deposit wallet), not the EOA. They
+ * are always post-quote flows.
+ *
+ * @param request - Quote request.
+ * @param transaction - Original transaction metadata.
+ * @returns True when this is a Predict withdraw post-quote flow.
+ */
+export function isPredictWithdraw(
+  request: QuoteRequest,
+  transaction: TransactionMeta,
+): boolean {
+  return Boolean(
+    request.isPostQuote &&
+      hasTransactionType(transaction, [TransactionType.predictWithdraw]),
+  );
+}
+
+/**
+ * Resolve the Polymarket Safe proxy address that holds the source token for a
+ * Safe-based Predict withdraw, and that must act as `msg.sender` when estimating
+ * gas for the withdraw leg.
+ *
+ * For Safe-based Predict withdraws the source token lives in the Polymarket
+ * Safe proxy rather than the EOA, so gas estimation for the deposit-style route
+ * must be anchored to the Safe. Its address is carried on the quote request as
+ * `refundTo` (written through to the request for the Safe variant). (Quote
+ * validation for this legacy variant is skipped entirely; see
+ * `shouldSkipValidation` in `relay-validation.ts`.)
+ *
+ * This does NOT apply to the deposit-wallet variant: there the submitted batch
+ * is a hardcoded approve + unwrap sent from the CREATE2 deposit wallet (see
+ * {@link buildPolymarketDepositWalletSimulation}), and `request.refundTo` is
+ * not the deposit wallet (only the outgoing Relay body carries it). That
+ * variant is handled by its own simulation builder, so this returns
+ * `undefined` for it.
+ *
+ * The Safe sender is only used for deposit-style Relay routes (those with a
+ * `deposit` step), mirroring the gas-estimation logic in `relay-quotes.ts`.
+ * Same-chain swap-only routes go through DEX aggregators that reject contract
+ * callers (anti-MEV `msg.sender == tx.origin` checks, ERC777-style callbacks,
+ * native wrap/unwrap requiring caller native balance), so those keep the EOA
+ * `from` and this returns `undefined`.
+ *
+ * @param request - Quote request.
+ * @param steps - Relay quote steps (used to detect a deposit-style route).
+ * @param transaction - Original transaction metadata.
+ * @returns The Safe proxy address, or `undefined` when the default EOA `from`
+ * should be used.
+ */
+export function getPredictWithdrawSafeAddress(
+  request: QuoteRequest,
+  steps: RelayQuoteStep[],
+  transaction: TransactionMeta,
+): Hex | undefined {
+  if (!isPredictWithdraw(request, transaction)) {
+    return undefined;
+  }
+
+  // Deposit-wallet withdraws are validated via their own simulation builder;
+  // `request.refundTo` is not the deposit wallet for that variant.
+  if (request.isPolymarketDepositWallet) {
+    return undefined;
+  }
+
+  const hasDepositStep = steps.some((step) => step.id === 'deposit');
+
+  if (!hasDepositStep) {
+    return undefined;
+  }
+
+  return request.refundTo;
+}
+
+/**
+ * Build the simulation for a Polymarket deposit-wallet Predict withdraw.
+ *
+ * The deposit-wallet variant does not submit the Relay quote's calldata. That
+ * calldata is a placeholder generated because the quote was requested with
+ * `useDepositAddress: true`; only the Relay deposit address is extracted from
+ * it. The transaction actually broadcast is a hardcoded two-call batch executed
+ * by the CREATE2 deposit wallet:
+ *
+ * 1. `approve(offramp, amount)` on pUSD
+ * 2. `unwrap(USDC.e, relayDepositAddress, amount)` on the offramp
+ *
+ * This mirrors {@link submitPolymarketWithdraw} exactly so validation simulates
+ * what is really broadcast. The deposit wallet is resolved via the client
+ * callback and used as `from`, so the simulation checks that the deposit wallet
+ * holds enough pUSD and that the unwrap succeeds. The client-side execution
+ * wrapper (how the deposit wallet batches the two calls on-chain) is opaque to
+ * the controller and is intentionally not modelled; the calls themselves only
+ * require `msg.sender` to be the deposit wallet.
+ *
+ * @param quote - Relay quote (source amount + deposit step).
+ * @param from - The user EOA that owns the deposit wallet.
+ * @param messenger - Controller messenger.
+ * @returns Simulation for the approve + unwrap batch from the deposit wallet.
+ */
+export async function buildPolymarketDepositWalletSimulation(
+  quote: TransactionPayQuote<RelayQuote>,
+  from: Hex,
+  messenger: TransactionPayControllerMessenger,
+): Promise<QuoteSimulation> {
+  const depositWalletAddress = await getDepositWalletAddress(messenger, from);
+  const relayDepositAddress = extractRelayDepositAddress(quote.original);
+  const amount = BigInt(quote.sourceAmount.raw);
+
+  return {
+    transactions: buildDepositWalletUnwrapCalls(
+      relayDepositAddress,
+      amount,
+    ).map((call) => ({
+      from: depositWalletAddress,
+      to: call.target,
+      data: call.data,
+      value: '0x0',
+    })),
+  };
+}
+
+/**
+ * Build the approve + unwrap batch that moves a deposit wallet's pUSD to the
+ * Relay deposit address as USDC.e. Shared by the simulation
+ * ({@link buildPolymarketDepositWalletSimulation}) and the real submit
+ * ({@link submitPolymarketWithdraw}) so both model the exact same calls:
+ *
+ * 1. `approve(offramp, amount)` on pUSD
+ * 2. `unwrap(USDC.e, relayDepositAddress, amount)` on the offramp
+ *
+ * @param relayDepositAddress - The Relay deposit address that receives the
+ * unwrapped USDC.e.
+ * @param amount - The pUSD amount to unwrap.
+ * @returns The two `{ target, data }` calls.
+ */
+function buildDepositWalletUnwrapCalls(
+  relayDepositAddress: Hex,
+  amount: bigint,
+): { target: Hex; data: Hex }[] {
+  return [
+    {
+      target: POLYGON_PUSD_ADDRESS,
+      data: encodeApprove(POLYMARKET_COLLATERAL_OFFRAMP_POLYGON, amount),
+    },
+    {
+      target: POLYMARKET_COLLATERAL_OFFRAMP_POLYGON,
+      data: encodeUnwrap({
+        asset: POLYGON_USDCE_ADDRESS,
+        recipient: relayDepositAddress,
+        amount,
+      }),
+    },
+  ];
+}
 
 export async function applyPolymarketDepositWalletOverrides(
   body: RelayQuoteRequest,
@@ -76,22 +243,9 @@ export async function submitPolymarketWithdraw(
   const result = await submitDepositWalletBatch(messenger, {
     eoa: from,
     depositWallet: depositWalletAddress,
-    calls: [
-      {
-        target: POLYGON_PUSD_ADDRESS,
-        value: '0',
-        data: encodeApprove(POLYMARKET_COLLATERAL_OFFRAMP_POLYGON, amount),
-      },
-      {
-        target: POLYMARKET_COLLATERAL_OFFRAMP_POLYGON,
-        value: '0',
-        data: encodeUnwrap({
-          asset: POLYGON_USDCE_ADDRESS,
-          recipient: relayDepositAddress,
-          amount,
-        }),
-      },
-    ],
+    calls: buildDepositWalletUnwrapCalls(relayDepositAddress, amount).map(
+      (call) => ({ ...call, value: '0' }),
+    ),
   });
 
   return { ...result, preSubmitUsdceBalance };

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.test.ts
@@ -708,7 +708,7 @@ describe('Relay Quotes Utils', () => {
       expect(body.recipient).toBe(TOKEN_TRANSFER_RECIPIENT_MOCK.toLowerCase());
     });
 
-    it('extracts recipient and sets refundTo when nested transactions include token transfer with delegation', async () => {
+    it('extracts recipient and defaults refundTo to sender when nested transactions include token transfer with delegation and no explicit refundTo', async () => {
       successfulFetchMock.mockResolvedValue({
         ok: true,
         json: async () => QUOTE_MOCK,
@@ -740,6 +740,42 @@ describe('Relay Quotes Utils', () => {
 
       expect(body.recipient).toBe(TOKEN_TRANSFER_RECIPIENT_MOCK);
       expect(body.refundTo).toBe(QUOTE_REQUEST_MOCK.from);
+    });
+
+    it('honours caller-specified refundTo over sender when nested transactions include token transfer with delegation', async () => {
+      successfulFetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => QUOTE_MOCK,
+      } as never);
+
+      const refundTo = '0xsafe000000000000000000000000000000000001' as Hex;
+
+      await getRelayQuotes({
+        accountSupports7702: true,
+        messenger,
+        requests: [{ ...QUOTE_REQUEST_MOCK, refundTo }],
+        transaction: {
+          ...TRANSACTION_META_MOCK,
+          nestedTransactions: [
+            {
+              data: NESTED_TRANSACTION_DATA_MOCK,
+            },
+            {
+              data: TOKEN_TRANSFER_DATA_MOCK,
+            },
+          ],
+          txParams: {
+            data: '0xabc' as Hex,
+          },
+        } as TransactionMeta,
+      });
+
+      const body = JSON.parse(
+        successfulFetchMock.mock.calls[0][1]?.body as string,
+      );
+
+      expect(body.recipient).toBe(TOKEN_TRANSFER_RECIPIENT_MOCK);
+      expect(body.refundTo).toBe(refundTo);
     });
 
     it('skips delegation for Hypercore deposits', async () => {

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.test.ts
@@ -708,7 +708,7 @@ describe('Relay Quotes Utils', () => {
       expect(body.recipient).toBe(TOKEN_TRANSFER_RECIPIENT_MOCK.toLowerCase());
     });
 
-    it('extracts recipient and defaults refundTo to sender when nested transactions include token transfer with delegation and no explicit refundTo', async () => {
+    it('extracts recipient and sets refundTo to sender when nested transactions include token transfer with delegation', async () => {
       successfulFetchMock.mockResolvedValue({
         ok: true,
         json: async () => QUOTE_MOCK,
@@ -740,42 +740,6 @@ describe('Relay Quotes Utils', () => {
 
       expect(body.recipient).toBe(TOKEN_TRANSFER_RECIPIENT_MOCK);
       expect(body.refundTo).toBe(QUOTE_REQUEST_MOCK.from);
-    });
-
-    it('honours caller-specified refundTo over sender when nested transactions include token transfer with delegation', async () => {
-      successfulFetchMock.mockResolvedValue({
-        ok: true,
-        json: async () => QUOTE_MOCK,
-      } as never);
-
-      const refundTo = '0xsafe000000000000000000000000000000000001' as Hex;
-
-      await getRelayQuotes({
-        accountSupports7702: true,
-        messenger,
-        requests: [{ ...QUOTE_REQUEST_MOCK, refundTo }],
-        transaction: {
-          ...TRANSACTION_META_MOCK,
-          nestedTransactions: [
-            {
-              data: NESTED_TRANSACTION_DATA_MOCK,
-            },
-            {
-              data: TOKEN_TRANSFER_DATA_MOCK,
-            },
-          ],
-          txParams: {
-            data: '0xabc' as Hex,
-          },
-        } as TransactionMeta,
-      });
-
-      const body = JSON.parse(
-        successfulFetchMock.mock.calls[0][1]?.body as string,
-      );
-
-      expect(body.recipient).toBe(TOKEN_TRANSFER_RECIPIENT_MOCK);
-      expect(body.refundTo).toBe(refundTo);
     });
 
     it('skips delegation for Hypercore deposits', async () => {

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.ts
@@ -2,10 +2,6 @@
 
 import { Interface } from '@ethersproject/abi';
 import { toHex } from '@metamask/controller-utils';
-import {
-  TransactionType,
-  hasTransactionType,
-} from '@metamask/transaction-controller';
 import type {
   AuthorizationList,
   TransactionMeta,
@@ -61,7 +57,11 @@ import {
 } from '../../utils/token.js';
 import { TOKEN_TRANSFER_FOUR_BYTE } from './constants.js';
 import { applyHyperliquidActivationFee } from './hyperliquid-activation.js';
-import { applyPolymarketDepositWalletOverrides } from './polymarket/withdraw.js';
+import {
+  applyPolymarketDepositWalletOverrides,
+  getPredictWithdrawSafeAddress,
+  isPredictWithdraw,
+} from './polymarket/withdraw.js';
 import { fetchRelayQuote } from './relay-api.js';
 import { getRelayMaxGasStationQuote } from './relay-max-gas-station.js';
 import { validateRelayQuotes } from './relay-validation.js';
@@ -536,7 +536,10 @@ async function processTransactions(
   // so any extra dust is also sent to the same address, rather than back to the user.
   if (tokenTransferData) {
     requestBody.recipient = getTransferRecipient(tokenTransferData);
-    requestBody.refundTo = request.from;
+    // Honour a caller-specified refund address (e.g. the Predict Safe proxy) so
+    // dust and failed-transaction refunds go to the intended account. Only fall
+    // back to the EOA when no explicit refundTo was provided.
+    requestBody.refundTo = request.refundTo ?? request.from;
   }
 
   const fundingRecipient = (transaction.txParams?.from as Hex) ?? request.from;
@@ -968,9 +971,7 @@ async function calculateSourceNetworkCost(
   const { chainId, data, maxFeePerGas, maxPriorityFeePerGas, to, value } =
     relayParams[0];
 
-  const isPredictWithdraw =
-    request.isPostQuote &&
-    hasTransactionType(transaction, [TransactionType.predictWithdraw]);
+  const isPredictWithdrawFlow = isPredictWithdraw(request, transaction);
 
   // `fromOverride = Safe proxy` is only valid for deposit-style Relay routes
   // where the deposit contract reads the user's source-token balance directly.
@@ -980,9 +981,11 @@ async function calculateSourceNetworkCost(
   // native balance). Simulating those from the Safe proxy reverts and breaks
   // gas estimation. For swap-only routes, fall back to the relay params'
   // EOA `from` so simulation succeeds.
-  const hasDepositStep = quote.steps.some((step) => step.id === 'deposit');
-  const useFromOverride = isPredictWithdraw && hasDepositStep;
-  const fromOverride = useFromOverride ? request.refundTo : undefined;
+  const fromOverride = getPredictWithdrawSafeAddress(
+    request,
+    quote.steps,
+    transaction,
+  );
 
   // For post-quote flows the original transaction will be prepended to the
   // batch at submission time. Include it in the gas estimation so
@@ -1078,7 +1081,7 @@ async function calculateSourceNetworkCost(
   // return nothing and force users to hold POL.
   // (`useFromOverride` only governs the gas-estimation `from` address, where
   // swap-style routes need EOA because DEX routers reject contract callers.)
-  if (isPredictWithdraw && request.refundTo) {
+  if (isPredictWithdrawFlow && request.refundTo) {
     log('Using proxy address for predict withdraw gas station simulation', {
       proxyAddress: request.refundTo,
       sourceTokenAddress,

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.ts
@@ -536,10 +536,7 @@ async function processTransactions(
   // so any extra dust is also sent to the same address, rather than back to the user.
   if (tokenTransferData) {
     requestBody.recipient = getTransferRecipient(tokenTransferData);
-    // Honour a caller-specified refund address (e.g. the Predict Safe proxy) so
-    // dust and failed-transaction refunds go to the intended account. Only fall
-    // back to the EOA when no explicit refundTo was provided.
-    requestBody.refundTo = request.refundTo ?? request.from;
+    requestBody.refundTo = request.from;
   }
 
   const fundingRecipient = (transaction.txParams?.from as Hex) ?? request.from;

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-validation.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-validation.test.ts
@@ -31,8 +31,7 @@ const { validateQuoteExecution } = jest.requireMock<
 
 const FROM_MOCK = '0xabcdef1234567890abcdef1234567890abcdef12' as Hex;
 const REFUND_TO_MOCK = '0x1111111111111111111111111111111111111111' as Hex;
-const DEPOSIT_WALLET_MOCK =
-  '0x2222222222222222222222222222222222222222' as Hex;
+const DEPOSIT_WALLET_MOCK = '0x2222222222222222222222222222222222222222' as Hex;
 const REQUEST_ID_MOCK = '0xreqid1234' as string;
 const CHAIN_ID_MOCK = '0x1' as Hex;
 const TOKEN_ADDRESS_MOCK = '0xtoken' as Hex;
@@ -216,13 +215,10 @@ describe('validateRelayQuotes', () => {
   });
 
   it('skips validation entirely for a Safe-based (non-deposit-wallet) Predict withdraw', async () => {
-    const quote = buildQuote(
-      { isPostQuote: true, refundTo: REFUND_TO_MOCK },
-      {
-        metamask: { gasLimits: [], is7702: false, isExecute: false },
-        steps: [DEPOSIT_STEP_MOCK],
-      } as unknown as Partial<RelayQuote>,
-    );
+    const quote = buildQuote({ isPostQuote: true, refundTo: REFUND_TO_MOCK }, {
+      metamask: { gasLimits: [], is7702: false, isExecute: false },
+      steps: [DEPOSIT_STEP_MOCK],
+    } as unknown as Partial<RelayQuote>);
 
     await validateRelayQuotes({
       messenger,
@@ -238,12 +234,9 @@ describe('validateRelayQuotes', () => {
   });
 
   it('skips validation for a swap-only Safe-based Predict withdraw (no deposit step)', async () => {
-    const quote = buildQuote(
-      { isPostQuote: true, refundTo: REFUND_TO_MOCK },
-      {
-        metamask: { gasLimits: [], is7702: false, isExecute: false },
-      } as Partial<RelayQuote>,
-    );
+    const quote = buildQuote({ isPostQuote: true, refundTo: REFUND_TO_MOCK }, {
+      metamask: { gasLimits: [], is7702: false, isExecute: false },
+    } as Partial<RelayQuote>);
 
     await validateRelayQuotes({
       messenger,

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-validation.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-validation.test.ts
@@ -1,4 +1,7 @@
-import { generateEIP7702BatchTransaction } from '@metamask/transaction-controller';
+import {
+  generateEIP7702BatchTransaction,
+  TransactionType,
+} from '@metamask/transaction-controller';
 import type { TransactionMeta } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 
@@ -27,9 +30,49 @@ const { validateQuoteExecution } = jest.requireMock<
 >('../../utils/validation');
 
 const FROM_MOCK = '0xabcdef1234567890abcdef1234567890abcdef12' as Hex;
+const REFUND_TO_MOCK = '0x1111111111111111111111111111111111111111' as Hex;
+const DEPOSIT_WALLET_MOCK =
+  '0x2222222222222222222222222222222222222222' as Hex;
 const REQUEST_ID_MOCK = '0xreqid1234' as string;
 const CHAIN_ID_MOCK = '0x1' as Hex;
 const TOKEN_ADDRESS_MOCK = '0xtoken' as Hex;
+
+// transfer(0x1234...7890, 1000000) encoded calldata; the recipient is decoded
+// as the Relay deposit address for the deposit-wallet unwrap.
+const TRANSFER_CALLDATA_MOCK =
+  '0xa9059cbb0000000000000000000000001234567890123456789012345678901234567890000000000000000000000000000000000000000000000000000000003b9aca00' as Hex;
+
+const DEPOSIT_STEP_MOCK = {
+  requestId: REQUEST_ID_MOCK,
+  id: 'deposit',
+  kind: 'transaction',
+  items: [],
+};
+
+const PREDICT_WITHDRAW_TRANSACTION_MOCK = {
+  id: 'tx-id',
+  txParams: { from: FROM_MOCK },
+  type: TransactionType.predictWithdraw,
+} as TransactionMeta;
+
+const PREDICT_WITHDRAW_TRANSACTION_WITH_NESTED_MOCK = {
+  id: 'tx-id',
+  txParams: {
+    from: FROM_MOCK,
+    to: '0xtoplevel' as Hex,
+    data: '0xtopleveldata' as Hex,
+    value: '0x0' as Hex,
+  },
+  type: TransactionType.predictWithdraw,
+  nestedTransactions: [
+    { to: '0xsafeapprove' as Hex, data: '0xsafeapprovedata' as Hex },
+    {
+      to: '0xsafewithdraw' as Hex,
+      data: '0xsafewithdrawdata' as Hex,
+      value: '0x0' as Hex,
+    },
+  ],
+} as TransactionMeta;
 
 function buildQuote(
   overrides: Partial<TransactionPayQuote<RelayQuote>['request']> = {},
@@ -94,8 +137,11 @@ const generateEIP7702BatchTransactionMock = jest.mocked(
 );
 
 describe('validateRelayQuotes', () => {
-  const { messenger, getRemoteFeatureFlagControllerStateMock } =
-    getMessengerMock();
+  const {
+    messenger,
+    getRemoteFeatureFlagControllerStateMock,
+    polymarketGetDepositWalletAddressMock,
+  } = getMessengerMock();
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -109,9 +155,7 @@ describe('validateRelayQuotes', () => {
       },
     });
 
-    getRelaySubmitCallsMock.mockResolvedValue({
-      calls: [],
-    });
+    getRelaySubmitCallsMock.mockResolvedValue({ calls: [] });
     getRelayExecuteRequestMock.mockResolvedValue(undefined as never);
     validateQuoteExecutionMock.mockResolvedValue(undefined);
     generateEIP7702BatchTransactionMock.mockReturnValue({
@@ -134,13 +178,77 @@ describe('validateRelayQuotes', () => {
     expect(validateQuoteExecutionMock).not.toHaveBeenCalled();
   });
 
-  it('skips validation for Polymarket deposit wallet quotes', async () => {
-    const quote = buildQuote({ isPolymarketDepositWallet: true });
+  it('validates Polymarket deposit wallet quotes by simulating the real approve + unwrap batch', async () => {
+    polymarketGetDepositWalletAddressMock.mockResolvedValue(
+      DEPOSIT_WALLET_MOCK,
+    );
+
+    const quote = buildQuote(
+      { isPolymarketDepositWallet: true, isPostQuote: true },
+      {
+        steps: [
+          {
+            ...DEPOSIT_STEP_MOCK,
+            items: [{ data: { data: TRANSFER_CALLDATA_MOCK } }],
+          },
+        ],
+      } as unknown as Partial<RelayQuote>,
+    );
 
     await validateRelayQuotes({
       messenger,
       quotes: [quote],
-      transaction: TRANSACTION_MOCK,
+      transaction: PREDICT_WITHDRAW_TRANSACTION_MOCK,
+    });
+
+    // The Relay submit calldata is a placeholder for this variant and must not
+    // be used to build the simulation.
+    expect(getRelaySubmitCallsMock).not.toHaveBeenCalled();
+    expect(polymarketGetDepositWalletAddressMock).toHaveBeenCalledWith({
+      eoa: FROM_MOCK,
+    });
+
+    const { transactions } =
+      validateQuoteExecutionMock.mock.calls[0][0].simulation;
+    expect(transactions).toHaveLength(2);
+    expect(transactions[0].from).toBe(DEPOSIT_WALLET_MOCK);
+    expect(transactions[1].from).toBe(DEPOSIT_WALLET_MOCK);
+  });
+
+  it('skips validation entirely for a Safe-based (non-deposit-wallet) Predict withdraw', async () => {
+    const quote = buildQuote(
+      { isPostQuote: true, refundTo: REFUND_TO_MOCK },
+      {
+        metamask: { gasLimits: [], is7702: false, isExecute: false },
+        steps: [DEPOSIT_STEP_MOCK],
+      } as unknown as Partial<RelayQuote>,
+    );
+
+    await validateRelayQuotes({
+      messenger,
+      quotes: [quote],
+      transaction: PREDICT_WITHDRAW_TRANSACTION_WITH_NESTED_MOCK,
+    });
+
+    // Legacy Safe withdraws convert USDC.e to pUSD outside the calls the
+    // controller can see, so a faithful simulation is impossible. The quote is
+    // skipped: no submit calls are built and no simulation is validated.
+    expect(getRelaySubmitCallsMock).not.toHaveBeenCalled();
+    expect(validateQuoteExecutionMock).not.toHaveBeenCalled();
+  });
+
+  it('skips validation for a swap-only Safe-based Predict withdraw (no deposit step)', async () => {
+    const quote = buildQuote(
+      { isPostQuote: true, refundTo: REFUND_TO_MOCK },
+      {
+        metamask: { gasLimits: [], is7702: false, isExecute: false },
+      } as Partial<RelayQuote>,
+    );
+
+    await validateRelayQuotes({
+      messenger,
+      quotes: [quote],
+      transaction: PREDICT_WITHDRAW_TRANSACTION_MOCK,
     });
 
     expect(getRelaySubmitCallsMock).not.toHaveBeenCalled();
@@ -639,6 +747,41 @@ describe('validateRelayQuotes', () => {
             .transactions[0];
         expect(batchTx).not.toHaveProperty('gas');
       });
+
+      it('skips validation for a deposit-style Safe Predict withdraw even when the quote is 7702', async () => {
+        const quote = buildQuote(
+          { isPostQuote: true, refundTo: REFUND_TO_MOCK },
+          {
+            metamask: { gasLimits: [21000], is7702: true, isExecute: false },
+            request: {
+              authorizationList: [
+                {
+                  address: '0xabc' as Hex,
+                  chainId: 1,
+                  nonce: 1,
+                  r: '0xr' as Hex,
+                  s: '0xs' as Hex,
+                  yParity: 0,
+                },
+              ],
+            },
+            steps: [DEPOSIT_STEP_MOCK],
+          } as unknown as Partial<RelayQuote>,
+        );
+
+        await validateRelayQuotes({
+          messenger,
+          quotes: [quote],
+          transaction: PREDICT_WITHDRAW_TRANSACTION_WITH_NESTED_MOCK,
+        });
+
+        // A Safe withdraw is a signed Safe `execTransaction` that converts USDC.e
+        // to pUSD outside the controller's visible calls, so it is skipped before
+        // any 7702 batch wrapper or simulation is built.
+        expect(generateEIP7702BatchTransactionMock).not.toHaveBeenCalled();
+        expect(getRelaySubmitCallsMock).not.toHaveBeenCalled();
+        expect(validateQuoteExecutionMock).not.toHaveBeenCalled();
+      });
     });
 
     describe('execute simulation (isExecute true)', () => {
@@ -794,6 +937,30 @@ describe('validateRelayQuotes', () => {
             }),
           }),
         );
+      });
+
+      it('skips validation for a deposit-style Safe Predict withdraw even when the quote is execute', async () => {
+        const quote = buildQuote(
+          { isPostQuote: true, refundTo: REFUND_TO_MOCK },
+          {
+            metamask: { gasLimits: [], is7702: false, isExecute: true },
+            steps: [DEPOSIT_STEP_MOCK],
+          } as unknown as Partial<RelayQuote>,
+        );
+
+        await validateRelayQuotes({
+          messenger,
+          quotes: [quote],
+          transaction: PREDICT_WITHDRAW_TRANSACTION_WITH_NESTED_MOCK,
+        });
+
+        // The real submit is a signed Safe `execTransaction`, not a
+        // `redeemDelegations` authorized for the EOA, and it converts USDC.e to
+        // pUSD outside the controller's visible calls. It is skipped before the
+        // execute request or any simulation is built.
+        expect(getRelayExecuteRequestMock).not.toHaveBeenCalled();
+        expect(getRelaySubmitCallsMock).not.toHaveBeenCalled();
+        expect(validateQuoteExecutionMock).not.toHaveBeenCalled();
       });
     });
   });

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-validation.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-validation.ts
@@ -93,13 +93,8 @@ function shouldSkipValidation(
     return true;
   }
 
-  // Safe-based (legacy) Predict withdraws move the source token (pUSD) out of a
-  // Polymarket Safe proxy for very old accounts. The Safe holds legacy USDC.e
-  // that is converted to pUSD outside the calls the controller can see, so a
-  // faithful simulation is not possible without synthesising calldata that is
-  // never broadcast. This is a long-tail legacy path, so simulation is skipped.
-  // The deposit-wallet variant is unaffected: its exact approve + unwrap batch
-  // is known and is still simulated (see buildPolymarketDepositWalletSimulation).
+  // Legacy Safe Predict withdraws convert USDC.e to pUSD outside the calls the
+  // controller can see, so they cannot be faithfully simulated and are skipped.
   if (
     isPredictWithdraw(request, transaction) &&
     !request.isPolymarketDepositWallet
@@ -113,21 +108,6 @@ function shouldSkipValidation(
   return false;
 }
 
-/**
- * Build the simulation used to validate a single relay quote.
- *
- * Polymarket deposit-wallet withdraws are a special case: the Relay quote's
- * calldata is a placeholder that is never broadcast (the quote was requested
- * with `useDepositAddress: true`). The transaction actually submitted is a
- * hardcoded approve + unwrap batch executed by the CREATE2 deposit wallet, so
- * validation simulates that batch directly. All other flows simulate the relay
- * submit calls. (Safe-based legacy Predict withdraws never reach here — they are
- * skipped in `shouldSkipValidation`.)
- *
- * @param request - Validation request (messenger, transaction, signal).
- * @param quote - Relay quote to validate.
- * @returns The simulation to pass to `validateQuoteExecution`.
- */
 async function buildValidationSimulation(
   request: ValidateRelayQuotesRequest,
   quote: TransactionPayQuote<RelayQuote>,
@@ -184,8 +164,6 @@ function buildRelayValidationSimulation(
   const { from, sourceChainId, targetChainId } = quote.request;
   const context = { from, sourceChainId, targetChainId };
 
-  // The execute and 7702 paths are authorized transactions executed by, and
-  // 7702-upgraded for, the user's EOA (`quote.request.from`).
   if (executeRequest) {
     log('Building execute simulation', context);
     return buildRelayExecuteSimulation(quote, executeRequest);
@@ -205,12 +183,6 @@ function buildRelayExecuteSimulation(
   const { value } = executeRequest.data;
   const valueHex = new BigNumber(value).toString(16).replace(/^/u, '0x') as Hex;
 
-  // The `redeemDelegations` transaction is executed by, and 7702-authorized for,
-  // the EOA the delegation was built for (`quote.request.from`). The `from` and
-  // `authorizationList[].from` must therefore stay the EOA so the simulation
-  // upgrades the correct account and models the real `msg.sender`. This path is
-  // never reached for Safe-based Predict withdraws (handled earlier by a direct
-  // source simulation), so the EOA is always both sender and source holder.
   const { from } = quote.request;
   return {
     transactions: [
@@ -236,13 +208,7 @@ function buildRelay7702BatchSimulation(
   quote: TransactionPayQuote<RelayQuote>,
   calls: TransactionParams[],
 ): QuoteSimulation {
-  const { sourceChainId } = quote.request;
-  // The batch call is an ERC-7821 `execute` on the sender's OWN account, which
-  // must be 7702-upgraded. That account is the EOA the batch was built for
-  // (`quote.request.from`). This path is never reached for Safe-based Predict
-  // withdraws (handled earlier by a direct source simulation), so the sender and
-  // authorization stay the EOA.
-  const { from } = quote.request;
+  const { from, sourceChainId } = quote.request;
   const gas = quote.original.metamask.gasLimits[0];
 
   const batchTx = generateEIP7702BatchTransaction(
@@ -254,11 +220,12 @@ function buildRelay7702BatchSimulation(
     })),
   );
 
-  // The account must appear upgraded for the simulation to succeed. The quote
-  // does not always carry an authorization, and there is no fast way to check
-  // the live upgrade state, so an authorization is always included: the
-  // delegator address comes from the quote when present, otherwise from the
-  // configured EIP-7702 upgrade contract for the chain.
+  // The batch call is an ERC-7821 `execute` on the sender's own account, so the
+  // account must appear upgraded for the simulation to succeed. The quote does
+  // not always carry an authorization, and there is no fast way to check the
+  // live upgrade state, so an authorization is always included: the delegator
+  // address comes from the quote when present, otherwise from the configured
+  // EIP-7702 upgrade contract for the chain.
   const address =
     quote.original.request.authorizationList?.[0]?.address ??
     getEIP7702UpgradeContractAddress(messenger, sourceChainId);

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-validation.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-validation.ts
@@ -23,6 +23,10 @@ import {
   isQuoteError,
 } from '../../utils/validation.js';
 import type { QuoteSimulation } from '../../utils/validation.js';
+import {
+  buildPolymarketDepositWalletSimulation,
+  isPredictWithdraw,
+} from './polymarket/withdraw.js';
 import { getRelayExecuteRequest } from './relay-submit-execute.js';
 import { getRelaySubmitCalls } from './relay-submit.js';
 import type { RelayExecuteRequest, RelayQuote } from './types.js';
@@ -44,37 +48,18 @@ export async function validateRelayQuotes(
   }
 
   for (const quote of request.quotes) {
-    if (shouldSkipValidation(quote)) {
+    if (shouldSkipValidation(quote, request.transaction)) {
       continue;
     }
 
     try {
-      const { calls } = await getRelaySubmitCalls({
-        messenger: request.messenger,
-        quote,
-        transaction: request.transaction,
-      });
-
-      const executeRequest = quote.original.metamask.isExecute
-        ? await getRelayExecuteRequest({
-            allParams: calls,
-            messenger: request.messenger,
-            quote,
-            requestId: quote.original.steps[0].requestId,
-            transaction: request.transaction,
-          })
-        : undefined;
+      const simulation = await buildValidationSimulation(request, quote);
 
       await validateQuoteExecution({
         messenger: request.messenger,
         quote,
         signal: request.signal,
-        simulation: buildRelayValidationSimulation(
-          request.messenger,
-          quote,
-          calls,
-          executeRequest,
-        ),
+        simulation,
       });
     } catch (error) {
       if (request.signal?.aborted) {
@@ -95,10 +80,87 @@ export async function validateRelayQuotes(
   }
 }
 
-function shouldSkipValidation(quote: TransactionPayQuote<RelayQuote>): boolean {
+function shouldSkipValidation(
+  quote: TransactionPayQuote<RelayQuote>,
+  transaction: TransactionMeta,
+): boolean {
   const { request } = quote;
-  return Boolean(
-    request.isHyperliquidSource ?? request.isPolymarketDepositWallet ?? false,
+
+  if (request.isHyperliquidSource) {
+    log('Skipping quote validation: Hyperliquid source', {
+      from: request.from,
+    });
+    return true;
+  }
+
+  // Safe-based (legacy) Predict withdraws move the source token (pUSD) out of a
+  // Polymarket Safe proxy for very old accounts. The Safe holds legacy USDC.e
+  // that is converted to pUSD outside the calls the controller can see, so a
+  // faithful simulation is not possible without synthesising calldata that is
+  // never broadcast. This is a long-tail legacy path, so simulation is skipped.
+  // The deposit-wallet variant is unaffected: its exact approve + unwrap batch
+  // is known and is still simulated (see buildPolymarketDepositWalletSimulation).
+  if (
+    isPredictWithdraw(request, transaction) &&
+    !request.isPolymarketDepositWallet
+  ) {
+    log('Skipping quote validation: legacy Safe Predict withdraw', {
+      from: request.from,
+    });
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Build the simulation used to validate a single relay quote.
+ *
+ * Polymarket deposit-wallet withdraws are a special case: the Relay quote's
+ * calldata is a placeholder that is never broadcast (the quote was requested
+ * with `useDepositAddress: true`). The transaction actually submitted is a
+ * hardcoded approve + unwrap batch executed by the CREATE2 deposit wallet, so
+ * validation simulates that batch directly. All other flows simulate the relay
+ * submit calls. (Safe-based legacy Predict withdraws never reach here — they are
+ * skipped in `shouldSkipValidation`.)
+ *
+ * @param request - Validation request (messenger, transaction, signal).
+ * @param quote - Relay quote to validate.
+ * @returns The simulation to pass to `validateQuoteExecution`.
+ */
+async function buildValidationSimulation(
+  request: ValidateRelayQuotesRequest,
+  quote: TransactionPayQuote<RelayQuote>,
+): Promise<QuoteSimulation> {
+  if (quote.request.isPolymarketDepositWallet) {
+    return await buildPolymarketDepositWalletSimulation(
+      quote,
+      quote.request.from,
+      request.messenger,
+    );
+  }
+
+  const { calls } = await getRelaySubmitCalls({
+    messenger: request.messenger,
+    quote,
+    transaction: request.transaction,
+  });
+
+  const executeRequest = quote.original.metamask.isExecute
+    ? await getRelayExecuteRequest({
+        allParams: calls,
+        messenger: request.messenger,
+        quote,
+        requestId: quote.original.steps[0].requestId,
+        transaction: request.transaction,
+      })
+    : undefined;
+
+  return buildRelayValidationSimulation(
+    request.messenger,
+    quote,
+    calls,
+    executeRequest,
   );
 }
 
@@ -122,6 +184,8 @@ function buildRelayValidationSimulation(
   const { from, sourceChainId, targetChainId } = quote.request;
   const context = { from, sourceChainId, targetChainId };
 
+  // The execute and 7702 paths are authorized transactions executed by, and
+  // 7702-upgraded for, the user's EOA (`quote.request.from`).
   if (executeRequest) {
     log('Building execute simulation', context);
     return buildRelayExecuteSimulation(quote, executeRequest);
@@ -140,18 +204,26 @@ function buildRelayExecuteSimulation(
 ): QuoteSimulation {
   const { value } = executeRequest.data;
   const valueHex = new BigNumber(value).toString(16).replace(/^/u, '0x') as Hex;
+
+  // The `redeemDelegations` transaction is executed by, and 7702-authorized for,
+  // the EOA the delegation was built for (`quote.request.from`). The `from` and
+  // `authorizationList[].from` must therefore stay the EOA so the simulation
+  // upgrades the correct account and models the real `msg.sender`. This path is
+  // never reached for Safe-based Predict withdraws (handled earlier by a direct
+  // source simulation), so the EOA is always both sender and source holder.
+  const { from } = quote.request;
   return {
     transactions: [
       {
         ...(executeRequest.data.authorizationList?.length
           ? {
               authorizationList: executeRequest.data.authorizationList.map(
-                (auth) => ({ address: auth.address, from: quote.request.from }),
+                (auth) => ({ address: auth.address, from }),
               ),
             }
           : {}),
         data: executeRequest.data.data,
-        from: quote.request.from,
+        from,
         to: executeRequest.data.to,
         value: valueHex,
       },
@@ -164,7 +236,13 @@ function buildRelay7702BatchSimulation(
   quote: TransactionPayQuote<RelayQuote>,
   calls: TransactionParams[],
 ): QuoteSimulation {
-  const { from, sourceChainId } = quote.request;
+  const { sourceChainId } = quote.request;
+  // The batch call is an ERC-7821 `execute` on the sender's OWN account, which
+  // must be 7702-upgraded. That account is the EOA the batch was built for
+  // (`quote.request.from`). This path is never reached for Safe-based Predict
+  // withdraws (handled earlier by a direct source simulation), so the sender and
+  // authorization stay the EOA.
+  const { from } = quote.request;
   const gas = quote.original.metamask.gasLimits[0];
 
   const batchTx = generateEIP7702BatchTransaction(
@@ -176,12 +254,11 @@ function buildRelay7702BatchSimulation(
     })),
   );
 
-  // The batch call is an ERC-7821 `execute` on the sender's own account, so the
-  // account must appear upgraded for the simulation to succeed. The quote does
-  // not always carry an authorization, and there is no fast way to check the
-  // live upgrade state, so an authorization is always included: the delegator
-  // address comes from the quote when present, otherwise from the configured
-  // EIP-7702 upgrade contract for the chain.
+  // The account must appear upgraded for the simulation to succeed. The quote
+  // does not always carry an authorization, and there is no fast way to check
+  // the live upgrade state, so an authorization is always included: the
+  // delegator address comes from the quote when present, otherwise from the
+  // configured EIP-7702 upgrade contract for the chain.
   const address =
     quote.original.request.authorizationList?.[0]?.address ??
     getEIP7702UpgradeContractAddress(messenger, sourceChainId);

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-validation.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-validation.ts
@@ -182,20 +182,18 @@ function buildRelayExecuteSimulation(
 ): QuoteSimulation {
   const { value } = executeRequest.data;
   const valueHex = new BigNumber(value).toString(16).replace(/^/u, '0x') as Hex;
-
-  const { from } = quote.request;
   return {
     transactions: [
       {
         ...(executeRequest.data.authorizationList?.length
           ? {
               authorizationList: executeRequest.data.authorizationList.map(
-                (auth) => ({ address: auth.address, from }),
+                (auth) => ({ address: auth.address, from: quote.request.from }),
               ),
             }
           : {}),
         data: executeRequest.data.data,
-        from,
+        from: quote.request.from,
         to: executeRequest.data.to,
         value: valueHex,
       },

--- a/packages/transaction-pay-controller/src/utils/validation.test.ts
+++ b/packages/transaction-pay-controller/src/utils/validation.test.ts
@@ -107,6 +107,78 @@ describe('validateQuoteExecution', () => {
       ).toBeUndefined();
     });
 
+    it('reads the source balance at the first simulation transaction from address', async () => {
+      const overrideAddress =
+        '0x1111111111111111111111111111111111111111' as Hex;
+      getLiveTokenBalanceMock.mockResolvedValue('500');
+
+      await validateQuoteExecution({
+        messenger: messengerMock.messenger,
+        quote: buildQuote({}, '500'),
+        simulation: buildSimulation({
+          transactions: [
+            {
+              data: TRANSFER_DATA_MOCK as Hex,
+              from: overrideAddress,
+              to: TOKEN_ADDRESS_MOCK,
+            },
+          ],
+        }),
+      });
+
+      expect(getLiveTokenBalanceMock).toHaveBeenCalledWith(
+        expect.anything(),
+        overrideAddress,
+        CHAIN_ID_MOCK,
+        TOKEN_ADDRESS_MOCK,
+      );
+    });
+
+    it('reads the source balance at the simulation sender (e.g. Safe proxy for Predict withdraws)', async () => {
+      const safeAddress = '0x5afe000000000000000000000000000000000001' as Hex;
+      getLiveTokenBalanceMock.mockResolvedValue('500');
+
+      await validateQuoteExecution({
+        messenger: messengerMock.messenger,
+        quote: buildQuote({}, '500'),
+        simulation: buildSimulation({
+          transactions: [
+            {
+              data: TRANSFER_DATA_MOCK as Hex,
+              // Safe-based Predict withdraws simulate the calls directly from the
+              // Safe proxy, so the sender is also the source-token holder.
+              from: safeAddress,
+              to: TOKEN_ADDRESS_MOCK,
+            },
+          ],
+        }),
+      });
+
+      expect(getLiveTokenBalanceMock).toHaveBeenCalledWith(
+        expect.anything(),
+        safeAddress,
+        CHAIN_ID_MOCK,
+        TOKEN_ADDRESS_MOCK,
+      );
+    });
+
+    it('falls back to the quote from address when the simulation has no transactions', async () => {
+      getLiveTokenBalanceMock.mockResolvedValue('500');
+
+      await validateQuoteExecution({
+        messenger: messengerMock.messenger,
+        quote: buildQuote({}, '500'),
+        simulation: buildSimulation({ transactions: [] }),
+      });
+
+      expect(getLiveTokenBalanceMock).toHaveBeenCalledWith(
+        expect.anything(),
+        FROM_MOCK,
+        CHAIN_ID_MOCK,
+        TOKEN_ADDRESS_MOCK,
+      );
+    });
+
     it('passes when live balance exceeds required amount', async () => {
       getLiveTokenBalanceMock.mockResolvedValue('9999');
 
@@ -308,6 +380,109 @@ describe('validateQuoteExecution', () => {
           }),
         }),
       ).toBeUndefined();
+    });
+
+    it('skips the check when the first transaction is not a source-token transfer, even if a later transfer exceeds the starting balance', async () => {
+      // The Safe starts with 0 source token; the first call produces it (e.g.
+      // unwrapping legacy USDC) before a later transfer spends it. The starting
+      // balance must not be treated as the constraint.
+      getLiveTokenBalanceMock.mockResolvedValue('0');
+
+      expect(
+        await validateQuoteExecution({
+          messenger: messengerMock.messenger,
+          // Post-quote (like a Safe withdraw) so the up-front required-amount
+          // check is skipped and the decoded-transfer check is what matters.
+          quote: buildQuote({ isPostQuote: true }, '50'),
+          simulation: buildSimulation({
+            transactions: [
+              {
+                // Unwrap on some other contract, not a source-token transfer.
+                data: '0xdeadbeef' as Hex,
+                from: FROM_MOCK,
+                to: '0x9999999999999999999999999999999999999999' as Hex,
+              },
+              {
+                // Transfer of 500 source token that only exists post-unwrap.
+                data: TRANSFER_DATA_MOCK as Hex,
+                from: FROM_MOCK,
+                to: TOKEN_ADDRESS_MOCK,
+              },
+            ],
+          }),
+        }),
+      ).toBeUndefined();
+    });
+
+    it('skips the check when there is more than one transaction, even if the first is a source-token transfer that exceeds the balance', async () => {
+      // A multi-step batch (e.g. Safe withdraw: transfer + a follow-up call)
+      // produces or transforms the source-token balance mid-batch, so the
+      // single-transfer balance heuristic does not apply.
+      getLiveTokenBalanceMock.mockResolvedValue('0');
+
+      expect(
+        await validateQuoteExecution({
+          messenger: messengerMock.messenger,
+          quote: buildQuote({ isPostQuote: true }, '50'),
+          simulation: buildSimulation({
+            transactions: [
+              {
+                data: TRANSFER_DATA_MOCK as Hex,
+                from: FROM_MOCK,
+                to: TOKEN_ADDRESS_MOCK,
+              },
+              {
+                data: '0xdeadbeef' as Hex,
+                from: FROM_MOCK,
+                to: '0x9999999999999999999999999999999999999999' as Hex,
+              },
+            ],
+          }),
+        }),
+      ).toBeUndefined();
+    });
+
+    it('skips the check for a single transfer that targets a non-source token', async () => {
+      getLiveTokenBalanceMock.mockResolvedValue('0');
+
+      expect(
+        await validateQuoteExecution({
+          messenger: messengerMock.messenger,
+          quote: buildQuote({ isPostQuote: true }, '50'),
+          simulation: buildSimulation({
+            transactions: [
+              {
+                data: TRANSFER_DATA_MOCK as Hex,
+                from: FROM_MOCK,
+                // Transfer on a different token, not the quote's source token.
+                to: '0x9999999999999999999999999999999999999999' as Hex,
+              },
+            ],
+          }),
+        }),
+      ).toBeUndefined();
+    });
+
+    it('runs the check for a single source-token transfer that exceeds the live balance', async () => {
+      getLiveTokenBalanceMock.mockResolvedValue('100');
+
+      await expect(
+        validateQuoteExecution({
+          messenger: messengerMock.messenger,
+          quote: buildQuote({}, '50'),
+          simulation: buildSimulation({
+            transactions: [
+              {
+                data: TRANSFER_DATA_MOCK as Hex,
+                from: FROM_MOCK,
+                to: TOKEN_ADDRESS_MOCK,
+              },
+            ],
+          }),
+        }),
+      ).rejects.toMatchObject({
+        info: { reason: 'insufficient-transfer-balance' },
+      });
     });
   });
 

--- a/packages/transaction-pay-controller/src/utils/validation.test.ts
+++ b/packages/transaction-pay-controller/src/utils/validation.test.ts
@@ -107,7 +107,7 @@ describe('validateQuoteExecution', () => {
       ).toBeUndefined();
     });
 
-    it('reads the source balance at the first simulation transaction from address', async () => {
+    it('reads the source balance at the quote from address', async () => {
       const overrideAddress =
         '0x1111111111111111111111111111111111111111' as Hex;
       getLiveTokenBalanceMock.mockResolvedValue('500');
@@ -124,51 +124,6 @@ describe('validateQuoteExecution', () => {
             },
           ],
         }),
-      });
-
-      expect(getLiveTokenBalanceMock).toHaveBeenCalledWith(
-        expect.anything(),
-        overrideAddress,
-        CHAIN_ID_MOCK,
-        TOKEN_ADDRESS_MOCK,
-      );
-    });
-
-    it('reads the source balance at the simulation sender (e.g. Safe proxy for Predict withdraws)', async () => {
-      const safeAddress = '0x5afe000000000000000000000000000000000001' as Hex;
-      getLiveTokenBalanceMock.mockResolvedValue('500');
-
-      await validateQuoteExecution({
-        messenger: messengerMock.messenger,
-        quote: buildQuote({}, '500'),
-        simulation: buildSimulation({
-          transactions: [
-            {
-              data: TRANSFER_DATA_MOCK as Hex,
-              // Safe-based Predict withdraws simulate the calls directly from the
-              // Safe proxy, so the sender is also the source-token holder.
-              from: safeAddress,
-              to: TOKEN_ADDRESS_MOCK,
-            },
-          ],
-        }),
-      });
-
-      expect(getLiveTokenBalanceMock).toHaveBeenCalledWith(
-        expect.anything(),
-        safeAddress,
-        CHAIN_ID_MOCK,
-        TOKEN_ADDRESS_MOCK,
-      );
-    });
-
-    it('falls back to the quote from address when the simulation has no transactions', async () => {
-      getLiveTokenBalanceMock.mockResolvedValue('500');
-
-      await validateQuoteExecution({
-        messenger: messengerMock.messenger,
-        quote: buildQuote({}, '500'),
-        simulation: buildSimulation({ transactions: [] }),
       });
 
       expect(getLiveTokenBalanceMock).toHaveBeenCalledWith(

--- a/packages/transaction-pay-controller/src/utils/validation.ts
+++ b/packages/transaction-pay-controller/src/utils/validation.ts
@@ -58,21 +58,10 @@ export async function validateQuoteExecution({
 }: QuoteExecutionRequest): Promise<void> {
   throwIfAborted(signal);
 
-  // Read the source-token balance at the account that actually holds it: the
-  // simulation sender (`transactions[0].from`), which both executes the
-  // transaction and holds the source token. For Safe-based Predict withdraws the
-  // builder simulates the calls directly from the Safe proxy, so the sender is
-  // already the source-token holder here too.
-  const sourceAddress = simulation.transactions[0]?.from ?? quote.request.from;
-
-  const liveBalance = await getLiveSourceBalance(
-    quote,
-    messenger,
-    sourceAddress,
-  );
+  const liveBalance = await getLiveSourceBalance(quote, messenger);
 
   log('Live source balance', {
-    from: sourceAddress,
+    from: quote.request.from,
     liveBalance,
     sourceChainId: quote.request.sourceChainId,
     sourceTokenAddress: quote.request.sourceTokenAddress,
@@ -204,9 +193,8 @@ function formatTokenAmount(
 async function getLiveSourceBalance(
   quote: TransactionPayQuote<unknown>,
   messenger: TransactionPayControllerMessenger,
-  sourceAddress: Hex,
 ): Promise<string> {
-  const { sourceChainId, sourceTokenAddress } = quote.request;
+  const { from, sourceChainId, sourceTokenAddress } = quote.request;
   const normalizedSourceTokenAddress = normalizeTokenAddress(
     sourceTokenAddress,
     sourceChainId,
@@ -216,7 +204,7 @@ async function getLiveSourceBalance(
   try {
     return await getLiveTokenBalance(
       messenger,
-      sourceAddress,
+      from,
       sourceChainId,
       normalizedSourceTokenAddress,
     );
@@ -268,16 +256,13 @@ function validateDecodedSourceTransfers(
   liveBalance: string,
   transactions: SimulationTransaction[],
 ): void {
-  // The decoded-transfer check compares a single source-token transfer amount
-  // against the sender's *starting* balance. That is only valid for the simple
-  // "spend what you already hold" case: exactly one transaction, and it is a
-  // source-token transfer. Any multi-step batch (e.g. a Safe-based Predict
-  // withdraw that unwraps legacy USDC into the source token before transferring
-  // it, or swaps/approvals) produces or transforms the source-token balance
-  // mid-batch, so the sender does not hold it up front and this static
-  // comparison would wrongly report insufficient funds. In those cases we skip
-  // the check and rely on the full on-chain simulation to catch real shortfalls.
-  if (transactions.length !== 1 || !isSourceTokenTransfer(quote, transactions[0])) {
+  // Only valid for a single source-token transfer. Multi-step batches produce
+  // or transform the source-token balance mid-batch, so comparing against the
+  // starting balance is wrong; rely on the full simulation instead.
+  if (
+    transactions.length !== 1 ||
+    !isSourceTokenTransfer(quote, transactions[0])
+  ) {
     log(
       'Skipping decoded source transfer check: not a single source-token transfer',
     );
@@ -314,13 +299,6 @@ function validateDecodedSourceTransfers(
   });
 }
 
-/**
- * Whether a simulation transaction is a transfer of the quote's source token.
- *
- * @param quote - Quote being validated (provides the source token + chain).
- * @param transaction - The simulation transaction to inspect.
- * @returns True when the transaction calls `transfer` on the source token.
- */
 function isSourceTokenTransfer(
   quote: TransactionPayQuote<unknown>,
   transaction: SimulationTransaction | undefined,

--- a/packages/transaction-pay-controller/src/utils/validation.ts
+++ b/packages/transaction-pay-controller/src/utils/validation.ts
@@ -58,10 +58,21 @@ export async function validateQuoteExecution({
 }: QuoteExecutionRequest): Promise<void> {
   throwIfAborted(signal);
 
-  const liveBalance = await getLiveSourceBalance(quote, messenger);
+  // Read the source-token balance at the account that actually holds it: the
+  // simulation sender (`transactions[0].from`), which both executes the
+  // transaction and holds the source token. For Safe-based Predict withdraws the
+  // builder simulates the calls directly from the Safe proxy, so the sender is
+  // already the source-token holder here too.
+  const sourceAddress = simulation.transactions[0]?.from ?? quote.request.from;
+
+  const liveBalance = await getLiveSourceBalance(
+    quote,
+    messenger,
+    sourceAddress,
+  );
 
   log('Live source balance', {
-    from: quote.request.from,
+    from: sourceAddress,
     liveBalance,
     sourceChainId: quote.request.sourceChainId,
     sourceTokenAddress: quote.request.sourceTokenAddress,
@@ -78,12 +89,10 @@ export async function validateQuoteExecution({
 
   validateRequiredSourceAmount(messenger, quote, liveBalance);
 
-  log('Quote source amount check passed');
-
   log('Checking decoded source transfers', {
     sourceChainId: quote.request.sourceChainId,
     sourceTokenAddress: quote.request.sourceTokenAddress,
-    transactionCount: simulation.transactions.length,
+    transactions: simulation.transactions,
   });
 
   validateDecodedSourceTransfers(
@@ -93,10 +102,17 @@ export async function validateQuoteExecution({
     simulation.transactions,
   );
 
-  log('Decoded source transfers check passed');
-
   throwIfAborted(signal);
 
+  await validateSimulation(messenger, quote, simulation, signal);
+}
+
+async function validateSimulation(
+  messenger: TransactionPayControllerMessenger,
+  quote: TransactionPayQuote<unknown>,
+  simulation: QuoteSimulation,
+  signal?: AbortSignal,
+): Promise<void> {
   log('Starting simulation', {
     chainId: quote.request.sourceChainId,
     transactions: simulation.transactions,
@@ -188,8 +204,9 @@ function formatTokenAmount(
 async function getLiveSourceBalance(
   quote: TransactionPayQuote<unknown>,
   messenger: TransactionPayControllerMessenger,
+  sourceAddress: Hex,
 ): Promise<string> {
-  const { from, sourceChainId, sourceTokenAddress } = quote.request;
+  const { sourceChainId, sourceTokenAddress } = quote.request;
   const normalizedSourceTokenAddress = normalizeTokenAddress(
     sourceTokenAddress,
     sourceChainId,
@@ -199,7 +216,7 @@ async function getLiveSourceBalance(
   try {
     return await getLiveTokenBalance(
       messenger,
-      from,
+      sourceAddress,
       sourceChainId,
       normalizedSourceTokenAddress,
     );
@@ -218,6 +235,10 @@ function validateRequiredSourceAmount(
   liveBalance: string,
 ): void {
   if (quote.request.isPostQuote || quote.request.paymentOverride) {
+    log('Skipping quote source amount check', {
+      hasPaymentOverride: Boolean(quote.request.paymentOverride),
+      isPostQuote: Boolean(quote.request.isPostQuote),
+    });
     return;
   }
 
@@ -225,6 +246,7 @@ function validateRequiredSourceAmount(
   const balance = new BigNumber(liveBalance);
 
   if (balance.isGreaterThanOrEqualTo(requiredAmount)) {
+    log('Quote source amount check passed');
     return;
   }
 
@@ -246,21 +268,37 @@ function validateDecodedSourceTransfers(
   liveBalance: string,
   transactions: SimulationTransaction[],
 ): void {
-  const decodedAmounts = getDecodedSourceTransferAmounts(quote, transactions);
+  // The decoded-transfer check compares a single source-token transfer amount
+  // against the sender's *starting* balance. That is only valid for the simple
+  // "spend what you already hold" case: exactly one transaction, and it is a
+  // source-token transfer. Any multi-step batch (e.g. a Safe-based Predict
+  // withdraw that unwraps legacy USDC into the source token before transferring
+  // it, or swaps/approvals) produces or transforms the source-token balance
+  // mid-batch, so the sender does not hold it up front and this static
+  // comparison would wrongly report insufficient funds. In those cases we skip
+  // the check and rely on the full on-chain simulation to catch real shortfalls.
+  if (transactions.length !== 1 || !isSourceTokenTransfer(quote, transactions[0])) {
+    log(
+      'Skipping decoded source transfer check: not a single source-token transfer',
+    );
+    return;
+  }
 
-  const requiredAmount = decodedAmounts
-    .reduce((total, amount) => total.plus(amount), new BigNumber(0))
-    .toString(10);
+  // `isSourceTokenTransfer` has already confirmed the data decodes to a
+  // transfer, so the amount is defined here.
+  const requiredAmount = decodeTransferAmount(
+    transactions[0].data as Hex,
+  ) as string;
 
   const balance = new BigNumber(liveBalance);
 
-  log('Decoded source transfer amounts', {
-    decodedAmounts,
+  log('Decoded source transfer amount', {
     liveBalance,
     requiredAmount,
   });
 
   if (balance.isGreaterThanOrEqualTo(requiredAmount)) {
+    log('Decoded source transfers check passed');
     return;
   }
 
@@ -276,17 +314,29 @@ function validateDecodedSourceTransfers(
   });
 }
 
-function getDecodedSourceTransferAmounts(
+/**
+ * Whether a simulation transaction is a transfer of the quote's source token.
+ *
+ * @param quote - Quote being validated (provides the source token + chain).
+ * @param transaction - The simulation transaction to inspect.
+ * @returns True when the transaction calls `transfer` on the source token.
+ */
+function isSourceTokenTransfer(
   quote: TransactionPayQuote<unknown>,
-  transactions: SimulationTransaction[],
-): string[] {
+  transaction: SimulationTransaction | undefined,
+): boolean {
+  if (!transaction?.to || !transaction.data) {
+    return false;
+  }
+
   const { sourceChainId, sourceTokenAddress } = quote.request;
+
   const isNativeSource =
     sourceTokenAddress.toLowerCase() ===
     getNativeToken(sourceChainId).toLowerCase();
 
   if (isNativeSource) {
-    return [];
+    return false;
   }
 
   const normalizedSourceTokenAddress = normalizeTokenAddress(
@@ -295,20 +345,17 @@ function getDecodedSourceTransferAmounts(
     TokenAddressTarget.MetaMask,
   ).toLowerCase();
 
-  return transactions
-    .filter(
-      (transaction) =>
-        transaction.to &&
-        normalizeTokenAddress(
-          transaction.to,
-          sourceChainId,
-          TokenAddressTarget.MetaMask,
-        ).toLowerCase() === normalizedSourceTokenAddress,
-    )
-    .map((transaction) =>
-      transaction.data ? decodeTransferAmount(transaction.data) : undefined,
-    )
-    .filter((amount): amount is string => amount !== undefined);
+  const normalizedTo = normalizeTokenAddress(
+    transaction.to,
+    sourceChainId,
+    TokenAddressTarget.MetaMask,
+  ).toLowerCase();
+
+  if (normalizedTo !== normalizedSourceTokenAddress) {
+    return false;
+  }
+
+  return decodeTransferAmount(transaction.data) !== undefined;
 }
 
 function decodeTransferAmount(data: Hex): string | undefined {


### PR DESCRIPTION
## Explanation

Quote validation for Polymarket Predict withdrawals produced false errors and blocked legitimate withdrawals, because it assumed the source token lived on the user's EOA and that the withdrawal could always be simulated. This PR fixes validation per variant:

- **Deposit-wallet withdrawals** — now validated (previously skipped). The placeholder Relay calldata is ignored and the real approve + unwrap batch is simulated from the CREATE2 deposit wallet that holds the funds. The batch construction is shared between the simulation and the submit so they can't drift.
- **Legacy Safe withdrawals** — now skip simulation entirely (logged). The source token is produced from legacy collateral outside the controller's visible calls, so a faithful simulation isn't possible.
- The decoded source-transfer balance check only runs for a single source-token transfer; multi-step batches are left to the full simulation.
- Validation skip/success paths now log consistently.

## References

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit de735eb258e580b2ce1591af9bae4770f722a6cd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->