### PR TITLE
feat: extend address scan result

### DIFF
--- a/packages/phishing-controller/CHANGELOG.md
+++ b/packages/phishing-controller/CHANGELOG.md
@@ -634,9 +634,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial release
-
   - As a result of converting our shared controllers repo into a monorepo ([#831](https://github.com/MetaMask/core/pull/831)), we've created this package from select parts of [`@metamask/controllers` v33.0.0](https://github.com/MetaMask/core/tree/v33.0.0), namely:
-
     - `src/third-party/PhishingController.ts`
     - `src/third-party/PhishingController.test.ts`
 

--- a/packages/phishing-controller/CHANGELOG.md
+++ b/packages/phishing-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `address_alert_response_flagged_by` to address scan results, exposing the security-alert vendors that flagged an address
+- Add `address_alert_response_flagged_by` to address scan results, exposing the security-alert vendors that flagged an address ([#9921](https://github.com/MetaMask/core/pull/9921))
 
 ### Changed
 

--- a/packages/phishing-controller/CHANGELOG.md
+++ b/packages/phishing-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `address_alert_response_flagged_by` to address scan results, exposing the security-alert vendors that flagged an address
+
 ### Changed
 
 - Bump `@metamask/transaction-controller` from `^69.4.0` to `^69.5.2` ([#9780](https://github.com/MetaMask/core/pull/9780), [#9798](https://github.com/MetaMask/core/pull/9798), [#9823](https://github.com/MetaMask/core/pull/9823))
@@ -630,7 +634,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial release
+
   - As a result of converting our shared controllers repo into a monorepo ([#831](https://github.com/MetaMask/core/pull/831)), we've created this package from select parts of [`@metamask/controllers` v33.0.0](https://github.com/MetaMask/core/tree/v33.0.0), namely:
+
     - `src/third-party/PhishingController.ts`
     - `src/third-party/PhishingController.test.ts`
 

--- a/packages/phishing-controller/src/PhishingController.test.ts
+++ b/packages/phishing-controller/src/PhishingController.test.ts
@@ -3551,6 +3551,7 @@ describe('PhishingController', () => {
     const mockResponse: AddressScanResult = {
       result_type: AddressScanResultType.Benign,
       label: '',
+      address_alert_response_flagged_by: [],
     };
 
     beforeEach(() => {
@@ -3565,7 +3566,7 @@ describe('PhishingController', () => {
       jest.useRealTimers();
     });
 
-    it('will return the scan result for a valid address', async () => {
+    it('will return the scan result, including vendor attribution, for a valid address', async () => {
       const scope = nock(SECURITY_ALERTS_BASE_URL)
         .post(ADDRESS_SCAN_ENDPOINT, {
           chain: 'ethereum',
@@ -3578,7 +3579,32 @@ describe('PhishingController', () => {
         testChainId,
         testAddress,
       );
-      expect(response).toMatchObject(mockResponse);
+      expect(response).toStrictEqual(mockResponse);
+      expect(scope.isDone()).toBe(true);
+    });
+
+    it('will default missing vendor attribution to an empty array', async () => {
+      const legacyResponse = {
+        result_type: AddressScanResultType.Benign,
+        label: '',
+      };
+      const scope = nock(SECURITY_ALERTS_BASE_URL)
+        .post(ADDRESS_SCAN_ENDPOINT, {
+          chain: 'ethereum',
+          address: testAddress.toLowerCase(),
+        })
+        .reply(200, legacyResponse);
+
+      const response = await rootMessenger.call(
+        'PhishingController:scanAddress',
+        testChainId,
+        testAddress,
+      );
+
+      expect(response).toStrictEqual({
+        ...legacyResponse,
+        address_alert_response_flagged_by: [],
+      });
       expect(scope.isDone()).toBe(true);
     });
 
@@ -3609,6 +3635,7 @@ describe('PhishingController', () => {
         expect(response).toMatchObject({
           result_type: AddressScanResultType.ErrorResult,
           label: '',
+          address_alert_response_flagged_by: [],
         });
         expect(scope.isDone()).toBe(true);
       },
@@ -3633,6 +3660,7 @@ describe('PhishingController', () => {
       expect(response).toMatchObject({
         result_type: AddressScanResultType.ErrorResult,
         label: '',
+        address_alert_response_flagged_by: [],
       });
       expect(scope.isDone()).toBe(false);
     });
@@ -3646,6 +3674,7 @@ describe('PhishingController', () => {
       expect(response).toMatchObject({
         result_type: AddressScanResultType.ErrorResult,
         label: '',
+        address_alert_response_flagged_by: [],
       });
     });
 
@@ -3659,6 +3688,7 @@ describe('PhishingController', () => {
       expect(response).toMatchObject({
         result_type: AddressScanResultType.ErrorResult,
         label: '',
+        address_alert_response_flagged_by: [],
       });
     });
 
@@ -3676,6 +3706,7 @@ describe('PhishingController', () => {
       expect(response).toMatchObject({
         result_type: AddressScanResultType.ErrorResult,
         label: '',
+        address_alert_response_flagged_by: [],
       });
       expect(scope.isDone()).toBe(false);
       cleanAll();
@@ -3754,11 +3785,13 @@ describe('PhishingController', () => {
       const mockResponse1: AddressScanResult = {
         result_type: AddressScanResultType.Benign,
         label: 'ethereum result',
+        address_alert_response_flagged_by: [],
       };
 
       const mockResponse2: AddressScanResult = {
         result_type: AddressScanResultType.Warning,
         label: 'polygon result',
+        address_alert_response_flagged_by: ['hypernative'],
       };
 
       const scope1 = nock(SECURITY_ALERTS_BASE_URL)

--- a/packages/phishing-controller/src/PhishingController.test.ts
+++ b/packages/phishing-controller/src/PhishingController.test.ts
@@ -42,6 +42,7 @@ import {
 } from './tests/utils.js';
 import type {
   PhishingDetectionScanResult,
+  AddressScanCacheData,
   AddressScanResult,
 } from './types.js';
 import {
@@ -3606,6 +3607,37 @@ describe('PhishingController', () => {
         address_alert_response_flagged_by: [],
       });
       expect(scope.isDone()).toBe(true);
+    });
+
+    it('defaults vendor attribution for a legacy cached result', async () => {
+      const cacheKey = `${testChainId}:${testAddress}`;
+      const { rootMessenger: messengerWithLegacyCache } = getPhishingController(
+        {
+          state: {
+            addressScanCache: {
+              [cacheKey]: {
+                data: {
+                  result_type: AddressScanResultType.Benign,
+                  label: '',
+                } as AddressScanCacheData,
+                timestamp: 0,
+              },
+            },
+          },
+        },
+      );
+
+      const response = await messengerWithLegacyCache.call(
+        'PhishingController:scanAddress',
+        testChainId,
+        testAddress,
+      );
+
+      expect(response).toStrictEqual({
+        result_type: AddressScanResultType.Benign,
+        label: '',
+        address_alert_response_flagged_by: [],
+      });
     });
 
     it.each([

--- a/packages/phishing-controller/src/PhishingController.ts
+++ b/packages/phishing-controller/src/PhishingController.ts
@@ -1466,6 +1466,7 @@ export class PhishingController extends BaseController<
       return {
         result_type: AddressScanResultType.ErrorResult,
         label: '',
+        address_alert_response_flagged_by: [],
       };
     }
 
@@ -1477,6 +1478,7 @@ export class PhishingController extends BaseController<
       return {
         result_type: AddressScanResultType.ErrorResult,
         label: '',
+        address_alert_response_flagged_by: [],
       };
     }
 
@@ -1486,6 +1488,8 @@ export class PhishingController extends BaseController<
       return {
         result_type: cachedResult.result_type,
         label: cachedResult.label,
+        address_alert_response_flagged_by:
+          cachedResult.address_alert_response_flagged_by ?? [],
       };
     }
 
@@ -1521,18 +1525,22 @@ export class PhishingController extends BaseController<
       return {
         result_type: AddressScanResultType.ErrorResult,
         label: '',
+        address_alert_response_flagged_by: [],
       };
     } else if ((apiResponse as { error?: string }).error) {
       return {
         result_type: AddressScanResultType.ErrorResult,
         label: '',
+        address_alert_response_flagged_by: [],
       };
     }
 
     const scanResult = apiResponse as AddressScanResult;
+    const flaggedBy = scanResult.address_alert_response_flagged_by ?? [];
     const result: AddressScanCacheData = {
       result_type: scanResult.result_type,
       label: scanResult.label,
+      address_alert_response_flagged_by: flaggedBy,
     };
 
     this.#addressScanCache.set(cacheKey, result);
@@ -1540,6 +1548,7 @@ export class PhishingController extends BaseController<
     return {
       result_type: scanResult.result_type,
       label: scanResult.label,
+      address_alert_response_flagged_by: flaggedBy,
     };
   }
 

--- a/packages/phishing-controller/src/types.ts
+++ b/packages/phishing-controller/src/types.ts
@@ -273,6 +273,10 @@ export type AddressScanResult = {
    * Additional label or description for the result
    */
   label: string;
+  /**
+   * The vendors that flagged the address during the scan.
+   */
+  address_alert_response_flagged_by: string[];
 };
 
 /**
@@ -281,6 +285,7 @@ export type AddressScanResult = {
 export type AddressScanCacheData = {
   result_type: AddressScanResultType;
   label: string;
+  address_alert_response_flagged_by: string[];
 };
 
 /**


### PR DESCRIPTION
## Explanation

Expose `address_alert_response_flagged_by` from the Security Alerts address-scan API through `@metamask/phishing-controller`.

The controller previously retained only `result_type` and `label`, which would drop the new vendor-attribution data from the Security Alerts API before it reached consumers. This change adds the field to the public scan result and address-scan cache, preserving vendor arrays from the API.

The field is always exposed as a `string[]`. Controller error paths, legacy API responses, and pre-existing cached entries default it to `[]`, keeping the result shape consistent while preserving existing scan behavior.

## References

- [PSAFE-599](https://consensyssoftware.atlassian.net/browse/PSAFE-599)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

[PSAFE-599]: https://consensyssoftware.atlassian.net/browse/PSAFE-599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive extension to address-scan results with empty-array defaults; scan decision logic is unchanged, though TypeScript consumers must accept the new required field on `AddressScanResult`.
> 
> **Overview**
> Adds **`address_alert_response_flagged_by`** (`string[]`) to public **`AddressScanResult`** and **`AddressScanCacheData`**, so `scanAddress` no longer drops Security Alerts vendor attribution before returning or caching results.
> 
> **`PhishingController.scanAddress`** now forwards vendor arrays from the API, stores them in the address-scan cache, and always includes the field on every path (success, cache hit, and errors). Legacy API payloads and older cached entries without the property default to **`[]`**, keeping the result shape stable.
> 
> Tests and the package changelog cover happy path, legacy API/cache behavior, and error responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f2dcfc93a6aad2b458d7ec06ef74730bde6ccc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->