### PR TITLE
feat: Add optional force option to updateRemoteFeatureFlags

### DIFF
--- a/packages/remote-feature-flag-controller/CHANGELOG.md
+++ b/packages/remote-feature-flag-controller/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add optional `force` argument to `updateRemoteFeatureFlags` to fetch even when the cache has not expired ([#9966](https://github.com/MetaMask/core/pull/9966))
+  - Defaults to `false`. Does not fetch when the controller is disabled.
+
 ## [6.0.0]
 
 ### Added

--- a/packages/remote-feature-flag-controller/src/remote-feature-flag-controller-method-action-types.ts
+++ b/packages/remote-feature-flag-controller/src/remote-feature-flag-controller-method-action-types.ts
@@ -9,6 +9,8 @@ import type { RemoteFeatureFlagController } from './remote-feature-flag-controll
  * Retrieves the remote feature flags, fetching from the API if necessary.
  * Uses caching to prevent redundant API calls and handles concurrent fetches.
  *
+ * @param force - When `true`, fetch even if the cache has not expired.
+ * Defaults to `false`. Has no effect when the controller is disabled.
  * @returns A promise that resolves to the current set of feature flags.
  */
 export type RemoteFeatureFlagControllerUpdateRemoteFeatureFlagsAction = {

--- a/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.test.ts
+++ b/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.test.ts
@@ -226,6 +226,52 @@ describe('RemoteFeatureFlagController', () => {
       expect(controller.state.remoteFeatureFlags).toStrictEqual(MOCK_FLAGS);
     });
 
+    it('fetches and updates state when cache is not expired if force is true', async () => {
+      const clientConfigApiService = buildClientConfigApiService({
+        remoteFeatureFlags: MOCK_FLAGS_TWO,
+      });
+      const { controller, messenger } = createController({
+        state: {
+          remoteFeatureFlags: MOCK_FLAGS,
+          cacheTimestamp: Date.now() - 10,
+        },
+        clientConfigApiService,
+      });
+
+      await messenger.call(
+        'RemoteFeatureFlagController:updateRemoteFeatureFlags',
+        true,
+      );
+
+      expect(
+        clientConfigApiService.fetchRemoteFeatureFlags,
+      ).toHaveBeenCalledTimes(1);
+      expect(controller.state.remoteFeatureFlags).toStrictEqual(MOCK_FLAGS_TWO);
+    });
+
+    it('does not fetch when disabled even if force is true', async () => {
+      const clientConfigApiService = buildClientConfigApiService({
+        remoteFeatureFlags: MOCK_FLAGS_TWO,
+      });
+      const { controller, messenger } = createController({
+        state: {
+          remoteFeatureFlags: MOCK_FLAGS,
+        },
+        clientConfigApiService,
+        disabled: true,
+      });
+
+      await messenger.call(
+        'RemoteFeatureFlagController:updateRemoteFeatureFlags',
+        true,
+      );
+
+      expect(
+        clientConfigApiService.fetchRemoteFeatureFlags,
+      ).not.toHaveBeenCalled();
+      expect(controller.state.remoteFeatureFlags).toStrictEqual(MOCK_FLAGS);
+    });
+
     it('resets cache and fetch when clientVersion changes', async () => {
       const versionedFlags = {
         exploreFeature: {

--- a/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.ts
+++ b/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.ts
@@ -316,10 +316,12 @@ export class RemoteFeatureFlagController extends BaseController<
    * Retrieves the remote feature flags, fetching from the API if necessary.
    * Uses caching to prevent redundant API calls and handles concurrent fetches.
    *
+   * @param force - When `true`, fetch even if the cache has not expired.
+   * Defaults to `false`. Has no effect when the controller is disabled.
    * @returns A promise that resolves to the current set of feature flags.
    */
-  async updateRemoteFeatureFlags(): Promise<void> {
-    if (this.#disabled || !this.#isCacheExpired()) {
+  async updateRemoteFeatureFlags(force = false): Promise<void> {
+    if (this.#disabled || (!force && !this.#isCacheExpired())) {
       return;
     }
 


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

This PR just adds an optional `force` arg to `updateRemoteFeatureFlags` for forcing an update whenever it's set to true.
Example use case: We'll want to force an update once canonical IDs are available on the platform sides so that the proper flag variants are served

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible optional parameter with narrow cache-bypass behavior; existing callers unchanged when omitting force.
> 
> **Overview**
> Adds an optional **`force`** argument (default **`false`**) to **`updateRemoteFeatureFlags`**, so callers can refresh remote flags from the API even when the cache is still valid—e.g. after a canonical profile ID becomes available so threshold segmentation can be re-fetched.
> 
> When **`force`** is **`true`**, the early return that skipped fetch on a fresh cache is bypassed; **disabled** controllers still never fetch, regardless of **`force`**. Messenger action types, JSDoc, changelog, and tests cover the enabled + forced path and the disabled + forced no-op.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b718057b2018a80a73f1e61f852c9571c092c52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->