### PR TITLE
feat: add `config-registry-{controller, api-service}` to `wallet`

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,6 +661,7 @@ linkStyle default opacity:0.5
   wallet --> approval_controller;
   wallet --> base_controller;
   wallet --> claims_controller;
+  wallet --> config_registry_controller;
   wallet --> connectivity_controller;
   wallet --> controller_utils;
   wallet --> gas_fee_controller;

--- a/README.md
+++ b/README.md
@@ -677,6 +677,7 @@ linkStyle default opacity:0.5
   wallet --> transaction_controller;
   wallet_cli --> analytics_controller;
   wallet_cli --> base_controller;
+  wallet_cli --> config_registry_controller;
   wallet_cli --> messenger;
   wallet_cli --> remote_feature_flag_controller;
   wallet_cli --> storage_service;

--- a/packages/wallet-cli/CHANGELOG.md
+++ b/packages/wallet-cli/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Wire the `configRegistryApiService` slot in the daemon wallet's instance options with `env: ConfigRegistryApiEnv.PRD`, required now that `@metamask/wallet` makes this slot mandatory ([#9928](https://github.com/MetaMask/core/pull/9928))
 - Add the `mm wallet send` command and a dedicated daemon `sendTransaction` RPC handler for sending a transaction through the daemon-hosted `TransactionController` ([#9636](https://github.com/MetaMask/core/pull/9636))
   - The command converts the ether `--value` to wei, resolves the network client (`--network-client-id` or `--chain-id`) and sender (defaulting to the selected account), previews the resolved plan, and broadcasts after confirmation, printing the resulting transaction hash. `--yes` skips the prompt; `--dry-run` resolves and validates without broadcasting.
   - The `sendTransaction` handler awaits the broadcast server-side and returns a serializable `{ transactionHash, transactionId, status }`, because `addTransaction`'s `result` promise cannot travel back over the generic `call` dispatch. Transactions are submitted as internal (auto-approved by the daemon).

--- a/packages/wallet-cli/CHANGELOG.md
+++ b/packages/wallet-cli/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Wire the `configRegistryApiService` slot in the daemon wallet's instance options with `env: ConfigRegistryApiEnv.PRD`, required now that `@metamask/wallet` makes this slot mandatory ([#9928](https://github.com/MetaMask/core/pull/9928))
 - Add the `mm wallet send` command and a dedicated daemon `sendTransaction` RPC handler for sending a transaction through the daemon-hosted `TransactionController` ([#9636](https://github.com/MetaMask/core/pull/9636))
   - The command converts the ether `--value` to wei, resolves the network client (`--network-client-id` or `--chain-id`) and sender (defaulting to the selected account), previews the resolved plan, and broadcasts after confirmation, printing the resulting transaction hash. `--yes` skips the prompt; `--dry-run` resolves and validates without broadcasting.
   - The `sendTransaction` handler awaits the broadcast server-side and returns a serializable `{ transactionHash, transactionId, status }`, because `addTransaction`'s `result` promise cannot travel back over the generic `call` dispatch. Transactions are submitted as internal (auto-approved by the daemon).

--- a/packages/wallet-cli/package.json
+++ b/packages/wallet-cli/package.json
@@ -51,6 +51,7 @@
     "@inquirer/password": "^5.1.1",
     "@metamask/analytics-controller": "^2.0.0",
     "@metamask/base-controller": "^9.1.0",
+    "@metamask/config-registry-controller": "^3.0.0",
     "@metamask/messenger": "^2.0.0",
     "@metamask/remote-feature-flag-controller": "^5.0.0",
     "@metamask/rpc-errors": "^7.0.2",

--- a/packages/wallet-cli/src/daemon/wallet-factory.ts
+++ b/packages/wallet-cli/src/daemon/wallet-factory.ts
@@ -3,8 +3,8 @@ import type {
   AnalyticsControllerGetStateAction,
   AnalyticsControllerTrackEventAction,
 } from '@metamask/analytics-controller';
-import { Messenger } from '@metamask/messenger';
 import { ConfigRegistryApiEnv } from '@metamask/config-registry-controller';
+import { Messenger } from '@metamask/messenger';
 import {
   ClientConfigApiService,
   ClientType,

--- a/packages/wallet-cli/src/daemon/wallet-factory.ts
+++ b/packages/wallet-cli/src/daemon/wallet-factory.ts
@@ -4,6 +4,7 @@ import type {
   AnalyticsControllerTrackEventAction,
 } from '@metamask/analytics-controller';
 import { Messenger } from '@metamask/messenger';
+import { ConfigRegistryApiEnv } from '@metamask/config-registry-controller';
 import {
   ClientConfigApiService,
   ClientType,
@@ -94,6 +95,9 @@ function buildInstanceOptions(
   infuraProjectId: string,
 ): WalletOptions['instanceOptions'] {
   return {
+    configRegistryApiService: {
+      env: ConfigRegistryApiEnv.PRD,
+    },
     approvalController: {
       // The daemon is headless, so there is no UI to open: requests are
       // resolved by the auto-approval subscription (see `subscribeToAutoApproval`)

--- a/packages/wallet-cli/tsconfig.build.json
+++ b/packages/wallet-cli/tsconfig.build.json
@@ -12,6 +12,7 @@
     {
       "path": "../base-controller/tsconfig.build.json"
     },
+    { "path": "../config-registry-controller/tsconfig.build.json" },
     { "path": "../messenger/tsconfig.build.json" },
     {
       "path": "../remote-feature-flag-controller/tsconfig.build.json"

--- a/packages/wallet-cli/tsconfig.json
+++ b/packages/wallet-cli/tsconfig.json
@@ -11,6 +11,9 @@
       "path": "../base-controller"
     },
     {
+      "path": "../config-registry-controller"
+    },
+    {
       "path": "../messenger"
     },
     {

--- a/packages/wallet/CHANGELOG.md
+++ b/packages/wallet/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add optional `instanceOptions.remoteFeatureFlagController.getCanonicalProfileId` constructor option to `RemoteFeatureFlagController` for threshold flag segmentation ([#9325](https://github.com/MetaMask/core/pull/9325))
 - Add optional `instanceOptions.remoteFeatureFlagController.metaMetricsFlags` constructor option to `RemoteFeatureFlagController` to segment flags by MetaMetrics ID ([#9325](https://github.com/MetaMask/core/pull/9325))
+- **BREAKING:** Wire `ConfigRegistryApiService` and `ConfigRegistryController` into the default wallet initialization ([#9928](https://github.com/MetaMask/core/pull/9928))
+  - Adds an optional `configRegistryApiService` slot to `instanceOptions` for optional `env` (defaults to production), `fetch`, and `policyOptions`. `fetch` defaults to `globalThis.fetch` via `ConfigRegistryApiService`.
+  - Adds an optional `configRegistryController` slot to `instanceOptions` for optional `pollingInterval` and `fallbackConfig`.
+  - `ConfigRegistryController` delegates `KeyringController:getState`, `RemoteFeatureFlagController:getState`, and `ConfigRegistryApiService:fetchConfig`, and subscribes to `KeyringController:unlock`, `KeyringController:lock`, and `RemoteFeatureFlagController:stateChange`.
+  - Consumers that pass their own root messenger and already wire `ConfigRegistryApiService` / `ConfigRegistryController` must remove their own before upgrading, or the duplicate registration will collide.
 
 ## [11.0.0]
 

--- a/packages/wallet/CHANGELOG.md
+++ b/packages/wallet/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add optional `instanceOptions.remoteFeatureFlagController.getCanonicalProfileId` constructor option to `RemoteFeatureFlagController` for threshold flag segmentation ([#9325](https://github.com/MetaMask/core/pull/9325))
 - Add optional `instanceOptions.remoteFeatureFlagController.metaMetricsFlags` constructor option to `RemoteFeatureFlagController` to segment flags by MetaMetrics ID ([#9325](https://github.com/MetaMask/core/pull/9325))
 - **BREAKING:** Wire `ConfigRegistryApiService` and `ConfigRegistryController` into the default wallet initialization ([#9928](https://github.com/MetaMask/core/pull/9928))
-  - Adds an optional `configRegistryApiService` slot to `instanceOptions` for optional `env` (defaults to production), `fetch`, and `policyOptions`. `fetch` defaults to `globalThis.fetch` via `ConfigRegistryApiService`.
+  - Adds a required `configRegistryApiService` slot to `instanceOptions` with a required `env` (`ConfigRegistryApiEnv`) and optional `fetch` and `policyOptions`. `fetch` defaults to `globalThis.fetch` via `ConfigRegistryApiService`.
   - Adds an optional `configRegistryController` slot to `instanceOptions` for optional `pollingInterval` and `fallbackConfig`.
   - `ConfigRegistryController` delegates `KeyringController:getState`, `RemoteFeatureFlagController:getState`, and `ConfigRegistryApiService:fetchConfig`, and subscribes to `KeyringController:unlock`, `KeyringController:lock`, and `RemoteFeatureFlagController:stateChange`.
   - Consumers that pass their own root messenger and already wire `ConfigRegistryApiService` / `ConfigRegistryController` must remove their own before upgrading, or the duplicate registration will collide.

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -61,6 +61,7 @@
     "@metamask/base-controller": "^9.1.0",
     "@metamask/browser-passworder": "^6.0.0",
     "@metamask/claims-controller": "^0.6.0",
+    "@metamask/config-registry-controller": "^3.0.0",
     "@metamask/connectivity-controller": "^0.3.0",
     "@metamask/controller-utils": "^12.3.0",
     "@metamask/gas-fee-controller": "^26.3.1",

--- a/packages/wallet/src/initialization/instances/config-registry-api-service/config-registry-api-service.test.ts
+++ b/packages/wallet/src/initialization/instances/config-registry-api-service/config-registry-api-service.test.ts
@@ -21,9 +21,11 @@ function getRootMessenger(): RootMessenger<DefaultActions, DefaultEvents> {
 }
 
 function makeFetchMock(response = MOCK_API_RESPONSE): jest.Mock {
-  return jest.fn().mockResolvedValue(
-    new globalThis.Response(JSON.stringify(response), { status: 200 }),
-  );
+  return jest
+    .fn()
+    .mockResolvedValue(
+      new globalThis.Response(JSON.stringify(response), { status: 200 }),
+    );
 }
 
 describe('configRegistryApiService', () => {

--- a/packages/wallet/src/initialization/instances/config-registry-api-service/config-registry-api-service.test.ts
+++ b/packages/wallet/src/initialization/instances/config-registry-api-service/config-registry-api-service.test.ts
@@ -41,28 +41,26 @@ describe('configRegistryApiService', () => {
     const instance = configRegistryApiService.init({
       state: undefined,
       messenger,
-      options: {},
+      options: { env: ConfigRegistryApiEnv.PRD },
     });
 
     expect(instance).toBeInstanceOf(ConfigRegistryApiService);
   });
 
-  it('defaults env to production', async () => {
+  it('uses the provided env to determine the API URL', async () => {
     const fetchMock = makeFetchMock();
     const messenger = configRegistryApiService.getMessenger(getRootMessenger());
 
     const instance = configRegistryApiService.init({
       state: undefined,
       messenger,
-      options: { fetch: fetchMock },
+      options: { env: ConfigRegistryApiEnv.UAT, fetch: fetchMock },
     });
 
     await instance.fetchConfig();
 
     const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
-    // PRD URL has no env prefix - UAT would contain "uat-"
-    expect(url).toContain('client-config.api.cx.metamask.io');
-    expect(url).not.toContain(ConfigRegistryApiEnv.UAT);
+    expect(url).toContain(ConfigRegistryApiEnv.UAT);
   });
 
   it('exposes its actions through the root messenger', async () => {
@@ -72,7 +70,7 @@ describe('configRegistryApiService', () => {
     configRegistryApiService.init({
       state: undefined,
       messenger,
-      options: { fetch: makeFetchMock() },
+      options: { env: ConfigRegistryApiEnv.PRD, fetch: makeFetchMock() },
     });
 
     const result = await rootMessenger.call(

--- a/packages/wallet/src/initialization/instances/config-registry-api-service/config-registry-api-service.test.ts
+++ b/packages/wallet/src/initialization/instances/config-registry-api-service/config-registry-api-service.test.ts
@@ -1,0 +1,81 @@
+import {
+  ConfigRegistryApiEnv,
+  ConfigRegistryApiService,
+} from '@metamask/config-registry-controller';
+import { Messenger } from '@metamask/messenger';
+
+import { defaultConfigurations } from '../../defaults.js';
+import type {
+  DefaultActions,
+  DefaultEvents,
+  RootMessenger,
+} from '../../defaults.js';
+import { configRegistryApiService } from './config-registry-api-service.js';
+
+const MOCK_API_RESPONSE = {
+  data: { version: '1.0.0', timestamp: 1234567890, chains: [] },
+};
+
+function getRootMessenger(): RootMessenger<DefaultActions, DefaultEvents> {
+  return new Messenger({ namespace: 'Root' });
+}
+
+function makeFetchMock(response = MOCK_API_RESPONSE): jest.Mock {
+  return jest.fn().mockResolvedValue(
+    new globalThis.Response(JSON.stringify(response), { status: 200 }),
+  );
+}
+
+describe('configRegistryApiService', () => {
+  it('is registered as a default initialization configuration', () => {
+    expect(Object.values(defaultConfigurations)).toContain(
+      configRegistryApiService,
+    );
+  });
+
+  it('initializes a ConfigRegistryApiService', () => {
+    const messenger = configRegistryApiService.getMessenger(getRootMessenger());
+
+    const instance = configRegistryApiService.init({
+      state: undefined,
+      messenger,
+      options: {},
+    });
+
+    expect(instance).toBeInstanceOf(ConfigRegistryApiService);
+  });
+
+  it('defaults env to production', async () => {
+    const fetchMock = makeFetchMock();
+    const messenger = configRegistryApiService.getMessenger(getRootMessenger());
+
+    const instance = configRegistryApiService.init({
+      state: undefined,
+      messenger,
+      options: { fetch: fetchMock },
+    });
+
+    await instance.fetchConfig();
+
+    const [url] = fetchMock.mock.calls[0] as [string, RequestInit];
+    // PRD URL has no env prefix - UAT would contain "uat-"
+    expect(url).toContain('client-config.api.cx.metamask.io');
+    expect(url).not.toContain(ConfigRegistryApiEnv.UAT);
+  });
+
+  it('exposes its actions through the root messenger', async () => {
+    const rootMessenger = getRootMessenger();
+    const messenger = configRegistryApiService.getMessenger(rootMessenger);
+
+    configRegistryApiService.init({
+      state: undefined,
+      messenger,
+      options: { fetch: makeFetchMock() },
+    });
+
+    const result = await rootMessenger.call(
+      'ConfigRegistryApiService:fetchConfig',
+    );
+    expect(result.modified).toBe(true);
+  });
+});

--- a/packages/wallet/src/initialization/instances/config-registry-api-service/config-registry-api-service.ts
+++ b/packages/wallet/src/initialization/instances/config-registry-api-service/config-registry-api-service.ts
@@ -1,7 +1,4 @@
-import {
-  ConfigRegistryApiEnv,
-  ConfigRegistryApiService,
-} from '@metamask/config-registry-controller';
+import { ConfigRegistryApiService } from '@metamask/config-registry-controller';
 import type { ConfigRegistryApiServiceMessenger } from '@metamask/config-registry-controller';
 import { Messenger } from '@metamask/messenger';
 
@@ -17,7 +14,7 @@ export const configRegistryApiService: InitializationConfiguration<
   init: ({ messenger, options }) =>
     new ConfigRegistryApiService({
       messenger,
-      env: options.env ?? ConfigRegistryApiEnv.PRD,
+      env: options.env,
       fetch: options.fetch,
       policyOptions: options.policyOptions,
     }),

--- a/packages/wallet/src/initialization/instances/config-registry-api-service/config-registry-api-service.ts
+++ b/packages/wallet/src/initialization/instances/config-registry-api-service/config-registry-api-service.ts
@@ -1,0 +1,29 @@
+import {
+  ConfigRegistryApiEnv,
+  ConfigRegistryApiService,
+} from '@metamask/config-registry-controller';
+import type { ConfigRegistryApiServiceMessenger } from '@metamask/config-registry-controller';
+import { Messenger } from '@metamask/messenger';
+
+import type { InitializationConfiguration } from '../../types.js';
+
+export type { ConfigRegistryApiServiceInstanceOptions } from './types.js';
+
+export const configRegistryApiService: InitializationConfiguration<
+  ConfigRegistryApiService,
+  ConfigRegistryApiServiceMessenger
+> = {
+  name: 'ConfigRegistryApiService',
+  init: ({ messenger, options }) =>
+    new ConfigRegistryApiService({
+      messenger,
+      env: options.env ?? ConfigRegistryApiEnv.PRD,
+      fetch: options.fetch,
+      policyOptions: options.policyOptions,
+    }),
+  getMessenger: (parent) =>
+    new Messenger({
+      namespace: 'ConfigRegistryApiService',
+      parent,
+    }),
+};

--- a/packages/wallet/src/initialization/instances/config-registry-api-service/types.ts
+++ b/packages/wallet/src/initialization/instances/config-registry-api-service/types.ts
@@ -1,0 +1,17 @@
+import type {
+  ConfigRegistryApiEnv,
+  ConfigRegistryApiService,
+} from '@metamask/config-registry-controller';
+
+type ConfigRegistryApiServiceOptions = ConstructorParameters<
+  typeof ConfigRegistryApiService
+>[0];
+
+/**
+ * Per-instance options for the wallet's `ConfigRegistryApiService`.
+ */
+export type ConfigRegistryApiServiceInstanceOptions = {
+  env?: ConfigRegistryApiEnv;
+  fetch?: ConfigRegistryApiServiceOptions['fetch'];
+  policyOptions?: ConfigRegistryApiServiceOptions['policyOptions'];
+};

--- a/packages/wallet/src/initialization/instances/config-registry-api-service/types.ts
+++ b/packages/wallet/src/initialization/instances/config-registry-api-service/types.ts
@@ -11,7 +11,7 @@ type ConfigRegistryApiServiceOptions = ConstructorParameters<
  * Per-instance options for the wallet's `ConfigRegistryApiService`.
  */
 export type ConfigRegistryApiServiceInstanceOptions = {
-  env?: ConfigRegistryApiEnv;
+  env: ConfigRegistryApiEnv;
   fetch?: ConfigRegistryApiServiceOptions['fetch'];
   policyOptions?: ConfigRegistryApiServiceOptions['policyOptions'];
 };

--- a/packages/wallet/src/initialization/instances/config-registry-controller/config-registry-controller.test.ts
+++ b/packages/wallet/src/initialization/instances/config-registry-controller/config-registry-controller.test.ts
@@ -1,6 +1,4 @@
-import {
-  ConfigRegistryController,
-} from '@metamask/config-registry-controller';
+import { ConfigRegistryController } from '@metamask/config-registry-controller';
 import { Messenger } from '@metamask/messenger';
 
 import { defaultConfigurations } from '../../defaults.js';

--- a/packages/wallet/src/initialization/instances/config-registry-controller/config-registry-controller.test.ts
+++ b/packages/wallet/src/initialization/instances/config-registry-controller/config-registry-controller.test.ts
@@ -1,0 +1,138 @@
+import {
+  ConfigRegistryController,
+} from '@metamask/config-registry-controller';
+import { Messenger } from '@metamask/messenger';
+
+import { defaultConfigurations } from '../../defaults.js';
+import type {
+  DefaultActions,
+  DefaultEvents,
+  RootMessenger,
+} from '../../defaults.js';
+import { configRegistryController } from './config-registry-controller.js';
+
+type ActionHandler = (...args: unknown[]) => unknown;
+
+type AnyMessenger = Messenger<string>;
+
+function getRootMessenger(): RootMessenger<DefaultActions, DefaultEvents> {
+  return new Messenger({ namespace: 'Root' });
+}
+
+function registerActionHandler(
+  parent: RootMessenger<DefaultActions, DefaultEvents>,
+  namespace: string,
+  actionType: string,
+  handler: ActionHandler,
+): void {
+  const messenger = new Messenger({
+    namespace,
+    parent: parent as unknown as AnyMessenger,
+  });
+
+  (
+    messenger as unknown as {
+      registerActionHandler(type: string, handler: ActionHandler): void;
+    }
+  ).registerActionHandler(actionType, handler);
+}
+
+function registerDependencies(
+  rootMessenger: RootMessenger<DefaultActions, DefaultEvents>,
+): void {
+  registerActionHandler(
+    rootMessenger,
+    'KeyringController',
+    'KeyringController:getState',
+    () => ({ isUnlocked: false }),
+  );
+  registerActionHandler(
+    rootMessenger,
+    'RemoteFeatureFlagController',
+    'RemoteFeatureFlagController:getState',
+    () => ({ remoteFeatureFlags: {} }),
+  );
+  registerActionHandler(
+    rootMessenger,
+    'ConfigRegistryApiService',
+    'ConfigRegistryApiService:fetchConfig',
+    async () => ({ modified: false }),
+  );
+}
+
+describe('configRegistryController', () => {
+  it('is registered as a default initialization configuration', () => {
+    expect(Object.values(defaultConfigurations)).toContain(
+      configRegistryController,
+    );
+  });
+
+  it('initializes a ConfigRegistryController', () => {
+    const rootMessenger = getRootMessenger();
+    registerDependencies(rootMessenger);
+    const messenger = configRegistryController.getMessenger(rootMessenger);
+
+    const instance = configRegistryController.init({
+      state: undefined,
+      messenger,
+      options: {},
+    });
+
+    expect(instance).toBeInstanceOf(ConfigRegistryController);
+  });
+
+  it('initializes with default state', () => {
+    const rootMessenger = getRootMessenger();
+    registerDependencies(rootMessenger);
+    const messenger = configRegistryController.getMessenger(rootMessenger);
+
+    const instance = configRegistryController.init({
+      state: undefined,
+      messenger,
+      options: {},
+    });
+
+    expect(instance.state).toStrictEqual({
+      configs: { networks: {} },
+      version: null,
+      lastFetched: null,
+      etag: null,
+    });
+  });
+
+  it('forwards provided state to the controller', () => {
+    const rootMessenger = getRootMessenger();
+    registerDependencies(rootMessenger);
+    const messenger = configRegistryController.getMessenger(rootMessenger);
+
+    const instance = configRegistryController.init({
+      state: { version: 'v1.0.0', lastFetched: 12345 },
+      messenger,
+      options: {},
+    });
+
+    expect(instance.state.version).toBe('v1.0.0');
+    expect(instance.state.lastFetched).toBe(12345);
+  });
+
+  it('exposes its state through the root messenger', () => {
+    const rootMessenger = getRootMessenger();
+    registerDependencies(rootMessenger);
+    const messenger = configRegistryController.getMessenger(rootMessenger);
+
+    configRegistryController.init({
+      state: undefined,
+      messenger,
+      options: {},
+    });
+
+    expect(
+      rootMessenger.call('ConfigRegistryController:getState'),
+    ).toStrictEqual({
+      configs: { networks: {} },
+      version: null,
+      lastFetched: null,
+      etag: null,
+    });
+  });
+});

--- a/packages/wallet/src/initialization/instances/config-registry-controller/config-registry-controller.ts
+++ b/packages/wallet/src/initialization/instances/config-registry-controller/config-registry-controller.ts
@@ -1,6 +1,4 @@
-import {
-  ConfigRegistryController,
-} from '@metamask/config-registry-controller';
+import { ConfigRegistryController } from '@metamask/config-registry-controller';
 import type { ConfigRegistryControllerMessenger } from '@metamask/config-registry-controller';
 import { Messenger } from '@metamask/messenger';
 

--- a/packages/wallet/src/initialization/instances/config-registry-controller/config-registry-controller.ts
+++ b/packages/wallet/src/initialization/instances/config-registry-controller/config-registry-controller.ts
@@ -1,0 +1,46 @@
+import {
+  ConfigRegistryController,
+} from '@metamask/config-registry-controller';
+import type { ConfigRegistryControllerMessenger } from '@metamask/config-registry-controller';
+import { Messenger } from '@metamask/messenger';
+
+import type { InitializationConfiguration } from '../../types.js';
+
+export type { ConfigRegistryControllerInstanceOptions } from './types.js';
+
+export const configRegistryController: InitializationConfiguration<
+  ConfigRegistryController,
+  ConfigRegistryControllerMessenger
+> = {
+  name: 'ConfigRegistryController',
+  init: ({ state, messenger, options }) =>
+    new ConfigRegistryController({
+      messenger,
+      state,
+      pollingInterval: options.pollingInterval,
+      fallbackConfig: options.fallbackConfig,
+    }),
+  getMessenger: (parent) => {
+    const messenger: ConfigRegistryControllerMessenger = new Messenger({
+      namespace: 'ConfigRegistryController',
+      parent,
+    });
+
+    parent.delegate({
+      messenger,
+      actions: [
+        'KeyringController:getState',
+        'RemoteFeatureFlagController:getState',
+        'ConfigRegistryApiService:fetchConfig',
+      ],
+      events: [
+        'KeyringController:unlock',
+        'KeyringController:lock',
+        // eslint-disable-next-line no-restricted-syntax
+        'RemoteFeatureFlagController:stateChange',
+      ],
+    });
+
+    return messenger;
+  },
+};

--- a/packages/wallet/src/initialization/instances/config-registry-controller/types.ts
+++ b/packages/wallet/src/initialization/instances/config-registry-controller/types.ts
@@ -1,0 +1,13 @@
+import type { ConfigRegistryController } from '@metamask/config-registry-controller';
+
+type ConfigRegistryControllerOptions = ConstructorParameters<
+  typeof ConfigRegistryController
+>[0];
+
+/**
+ * Per-instance options for the wallet's `ConfigRegistryController`.
+ */
+export type ConfigRegistryControllerInstanceOptions = {
+  pollingInterval?: ConfigRegistryControllerOptions['pollingInterval'];
+  fallbackConfig?: ConfigRegistryControllerOptions['fallbackConfig'];
+};

--- a/packages/wallet/src/initialization/instances/index.ts
+++ b/packages/wallet/src/initialization/instances/index.ts
@@ -3,6 +3,8 @@ export { addressBookController } from './address-book-controller/address-book-co
 export { approvalController } from './approval-controller/approval-controller.js';
 export { claimsController } from './claims-controller/claims-controller.js';
 export { claimsService } from './claims-service/claims-service.js';
+export { configRegistryApiService } from './config-registry-api-service/config-registry-api-service.js';
+export { configRegistryController } from './config-registry-controller/config-registry-controller.js';
 export { connectivityController } from './connectivity-controller/connectivity-controller.js';
 export { gasFeeController } from './gas-fee-controller/gas-fee-controller.js';
 export { keyringController } from './keyring-controller/keyring-controller.js';

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -37,7 +37,7 @@ export type WalletOptions = {
 export type InstanceSpecificOptions = {
   approvalController?: ApprovalControllerInstanceOptions;
   claimsService?: ClaimsServiceInstanceOptions;
-  configRegistryApiService?: ConfigRegistryApiServiceInstanceOptions;
+  configRegistryApiService: ConfigRegistryApiServiceInstanceOptions;
   configRegistryController?: ConfigRegistryControllerInstanceOptions;
   connectivityController: ConnectivityControllerInstanceOptions;
   gasFeeController: GasFeeControllerInstanceOptions;

--- a/packages/wallet/src/types.ts
+++ b/packages/wallet/src/types.ts
@@ -7,6 +7,8 @@ import type {
 } from './initialization/defaults.js';
 import type { ApprovalControllerInstanceOptions } from './initialization/instances/approval-controller/types.js';
 import type { ClaimsServiceInstanceOptions } from './initialization/instances/claims-service/types.js';
+import type { ConfigRegistryApiServiceInstanceOptions } from './initialization/instances/config-registry-api-service/types.js';
+import type { ConfigRegistryControllerInstanceOptions } from './initialization/instances/config-registry-controller/types.js';
 import type { ConnectivityControllerInstanceOptions } from './initialization/instances/connectivity-controller/types.js';
 import type { GasFeeControllerInstanceOptions } from './initialization/instances/gas-fee-controller/types.js';
 import type { KeyringControllerInstanceOptions } from './initialization/instances/keyring-controller/types.js';
@@ -35,6 +37,8 @@ export type WalletOptions = {
 export type InstanceSpecificOptions = {
   approvalController?: ApprovalControllerInstanceOptions;
   claimsService?: ClaimsServiceInstanceOptions;
+  configRegistryApiService?: ConfigRegistryApiServiceInstanceOptions;
+  configRegistryController?: ConfigRegistryControllerInstanceOptions;
   connectivityController: ConnectivityControllerInstanceOptions;
   gasFeeController: GasFeeControllerInstanceOptions;
   keyringController?: KeyringControllerInstanceOptions;

--- a/packages/wallet/tsconfig.build.json
+++ b/packages/wallet/tsconfig.build.json
@@ -10,6 +10,7 @@
     { "path": "../address-book-controller/tsconfig.build.json" },
     { "path": "../approval-controller/tsconfig.build.json" },
     { "path": "../claims-controller/tsconfig.build.json" },
+    { "path": "../config-registry-controller/tsconfig.build.json" },
     { "path": "../base-controller/tsconfig.build.json" },
     { "path": "../connectivity-controller/tsconfig.build.json" },
     { "path": "../controller-utils/tsconfig.build.json" },

--- a/packages/wallet/tsconfig.json
+++ b/packages/wallet/tsconfig.json
@@ -17,6 +17,9 @@
       "path": "../claims-controller"
     },
     {
+      "path": "../config-registry-controller"
+    },
+    {
       "path": "../base-controller"
     },
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6529,7 +6529,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/config-registry-controller@npm:^3.0.0, @metamask/config-registry-controller@workspace:packages/config-registry-controller":
+"@metamask/config-registry-controller@npm:^3.0.0, @metamask/config-registry-controller@workspace:^, @metamask/config-registry-controller@workspace:packages/config-registry-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/config-registry-controller@workspace:packages/config-registry-controller"
   dependencies:
@@ -9481,6 +9481,7 @@ __metadata:
     "@metamask/analytics-controller": "npm:^2.0.0"
     "@metamask/auto-changelog": "npm:^6.1.0"
     "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/config-registry-controller": "workspace:^"
     "@metamask/foundryup": "npm:^1.0.1"
     "@metamask/messenger": "npm:^2.0.0"
     "@metamask/remote-feature-flag-controller": "npm:^5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9552,6 +9552,7 @@ __metadata:
     "@metamask/base-controller": "npm:^9.1.0"
     "@metamask/browser-passworder": "npm:^6.0.0"
     "@metamask/claims-controller": "npm:^0.6.0"
+    "@metamask/config-registry-controller": "npm:^3.0.0"
     "@metamask/connectivity-controller": "npm:^0.3.0"
     "@metamask/controller-utils": "npm:^12.3.0"
     "@metamask/gas-fee-controller": "npm:^26.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6529,7 +6529,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/config-registry-controller@npm:^3.0.0, @metamask/config-registry-controller@workspace:^, @metamask/config-registry-controller@workspace:packages/config-registry-controller":
+"@metamask/config-registry-controller@npm:^3.0.0, @metamask/config-registry-controller@workspace:packages/config-registry-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/config-registry-controller@workspace:packages/config-registry-controller"
   dependencies:
@@ -9481,7 +9481,7 @@ __metadata:
     "@metamask/analytics-controller": "npm:^2.0.0"
     "@metamask/auto-changelog": "npm:^6.1.0"
     "@metamask/base-controller": "npm:^9.1.0"
-    "@metamask/config-registry-controller": "workspace:^"
+    "@metamask/config-registry-controller": "npm:^3.0.0"
     "@metamask/foundryup": "npm:^1.0.1"
     "@metamask/messenger": "npm:^2.0.0"
     "@metamask/remote-feature-flag-controller": "npm:^5.0.0"


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->
Adding `@metamask/config-registry-controller` to the `wallet` package.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->
* Fixes https://consensyssoftware.atlassian.net/browse/WPN-1894

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking constructor API plus new remote config fetch on wallet startup. Duplicate messenger registration can fail existing consumers that already wire these controllers.
> 
> **Overview**
> **BREAKING:** Default wallet init now constructs `ConfigRegistryApiService` and `ConfigRegistryController`, so remote config registry is part of the core wallet graph.
> 
> `instanceOptions.configRegistryApiService` is **required** (`env`, optional `fetch` / `policyOptions`). `configRegistryController` is optional (`pollingInterval`, `fallbackConfig`). The controller messenger delegates keyring, remote feature flags, and `ConfigRegistryApiService:fetchConfig`.
> 
> Consumers that already register these on a custom root messenger must drop their own wiring or registrations will collide. `wallet-cli` passes `ConfigRegistryApiEnv.PRD`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4777e5348edf58cbe73ea6b340ed16484fb59dc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->