### PR TITLE
fix(perps-controller): consume candle unsubscribe failures

### DIFF
--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Consume rejected HyperLiquid candle unsubscriptions so cleanup cannot emit an unhandled promise rejection.
+- Consume rejected HyperLiquid candle unsubscriptions so cleanup cannot emit an unhandled promise rejection ([#9939](https://github.com/MetaMask/core/pull/9939))
 
 ## [12.2.0]
 

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Default `DEFAULT_PRO_LAYOUT_PREFERENCES.chartExpanded` to `true` so the chart is visible when a user first enters Pro mode; a persisted `chartExpanded` value still wins, so users who hid the chart keep it hidden ([#9920](https://github.com/MetaMask/core/pull/9920))
 
+### Fixed
+
+- Consume rejected HyperLiquid candle unsubscriptions so cleanup cannot emit an unhandled promise rejection.
+
 ## [12.2.0]
 
 ### Added

--- a/packages/perps-controller/src/services/HyperLiquidClientService.ts
+++ b/packages/perps-controller/src/services/HyperLiquidClientService.ts
@@ -734,9 +734,54 @@ export class HyperLiquidClientService {
     let currentCandleData: CandleData | null = null;
     let wsUnsubscribe: (() => void) | null = null;
     let isUnsubscribed = false;
+    let hasUnsubscribeStarted = false;
     // Store the subscription promise to enable cleanup even when pending
     // This fixes a race condition where component unmounts before subscription resolves
-    let subscriptionPromise: Promise<{ unsubscribe: () => void }> | null = null;
+    type CandleSubscription = Awaited<
+      ReturnType<typeof subscriptionClient.candle>
+    >;
+    let subscriptionPromise: Promise<CandleSubscription> | null = null;
+
+    const unsubscribeFromCandles = (subscription: CandleSubscription): void => {
+      if (hasUnsubscribeStarted) {
+        return;
+      }
+      hasUnsubscribeStarted = true;
+
+      const logUnsubscribeError = (error: unknown): void => {
+        const errorInstance = ensureError(
+          error,
+          'HyperLiquidClientService.subscribeToCandles',
+        );
+
+        if (errorInstance.message.startsWith('Already unsubscribed')) {
+          return;
+        }
+
+        this.#deps.logger.error(errorInstance, {
+          tags: {
+            feature: PERPS_CONSTANTS.FeatureName,
+            service: 'HyperLiquidClientService',
+            network: this.#isTestnet ? 'testnet' : 'mainnet',
+          },
+          context: {
+            name: 'websocket_unsubscription',
+            data: {
+              operation: 'subscribeToCandles',
+              symbol,
+              interval,
+              phase: 'ws_unsubscription',
+            },
+          },
+        });
+      };
+
+      try {
+        Promise.resolve(subscription.unsubscribe()).catch(logUnsubscribeError);
+      } catch (error) {
+        logUnsubscribeError(error);
+      }
+    };
 
     // AbortController to cancel in-flight REST calls (candleSnapshot) on cleanup.
     // Prevents rate limit exhaustion when rapidly switching markets (#28141).
@@ -825,7 +870,7 @@ export class HyperLiquidClientService {
         // Store cleanup function when subscription resolves
         try {
           const sub = await subscriptionPromise;
-          wsUnsubscribe = (): void => sub.unsubscribe();
+          wsUnsubscribe = (): void => unsubscribeFromCandles(sub);
           // If already unsubscribed while waiting, clean up immediately
           if (isUnsubscribed) {
             wsUnsubscribe();
@@ -912,7 +957,7 @@ export class HyperLiquidClientService {
         // This prevents WebSocket subscription leaks when component unmounts
         // before the subscription promise resolves
         subscriptionPromise
-          .then((sub) => sub.unsubscribe())
+          .then((sub) => unsubscribeFromCandles(sub))
           .catch(() => {
             // Ignore errors during cleanup - subscription may have failed
           });

--- a/packages/perps-controller/tests/src/services/HyperLiquidClientService.test.ts
+++ b/packages/perps-controller/tests/src/services/HyperLiquidClientService.test.ts
@@ -1411,6 +1411,74 @@ describe('HyperLiquidClientService', () => {
       // Assert - WebSocket should be cleaned up immediately after establishing
       expect(mockWsUnsubscribe).toHaveBeenCalled();
     });
+
+    it('consumes a rejected unsubscribe after the subscription resolves', async () => {
+      mockInfoClientHttp.candleSnapshot = jest.fn().mockResolvedValue([]);
+      const unsubscribeError = new Error('Unsubscribe request failed');
+      const mockWsUnsubscribe = jest.fn().mockRejectedValue(unsubscribeError);
+      const unhandledRejectionListener = jest.fn();
+      process.on('unhandledRejection', unhandledRejectionListener);
+      (mockSubscriptionClient as any).candle = jest
+        .fn()
+        .mockResolvedValue({ unsubscribe: mockWsUnsubscribe });
+
+      const unsubscribe = service.subscribeToCandles({
+        symbol: 'BTC',
+        interval: '1h' as ValidCandleInterval,
+        callback: jest.fn(),
+      });
+      await jest.advanceTimersByTimeAsync(100);
+      mockDeps.logger.error.mockClear();
+
+      unsubscribe();
+      await jest.advanceTimersByTimeAsync(100);
+      process.off('unhandledRejection', unhandledRejectionListener);
+
+      expect(unhandledRejectionListener).not.toHaveBeenCalled();
+      expect(mockDeps.logger.error).toHaveBeenCalledWith(
+        unsubscribeError,
+        expect.objectContaining({
+          context: expect.objectContaining({
+            name: 'websocket_unsubscription',
+          }),
+        }),
+      );
+    });
+
+    it('treats an Already unsubscribed rejection as idempotent during late cleanup', async () => {
+      mockInfoClientHttp.candleSnapshot = jest.fn().mockResolvedValue([]);
+      let resolveWsSubscription: (value: any) => void = () => {
+        // Intentionally empty until the test captures the resolver.
+      };
+      const delayedWsPromise = new Promise((resolve) => {
+        resolveWsSubscription = resolve;
+      });
+      const mockWsUnsubscribe = jest
+        .fn()
+        .mockRejectedValue(new Error('Already unsubscribed from candle feed'));
+      const unhandledRejectionListener = jest.fn();
+      process.on('unhandledRejection', unhandledRejectionListener);
+      (mockSubscriptionClient as any).candle = jest
+        .fn()
+        .mockReturnValue(delayedWsPromise);
+
+      const unsubscribe = service.subscribeToCandles({
+        symbol: 'BTC',
+        interval: '1h' as ValidCandleInterval,
+        callback: jest.fn(),
+      });
+      await jest.advanceTimersByTimeAsync(50);
+      unsubscribe();
+      mockDeps.logger.error.mockClear();
+
+      resolveWsSubscription({ unsubscribe: mockWsUnsubscribe });
+      await jest.advanceTimersByTimeAsync(100);
+      process.off('unhandledRejection', unhandledRejectionListener);
+
+      expect(mockWsUnsubscribe).toHaveBeenCalledTimes(1);
+      expect(unhandledRejectionListener).not.toHaveBeenCalled();
+      expect(mockDeps.logger.error).not.toHaveBeenCalled();
+    });
   });
 
   describe('Reconnection and Terminate Event', () => {


### PR DESCRIPTION
## Explanation

Candle cleanup currently drops the promise returned by the HyperLiquid SDK unsubscribe call. A rejected cleanup therefore becomes an unhandled promise rejection during Mobile foreground recovery.

This change routes resolved and pending cleanup through one idempotent helper. It consumes async rejections, catches synchronous throws, ignores the SDK's already-unsubscribed result, and logs unexpected failures.

## References

- Related to MetaMask/metamask-mobile#34948
- Mobile uses a temporary Yarn patch until this fix is released.

## Validation

- Focused HyperLiquidClientService suite: 90/90 passed
- Changed-file ESLint and formatting passed
- Perps controller changelog validation passed
- The standalone package build requires prebuilt workspace dependency outputs in a fresh checkout; CI will run the complete build graph.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation as appropriate
- [x] I've communicated my changes to consumers by updating the package changelog
- [ ] I've introduced breaking changes in this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Defensive error handling on candle subscription teardown only; no trading, auth, or data-path changes.
> 
> **Overview**
> Stops HyperLiquid candle cleanup from dropping the SDK `unsubscribe()` promise, which could become an unhandled rejection (notably during Mobile foreground recovery).
> 
> `subscribeToCandles` now routes resolved and pending teardown through one idempotent helper: it consumes async rejections, catches sync throws, ignores the SDK's "Already unsubscribed" result, and logs unexpected failures. Tests cover both the logged failure path and the idempotent late-cleanup path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 377bfed7b7d28812b2f5c91d9e6ef9cccbdf12eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->