### PR TITLE
feat: start tracking on AccountTreeController:initialized

### DIFF
--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -9,8 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Subscribe to `AccountTreeController:initialized` (typed as `AccountTreeControllerInitializedEvent`) so asset tracking starts only after the account tree is fully built, instead of on intermediate `AccountTreeController:stateChange` events during `init()` ([#9892](https://github.com/MetaMask/core/pull/9892))
-  - Hosts that restrict which events flow through the `AssetsController` messenger must now also delegate `AccountTreeController:initialized`
+- **BREAKING:** Subscribe to `AccountTreeController:initialized` / `:uninitialized` (typed as `AccountTreeControllerInitializedEvent` / `AccountTreeControllerUninitializedEvent`) so asset tracking starts only after the account tree is fully built, instead of on intermediate `AccountTreeController:stateChange` events during `init()` or on unlock before the tree is ready ([#9892](https://github.com/MetaMask/core/pull/9892))
+  - Hosts that restrict which events flow through the `AssetsController` messenger must now also delegate `AccountTreeController:initialized` and `AccountTreeController:uninitialized`
+- Reduce Accounts API calls on startup and refresh:
+  - Skip `AccountsApiDataSource` subscribe-time initial poll after a forced `getAssets` balance fetch
+  - Ignore init-time `AccountTreeController:selectedAccountGroupChange` (including same-group re-emits and events before tracking starts) so `:initialized` owns first start; only refresh on real group switches while tracking
+  - Skip Accounts API middleware when `dataTypes` does not include `balance` (e.g. price-only refreshes)
 
 ## [13.1.4]
 

--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING:** Subscribe to `AccountTreeController:initialized` (typed as `AccountTreeControllerInitializedEvent`) so asset tracking starts only after the account tree is fully built, instead of on intermediate `AccountTreeController:stateChange` events during `init()`
+  - Hosts that restrict which events flow through the `AssetsController` messenger must now also delegate `AccountTreeController:initialized`
+
 ## [13.1.4]
 
 ### Changed

--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Subscribe to `AccountTreeController:initialized` (typed as `AccountTreeControllerInitializedEvent`) so asset tracking starts only after the account tree is fully built, instead of on intermediate `AccountTreeController:stateChange` events during `init()`
+- **BREAKING:** Subscribe to `AccountTreeController:initialized` (typed as `AccountTreeControllerInitializedEvent`) so asset tracking starts only after the account tree is fully built, instead of on intermediate `AccountTreeController:stateChange` events during `init()` ([#9892](https://github.com/MetaMask/core/pull/9892))
   - Hosts that restrict which events flow through the `AssetsController` messenger must now also delegate `AccountTreeController:initialized`
 
 ## [13.1.4]

--- a/packages/assets-controller/src/AssetsController.test.ts
+++ b/packages/assets-controller/src/AssetsController.test.ts
@@ -99,8 +99,9 @@ const MOCK_ASSET_ID_LOWERCASE =
 const MOCK_NATIVE_ASSET_ID = 'eip155:1/slip44:60' as Caip19AssetId;
 
 /**
- * Activate asset tracking by marking the UI open and the keyring unlocked,
- * then flushing the async startup so the controller is in its running state.
+ * Activate asset tracking by marking the UI open, the keyring unlocked, and
+ * the account tree initialized, then flushing the async startup so the
+ * controller is in its running state.
  *
  * @param messenger - The root messenger used to publish lifecycle events.
  */
@@ -111,6 +112,10 @@ async function activateTracking(messenger: RootMessenger): Promise<void> {
     }
   ).publish('ClientController:stateChange', { isUiOpen: true });
   messenger.publish('KeyringController:unlock');
+  (messenger.publish as CallableFunction)(
+    'AccountTreeController:initialized',
+    {},
+  );
   await flushPromises();
 }
 
@@ -2683,6 +2688,10 @@ describe('AssetsController', () => {
             }
           ).publish('ClientController:stateChange', { isUiOpen: true });
           messenger.publish('KeyringController:unlock');
+          (messenger.publish as CallableFunction)(
+            'AccountTreeController:initialized',
+            {},
+          );
 
           await flushPromises();
 
@@ -2908,22 +2917,24 @@ describe('AssetsController', () => {
   });
 
   describe('keyring lifecycle', () => {
-    it('starts tracking on keyring unlock', async () => {
-      await withController(async ({ messenger }) => {
-        messenger.publish('KeyringController:unlock');
-        await new Promise(process.nextTick);
+    it('does not start tracking on unlock until the account tree is initialized', async () => {
+      await withController(async ({ controller, messenger }) => {
+        const getAssetsSpy = jest.spyOn(controller, 'getAssets');
 
-        expect(true).toBe(true);
+        messenger.publish('KeyringController:unlock');
+        await flushPromises();
+
+        expect(getAssetsSpy).not.toHaveBeenCalled();
+        getAssetsSpy.mockRestore();
       });
     });
 
     it('stops tracking on keyring lock', async () => {
       await withController(async ({ messenger }) => {
-        messenger.publish('KeyringController:unlock');
-        await new Promise(process.nextTick);
+        await activateTracking(messenger);
 
         messenger.publish('KeyringController:lock');
-        await new Promise(process.nextTick);
+        await flushPromises();
 
         expect(true).toBe(true);
       });
@@ -2962,6 +2973,10 @@ describe('AssetsController', () => {
             }
           ).publish('ClientController:stateChange', { isUiOpen: true });
           messenger.publish('KeyringController:unlock');
+          (messenger.publish as CallableFunction)(
+            'AccountTreeController:initialized',
+            {},
+          );
 
           // Allow #start() -> getAssets() to resolve so the callback runs
           await new Promise((resolve) => setTimeout(resolve, 100));
@@ -3067,6 +3082,10 @@ describe('AssetsController', () => {
             }
           ).publish('ClientController:stateChange', { isUiOpen: true });
           messenger.publish('KeyringController:unlock');
+          (messenger.publish as CallableFunction)(
+            'AccountTreeController:initialized',
+            {},
+          );
 
           await flushPromises();
 
@@ -3097,13 +3116,17 @@ describe('AssetsController', () => {
           controllerOptions: { trace },
         },
         async ({ controller, messenger }) => {
-          // UI must be open and keyring unlocked for asset tracking to run
+          // UI must be open, keyring unlocked, and account tree ready
           (
             messenger as unknown as {
               publish: (topic: string, payload?: unknown) => void;
             }
           ).publish('ClientController:stateChange', { isUiOpen: true });
           messenger.publish('KeyringController:unlock');
+          (messenger.publish as CallableFunction)(
+            'AccountTreeController:initialized',
+            {},
+          );
           await new Promise((resolve) => setTimeout(resolve, 100));
 
           messenger.publish('KeyringController:unlock');
@@ -3383,6 +3406,10 @@ describe('AssetsController', () => {
           }
         ).publish('ClientController:stateChange', { isUiOpen: true });
         messenger.publish('KeyringController:unlock');
+        (messenger.publish as CallableFunction)(
+          'AccountTreeController:initialized',
+          {},
+        );
         await flushPromises();
 
         getAssetsSpy.mockClear();
@@ -3414,19 +3441,33 @@ describe('AssetsController', () => {
   });
 
   describe('account group changes', () => {
-    it('handles account group change', async () => {
+    it('refreshes assets when the selected group changes while tracking', async () => {
       await withController(async ({ controller, messenger }) => {
         const getAssetsSpy = jest
           .spyOn(controller, 'getAssets')
-          .mockResolvedValue([]);
+          .mockResolvedValue({});
+
+        (
+          messenger as unknown as {
+            publish: (topic: string, payload?: unknown) => void;
+          }
+        ).publish('ClientController:stateChange', { isUiOpen: true });
+        messenger.publish('KeyringController:unlock');
+        (messenger.publish as CallableFunction)(
+          'AccountTreeController:initialized',
+          {},
+        );
+        await flushPromises();
+
+        getAssetsSpy.mockClear();
 
         (messenger.publish as CallableFunction)(
           'AccountTreeController:selectedAccountGroupChange',
+          'entropy:mock-keyring-id-1/1',
           'entropy:mock-keyring-id-1/0',
-          '',
         );
 
-        await new Promise(process.nextTick);
+        await flushPromises();
 
         expect(getAssetsSpy).toHaveBeenCalled();
         getAssetsSpy.mockRestore();
@@ -3443,7 +3484,72 @@ describe('AssetsController', () => {
           'entropy:mock-keyring-id-1/0',
         );
 
-        await new Promise(process.nextTick);
+        await flushPromises();
+
+        expect(getAssetsSpy).not.toHaveBeenCalled();
+        getAssetsSpy.mockRestore();
+      });
+    });
+
+    it('skips init-time selectedAccountGroupChange so :initialized owns first start', async () => {
+      await withController(async ({ controller, messenger }) => {
+        const getAssetsSpy = jest.spyOn(controller, 'getAssets');
+
+        (
+          messenger as unknown as {
+            publish: (topic: string, payload?: unknown) => void;
+          }
+        ).publish('ClientController:stateChange', { isUiOpen: true });
+        messenger.publish('KeyringController:unlock');
+        await flushPromises();
+
+        // ATC always publishes this on init, even when the group did not change.
+        (messenger.publish as CallableFunction)(
+          'AccountTreeController:selectedAccountGroupChange',
+          'entropy:mock-keyring-id-1/0',
+          '',
+        );
+        await flushPromises();
+
+        expect(getAssetsSpy).not.toHaveBeenCalled();
+
+        (messenger.publish as CallableFunction)(
+          'AccountTreeController:initialized',
+          {},
+        );
+        await flushPromises();
+
+        expect(getAssetsSpy).toHaveBeenCalled();
+        getAssetsSpy.mockRestore();
+      });
+    });
+
+    it('skips selectedAccountGroupChange when group id did not change', async () => {
+      await withController(async ({ controller, messenger }) => {
+        const getAssetsSpy = jest
+          .spyOn(controller, 'getAssets')
+          .mockResolvedValue({});
+
+        (
+          messenger as unknown as {
+            publish: (topic: string, payload?: unknown) => void;
+          }
+        ).publish('ClientController:stateChange', { isUiOpen: true });
+        messenger.publish('KeyringController:unlock');
+        (messenger.publish as CallableFunction)(
+          'AccountTreeController:initialized',
+          {},
+        );
+        await flushPromises();
+
+        getAssetsSpy.mockClear();
+
+        (messenger.publish as CallableFunction)(
+          'AccountTreeController:selectedAccountGroupChange',
+          'entropy:mock-keyring-id-1/0',
+          'entropy:mock-keyring-id-1/0',
+        );
+        await flushPromises();
 
         expect(getAssetsSpy).not.toHaveBeenCalled();
         getAssetsSpy.mockRestore();

--- a/packages/assets-controller/src/AssetsController.test.ts
+++ b/packages/assets-controller/src/AssetsController.test.ts
@@ -3451,8 +3451,8 @@ describe('AssetsController', () => {
     });
   });
 
-  describe('account tree state change', () => {
-    it('triggers start when tree initializes after unlock with empty accounts', async () => {
+  describe('account tree initialized', () => {
+    it('triggers start when the tree initializes after unlock with empty accounts', async () => {
       const getAccountsMock = jest.fn().mockReturnValue([]);
 
       const messenger: RootMessenger = new Messenger({
@@ -3461,6 +3461,14 @@ describe('AssetsController', () => {
       messenger.registerActionHandler(
         'AccountTreeController:getAccountsFromSelectedAccountGroup',
         getAccountsMock,
+      );
+      (
+        messenger as {
+          registerActionHandler: (a: string, h: () => unknown) => void;
+        }
+      ).registerActionHandler(
+        'AccountsController:getSelectedAccount',
+        () => undefined,
       );
       messenger.registerActionHandler(
         'NetworkEnablementController:getState',
@@ -3516,12 +3524,21 @@ describe('AssetsController', () => {
 
       expect(getAssetsSpy).not.toHaveBeenCalled();
 
-      // Step 2: AccountTreeController.init() completes — accounts now available
+      // Intermediate tree mutations during init must not start tracking.
       getAccountsMock.mockReturnValue([createMockInternalAccount()]);
       (messenger.publish as CallableFunction)(
         'AccountTreeController:stateChange',
         {},
         [],
+      );
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(getAssetsSpy).not.toHaveBeenCalled();
+
+      // Step 2: AccountTreeController.init() completes — tree is ready
+      (messenger.publish as CallableFunction)(
+        'AccountTreeController:initialized',
+        {},
       );
       await new Promise((resolve) => setTimeout(resolve, 100));
 
@@ -3540,6 +3557,8 @@ describe('AssetsController', () => {
           assetsForPriceUpdate: expect.arrayContaining(['eip155:1/slip44:60']),
         }),
       );
+
+      controller.destroy();
     });
   });
 });

--- a/packages/assets-controller/src/AssetsController.ts
+++ b/packages/assets-controller/src/AssetsController.ts
@@ -3,6 +3,7 @@ import type {
   AccountTreeControllerInitializedEvent,
   AccountTreeControllerSelectedAccountGroupChangeEvent,
   AccountTreeControllerStateChangeEvent,
+  AccountTreeControllerUninitializedEvent,
 } from '@metamask/account-tree-controller';
 import type { AccountsControllerGetSelectedAccountAction } from '@metamask/accounts-controller';
 import { BaseController } from '@metamask/base-controller';
@@ -347,6 +348,7 @@ type AllowedEvents =
   | AccountTreeControllerSelectedAccountGroupChangeEvent
   | AccountTreeControllerStateChangeEvent
   | AccountTreeControllerInitializedEvent
+  | AccountTreeControllerUninitializedEvent
   | ClientControllerStateChangeEvent
   | KeyringControllerLockEvent
   | KeyringControllerUnlockEvent
@@ -747,6 +749,12 @@ export class AssetsController extends BaseController<
   /** Whether the keyring is unlocked. Combined with #uiOpen for #updateActive. */
   #keyringUnlocked = false;
 
+  /**
+   * Whether `AccountTreeController` has finished `init()`. Unlock / UI-open
+   * alone must not start fetches — the tree can still be mid-build.
+   */
+  #accountTreeInitialized = false;
+
   readonly #controllerMutex = new Mutex();
 
   /** Serializes account-switch fetch + subscribe to prevent overlapping races. */
@@ -1105,8 +1113,10 @@ export class AssetsController extends BaseController<
     // Subscribe to account group changes (when user switches between account groups like Account 1 -> Account 2)
     this.messenger.subscribe(
       'AccountTreeController:selectedAccountGroupChange',
-      (groupId) => {
-        this.#handleAccountGroupChanged(groupId).catch(console.error);
+      (groupId, previousGroupId) => {
+        this.#handleAccountGroupChanged(groupId, previousGroupId).catch(
+          console.error,
+        );
       },
     );
 
@@ -1199,7 +1209,12 @@ export class AssetsController extends BaseController<
     // happen before `AccountTreeController.init()`, and `:stateChange` fires
     // for intermediate mutations during that build.
     this.messenger.subscribe('AccountTreeController:initialized', () => {
-      this.#handleAccountTreeInitialized();
+      this.#accountTreeInitialized = true;
+      this.#updateActive();
+    });
+    this.messenger.subscribe('AccountTreeController:uninitialized', () => {
+      this.#accountTreeInitialized = false;
+      this.#updateActive();
     });
   }
 
@@ -1260,29 +1275,18 @@ export class AssetsController extends BaseController<
   }
 
   /**
-   * Start or stop asset tracking based on client (UI) open state and keyring
-   * unlock state. Only runs when both UI is open and keyring is unlocked.
+   * Start or stop asset tracking based on client (UI) open state, keyring
+   * unlock state, and account-tree readiness. Only runs when the UI is open,
+   * the keyring is unlocked, and the account tree has finished `init()`.
    */
   #updateActive(): void {
-    const shouldRun = this.#uiOpen && this.#keyringUnlocked;
+    const shouldRun =
+      this.#uiOpen && this.#keyringUnlocked && this.#accountTreeInitialized;
     if (shouldRun) {
       this.#start();
     } else {
       this.#stop();
     }
-  }
-
-  /**
-   * Handle `AccountTreeController:initialized`. Starts asset tracking once
-   * the tree is fully built. No-op unless the UI is open and the keyring is
-   * unlocked; `#start()` is idempotent if subscriptions are already active.
-   */
-  #handleAccountTreeInitialized(): void {
-    const shouldRun = this.#uiOpen && this.#keyringUnlocked;
-    if (!shouldRun) {
-      return;
-    }
-    this.#start();
   }
 
   /**
@@ -1293,8 +1297,12 @@ export class AssetsController extends BaseController<
    * `:initialized` instead, so we do not fetch on every tree mutation.
    */
   #handleAccountTreeStateChange(): void {
-    const shouldRun = this.#uiOpen && this.#keyringUnlocked;
-    if (!shouldRun || this.#activeSubscriptions.size === 0) {
+    const shouldRun =
+      this.#uiOpen &&
+      this.#keyringUnlocked &&
+      this.#accountTreeInitialized &&
+      this.#activeSubscriptions.size > 0;
+    if (!shouldRun) {
       return;
     }
     const accounts = this.#getSelectedAccounts();
@@ -1342,7 +1350,7 @@ export class AssetsController extends BaseController<
         chainIds: [...this.#enabledChains],
         forceUpdate: true,
       });
-      this.#subscribeAssets();
+      this.#subscribeAssets({ skipInitialFetch: true });
       if (newAccounts.length > 0) {
         await this.getAssets(newAccounts, {
           chainIds: [...this.#enabledChains],
@@ -1352,7 +1360,7 @@ export class AssetsController extends BaseController<
       this.#fetchMissingPricesWithoutCache(accounts, [...this.#enabledChains]);
     } catch (error) {
       log('Failed to fetch assets after tree change', error);
-      this.#subscribeAssets();
+      this.#subscribeAssets({ skipInitialFetch: true });
       this.#fetchMissingPricesWithoutCache(accounts, [...this.#enabledChains]);
     } finally {
       releaseLock();
@@ -1375,13 +1383,14 @@ export class AssetsController extends BaseController<
       // and default tracked assets that were never returned by balance APIs.
       this.#ensureNativeBalancesDefaultZero();
       this.#ensureDefaultTrackedAssetsSeeded();
-      this.#subscribeAssets();
+      // Balances were just force-fetched — skip AccountsApi's subscribe-time poll.
+      this.#subscribeAssets({ skipInitialFetch: true });
       this.#fetchMissingPricesWithoutCache(accounts, [...this.#enabledChains]);
     } catch (error) {
       log('Failed to fetch assets on startup', error);
       this.#ensureNativeBalancesDefaultZero();
       this.#ensureDefaultTrackedAssetsSeeded();
-      this.#subscribeAssets();
+      this.#subscribeAssets({ skipInitialFetch: true });
       this.#fetchMissingPricesWithoutCache(accounts, [...this.#enabledChains]);
     } finally {
       releaseLock();
@@ -3169,8 +3178,12 @@ export class AssetsController extends BaseController<
 
   /**
    * Subscribe to asset updates for all selected accounts.
+   *
+   * @param options - Subscription options.
+   * @param options.skipInitialFetch - When true, AccountsApi skips its
+   * one-shot subscribe poll (use after a force `getAssets` for the same scope).
    */
-  #subscribeAssets(): void {
+  #subscribeAssets(options?: { skipInitialFetch?: boolean }): void {
     const accounts = this.#getSelectedAccounts();
     const enabledChains = [...this.#enabledChains];
     if (accounts.length === 0 || enabledChains.length === 0) {
@@ -3178,7 +3191,7 @@ export class AssetsController extends BaseController<
     }
 
     // Subscribe to balance updates (batched by data source)
-    this.#subscribeAssetsBalance(accounts, enabledChains);
+    this.#subscribeAssetsBalance(accounts, enabledChains, options);
 
     // Subscribe to staked balance updates (separate from regular balance chain-claiming)
     this.#subscribeStakedBalance(accounts, enabledChains);
@@ -3200,10 +3213,13 @@ export class AssetsController extends BaseController<
    *
    * @param accounts - Accounts to subscribe balance updates for.
    * @param chainIds - Chain IDs to subscribe for.
+   * @param options - Subscription options.
+   * @param options.skipInitialFetch - Forwarded to AccountsApi subscribe.
    */
   #subscribeAssetsBalance(
     accounts: InternalAccount[],
     chainIds: ChainId[],
+    options?: { skipInitialFetch?: boolean },
   ): void {
     const chainToAccounts = this.#buildChainToAccountsMap(
       accounts,
@@ -3250,7 +3266,12 @@ export class AssetsController extends BaseController<
           return true;
         });
       if (accountsForSource.length > 0) {
-        this.#subscribeDataSource(source, accountsForSource, assignedChains);
+        this.#subscribeDataSource(source, accountsForSource, assignedChains, {
+          ...(options?.skipInitialFetch &&
+          source === this.#accountsApiDataSource
+            ? { skipInitialFetch: true }
+            : {}),
+        });
       }
     }
 
@@ -3400,12 +3421,17 @@ export class AssetsController extends BaseController<
    * @param options - Optional subscription overrides.
    * @param options.subscriptionKey - Custom subscription key (default: `ds:<sourceId>`).
    * @param options.customAssetsOnly - When true, only poll customAssets for these chains.
+   * @param options.skipInitialFetch - When true, skip the data source's subscribe-time fetch.
    */
   #subscribeDataSource(
     source: AbstractDataSource<string, DataSourceState>,
     accounts: InternalAccount[],
     chains: ChainId[],
-    options: { subscriptionKey?: string; customAssetsOnly?: boolean } = {},
+    options: {
+      subscriptionKey?: string;
+      customAssetsOnly?: boolean;
+      skipInitialFetch?: boolean;
+    } = {},
   ): void {
     const sourceId = source.getName();
     const subscriptionKey = options.subscriptionKey ?? `ds:${sourceId}`;
@@ -3419,6 +3445,7 @@ export class AssetsController extends BaseController<
       accountCount: accounts.length,
       chainCount: chains.length,
       customAssetsOnly: options.customAssetsOnly === true,
+      skipInitialFetch: options.skipInitialFetch === true,
     });
 
     const subscribeReq: SubscriptionRequest = {
@@ -3435,6 +3462,9 @@ export class AssetsController extends BaseController<
       onAssetsUpdate: (response, request) =>
         this.handleAssetsUpdate(response, sourceId, request),
       getAssetsState: () => this.state,
+      ...(options.skipInitialFetch === true
+        ? { skipInitialFetch: true }
+        : {}),
     };
 
     source.subscribe(subscribeReq).catch((error) => {
@@ -3580,9 +3610,23 @@ export class AssetsController extends BaseController<
   // EVENT HANDLERS
   // ============================================================================
 
-  async #handleAccountGroupChanged(groupId: string): Promise<void> {
+  async #handleAccountGroupChanged(
+    groupId: string,
+    previousGroupId: string = '',
+  ): Promise<void> {
     // The selected account group can be empty during onboarding or wallet reset.
     if (!groupId) {
+      return;
+    }
+
+    // First start is owned by `AccountTreeController:initialized` / `#start`.
+    // ATC also re-publishes `selectedAccountGroupChange` on every `init()`
+    // (including when the group did not change) so late subscribers can catch
+    // up — ignore those until we are already tracking.
+    if (this.#activeSubscriptions.size === 0) {
+      return;
+    }
+    if (groupId === previousGroupId) {
       return;
     }
 
@@ -3591,6 +3635,8 @@ export class AssetsController extends BaseController<
     log('Account group changed', {
       accountCount: accounts.length,
       accountIds: accounts.map((a) => a.id),
+      groupId,
+      previousGroupId,
     });
 
     this.#lastKnownAccountIds = new Set(accounts.map((a) => a.id));
@@ -3607,7 +3653,8 @@ export class AssetsController extends BaseController<
       this.#ensureNativeBalancesDefaultZero();
       this.#ensureDefaultTrackedAssetsSeeded();
       // Subscribe after seed so the price poll sees natives / defaults.
-      this.#subscribeAssets();
+      // Balances were just force-fetched — skip AccountsApi's subscribe-time poll.
+      this.#subscribeAssets({ skipInitialFetch: true });
       this.#fetchMissingPricesWithoutCache(accounts, [...this.#enabledChains]);
     } finally {
       releaseLock();

--- a/packages/assets-controller/src/AssetsController.ts
+++ b/packages/assets-controller/src/AssetsController.ts
@@ -1,5 +1,6 @@
 import type {
   AccountTreeControllerGetAccountsFromSelectedAccountGroupAction,
+  AccountTreeControllerInitializedEvent,
   AccountTreeControllerSelectedAccountGroupChangeEvent,
   AccountTreeControllerStateChangeEvent,
 } from '@metamask/account-tree-controller';
@@ -345,6 +346,7 @@ type AllowedEvents =
   // AssetsController
   | AccountTreeControllerSelectedAccountGroupChangeEvent
   | AccountTreeControllerStateChangeEvent
+  | AccountTreeControllerInitializedEvent
   | ClientControllerStateChangeEvent
   | KeyringControllerLockEvent
   | KeyringControllerUnlockEvent
@@ -1108,13 +1110,10 @@ export class AssetsController extends BaseController<
       },
     );
 
-    // Catch the initial tree build. On returning users,
-    // `selectedAccountGroupChange` does NOT fire when the persisted group
-    // is unchanged, and `accountTreeChange` doesn't fire either (init()
-    // rebuilds from persisted accounts without publishing it).
-    // The base-controller `:stateChange` event is guaranteed to fire
-    // when init() calls this.update(). #start() is idempotent so
-    // repeated fires are safe.
+    // Catch post-init tree mutations that change the selected account set
+    // (e.g. a snap account added to the current group) without changing
+    // the selected group id. Intermediate `:stateChange` events during
+    // `AccountTreeController.init()` are ignored until `:initialized`.
     this.messenger.subscribe('AccountTreeController:stateChange', () => {
       this.#handleAccountTreeStateChange();
     });
@@ -1196,6 +1195,12 @@ export class AssetsController extends BaseController<
         this.#onTransactionConfirmed(transactionMeta);
       },
     );
+    // Start tracking only after the account tree is fully built. Unlock can
+    // happen before `AccountTreeController.init()`, and `:stateChange` fires
+    // for intermediate mutations during that build.
+    this.messenger.subscribe('AccountTreeController:initialized', () => {
+      this.#handleAccountTreeInitialized();
+    });
   }
 
   #onUnapprovedTransactionAdded(transactionMeta: TransactionMeta): void {
@@ -1268,56 +1273,63 @@ export class AssetsController extends BaseController<
   }
 
   /**
-   * Handle AccountTreeController state changes.
-   * If already running, re-subscribe only when the set of selected accounts
-   * has actually changed (e.g. a snap account was added after initial startup).
-   * This guards against the many tree mutations that don't affect which
-   * accounts are selected — without this check every tree update would
-   * trigger a redundant full re-subscribe + forceUpdate fetch.
-   * If not running yet, delegate to #start() for the normal start flow.
+   * Handle `AccountTreeController:initialized`. Starts asset tracking once
+   * the tree is fully built. No-op unless the UI is open and the keyring is
+   * unlocked; `#start()` is idempotent if subscriptions are already active.
    */
-  #handleAccountTreeStateChange(): void {
+  #handleAccountTreeInitialized(): void {
     const shouldRun = this.#uiOpen && this.#keyringUnlocked;
     if (!shouldRun) {
       return;
     }
-    if (this.#activeSubscriptions.size > 0) {
-      const accounts = this.#getSelectedAccounts();
-      const currentIds = new Set(accounts.map((a) => a.id));
+    this.#start();
+  }
 
-      const accountsChanged =
-        currentIds.size !== this.#lastKnownAccountIds.size ||
-        [...currentIds].some((id) => !this.#lastKnownAccountIds.has(id));
-
-      if (!accountsChanged) {
-        return;
-      }
-
-      const hasOverlap = [...currentIds].some((id) =>
-        this.#lastKnownAccountIds.has(id),
-      );
-      if (!hasOverlap && this.#lastKnownAccountIds.size > 0) {
-        return;
-      }
-
-      log('Account tree changed with new accounts, re-subscribing', {
-        previousCount: this.#lastKnownAccountIds.size,
-        currentCount: currentIds.size,
-      });
-
-      const newAccounts = accounts.filter(
-        (account) => !this.#lastKnownAccountIds.has(account.id),
-      );
-
-      this.#lastKnownAccountIds = currentIds;
-      this.#ensureNativeBalancesDefaultZero();
-      this.#ensureDefaultTrackedAssetsSeeded();
-      this.#runAccountTreeRefresh(accounts, newAccounts).catch((error) => {
-        log('Failed to refresh assets after tree change', error);
-      });
-    } else {
-      this.#start();
+  /**
+   * Handle AccountTreeController state changes after the tree is initialized.
+   * Re-subscribe only when the set of selected accounts has actually changed
+   * (e.g. a snap account was added after initial startup). Intermediate
+   * `:stateChange` events during `init()` are ignored — startup is driven by
+   * `:initialized` instead, so we do not fetch on every tree mutation.
+   */
+  #handleAccountTreeStateChange(): void {
+    const shouldRun = this.#uiOpen && this.#keyringUnlocked;
+    if (!shouldRun || this.#activeSubscriptions.size === 0) {
+      return;
     }
+    const accounts = this.#getSelectedAccounts();
+    const currentIds = new Set(accounts.map((a) => a.id));
+
+    const accountsChanged =
+      currentIds.size !== this.#lastKnownAccountIds.size ||
+      [...currentIds].some((id) => !this.#lastKnownAccountIds.has(id));
+
+    if (!accountsChanged) {
+      return;
+    }
+
+    const hasOverlap = [...currentIds].some((id) =>
+      this.#lastKnownAccountIds.has(id),
+    );
+    if (!hasOverlap && this.#lastKnownAccountIds.size > 0) {
+      return;
+    }
+
+    log('Account tree changed with new accounts, re-subscribing', {
+      previousCount: this.#lastKnownAccountIds.size,
+      currentCount: currentIds.size,
+    });
+
+    const newAccounts = accounts.filter(
+      (account) => !this.#lastKnownAccountIds.has(account.id),
+    );
+
+    this.#lastKnownAccountIds = currentIds;
+    this.#ensureNativeBalancesDefaultZero();
+    this.#ensureDefaultTrackedAssetsSeeded();
+    this.#runAccountTreeRefresh(accounts, newAccounts).catch((error) => {
+      log('Failed to refresh assets after tree change', error);
+    });
   }
 
   async #runAccountTreeRefresh(

--- a/packages/assets-controller/src/AssetsController.ts
+++ b/packages/assets-controller/src/AssetsController.ts
@@ -3462,9 +3462,7 @@ export class AssetsController extends BaseController<
       onAssetsUpdate: (response, request) =>
         this.handleAssetsUpdate(response, sourceId, request),
       getAssetsState: () => this.state,
-      ...(options.skipInitialFetch === true
-        ? { skipInitialFetch: true }
-        : {}),
+      ...(options.skipInitialFetch === true ? { skipInitialFetch: true } : {}),
     };
 
     source.subscribe(subscribeReq).catch((error) => {

--- a/packages/assets-controller/src/__fixtures__/MockAssetControllerMessenger.ts
+++ b/packages/assets-controller/src/__fixtures__/MockAssetControllerMessenger.ts
@@ -68,6 +68,7 @@ export function createMockAssetControllerMessenger(): {
       'AccountTreeController:selectedAccountGroupChange',
       'AccountTreeController:stateChange',
       'AccountTreeController:initialized',
+      'AccountTreeController:uninitialized',
       'ClientController:stateChange',
       'KeyringController:lock',
       'KeyringController:unlock',

--- a/packages/assets-controller/src/__fixtures__/MockAssetControllerMessenger.ts
+++ b/packages/assets-controller/src/__fixtures__/MockAssetControllerMessenger.ts
@@ -67,6 +67,7 @@ export function createMockAssetControllerMessenger(): {
       // AssetsController
       'AccountTreeController:selectedAccountGroupChange',
       'AccountTreeController:stateChange',
+      'AccountTreeController:initialized',
       'ClientController:stateChange',
       'KeyringController:lock',
       'KeyringController:unlock',

--- a/packages/assets-controller/src/data-sources/AbstractDataSource.ts
+++ b/packages/assets-controller/src/data-sources/AbstractDataSource.ts
@@ -26,6 +26,12 @@ export type SubscriptionRequest = {
    * Provided by the controller when subscribing.
    */
   getAssetsState?: () => AssetsControllerStateInternal;
+  /**
+   * When true, skip the one-shot fetch that normally runs when a subscription
+   * is created. Used after the controller has already force-fetched balances
+   * for the same accounts/chains so we do not immediately hit the API again.
+   */
+  skipInitialFetch?: boolean;
 };
 
 /**

--- a/packages/assets-controller/src/data-sources/AccountsApiDataSource.test.ts
+++ b/packages/assets-controller/src/data-sources/AccountsApiDataSource.test.ts
@@ -947,6 +947,34 @@ describe('AccountsApiDataSource', () => {
     controller.destroy();
   });
 
+  it('middleware skips Accounts API when balance is not requested', async () => {
+    const { controller, apiClient } = await setupController({
+      balances: [
+        createMockBalanceItem(
+          `eip155:1:${MOCK_ADDRESS}`,
+          'eip155:1/slip44:60',
+          '1',
+        ),
+      ],
+    });
+
+    apiClient.accounts.fetchV5MultiAccountBalances.mockClear();
+
+    const next = jest.fn().mockResolvedValue(undefined);
+    const context = createMiddlewareContext({
+      request: createDataRequest({ dataTypes: ['price'] }),
+    });
+
+    await controller.assetsMiddleware(context, next);
+
+    expect(
+      apiClient.accounts.fetchV5MultiAccountBalances,
+    ).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(context);
+
+    controller.destroy();
+  });
+
   it('middleware removes handled chains from next request', async () => {
     const { controller } = await setupController({ supportedChains: [1] });
 
@@ -979,6 +1007,28 @@ describe('AccountsApiDataSource', () => {
     });
 
     expect(assetsUpdateHandler).toHaveBeenCalledTimes(1);
+
+    controller.destroy();
+  });
+
+  it('subscribe skips initial fetch when skipInitialFetch is true', async () => {
+    const { controller, assetsUpdateHandler, apiClient } =
+      await setupController();
+
+    apiClient.accounts.fetchV5MultiAccountBalances.mockClear();
+
+    await controller.subscribe({
+      subscriptionId: 'sub-1',
+      request: createDataRequest(),
+      isUpdate: false,
+      onAssetsUpdate: assetsUpdateHandler,
+      skipInitialFetch: true,
+    });
+
+    expect(assetsUpdateHandler).not.toHaveBeenCalled();
+    expect(
+      apiClient.accounts.fetchV5MultiAccountBalances,
+    ).not.toHaveBeenCalled();
 
     controller.destroy();
   });

--- a/packages/assets-controller/src/data-sources/AccountsApiDataSource.ts
+++ b/packages/assets-controller/src/data-sources/AccountsApiDataSource.ts
@@ -24,6 +24,7 @@ import type {
   Middleware,
   AssetsControllerStateInternal,
 } from '../types.js';
+import { forDataTypes } from '../types.js';
 import { fetchWithTimeout, normalizeAssetId } from '../utils/index.js';
 import {
   getMigrationStages,
@@ -782,7 +783,7 @@ export class AccountsApiDataSource extends AbstractDataSource<
 
       // No chains handled - pass context unchanged
       return next(context);
-    };
+    });
   }
 
   // ============================================================================
@@ -790,7 +791,8 @@ export class AccountsApiDataSource extends AbstractDataSource<
   // ============================================================================
 
   async subscribe(subscriptionRequest: SubscriptionRequest): Promise<void> {
-    const { request, subscriptionId, isUpdate } = subscriptionRequest;
+    const { request, subscriptionId, isUpdate, skipInitialFetch } =
+      subscriptionRequest;
 
     // Store state accessor for filtering when tokenDetectionEnabled is false
     if (subscriptionRequest.getAssetsState) {
@@ -879,8 +881,12 @@ export class AccountsApiDataSource extends AbstractDataSource<
       onAssetsUpdate: subscriptionRequest.onAssetsUpdate,
     });
 
-    // Initial fetch
-    await pollFn();
+    // Interval above still polls on the normal cadence. This only skips the
+    // one-shot fetch at subscribe time when the controller already ran a
+    // force getAssets for the same scope (startup / group refresh).
+    if (!skipInitialFetch) {
+      await pollFn();
+    }
   }
 
   // ============================================================================

--- a/packages/assets-controller/src/data-sources/AccountsApiDataSource.ts
+++ b/packages/assets-controller/src/data-sources/AccountsApiDataSource.ts
@@ -24,7 +24,6 @@ import type {
   Middleware,
   AssetsControllerStateInternal,
 } from '../types.js';
-import { forDataTypes } from '../types.js';
 import { fetchWithTimeout, normalizeAssetId } from '../utils/index.js';
 import {
   getMigrationStages,
@@ -722,6 +721,11 @@ export class AccountsApiDataSource extends AbstractDataSource<
     return async (context, next) => {
       const { request } = context;
 
+      // Price/metadata-only requests must not hit the Accounts API.
+      if (!request.dataTypes.includes('balance')) {
+        return next(context);
+      }
+
       // If no chains requested, skip to next middleware
       if (request.chainIds.length === 0) {
         return next(context);
@@ -783,7 +787,7 @@ export class AccountsApiDataSource extends AbstractDataSource<
 
       // No chains handled - pass context unchanged
       return next(context);
-    });
+    };
   }
 
   // ============================================================================


### PR DESCRIPTION
Subscribe to AccountTreeController:initialized so asset tracking starts only after the tree is fully built, instead of on intermediate stateChange events during init. Hosts must now also delegate the new event through the AssetsController messenger.

Extension PR: https://github.com/MetaMask/metamask-extension/pull/45579
Mobile PR: https://github.com/MetaMask/metamask-mobile/pull/34866

## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 22007ec7074e55acb45569660bf6997d99aea165. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->