### PR TITLE
fix(react-data-query): Revert change to `TData` for `useInfiniteQuery`

### DIFF
--- a/packages/react-data-query/CHANGELOG.md
+++ b/packages/react-data-query/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Upgrade `@tanstack/query-core` and `@tanstack/react-query` from `^4.43.0` to `^5.62.16` ([#9563](https://github.com/MetaMask/core/pull/9563), [#9941](https://github.com/MetaMask/core/pull/9941))
+- **BREAKING:** Upgrade `@tanstack/query-core` and `@tanstack/react-query` from `^4.43.0` to `^5.62.16` ([#9563](https://github.com/MetaMask/core/pull/9563), [#9941](https://github.com/MetaMask/core/pull/9941), [#9953](https://github.com/MetaMask/core/pull/9953))
   - `createUIQueryClient`'s `invalidateQueries` override now matches the TanStack Query v5 signature (`filters`, `options`) instead of the v4 overload style that relied on `parseFilterArgs`.
   - Consumers must migrate to TanStack Query v5 APIs (for example `gcTime` instead of `cacheTime`, and `initialPageParam` for infinite queries).
   - `TError` in both hooks now defaults to `DefaultError`.

--- a/packages/react-data-query/src/hooks.ts
+++ b/packages/react-data-query/src/hooks.ts
@@ -10,6 +10,7 @@ import {
   UseQueryResult,
   UseInfiniteQueryResult,
   DefaultError,
+  InfiniteData,
 } from '@tanstack/react-query';
 
 /**
@@ -58,7 +59,7 @@ export function useQuery<
 export function useInfiniteQuery<
   TQueryFnData = unknown,
   TError = DefaultError,
-  TData = TQueryFnData,
+  TData = InfiniteData<TQueryFnData>,
   TQueryKey extends QueryKey = QueryKey,
   TPageParam = unknown,
 >(


### PR DESCRIPTION
## Explanation

In my previous [PR](https://github.com/MetaMask/core/pull/9941), I read the types wrong and changed the `TData` default erroneously. This PR rectifies that.

## References

https://consensyssoftware.atlassian.net/browse/WPC-1245

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only correction for hook generics; no runtime behavior change beyond restoring expected TypeScript inference for infinite queries.
> 
> **Overview**
> Corrects the **`useInfiniteQuery`** generic default for **`TData`**, changing it back from **`TQueryFnData`** to **`InfiniteData<TQueryFnData>`** so it matches TanStack Query v5’s infinite-query result shape (fixing a mistaken type change from the v5 upgrade).
> 
> Adds the **`InfiniteData`** import used by that default. The unreleased changelog entry for the TanStack v5 breaking change now also references PR **#9953**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b5738addf5baa0129c54f8bc43ec8b2c92af882. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->