### PR TITLE
fix(perps-controller): map Terminal v1 category onto client marketType

### DIFF
--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Report the take profit (or stop loss) price on a `Position` when its only trigger for that direction is a partial, quantity-scoped one ([#9912](https://github.com/MetaMask/core/pull/9912))
   - `takeProfitPrice`/`stopLossPrice` were only ever scanned from position-bound triggers, so a position whose sole take profit closed it partially reported `takeProfitCount: 1` with no price, and clients rendering the scalar showed none. Applies to the REST `getPositions`, `getUserDataSnapshot`, and WebSocket position paths alike.
   - Two or more triggers in a direction still report the scanned price, because no single price describes them and clients render the count instead.
+- Map Terminal v1 `category` aliases (`pre_ipo` → `pre-ipo`, `stocks` → `stock`) when `marketType` is absent, so Pre-IPO markets such as Unitree appear under that filter without a static symbol list
+- Reclassify `xyz:CBRS` and `xyz:SPCX` from `pre-ipo` to `stock` in `HIP3_ASSET_MARKET_TYPES` now that they are public (Terminal already sends `stocks`). Leave `xyz:IPOP` as Pre-IPO
 
 ## [12.1.0]
 

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `takeProfitPrice`/`stopLossPrice` were only ever scanned from position-bound triggers, so a position whose sole take profit closed it partially reported `takeProfitCount: 1` with no price, and clients rendering the scalar showed none. Applies to the REST `getPositions`, `getUserDataSnapshot`, and WebSocket position paths alike.
   - Two or more triggers in a direction still report the scanned price, because no single price describes them and clients render the count instead.
 - Map Terminal v1 `category` aliases (`pre_ipo` → `pre-ipo`, `stocks` → `stock`) when `marketType` is absent, so Pre-IPO markets such as Unitree appear under that filter without a static symbol list
+- Clear `isNewMarket` on the v1 Terminal enrich path once a `marketType` is applied, matching the v2 snapshot rule so categorized HIP-3 markets are not also in the controller `new` bucket
 - Reclassify `xyz:CBRS` and `xyz:SPCX` from `pre-ipo` to `stock` in `HIP3_ASSET_MARKET_TYPES` now that they are public (Terminal already sends `stocks`). Leave `xyz:IPOP` as Pre-IPO
 
 ## [12.1.0]

--- a/packages/perps-controller/src/constants/hyperLiquidConfig.ts
+++ b/packages/perps-controller/src/constants/hyperLiquidConfig.ts
@@ -367,6 +367,8 @@ export const HIP3_ASSET_MARKET_TYPES: Record<string, MarketType> = {
   'xyz:ARM': MarketCategory.Stock,
   'xyz:BX': MarketCategory.Stock,
   'xyz:LITE': MarketCategory.Stock,
+  'xyz:CBRS': MarketCategory.Stock,
+  'xyz:SPCX': MarketCategory.Stock,
 
   // xyz DEX - Stocks (Korea)
   'xyz:SKHX': MarketCategory.Stock,
@@ -378,8 +380,6 @@ export const HIP3_ASSET_MARKET_TYPES: Record<string, MarketType> = {
   'xyz:KIOXIA': MarketCategory.Stock,
 
   // xyz DEX - Pre-IPO
-  'xyz:CBRS': MarketCategory.PreIpo,
-  'xyz:SPCX': MarketCategory.PreIpo,
   'xyz:IPOP': MarketCategory.PreIpo,
 
   // xyz DEX - Indices

--- a/packages/perps-controller/src/services/MarketDataService.ts
+++ b/packages/perps-controller/src/services/MarketDataService.ts
@@ -1414,8 +1414,10 @@ export class MarketDataService {
    * Merge Terminal API metadata into provider-sourced PerpsMarketData.
    * For each market, if the terminal metadata map contains an entry for its
    * symbol, override name/description/marketType and attach
-   * keywords/tags/categories. Unmatched markets keep their provider-sourced
-   * values.
+   * keywords/tags/categories. Applying a marketType clears a stale
+   * isNewMarket flag so the v1 enrich path matches the v2 snapshot rule
+   * (categorized HIP-3 is not the controller "new" bucket). Unmatched markets
+   * keep their provider-sourced values.
    *
    * @param markets - Markets from the provider.
    * @param metadata - Per-symbol metadata from the Terminal API.
@@ -1437,7 +1439,10 @@ export class MarketDataService {
         ...(meta.description !== undefined && {
           description: meta.description,
         }),
-        ...(meta.marketType !== undefined && { marketType: meta.marketType }),
+        ...(meta.marketType !== undefined && {
+          marketType: meta.marketType,
+          ...(market.isNewMarket === true && { isNewMarket: false }),
+        }),
         ...(meta.keywords !== undefined && { keywords: meta.keywords }),
         ...(meta.tags !== undefined && { tags: meta.tags }),
         ...(meta.categories !== undefined && { categories: meta.categories }),

--- a/packages/perps-controller/src/services/TerminalMarketService.ts
+++ b/packages/perps-controller/src/services/TerminalMarketService.ts
@@ -111,6 +111,7 @@ const TerminalPerpetualItemStruct = type({
   minimumOrderSize: optional(number()),
   keywords: optional(nullable(array(string()))),
   tags: optional(nullable(array(string()))),
+  category: optional(nullable(string())),
   categories: optional(nullable(array(string()))),
   marketType: optional(nullable(string())),
   listedAt: optional(nullable(union([number(), string()]))),
@@ -633,13 +634,9 @@ export class TerminalMarketService {
     };
   }
 
-  #marketTypeFor(
-    dex: string,
-    category: string | null,
+  #categoryToMarketType(
+    category: string | null | undefined,
   ): TerminalAssetMetadata['marketType'] | undefined {
-    if (dex === 'main') {
-      return MarketCategory.CryptoCurrency;
-    }
     if (category === 'stocks') {
       return MarketCategory.Stock;
     }
@@ -650,6 +647,16 @@ export class TerminalMarketService {
       return category as TerminalAssetMetadata['marketType'];
     }
     return undefined;
+  }
+
+  #marketTypeFor(
+    dex: string,
+    category: string | null,
+  ): TerminalAssetMetadata['marketType'] | undefined {
+    if (dex === 'main') {
+      return MarketCategory.CryptoCurrency;
+    }
+    return this.#categoryToMarketType(category);
   }
 
   #cloneGlobalSnapshotResult(
@@ -788,6 +795,11 @@ export class TerminalMarketService {
       ) {
         entry.marketType =
           item.marketType as TerminalAssetMetadata['marketType'];
+      } else {
+        const fromCategory = this.#categoryToMarketType(item.category);
+        if (fromCategory) {
+          entry.marketType = fromCategory;
+        }
       }
 
       if (item.listedAt !== null && item.listedAt !== undefined) {

--- a/packages/perps-controller/tests/src/constants/hyperLiquidConfig.test.ts
+++ b/packages/perps-controller/tests/src/constants/hyperLiquidConfig.test.ts
@@ -24,6 +24,8 @@ describe('HIP3_ASSET_MARKET_TYPES', () => {
     expect(HIP3_ASSET_MARKET_TYPES['xyz:ARM']).toBe('stock');
     expect(HIP3_ASSET_MARKET_TYPES['xyz:BX']).toBe('stock');
     expect(HIP3_ASSET_MARKET_TYPES['xyz:LITE']).toBe('stock');
+    expect(HIP3_ASSET_MARKET_TYPES['xyz:CBRS']).toBe('stock');
+    expect(HIP3_ASSET_MARKET_TYPES['xyz:SPCX']).toBe('stock');
   });
 
   it('classifies USAR as stock (USA Rare Earth)', () => {
@@ -37,8 +39,6 @@ describe('HIP3_ASSET_MARKET_TYPES', () => {
   });
 
   it('classifies pre-IPO markets correctly', () => {
-    expect(HIP3_ASSET_MARKET_TYPES['xyz:CBRS']).toBe('pre-ipo');
-    expect(HIP3_ASSET_MARKET_TYPES['xyz:SPCX']).toBe('pre-ipo');
     expect(HIP3_ASSET_MARKET_TYPES['xyz:IPOP']).toBe('pre-ipo');
   });
 

--- a/packages/perps-controller/tests/src/services/MarketDataService.test.ts
+++ b/packages/perps-controller/tests/src/services/MarketDataService.test.ts
@@ -19,6 +19,7 @@ import type {
 } from '../../../src/types/index.js';
 import type { CandleData } from '../../../src/types/perps-types.js';
 import { resetPerpsRestCacheForTests } from '../../../src/utils/coalescePerpsRestRequest.js';
+import { matchesCategory } from '../../../src/utils/marketUtils.js';
 /* eslint-disable */
 import {
   createMockHyperLiquidProvider,
@@ -1683,9 +1684,83 @@ describe('MarketDataService', () => {
         expect(result[0]?.tags).toEqual(['top-10']);
         expect(result[0]?.categories).toEqual(['crypto']);
         expect(result[0]?.marketType).toBe('crypto');
+        expect(result[0]).not.toHaveProperty('isNewMarket');
         expect(result[1]?.name).toBe('Ethereum');
         expect(result[1]?.keywords).toEqual(['defi']);
         expect(result[1]?.description).toBeUndefined();
+      });
+
+      it('clears isNewMarket when Terminal metadata supplies a marketType', async () => {
+        const unitreeMarket: PerpsMarketData = {
+          symbol: 'xyz:UNITREE',
+          name: 'xyz:UNITREE',
+          maxLeverage: '10x',
+          price: '$1.00',
+          change24h: '+$0.10',
+          change24hPercent: '+10.00%',
+          volume: '$100000',
+          isHip3: true,
+          isNewMarket: true,
+        };
+        mockTerminalService.fetchMarkets.mockResolvedValue({
+          markets: [
+            {
+              name: 'xyz:UNITREE',
+              szDecimals: 0,
+              maxLeverage: 10,
+              marginTableId: 0,
+            },
+          ],
+          metadata: new Map<string, TerminalAssetMetadata>([
+            ['xyz:UNITREE', { name: 'Unitree', marketType: 'pre-ipo' }],
+          ]),
+        });
+        mockProvider.getMarketDataWithPrices.mockResolvedValue([unitreeMarket]);
+
+        const result = await serviceWithTerminal.getMarketDataWithPrices({
+          provider: mockProvider,
+          params: { useTerminalApi: true },
+          context: mockContext,
+        });
+
+        expect(result[0]?.marketType).toBe('pre-ipo');
+        expect(result[0]?.isNewMarket).toBe(false);
+        expect(matchesCategory(result[0] as PerpsMarketData, 'pre-ipo')).toBe(
+          true,
+        );
+        expect(matchesCategory(result[0] as PerpsMarketData, 'new')).toBe(
+          false,
+        );
+      });
+
+      it('preserves isNewMarket when Terminal metadata has no marketType', async () => {
+        const unitreeMarket: PerpsMarketData = {
+          symbol: 'xyz:UNITREE',
+          name: 'xyz:UNITREE',
+          maxLeverage: '10x',
+          price: '$1.00',
+          change24h: '+$0.10',
+          change24hPercent: '+10.00%',
+          volume: '$100000',
+          isHip3: true,
+          isNewMarket: true,
+        };
+        mockTerminalService.fetchMarkets.mockResolvedValue({
+          markets: terminalMarkets,
+          metadata: new Map<string, TerminalAssetMetadata>([
+            ['xyz:UNITREE', { name: 'Unitree' }],
+          ]),
+        });
+        mockProvider.getMarketDataWithPrices.mockResolvedValue([unitreeMarket]);
+
+        const result = await serviceWithTerminal.getMarketDataWithPrices({
+          provider: mockProvider,
+          params: { useTerminalApi: true },
+          context: mockContext,
+        });
+
+        expect(result[0]?.marketType).toBeUndefined();
+        expect(result[0]?.isNewMarket).toBe(true);
       });
 
       it('preserves provider name when terminal metadata omits name', async () => {

--- a/packages/perps-controller/tests/src/services/TerminalMarketService.test.ts
+++ b/packages/perps-controller/tests/src/services/TerminalMarketService.test.ts
@@ -432,7 +432,11 @@ describe('TerminalMarketService', () => {
         statusText: 'OK',
         json: () =>
           Promise.resolve([
-            { symbol: 'xyz:CBRS', name: 'Cerebras Systems', category: 'stocks' },
+            {
+              symbol: 'xyz:CBRS',
+              name: 'Cerebras Systems',
+              category: 'stocks',
+            },
           ]),
       } as Response);
 

--- a/packages/perps-controller/tests/src/services/TerminalMarketService.test.ts
+++ b/packages/perps-controller/tests/src/services/TerminalMarketService.test.ts
@@ -372,6 +372,91 @@ describe('TerminalMarketService', () => {
       expect(metadata.get('FOO')?.marketType).toBeUndefined();
     });
 
+    it('maps Terminal category pre_ipo to marketType pre-ipo when marketType is absent', async () => {
+      jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: () =>
+          Promise.resolve([
+            {
+              symbol: 'xyz:UNITREE',
+              name: 'Unitree Technology',
+              category: 'pre_ipo',
+            },
+            {
+              symbol: 'xyz:CXMT',
+              name: 'ChangXin Technology',
+              category: 'pre_ipo',
+            },
+            {
+              symbol: 'xyz:SKHY',
+              name: 'SK Hynix ADR',
+              category: 'pre_ipo',
+            },
+          ]),
+      } as Response);
+
+      const { metadata } = await service.fetchMarkets();
+
+      expect(metadata.get('xyz:UNITREE')?.marketType).toBe('pre-ipo');
+      expect(metadata.get('xyz:CXMT')?.marketType).toBe('pre-ipo');
+      expect(metadata.get('xyz:SKHY')?.marketType).toBe('pre-ipo');
+    });
+
+    it('prefers explicit marketType over category pre_ipo', async () => {
+      jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: () =>
+          Promise.resolve([
+            {
+              symbol: 'xyz:UNITREE',
+              name: 'Unitree Technology',
+              category: 'pre_ipo',
+              marketType: 'stock',
+            },
+          ]),
+      } as Response);
+
+      const { metadata } = await service.fetchMarkets();
+
+      expect(metadata.get('xyz:UNITREE')?.marketType).toBe('stock');
+    });
+
+    it('maps Terminal category stocks to marketType stock when marketType is absent', async () => {
+      jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: () =>
+          Promise.resolve([
+            { symbol: 'xyz:CBRS', name: 'Cerebras Systems', category: 'stocks' },
+          ]),
+      } as Response);
+
+      const { metadata } = await service.fetchMarkets();
+
+      expect(metadata.get('xyz:CBRS')?.marketType).toBe('stock');
+    });
+
+    it('does not map an unknown Terminal category to marketType', async () => {
+      jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: () =>
+          Promise.resolve([
+            { symbol: 'xyz:FOO', name: 'Foo', category: 'unknown' },
+          ]),
+      } as Response);
+
+      const { metadata } = await service.fetchMarkets();
+
+      expect(metadata.get('xyz:FOO')?.marketType).toBeUndefined();
+    });
+
     it('uses defaults for missing numeric fields', async () => {
       jest.spyOn(globalThis, 'fetch').mockResolvedValue({
         ok: true,


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## What is the current state of things and why does it need to change?

Mobile's Pre-IPO chip filters on `marketType === "pre-ipo"`. Production Terminal v1 already sends Unitree, CXMT, and SKHY as `category: "pre_ipo"`, but v1 `#extractMetadata` only copied `marketType` / `categories` and dropped `category`. Those markets left `marketType` unset and did not appear under Pre-IPO.

Cerebras (`xyz:CBRS`) and SpaceX (`xyz:SPCX`) are public. Terminal already classifies them as `stocks`, but `HIP3_ASSET_MARKET_TYPES` still tags them `pre-ipo` from an older client override, so they stay on the Pre-IPO chip when Terminal does not set `marketType`.

## What is the solution your changes offer and how does it work?

`#categoryToMarketType` is the single Terminal → client alias table (`pre_ipo` → `pre-ipo`, `stocks` → `stock`, plus passthrough of values already in `MarketCategory`). v2 `#marketTypeFor` and v1 `#extractMetadata` both use it. Explicit v1 `marketType` still wins.

When Terminal is on, Unitree / CXMT / SKHY get `pre-ipo` from `category`, and CBRS / SPCX get `stock`. `HIP3_ASSET_MARKET_TYPES` moves CBRS and SPCX to `stock` so the HyperLiquid-direct fallback matches. `xyz:IPOP` (Quantinuum) stays Pre-IPO.

## Are there any changes whose purpose might not obvious to those unfamiliar with the domain?

This is not a typo in the mobile filter and not an old-app shim. Terminal and the client use different field names and spellings today (`category: "pre_ipo"` vs `marketType: "pre-ipo"`). The controller is the adapter; changing the chip to compare `"pre_ipo"` would still miss Unitree (`marketType` is unset) and would drop markets that already use `"pre-ipo"`.

We do not map only `pre_ipo` and leave `stocks` alone. That was protecting the stale CBRS/SPCX Pre-IPO override.

## If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?

Only `@metamask/perps-controller` changed. No other package in this repo.

## If you had to upgrade a dependency, why did you do so?

No dependency upgrades.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized market classification and filter-bucket behavior in perps-controller; no auth, trading, or payment paths.
> 
> **Overview**
> Fixes Pre-IPO and stock category filters when Mobile uses Terminal v1 metadata: markets like Unitree were sent as `category: "pre_ipo"` but never got `marketType`, so they did not match `pre-ipo`.
> 
> **Terminal → client mapping:** Adds shared `#categoryToMarketType` (`pre_ipo` → `pre-ipo`, `stocks` → `stock`, plus valid `MarketCategory` passthrough). v1 `#extractMetadata` now reads `category` on the schema and uses this when `marketType` is missing; explicit `marketType` still wins. v2 `#marketTypeFor` delegates to the same helper.
> 
> **Enrichment parity:** When v1 Terminal metadata applies a `marketType`, `MarketDataService` clears `isNewMarket` so categorized HIP-3 markets are not also in the `new` filter (aligned with the v2 snapshot path).
> 
> **Static fallback:** Moves `xyz:CBRS` and `xyz:SPCX` from `pre-ipo` to `stock` in `HIP3_ASSET_MARKET_TYPES` when Terminal/HyperLiquid fallback is used; `xyz:IPOP` stays Pre-IPO.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d1b7ca56c2ffd6fa6f9505ba25d20a973121a6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->