### PR TITLE
feat: export isAddressScanSupportedChainId

### DIFF
--- a/packages/phishing-controller/CHANGELOG.md
+++ b/packages/phishing-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `isAddressScanSupportedChainId` so clients can check whether `scanAddress` will call the Security Alerts API for a chain ID, without duplicating `DEFAULT_CHAIN_ID_TO_NAME` and `ADDRESS_SCAN_SUPPORTED_CHAINS`
+- Add `isAddressScanSupportedChainId` so clients can check whether `scanAddress` will call the Security Alerts API for a chain ID, without duplicating `DEFAULT_CHAIN_ID_TO_NAME` and `ADDRESS_SCAN_SUPPORTED_CHAINS` ([#9946](https://github.com/MetaMask/core/pull/9946))
 
 ### Changed
 

--- a/packages/phishing-controller/CHANGELOG.md
+++ b/packages/phishing-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `isAddressScanSupportedChainId` so clients can check whether `scanAddress` will call the Security Alerts API for a chain ID, without duplicating `DEFAULT_CHAIN_ID_TO_NAME` and `ADDRESS_SCAN_SUPPORTED_CHAINS`
+
 ### Changed
 
 - Bump `@metamask/transaction-controller` from `^69.4.0` to `^69.5.2` ([#9780](https://github.com/MetaMask/core/pull/9780), [#9798](https://github.com/MetaMask/core/pull/9798), [#9823](https://github.com/MetaMask/core/pull/9823))

--- a/packages/phishing-controller/src/PhishingController.ts
+++ b/packages/phishing-controller/src/PhishingController.ts
@@ -71,7 +71,7 @@ import {
   splitCacheHits,
   resolveChainName,
   getPathnameFromUrl,
-  isAddressScanSupportedChain,
+  getAddressScanSupportedChain,
   isApprovalSupportedChain,
   isTokenScanSupportedChain,
 } from './utils.js';
@@ -1471,9 +1471,9 @@ export class PhishingController extends BaseController<
 
     const normalizedChainId = chainId.toLowerCase();
     const normalizedAddress = address.toLowerCase();
-    const chain = resolveChainName(normalizedChainId);
+    const chain = getAddressScanSupportedChain(normalizedChainId);
 
-    if (!chain || !isAddressScanSupportedChain(chain)) {
+    if (!chain) {
       return {
         result_type: AddressScanResultType.ErrorResult,
         label: '',

--- a/packages/phishing-controller/src/index.ts
+++ b/packages/phishing-controller/src/index.ts
@@ -35,6 +35,7 @@ export type { CacheEntry } from './CacheManager.js';
 export {
   PHISHING_DETECTION_PATH_BASED_ROOT_DOMAINS,
   getPhishingDetectionScanUrlParam,
+  isAddressScanSupportedChainId,
   isPhishingDetectionPathBasedHostname,
 } from './utils.js';
 

--- a/packages/phishing-controller/src/utils.test.ts
+++ b/packages/phishing-controller/src/utils.test.ts
@@ -7,11 +7,13 @@ import {
   domainToParts,
   fetchTimeNow,
   generateParentDomains,
+  getAddressScanSupportedChain,
   getHostnameAndPathComponents,
   getHostnameFromUrl,
   getHostnameFromWebUrl,
   getPhishingDetectionScanUrlParam,
   isAddressScanSupportedChain,
+  isAddressScanSupportedChainId,
   isPhishingDetectionPathBasedHostname,
   isTokenScanSupportedChain,
   matchPartsAgainstList,
@@ -1284,6 +1286,54 @@ describe('isAddressScanSupportedChain', () => {
   it('returns false for unknown chains', () => {
     expect(isAddressScanSupportedChain('unknown-chain')).toBe(false);
     expect(isAddressScanSupportedChain('')).toBe(false);
+  });
+});
+
+describe('getAddressScanSupportedChain', () => {
+  it('returns the chain name for an address-scan supported hex chain ID', () => {
+    expect(getAddressScanSupportedChain('0x1')).toBe('ethereum');
+    expect(getAddressScanSupportedChain('0x1237')).toBe('robinhood');
+  });
+
+  it('matches chain IDs case-insensitively', () => {
+    expect(getAddressScanSupportedChain('0X1')).toBe('ethereum');
+  });
+
+  it('returns null for a mapped chain that is not address-scan supported', () => {
+    expect(getAddressScanSupportedChain('0x343b')).toBeNull();
+  });
+
+  it('returns null for an unmapped chain ID', () => {
+    expect(getAddressScanSupportedChain('0xa4ec')).toBeNull();
+    expect(getAddressScanSupportedChain('0xdeadbeef')).toBeNull();
+  });
+
+  it('returns null for non-EVM chain names that are not address-scan supported', () => {
+    expect(getAddressScanSupportedChain('solana')).toBeNull();
+  });
+});
+
+describe('isAddressScanSupportedChainId', () => {
+  it('returns true for address-scan supported hex chain IDs', () => {
+    expect(isAddressScanSupportedChainId('0x1')).toBe(true);
+    expect(isAddressScanSupportedChainId('0x1237')).toBe(true);
+  });
+
+  it('matches chain IDs case-insensitively', () => {
+    expect(isAddressScanSupportedChainId('0X1')).toBe(true);
+  });
+
+  it('returns false for a mapped chain that is not address-scan supported', () => {
+    expect(isAddressScanSupportedChainId('0x343b')).toBe(false);
+  });
+
+  it('returns false for an unmapped chain ID', () => {
+    expect(isAddressScanSupportedChainId('0xa4ec')).toBe(false);
+    expect(isAddressScanSupportedChainId('0xdeadbeef')).toBe(false);
+  });
+
+  it('returns false for non-EVM chain names that are not address-scan supported', () => {
+    expect(isAddressScanSupportedChainId('solana')).toBe(false);
   });
 });
 

--- a/packages/phishing-controller/src/utils.ts
+++ b/packages/phishing-controller/src/utils.ts
@@ -550,6 +550,39 @@ export const resolveChainName = (
 };
 
 /**
+ * Resolves a chain ID to a Blockaid address-scan chain name, or `null` if
+ * `scanAddress` would not call the Security Alerts API for this chain.
+ *
+ * @param chainId - Hex chain ID for EVM chains (e.g. `'0x1'`) or a chain
+ * name for non-EVM chains (e.g. `'solana'`).
+ * @returns The address-scan chain name, or `null` if unsupported.
+ */
+export const getAddressScanSupportedChain = (
+  chainId: string,
+): AddressScanSupportedChain | null => {
+  const chain = resolveChainName(chainId);
+  if (!chain || !isAddressScanSupportedChain(chain)) {
+    return null;
+  }
+  return chain;
+};
+
+/**
+ * Determines whether `scanAddress` will call the Security Alerts API for
+ * this chain, rather than immediately returning `ErrorResult`.
+ *
+ * Matches the gate inside `scanAddress`: the chain ID must resolve via
+ * {@link resolveChainName}, and that name must be in
+ * `ADDRESS_SCAN_SUPPORTED_CHAINS`.
+ *
+ * @param chainId - Hex chain ID for EVM chains (e.g. `'0x1'`) or a chain
+ * name for non-EVM chains (e.g. `'solana'`).
+ * @returns `true` if an address scan would hit the API.
+ */
+export const isAddressScanSupportedChainId = (chainId: string): boolean =>
+  getAddressScanSupportedChain(chainId) !== null;
+
+/**
  * Split tokens into cached results and tokens that need to be fetched.
  *
  * @param cache - Cache-like object with get method.


### PR DESCRIPTION
## Explanation

**Summary**

Export `isAddressScanSupportedChainId` from `@metamask/phishing-controller` so clients can ask the same question `scanAddress` asks, without copying the chain tables.

**Problem**

`scanAddress` returns `ErrorResult` immediately when a chain ID does not resolve, or when the resolved name is not in `ADDRESS_SCAN_SUPPORTED_CHAINS`. Those tables and helpers already live in this package, but they are not part of the public export. Clients that need the check (for example enforced-simulation eligibility in the extension) have to duplicate the hex ID list. That list then drifts when Blockaid coverage changes.

**Solution**

Add `getAddressScanSupportedChain` / `isAddressScanSupportedChainId` as the composed gate (`resolveChainName` then `isAddressScanSupportedChain`). Export only `isAddressScanSupportedChainId` from the package root. Point `scanAddress` at `getAddressScanSupportedChain` so the public helper and the runtime scan cannot diverge.

Exporting the raw slug list would still leave clients composing hex IDs incorrectly. The boolean is the API eligibility callers need.

**Risk**

- Additive public API. No breaking change.
- `isAddressScanSupportedChain` and `resolveChainName` stay unexported. Callers that need the slug can wait or import is not supported; `scanAddress` still returns the slug internally for the API body.

## References

* Related to https://github.com/MetaMask/metamask-extension/pull/45732
* Related to https://consensyssoftware.atlassian.net/browse/PSAFE-571

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive public API and a small refactor of existing scan gating with no change to supported-chain semantics beyond shared helper usage.
> 
> **Overview**
> Adds a **public** `isAddressScanSupportedChainId` export so callers can tell whether `scanAddress` would hit the Security Alerts API or return `ErrorResult` immediately, without copying chain ID tables.
> 
> Internally, **`getAddressScanSupportedChain`** centralizes the same gate (`resolveChainName` plus `isAddressScanSupportedChain`); **`scanAddress`** now uses that helper so runtime behavior and the exported boolean stay aligned. Only the boolean is exported from the package entrypoint; tests and the changelog document the addition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54307d049379b5faf37e73235a77e5be0d1186ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->