### PR TITLE
fix(base-data-service): replace cached page in place on re-fetch

### DIFF
--- a/packages/base-data-service/CHANGELOG.md
+++ b/packages/base-data-service/CHANGELOG.md
@@ -46,6 +46,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/messenger` from `^1.2.0` to `^2.0.0` ([#9392](https://github.com/MetaMask/core/pull/9392))
 - Add dependency `cockatiel` (`^3.1.2`) ([#9418](https://github.com/MetaMask/core/pull/9418))
 
+### Fixed
+
+- Prevent `fetchInfiniteQuery` from duplicating a page when re-fetching a page param that is already present in the cache ([#9900](https://github.com/MetaMask/core/issues/9900))
+  - The fresh page now replaces the cached one in place instead of being appended or prepended, which previously left duplicate, out-of-order pages in the cache.
+
 ## [0.1.3]
 
 ### Changed

--- a/packages/base-data-service/CHANGELOG.md
+++ b/packages/base-data-service/CHANGELOG.md
@@ -48,7 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Prevent `fetchInfiniteQuery` from duplicating a page when re-fetching a page param that is already present in the cache ([#9900](https://github.com/MetaMask/core/issues/9900))
+- Prevent `fetchInfiniteQuery` from duplicating a page when re-fetching a page param that is already present in the cache ([#9915](https://github.com/MetaMask/core/pull/9915), [#9900](https://github.com/MetaMask/core/issues/9900))
   - The fresh page now replaces the cached one in place instead of being appended or prepended, which previously left duplicate, out-of-order pages in the cache.
 
 ## [0.1.3]

--- a/packages/base-data-service/src/BaseDataService.test.ts
+++ b/packages/base-data-service/src/BaseDataService.test.ts
@@ -215,6 +215,55 @@ describe('BaseDataService', () => {
     expect(cacheUpdate.state.queries[0].state.data.pages).toHaveLength(1);
   });
 
+  it('does not corrupt the cache when refetching a page with no adjacent pages', async () => {
+    cleanAll();
+    const messenger = new Messenger({ namespace: serviceName });
+    const service = new ExampleDataService(messenger);
+    const publishSpy = jest.spyOn(messenger, 'publish');
+
+    const pageBody = {
+      data: [
+        {
+          hash: '0xcecd28aa5bd781ffd2a6d960578ffc6c89ac390e8d02baebc977a827956394e9',
+          timestamp: '2025-12-29T11:51:08.000Z',
+        },
+      ],
+      pageInfo: {
+        count: 1,
+        hasNextPage: false,
+        hasPreviousPage: false,
+        startCursor: null,
+        endCursor: null,
+      },
+    };
+    mockTransactionsPage2({ status: 200, body: pageBody });
+    mockTransactionsPage2({ status: 200, body: pageBody });
+
+    const page = await service.getActivity(TEST_ADDRESS, {
+      after: TRANSACTIONS_PAGE_2_CURSOR,
+    });
+    expect(page.data).toHaveLength(1);
+
+    // Refetch a page whose getNextPageParam and getPreviousPageParam both
+    // return null. query-core skips the fetch entirely, so no duplicate is
+    // added and the cache must not be corrupted by pop/shift.
+    const pageAgain = await service.getActivity(TEST_ADDRESS, {
+      after: TRANSACTIONS_PAGE_2_CURSOR,
+    });
+    expect(pageAgain.data).toStrictEqual(page.data);
+
+    const queryKey = ['ExampleDataService:getActivity', TEST_ADDRESS];
+    const hash = hashKey(queryKey);
+    const cacheUpdate = publishSpy.mock.calls
+      .filter(([event]) => event === `ExampleDataService:cacheUpdated:${hash}`)
+      .at(-1)?.[1] as {
+      state: { queries: [{ state: { data: { pages: unknown[] } } }] };
+    };
+
+    // The cache must still hold the single page.
+    expect(cacheUpdate.state.queries[0].state.data.pages).toHaveLength(1);
+  });
+
   it('emits `:cacheUpdated` events when cache is updated', async () => {
     const messenger = new Messenger({ namespace: serviceName });
     const service = new ExampleDataService(messenger);

--- a/packages/base-data-service/src/BaseDataService.test.ts
+++ b/packages/base-data-service/src/BaseDataService.test.ts
@@ -121,6 +121,100 @@ describe('BaseDataService', () => {
     expect(page2.data).not.toStrictEqual(page3.data);
   });
 
+  it('replaces an already-cached page in place when fetching it again', async () => {
+    cleanAll();
+    const messenger = new Messenger({ namespace: serviceName });
+    const service = new ExampleDataService(messenger);
+    const publishSpy = jest.spyOn(messenger, 'publish');
+
+    const page2Body = {
+      data: [
+        {
+          hash: '0xcecd28aa5bd781ffd2a6d960578ffc6c89ac390e8d02baebc977a827956394e9',
+          timestamp: '2025-12-29T11:51:08.000Z',
+        },
+      ],
+      pageInfo: {
+        count: 1,
+        hasNextPage: false,
+        hasPreviousPage: true,
+        startCursor: 'page1-cursor',
+        endCursor: 'page3-cursor',
+      },
+    };
+    mockTransactionsPage2({ status: 200, body: page2Body });
+    mockTransactionsPage2({ status: 200, body: page2Body });
+
+    const page2 = await service.getActivity(TEST_ADDRESS, {
+      after: TRANSACTIONS_PAGE_2_CURSOR,
+    });
+    expect(page2.data).toHaveLength(1);
+
+    // A refetch re-requests a page that is already present in the cache.
+    const page2Again = await service.getActivity(TEST_ADDRESS, {
+      after: TRANSACTIONS_PAGE_2_CURSOR,
+    });
+    expect(page2Again.data).toStrictEqual(page2.data);
+
+    const queryKey = ['ExampleDataService:getActivity', TEST_ADDRESS];
+    const hash = hashKey(queryKey);
+    const cacheUpdate = publishSpy.mock.calls
+      .filter(([event]) => event === `ExampleDataService:cacheUpdated:${hash}`)
+      .at(-1)?.[1] as {
+      state: { queries: [{ state: { data: { pages: unknown[] } } }] };
+    };
+
+    // The cache must hold each page exactly once.
+    expect(cacheUpdate.state.queries[0].state.data.pages).toHaveLength(1);
+  });
+
+  it('replaces an already-cached page in place when fetching it again in the forward direction', async () => {
+    cleanAll();
+    const messenger = new Messenger({ namespace: serviceName });
+    const service = new ExampleDataService(messenger);
+    const publishSpy = jest.spyOn(messenger, 'publish');
+
+    const page2Body = {
+      data: [
+        {
+          hash: '0xcecd28aa5bd781ffd2a6d960578ffc6c89ac390e8d02baebc977a827956394e9',
+          timestamp: '2025-12-29T11:51:08.000Z',
+        },
+      ],
+      pageInfo: {
+        count: 1,
+        hasNextPage: true,
+        hasPreviousPage: false,
+        startCursor: null,
+        endCursor: TRANSACTIONS_PAGE_2_CURSOR,
+      },
+    };
+    mockTransactionsPage2({ status: 200, body: page2Body });
+    mockTransactionsPage2({ status: 200, body: page2Body });
+
+    const page2 = await service.getActivity(TEST_ADDRESS, {
+      after: TRANSACTIONS_PAGE_2_CURSOR,
+    });
+    expect(page2.data).toHaveLength(1);
+
+    // A refetch re-requests a page that is already present in the cache.
+    const page2Again = await service.getActivity(TEST_ADDRESS, {
+      after: TRANSACTIONS_PAGE_2_CURSOR,
+    });
+    expect(page2Again.data).toStrictEqual(page2.data);
+
+    const queryKey = ['ExampleDataService:getActivity', TEST_ADDRESS];
+    const hash = hashKey(queryKey);
+    const cacheUpdate = publishSpy.mock.calls
+      .filter(([event]) => event === `ExampleDataService:cacheUpdated:${hash}`)
+      .at(-1)?.[1] as {
+      state: { queries: [{ state: { data: { pages: unknown[] } } }] };
+    };
+
+    // The cache must hold each page exactly once.
+    expect(cacheUpdate.state.queries[0].state.data.pages).toHaveLength(1);
+  });
+
   it('emits `:cacheUpdated` events when cache is updated', async () => {
     const messenger = new Messenger({ namespace: serviceName });
     const service = new ExampleDataService(messenger);

--- a/packages/base-data-service/src/BaseDataService.ts
+++ b/packages/base-data-service/src/BaseDataService.ts
@@ -333,6 +333,11 @@ export class BaseDataService<
     }
 
     const { pages, pageParams } = query.state.data;
+
+    const existingIndex = pageParams.findIndex((param) =>
+      deepEqual(param, pageParam),
+    );
+
     const next = options.getNextPageParam(
       pages[pages.length - 1],
       pages,
@@ -346,6 +351,28 @@ export class BaseDataService<
       { ...query.options, meta: { pageParam } },
       { meta: { fetchMore: { direction } } },
     );
+
+    if (existingIndex !== -1) {
+      // The requested page was already cached. `query.fetch` appended or
+      // prepended a fresh copy instead of replacing it, which would leave
+      // duplicate, out-of-order pages in the cache. Collapse the duplicate
+      // and keep the fresh page at the original position.
+      const isForward = direction === 'forward';
+      const nextPages = [...result.pages];
+      const nextPageParams = [...result.pageParams];
+      const freshPage = isForward ? nextPages.pop() : nextPages.shift();
+      if (isForward) {
+        nextPageParams.pop();
+      } else {
+        nextPageParams.shift();
+      }
+      nextPages[existingIndex] = freshPage as TData;
+      this.#queryClient.setQueryData(options.queryKey, {
+        pages: nextPages,
+        pageParams: nextPageParams,
+      });
+      return freshPage as TData;
+    }
 
     const pageIndex = result.pageParams.findIndex((param) =>
       deepEqual(param, pageParam),

--- a/packages/base-data-service/src/BaseDataService.ts
+++ b/packages/base-data-service/src/BaseDataService.ts
@@ -353,25 +353,33 @@ export class BaseDataService<
     );
 
     if (existingIndex !== -1) {
-      // The requested page was already cached. `query.fetch` appended or
-      // prepended a fresh copy instead of replacing it, which would leave
+      // The requested page was already cached. `query.fetch` appends or
+      // prepends a fresh copy instead of replacing it, which would leave
       // duplicate, out-of-order pages in the cache. Collapse the duplicate
       // and keep the fresh page at the original position.
-      const isForward = direction === 'forward';
-      const nextPages = [...result.pages];
-      const nextPageParams = [...result.pageParams];
-      const freshPage = isForward ? nextPages.pop() : nextPages.shift();
-      if (isForward) {
-        nextPageParams.pop();
-      } else {
-        nextPageParams.shift();
+      //
+      // `query.fetch` may skip the fetch entirely when
+      // `getNextPageParam`/`getPreviousPageParam` returns null (no more
+      // pages in that direction). In that case `result.pages` is the
+      // existing data unchanged, so there is no duplicate to collapse.
+      if (result.pages.length > pages.length) {
+        const isForward = direction === 'forward';
+        const nextPages = [...result.pages];
+        const nextPageParams = [...result.pageParams];
+        const freshPage = isForward ? nextPages.pop() : nextPages.shift();
+        if (isForward) {
+          nextPageParams.pop();
+        } else {
+          nextPageParams.shift();
+        }
+        nextPages[existingIndex] = freshPage as TData;
+        this.#queryClient.setQueryData(options.queryKey, {
+          pages: nextPages,
+          pageParams: nextPageParams,
+        });
+        return freshPage as TData;
       }
-      nextPages[existingIndex] = freshPage as TData;
-      this.#queryClient.setQueryData(options.queryKey, {
-        pages: nextPages,
-        pageParams: nextPageParams,
-      });
-      return freshPage as TData;
+      return pages[existingIndex];
     }
 
     const pageIndex = result.pageParams.findIndex((param) =>


### PR DESCRIPTION
## Explanation

Fixes #9900

`BaseDataService.fetchInfiniteQuery` forwarded re-fetches of an already-cached page param to `query.fetch` with a `fetchMore` direction. query-core's infinite-query behavior merges a fetched page by appending (forward) or prepending (backward) it, so re-requesting a page that was already in the cache left a **duplicate, out-of-order copy** in the cache. As the issue reports, the service cache grew on every refetch (e.g. `[1, 2]` → `[2, 1, 2]` → `[2, 1, 2, 3]`), and a newly hydrating observer could briefly receive the corrupted pages.

The fix detects that the requested page param is already present before the fetch, and after the fetch completes, collapses the edge-merged duplicate and places the fresh page at the original index via `setQueryData`. The fresh page is returned to the caller.

## Changes

- `fetchInfiniteQuery`: record the existing page index before fetching; when present, normalize the merged result so the cache holds each page exactly once, in order, with fresh data.
- Tests: two new cases covering the backward and forward `fetchMore` directions, asserting the cache holds each page once after a re-fetch.

## Checklist

- [x] Tests added/updated for the change (RED before the fix: cache held 2 copies; GREEN after)
- [x] `yarn workspace @metamask/base-data-service run test` passes (100% statements/lines/functions, branches above threshold)
- [x] `yarn lint:tsc` and ESLint on the changed files pass
- [x] Changelog entry added and validated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches infinite-query cache merge in BaseDataService, which can affect paginated data for all subclasses. Logic is small and covered by tests, but incorrect collapse would still corrupt page order.
> 
> **Overview**
> Stops `fetchInfiniteQuery` from duplicating pages when the same page param is requested again. query-core was appending or prepending a fresh copy, so the cache grew and went out of order.
> 
> If the page param is already in the cache, the extra merged page is collapsed and the fresh data is written back at the original index via `setQueryData`. If query-core skips the fetch (no next/previous page), the existing page is returned unchanged.
> 
> Tests cover backward and forward refetch, plus a no-adjacent-pages case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f7c5ad09f78c7ea6974e166465c307498611bba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->