### PR TITLE
fix(perps-controller): bound optional provider diagnostics

### DIFF
--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -15,11 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Bound HyperLiquid combined-price debug payloads so large spot-market maps do not stall React Native DevTools and other CDP clients.
 - Default `DEFAULT_PRO_LAYOUT_PREFERENCES.chartExpanded` to `true` so the chart is visible when a user first enters Pro mode; a persisted `chartExpanded` value still wins, so users who hid the chart keep it hidden ([#9920](https://github.com/MetaMask/core/pull/9920))
 - Restore pending trade configurations for 30 seconds instead of five minutes, include the `reduceOnly` setting, and clear the draft after a successful order while retaining leverage and the selected order type ([#9922](https://github.com/MetaMask/core/pull/9922))
 
 ### Fixed
 
+- Ignore missing optional MYX constructors when a consumer excludes the MYX module from its bundle.
 - Consume rejected HyperLiquid candle unsubscriptions so cleanup cannot emit an unhandled promise rejection ([#9939](https://github.com/MetaMask/core/pull/9939))
 
 ## [12.2.0]

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -15,13 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bound HyperLiquid combined-price debug payloads so large spot-market maps do not stall React Native DevTools and other CDP clients.
+- Bound HyperLiquid combined-price debug payloads so large spot-market maps do not stall React Native DevTools and other CDP clients ([#9942](https://github.com/MetaMask/core/pull/9942))
 - Default `DEFAULT_PRO_LAYOUT_PREFERENCES.chartExpanded` to `true` so the chart is visible when a user first enters Pro mode; a persisted `chartExpanded` value still wins, so users who hid the chart keep it hidden ([#9920](https://github.com/MetaMask/core/pull/9920))
 - Restore pending trade configurations for 30 seconds instead of five minutes, include the `reduceOnly` setting, and clear the draft after a successful order while retaining leverage and the selected order type ([#9922](https://github.com/MetaMask/core/pull/9922))
 
 ### Fixed
 
-- Ignore missing optional MYX constructors when a consumer excludes the MYX module from its bundle.
+- Ignore missing optional MYX constructors when a consumer excludes the MYX module from its bundle ([#9942](https://github.com/MetaMask/core/pull/9942))
 - Consume rejected HyperLiquid candle unsubscriptions so cleanup cannot emit an unhandled promise rejection ([#9939](https://github.com/MetaMask/core/pull/9939))
 
 ## [12.2.0]

--- a/packages/perps-controller/src/PerpsController.ts
+++ b/packages/perps-controller/src/PerpsController.ts
@@ -2322,19 +2322,22 @@ export class PerpsController extends BaseController<
    *
    * @param MYXProvider - Constructor class for the MYX provider.
    */
-  protected registerMYXProvider(
-    MYXProvider: new (opts: {
-      isTestnet: boolean;
-      platformDependencies: PerpsPlatformDependencies;
-      messenger: PerpsControllerMessenger;
-      myxAuthConfig: ReturnType<typeof resolveMyxAuthConfig>;
-    }) => PerpsProvider,
-  ): void {
+  protected registerMYXProvider(MYXProvider: unknown): void {
+    if (typeof MYXProvider !== 'function') {
+      return;
+    }
+
     const myxIsTestnet =
       PROVIDER_CONFIG.MYX_TESTNET_ONLY || this.state.isTestnet;
     const myx = this.#options.clientConfig?.providerCredentials?.myx ?? {};
     const myxAuthConfig = resolveMyxAuthConfig(myx, myxIsTestnet);
-    const myxProvider = new MYXProvider({
+    const MYXProviderConstructor = MYXProvider as new (opts: {
+      isTestnet: boolean;
+      platformDependencies: PerpsPlatformDependencies;
+      messenger: PerpsControllerMessenger;
+      myxAuthConfig: ReturnType<typeof resolveMyxAuthConfig>;
+    }) => PerpsProvider;
+    const myxProvider = new MYXProviderConstructor({
       isTestnet: myxIsTestnet,
       platformDependencies: this.#options.infrastructure,
       messenger: this.messenger,

--- a/packages/perps-controller/src/providers/HyperLiquidProvider.ts
+++ b/packages/perps-controller/src/providers/HyperLiquidProvider.ts
@@ -9488,20 +9488,16 @@ export class HyperLiquidProvider implements PerpsProvider {
       },
     );
 
-    // Debug: Log combinedAllMids to diagnose price lookup issues
-    const hip3Keys = Object.keys(combinedAllMids).filter((key) =>
-      key.includes(':'),
-    );
+    // Keep this diagnostic bounded. Logging every price stalls React Native
+    // DevTools and other CDP clients when thousands of spot keys are present.
+    const allMidEntries = Object.entries(combinedAllMids);
+    const hip3Entries = allMidEntries.filter(([key]) => key.includes(':'));
     this.#deps.debugLogger.log('Combined allMids price data:', {
-      totalKeys: Object.keys(combinedAllMids).length,
-      allKeys: Object.keys(combinedAllMids),
-      hip3Keys,
-      hip3Prices: Object.fromEntries(
-        hip3Keys.map((key) => [key, combinedAllMids[key]]),
-      ),
-      samplePrices: Object.fromEntries(
-        Object.entries(combinedAllMids).slice(0, 5),
-      ),
+      totalKeys: allMidEntries.length,
+      hip3Keys: hip3Entries.length,
+      keySample: allMidEntries.slice(0, 5).map(([key]) => key),
+      hip3KeySample: hip3Entries.slice(0, 5).map(([key]) => key),
+      samplePrices: Object.fromEntries(allMidEntries.slice(0, 5)),
     });
 
     // Transform to UI-friendly format using standalone utility

--- a/packages/perps-controller/tests/src/PerpsController.providers-cache.test.ts
+++ b/packages/perps-controller/tests/src/PerpsController.providers-cache.test.ts
@@ -373,10 +373,8 @@ class TestablePerpsController extends PerpsController {
     return this.hasStandaloneProvider();
   }
 
-  public testRegisterMYXProvider(
-    MYXProvider: new (opts: Record<string, unknown>) => PerpsProvider,
-  ) {
-    this.registerMYXProvider(MYXProvider as never);
+  public testRegisterMYXProvider(MYXProvider: unknown) {
+    this.registerMYXProvider(MYXProvider);
   }
 
   public testHandleMYXImportError(error: unknown) {
@@ -842,6 +840,12 @@ describe('PerpsController', () => {
       expect(MockMYXConstructor).toHaveBeenCalledWith(
         expect.objectContaining({ isTestnet: false }),
       );
+    });
+
+    it('registerMYXProvider ignores a missing optional constructor', () => {
+      controller.testRegisterMYXProvider(undefined);
+
+      expect(controller.testGetProviders().has('myx')).toBe(false);
     });
 
     it('handleMYXImportError logs debug for MODULE_NOT_FOUND errors', () => {


### PR DESCRIPTION
## What changed

- Limit the HyperLiquid combined-price debug record to counts and five-key samples instead of serializing every market and price.
- Ignore an absent MYX constructor when a consumer intentionally excludes the optional MYX module from its bundle.

## Why

A full HyperLiquid snapshot currently logs more than 3,000 keys. In React Native development builds, that payload can fill the inspector socket and stall DevTools/CDP while the app itself remains responsive.

MetaMask Mobile also excludes the optional MYX implementation. Metro resolves that import to an empty module, so registration must skip the missing constructor instead of calling it and logging a `prototype` error.

Neither change affects market data, provider selection, or production behavior. They only bound development diagnostics and make the existing optional-module contract explicit.

## Validation

- Focused MYX registration cases pass, including a missing constructor.
- Changed-file ESLint passes.
- Oxfmt and changelog validation pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Debug-log shaping and optional MYX registration guards only; market data paths and production trading behavior are unchanged.
> 
> **Overview**
> Shrinks **HyperLiquid** combined `allMids` debug output so React Native DevTools and other CDP clients are not flooded when thousands of spot keys exist. The log now reports **counts** and **five-key samples** instead of every key and full HIP-3 price maps.
> 
> **MYX** registration in `registerMYXProvider` now **no-ops** when the dynamic import resolves to a non-constructor (e.g. Metro stubbing an excluded optional module), avoiding prototype errors on MetaMask Mobile without changing trading or provider selection when MYX is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f89080b9c493554637fc73e47ccac0d5ad10007. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->