### PR TITLE
fix(perps-controller): default Pro mode chart to expanded

### DIFF
--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -11,9 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `resolvePositionTriggerSummaryPrice` to `@metamask/perps-controller/utils`, which resolves the scalar TP/SL summary price a position reports for one direction from its trigger orders ([#9912](https://github.com/MetaMask/core/pull/9912))
 
+### Changed
+
+- Default `DEFAULT_PRO_LAYOUT_PREFERENCES.chartExpanded` to `true` so the chart is visible when a user first enters Pro mode; a persisted `chartExpanded` value still wins, so users who hid the chart keep it hidden ([#9920](https://github.com/MetaMask/core/pull/9920))
+
 ### Fixed
 
-- Show the chart by default on the first switch to Perps Pro mode while preserving the user's chart visibility preference on subsequent switches ([TAT-3782](https://consensyssoftware.atlassian.net/browse/TAT-3782))
 - Report the take profit (or stop loss) price on a `Position` when its only trigger for that direction is a partial, quantity-scoped one ([#9912](https://github.com/MetaMask/core/pull/9912))
   - `takeProfitPrice`/`stopLossPrice` were only ever scanned from position-bound triggers, so a position whose sole take profit closed it partially reported `takeProfitCount: 1` with no price, and clients rendering the scalar showed none. Applies to the REST `getPositions`, `getUserDataSnapshot`, and WebSocket position paths alike.
   - Two or more triggers in a direction still report the scanned price, because no single price describes them and clients render the count instead.

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Default `DEFAULT_PRO_LAYOUT_PREFERENCES.chartExpanded` to `true` so the chart is visible when a user first enters Pro mode; a persisted `chartExpanded` value still wins, so users who hid the chart keep it hidden ([#9920](https://github.com/MetaMask/core/pull/9920))
+
 ## [12.2.0]
 
 ### Added
@@ -17,10 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - A `scaleSkew` that is not a finite number above 0 is rejected by `validateOrderParams` with the existing `ORDER_SCALE_RANGE_INVALID` error code, and carrying it on any non-`scale` order type is rejected with the existing `ORDER_STRATEGY_PARAMS_NOT_SUPPORTED`.
   - A skew that pushes a rung below the venue's per-order minimum or onto a zero size-grid slice is rejected before anything is signed, with the existing `ORDER_SCALE_NOTIONAL_TOO_SMALL` / `ORDER_SCALE_SIZE_TOO_SMALL`.
 - Add `resolvePositionTriggerSummaryPrice` to `@metamask/perps-controller/utils`, which resolves the scalar TP/SL summary price a position reports for one direction from its trigger orders ([#9912](https://github.com/MetaMask/core/pull/9912))
-
-### Changed
-
-- Default `DEFAULT_PRO_LAYOUT_PREFERENCES.chartExpanded` to `true` so the chart is visible when a user first enters Pro mode; a persisted `chartExpanded` value still wins, so users who hid the chart keep it hidden ([#9920](https://github.com/MetaMask/core/pull/9920))
 
 ### Fixed
 

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Show the chart by default on the first switch to Perps Pro mode while preserving the user's chart visibility preference on subsequent switches ([TAT-3782](https://consensyssoftware.atlassian.net/browse/TAT-3782))
 - Report the take profit (or stop loss) price on a `Position` when its only trigger for that direction is a partial, quantity-scoped one ([#9912](https://github.com/MetaMask/core/pull/9912))
   - `takeProfitPrice`/`stopLossPrice` were only ever scanned from position-bound triggers, so a position whose sole take profit closed it partially reported `takeProfitCount: 1` with no price, and clients rendering the scalar showed none. Applies to the REST `getPositions`, `getUserDataSnapshot`, and WebSocket position paths alike.
   - Two or more triggers in a direction still report the scanned price, because no single price describes them and clients render the count instead.

--- a/packages/perps-controller/src/PerpsController.ts
+++ b/packages/perps-controller/src/PerpsController.ts
@@ -30,7 +30,6 @@ import { PerpsMeasurementName } from './constants/performanceMetrics.js';
 import type {
   SortOptionId,
   ProLayoutPreferences,
-  PerpsMode,
 } from './constants/perpsConfig.js';
 import {
   PERPS_CONSTANTS,
@@ -40,6 +39,7 @@ import {
   MAX_SLIPPAGE_BOUNDS,
   DEFAULT_PERPS_MODE,
   DEFAULT_PRO_LAYOUT_PREFERENCES,
+  PerpsMode,
 } from './constants/perpsConfig.js';
 import type { PerpsControllerMethodActions } from './PerpsController-method-action-types.js';
 import { PERPS_ERROR_CODES } from './perpsErrorCodes.js';
@@ -475,6 +475,10 @@ export type PerpsControllerState = {
   // Perps interface mode (lite/pro), network-independent global preference.
   mode: PerpsMode;
 
+  // Tracks whether the user has entered Pro mode so its first-use defaults are
+  // applied only once.
+  hasEnteredProMode?: boolean;
+
   // Error handling
   lastError: string | null;
   lastUpdateTimestamp: number;
@@ -577,6 +581,7 @@ export const getDefaultPerpsControllerState = (): PerpsControllerState => ({
   },
   proLayoutPreferences: { ...DEFAULT_PRO_LAYOUT_PREFERENCES },
   mode: DEFAULT_PERPS_MODE,
+  hasEnteredProMode: false,
   hip3ConfigVersion: 0,
   selectedPaymentToken: null,
   cachedMarketDataByProvider: {},
@@ -760,6 +765,12 @@ const metadata: StateMetadata<PerpsControllerState> = {
     persist: true,
     includeInDebugSnapshot: false,
     usedInUi: true,
+  },
+  hasEnteredProMode: {
+    includeInStateLogs: true,
+    persist: true,
+    includeInDebugSnapshot: false,
+    usedInUi: false,
   },
   hip3ConfigVersion: {
     includeInStateLogs: true,
@@ -1137,11 +1148,22 @@ export class PerpsController extends BaseController<
     infrastructure,
     deferEligibilityCheck = false,
   }: PerpsControllerOptions) {
+    // A persisted mode without this flag comes from a controller version that
+    // already supported Pro mode. Treat those users as returning users so an
+    // existing hidden-chart preference is not overwritten after upgrading.
+    const hasEnteredProMode =
+      state.hasEnteredProMode ??
+      Object.prototype.hasOwnProperty.call(state, 'mode');
+
     super({
       name: 'PerpsController',
       metadata,
       messenger,
-      state: { ...getDefaultPerpsControllerState(), ...state },
+      state: {
+        ...getDefaultPerpsControllerState(),
+        ...state,
+        hasEnteredProMode,
+      },
     });
 
     this.#eligibilityCheckDeferred = deferEligibilityCheck;
@@ -5814,6 +5836,14 @@ export class PerpsController extends BaseController<
    */
   setPerpsMode(mode: PerpsMode): void {
     this.update((state) => {
+      if (mode === PerpsMode.Pro && !state.hasEnteredProMode) {
+        state.proLayoutPreferences = {
+          ...state.proLayoutPreferences,
+          chartExpanded: true,
+        };
+        state.hasEnteredProMode = true;
+      }
+
       state.mode = mode;
     });
   }

--- a/packages/perps-controller/src/PerpsController.ts
+++ b/packages/perps-controller/src/PerpsController.ts
@@ -30,6 +30,7 @@ import { PerpsMeasurementName } from './constants/performanceMetrics.js';
 import type {
   SortOptionId,
   ProLayoutPreferences,
+  PerpsMode,
 } from './constants/perpsConfig.js';
 import {
   PERPS_CONSTANTS,
@@ -39,7 +40,6 @@ import {
   MAX_SLIPPAGE_BOUNDS,
   DEFAULT_PERPS_MODE,
   DEFAULT_PRO_LAYOUT_PREFERENCES,
-  PerpsMode,
 } from './constants/perpsConfig.js';
 import type { PerpsControllerMethodActions } from './PerpsController-method-action-types.js';
 import { PERPS_ERROR_CODES } from './perpsErrorCodes.js';
@@ -475,10 +475,6 @@ export type PerpsControllerState = {
   // Perps interface mode (lite/pro), network-independent global preference.
   mode: PerpsMode;
 
-  // Tracks whether the user has entered Pro mode so its first-use defaults are
-  // applied only once.
-  hasEnteredProMode?: boolean;
-
   // Error handling
   lastError: string | null;
   lastUpdateTimestamp: number;
@@ -581,7 +577,6 @@ export const getDefaultPerpsControllerState = (): PerpsControllerState => ({
   },
   proLayoutPreferences: { ...DEFAULT_PRO_LAYOUT_PREFERENCES },
   mode: DEFAULT_PERPS_MODE,
-  hasEnteredProMode: false,
   hip3ConfigVersion: 0,
   selectedPaymentToken: null,
   cachedMarketDataByProvider: {},
@@ -765,12 +760,6 @@ const metadata: StateMetadata<PerpsControllerState> = {
     persist: true,
     includeInDebugSnapshot: false,
     usedInUi: true,
-  },
-  hasEnteredProMode: {
-    includeInStateLogs: true,
-    persist: true,
-    includeInDebugSnapshot: false,
-    usedInUi: false,
   },
   hip3ConfigVersion: {
     includeInStateLogs: true,
@@ -1148,22 +1137,11 @@ export class PerpsController extends BaseController<
     infrastructure,
     deferEligibilityCheck = false,
   }: PerpsControllerOptions) {
-    // A persisted mode without this flag comes from a controller version that
-    // already supported Pro mode. Treat those users as returning users so an
-    // existing hidden-chart preference is not overwritten after upgrading.
-    const hasEnteredProMode =
-      state.hasEnteredProMode ??
-      Object.prototype.hasOwnProperty.call(state, 'mode');
-
     super({
       name: 'PerpsController',
       metadata,
       messenger,
-      state: {
-        ...getDefaultPerpsControllerState(),
-        ...state,
-        hasEnteredProMode,
-      },
+      state: { ...getDefaultPerpsControllerState(), ...state },
     });
 
     this.#eligibilityCheckDeferred = deferEligibilityCheck;
@@ -5836,14 +5814,6 @@ export class PerpsController extends BaseController<
    */
   setPerpsMode(mode: PerpsMode): void {
     this.update((state) => {
-      if (mode === PerpsMode.Pro && !state.hasEnteredProMode) {
-        state.proLayoutPreferences = {
-          ...state.proLayoutPreferences,
-          chartExpanded: true,
-        };
-        state.hasEnteredProMode = true;
-      }
-
       state.mode = mode;
     });
   }

--- a/packages/perps-controller/src/constants/perpsConfig.ts
+++ b/packages/perps-controller/src/constants/perpsConfig.ts
@@ -571,7 +571,7 @@ export type ProLayoutPreferences = {
  */
 export const DEFAULT_PRO_LAYOUT_PREFERENCES: ProLayoutPreferences = {
   orderBookExpanded: false,
-  chartExpanded: false,
+  chartExpanded: true,
   orderBookPosition: 'left',
   orderFormPosition: 'right',
   positionsSideFilter: 'all',

--- a/packages/perps-controller/tests/src/PerpsController.configuration.test.ts
+++ b/packages/perps-controller/tests/src/PerpsController.configuration.test.ts
@@ -851,15 +851,12 @@ describe('PerpsController', () => {
   describe('perps mode', () => {
     it('defaults to lite mode', () => {
       expect(controller.state.mode).toBe(PerpsMode.Lite);
-      expect(controller.state.hasEnteredProMode).toBe(false);
     });
 
-    it('shows the chart on the first switch to pro mode', () => {
+    it('sets the mode to pro', () => {
       controller.setPerpsMode(PerpsMode.Pro);
 
       expect(controller.state.mode).toBe(PerpsMode.Pro);
-      expect(controller.state.hasEnteredProMode).toBe(true);
-      expect(controller.getProLayoutPreferences().chartExpanded).toBe(true);
     });
 
     it('sets the mode back to lite', () => {
@@ -867,55 +864,6 @@ describe('PerpsController', () => {
       controller.setPerpsMode(PerpsMode.Lite);
 
       expect(controller.state.mode).toBe(PerpsMode.Lite);
-    });
-
-    it('preserves a hidden chart on subsequent switches to pro mode', () => {
-      controller.setPerpsMode(PerpsMode.Pro);
-      controller.setProLayoutPreferences({ chartExpanded: false });
-      controller.setPerpsMode(PerpsMode.Lite);
-
-      controller.setPerpsMode(PerpsMode.Pro);
-
-      expect(controller.getProLayoutPreferences().chartExpanded).toBe(false);
-    });
-
-    it('preserves a visible chart on subsequent switches to pro mode', () => {
-      controller.setPerpsMode(PerpsMode.Pro);
-      controller.setPerpsMode(PerpsMode.Lite);
-
-      controller.setPerpsMode(PerpsMode.Pro);
-
-      expect(controller.getProLayoutPreferences().chartExpanded).toBe(true);
-    });
-
-    it('does not overwrite a hidden chart when setting pro mode twice', () => {
-      controller.setPerpsMode(PerpsMode.Pro);
-      controller.setProLayoutPreferences({ chartExpanded: false });
-
-      controller.setPerpsMode(PerpsMode.Pro);
-
-      expect(controller.getProLayoutPreferences().chartExpanded).toBe(false);
-    });
-
-    it('preserves a legacy user hidden-chart preference after upgrading', () => {
-      const legacyController = new TestablePerpsController({
-        messenger: createMockMessenger(),
-        state: {
-          mode: PerpsMode.Lite,
-          proLayoutPreferences: {
-            ...getDefaultPerpsControllerState().proLayoutPreferences,
-            chartExpanded: false,
-          },
-        },
-        infrastructure: mockInfrastructure,
-      });
-
-      legacyController.setPerpsMode(PerpsMode.Pro);
-
-      expect(legacyController.state.hasEnteredProMode).toBe(true);
-      expect(legacyController.getProLayoutPreferences().chartExpanded).toBe(
-        false,
-      );
     });
   });
 

--- a/packages/perps-controller/tests/src/PerpsController.configuration.test.ts
+++ b/packages/perps-controller/tests/src/PerpsController.configuration.test.ts
@@ -694,10 +694,10 @@ describe('PerpsController', () => {
   });
 
   describe('pro layout preferences', () => {
-    it('defaults to collapsed order book, collapsed chart, reserved positions, and positions/orders sort/filter defaults', () => {
+    it('defaults to collapsed order book, expanded chart, reserved positions, and positions/orders sort/filter defaults', () => {
       expect(controller.getProLayoutPreferences()).toEqual({
         orderBookExpanded: false,
-        chartExpanded: false,
+        chartExpanded: true,
         orderBookPosition: 'left',
         orderFormPosition: 'right',
         positionsSideFilter: 'all',
@@ -714,7 +714,7 @@ describe('PerpsController', () => {
 
       expect(controller.getProLayoutPreferences()).toEqual({
         orderBookExpanded: true,
-        chartExpanded: false,
+        chartExpanded: true,
         orderBookPosition: 'left',
         orderFormPosition: 'right',
         positionsSideFilter: 'all',
@@ -743,7 +743,7 @@ describe('PerpsController', () => {
 
       expect(controller.getProLayoutPreferences()).toEqual({
         orderBookExpanded: true,
-        chartExpanded: false,
+        chartExpanded: true,
         orderBookPosition: 'right',
         orderFormPosition: 'left',
         positionsSideFilter: 'long',
@@ -766,7 +766,7 @@ describe('PerpsController', () => {
 
       expect(controller.getProLayoutPreferences()).toEqual({
         orderBookExpanded: false,
-        chartExpanded: false,
+        chartExpanded: true,
         orderBookPosition: 'left',
         orderFormPosition: 'right',
         positionsSideFilter: 'all',
@@ -789,7 +789,7 @@ describe('PerpsController', () => {
 
       expect(controller.getProLayoutPreferences()).toEqual({
         orderBookExpanded: false,
-        chartExpanded: false,
+        chartExpanded: true,
         orderBookPosition: 'left',
         orderFormPosition: 'right',
         positionsSideFilter: 'all',
@@ -807,7 +807,7 @@ describe('PerpsController', () => {
 
       expect(controller.getProLayoutPreferences()).toEqual({
         orderBookExpanded: false,
-        chartExpanded: false,
+        chartExpanded: true,
         orderBookPosition: 'left',
         orderFormPosition: 'right',
         positionsSideFilter: 'long',
@@ -820,9 +820,9 @@ describe('PerpsController', () => {
     });
 
     it('persists the update to controller state', () => {
-      controller.setProLayoutPreferences({ chartExpanded: true });
+      controller.setProLayoutPreferences({ chartExpanded: false });
 
-      expect(controller.state.proLayoutPreferences.chartExpanded).toBe(true);
+      expect(controller.state.proLayoutPreferences.chartExpanded).toBe(false);
     });
 
     it('fills in defaults for fields missing from persisted state', () => {
@@ -835,7 +835,7 @@ describe('PerpsController', () => {
 
       expect(controller.getProLayoutPreferences()).toEqual({
         orderBookExpanded: true,
-        chartExpanded: false,
+        chartExpanded: true,
         orderBookPosition: 'left',
         orderFormPosition: 'right',
         positionsSideFilter: 'all',

--- a/packages/perps-controller/tests/src/PerpsController.configuration.test.ts
+++ b/packages/perps-controller/tests/src/PerpsController.configuration.test.ts
@@ -851,12 +851,15 @@ describe('PerpsController', () => {
   describe('perps mode', () => {
     it('defaults to lite mode', () => {
       expect(controller.state.mode).toBe(PerpsMode.Lite);
+      expect(controller.state.hasEnteredProMode).toBe(false);
     });
 
-    it('sets the mode to pro', () => {
+    it('shows the chart on the first switch to pro mode', () => {
       controller.setPerpsMode(PerpsMode.Pro);
 
       expect(controller.state.mode).toBe(PerpsMode.Pro);
+      expect(controller.state.hasEnteredProMode).toBe(true);
+      expect(controller.getProLayoutPreferences().chartExpanded).toBe(true);
     });
 
     it('sets the mode back to lite', () => {
@@ -864,6 +867,55 @@ describe('PerpsController', () => {
       controller.setPerpsMode(PerpsMode.Lite);
 
       expect(controller.state.mode).toBe(PerpsMode.Lite);
+    });
+
+    it('preserves a hidden chart on subsequent switches to pro mode', () => {
+      controller.setPerpsMode(PerpsMode.Pro);
+      controller.setProLayoutPreferences({ chartExpanded: false });
+      controller.setPerpsMode(PerpsMode.Lite);
+
+      controller.setPerpsMode(PerpsMode.Pro);
+
+      expect(controller.getProLayoutPreferences().chartExpanded).toBe(false);
+    });
+
+    it('preserves a visible chart on subsequent switches to pro mode', () => {
+      controller.setPerpsMode(PerpsMode.Pro);
+      controller.setPerpsMode(PerpsMode.Lite);
+
+      controller.setPerpsMode(PerpsMode.Pro);
+
+      expect(controller.getProLayoutPreferences().chartExpanded).toBe(true);
+    });
+
+    it('does not overwrite a hidden chart when setting pro mode twice', () => {
+      controller.setPerpsMode(PerpsMode.Pro);
+      controller.setProLayoutPreferences({ chartExpanded: false });
+
+      controller.setPerpsMode(PerpsMode.Pro);
+
+      expect(controller.getProLayoutPreferences().chartExpanded).toBe(false);
+    });
+
+    it('preserves a legacy user hidden-chart preference after upgrading', () => {
+      const legacyController = new TestablePerpsController({
+        messenger: createMockMessenger(),
+        state: {
+          mode: PerpsMode.Lite,
+          proLayoutPreferences: {
+            ...getDefaultPerpsControllerState().proLayoutPreferences,
+            chartExpanded: false,
+          },
+        },
+        infrastructure: mockInfrastructure,
+      });
+
+      legacyController.setPerpsMode(PerpsMode.Pro);
+
+      expect(legacyController.state.hasEnteredProMode).toBe(true);
+      expect(legacyController.getProLayoutPreferences().chartExpanded).toBe(
+        false,
+      );
     });
   });
 

--- a/packages/perps-controller/tests/src/selectors.test.ts
+++ b/packages/perps-controller/tests/src/selectors.test.ts
@@ -633,7 +633,7 @@ describe('PerpsController selectors', () => {
   describe('selectProLayoutPreferences', () => {
     const defaults = {
       orderBookExpanded: false,
-      chartExpanded: false,
+      chartExpanded: true,
       orderBookPosition: 'left',
       orderFormPosition: 'right',
       positionsSideFilter: 'all',
@@ -647,7 +647,7 @@ describe('PerpsController selectors', () => {
     it('returns the pro-mode layout preferences', () => {
       const proLayoutPreferences = {
         orderBookExpanded: true,
-        chartExpanded: true,
+        chartExpanded: false,
         orderBookPosition: 'right' as const,
         orderFormPosition: 'left' as const,
         positionsSideFilter: 'long' as const,


### PR DESCRIPTION
## Explanation

When a user entered Pro mode, the chart was collapsed because `DEFAULT_PRO_LAYOUT_PREFERENCES.chartExpanded` was `false`. Users landing in Pro mode for the first time saw no chart and could easily miss that one existed at all.

This changes that default to `true`. Because `getProLayoutPreferences` merges persisted state over the defaults, the new default only applies to users who have never toggled the chart — anyone who explicitly collapsed the chart keeps it collapsed.

Implementation notes:

- The only production change is the one-line default flip in `packages/perps-controller/src/constants/perpsConfig.ts`.
- Earlier iterations of this PR added a persisted `hasEnteredProMode` flag and a first-entry override inside `setPerpsMode`; that was removed in favor of the simpler default change, so no new state field is introduced.
- Test expectations in `PerpsController.configuration.test.ts` and `selectors.test.ts` were updated to reflect the new default, including flipping the "persists the update to controller state" case to set `chartExpanded: false` so it still exercises a real change away from the default.

## References

- [TAT-3782](https://consensyssoftware.atlassian.net/browse/TAT-3782)

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


[TAT-3782]: https://consensyssoftware.atlassian.net/browse/TAT-3782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit b519cce988cef8942406e479c0d08d87eca8af46. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->