### PR TITLE
feat(client-utils): add shared mobile activity types

### DIFF
--- a/packages/client-utils/CHANGELOG.md
+++ b/packages/client-utils/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `stake` / `unstake` activity kinds and a `PerpsOrderKind` type covering every perps order kind ([#9916](https://github.com/MetaMask/core/pull/9916))
+- Add `ActivityItem` variants for staking, prediction, and perps activity kinds that previously had no matching data shape ([#9916](https://github.com/MetaMask/core/pull/9916))
+
 ### Changed
 
 - Bump `@metamask/core-backend` from `^8.1.1` to `^8.1.2` ([#9886](https://github.com/MetaMask/core/pull/9886))

--- a/packages/client-utils/src/types.ts
+++ b/packages/client-utils/src/types.ts
@@ -1,6 +1,18 @@
 import type { ValueTransfer as _ValueTransfer } from '@metamask/core-backend';
 import type { CaipChainId } from '@metamask/utils';
 
+export type PerpsOrderKind =
+  | 'marketShort'
+  | 'stopMarketCloseShort'
+  | 'marketCloseShort'
+  | 'limitShort'
+  | 'limitCloseShort'
+  | 'marketLong'
+  | 'stopMarketCloseLong'
+  | 'marketCloseLong'
+  | 'limitLong'
+  | 'limitCloseLong';
+
 export type ActivityKind =
   | 'receive'
   | 'sell'
@@ -25,6 +37,8 @@ export type ActivityKind =
   | 'smartAccountUpgrade'
   | 'lendingDeposit'
   | 'lendingWithdrawal'
+  | 'stake'
+  | 'unstake'
   | 'predictionsAddFunds'
   | 'predictionsWithdrawFunds'
   | 'predictionClaimWinnings'
@@ -44,9 +58,7 @@ export type ActivityKind =
   | 'perpsReceivedFundingFees'
   | 'perpsCloseShortTakeProfit'
   | 'perpsCloseLongTakeProfit'
-  | 'marketShort'
-  | 'stopMarketCloseShort'
-  | 'marketCloseShort'
+  | PerpsOrderKind
   | 'assetActivation'
   | 'assetDeactivation'
   | 'rampBuy'
@@ -162,6 +174,39 @@ export type ActivityItem =
         fiat?: FiatAmount;
         networkFee?: FiatAmount;
         token?: TokenAmount;
+      }
+    >
+  | ActivityData<
+      | 'stake'
+      | 'unstake'
+      | 'sell'
+      | 'contractDeployment'
+      | 'smartAccountUpgrade'
+      | 'predictionsAddFunds'
+      | 'predictionsWithdrawFunds'
+      | 'predictionClaimWinnings'
+      | 'predictionCashedOut'
+      | 'predictionPlaced'
+      | 'perpsOpenLong'
+      | 'perpsCloseLong'
+      | 'perpsCloseLongLiquidated'
+      | 'perpsCloseLongStopLoss'
+      | 'perpsOpenShort'
+      | 'perpsCloseShort'
+      | 'perpsCloseShortLiquidated'
+      | 'perpsCloseShortStopLoss'
+      | 'perpsPaidFundingFees'
+      | 'perpsReceivedFundingFees'
+      | 'perpsCloseShortTakeProfit'
+      | 'perpsCloseLongTakeProfit'
+      | PerpsOrderKind,
+      {
+        from?: string;
+        to?: string;
+        token?: TokenAmount;
+        sourceToken?: TokenAmount;
+        destinationToken?: TokenAmount;
+        fees?: Fee[];
       }
     >
   | ActivityData<


### PR DESCRIPTION
## Explanation

Mobile still extends `ActivityKind` and `ActivityItem` locally for staking, prediction, and perps activity. This adds those remaining variants to `@metamask/client-utils` so Mobile can remove its temporary type shim.

## References

- Related to https://github.com/MetaMask/metamask-mobile/pull/35059

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e68fb6d761c3b5b30f397013fd64d2587dc6e15c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->