### PR TITLE
refactor!: drop `profile-sync-controller` dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,6 @@ linkStyle default opacity:0.5
   config_registry_controller --> keyring_controller;
   config_registry_controller --> messenger;
   config_registry_controller --> polling_controller;
-  config_registry_controller --> profile_sync_controller;
   config_registry_controller --> remote_feature_flag_controller;
   connectivity_controller --> base_controller;
   connectivity_controller --> messenger;

--- a/packages/config-registry-controller/CHANGELOG.md
+++ b/packages/config-registry-controller/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `ConfigRegistryApiEnv` enum to select the API environment for the service ([#0000](https://github.com/MetaMask/core/pull/0000))
+
 ### Changed
 
+- **BREAKING:** The `env` optional constructor option type is now `ConfigRegistryApiEnv` ([#0000](https://github.com/MetaMask/core/pull/0000))
+  - Previously, constructor options were reusing the `SDK.Env` enum from `@metamask/profile-sync-controller`.
 - Bump `@metamask/superstruct` from `^3.1.0` to `^3.4.1` ([#9754](https://github.com/MetaMask/core/pull/9754))
 - Bump `@metamask/keyring-controller` from `^27.1.0` to `^27.1.1` ([#9791](https://github.com/MetaMask/core/pull/9791))
 

--- a/packages/config-registry-controller/CHANGELOG.md
+++ b/packages/config-registry-controller/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `ConfigRegistryApiEnv` enum to select the API environment for the service ([#0000](https://github.com/MetaMask/core/pull/0000))
+- Add `ConfigRegistryApiEnv` enum to select the API environment for the service ([#9918](https://github.com/MetaMask/core/pull/9918))
 
 ### Changed
 
-- **BREAKING:** The `env` optional constructor option type is now `ConfigRegistryApiEnv` ([#0000](https://github.com/MetaMask/core/pull/0000))
+- **BREAKING:** The `env` optional constructor option type is now `ConfigRegistryApiEnv` ([#9918](https://github.com/MetaMask/core/pull/9918))
   - Previously, constructor options were reusing the `SDK.Env` enum from `@metamask/profile-sync-controller`.
 - Bump `@metamask/superstruct` from `^3.1.0` to `^3.4.1` ([#9754](https://github.com/MetaMask/core/pull/9754))
 - Bump `@metamask/keyring-controller` from `^27.1.0` to `^27.1.1` ([#9791](https://github.com/MetaMask/core/pull/9791))

--- a/packages/config-registry-controller/package.json
+++ b/packages/config-registry-controller/package.json
@@ -61,7 +61,6 @@
     "@metamask/keyring-controller": "^27.1.1",
     "@metamask/messenger": "^2.0.0",
     "@metamask/polling-controller": "^16.0.9",
-    "@metamask/profile-sync-controller": "^29.0.0",
     "@metamask/remote-feature-flag-controller": "^5.0.0",
     "@metamask/superstruct": "^3.4.1",
     "@metamask/utils": "^11.11.0",

--- a/packages/config-registry-controller/src/config-registry-api-service/config-registry-api-service.test.ts
+++ b/packages/config-registry-controller/src/config-registry-api-service/config-registry-api-service.test.ts
@@ -1,8 +1,10 @@
-import { SDK } from '@metamask/profile-sync-controller';
 import nock from 'nock';
 
 import { createMockNetworkConfig } from '../../tests/helpers.js';
-import { ConfigRegistryApiService } from './config-registry-api-service.js';
+import {
+  ConfigRegistryApiEnv,
+  ConfigRegistryApiService,
+} from './config-registry-api-service.js';
 import type {
   ConfigRegistryApiServiceMessenger,
   ConfigRegistryApiServiceOptions,
@@ -45,7 +47,7 @@ describe('ConfigRegistryApiService', () => {
           .get(CONFIG_PATH)
           .reply(200, MOCK_API_RESPONSE);
 
-        const service = createService({ env: SDK.Env.UAT });
+        const service = createService({ env: ConfigRegistryApiEnv.UAT });
         await service.fetchConfig();
         expect(scope.isDone()).toBe(true);
       });
@@ -55,7 +57,7 @@ describe('ConfigRegistryApiService', () => {
           .get(CONFIG_PATH)
           .reply(200, MOCK_API_RESPONSE);
 
-        const service = createService({ env: SDK.Env.DEV });
+        const service = createService({ env: ConfigRegistryApiEnv.DEV });
         await service.fetchConfig();
         expect(scope.isDone()).toBe(true);
       });
@@ -65,7 +67,7 @@ describe('ConfigRegistryApiService', () => {
           .get(CONFIG_PATH)
           .reply(200, MOCK_API_RESPONSE);
 
-        const service = createService({ env: SDK.Env.PRD });
+        const service = createService({ env: ConfigRegistryApiEnv.PRD });
         await service.fetchConfig();
         expect(scope.isDone()).toBe(true);
       });

--- a/packages/config-registry-controller/src/config-registry-api-service/config-registry-api-service.ts
+++ b/packages/config-registry-controller/src/config-registry-api-service/config-registry-api-service.ts
@@ -4,7 +4,6 @@ import type {
   ServicePolicy,
 } from '@metamask/controller-utils';
 import type { Messenger } from '@metamask/messenger';
-import { SDK } from '@metamask/profile-sync-controller';
 import type { IDisposable } from 'cockatiel';
 
 import type { ConfigRegistryApiServiceMethodActions } from './config-registry-api-service-method-action-types.js';
@@ -16,6 +15,12 @@ import type {
 import { validateRegistryConfigApiResponse } from './types.js';
 
 const ENDPOINT_PATH = '/config/networks';
+
+export enum ConfigRegistryApiEnv {
+  DEV = 'dev',
+  UAT = 'uat',
+  PRD = 'prod',
+}
 
 /**
  * The name of the {@link ConfigRegistryApiService}, used to namespace the
@@ -66,8 +71,8 @@ export type ConfigRegistryApiServiceMessenger = Messenger<
  * @param env - The environment to get the URL for.
  * @returns The base URL for the environment.
  */
-function getConfigRegistryUrl(env: SDK.Env): string {
-  const envPrefix = env === SDK.Env.PRD ? '' : `${env}-`;
+function getConfigRegistryUrl(env: ConfigRegistryApiEnv): string {
+  const envPrefix = env === ConfigRegistryApiEnv.PRD ? '' : `${env}-`;
   return `https://client-config.${envPrefix}api.cx.metamask.io/v1${ENDPOINT_PATH}`;
 }
 
@@ -77,7 +82,7 @@ export type ConfigRegistryApiServiceOptions = {
    * independently and register its actions.
    */
   messenger: ConfigRegistryApiServiceMessenger;
-  env?: SDK.Env;
+  env?: ConfigRegistryApiEnv;
   fetch?: typeof fetch;
   /**
    * Options to pass to `createServicePolicy`, which wraps each request.
@@ -111,7 +116,7 @@ export class ConfigRegistryApiService {
    */
   constructor({
     messenger,
-    env = SDK.Env.UAT,
+    env = ConfigRegistryApiEnv.UAT,
     fetch: customFetch = globalThis.fetch,
     policyOptions = {},
   }: ConfigRegistryApiServiceOptions) {

--- a/packages/config-registry-controller/src/index.ts
+++ b/packages/config-registry-controller/src/index.ts
@@ -27,12 +27,14 @@ export type {
   ConfigRegistryApiServiceActions,
   ConfigRegistryApiServiceEvents,
   ConfigRegistryApiServiceMessenger,
-  ConfigRegistryApiEnv
 } from './config-registry-api-service/config-registry-api-service.js';
 export type {
   ConfigRegistryApiServiceFetchConfigAction,
   ConfigRegistryApiServiceMethodActions,
 } from './config-registry-api-service/config-registry-api-service-method-action-types.js';
 export type { NetworkFilterOptions } from './config-registry-api-service/filters.js';
-export { ConfigRegistryApiService } from './config-registry-api-service/config-registry-api-service.js';
+export {
+  ConfigRegistryApiService,
+  ConfigRegistryApiEnv,
+} from './config-registry-api-service/config-registry-api-service.js';
 export { filterNetworks } from './config-registry-api-service/filters.js';

--- a/packages/config-registry-controller/src/index.ts
+++ b/packages/config-registry-controller/src/index.ts
@@ -27,6 +27,7 @@ export type {
   ConfigRegistryApiServiceActions,
   ConfigRegistryApiServiceEvents,
   ConfigRegistryApiServiceMessenger,
+  ConfigRegistryApiEnv
 } from './config-registry-api-service/config-registry-api-service.js';
 export type {
   ConfigRegistryApiServiceFetchConfigAction,

--- a/packages/config-registry-controller/tsconfig.build.json
+++ b/packages/config-registry-controller/tsconfig.build.json
@@ -12,7 +12,6 @@
     { "path": "../keyring-controller/tsconfig.build.json" },
     { "path": "../messenger/tsconfig.build.json" },
     { "path": "../polling-controller/tsconfig.build.json" },
-    { "path": "../profile-sync-controller/tsconfig.build.json" },
     { "path": "../remote-feature-flag-controller/tsconfig.build.json" }
   ],
   "include": ["../../types", "./src"]

--- a/packages/config-registry-controller/tsconfig.json
+++ b/packages/config-registry-controller/tsconfig.json
@@ -9,7 +9,6 @@
     { "path": "../keyring-controller" },
     { "path": "../messenger" },
     { "path": "../polling-controller" },
-    { "path": "../profile-sync-controller" },
     { "path": "../remote-feature-flag-controller" }
   ],
   "include": ["../../types", "./src", "./tests"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -6539,7 +6539,6 @@ __metadata:
     "@metamask/keyring-controller": "npm:^27.1.1"
     "@metamask/messenger": "npm:^2.0.0"
     "@metamask/polling-controller": "npm:^16.0.9"
-    "@metamask/profile-sync-controller": "npm:^29.0.0"
     "@metamask/remote-feature-flag-controller": "npm:^5.0.0"
     "@metamask/superstruct": "npm:^3.4.1"
     "@metamask/utils": "npm:^11.11.0"


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->
The `@metamask/config-registry-controller` dependency over `@metamask/profile-sync-controller` is being dropped, by adding a new `ConfigRegistryApiEnv` enum to `config-registry-controller` package.

The new enum can be used to select the API environment the service should use.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->
* Fixes https://consensyssoftware.atlassian.net/browse/WPN-1895

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit bd1827596f542f4799d8e59bd5e2f8b7d84cf0fd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->