### PR TITLE
fix(react-data-query): Match generics to TanStack defaults

### DIFF
--- a/packages/react-data-query/CHANGELOG.md
+++ b/packages/react-data-query/CHANGELOG.md
@@ -9,9 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Upgrade `@tanstack/query-core` and `@tanstack/react-query` from `^4.43.0` to `^5.62.16` ([#9563](https://github.com/MetaMask/core/pull/9563))
+- **BREAKING:** Upgrade `@tanstack/query-core` and `@tanstack/react-query` from `^4.43.0` to `^5.62.16` ([#9563](https://github.com/MetaMask/core/pull/9563), [#9941](https://github.com/MetaMask/core/pull/9941))
   - `createUIQueryClient`'s `invalidateQueries` override now matches the TanStack Query v5 signature (`filters`, `options`) instead of the v4 overload style that relied on `parseFilterArgs`.
   - Consumers must migrate to TanStack Query v5 APIs (for example `gcTime` instead of `cacheTime`, and `initialPageParam` for infinite queries).
+  - `TError` in both hooks now defaults to `DefaultError`.
 - **BREAKING:** Constrain `createUIQueryClient`'s messenger-like type to match the given data services ([#9475](https://github.com/MetaMask/core/pull/9475))
   - The messenger-like object that `createUIQueryClient` takes must minimally support actions or `:cacheUpdated:${hash}` events which are namespaced by the provided data service names.
   - If you're passing a messenger, it should "just work" as long as your messenger supports the right actions and events.

--- a/packages/react-data-query/src/hooks.ts
+++ b/packages/react-data-query/src/hooks.ts
@@ -2,7 +2,6 @@ import { QueryKey } from '@metamask/base-data-service';
 import {
   useQuery as useQueryTanStack,
   useInfiniteQuery as useInfiniteQueryTanStack,
-  InfiniteData,
   OmitKeyof,
   UseQueryOptions,
   InitialDataFunction,
@@ -10,6 +9,7 @@ import {
   UseInfiniteQueryOptions,
   UseQueryResult,
   UseInfiniteQueryResult,
+  DefaultError,
 } from '@tanstack/react-query';
 
 /**
@@ -31,7 +31,7 @@ const DATA_SERVICE_QUERY_DEFAULTS = {
  */
 export function useQuery<
   TQueryFnData = unknown,
-  TError = unknown,
+  TError = DefaultError,
   TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
 >(
@@ -57,8 +57,8 @@ export function useQuery<
  */
 export function useInfiniteQuery<
   TQueryFnData = unknown,
-  TError = unknown,
-  TData = InfiniteData<TQueryFnData>,
+  TError = DefaultError,
+  TData = TQueryFnData,
   TQueryKey extends QueryKey = QueryKey,
   TPageParam = unknown,
 >(


### PR DESCRIPTION
## Explanation

Ensure generics in `react-data-query` hooks match the TanStack defaults to prevent type errors. Also fixes an issue introduced in the PR that bumped to v5.

## References

https://consensyssoftware.atlassian.net/browse/WPC-1245

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Runtime behavior is unchanged; only TypeScript generic defaults and changelog text are updated.
> 
> **Overview**
> Aligns **`useQuery`** and **`useInfiniteQuery`** generic defaults with TanStack Query v5 so types line up after the v5 upgrade and stop surfacing inference errors.
> 
> **`TError`** now defaults to **`DefaultError`** (was **`unknown`**) on both hooks. **`useInfiniteQuery`**’s **`TData`** default is **`TQueryFnData`** instead of **`InfiniteData<TQueryFnData>`**, matching upstream; the unused **`InfiniteData`** import is removed. The unreleased changelog notes the **`TError`** change and links PR **#9941** on the existing v5 breaking entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af72282708eb0d940004af989381323282ea0aa0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->