### PR TITLE
fix(network-connection-banner-controller): subscribe to ClientController:stateChange

### DIFF
--- a/packages/network-connection-banner-controller/CHANGELOG.md
+++ b/packages/network-connection-banner-controller/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **BREAKING:** `NetworkConnectionBannerControllerMessenger` now requires the `ClientController:stateChange` event to be delegated instead of `ClientController:stateChanged` ([#9893](https://github.com/MetaMask/core/pull/9893))
-  - `ClientController:stateChanged` is not declared by `@metamask/client-controller`, so clients had to suppress a type error to delegate it.
   - Clients delegating `ClientController:stateChanged` must switch to `ClientController:stateChange`, otherwise the controller no longer receives UI open state and the banner never shows.
 - Bump `@metamask/network-controller` from `^35.0.0` to `^35.0.1` ([#9758](https://github.com/MetaMask/core/pull/9758))
 - Bump `@metamask/network-enablement-controller` from `^6.0.1` to `^6.0.3` ([#9740](https://github.com/MetaMask/core/pull/9740), [#9791](https://github.com/MetaMask/core/pull/9791))

--- a/packages/network-connection-banner-controller/CHANGELOG.md
+++ b/packages/network-connection-banner-controller/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **BREAKING:** `NetworkConnectionBannerControllerMessenger` now requires the `ClientController:stateChange` event to be delegated instead of `ClientController:stateChanged` ([#9893](https://github.com/MetaMask/core/pull/9893))
-  - Clients delegating `ClientController:stateChanged` must switch to `ClientController:stateChange`.
-  - Fixes the controller never starting (and the banner never showing) for clients that delegate the `ClientController:stateChange` event exported by `@metamask/client-controller`.
+  - `ClientController:stateChanged` is not declared by `@metamask/client-controller`, so clients had to suppress a type error to delegate it.
+  - Clients delegating `ClientController:stateChanged` must switch to `ClientController:stateChange`, otherwise the controller no longer receives UI open state and the banner never shows.
 - Bump `@metamask/network-controller` from `^35.0.0` to `^35.0.1` ([#9758](https://github.com/MetaMask/core/pull/9758))
 - Bump `@metamask/network-enablement-controller` from `^6.0.1` to `^6.0.3` ([#9740](https://github.com/MetaMask/core/pull/9740), [#9791](https://github.com/MetaMask/core/pull/9791))
 - Bump `@metamask/keyring-controller` from `^27.1.0` to `^27.1.1` ([#9791](https://github.com/MetaMask/core/pull/9791))

--- a/packages/network-connection-banner-controller/CHANGELOG.md
+++ b/packages/network-connection-banner-controller/CHANGELOG.md
@@ -9,8 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** `NetworkConnectionBannerControllerMessenger` now requires the `ClientController:stateChange` event to be delegated instead of `ClientController:stateChanged` ([#9893](https://github.com/MetaMask/core/pull/9893))
-  - Clients delegating `ClientController:stateChanged` must switch to `ClientController:stateChange`, otherwise the controller no longer receives UI open state and the banner never shows.
+- **BREAKING:** `NetworkConnectionBannerControllerMessenger` now requires `ClientController:stateChange` to be delegated instead of `ClientController:stateChanged` ([#9893](https://github.com/MetaMask/core/pull/9893))
 - Bump `@metamask/network-controller` from `^35.0.0` to `^35.0.1` ([#9758](https://github.com/MetaMask/core/pull/9758))
 - Bump `@metamask/network-enablement-controller` from `^6.0.1` to `^6.0.3` ([#9740](https://github.com/MetaMask/core/pull/9740), [#9791](https://github.com/MetaMask/core/pull/9791))
 - Bump `@metamask/keyring-controller` from `^27.1.0` to `^27.1.1` ([#9791](https://github.com/MetaMask/core/pull/9791))

--- a/packages/network-connection-banner-controller/CHANGELOG.md
+++ b/packages/network-connection-banner-controller/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING:** `NetworkConnectionBannerControllerMessenger` now requires the `ClientController:stateChange` event to be delegated instead of `ClientController:stateChanged` ([#9893](https://github.com/MetaMask/core/pull/9893))
+  - Clients delegating `ClientController:stateChanged` must switch to `ClientController:stateChange`.
+  - Fixes the controller never starting (and the banner never showing) for clients that delegate the `ClientController:stateChange` event exported by `@metamask/client-controller`.
 - Bump `@metamask/network-controller` from `^35.0.0` to `^35.0.1` ([#9758](https://github.com/MetaMask/core/pull/9758))
 - Bump `@metamask/network-enablement-controller` from `^6.0.1` to `^6.0.3` ([#9740](https://github.com/MetaMask/core/pull/9740), [#9791](https://github.com/MetaMask/core/pull/9791))
 - Bump `@metamask/keyring-controller` from `^27.1.0` to `^27.1.1` ([#9791](https://github.com/MetaMask/core/pull/9791))

--- a/packages/network-connection-banner-controller/README.md
+++ b/packages/network-connection-banner-controller/README.md
@@ -13,7 +13,7 @@ from the same failure start and must be greater than the degraded one.
 The controller stays dormant after construction so the 5s / 30s escalation
 timers do not run before a user is actually looking at the wallet (e.g. while
 the app is still on the lock screen). It manages its own lifecycle by
-subscribing to `ClientController:stateChanged` and
+subscribing to `ClientController:stateChange` and
 `KeyringController:unlock` / `KeyringController:lock`: evaluation runs only
 while the client UI is open on an unlocked wallet. When either condition
 stops holding, pending timers are cancelled and the banner state resets to

--- a/packages/network-connection-banner-controller/src/NetworkConnectionBannerController.test.ts
+++ b/packages/network-connection-banner-controller/src/NetworkConnectionBannerController.test.ts
@@ -1843,7 +1843,8 @@ async function withController<ReturnValue>(
       'NetworkEnablementController:stateChange',
       // eslint-disable-next-line no-restricted-syntax -- awaiting upstream :stateChanged migration
       'ConnectivityController:stateChange',
-      'ClientController:stateChanged',
+      // eslint-disable-next-line no-restricted-syntax -- awaiting upstream :stateChanged migration
+      'ClientController:stateChange',
       'KeyringController:unlock',
       'KeyringController:lock',
     ],
@@ -1857,7 +1858,7 @@ async function withController<ReturnValue>(
   });
 
   const setUiOpen = (isUiOpen: boolean): void => {
-    rootMessenger.publish('ClientController:stateChanged', { isUiOpen }, []);
+    rootMessenger.publish('ClientController:stateChange', { isUiOpen }, []);
   };
   const setKeyringUnlocked = (isUnlocked: boolean): void => {
     rootMessenger.publish(

--- a/packages/network-connection-banner-controller/src/NetworkConnectionBannerController.ts
+++ b/packages/network-connection-banner-controller/src/NetworkConnectionBannerController.ts
@@ -5,7 +5,7 @@ import type {
 } from '@metamask/base-controller';
 import { BaseController } from '@metamask/base-controller';
 import { clientControllerSelectors } from '@metamask/client-controller';
-import type { ClientControllerState } from '@metamask/client-controller';
+import type { ClientControllerStateChangeEvent } from '@metamask/client-controller';
 import {
   CONNECTIVITY_STATUSES,
   connectivityControllerSelectors,
@@ -265,16 +265,6 @@ export type NetworkConnectionBannerControllerEvents =
   NetworkConnectionBannerControllerStateChangedEvent;
 
 /**
- * Published when the state of `ClientController` changes. Defined here
- * because the `client-controller` package still exports the legacy
- * `:stateChange` event type.
- */
-type ClientControllerStateChangedEvent = ControllerStateChangedEvent<
-  'ClientController',
-  ClientControllerState
->;
-
-/**
  * Events from other messengers that
  * {@link NetworkConnectionBannerControllerMessenger} subscribes to.
  */
@@ -282,7 +272,7 @@ type AllowedEvents =
   | NetworkControllerStateChangeEvent
   | NetworkEnablementControllerStateChangeEvent
   | ConnectivityControllerStateChangeEvent
-  | ClientControllerStateChangedEvent
+  | ClientControllerStateChangeEvent
   | KeyringControllerUnlockEvent
   | KeyringControllerLockEvent;
 
@@ -474,7 +464,8 @@ export class NetworkConnectionBannerController extends BaseController<
     // Lifecycle: evaluate RPC health (and run the banner escalation timers)
     // only while the client UI is open on an unlocked wallet.
     this.messenger.subscribe(
-      'ClientController:stateChanged',
+      // eslint-disable-next-line no-restricted-syntax -- awaiting upstream :stateChanged migration
+      'ClientController:stateChange',
       (isUiOpen) => {
         this.#isUiOpen = isUiOpen;
         this.#updateLifecycle();


### PR DESCRIPTION
## Explanation

`NetworkConnectionBannerController` subscribes to `ClientController:stateChanged` using an event type it defines locally. `@metamask/client-controller` only declares and exports `ClientController:stateChange`.

It works at runtime because `BaseController` publishes both names. This is a contract cleanup, not a behavior fix.

Now the controller uses the exported `ClientControllerStateChangeEvent`, dropping the duplicated local type and matching the three other upstream subscriptions in the file.

Breaking: clients must delegate `ClientController:stateChange` instead of `ClientController:stateChanged`, otherwise the controller stops receiving UI open state and the banner never shows. Both extension and mobile need the one line swap.

## References

- Introduced in #9041

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by updating changelogs for packages I've changed
- [x] I've introduced breaking changes in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit ec8b9d7d301e82bafb66b23a463bf63497ecf360. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->