### PR TITLE
feat(assets-controller): add RPC vs Accounts API balance reconciliation

### DIFF
--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `refreshAccountChainBalancesFromRpc` to fetch a single asset via RPC and Accounts API, report Sentry mismatches when Accounts API ≠ RPC or state ≠ Accounts API, and merge the RPC balance into state (no-op when basic functionality is off)
+- Add `refreshAccountChainBalancesFromRpc` to fetch a single asset via RPC and Accounts API, report Sentry mismatches when Accounts API ≠ RPC or state ≠ Accounts API, and merge the RPC balance into state (no-op when basic functionality is off or for staking vault assets) ([#9910](https://github.com/MetaMask/core/pull/9910))
 
 ### Changed
 

--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `refreshAccountChainBalancesFromRpc` to fetch a single asset via RPC and Accounts API, report Sentry mismatches when Accounts API ≠ RPC or state ≠ Accounts API, and merge the RPC balance into state (no-op when basic functionality is off)
+
 ### Changed
 
 - **BREAKING:** Subscribe to `AccountTreeController:initialized` / `:uninitialized` (typed as `AccountTreeControllerInitializedEvent` / `AccountTreeControllerUninitializedEvent`) so asset tracking starts only after the account tree is fully built, instead of on intermediate `AccountTreeController:stateChange` events during `init()` or on unlock before the tree is ready ([#9892](https://github.com/MetaMask/core/pull/9892))

--- a/packages/assets-controller/src/AssetsController.test.ts
+++ b/packages/assets-controller/src/AssetsController.test.ts
@@ -19,8 +19,10 @@ import type {
   AssetsControllerState,
 } from './AssetsController.js';
 import type { AccountsApiDataSourceConfig } from './data-sources/AccountsApiDataSource.js';
+import { AccountsApiDataSource } from './data-sources/AccountsApiDataSource.js';
 import type { PriceDataSourceConfig } from './data-sources/PriceDataSource.js';
 import { PriceDataSource } from './data-sources/PriceDataSource.js';
+import { RpcDataSource } from './data-sources/RpcDataSource.js';
 import { TokenDataSource } from './data-sources/TokenDataSource.js';
 import { buildDefaultAssetsInfo } from './defaults.js';
 import type { Assets3346MigrationState } from './migrations/healAssetsInfoMetadata.js';
@@ -3665,6 +3667,591 @@ describe('AssetsController', () => {
       );
 
       controller.destroy();
+    });
+  });
+
+  describe('refreshAccountChainBalancesFromRpc', () => {
+    it('does nothing when basic functionality is disabled', async () => {
+      await withController(
+        { isBasicFunctionality: () => false },
+        async ({ controller }) => {
+          const rpcFetchSpy = jest.spyOn(RpcDataSource.prototype, 'fetch');
+          const accountsApiFetchSpy = jest.spyOn(
+            AccountsApiDataSource.prototype,
+            'fetch',
+          );
+
+          await controller.refreshAccountChainBalancesFromRpc(
+            MOCK_ACCOUNT_ID,
+            MOCK_NATIVE_ASSET_ID,
+          );
+
+          expect(rpcFetchSpy).not.toHaveBeenCalled();
+          expect(accountsApiFetchSpy).not.toHaveBeenCalled();
+
+          rpcFetchSpy.mockRestore();
+          accountsApiFetchSpy.mockRestore();
+        },
+      );
+    });
+
+    it('does nothing when the account is not in the selected group', async () => {
+      await withController(async ({ controller }) => {
+        const rpcFetchSpy = jest.spyOn(RpcDataSource.prototype, 'fetch');
+        const accountsApiFetchSpy = jest.spyOn(
+          AccountsApiDataSource.prototype,
+          'fetch',
+        );
+
+        await controller.refreshAccountChainBalancesFromRpc(
+          'other-account-id' as AccountId,
+          MOCK_NATIVE_ASSET_ID,
+        );
+
+        expect(rpcFetchSpy).not.toHaveBeenCalled();
+        expect(accountsApiFetchSpy).not.toHaveBeenCalled();
+
+        rpcFetchSpy.mockRestore();
+        accountsApiFetchSpy.mockRestore();
+      });
+    });
+
+    it('throws when accountId is empty', async () => {
+      await withController(async ({ controller }) => {
+        await expect(
+          controller.refreshAccountChainBalancesFromRpc(
+            '' as AccountId,
+            MOCK_NATIVE_ASSET_ID,
+          ),
+        ).rejects.toThrow('accountId must be a non-empty string');
+      });
+    });
+
+    it('throws when assetId is invalid', async () => {
+      await withController(async ({ controller }) => {
+        await expect(
+          controller.refreshAccountChainBalancesFromRpc(
+            MOCK_ACCOUNT_ID,
+            'not-a-caip-19-id' as Caip19AssetId,
+          ),
+        ).rejects.toThrow('invalid CAIP-19 assetId');
+      });
+    });
+
+    it('updates state with the RPC balance when all sources agree', async () => {
+      const captureException = jest.fn();
+
+      await withController(
+        {
+          state: {
+            assetsBalance: {
+              [MOCK_ACCOUNT_ID]: {
+                [MOCK_NATIVE_ASSET_ID]: { amount: '1.5' },
+              },
+            },
+          },
+          controllerOptions: { captureException },
+        },
+        async ({ controller }) => {
+          const rpcFetchSpy = jest
+            .spyOn(RpcDataSource.prototype, 'fetch')
+            .mockResolvedValue({
+              assetsBalance: {
+                [MOCK_ACCOUNT_ID]: {
+                  [MOCK_NATIVE_ASSET_ID]: { amount: '1.5' },
+                },
+              },
+            });
+          const accountsApiFetchSpy = jest
+            .spyOn(AccountsApiDataSource.prototype, 'fetch')
+            .mockResolvedValue({
+              assetsBalance: {
+                [MOCK_ACCOUNT_ID]: {
+                  [MOCK_NATIVE_ASSET_ID]: { amount: '1.5' },
+                },
+              },
+            });
+
+          await controller.refreshAccountChainBalancesFromRpc(
+            MOCK_ACCOUNT_ID,
+            MOCK_NATIVE_ASSET_ID,
+          );
+
+          expect(captureException).not.toHaveBeenCalled();
+          expect(
+            controller.state.assetsBalance[MOCK_ACCOUNT_ID]?.[
+              MOCK_NATIVE_ASSET_ID
+            ],
+          ).toStrictEqual({ amount: '1.5' });
+          expect(accountsApiFetchSpy).toHaveBeenCalledWith(
+            expect.objectContaining({ forceUpdate: true }),
+          );
+
+          rpcFetchSpy.mockRestore();
+          accountsApiFetchSpy.mockRestore();
+        },
+      );
+    });
+
+    it('reports an Accounts API vs RPC mismatch and merges RPC into state', async () => {
+      const captureException = jest.fn();
+
+      await withController(
+        {
+          state: {
+            assetsBalance: {
+              [MOCK_ACCOUNT_ID]: {
+                [MOCK_NATIVE_ASSET_ID]: { amount: '2' },
+              },
+            },
+          },
+          controllerOptions: { captureException },
+        },
+        async ({ controller }) => {
+          const rpcFetchSpy = jest
+            .spyOn(RpcDataSource.prototype, 'fetch')
+            .mockResolvedValue({
+              assetsBalance: {
+                [MOCK_ACCOUNT_ID]: {
+                  [MOCK_NATIVE_ASSET_ID]: { amount: '3' },
+                },
+              },
+            });
+          const accountsApiFetchSpy = jest
+            .spyOn(AccountsApiDataSource.prototype, 'fetch')
+            .mockResolvedValue({
+              assetsBalance: {
+                [MOCK_ACCOUNT_ID]: {
+                  [MOCK_NATIVE_ASSET_ID]: { amount: '2' },
+                },
+              },
+            });
+
+          await controller.refreshAccountChainBalancesFromRpc(
+            MOCK_ACCOUNT_ID,
+            MOCK_NATIVE_ASSET_ID,
+          );
+
+          expect(captureException).toHaveBeenCalledWith(
+            expect.objectContaining({
+              message: expect.stringContaining('balance mismatch'),
+            }),
+          );
+          expect(
+            controller.state.assetsBalance[MOCK_ACCOUNT_ID]?.[
+              MOCK_NATIVE_ASSET_ID
+            ],
+          ).toStrictEqual({ amount: '3' });
+
+          rpcFetchSpy.mockRestore();
+          accountsApiFetchSpy.mockRestore();
+        },
+      );
+    });
+
+    it('reports a state vs Accounts API mismatch when RPC agrees with Accounts API', async () => {
+      const captureException = jest.fn();
+
+      await withController(
+        {
+          state: {
+            assetsBalance: {
+              [MOCK_ACCOUNT_ID]: {
+                [MOCK_NATIVE_ASSET_ID]: { amount: '1' },
+              },
+            },
+          },
+          controllerOptions: { captureException },
+        },
+        async ({ controller }) => {
+          const rpcFetchSpy = jest
+            .spyOn(RpcDataSource.prototype, 'fetch')
+            .mockResolvedValue({
+              assetsBalance: {
+                [MOCK_ACCOUNT_ID]: {
+                  [MOCK_NATIVE_ASSET_ID]: { amount: '2' },
+                },
+              },
+            });
+          const accountsApiFetchSpy = jest
+            .spyOn(AccountsApiDataSource.prototype, 'fetch')
+            .mockResolvedValue({
+              assetsBalance: {
+                [MOCK_ACCOUNT_ID]: {
+                  [MOCK_NATIVE_ASSET_ID]: { amount: '2' },
+                },
+              },
+            });
+
+          await controller.refreshAccountChainBalancesFromRpc(
+            MOCK_ACCOUNT_ID,
+            MOCK_NATIVE_ASSET_ID,
+          );
+
+          expect(captureException).toHaveBeenCalledWith(
+            expect.objectContaining({
+              message: expect.stringContaining('balance mismatch'),
+            }),
+          );
+          expect(
+            controller.state.assetsBalance[MOCK_ACCOUNT_ID]?.[
+              MOCK_NATIVE_ASSET_ID
+            ],
+          ).toStrictEqual({ amount: '2' });
+
+          rpcFetchSpy.mockRestore();
+          accountsApiFetchSpy.mockRestore();
+        },
+      );
+    });
+
+    it('does not report a mismatch when state matches Accounts API but RPC differs only via missing RPC', async () => {
+      const captureException = jest.fn();
+
+      await withController(
+        {
+          state: {
+            assetsBalance: {
+              [MOCK_ACCOUNT_ID]: {
+                [MOCK_NATIVE_ASSET_ID]: { amount: '2' },
+              },
+            },
+          },
+          controllerOptions: { captureException },
+        },
+        async ({ controller }) => {
+          const rpcFetchSpy = jest
+            .spyOn(RpcDataSource.prototype, 'fetch')
+            .mockResolvedValue({});
+          const accountsApiFetchSpy = jest
+            .spyOn(AccountsApiDataSource.prototype, 'fetch')
+            .mockResolvedValue({
+              assetsBalance: {
+                [MOCK_ACCOUNT_ID]: {
+                  [MOCK_NATIVE_ASSET_ID]: { amount: '2' },
+                },
+              },
+            });
+
+          await controller.refreshAccountChainBalancesFromRpc(
+            MOCK_ACCOUNT_ID,
+            MOCK_NATIVE_ASSET_ID,
+          );
+
+          expect(captureException).not.toHaveBeenCalled();
+          expect(
+            controller.state.assetsBalance[MOCK_ACCOUNT_ID]?.[
+              MOCK_NATIVE_ASSET_ID
+            ],
+          ).toStrictEqual({ amount: '2' });
+
+          rpcFetchSpy.mockRestore();
+          accountsApiFetchSpy.mockRestore();
+        },
+      );
+    });
+
+    it('does not update state when RPC returns no balance for the asset', async () => {
+      await withController(
+        {
+          state: {
+            assetsBalance: {
+              [MOCK_ACCOUNT_ID]: {
+                [MOCK_NATIVE_ASSET_ID]: { amount: '1' },
+              },
+            },
+          },
+        },
+        async ({ controller }) => {
+          const rpcFetchSpy = jest
+            .spyOn(RpcDataSource.prototype, 'fetch')
+            .mockResolvedValue({});
+          const accountsApiFetchSpy = jest
+            .spyOn(AccountsApiDataSource.prototype, 'fetch')
+            .mockResolvedValue({
+              assetsBalance: {
+                [MOCK_ACCOUNT_ID]: {
+                  [MOCK_NATIVE_ASSET_ID]: { amount: '1' },
+                },
+              },
+            });
+
+          await controller.refreshAccountChainBalancesFromRpc(
+            MOCK_ACCOUNT_ID,
+            MOCK_NATIVE_ASSET_ID,
+          );
+
+          expect(
+            controller.state.assetsBalance[MOCK_ACCOUNT_ID]?.[
+              MOCK_NATIVE_ASSET_ID
+            ],
+          ).toStrictEqual({ amount: '1' });
+
+          rpcFetchSpy.mockRestore();
+          accountsApiFetchSpy.mockRestore();
+        },
+      );
+    });
+
+    it('updates state when Accounts API fails but RPC succeeds', async () => {
+      const captureException = jest.fn();
+
+      await withController(
+        {
+          state: {
+            assetsBalance: {
+              [MOCK_ACCOUNT_ID]: {
+                [MOCK_NATIVE_ASSET_ID]: { amount: '1' },
+              },
+            },
+          },
+          controllerOptions: { captureException },
+        },
+        async ({ controller }) => {
+          const rpcFetchSpy = jest
+            .spyOn(RpcDataSource.prototype, 'fetch')
+            .mockResolvedValue({
+              assetsBalance: {
+                [MOCK_ACCOUNT_ID]: {
+                  [MOCK_NATIVE_ASSET_ID]: { amount: '2' },
+                },
+              },
+            });
+          const accountsApiFetchSpy = jest
+            .spyOn(AccountsApiDataSource.prototype, 'fetch')
+            .mockRejectedValue(new Error('Accounts API unavailable'));
+
+          await controller.refreshAccountChainBalancesFromRpc(
+            MOCK_ACCOUNT_ID,
+            MOCK_NATIVE_ASSET_ID,
+          );
+
+          expect(captureException).not.toHaveBeenCalled();
+          expect(
+            controller.state.assetsBalance[MOCK_ACCOUNT_ID]?.[
+              MOCK_NATIVE_ASSET_ID
+            ],
+          ).toStrictEqual({ amount: '2' });
+
+          rpcFetchSpy.mockRestore();
+          accountsApiFetchSpy.mockRestore();
+        },
+      );
+    });
+
+    it('fetches Accounts API before RPC', async () => {
+      await withController(async ({ controller }) => {
+        const callOrder: string[] = [];
+
+        jest
+          .spyOn(AccountsApiDataSource.prototype, 'fetch')
+          .mockImplementation(async () => {
+            callOrder.push('accountsApi');
+            return {
+              assetsBalance: {
+                [MOCK_ACCOUNT_ID]: {
+                  [MOCK_NATIVE_ASSET_ID]: { amount: '1' },
+                },
+              },
+            };
+          });
+        jest.spyOn(RpcDataSource.prototype, 'fetch').mockImplementation(async () => {
+          callOrder.push('rpc');
+          return {
+            assetsBalance: {
+              [MOCK_ACCOUNT_ID]: {
+                [MOCK_NATIVE_ASSET_ID]: { amount: '1' },
+              },
+            },
+          };
+        });
+
+        await controller.refreshAccountChainBalancesFromRpc(
+          MOCK_ACCOUNT_ID,
+          MOCK_NATIVE_ASSET_ID,
+        );
+
+        expect(callOrder).toStrictEqual(['accountsApi', 'rpc']);
+
+        jest.restoreAllMocks();
+      });
+    });
+
+    it('reports both Accounts API vs RPC and state vs Accounts API mismatches', async () => {
+      const captureException = jest.fn();
+
+      await withController(
+        {
+          state: {
+            assetsBalance: {
+              [MOCK_ACCOUNT_ID]: {
+                [MOCK_NATIVE_ASSET_ID]: { amount: '1' },
+              },
+            },
+          },
+          controllerOptions: { captureException },
+        },
+        async ({ controller }) => {
+          jest.spyOn(RpcDataSource.prototype, 'fetch').mockResolvedValue({
+            assetsBalance: {
+              [MOCK_ACCOUNT_ID]: {
+                [MOCK_NATIVE_ASSET_ID]: { amount: '3' },
+              },
+            },
+          });
+          jest.spyOn(AccountsApiDataSource.prototype, 'fetch').mockResolvedValue({
+            assetsBalance: {
+              [MOCK_ACCOUNT_ID]: {
+                [MOCK_NATIVE_ASSET_ID]: { amount: '2' },
+              },
+            },
+          });
+
+          await controller.refreshAccountChainBalancesFromRpc(
+            MOCK_ACCOUNT_ID,
+            MOCK_NATIVE_ASSET_ID,
+          );
+
+          expect(captureException).toHaveBeenCalledWith(
+            expect.objectContaining({
+              message: expect.stringMatching(
+                /state=1.*accountsApi=2.*rpc=3|accountsApi=2.*rpc=3.*state=1/,
+              ),
+            }),
+          );
+          expect(
+            controller.state.assetsBalance[MOCK_ACCOUNT_ID]?.[
+              MOCK_NATIVE_ASSET_ID
+            ],
+          ).toStrictEqual({ amount: '3' });
+
+          jest.restoreAllMocks();
+        },
+      );
+    });
+
+    it('does not report a mismatch when there is no state entry and Accounts API matches RPC', async () => {
+      const captureException = jest.fn();
+
+      await withController(
+        {
+          controllerOptions: { captureException },
+        },
+        async ({ controller }) => {
+          jest.spyOn(RpcDataSource.prototype, 'fetch').mockResolvedValue({
+            assetsBalance: {
+              [MOCK_ACCOUNT_ID]: {
+                [MOCK_NATIVE_ASSET_ID]: { amount: '5' },
+              },
+            },
+          });
+          jest.spyOn(AccountsApiDataSource.prototype, 'fetch').mockResolvedValue({
+            assetsBalance: {
+              [MOCK_ACCOUNT_ID]: {
+                [MOCK_NATIVE_ASSET_ID]: { amount: '5' },
+              },
+            },
+          });
+
+          await controller.refreshAccountChainBalancesFromRpc(
+            MOCK_ACCOUNT_ID,
+            MOCK_NATIVE_ASSET_ID,
+          );
+
+          expect(captureException).not.toHaveBeenCalled();
+          expect(
+            controller.state.assetsBalance[MOCK_ACCOUNT_ID]?.[
+              MOCK_NATIVE_ASSET_ID
+            ],
+          ).toStrictEqual({ amount: '5' });
+
+          jest.restoreAllMocks();
+        },
+      );
+    });
+
+    it('does not update state when RPC fetch fails but reports state vs Accounts API mismatch', async () => {
+      const captureException = jest.fn();
+
+      await withController(
+        {
+          state: {
+            assetsBalance: {
+              [MOCK_ACCOUNT_ID]: {
+                [MOCK_NATIVE_ASSET_ID]: { amount: '1' },
+              },
+            },
+          },
+          controllerOptions: { captureException },
+        },
+        async ({ controller }) => {
+          jest
+            .spyOn(RpcDataSource.prototype, 'fetch')
+            .mockRejectedValue(new Error('RPC unavailable'));
+          jest.spyOn(AccountsApiDataSource.prototype, 'fetch').mockResolvedValue({
+            assetsBalance: {
+              [MOCK_ACCOUNT_ID]: {
+                [MOCK_NATIVE_ASSET_ID]: { amount: '2' },
+              },
+            },
+          });
+
+          await controller.refreshAccountChainBalancesFromRpc(
+            MOCK_ACCOUNT_ID,
+            MOCK_NATIVE_ASSET_ID,
+          );
+
+          expect(captureException).toHaveBeenCalledWith(
+            expect.objectContaining({
+              message: expect.stringContaining('balance mismatch'),
+            }),
+          );
+          expect(
+            controller.state.assetsBalance[MOCK_ACCOUNT_ID]?.[
+              MOCK_NATIVE_ASSET_ID
+            ],
+          ).toStrictEqual({ amount: '1' });
+
+          jest.restoreAllMocks();
+        },
+      );
+    });
+
+    it('includes customAssets in the RPC request for ERC-20 assets', async () => {
+      await withController(async ({ controller }) => {
+        const rpcFetchSpy = jest
+          .spyOn(RpcDataSource.prototype, 'fetch')
+          .mockResolvedValue({
+            assetsBalance: {
+              [MOCK_ACCOUNT_ID]: {
+                [MOCK_ASSET_ID]: { amount: '100' },
+              },
+            },
+          });
+        const accountsApiFetchSpy = jest
+          .spyOn(AccountsApiDataSource.prototype, 'fetch')
+          .mockResolvedValue({
+            assetsBalance: {
+              [MOCK_ACCOUNT_ID]: {
+                [MOCK_ASSET_ID]: { amount: '100' },
+              },
+            },
+          });
+
+        await controller.refreshAccountChainBalancesFromRpc(
+          MOCK_ACCOUNT_ID,
+          MOCK_ASSET_ID,
+        );
+
+        expect(rpcFetchSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            customAssets: [MOCK_ASSET_ID],
+          }),
+        );
+
+        rpcFetchSpy.mockRestore();
+        accountsApiFetchSpy.mockRestore();
+      });
     });
   });
 });

--- a/packages/assets-controller/src/AssetsController.test.ts
+++ b/packages/assets-controller/src/AssetsController.test.ts
@@ -4055,16 +4055,18 @@ describe('AssetsController', () => {
               },
             };
           });
-        jest.spyOn(RpcDataSource.prototype, 'fetch').mockImplementation(async () => {
-          callOrder.push('rpc');
-          return {
-            assetsBalance: {
-              [MOCK_ACCOUNT_ID]: {
-                [MOCK_NATIVE_ASSET_ID]: { amount: '1' },
+        jest
+          .spyOn(RpcDataSource.prototype, 'fetch')
+          .mockImplementation(async () => {
+            callOrder.push('rpc');
+            return {
+              assetsBalance: {
+                [MOCK_ACCOUNT_ID]: {
+                  [MOCK_NATIVE_ASSET_ID]: { amount: '1' },
+                },
               },
-            },
-          };
-        });
+            };
+          });
 
         await controller.refreshAccountChainBalancesFromRpc(
           MOCK_ACCOUNT_ID,
@@ -4099,13 +4101,15 @@ describe('AssetsController', () => {
               },
             },
           });
-          jest.spyOn(AccountsApiDataSource.prototype, 'fetch').mockResolvedValue({
-            assetsBalance: {
-              [MOCK_ACCOUNT_ID]: {
-                [MOCK_NATIVE_ASSET_ID]: { amount: '2' },
+          jest
+            .spyOn(AccountsApiDataSource.prototype, 'fetch')
+            .mockResolvedValue({
+              assetsBalance: {
+                [MOCK_ACCOUNT_ID]: {
+                  [MOCK_NATIVE_ASSET_ID]: { amount: '2' },
+                },
               },
-            },
-          });
+            });
 
           await controller.refreshAccountChainBalancesFromRpc(
             MOCK_ACCOUNT_ID,
@@ -4115,7 +4119,7 @@ describe('AssetsController', () => {
           expect(captureException).toHaveBeenCalledWith(
             expect.objectContaining({
               message: expect.stringMatching(
-                /state=1.*accountsApi=2.*rpc=3|accountsApi=2.*rpc=3.*state=1/,
+                /state=1.*accountsApi=2.*rpc=3|accountsApi=2.*rpc=3.*state=1/u,
               ),
             }),
           );
@@ -4145,13 +4149,15 @@ describe('AssetsController', () => {
               },
             },
           });
-          jest.spyOn(AccountsApiDataSource.prototype, 'fetch').mockResolvedValue({
-            assetsBalance: {
-              [MOCK_ACCOUNT_ID]: {
-                [MOCK_NATIVE_ASSET_ID]: { amount: '5' },
+          jest
+            .spyOn(AccountsApiDataSource.prototype, 'fetch')
+            .mockResolvedValue({
+              assetsBalance: {
+                [MOCK_ACCOUNT_ID]: {
+                  [MOCK_NATIVE_ASSET_ID]: { amount: '5' },
+                },
               },
-            },
-          });
+            });
 
           await controller.refreshAccountChainBalancesFromRpc(
             MOCK_ACCOUNT_ID,
@@ -4188,13 +4194,15 @@ describe('AssetsController', () => {
           jest
             .spyOn(RpcDataSource.prototype, 'fetch')
             .mockRejectedValue(new Error('RPC unavailable'));
-          jest.spyOn(AccountsApiDataSource.prototype, 'fetch').mockResolvedValue({
-            assetsBalance: {
-              [MOCK_ACCOUNT_ID]: {
-                [MOCK_NATIVE_ASSET_ID]: { amount: '2' },
+          jest
+            .spyOn(AccountsApiDataSource.prototype, 'fetch')
+            .mockResolvedValue({
+              assetsBalance: {
+                [MOCK_ACCOUNT_ID]: {
+                  [MOCK_NATIVE_ASSET_ID]: { amount: '2' },
+                },
               },
-            },
-          });
+            });
 
           await controller.refreshAccountChainBalancesFromRpc(
             MOCK_ACCOUNT_ID,
@@ -4211,6 +4219,145 @@ describe('AssetsController', () => {
               MOCK_NATIVE_ASSET_ID
             ],
           ).toStrictEqual({ amount: '1' });
+
+          jest.restoreAllMocks();
+        },
+      );
+    });
+
+    it('does nothing for staking vault assets', async () => {
+      const STAKING_ASSET_ID =
+        'eip155:1/erc20:0x4fef9d741011476750a243ac70b9789a63dd47df' as Caip19AssetId;
+
+      await withController(
+        {
+          state: {
+            assetsBalance: {
+              [MOCK_ACCOUNT_ID]: {
+                [STAKING_ASSET_ID]: { amount: '1.5' },
+              },
+            },
+          },
+        },
+        async ({ controller }) => {
+          const rpcFetchSpy = jest.spyOn(RpcDataSource.prototype, 'fetch');
+          const accountsApiFetchSpy = jest.spyOn(
+            AccountsApiDataSource.prototype,
+            'fetch',
+          );
+
+          await controller.refreshAccountChainBalancesFromRpc(
+            MOCK_ACCOUNT_ID,
+            STAKING_ASSET_ID,
+          );
+
+          expect(rpcFetchSpy).not.toHaveBeenCalled();
+          expect(accountsApiFetchSpy).not.toHaveBeenCalled();
+          expect(
+            controller.state.assetsBalance[MOCK_ACCOUNT_ID]?.[STAKING_ASSET_ID],
+          ).toStrictEqual({ amount: '1.5' });
+
+          rpcFetchSpy.mockRestore();
+          accountsApiFetchSpy.mockRestore();
+        },
+      );
+    });
+
+    it('does not overwrite state when RPC reports a chain error', async () => {
+      const captureException = jest.fn();
+
+      await withController(
+        {
+          state: {
+            assetsBalance: {
+              [MOCK_ACCOUNT_ID]: {
+                [MOCK_NATIVE_ASSET_ID]: { amount: '1.5' },
+              },
+            },
+          },
+          controllerOptions: { captureException },
+        },
+        async ({ controller }) => {
+          jest.spyOn(RpcDataSource.prototype, 'fetch').mockResolvedValue({
+            assetsBalance: {
+              [MOCK_ACCOUNT_ID]: {
+                [MOCK_NATIVE_ASSET_ID]: { amount: '0' },
+              },
+            },
+            errors: {
+              'eip155:1': 'RPC fetch failed',
+            },
+          });
+          jest
+            .spyOn(AccountsApiDataSource.prototype, 'fetch')
+            .mockResolvedValue({
+              assetsBalance: {
+                [MOCK_ACCOUNT_ID]: {
+                  [MOCK_NATIVE_ASSET_ID]: { amount: '1.5' },
+                },
+              },
+            });
+
+          await controller.refreshAccountChainBalancesFromRpc(
+            MOCK_ACCOUNT_ID,
+            MOCK_NATIVE_ASSET_ID,
+          );
+
+          expect(captureException).not.toHaveBeenCalled();
+          expect(
+            controller.state.assetsBalance[MOCK_ACCOUNT_ID]?.[
+              MOCK_NATIVE_ASSET_ID
+            ],
+          ).toStrictEqual({ amount: '1.5' });
+
+          jest.restoreAllMocks();
+        },
+      );
+    });
+
+    it('does not report a mismatch when amounts differ only by formatting', async () => {
+      const captureException = jest.fn();
+
+      await withController(
+        {
+          state: {
+            assetsBalance: {
+              [MOCK_ACCOUNT_ID]: {
+                [MOCK_NATIVE_ASSET_ID]: { amount: '1.500' },
+              },
+            },
+          },
+          controllerOptions: { captureException },
+        },
+        async ({ controller }) => {
+          jest.spyOn(RpcDataSource.prototype, 'fetch').mockResolvedValue({
+            assetsBalance: {
+              [MOCK_ACCOUNT_ID]: {
+                [MOCK_NATIVE_ASSET_ID]: { amount: '1.5' },
+              },
+            },
+          });
+          jest
+            .spyOn(AccountsApiDataSource.prototype, 'fetch')
+            .mockResolvedValue({
+              assetsBalance: {
+                [MOCK_ACCOUNT_ID]: {
+                  [MOCK_NATIVE_ASSET_ID]: { amount: '1.5' },
+                },
+              },
+            });
+
+          await controller.refreshAccountChainBalancesFromRpc(
+            MOCK_ACCOUNT_ID,
+            MOCK_NATIVE_ASSET_ID,
+          );
+
+          expect(captureException).not.toHaveBeenCalled();
+          expect(
+            controller.state.assetsBalance[MOCK_ACCOUNT_ID]?.[
+              MOCK_NATIVE_ASSET_ID
+            ],
+          ).toStrictEqual({ amount: '1.5' });
 
           jest.restoreAllMocks();
         },

--- a/packages/assets-controller/src/AssetsController.ts
+++ b/packages/assets-controller/src/AssetsController.ts
@@ -225,6 +225,7 @@ const TRACE_UPDATE_PIPELINE = 'AssetsUpdatePipeline';
 const TRACE_UPDATE_PARENT = 'AssetsUpdateEnrichment';
 const TRACE_SUBSCRIPTION_ERROR = 'AssetsSubscriptionError';
 const TRACE_STATE_SIZE = 'AssetsStateSize';
+const TRACE_BALANCE_MISMATCH = 'AssetsBalanceMismatch';
 
 const log = createModuleLogger(projectLogger, CONTROLLER_NAME);
 
@@ -3869,6 +3870,137 @@ export class AssetsController extends BaseController<
     });
     this.#ensureNativeBalancesDefaultZero();
     this.#fetchMissingPricesWithoutCache(accounts, [caipChainId]);
+  }
+
+  /**
+   * Fetch a single asset balance via RPC and a fresh Accounts API snapshot,
+   * report mismatches to Sentry when either (1) Accounts API ≠ RPC or
+   * (2) state ≠ Accounts API, then merge the RPC amount into state.
+   *
+   * No-op when basic functionality is disabled (RPC-only mode).
+   *
+   * @param accountId - Account whose balance should be refreshed.
+   * @param assetId - CAIP-19 asset ID to refresh (chain is derived from this).
+   */
+  async refreshAccountChainBalancesFromRpc(
+    accountId: AccountId,
+    assetId: Caip19AssetId,
+  ): Promise<void> {
+    if (!this.#isBasicFunctionality()) {
+      return;
+    }
+
+    this.#assertNonEmptyAccountId(
+      accountId,
+      'refreshAccountChainBalancesFromRpc',
+    );
+
+    const normalizedAssetId = this.#normalizeAssetIdOrThrow(
+      assetId,
+      'refreshAccountChainBalancesFromRpc',
+    );
+
+    const account = this.#getSelectedAccounts().find(
+      (candidate) => candidate.id === accountId,
+    );
+    if (!account) {
+      return;
+    }
+
+    const chainId = extractChainId(normalizedAssetId);
+    const stateAmount =
+      this.state.assetsBalance[accountId]?.[normalizedAssetId]?.amount;
+
+    const request = this.#buildDataRequest([account], [chainId], {
+      dataTypes: ['balance'],
+      ...(this.#getAssetType(normalizedAssetId) === 'erc20'
+        ? { customAssets: [normalizedAssetId] }
+        : {}),
+    });
+
+    let rpcAmount: string | undefined;
+    let accountsApiAmount: string | undefined;
+
+    try {
+      const accountsApiResponse = await this.#accountsApiDataSource.fetch({
+        ...request,
+        forceUpdate: true,
+      });
+      accountsApiAmount =
+        accountsApiResponse.assetsBalance?.[accountId]?.[normalizedAssetId]
+          ?.amount;
+    } catch (error) {
+      log('Accounts API balance fetch failed during RPC reconciliation', {
+        accountId,
+        assetId: normalizedAssetId,
+        error,
+      });
+    }
+
+    try {
+      const rpcResponse = await this.#rpcDataSource.fetch(request);
+      rpcAmount =
+        rpcResponse.assetsBalance?.[accountId]?.[normalizedAssetId]?.amount;
+    } catch (error) {
+      log('RPC balance refresh failed', {
+        accountId,
+        assetId: normalizedAssetId,
+        error,
+      });
+    }
+
+    const accountsApiRpcMismatch =
+      accountsApiAmount !== undefined &&
+      rpcAmount !== undefined &&
+      accountsApiAmount !== rpcAmount;
+    const stateAccountsApiMismatch =
+      stateAmount !== undefined &&
+      accountsApiAmount !== undefined &&
+      stateAmount !== accountsApiAmount;
+
+    if (accountsApiRpcMismatch || stateAccountsApiMismatch) {
+      const mismatchMessage = `AssetsController balance mismatch for ${normalizedAssetId} (account ${accountId}): state=${stateAmount ?? 'n/a'}, accountsApi=${accountsApiAmount ?? 'n/a'}, rpc=${rpcAmount ?? 'n/a'}`;
+
+      log(mismatchMessage, {
+        accountId,
+        assetId: normalizedAssetId,
+        chainId,
+        stateAmount,
+        accountsApiAmount,
+        rpcAmount,
+        accountsApiRpcMismatch,
+        stateAccountsApiMismatch,
+      });
+
+      this.#captureException?.(new Error(mismatchMessage));
+      emitTrace({
+        name: TRACE_BALANCE_MISMATCH,
+        trace: this.#trace,
+        data: {
+          account_id: accountId,
+          asset_id: normalizedAssetId,
+          chain_id: chainId,
+          state_amount: stateAmount ?? 'n/a',
+          accounts_api_amount: accountsApiAmount ?? 'n/a',
+          rpc_amount: rpcAmount ?? 'n/a',
+          accounts_api_rpc_mismatch: accountsApiRpcMismatch,
+          state_accounts_api_mismatch: stateAccountsApiMismatch,
+        },
+      });
+    }
+
+    if (rpcAmount === undefined) {
+      return;
+    }
+
+    await this.#updateState({
+      assetsBalance: {
+        [accountId]: {
+          [normalizedAssetId]: { amount: rpcAmount },
+        },
+      },
+      updateMode: 'merge',
+    });
   }
 
   /**

--- a/packages/assets-controller/src/AssetsController.ts
+++ b/packages/assets-controller/src/AssetsController.ts
@@ -3907,9 +3907,24 @@ export class AssetsController extends BaseController<
       return;
     }
 
+    if (isStakingContractAssetId(normalizedAssetId)) {
+      return;
+    }
+
     const chainId = extractChainId(normalizedAssetId);
     const stateAmount =
       this.state.assetsBalance[accountId]?.[normalizedAssetId]?.amount;
+    const assetDecimals = (
+      this.state.assetsInfo[normalizedAssetId] as
+        | { decimals?: number }
+        | undefined
+    )?.decimals;
+    const normalizeForCompare = (
+      amount: string | undefined,
+    ): string | undefined =>
+      amount === undefined
+        ? undefined
+        : normalizeAmountString(amount, assetDecimals);
 
     const request = this.#buildDataRequest([account], [chainId], {
       dataTypes: ['balance'],
@@ -3939,8 +3954,17 @@ export class AssetsController extends BaseController<
 
     try {
       const rpcResponse = await this.#rpcDataSource.fetch(request);
-      rpcAmount =
-        rpcResponse.assetsBalance?.[accountId]?.[normalizedAssetId]?.amount;
+      if (rpcResponse.errors?.[chainId] === undefined) {
+        rpcAmount =
+          rpcResponse.assetsBalance?.[accountId]?.[normalizedAssetId]?.amount;
+      } else {
+        log('RPC balance refresh failed for chain during reconciliation', {
+          accountId,
+          assetId: normalizedAssetId,
+          chainId,
+          error: rpcResponse.errors[chainId],
+        });
+      }
     } catch (error) {
       log('RPC balance refresh failed', {
         accountId,
@@ -3949,14 +3973,18 @@ export class AssetsController extends BaseController<
       });
     }
 
+    const normalizedStateAmount = normalizeForCompare(stateAmount);
+    const normalizedAccountsApiAmount = normalizeForCompare(accountsApiAmount);
+    const normalizedRpcAmount = normalizeForCompare(rpcAmount);
+
     const accountsApiRpcMismatch =
-      accountsApiAmount !== undefined &&
-      rpcAmount !== undefined &&
-      accountsApiAmount !== rpcAmount;
+      normalizedAccountsApiAmount !== undefined &&
+      normalizedRpcAmount !== undefined &&
+      normalizedAccountsApiAmount !== normalizedRpcAmount;
     const stateAccountsApiMismatch =
-      stateAmount !== undefined &&
-      accountsApiAmount !== undefined &&
-      stateAmount !== accountsApiAmount;
+      normalizedStateAmount !== undefined &&
+      normalizedAccountsApiAmount !== undefined &&
+      normalizedStateAmount !== normalizedAccountsApiAmount;
 
     if (accountsApiRpcMismatch || stateAccountsApiMismatch) {
       const mismatchMessage = `AssetsController balance mismatch for ${normalizedAssetId} (account ${accountId}): state=${stateAmount ?? 'n/a'}, accountsApi=${accountsApiAmount ?? 'n/a'}, rpc=${rpcAmount ?? 'n/a'}`;


### PR DESCRIPTION
## Summary

- Add `refreshAccountChainBalancesFromRpc(accountId, assetId)` to fetch a single asset balance via Accounts API (`forceUpdate`) and RPC, compare the two sources against each other and against current state, and report Sentry issues when Accounts API ≠ RPC or state ≠ Accounts API.
- Merge the RPC balance into controller state when RPC returns a value.
- No-op when basic functionality is disabled (RPC-only mode).

## Test plan

- [x] `yarn workspace @metamask/assets-controller run jest --no-coverage src/AssetsController.test.ts -t "refreshAccountChainBalancesFromRpc"` (15 tests)
- [ ] `yarn workspace @metamask/assets-controller run build`


Made with [Cursor](https://cursor.com)