### PR TITLE
fix(perps): align HIP-3 market contexts

### DIFF
--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Keep selectively allowlisted HIP-3 markets aligned with their volume, open-interest, funding, and previous-price contexts ([#9971](https://github.com/MetaMask/core/pull/9971))
+- Display tiny nonzero funding rates as `<0.0001%` or `>-0.0001%` instead of `0.0000%` ([#9971](https://github.com/MetaMask/core/pull/9971))
 - Ignore missing optional MYX constructors when a consumer excludes the MYX module from its bundle ([#9942](https://github.com/MetaMask/core/pull/9942))
 - Consume rejected HyperLiquid candle unsubscriptions so cleanup cannot emit an unhandled promise rejection ([#9939](https://github.com/MetaMask/core/pull/9939))
 

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Keep selectively allowlisted HIP-3 markets aligned with their volume, open-interest, funding, and previous-price contexts ([#9971](https://github.com/MetaMask/core/pull/9971))
-- Display tiny nonzero funding rates as `<0.0001%` or `>-0.0001%` instead of `0.0000%` ([#9971](https://github.com/MetaMask/core/pull/9971))
+- Display tiny nonzero funding rates as `<0.0001%` or `-<0.0001%` instead of `0.0000%` ([#9971](https://github.com/MetaMask/core/pull/9971))
 - Ignore missing optional MYX constructors when a consumer excludes the MYX module from its bundle ([#9942](https://github.com/MetaMask/core/pull/9942))
 - Consume rejected HyperLiquid candle unsubscriptions so cleanup cannot emit an unhandled promise rejection ([#9939](https://github.com/MetaMask/core/pull/9939))
 

--- a/packages/perps-controller/src/providers/HyperLiquidProvider.ts
+++ b/packages/perps-controller/src/providers/HyperLiquidProvider.ts
@@ -9592,21 +9592,29 @@ export class HyperLiquidProvider implements PerpsProvider {
     results.forEach((result) => {
       if (result.success && result.meta?.universe) {
         const marketsFromDex = result.meta.universe;
-        const filteredMarkets =
-          result.dex === null
-            ? marketsFromDex
-            : marketsFromDex.filter((asset) =>
-                shouldIncludeMarket(
-                  asset.name,
-                  result.dex,
-                  this.#hip3Enabled,
-                  this.#compiledAllowlistPatterns,
-                  this.#compiledBlocklistPatterns,
-                ),
-              );
+        const filteredMarketsWithContexts = marketsFromDex
+          .map((market, index) => ({
+            market,
+            assetCtx: result.assetCtxs[index],
+          }))
+          .filter(
+            ({ market }) =>
+              result.dex === null ||
+              shouldIncludeMarket(
+                market.name,
+                result.dex,
+                this.#hip3Enabled,
+                this.#compiledAllowlistPatterns,
+                this.#compiledBlocklistPatterns,
+              ),
+          );
 
-        combinedUniverse.push(...filteredMarkets);
-        combinedAssetCtxs.push(...result.assetCtxs);
+        combinedUniverse.push(
+          ...filteredMarketsWithContexts.map(({ market }) => market),
+        );
+        combinedAssetCtxs.push(
+          ...filteredMarketsWithContexts.map(({ assetCtx }) => assetCtx),
+        );
         Object.assign(combinedAllMids, result.allMids);
       }
     });

--- a/packages/perps-controller/src/utils/perpsFormatters.ts
+++ b/packages/perps-controller/src/utils/perpsFormatters.ts
@@ -604,6 +604,7 @@ export const formatPercentage = (
  * @returns Formatted funding rate as percentage string
  * @example formatFundingRate(0.0005) => "0.0500%"
  * @example formatFundingRate(-0.0001) => "-0.0100%"
+ * @example formatFundingRate(0.000000059) => "<0.0001%"
  * @example formatFundingRate(undefined) => "0.0000%"
  */
 export const formatFundingRate = (
@@ -618,6 +619,14 @@ export const formatFundingRate = (
 
   const percentage = value * FUNDING_RATE_CONFIG.PercentageMultiplier;
   const formatted = percentage.toFixed(FUNDING_RATE_CONFIG.Decimals);
+  const minimumDisplayPercentage = 10 ** -FUNDING_RATE_CONFIG.Decimals;
+
+  if (value !== 0 && parseFloat(formatted) === 0) {
+    const threshold = minimumDisplayPercentage.toFixed(
+      FUNDING_RATE_CONFIG.Decimals,
+    );
+    return value > 0 ? `<${threshold}%` : `>-${threshold}%`;
+  }
 
   // Check if the result is effectively zero
   if (showZero && parseFloat(formatted) === 0) {

--- a/packages/perps-controller/src/utils/perpsFormatters.ts
+++ b/packages/perps-controller/src/utils/perpsFormatters.ts
@@ -605,6 +605,7 @@ export const formatPercentage = (
  * @example formatFundingRate(0.0005) => "0.0500%"
  * @example formatFundingRate(-0.0001) => "-0.0100%"
  * @example formatFundingRate(0.000000059) => "<0.0001%"
+ * @example formatFundingRate(-0.000000059) => "-<0.0001%"
  * @example formatFundingRate(undefined) => "0.0000%"
  */
 export const formatFundingRate = (
@@ -625,7 +626,7 @@ export const formatFundingRate = (
     const threshold = minimumDisplayPercentage.toFixed(
       FUNDING_RATE_CONFIG.Decimals,
     );
-    return value > 0 ? `<${threshold}%` : `>-${threshold}%`;
+    return value > 0 ? `<${threshold}%` : `-<${threshold}%`;
   }
 
   // Check if the result is effectively zero

--- a/packages/perps-controller/tests/src/providers/HyperLiquidProvider.data.test.ts
+++ b/packages/perps-controller/tests/src/providers/HyperLiquidProvider.data.test.ts
@@ -838,6 +838,87 @@ describe('HyperLiquidProvider', () => {
       expect(markets).toEqual([]);
     });
 
+    it('keeps HIP-3 asset contexts aligned after allowlist filtering', async () => {
+      const mainMeta = {
+        universe: [{ name: 'BTC', szDecimals: 3, maxLeverage: 50 }],
+      };
+      const mainAssetCtx = {
+        funding: '0.0001',
+        openInterest: '1000',
+        prevDayPx: '49000',
+        dayNtlVlm: '1000000',
+        markPx: '50000',
+        midPx: '50000',
+        oraclePx: '50000',
+      };
+      const ioMeta = {
+        collateralToken: 0,
+        universe: [
+          { name: 'io:PREIPO', szDecimals: 3, maxLeverage: 3 },
+          { name: 'io:ANTH', szDecimals: 3, maxLeverage: 3 },
+        ],
+      };
+      const ioAssetCtxs = [
+        {
+          funding: '0.0002',
+          openInterest: '10',
+          prevDayPx: '100',
+          dayNtlVlm: '100',
+          markPx: '100',
+          midPx: '100',
+          oraclePx: '100',
+        },
+        {
+          funding: '0.000000059',
+          openInterest: '1766.312',
+          prevDayPx: '1998.2',
+          dayNtlVlm: '10536801.2081',
+          markPx: '2009.3',
+          midPx: '2010.1',
+          oraclePx: '2009.3',
+        },
+      ];
+      const mockInfoClient = createMockInfoClient({
+        perpDexs: jest
+          .fn()
+          .mockResolvedValue([null, { name: 'io', url: 'https://io.example' }]),
+        metaAndAssetCtxs: jest
+          .fn()
+          .mockImplementation((params?: { dex?: string }) =>
+            params?.dex === 'io'
+              ? Promise.resolve([ioMeta, ioAssetCtxs])
+              : Promise.resolve([mainMeta, [mainAssetCtx]]),
+          ),
+        allMids: jest.fn().mockImplementation((params?: { dex?: string }) =>
+          params?.dex === 'io'
+            ? Promise.resolve({
+                'io:PREIPO': '100',
+                'io:ANTH': '2010.1',
+              })
+            : Promise.resolve({ BTC: '50000' }),
+        ),
+      });
+      mockClientService.getInfoClient = jest
+        .fn()
+        .mockReturnValue(mockInfoClient);
+      const hip3Provider = createTestProvider({
+        hip3Enabled: true,
+        allowlistMarkets: ['io:ANTH'],
+      });
+
+      const markets = await hip3Provider.getMarketDataWithPrices();
+
+      expect(markets).toEqual([
+        expect.objectContaining({ symbol: 'BTC' }),
+        expect.objectContaining({
+          symbol: 'io:ANTH',
+          volume: '$10536801',
+          openInterest: '$3550464',
+          fundingRate: 0.000000059,
+        }),
+      ]);
+    });
+
     it('handles data retrieval errors gracefully', async () => {
       (
         mockClientService.getInfoClient().clearinghouseState as jest.Mock

--- a/packages/perps-controller/tests/src/utils/perpsFormatters.test.ts
+++ b/packages/perps-controller/tests/src/utils/perpsFormatters.test.ts
@@ -283,6 +283,22 @@ describe('formatFundingRate', () => {
     expect(formatFundingRate(0)).toBe('0.0000%');
   });
 
+  it('shows a threshold for positive rates below display precision', () => {
+    const value = 0.000000059;
+
+    const result = formatFundingRate(value);
+
+    expect(result).toBe('<0.0001%');
+  });
+
+  it('shows a threshold for negative rates below display precision', () => {
+    const value = -0.000000059;
+
+    const result = formatFundingRate(value);
+
+    expect(result).toBe('>-0.0001%');
+  });
+
   it('returns empty string for undefined when showZero is false', () => {
     expect(formatFundingRate(undefined, { showZero: false })).toBe('');
   });

--- a/packages/perps-controller/tests/src/utils/perpsFormatters.test.ts
+++ b/packages/perps-controller/tests/src/utils/perpsFormatters.test.ts
@@ -296,7 +296,7 @@ describe('formatFundingRate', () => {
 
     const result = formatFundingRate(value);
 
-    expect(result).toBe('>-0.0001%');
+    expect(result).toBe('-<0.0001%');
   });
 
   it('returns empty string for undefined when showZero is false', () => {


### PR DESCRIPTION
## Explanation

Selective HIP-3 allowlists filtered the market universe without filtering the parallel asset-context array. Markets such as `io:ANTH` then inherited volume, open-interest, funding, and previous-price data from another market.

This change filters each market together with its same-index context. It also displays tiny nonzero funding rates as `<0.0001%` or `-<0.0001%` instead of `0.0000%`.

## References

- Jira: https://consensyssoftware.atlassian.net/browse/TAT-3841
- Mobile consumer PR: https://github.com/MetaMask/metamask-mobile/pull/35312

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by updating changelogs for packages I've changed
- [ ] I've introduced breaking changes in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes market-overview data correctness for allowlisted HIP-3 symbols and funding-rate UI text; trading logic is untouched, but wrong stats could mislead users before this fix.
> 
> **Overview**
> Fixes **wrong market stats on selectively allowlisted HIP-3 markets** by filtering each DEX’s `universe` entry together with its same-index `assetCtx` in `#mergeDexResultsInto`, instead of dropping markets from the list while still appending the full context array (which could attach another symbol’s volume, open interest, funding, and prior price to markets like `io:ANTH`).
> 
> Updates **`formatFundingRate`** so tiny nonzero rates that round to `0.0000%` at four decimal places render as **`<0.0001%`** or **`-<0.0001%`**, signaling activity below display precision rather than a flat zero.
> 
> Changelog and tests cover the alignment regression and the new funding threshold strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7b23c0180ed88a984aee660acb1ebe215d3715a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->