### PR TITLE
fix: fallback to 0 when intent gasLimit is unavailable

### DIFF
--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fallback to `0` if trade `gasLimit` is null
+- Fallback to `0` if trade `gasLimit` is null ([#9902](https://github.com/MetaMask/core/pull/9902))
 
 ## [79.2.0]
 

--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/assets-controller` from `^13.1.2` to `^13.1.4` ([#9873](https://github.com/MetaMask/core/pull/9873), [#9886](https://github.com/MetaMask/core/pull/9886))
 - Bump `@metamask/assets-controllers` from `^111.1.0` to `^111.1.1` ([#9886](https://github.com/MetaMask/core/pull/9886))
 
+### Fixed
+
+- Fallback to `0` if trade `gasLimit` is null
+
 ## [79.2.0]
 
 ### Added

--- a/packages/bridge-controller/src/utils/quote-metadata/calculators.test.ts
+++ b/packages/bridge-controller/src/utils/quote-metadata/calculators.test.ts
@@ -642,9 +642,9 @@ describe('Quote Metadata Utils', () => {
         usdExchangeRate: '1500',
       });
 
-      expect(result?.total?.amount).toBeUndefined();
-      expect(result?.total?.valueInCurrency).toBeUndefined();
-      expect(result?.total?.usd).toBeUndefined();
+      expect(result?.total?.amount).toBe('0');
+      expect(result?.total?.valueInCurrency).toBe('0');
+      expect(result?.total?.usd).toBe('0');
     });
 
     it('should handle missing approval', () => {
@@ -682,7 +682,7 @@ describe('Quote Metadata Utils', () => {
         usdExchangeRate: '1500',
       });
 
-      expect(result?.total?.amount).toBeUndefined();
+      expect(result?.total?.amount).toBe('0.0001');
     });
 
     it('should handle missing trade gasLimit, with l1GasFeesInHexWei', () => {
@@ -737,7 +737,7 @@ describe('Quote Metadata Utils', () => {
         usdExchangeRate: '1500',
       });
 
-      expect(result?.total?.amount).toBeUndefined();
+      expect(result?.total?.amount).toBe('0');
     });
 
     it('should handle large gas limits and fees', () => {

--- a/packages/bridge-controller/src/utils/quote-metadata/calculators.ts
+++ b/packages/bridge-controller/src/utils/quote-metadata/calculators.ts
@@ -163,12 +163,9 @@ const calcTotalGasFee = ({
   nativeToDisplayCurrencyExchangeRate?: string;
   nativeToUsdExchangeRate?: string;
 }) => {
-  const totalGasLimitInDec =
-    tradeGasLimit || approvalGasLimit || resetApprovalGasLimit
-      ? new BigNumber(tradeGasLimit?.toFixed() ?? '0')
-          .plus(approvalGasLimit?.toFixed() ?? '0')
-          .plus(resetApprovalGasLimit?.toFixed() ?? '0')
-      : undefined;
+  const totalGasLimitInDec = new BigNumber(tradeGasLimit?.toFixed() ?? '0')
+    .plus(approvalGasLimit?.toFixed() ?? '0')
+    .plus(resetApprovalGasLimit?.toFixed() ?? '0');
 
   const l1GasFeesInDecGWei = l1GasFeesInHexWei
     ? weiHexToGweiDec(toHex(l1GasFeesInHexWei))


### PR DESCRIPTION
## Explanation

V1<>V2 quote transformation throws an error when a swap intent quote's gasLimit is not defined

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Related to https://github.com/MetaMask/metamask-extension/issues/45586

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 3280162af8883520c6bf1a1c5e2dcb4b4af096b2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->