### PR TITLE
chore: Remove ocap-kernel ownership from wallet-cli

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -115,7 +115,7 @@
 /packages/sample-controllers                      @MetaMask/core-platform
 /packages/selected-network-controller             @MetaMask/core-platform
 /packages/wallet                                  @MetaMask/core-platform
-/packages/wallet-cli                              @MetaMask/core-platform @MetaMask/ocap-kernel
+/packages/wallet-cli                              @MetaMask/core-platform
 /packages/wallet-framework-docs                   @MetaMask/core-platform
 
 ## Web3Auth Team

--- a/codeowners.ts
+++ b/codeowners.ts
@@ -365,7 +365,7 @@ const PACKAGES: Record<string, PackageInfo> = {
     teams: ['@MetaMask/core-platform'],
   },
   'wallet-cli': {
-    teams: ['@MetaMask/core-platform', '@MetaMask/ocap-kernel'],
+    teams: ['@MetaMask/core-platform'],
   },
   'wallet-framework-docs': {
     teams: ['@MetaMask/core-platform'],

--- a/teams.json
+++ b/teams.json
@@ -61,7 +61,7 @@
   "metamask/react-data-query": "team-core-platform",
   "metamask/profile-metrics-controller": "team-mobile-platform,team-extension-platform",
   "metamask/wallet": "team-core-platform",
-  "metamask/wallet-cli": "team-core-platform,team-ocap-kernel",
+  "metamask/wallet-cli": "team-core-platform",
   "metamask/passkey-controller": "team-onboarding",
   "metamask/seedless-onboarding-controller": "team-onboarding",
   "metamask/shield-controller": "team-shield",


### PR DESCRIPTION
## Explanation

Removes `@MetaMask/ocap-kernel` co-ownership from the `wallet-cli` package in `CODEOWNERS`, `codeowners.ts`, and `teams.json`. The package is now solely owned by `@MetaMask/core-platform`.

## References

N/A

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them