### PR TITLE
fix(perps): target preload performance measurements

### DIFF
--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add the optional `PerpsPerformance.onControllerConstructed` hook and optional trace ID parameter to `PerpsTracer.setMeasurement`, allowing clients to correlate controller construction and preload measurements with the intended trace ([#9906](https://github.com/MetaMask/core/pull/9906))
 - Add `PERPS_EVENT_PROPERTY.PREVIOUS_LEVERAGE` (`previous_leverage`) for Perp UI Interaction `leverage_changed` events so clients can import the Segment property key from `@metamask/perps-controller` instead of a local interim constant ([#9881](https://github.com/MetaMask/core/pull/9881))
+
+### Changed
+
+- Target market and user preload measurements to their named traces, and omit wallet addresses from user-preload trace data ([#9906](https://github.com/MetaMask/core/pull/9906))
 
 ## [12.0.0]
 

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add the optional `PerpsPerformance.onControllerConstructed` hook and optional trace ID parameter to `PerpsTracer.setMeasurement`, allowing clients to correlate controller construction and preload measurements with the intended trace ([#9906](https://github.com/MetaMask/core/pull/9906))
+- Add the optional `PerpsPerformance.onControllerConstructed` post-hydration timestamp hook ([#9906](https://github.com/MetaMask/core/pull/9906))
+- Add an explicit trace ID overload to `PerpsTracer.setMeasurement`, allowing clients to target preload measurements to their named trace ([#9906](https://github.com/MetaMask/core/pull/9906))
 - Add `PERPS_EVENT_PROPERTY.PREVIOUS_LEVERAGE` (`previous_leverage`) for Perp UI Interaction `leverage_changed` events so clients can import the Segment property key from `@metamask/perps-controller` instead of a local interim constant ([#9881](https://github.com/MetaMask/core/pull/9881))
 
 ### Changed

--- a/packages/perps-controller/src/PerpsController.ts
+++ b/packages/perps-controller/src/PerpsController.ts
@@ -4204,9 +4204,7 @@ export class PerpsController extends BaseController<
         },
       });
 
-      this.#debugLog('PerpsController: Fetching user data in background', {
-        userAddress,
-      });
+      this.#debugLog('PerpsController: Fetching user data in background');
 
       if (activeProvider === 'hyperliquid') {
         const snapshot = await this.getUserDataSnapshot();

--- a/packages/perps-controller/src/PerpsController.ts
+++ b/packages/perps-controller/src/PerpsController.ts
@@ -1236,6 +1236,9 @@ export class PerpsController extends BaseController<
     // Eagerly hydrate in-memory caches from disk so hooks see data on first render.
     // Must happen at construction time — before any React component mounts.
     this.#hydrateCacheFromDiskSync();
+    this.#options.infrastructure.performance.onControllerConstructed?.(
+      this.#options.infrastructure.performance.now(),
+    );
   }
 
   // ============================================================================
@@ -4057,6 +4060,7 @@ export class PerpsController extends BaseController<
         PerpsMeasurementName.PerpsMarketDataPreload,
         performance.now() - preloadStart,
         'millisecond',
+        traceId,
       );
     } catch (error) {
       traceData = {
@@ -4198,7 +4202,6 @@ export class PerpsController extends BaseController<
           provider: activeProvider,
           isTestnet,
         },
-        data: { userAddress },
       });
 
       this.#debugLog('PerpsController: Fetching user data in background', {
@@ -4221,6 +4224,7 @@ export class PerpsController extends BaseController<
           PerpsMeasurementName.PerpsUserDataPreload,
           performance.now() - preloadStart,
           'millisecond',
+          traceId,
         );
         return;
       }
@@ -4335,6 +4339,7 @@ export class PerpsController extends BaseController<
         PerpsMeasurementName.PerpsUserDataPreload,
         performance.now() - preloadStart,
         'millisecond',
+        traceId,
       );
     } catch (error) {
       traceData = {

--- a/packages/perps-controller/src/types/index.ts
+++ b/packages/perps-controller/src/types/index.ts
@@ -1941,8 +1941,15 @@ export type PerpsPerformance = {
    * Optional platform hook invoked once after constructor disk hydration.
    * Receives `performance.now()` — not a Sentry write.
    */
-  onControllerConstructed?(monotonicMs: number): void;
+  onControllerConstructed?: (monotonicMs: number) => void;
 };
+
+type PerpsSetMeasurement = ((
+  name: string,
+  value: number,
+  unit: string,
+) => void) &
+  ((name: string, value: number, unit: string, id: string) => void);
 
 /**
  * Injectable tracer interface for Sentry/observability tracing.
@@ -1966,7 +1973,7 @@ export type PerpsTracer = {
     data?: Record<string, PerpsTraceValue>;
   }): void;
 
-  setMeasurement(name: string, value: number, unit: string, id?: string): void;
+  setMeasurement: PerpsSetMeasurement;
 
   addBreadcrumb(breadcrumb: {
     category: string;

--- a/packages/perps-controller/src/types/index.ts
+++ b/packages/perps-controller/src/types/index.ts
@@ -1937,6 +1937,11 @@ export type PerpsStreamManager = {
  */
 export type PerpsPerformance = {
   now(): number;
+  /**
+   * Optional platform hook invoked once after constructor disk hydration.
+   * Receives `performance.now()` — not a Sentry write.
+   */
+  onControllerConstructed?(monotonicMs: number): void;
 };
 
 /**
@@ -1961,7 +1966,7 @@ export type PerpsTracer = {
     data?: Record<string, PerpsTraceValue>;
   }): void;
 
-  setMeasurement(name: string, value: number, unit: string): void;
+  setMeasurement(name: string, value: number, unit: string, id?: string): void;
 
   addBreadcrumb(breadcrumb: {
     category: string;

--- a/packages/perps-controller/tests/src/PerpsController.providers-cache.test.ts
+++ b/packages/perps-controller/tests/src/PerpsController.providers-cache.test.ts
@@ -1384,6 +1384,23 @@ describe('PerpsController', () => {
       ).toHaveLength(1);
     });
 
+    it('publishes one construction timestamp after disk hydration and does not write Sentry at construct', () => {
+      const infra = createMockInfrastructure();
+      (infra.performance.now as jest.Mock).mockReturnValue(321);
+      const onControllerConstructed = jest.fn();
+      infra.performance.onControllerConstructed = onControllerConstructed;
+
+      new TestablePerpsController({
+        messenger: createMockMessenger(),
+        state: getDefaultPerpsControllerState(),
+        infrastructure: infra,
+      });
+
+      expect(onControllerConstructed).toHaveBeenCalledTimes(1);
+      expect(onControllerConstructed).toHaveBeenCalledWith(321);
+      expect(infra.tracer.setMeasurement).not.toHaveBeenCalled();
+    });
+
     it('does not hydrate expired Terminal trend provenance from disk', () => {
       const infra = createMockInfrastructure();
       (infra.diskCache.getItemSync as jest.Mock).mockImplementation(
@@ -2115,6 +2132,13 @@ describe('PerpsController', () => {
       expect(mockInfrastructure.tracer.trace).toHaveBeenCalled();
       expect(mockInfrastructure.tracer.endTrace).toHaveBeenCalled();
       expect(mockInfrastructure.tracer.setMeasurement).toHaveBeenCalled();
+      const traceId = mockInfrastructure.tracer.trace.mock.calls[0][0].id;
+      expect(mockInfrastructure.tracer.setMeasurement).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Number),
+        'millisecond',
+        traceId,
+      );
     });
   });
 
@@ -2633,6 +2657,35 @@ describe('PerpsController', () => {
         expect.objectContaining({
           identity: expect.objectContaining({ network: 'testnet' }),
         }),
+      );
+    });
+
+    it('does not put userAddress on user-preload trace data and targets the named trace id', async () => {
+      preloadMockProvider.getMarketDataWithPrices.mockResolvedValue([]);
+      preloadMockProvider.getWebSocketConnectionState.mockReturnValue(
+        WSState.Disconnected,
+      );
+      preloadController.testMarkInitialized();
+      preloadController.testSetProviders(
+        new Map([['hyperliquid', preloadMockProvider]]),
+      );
+
+      preloadController.startMarketDataPreload();
+      await jest.advanceTimersByTimeAsync(100);
+
+      const userPreloadTrace = preloadInfrastructure.tracer.trace.mock.calls
+        .map((call) => call[0])
+        .find((params) => params.name === 'Perps User Data Preload');
+      expect(userPreloadTrace).toBeDefined();
+      expect(userPreloadTrace?.data).toBeUndefined();
+      expect(JSON.stringify(userPreloadTrace)).not.toContain(
+        mockEvmAccount.address,
+      );
+      expect(preloadInfrastructure.tracer.setMeasurement).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Number),
+        'millisecond',
+        userPreloadTrace?.id,
       );
     });
 

--- a/packages/perps-controller/tests/src/PerpsController.providers-cache.test.ts
+++ b/packages/perps-controller/tests/src/PerpsController.providers-cache.test.ts
@@ -1398,6 +1398,9 @@ describe('PerpsController', () => {
 
       expect(onControllerConstructed).toHaveBeenCalledTimes(1);
       expect(onControllerConstructed).toHaveBeenCalledWith(321);
+      expect(
+        (infra.diskCache.getItemSync as jest.Mock).mock.invocationCallOrder[0],
+      ).toBeLessThan(onControllerConstructed.mock.invocationCallOrder[0]);
       expect(infra.tracer.setMeasurement).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
## Description

Targets Perps preload measurements to their named trace IDs, exposes a post-hydration controller construction timestamp to clients, and removes the wallet address from user-preload trace data. This is the minimal Core contract required by the Perps loading dashboard; market and account bootstrap behavior is unchanged.

## Changelog

- Added optional Perps performance hooks for controller construction and explicit trace-targeted measurements.
- Removed wallet addresses from Perps user-preload traces.

## Validation

- Focused PerpsController Jest: 3 passed
- Targeted ESLint: passed
- Prettier and git diff checks: passed
- Repository pre-push lint is locally blocked by unrelated untracked harness overlays and tsc cache files; GitHub CI is the clean full-repository gate.

## Related

Follow-up to #9815.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry and optional DI hooks only; preload and trading paths are unchanged aside from trace targeting and PII removal from traces.
> 
> **Overview**
> Extends the Perps observability contract for the loading dashboard without changing market or account bootstrap behavior.
> 
> **`PerpsPerformance`** gains an optional **`onControllerConstructed`** callback, invoked once after synchronous disk hydration in the constructor with `performance.now()` (no Sentry write at construct time).
> 
> **`PerpsTracer.setMeasurement`** is typed as an overload that accepts an optional fourth **`id`** argument; market and user preload paths now pass the same **`traceId`** used when opening those named traces so durations attach to the correct span.
> 
> **User data preload** no longer puts **`userAddress`** on the `Perps User Data Preload` trace `data` or in debug logs tied to that flow, reducing PII in telemetry while fetch behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 308f4c8b8c9a4fd2f2ced7d9b415b14c9240abb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->