### PR TITLE
fix(eth-json-rpc-middleware): accept numeric chainId in transaction params

### DIFF
--- a/packages/eth-json-rpc-middleware/CHANGELOG.md
+++ b/packages/eth-json-rpc-middleware/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/superstruct` from `^3.1.0` to `^3.4.1` ([#9754](https://github.com/MetaMask/core/pull/9754))
 
+### Fixed
+
+- Accept a numeric `chainId` in `eth_sendTransaction` and `eth_signTransaction` params ([#9965](https://github.com/MetaMask/core/pull/9965))
+  - `chainId` is now validated as a quantity (hex string or number), matching `gas`, `nonce`, `value`, and the other numerical fields
+  - Previously it was restricted to a string, so dapps sending a number were rejected with `-32602 Invalid params`
+
 ## [24.0.0]
 
 ### Changed

--- a/packages/eth-json-rpc-middleware/src/utils/validation.test.ts
+++ b/packages/eth-json-rpc-middleware/src/utils/validation.test.ts
@@ -333,6 +333,37 @@ describe('Validation Utils', () => {
       ).not.toThrow();
     });
 
+    it('does not throw when `chainId` is a number', () => {
+      expect(() =>
+        validateTransactionParams({
+          from: VALID_FROM,
+          to: VALID_TO,
+          chainId: 1,
+        }),
+      ).not.toThrow();
+    });
+
+    it('does not throw when `chainId` is a hex string', () => {
+      expect(() =>
+        validateTransactionParams({
+          from: VALID_FROM,
+          to: VALID_TO,
+          chainId: '0x1',
+        }),
+      ).not.toThrow();
+    });
+
+    it('throws for an extraneous top-level key alongside a numeric `chainId`', () => {
+      expect(() =>
+        validateTransactionParams({
+          from: VALID_FROM,
+          to: VALID_TO,
+          chainId: 1,
+          extraKey: 'unexpected',
+        }),
+      ).toThrow(/Invalid params/u);
+    });
+
     it.each([
       ['null', null],
       ['undefined', undefined],

--- a/packages/eth-json-rpc-middleware/src/utils/validation.ts
+++ b/packages/eth-json-rpc-middleware/src/utils/validation.ts
@@ -263,7 +263,7 @@ export const TransactionParamsStruct = object({
       }),
     ),
   ),
-  chainId: optional(string()),
+  chainId: optional(QuantityStruct),
   data: optional(string()),
   from: string(),
   gas: optional(QuantityStruct),


### PR DESCRIPTION
## Explanation

`TransactionParamsStruct` in `packages/eth-json-rpc-middleware/src/utils/validation.ts` declares a `QuantityStruct = union([string(), number()])` for numerical transaction fields, with the comment:

> Numerical fields accept both hex strings and numbers, as some dapps send numbers and `TransactionController` normalizes them downstream.

Every quantity field uses it — `gas`, `gasLimit`, `gasPrice`, `maxFeePerGas`, `maxPriorityFeePerGas`, `nonce`, `value` — except `chainId`, which was left as `optional(string())`. That looks like an oversight rather than a deliberate exclusion, since the stated policy applies to `chainId` just as much.

The consequence is that any `eth_sendTransaction` / `eth_signTransaction` whose `chainId` is a JSON number is rejected with `-32602 Invalid params: chainId - Expected a string, but received: 4663`, even though the value is well-formed and would be normalized downstream. This shipped with the strict-validation change in #9482 (v24.0.0) and is a production regression in MetaMask extension 13.45.0 and metamask-mobile 8.8.0+.

For a concrete producer of a numeric `chainId`: the Uniswap interface types its request as `chainId: number`, its `hexlifyTransaction` helper hex-encodes six fields but not `chainId`, and it then calls `provider.send('eth_sendTransaction', ...)` directly, bypassing ethers' own hexlification. ethers v6, ethers v5, and web3.js v4 all hex-encode top-level `chainId`; viem omits it entirely — so this is reached by dapps that build params by hand, exactly the case the `QuantityStruct` comment describes.

The fix is one character of scope: `chainId: optional(QuantityStruct)`.

Deliberately out of scope: the `authorizationList[].chainId` / `nonce` / `yParity` fields are also string-only, but for those the string-only type is arguably correct. `execution-apis`' `transaction.yaml` types them as `uint` / `byte`, which resolve to hex-string patterns in `base-types.yaml`, and both viem (`formatAuthorizationList`) and ethers v6 (`getRpcTransaction`) hex-encode them before they reach the provider. There is no reported breakage there, and widening them would loosen validation with no evidence behind it — happy to include it if reviewers prefer symmetry.

The hardening added in #9482 is unaffected — unknown top-level keys, ill-typed fields, and oversized payloads are still rejected, and there is a new test asserting that an extraneous key alongside a numeric `chainId` still throws.

## Verification

- `yarn jest src/utils/validation.test.ts` in `packages/eth-json-rpc-middleware` — 45/45 pass.
- With line 266 reverted to `optional(string())` and the new tests kept, exactly one test fails (`does not throw when \`chainId\` is a number`), confirming the added coverage is load-bearing.
- `eslint` clean on both changed files.
- Not run: the full monorepo suite.

## References

- Fixes #9964
- Related to MetaMask/metamask-extension#45763 (Sev1-high regression; cross-repo, so this PR cannot auto-close it)
- Regressed by #9482
- MetaMask/metamask-extension#45766 applies this same one-line change as a yarn patch of `24.0.0`, as a stopgap for users on already-shipped extension versions. It's intended to be reverted in favour of a `24.0.1` bump once this lands, so a patch release here would let that be dropped.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them
