### PR TITLE
fix(assets-controller): bypass balance cache on every poll tick

### DIFF
--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `AccountsApiDataSource` now passes `forceUpdate: true` on every recurring poll tick, so balance polling always bypasses the TanStack Query cache instead of `STALE_TIMES.BALANCES` (60s, in `@metamask/core-backend`) silently serving a cached response on roughly every other tick when `pollInterval` (default 30s) is shorter than the stale time ([#9926](https://github.com/MetaMask/core/pull/9926))
+- Fix `AccountsApiDataSource` polling being served stale cached balances on roughly every other tick, since the 60s balances cache outlived the 30s poll interval ([#9926](https://github.com/MetaMask/core/pull/9926))
 
 ## [14.0.0]
 

--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `AccountsApiDataSource` now passes `forceUpdate: true` on every recurring poll tick, so balance polling always bypasses the TanStack Query cache instead of `STALE_TIMES.BALANCES` (60s, in `@metamask/core-backend`) silently serving a cached response on roughly every other tick when `pollInterval` (default 30s) is shorter than the stale time
+- `AccountsApiDataSource` now passes `forceUpdate: true` on every recurring poll tick, so balance polling always bypasses the TanStack Query cache instead of `STALE_TIMES.BALANCES` (60s, in `@metamask/core-backend`) silently serving a cached response on roughly every other tick when `pollInterval` (default 30s) is shorter than the stale time ([#9926](https://github.com/MetaMask/core/pull/9926))
 
 ## [14.0.0]
 

--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `AccountsApiDataSource` now passes `forceUpdate: true` on every recurring poll tick, so balance polling always bypasses the TanStack Query cache instead of `STALE_TIMES.BALANCES` (60s, in `@metamask/core-backend`) silently serving a cached response on roughly every other tick when `pollInterval` (default 30s) is shorter than the stale time
+
 ## [14.0.0]
 
 ### Changed

--- a/packages/assets-controller/src/data-sources/AccountsApiDataSource.test.ts
+++ b/packages/assets-controller/src/data-sources/AccountsApiDataSource.test.ts
@@ -1015,11 +1015,6 @@ describe('AccountsApiDataSource', () => {
     const { controller, apiClient, assetsUpdateHandler } =
       await setupController();
 
-    // Both the initial poll (triggered synchronously by `subscribe`) and every
-    // recurring poll tick must set `forceUpdate: true`, otherwise a poll tick
-    // shorter than `STALE_TIMES.BALANCES` (e.g. the default 30s `pollInterval`
-    // vs a 60s balances stale time) can be silently served a cached response
-    // instead of refreshing balances. See `fetch`'s `fetchOptions` branch.
     await controller.subscribe({
       subscriptionId: 'sub-1',
       request: createDataRequest(),

--- a/packages/assets-controller/src/data-sources/AccountsApiDataSource.test.ts
+++ b/packages/assets-controller/src/data-sources/AccountsApiDataSource.test.ts
@@ -1011,6 +1011,31 @@ describe('AccountsApiDataSource', () => {
     controller.destroy();
   });
 
+  it('subscribe polling fetch always bypasses the TanStack cache', async () => {
+    const { controller, apiClient, assetsUpdateHandler } =
+      await setupController();
+
+    // Both the initial poll (triggered synchronously by `subscribe`) and every
+    // recurring poll tick must set `forceUpdate: true`, otherwise a poll tick
+    // shorter than `STALE_TIMES.BALANCES` (e.g. the default 30s `pollInterval`
+    // vs a 60s balances stale time) can be silently served a cached response
+    // instead of refreshing balances. See `fetch`'s `fetchOptions` branch.
+    await controller.subscribe({
+      subscriptionId: 'sub-1',
+      request: createDataRequest(),
+      isUpdate: false,
+      onAssetsUpdate: assetsUpdateHandler,
+    });
+
+    expect(apiClient.accounts.fetchV5MultiAccountBalances).toHaveBeenCalledWith(
+      [`eip155:1:${MOCK_ADDRESS}`],
+      undefined,
+      { staleTime: 0, gcTime: 0 },
+    );
+
+    controller.destroy();
+  });
+
   it('subscribe skips initial fetch when skipInitialFetch is true', async () => {
     const { controller, assetsUpdateHandler, apiClient } =
       await setupController();

--- a/packages/assets-controller/src/data-sources/AccountsApiDataSource.ts
+++ b/packages/assets-controller/src/data-sources/AccountsApiDataSource.ts
@@ -857,10 +857,18 @@ export class AccountsApiDataSource extends AbstractDataSource<
           return;
         }
 
-        // Use stored request (which gets updated on account changes)
+        // Use stored request (which gets updated on account changes).
+        // forceUpdate bypasses the TanStack Query cache (staleTime/gcTime 0/0,
+        // see `fetch` above) so each recurring poll tick issues a real network
+        // request. Without it, `fetchOptions` is `undefined` and the default
+        // `STALE_TIMES.BALANCES` (60s, in `@metamask/core-backend`) applies,
+        // which is longer than the default 30s `pollInterval` — causing every
+        // other poll tick to be silently served a cached response instead of
+        // refreshing balances.
         const fetchResponse = await this.fetch({
           ...subscription.request,
           chainIds: subscription.chains,
+          forceUpdate: true,
         });
 
         // Report update to AssetsController via callback

--- a/packages/assets-controller/src/data-sources/AccountsApiDataSource.ts
+++ b/packages/assets-controller/src/data-sources/AccountsApiDataSource.ts
@@ -858,13 +858,8 @@ export class AccountsApiDataSource extends AbstractDataSource<
         }
 
         // Use stored request (which gets updated on account changes).
-        // forceUpdate bypasses the TanStack Query cache (staleTime/gcTime 0/0,
-        // see `fetch` above) so each recurring poll tick issues a real network
-        // request. Without it, `fetchOptions` is `undefined` and the default
-        // `STALE_TIMES.BALANCES` (60s, in `@metamask/core-backend`) applies,
-        // which is longer than the default 30s `pollInterval` — causing every
-        // other poll tick to be silently served a cached response instead of
-        // refreshing balances.
+        // forceUpdate so we don't get a stale response from the cache
+        // (STALE_TIMES.BALANCES is 60s, longer than our 30s poll interval).
         const fetchResponse = await this.fetch({
           ...subscription.request,
           chainIds: subscription.chains,


### PR DESCRIPTION
## Explanation

`AccountsApiDataSource` polls for balances every 30s, but the underlying `ApiPlatformClient` caches responses for 60s (`STALE_TIMES.BALANCES`). Since the poll didn't pass `forceUpdate`, every other tick was served the cached response instead of hitting the network — balances only actually refreshed every ~60s.

This passes `forceUpdate: true` on the poll's fetch call so it always bypasses the cache, same as other call sites (unlock, account switch, tx confirmation) already do.

Kept the fix scoped to just the poll instead of removing caching everywhere, since #9591 added `forceUpdate` specifically to avoid bursts of duplicate calls when multiple triggers fire close together, and the unmerged #9867 ran into that regression by disabling the cache globally.

## References

* Related to #9591
* Related to (closed) #9867 
* Ticket: https://consensyssoftware.atlassian.net/browse/ASSETS-3899

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow cache-bypass on the 30s poll path only; does not change auth or other fetch sites. Slightly more Accounts API traffic on that interval, which is the intended behavior.
> 
> **Overview**
> Fixes `AccountsApiDataSource` polling serving stale balances on roughly every other tick. The 30s poll used `fetch()` without `forceUpdate`, so the 60s TanStack balances cache (`STALE_TIMES.BALANCES`) won.
> 
> Recurring `pollFn` now passes `forceUpdate: true` so each tick hits the network (`staleTime: 0, gcTime: 0`), matching other authoritative refreshes. Bypass is scoped to the poll only so nearby unlock/switch/tx triggers still share the cache.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1624631e28be9ab6c12db3e97de28601417daf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->