### PR TITLE
Release/1206.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "1205.0.0",
+  "version": "1206.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {

--- a/packages/passkey-controller/CHANGELOG.md
+++ b/packages/passkey-controller/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.0]
+
 ### Added
 
 - Added new util, `getAAGUIDFromRegistrationResponse` to read the authenticator AAGUID from a `navigator.credentials.create()` result. ([#9951](https://github.com/MetaMask/core/pull/9951))
@@ -110,7 +112,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Registration verification requires the credential `id`/`rawId` to match the credential id in authenticator data; vault wrapping key derivation uses that verified credential id so enrollment keys align with the stored credential.
 - Registration options request attestation conveyance `'none'` so clients are not asked for direct attestation formats the verifier does not implement (`none` and self-attested `packed` only).
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/passkey-controller@3.0.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/passkey-controller@3.1.0...HEAD
+[3.1.0]: https://github.com/MetaMask/core/compare/@metamask/passkey-controller@3.0.0...@metamask/passkey-controller@3.1.0
 [3.0.0]: https://github.com/MetaMask/core/compare/@metamask/passkey-controller@2.1.0...@metamask/passkey-controller@3.0.0
 [2.1.0]: https://github.com/MetaMask/core/compare/@metamask/passkey-controller@2.0.1...@metamask/passkey-controller@2.1.0
 [2.0.1]: https://github.com/MetaMask/core/compare/@metamask/passkey-controller@2.0.0...@metamask/passkey-controller@2.0.1

--- a/packages/passkey-controller/package.json
+++ b/packages/passkey-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/passkey-controller",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Controller and utilities for passkey-based wallet unlock",
   "keywords": [
     "Ethereum",

--- a/packages/wallet/CHANGELOG.md
+++ b/packages/wallet/CHANGELOG.md
@@ -7,13 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `@metamask/passkey-controller` from `^3.0.0` to `^3.1.0`. ([#9952](https://github.com/MetaMask/core/pull/9952))
+
 ## [12.0.1]
 
 ### Changed
 
 - Bump `@metamask/remote-feature-flag-controller` from `^5.0.0` to `^6.0.0` ([#9945](https://github.com/MetaMask/core/pull/9945))
   - This should have been included in 12.0.0.
-- Bump `@metamask/passkey-controller` from `^3.0.0` to `^3.1.0`. ([#9952](https://github.com/MetaMask/core/pull/9952))
 
 ## [12.0.0]
 

--- a/packages/wallet/CHANGELOG.md
+++ b/packages/wallet/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/remote-feature-flag-controller` from `^5.0.0` to `^6.0.0` ([#9945](https://github.com/MetaMask/core/pull/9945))
   - This should have been included in 12.0.0.
+- Bump `@metamask/passkey-controller` from `^3.0.0` to `^3.1.0`. ([#9952](https://github.com/MetaMask/core/pull/9952))
 
 ## [12.0.0]
 

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -68,7 +68,7 @@
     "@metamask/keyring-controller": "^27.1.1",
     "@metamask/messenger": "^2.0.0",
     "@metamask/network-controller": "^35.0.1",
-    "@metamask/passkey-controller": "^3.0.0",
+    "@metamask/passkey-controller": "^3.1.0",
     "@metamask/remote-feature-flag-controller": "^6.0.0",
     "@metamask/scure-bip39": "^2.1.1",
     "@metamask/seedless-onboarding-controller": "^10.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8300,7 +8300,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/passkey-controller@npm:^3.0.0, @metamask/passkey-controller@workspace:packages/passkey-controller":
+"@metamask/passkey-controller@npm:^3.1.0, @metamask/passkey-controller@workspace:packages/passkey-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/passkey-controller@workspace:packages/passkey-controller"
   dependencies:
@@ -9560,7 +9560,7 @@ __metadata:
     "@metamask/keyring-controller": "npm:^27.1.1"
     "@metamask/messenger": "npm:^2.0.0"
     "@metamask/network-controller": "npm:^35.0.1"
-    "@metamask/passkey-controller": "npm:^3.0.0"
+    "@metamask/passkey-controller": "npm:^3.1.0"
     "@metamask/remote-feature-flag-controller": "npm:^6.0.0"
     "@metamask/scure-bip39": "npm:^2.1.1"
     "@metamask/seedless-onboarding-controller": "npm:^10.1.1"


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Minor release of `@metamask/passkey-controller`

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and dependency metadata only; functional passkey changes were shipped in prior PRs referenced by the changelog.
> 
> **Overview**
> This PR **cuts the monorepo release** by bumping `@metamask/core-monorepo` to **1206.0.0** and publishing **`@metamask/passkey-controller` 3.1.0** (from 3.0.0), with changelog sections and compare links updated accordingly.
> 
> The **3.1.0** notes (already landed in earlier PRs) cover exporting **`getAAGUIDFromRegistrationResponse`** and bumping **`@metamask/keyring-controller`** to `^27.1.1`. **`@metamask/wallet`** is updated to depend on **`@metamask/passkey-controller` ^3.1.0**, with an Unreleased changelog entry; **`yarn.lock`** is refreshed to match.
> 
> There are **no application source changes** in this diff—only versioning, changelogs, and lockfile updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfbe002ad753bc7f450725e7808cc3f36c2a6e4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->