### PR TITLE
fix(base-data-service): drive later infinite pages with setQueryData

### DIFF
--- a/packages/money-account-api-data-service/src/money-account-api-data-service.ts
+++ b/packages/money-account-api-data-service/src/money-account-api-data-service.ts
@@ -385,6 +385,7 @@ export class MoneyAccountApiDataService extends BaseDataService<
           options?.chainId ?? null,
           options?.limit ?? null,
         ],
+        initialPageParam: null,
         staleTime: DEFAULT_STALE_TIME_MS,
         queryFn: async (context) => {
           const cursor = context.pageParam as string | null | undefined;
@@ -436,6 +437,7 @@ export class MoneyAccountApiDataService extends BaseDataService<
             },
           );
         },
+        getNextPageParam: (lastPage) => lastPage.next_cursor,
       },
       options?.cursor ?? undefined,
     );


### PR DESCRIPTION
Stacked on #9896, opening against that branch.

## Problem

The cached path uses `query.fetch`, which cannot fetch a later page when the UI has multiple observers on the same query. `fetchNextPage` comes back `undefined` and the observer then crashes in `getNextPageParam` (`Cannot destructure property 'pageInfo' of undefined`). That is why the `react-data-query` and `money-account` test jobs are red on the branch.

## Fix

- Route the first page and a cold cache through `fetchInfiniteQuery` as before.
- Fetch a later page directly and merge it into the infinite cache with `setQueryData` (append the next page, prepend an earlier one). This is the one thing `query.fetch` cannot do for the multi observer flow in v5.
- Align the `react-data-query` observers on a `null` first page param (`getActivity` uses `null`), which was the immediate cause of the red `react-data-query` job.
- Give `MoneyAccountApiDataService.fetchHistory` the now required `getNextPageParam` and `initialPageParam`.

## Verification

`base-data-service` (66), `react-data-query` (14), and `money-account` (47) tests all pass locally, with typecheck, eslint, and oxfmt clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 742bd898a1e18d801449df23340af4c545820273. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->