### PR TITLE
feat: use split relay and iron disclaimer submission

### DIFF
--- a/packages/kyc-controller/ARCHITECTURE.md
+++ b/packages/kyc-controller/ARCHITECTURE.md
@@ -122,20 +122,22 @@ Exposed messenger actions (`MESSENGER_EXPOSED_METHODS`):
 Exposed messenger actions (`MESSENGER_EXPOSED_METHODS`):
 
 `getGeoCountry`, `fetchDisclaimers`, `createSession`, `checkKycRequired`,
-`createVendorCustomer`, `submitConsents`, `fetchKycStatus`, `createUkycSession`,
-`createJourney`.
+`createVendorCustomer`, `submitVendorDisclaimers`, `fetchSessionDisclaimers`, `submitSessionDisclaimers`,
+`fetchKycStatus`, `createUkycSession`, `createJourney`.
 
 Endpoints:
 
 | Method                 | HTTP   | Endpoint                                 | Purpose                                                                 |
 | ---------------------- | ------ | ---------------------------------------- | ----------------------------------------------------------------------- |
 | `getGeoCountry`        | —      | (geolocation action)                     | Resolve alpha-3 country                                                 |
-| `fetchDisclaimers`     | `GET`  | `/vendors/{vendor}/disclaimers?country=` | Terms to accept (`vendor` defaults to `moonpay`)                        |
-| `createSession`        | `POST` | `/vendors/moonpay/sessions`              | Create MoonPay vendor session                                           |
-| `checkKycRequired`     | `POST` | `/vendors/{vendor}/kyc-required`         | Is KYC required? (normalizes `required` → `kycRequired`)                |
-| `createVendorCustomer` | `POST` | `/vendors/{vendor}/customers`            | Create or resume an empty-shell vendor customer                         |
-| `submitConsents`       | `POST` | `/consents`                              | Post T&C1 + T&C2 consents (204 No Content)                              |
-| `fetchKycStatus`       | `GET`  | `/kyc/status`                            | User-keyed simplified KYC status                                        |
+| `fetchDisclaimers`           | `GET`  | `/vendors/{vendor}/disclaimers?country=`     | Vendor T&Cs to accept (`vendor` defaults to `moonpay`)                      |
+| `createSession`              | `POST` | `/vendors/moonpay/sessions`                  | Create MoonPay vendor session                                               |
+| `checkKycRequired`           | `POST` | `/vendors/{vendor}/kyc-required`             | Is KYC required? (normalizes `required` → `kycRequired`)                    |
+| `createVendorCustomer`       | `POST` | `/vendors/{vendor}/customers`                | Create or resume an empty-shell vendor customer                             |
+| `submitVendorDisclaimers`    | `POST` | `/vendors/{vendor}/disclaimers`              | Record vendor T&C signings (`disclaimerIds`)                                |
+| `fetchSessionDisclaimers`    | `GET`  | `/sessions/{id}/disclaimers`                 | Session-scoped idOS + KYC-provider catalog                                  |
+| `submitSessionDisclaimers`   | `POST` | `/sessions/{id}/disclaimers`                 | Record `{ idOS, kycProvider, credentialReusabilityConsentGiven }` consents |
+| `fetchKycStatus`             | `GET`  | `/kyc/status`                                | User-keyed simplified KYC status                                            |
 | `createUkycSession`    | `POST` | `/sessions`                              | Start SumSub sub-flow (wrapped key + read-only `ukyc_capability_token`) |
 | `createJourney`        | `POST` | `/sessions/{id}/journey`                 | Create verification journey → applicant token                           |
 
@@ -200,8 +202,11 @@ classDiagram
 State metadata highlights (`kycControllerMetadata`):
 
 - **Persisted** (`persist: true`): `termsAcceptedAt`, `acceptedDisclaimerIds`,
-  `termsAcceptedVendor`, `kycRequiredByProduct`, `lastCheckedAt`. These survive
-  restarts so the flow can skip already-accepted terms and reuse cached results.
+  `termsAcceptedVendor`, `sumsubTncAccepted`, `idosTncAccepted`,
+  `kycRequiredByProduct`, `lastCheckedAt`. These survive restarts so the flow
+  can skip already-accepted terms and reuse cached results. Session-scoped
+  `sessionDisclaimers` and `credentialReusabilityConsentGiven` are in-memory
+  only (`persist: false`) and are cleared on `reset()`.
   Acceptance is vendor-scoped: `initialize` (and `createVendorCustomer`) drops
   the stored acceptance when it belongs to a different vendor, so one vendor's
   disclaimer ids are never submitted to another. The drop waits until the
@@ -262,14 +267,18 @@ stateDiagram-v2
 
 > **Non-MoonPay vendors use a consents path.** `initialize({ vendor: 'iron' })`
 > creates an empty-shell customer, loads vendor disclaimers, and — after terms
-> are accepted — posts consents and launches SumSub. MoonPay Check/Auth frames
-> are skipped; `phase` moves `terms → session → submit → done`. A SumSub
-> failure (thrown step or SDK close without completion) rewinds to `terms`
-> instead of forcing `done`. A terminal UKYC rejection after the SDK reported
-> `Completed` still finishes as `done` so `refreshKycStatus` can surface the
-> decision. `acceptTermsAndStartSession` requires
-> `sumsubTncSigned` and `idosTncSigned` (T&C2) for every vendor; omitted flags
-> fail the flow instead of defaulting to `true`.
+> are accepted — records vendor T&Cs (`POST /vendors/{vendor}/disclaimers`),
+> creates a UKYC session, records session-scoped idOS / KYC-provider
+> disclaimers, and launches SumSub. MoonPay Check/Auth frames are skipped;
+> `phase` moves `terms → session → submit → done`. A SumSub failure (thrown step
+> or SDK close without completion) rewinds to `terms` instead of forcing `done`.
+> A terminal UKYC rejection after the SDK reported `Completed` still finishes as
+> `done` so `refreshKycStatus` can surface the decision.
+> `acceptTermsAndStartSession` requires `sumsubTncSigned` and `idosTncSigned`
+> (T&C2) for every vendor; omitted flags fail the flow instead of defaulting to
+> `true`. Those flags are mapped onto the session catalog's `idOS` /
+> `kycProvider` document records; `credentialReusabilityConsentGiven` is
+> forwarded as well (defaults to `false`).
 
 > **`initialize` and `createVendorCustomer` never tear down an active flow.** If
 > `phase` is already one of the in-progress phases (`session`, `check`, `auth`,
@@ -510,7 +519,7 @@ graph LR
         C_ext["Allowed (delegated):<br/>KycService:*"]
     end
     subgraph SvcMsgr["KycServiceMessenger"]
-        S_own["Own actions:<br/>KycService: 6 methods"]
+        S_own["Own actions:<br/>KycService: messenger methods"]
         S_ext["Allowed (delegated):<br/>AuthenticationController:getBearerToken<br/>GeolocationController:getGeolocation"]
     end
 
@@ -586,7 +595,7 @@ graph TB
 - **`kyc-service-init.ts`** constructs `KycService` with an `env` derived from
   `isProduction()` and (currently) a dev `baseUrl` override. It does not inject
   a `fetch`; `KycService` defaults to the runtime's native `fetch`.
-- **`kyc-controller-messenger.ts`** delegates the six `KycService:*` actions to
+- **`kyc-controller-messenger.ts`** delegates `KycService:*` actions to
   the controller's messenger.
 - **`kyc-service-messenger.ts`** delegates
   `AuthenticationController:getBearerToken` and

--- a/packages/kyc-controller/ARCHITECTURE.md
+++ b/packages/kyc-controller/ARCHITECTURE.md
@@ -127,19 +127,19 @@ Exposed messenger actions (`MESSENGER_EXPOSED_METHODS`):
 
 Endpoints:
 
-| Method                 | HTTP   | Endpoint                                 | Purpose                                                                 |
-| ---------------------- | ------ | ---------------------------------------- | ----------------------------------------------------------------------- |
-| `getGeoCountry`        | —      | (geolocation action)                     | Resolve alpha-3 country                                                 |
-| `fetchDisclaimers`           | `GET`  | `/vendors/{vendor}/disclaimers?country=`     | Vendor T&Cs to accept (`vendor` defaults to `moonpay`)                      |
-| `createSession`              | `POST` | `/vendors/moonpay/sessions`                  | Create MoonPay vendor session                                               |
-| `checkKycRequired`           | `POST` | `/vendors/{vendor}/kyc-required`             | Is KYC required? (normalizes `required` → `kycRequired`)                    |
-| `createVendorCustomer`       | `POST` | `/vendors/{vendor}/customers`                | Create or resume an empty-shell vendor customer                             |
-| `submitVendorDisclaimers`    | `POST` | `/vendors/{vendor}/disclaimers`              | Record vendor T&C signings (`disclaimerIds`)                                |
-| `fetchSessionDisclaimers`    | `GET`  | `/sessions/{id}/disclaimers`                 | Session-scoped idOS + KYC-provider catalog                                  |
-| `submitSessionDisclaimers`   | `POST` | `/sessions/{id}/disclaimers`                 | Record `{ idOS, kycProvider, credentialReusabilityConsentGiven }` consents |
-| `fetchKycStatus`             | `GET`  | `/kyc/status`                                | User-keyed simplified KYC status                                            |
-| `createUkycSession`    | `POST` | `/sessions`                              | Start SumSub sub-flow (wrapped key + read-only `ukyc_capability_token`) |
-| `createJourney`        | `POST` | `/sessions/{id}/journey`                 | Create verification journey → applicant token                           |
+| Method                     | HTTP   | Endpoint                                 | Purpose                                                                    |
+| -------------------------- | ------ | ---------------------------------------- | -------------------------------------------------------------------------- |
+| `getGeoCountry`            | —      | (geolocation action)                     | Resolve alpha-3 country                                                    |
+| `fetchDisclaimers`         | `GET`  | `/vendors/{vendor}/disclaimers?country=` | Vendor T&Cs to accept (`vendor` defaults to `moonpay`)                     |
+| `createSession`            | `POST` | `/vendors/moonpay/sessions`              | Create MoonPay vendor session                                              |
+| `checkKycRequired`         | `POST` | `/vendors/{vendor}/kyc-required`         | Is KYC required? (normalizes `required` → `kycRequired`)                   |
+| `createVendorCustomer`     | `POST` | `/vendors/{vendor}/customers`            | Create or resume an empty-shell vendor customer                            |
+| `submitVendorDisclaimers`  | `POST` | `/vendors/{vendor}/disclaimers`          | Record vendor T&C signings (`disclaimerIds`)                               |
+| `fetchSessionDisclaimers`  | `GET`  | `/sessions/{id}/disclaimers`             | Session-scoped idOS + KYC-provider catalog                                 |
+| `submitSessionDisclaimers` | `POST` | `/sessions/{id}/disclaimers`             | Record `{ idOS, kycProvider, credentialReusabilityConsentGiven }` consents |
+| `fetchKycStatus`           | `GET`  | `/kyc/status`                            | User-keyed simplified KYC status                                           |
+| `createUkycSession`        | `POST` | `/sessions`                              | Start SumSub sub-flow (wrapped key + read-only `ukyc_capability_token`)    |
+| `createJourney`            | `POST` | `/sessions/{id}/journey`                 | Create verification journey → applicant token                              |
 
 ### 2.3 `crypto.ts`
 

--- a/packages/kyc-controller/CHANGELOG.md
+++ b/packages/kyc-controller/CHANGELOG.md
@@ -9,10 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add session-scoped disclaimer APIs on `KycService` for the idOS / KYC-provider catalog:
+  - `fetchSessionDisclaimers({ sessionId })` calls `GET /sessions/{sessionId}/disclaimers`
+  - `submitSessionDisclaimers({ sessionId, idOS, kycProvider, credentialReusabilityConsentGiven })` calls `POST /sessions/{sessionId}/disclaimers`
+- Add `KycService.submitVendorDisclaimers({ vendor, disclaimerIds })` (`POST /vendors/{vendor}/disclaimers`) to record Iron T&C signings, plus the `KycVendorSigning` response type. The consents path calls this alongside session-scoped disclaimers; vendor T&C ids are no longer sent on the session disclaimer POST.
+- Add `KycConsentDocument`, `KycConsentRecord`, and `KycSessionDisclaimers` types for that catalog, plus in-memory `credentialReusabilityConsentGiven` and `sessionDisclaimers` controller state. `acceptTermsAndStartSession` forwards optional `credentialReusabilityConsentGiven` (default `false`).
 - Parameterize Universal KYC vendor HTTP on `KycService` so identity vendors share one client surface instead of vendor-branded methods ([#9908](https://github.com/MetaMask/core/pull/9908)):
   - `fetchDisclaimers({ vendor, country })` and `checkKycRequired({ vendor, ... })` call `/vendors/{vendor}/disclaimers` and `/vendors/{vendor}/kyc-required` (`vendor` defaults to `moonpay`)
   - `createVendorCustomer({ vendor, email })` calls `POST /vendors/{vendor}/customers`
-  - `submitConsents({ disclaimerIds, ... })` posts `POST /consents` (wire body still uses `ironDisclaimerIds`)
   - `fetchKycStatus()` reads `GET /kyc/status`
 - Add a consents-path KYC flow on `KycController` for non-MoonPay vendors (currently `iron`): empty-shell customer → disclaimers → consents → SumSub, skipping MoonPay Check/Auth frames. `initialize({ vendor })` and `createVendorCustomer({ vendor, email })` drive the path; `acceptTermsAndStartSession` requires `sumsubTncSigned` / `idosTncSigned`. ([#9908](https://github.com/MetaMask/core/pull/9908))
 - Add `KycController.refreshKycStatus()` and the `KycController:statusChanged` event so consumers can poll user-keyed KYC status for toast / banner surfaces. ([#9908](https://github.com/MetaMask/core/pull/9908))
@@ -25,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING:** Replace `KycService.submitConsents` (`POST /consents`) with session-scoped `fetchSessionDisclaimers` / `submitSessionDisclaimers` plus vendor T&C recording via `submitVendorDisclaimers`. Consents now use `{ key, version }` document records plus `credentialReusabilityConsentGiven` instead of Iron disclaimer ids and boolean T&C flags, and they require a UKYC session id. Iron content ids are posted separately to `POST /vendors/{vendor}/disclaimers`. The consents path records vendor T&Cs, then creates the UKYC session, then records session disclaimers. A 409 conflict is re-checked with a GET and only treated as success when every accepted document is consented.
 - Make the `fetch` option on the `KycService` constructor optional; it now defaults to the runtime's native `fetch` (browser, React Native, Node 18+), so consumers no longer need to inject one. ([#9908](https://github.com/MetaMask/core/pull/9908))
 - **BREAKING:** Invalidate terms acceptance when `termsAcceptedVendor` is `null` (pre-migration state), forcing reacceptance after the multi-vendor upgrade to ensure users review current vendor terms. ([#9908](https://github.com/MetaMask/core/pull/9908))
 - **BREAKING:** Require `sumsubTncSigned` and `idosTncSigned` on `acceptTermsAndStartSession` for every vendor, so callers explicitly declare T&C2 acceptance. Zero-argument calls and omitted flags fail instead of defaulting to `true`. ([#9908](https://github.com/MetaMask/core/pull/9908))

--- a/packages/kyc-controller/CHANGELOG.md
+++ b/packages/kyc-controller/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add session-scoped disclaimer APIs on `KycService` for the idOS / KYC-provider catalog:
+- Add session-scoped disclaimer APIs on `KycService` for the idOS / KYC-provider catalog ([#9979](https://github.com/MetaMask/core/pull/9979)):
   - `fetchSessionDisclaimers({ sessionId })` calls `GET /sessions/{sessionId}/disclaimers`
   - `submitSessionDisclaimers({ sessionId, idOS, kycProvider, credentialReusabilityConsentGiven })` calls `POST /sessions/{sessionId}/disclaimers`
-- Add `KycService.submitVendorDisclaimers({ vendor, disclaimerIds })` (`POST /vendors/{vendor}/disclaimers`) to record Iron T&C signings, plus the `KycVendorSigning` response type. The consents path calls this alongside session-scoped disclaimers; vendor T&C ids are no longer sent on the session disclaimer POST.
-- Add `KycConsentDocument`, `KycConsentRecord`, and `KycSessionDisclaimers` types for that catalog, plus in-memory `credentialReusabilityConsentGiven` and `sessionDisclaimers` controller state. `acceptTermsAndStartSession` forwards optional `credentialReusabilityConsentGiven` (default `false`).
+- Add `KycService.submitVendorDisclaimers({ vendor, disclaimerIds })` (`POST /vendors/{vendor}/disclaimers`) to record Iron T&C signings, plus the `KycVendorSigning` response type. The consents path calls this alongside session-scoped disclaimers; vendor T&C ids are no longer sent on the session disclaimer POST. ([#9979](https://github.com/MetaMask/core/pull/9979))
+- Add `KycConsentDocument`, `KycConsentRecord`, and `KycSessionDisclaimers` types for that catalog, plus in-memory `credentialReusabilityConsentGiven` and `sessionDisclaimers` controller state. `acceptTermsAndStartSession` forwards optional `credentialReusabilityConsentGiven` (default `false`). ([#9979](https://github.com/MetaMask/core/pull/9979))
 - Parameterize Universal KYC vendor HTTP on `KycService` so identity vendors share one client surface instead of vendor-branded methods ([#9908](https://github.com/MetaMask/core/pull/9908)):
   - `fetchDisclaimers({ vendor, country })` and `checkKycRequired({ vendor, ... })` call `/vendors/{vendor}/disclaimers` and `/vendors/{vendor}/kyc-required` (`vendor` defaults to `moonpay`)
   - `createVendorCustomer({ vendor, email })` calls `POST /vendors/{vendor}/customers`
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Replace `KycService.submitConsents` (`POST /consents`) with session-scoped `fetchSessionDisclaimers` / `submitSessionDisclaimers` plus vendor T&C recording via `submitVendorDisclaimers`. Consents now use `{ key, version }` document records plus `credentialReusabilityConsentGiven` instead of Iron disclaimer ids and boolean T&C flags, and they require a UKYC session id. Iron content ids are posted separately to `POST /vendors/{vendor}/disclaimers`. The consents path records vendor T&Cs, then creates the UKYC session, then records session disclaimers. A 409 conflict is re-checked with a GET and only treated as success when every accepted document is consented.
+- **BREAKING:** Replace `KycService.submitConsents` (`POST /consents`) with session-scoped `fetchSessionDisclaimers` / `submitSessionDisclaimers` plus vendor T&C recording via `submitVendorDisclaimers`. Consents now use `{ key, version }` document records plus `credentialReusabilityConsentGiven` instead of Iron disclaimer ids and boolean T&C flags, and they require a UKYC session id. Iron content ids are posted separately to `POST /vendors/{vendor}/disclaimers`. The consents path records vendor T&Cs, then creates the UKYC session, then records session disclaimers. A 409 conflict is re-checked with a GET and only treated as success when every accepted document is consented. ([#9979](https://github.com/MetaMask/core/pull/9979))
 - Make the `fetch` option on the `KycService` constructor optional; it now defaults to the runtime's native `fetch` (browser, React Native, Node 18+), so consumers no longer need to inject one. ([#9908](https://github.com/MetaMask/core/pull/9908))
 - **BREAKING:** Invalidate terms acceptance when `termsAcceptedVendor` is `null` (pre-migration state), forcing reacceptance after the multi-vendor upgrade to ensure users review current vendor terms. ([#9908](https://github.com/MetaMask/core/pull/9908))
 - **BREAKING:** Require `sumsubTncSigned` and `idosTncSigned` on `acceptTermsAndStartSession` for every vendor, so callers explicitly declare T&C2 acceptance. Zero-argument calls and omitted flags fail instead of defaulting to `true`. ([#9908](https://github.com/MetaMask/core/pull/9908))

--- a/packages/kyc-controller/src/KycController-method-action-types.ts
+++ b/packages/kyc-controller/src/KycController-method-action-types.ts
@@ -66,6 +66,9 @@ export type KycControllerLoadDisclaimersAction = {
  * Required for every vendor so callers explicitly declare acceptance.
  * @param params.idosTncSigned - Whether idOS T&C were accepted (T&C2).
  * Required for every vendor so callers explicitly declare acceptance.
+ * @param params.credentialReusabilityConsentGiven - Whether the customer
+ * consented to reuse existing idOS credentials. Used when recording
+ * session-scoped disclaimers on the consents path. Defaults to `false`.
  */
 export type KycControllerAcceptTermsAndStartSessionAction = {
   type: `KycController:acceptTermsAndStartSession`;
@@ -180,6 +183,9 @@ export type KycControllerGetCustomerIdentityAction = {
  * the UKYC session (handing over the wrapped key and the token);
  * 5. fetches the SumSub applicant access token; and
  * 6. presents the SDK via the injected launcher.
+ *
+ * If a UKYC session already exists (the consents path creates it before
+ * recording session disclaimers), steps 1–4 are skipped.
  *
  * If session creation reports the applicant is already approved on the relay
  * while the vendor is still finalizing (`kycStatus: approved`,

--- a/packages/kyc-controller/src/KycController.test.ts
+++ b/packages/kyc-controller/src/KycController.test.ts
@@ -1,3 +1,4 @@
+import { HttpError } from '@metamask/controller-utils';
 import { Messenger, MOCK_ANY_NAMESPACE } from '@metamask/messenger';
 import type {
   MockAnyNamespace,
@@ -15,7 +16,7 @@ import {
   KycController,
 } from './KycController.js';
 import type { KycControllerMessenger } from './KycController.js';
-import type { KycSumSubLauncher } from './types.js';
+import type { KycSessionDisclaimers, KycSumSubLauncher } from './types.js';
 import { verifyJwtChain } from './ukyc/jwtChain.js';
 import { wrapEncryptionKey } from './ukyc/wrapEncryptionKey.js';
 
@@ -46,6 +47,28 @@ const mockVerifyJwtChain = verifyJwtChain as jest.MockedFunction<
 const mockWrapEncryptionKey = wrapEncryptionKey as jest.MockedFunction<
   typeof wrapEncryptionKey
 >;
+
+const MOCK_SESSION_DISCLAIMERS: KycSessionDisclaimers = {
+  idOS: [
+    {
+      key: 'idos-tos',
+      version: '1',
+      title: 'idOS ToS',
+      url: 'https://idos.example/tos',
+      consented: false,
+    },
+  ],
+  kycProvider: [
+    {
+      key: 'sumsub-tos',
+      version: '1',
+      title: 'SumSub ToS',
+      url: 'https://sumsub.example/tos',
+      consented: false,
+    },
+  ],
+  credentialReusabilityConsentGiven: false,
+};
 
 /**
  * Builds an encrypted envelope for a recipient's X25519 public key.
@@ -382,6 +405,7 @@ describe('KycController', () => {
           expect(controller.state.sumsubTncAccepted).toBe(true);
           expect(controller.state.idosTncAccepted).toBe(true);
           expect(controller.state.phase).toBe('check');
+          expect(handlers.submitVendorDisclaimers).not.toHaveBeenCalled();
         },
       );
     });
@@ -2413,7 +2437,11 @@ describe('KycController', () => {
             product: 'money',
           });
 
-          expect(handlers.submitConsents).toHaveBeenCalled();
+          expect(handlers.fetchSessionDisclaimers).toHaveBeenCalled();
+          expect(handlers.submitVendorDisclaimers).toHaveBeenCalledWith({
+            vendor: 'iron',
+            disclaimerIds: ['d1'],
+          });
           expect(handlers.createSession).not.toHaveBeenCalled();
           expect(controller.state.phase).toBe('done');
           controller.reset();
@@ -2439,7 +2467,7 @@ describe('KycController', () => {
 
           await controller.initialize({ email: 'a@b.co', vendor: 'iron' });
 
-          expect(handlers.submitConsents).not.toHaveBeenCalled();
+          expect(handlers.submitSessionDisclaimers).not.toHaveBeenCalled();
           expect(controller.state.termsAcceptedAt).toBeNull();
           expect(controller.state.acceptedDisclaimerIds).toStrictEqual([]);
           expect(controller.state.termsAcceptedVendor).toBeNull();
@@ -2740,7 +2768,21 @@ describe('KycController', () => {
           },
         },
         async ({ controller, handlers, launcher }) => {
-          handlers.submitConsents.mockResolvedValue(undefined);
+          handlers.fetchSessionDisclaimers.mockResolvedValue(
+            MOCK_SESSION_DISCLAIMERS,
+          );
+          handlers.submitSessionDisclaimers.mockResolvedValue({
+            ...MOCK_SESSION_DISCLAIMERS,
+            credentialReusabilityConsentGiven: true,
+            idOS: MOCK_SESSION_DISCLAIMERS.idOS.map((doc) => ({
+              ...doc,
+              consented: true,
+            })),
+            kycProvider: MOCK_SESSION_DISCLAIMERS.kycProvider.map((doc) => ({
+              ...doc,
+              consented: true,
+            })),
+          });
           handlers.fetchKycStatus.mockResolvedValue({ status: 'pending' });
           launcher.launch.mockImplementation(async ({ onStatusChange }) => {
             onStatusChange?.('InProgress', 'Completed');
@@ -2755,11 +2797,28 @@ describe('KycController', () => {
           });
 
           expect(handlers.createSession).not.toHaveBeenCalled();
-          expect(handlers.submitConsents).toHaveBeenCalledWith({
+          expect(handlers.submitVendorDisclaimers).toHaveBeenCalledWith({
+            vendor: 'iron',
             disclaimerIds: ['d1'],
-            sumsubTncSigned: true,
-            idosTncSigned: true,
           });
+          expect(handlers.fetchSessionDisclaimers).toHaveBeenCalledWith({
+            sessionId: 'sid',
+          });
+          expect(handlers.submitSessionDisclaimers).toHaveBeenCalledWith({
+            sessionId: 'sid',
+            idOS: [{ key: 'idos-tos', version: '1' }],
+            kycProvider: [{ key: 'sumsub-tos', version: '1' }],
+            credentialReusabilityConsentGiven: false,
+          });
+          expect(handlers.createUkycSession).toHaveBeenCalledTimes(1);
+          expect(
+            handlers.submitVendorDisclaimers.mock.invocationCallOrder[0],
+          ).toBeLessThan(handlers.createUkycSession.mock.invocationCallOrder[0]);
+          expect(
+            handlers.createUkycSession.mock.invocationCallOrder[0],
+          ).toBeLessThan(
+            handlers.fetchSessionDisclaimers.mock.invocationCallOrder[0],
+          );
           expect(handlers.createUkycSession).toHaveBeenCalledWith(
             expect.objectContaining({ vendor: 'iron' }),
           );
@@ -2769,6 +2828,325 @@ describe('KycController', () => {
           expect(controller.state.userStatus).toBe('pending');
           expect(controller.state.phase).toBe('done');
           expect(controller.state.sumsub.status).toBe('complete');
+          expect(controller.state.sessionDisclaimers?.idOS[0]?.consented).toBe(
+            true,
+          );
+          controller.reset();
+        },
+      );
+    });
+
+    it('forwards credential reusability consent onto session disclaimers', async () => {
+      await withController(
+        {
+          options: {
+            state: {
+              activeVendor: 'iron',
+              disclaimers: [{ id: 'd1', display_name: 'T', url: 'u' }],
+            },
+            userStatusPollIntervalMs: 60_000,
+          },
+        },
+        async ({ controller, handlers, launcher }) => {
+          launcher.launch.mockImplementation(async ({ onStatusChange }) => {
+            onStatusChange?.('InProgress', 'Completed');
+            return { ok: true };
+          });
+
+          await controller.acceptTermsAndStartSession({
+            email: 'a@b.co',
+            product: 'money',
+            sumsubTncSigned: true,
+            idosTncSigned: true,
+            credentialReusabilityConsentGiven: true,
+          });
+
+          expect(handlers.submitSessionDisclaimers).toHaveBeenCalledWith({
+            sessionId: 'sid',
+            idOS: [{ key: 'idos-tos', version: '1' }],
+            kycProvider: [{ key: 'sumsub-tos', version: '1' }],
+            credentialReusabilityConsentGiven: true,
+          });
+          expect(controller.state.credentialReusabilityConsentGiven).toBe(true);
+          controller.reset();
+        },
+      );
+    });
+
+    it('treats a 409 conflict as already-recorded consents', async () => {
+      await withController(
+        {
+          options: {
+            state: {
+              activeVendor: 'iron',
+              disclaimers: [{ id: 'd1', display_name: 'T', url: 'u' }],
+            },
+            userStatusPollIntervalMs: 60_000,
+          },
+        },
+        async ({ controller, handlers, launcher }) => {
+          const consentedCatalog = {
+            ...MOCK_SESSION_DISCLAIMERS,
+            credentialReusabilityConsentGiven: false,
+            idOS: MOCK_SESSION_DISCLAIMERS.idOS.map((doc) => ({
+              ...doc,
+              consented: true,
+            })),
+            kycProvider: MOCK_SESSION_DISCLAIMERS.kycProvider.map((doc) => ({
+              ...doc,
+              consented: true,
+            })),
+          };
+          handlers.fetchSessionDisclaimers
+            .mockResolvedValueOnce(MOCK_SESSION_DISCLAIMERS)
+            .mockResolvedValueOnce(consentedCatalog);
+          handlers.submitSessionDisclaimers.mockRejectedValue(
+            new HttpError(
+              409,
+              "Fetching 'disclaimers' failed with status '409'",
+            ),
+          );
+          launcher.launch.mockImplementation(async ({ onStatusChange }) => {
+            onStatusChange?.('InProgress', 'Completed');
+            return { ok: true };
+          });
+
+          await controller.acceptTermsAndStartSession({
+            email: 'a@b.co',
+            product: 'money',
+            sumsubTncSigned: true,
+            idosTncSigned: true,
+          });
+
+          expect(handlers.fetchSessionDisclaimers).toHaveBeenCalledTimes(2);
+          expect(controller.state.phase).toBe('done');
+          expect(launcher.launch).toHaveBeenCalled();
+          controller.reset();
+        },
+      );
+    });
+
+    it('treats a 409 as recorded when declined idOS documents stay unconsented', async () => {
+      await withController(
+        {
+          options: {
+            state: {
+              activeVendor: 'iron',
+              disclaimers: [{ id: 'd1', display_name: 'T', url: 'u' }],
+            },
+            userStatusPollIntervalMs: 60_000,
+          },
+        },
+        async ({ controller, handlers, launcher }) => {
+          const afterConflict = {
+            ...MOCK_SESSION_DISCLAIMERS,
+            kycProvider: MOCK_SESSION_DISCLAIMERS.kycProvider.map((doc) => ({
+              ...doc,
+              consented: true,
+            })),
+          };
+          handlers.fetchSessionDisclaimers
+            .mockResolvedValueOnce(MOCK_SESSION_DISCLAIMERS)
+            .mockResolvedValueOnce(afterConflict);
+          handlers.submitSessionDisclaimers.mockRejectedValue(
+            new HttpError(
+              409,
+              "Fetching 'disclaimers' failed with status '409'",
+            ),
+          );
+          launcher.launch.mockImplementation(async ({ onStatusChange }) => {
+            onStatusChange?.('InProgress', 'Completed');
+            return { ok: true };
+          });
+
+          await controller.acceptTermsAndStartSession({
+            email: 'a@b.co',
+            product: 'money',
+            sumsubTncSigned: true,
+            idosTncSigned: false,
+          });
+
+          expect(controller.state.phase).toBe('done');
+          expect(launcher.launch).toHaveBeenCalled();
+          controller.reset();
+        },
+      );
+    });
+
+    it('fails closed when a 409 leaves credential reuse unconsented', async () => {
+      await withController(
+        {
+          options: {
+            state: {
+              activeVendor: 'iron',
+              disclaimers: [{ id: 'd1', display_name: 'T', url: 'u' }],
+            },
+          },
+        },
+        async ({ controller, handlers, launcher }) => {
+          const consentedDocs = {
+            idOS: MOCK_SESSION_DISCLAIMERS.idOS.map((doc) => ({
+              ...doc,
+              consented: true,
+            })),
+            kycProvider: MOCK_SESSION_DISCLAIMERS.kycProvider.map((doc) => ({
+              ...doc,
+              consented: true,
+            })),
+            credentialReusabilityConsentGiven: false,
+          };
+          handlers.fetchSessionDisclaimers.mockResolvedValue(consentedDocs);
+          handlers.submitSessionDisclaimers.mockRejectedValue(
+            new HttpError(
+              409,
+              "Fetching 'disclaimers' failed with status '409'",
+            ),
+          );
+          handlers.fetchDisclaimers.mockResolvedValue([]);
+
+          await controller.acceptTermsAndStartSession({
+            email: 'a@b.co',
+            product: 'money',
+            sumsubTncSigned: true,
+            idosTncSigned: true,
+            credentialReusabilityConsentGiven: true,
+          });
+
+          expect(controller.state.phase).toBe('terms');
+          expect(controller.state.error).toMatch(/Consents session failed/u);
+          expect(launcher.launch).not.toHaveBeenCalled();
+        },
+      );
+    });
+
+    it('fails closed when a 409 leaves accepted documents unconsented', async () => {
+      await withController(
+        {
+          options: {
+            state: {
+              activeVendor: 'iron',
+              disclaimers: [{ id: 'd1', display_name: 'T', url: 'u' }],
+            },
+          },
+        },
+        async ({ controller, handlers, launcher }) => {
+          handlers.fetchSessionDisclaimers.mockResolvedValue(
+            MOCK_SESSION_DISCLAIMERS,
+          );
+          handlers.submitSessionDisclaimers.mockRejectedValue(
+            new HttpError(
+              409,
+              "Fetching 'disclaimers' failed with status '409'",
+            ),
+          );
+          handlers.fetchDisclaimers.mockResolvedValue([]);
+
+          await controller.acceptTermsAndStartSession({
+            email: 'a@b.co',
+            product: 'money',
+            sumsubTncSigned: true,
+            idosTncSigned: true,
+          });
+
+          expect(controller.state.phase).toBe('terms');
+          expect(controller.state.error).toMatch(/Consents session failed/u);
+          expect(launcher.launch).not.toHaveBeenCalled();
+        },
+      );
+    });
+
+    it('omits already-consented catalog documents from the POST body', async () => {
+      await withController(
+        {
+          options: {
+            state: {
+              activeVendor: 'iron',
+              disclaimers: [{ id: 'd1', display_name: 'T', url: 'u' }],
+            },
+            userStatusPollIntervalMs: 60_000,
+          },
+        },
+        async ({ controller, handlers, launcher }) => {
+          handlers.fetchSessionDisclaimers.mockResolvedValue({
+            idOS: [
+              {
+                key: 'idos-tos',
+                version: '1',
+                title: 'idOS ToS',
+                url: 'https://idos.example/tos',
+                consented: true,
+              },
+              {
+                key: 'idos-privacy',
+                version: '2',
+                title: 'idOS Privacy',
+                url: 'https://idos.example/privacy',
+                consented: false,
+              },
+            ],
+            kycProvider: MOCK_SESSION_DISCLAIMERS.kycProvider,
+            credentialReusabilityConsentGiven: false,
+          });
+          launcher.launch.mockImplementation(async ({ onStatusChange }) => {
+            onStatusChange?.('InProgress', 'Completed');
+            return { ok: true };
+          });
+
+          await controller.acceptTermsAndStartSession({
+            email: 'a@b.co',
+            product: 'money',
+            sumsubTncSigned: true,
+            idosTncSigned: true,
+          });
+
+          expect(handlers.submitSessionDisclaimers).toHaveBeenCalledWith({
+            sessionId: 'sid',
+            idOS: [{ key: 'idos-privacy', version: '2' }],
+            kycProvider: [{ key: 'sumsub-tos', version: '1' }],
+            credentialReusabilityConsentGiven: false,
+          });
+          controller.reset();
+        },
+      );
+    });
+
+    it('skips posting session disclaimers when the catalog is already consented', async () => {
+      await withController(
+        {
+          options: {
+            state: {
+              activeVendor: 'iron',
+              disclaimers: [{ id: 'd1', display_name: 'T', url: 'u' }],
+            },
+            userStatusPollIntervalMs: 60_000,
+          },
+        },
+        async ({ controller, handlers, launcher }) => {
+          handlers.fetchSessionDisclaimers.mockResolvedValue({
+            ...MOCK_SESSION_DISCLAIMERS,
+            idOS: MOCK_SESSION_DISCLAIMERS.idOS.map((doc) => ({
+              ...doc,
+              consented: true,
+            })),
+            kycProvider: MOCK_SESSION_DISCLAIMERS.kycProvider.map((doc) => ({
+              ...doc,
+              consented: true,
+            })),
+          });
+          launcher.launch.mockImplementation(async ({ onStatusChange }) => {
+            onStatusChange?.('InProgress', 'Completed');
+            return { ok: true };
+          });
+
+          await controller.acceptTermsAndStartSession({
+            email: 'a@b.co',
+            product: 'money',
+            sumsubTncSigned: true,
+            idosTncSigned: true,
+          });
+
+          expect(handlers.submitSessionDisclaimers).not.toHaveBeenCalled();
+          expect(launcher.launch).toHaveBeenCalled();
           controller.reset();
         },
       );
@@ -2794,7 +3172,7 @@ describe('KycController', () => {
           expect(controller.state.phase).toBe('error');
           expect(controller.state.error).toMatch(/Missing T&C2 acceptance/u);
           expect(controller.state.termsAcceptedAt).toBeNull();
-          expect(handlers.submitConsents).not.toHaveBeenCalled();
+          expect(handlers.submitSessionDisclaimers).not.toHaveBeenCalled();
         },
       );
     });
@@ -2818,12 +3196,12 @@ describe('KycController', () => {
 
           expect(controller.state.phase).toBe('error');
           expect(controller.state.error).toMatch(/Missing T&C2 acceptance/u);
-          expect(handlers.submitConsents).not.toHaveBeenCalled();
+          expect(handlers.submitSessionDisclaimers).not.toHaveBeenCalled();
         },
       );
     });
 
-    it('submits explicit T&C2 false flags on the consents path', async () => {
+    it('does not post session disclaimers when T&C2 is declined', async () => {
       await withController(
         {
           options: {
@@ -2847,13 +3225,14 @@ describe('KycController', () => {
             idosTncSigned: false,
           });
 
-          expect(handlers.submitConsents).toHaveBeenCalledWith({
-            disclaimerIds: ['d1'],
-            sumsubTncSigned: false,
-            idosTncSigned: false,
-          });
+          expect(handlers.submitSessionDisclaimers).not.toHaveBeenCalled();
           expect(controller.state.sumsubTncAccepted).toBe(false);
           expect(controller.state.idosTncAccepted).toBe(false);
+          expect(handlers.submitVendorDisclaimers).toHaveBeenCalledWith({
+            vendor: 'iron',
+            disclaimerIds: ['d1'],
+          });
+          expect(launcher.launch).toHaveBeenCalled();
           controller.reset();
         },
       );
@@ -2936,6 +3315,32 @@ describe('KycController', () => {
       );
     });
 
+    it('returns to terms when the SumSub journey fails after consents', async () => {
+      await withController(
+        {
+          options: {
+            state: {
+              activeVendor: 'iron',
+              disclaimers: [{ id: 'd1', display_name: 'T', url: 'u' }],
+            },
+          },
+        },
+        async ({ controller, handlers }) => {
+          handlers.createJourney.mockRejectedValue(new Error('journey down'));
+          handlers.fetchDisclaimers.mockResolvedValue([]);
+
+          await controller.acceptTermsAndStartSession({
+            email: 'a@b.co',
+            sumsubTncSigned: true,
+            idosTncSigned: true,
+          });
+
+          expect(controller.state.phase).toBe('terms');
+          expect(controller.state.error).toMatch(/journey down/u);
+        },
+      );
+    });
+
     it('returns to terms when SumSub closes without completion during the Iron session', async () => {
       await withController(
         {
@@ -2961,7 +3366,8 @@ describe('KycController', () => {
           });
 
           expect(controller.state.phase).toBe('terms');
-          expect(controller.state.sumsub.status).toBe('failed');
+          expect(controller.state.sumsub.status).toBe('idle');
+          expect(controller.state.sumsub.sessionId).toBeNull();
           expect(controller.state.termsAcceptedAt).toBeNull();
           expect(controller.state.error).toMatch(/Consents session failed/u);
           expect(handlers.fetchKycStatus).not.toHaveBeenCalled();
@@ -3057,9 +3463,11 @@ describe('KycController', () => {
           let release: () => void = () => {
             // placeholder
           };
-          handlers.submitConsents.mockReturnValue(
-            new Promise<void>((resolve) => {
-              release = resolve;
+          handlers.fetchSessionDisclaimers.mockReturnValue(
+            new Promise<KycSessionDisclaimers>((resolve) => {
+              release = (): void => {
+                resolve(MOCK_SESSION_DISCLAIMERS);
+              };
             }),
           );
 
@@ -3073,7 +3481,7 @@ describe('KycController', () => {
           await pending;
 
           expect(controller.state.phase).toBe('idle');
-          expect(handlers.createUkycSession).not.toHaveBeenCalled();
+          expect(handlers.submitSessionDisclaimers).not.toHaveBeenCalled();
         },
       );
     });
@@ -3104,9 +3512,11 @@ describe('KycController', () => {
             sumsubTncSigned: true,
             idosTncSigned: true,
           });
-          // Consents + UKYC session run first; wait until launch is pending.
-          await Promise.resolve();
-          await Promise.resolve();
+          // Session create + session disclaimers run first; wait until launch
+          // is pending so reset races with an in-flight SDK presentation.
+          while (launcher.launch.mock.calls.length === 0) {
+            await Promise.resolve();
+          }
           controller.reset();
           releaseLaunch({ ok: true });
           await pending;
@@ -3131,8 +3541,8 @@ describe('KycController', () => {
           let release: (error: Error) => void = () => {
             // placeholder
           };
-          handlers.submitConsents.mockReturnValue(
-            new Promise<void>((_resolve, reject) => {
+          handlers.createUkycSession.mockReturnValue(
+            new Promise((_resolve, reject) => {
               release = reject;
             }),
           );
@@ -3142,12 +3552,402 @@ describe('KycController', () => {
             sumsubTncSigned: true,
             idosTncSigned: true,
           });
+          while (handlers.createUkycSession.mock.calls.length === 0) {
+            await Promise.resolve();
+          }
           controller.reset();
           release(new Error('late consent failure'));
           await pending;
 
           expect(controller.state.phase).toBe('idle');
           expect(controller.state.error).toBeNull();
+        },
+      );
+    });
+
+    it('skips SumSub when the consents-path session is already vendor-processing', async () => {
+      await withController(
+        {
+          options: {
+            state: {
+              activeVendor: 'iron',
+              disclaimers: [{ id: 'd1', display_name: 'T', url: 'u' }],
+            },
+            userStatusPollIntervalMs: 60_000,
+          },
+        },
+        async ({ controller, handlers, launcher }) => {
+          handlers.createUkycSession.mockResolvedValue({
+            sessionId: 'sid',
+            kycStatus: 'approved',
+            finalStatus: 'pending',
+          });
+          handlers.fetchKycStatus.mockRejectedValue(new Error('status down'));
+
+          await controller.acceptTermsAndStartSession({
+            email: 'a@b.co',
+            product: 'money',
+            sumsubTncSigned: true,
+            idosTncSigned: true,
+          });
+
+          expect(handlers.fetchSessionDisclaimers).toHaveBeenCalledWith({
+            sessionId: 'sid',
+          });
+          expect(launcher.launch).not.toHaveBeenCalled();
+          expect(controller.state.sumsub.status).toBe('vendorProcessing');
+          expect(controller.state.phase).toBe('done');
+          controller.reset();
+        },
+      );
+    });
+
+    it('ignores a 409 re-fetch that settles after reset', async () => {
+      await withController(
+        {
+          options: {
+            state: {
+              activeVendor: 'iron',
+              disclaimers: [{ id: 'd1', display_name: 'T', url: 'u' }],
+            },
+          },
+        },
+        async ({ controller, handlers }) => {
+          handlers.fetchSessionDisclaimers
+            .mockResolvedValueOnce(MOCK_SESSION_DISCLAIMERS)
+            .mockImplementationOnce(async () => {
+              controller.reset();
+              return MOCK_SESSION_DISCLAIMERS;
+            });
+          handlers.submitSessionDisclaimers.mockRejectedValue(
+            new HttpError(
+              409,
+              "Fetching 'disclaimers' failed with status '409'",
+            ),
+          );
+
+          await controller.acceptTermsAndStartSession({
+            email: 'a@b.co',
+            sumsubTncSigned: true,
+            idosTncSigned: true,
+          });
+
+          expect(controller.state.phase).toBe('idle');
+          expect(controller.state.sessionDisclaimers).toBeNull();
+        },
+      );
+    });
+
+    it('ignores a session-disclaimer fetch that settles after reset', async () => {
+      await withController(
+        {
+          options: {
+            state: {
+              activeVendor: 'iron',
+              disclaimers: [{ id: 'd1', display_name: 'T', url: 'u' }],
+            },
+          },
+        },
+        async ({ controller, handlers }) => {
+          handlers.fetchSessionDisclaimers.mockImplementation(async () => {
+            controller.reset();
+            return MOCK_SESSION_DISCLAIMERS;
+          });
+
+          await controller.acceptTermsAndStartSession({
+            email: 'a@b.co',
+            sumsubTncSigned: true,
+            idosTncSigned: true,
+          });
+
+          expect(controller.state.phase).toBe('idle');
+          expect(handlers.submitSessionDisclaimers).not.toHaveBeenCalled();
+        },
+      );
+    });
+
+    it('returns to terms when recording vendor disclaimers fails', async () => {
+      await withController(
+        {
+          options: {
+            state: {
+              activeVendor: 'iron',
+              disclaimers: [{ id: 'd1', display_name: 'T', url: 'u' }],
+            },
+          },
+        },
+        async ({ controller, handlers }) => {
+          handlers.submitVendorDisclaimers.mockRejectedValue(
+            new Error('iron signings down'),
+          );
+          handlers.fetchDisclaimers.mockResolvedValue([]);
+
+          await controller.acceptTermsAndStartSession({
+            email: 'a@b.co',
+            sumsubTncSigned: true,
+            idosTncSigned: true,
+          });
+
+          expect(controller.state.phase).toBe('terms');
+          expect(controller.state.error).toMatch(/iron signings down/u);
+          expect(handlers.createUkycSession).not.toHaveBeenCalled();
+          expect(handlers.submitSessionDisclaimers).not.toHaveBeenCalled();
+          expect(controller.state.sumsub.sessionId).toBeNull();
+        },
+      );
+    });
+
+    it('ignores vendor disclaimer recording that settles after reset', async () => {
+      await withController(
+        {
+          options: {
+            state: {
+              activeVendor: 'iron',
+              disclaimers: [{ id: 'd1', display_name: 'T', url: 'u' }],
+            },
+          },
+        },
+        async ({ controller, handlers }) => {
+          handlers.submitVendorDisclaimers.mockImplementation(async () => {
+            controller.reset();
+            return [{ id: 'sign-1', customer_id: 'cust-1', content_id: 'd1' }];
+          });
+
+          await controller.acceptTermsAndStartSession({
+            email: 'a@b.co',
+            sumsubTncSigned: true,
+            idosTncSigned: true,
+          });
+
+          expect(controller.state.phase).toBe('idle');
+          expect(handlers.createUkycSession).not.toHaveBeenCalled();
+        },
+      );
+    });
+
+    it('returns to terms when recording session disclaimers fails', async () => {
+      await withController(
+        {
+          options: {
+            state: {
+              activeVendor: 'iron',
+              disclaimers: [{ id: 'd1', display_name: 'T', url: 'u' }],
+            },
+          },
+        },
+        async ({ controller, handlers }) => {
+          handlers.submitSessionDisclaimers.mockRejectedValue(
+            new HttpError(500, "Fetching 'disclaimers' failed with status '500'"),
+          );
+          handlers.fetchDisclaimers.mockResolvedValue([]);
+
+          await controller.acceptTermsAndStartSession({
+            email: 'a@b.co',
+            sumsubTncSigned: true,
+            idosTncSigned: true,
+          });
+
+          expect(controller.state.phase).toBe('terms');
+          expect(controller.state.error).toMatch(/Consents session failed/u);
+          expect(controller.state.sessionDisclaimers).toBeNull();
+          expect(controller.state.sumsub.sessionId).toBeNull();
+          expect(controller.state.sumsub.status).toBe('idle');
+        },
+      );
+    });
+
+    it('fails closed when an accepted catalog category is empty', async () => {
+      await withController(
+        {
+          options: {
+            state: {
+              activeVendor: 'iron',
+              disclaimers: [{ id: 'd1', display_name: 'T', url: 'u' }],
+            },
+          },
+        },
+        async ({ controller, handlers, launcher }) => {
+          handlers.fetchSessionDisclaimers.mockResolvedValue({
+            idOS: [],
+            kycProvider: MOCK_SESSION_DISCLAIMERS.kycProvider,
+            credentialReusabilityConsentGiven: false,
+          });
+          handlers.fetchDisclaimers.mockResolvedValue([]);
+
+          await controller.acceptTermsAndStartSession({
+            email: 'a@b.co',
+            sumsubTncSigned: true,
+            idosTncSigned: true,
+          });
+
+          expect(controller.state.phase).toBe('terms');
+          expect(controller.state.error).toMatch(
+            /missing documents for an accepted category/u,
+          );
+          expect(handlers.submitSessionDisclaimers).not.toHaveBeenCalled();
+          expect(controller.state.sumsub.sessionId).toBeNull();
+          expect(launcher.launch).not.toHaveBeenCalled();
+        },
+      );
+    });
+
+    it('fails closed when an accepted KYC-provider catalog is empty', async () => {
+      await withController(
+        {
+          options: {
+            state: {
+              activeVendor: 'iron',
+              disclaimers: [{ id: 'd1', display_name: 'T', url: 'u' }],
+            },
+          },
+        },
+        async ({ controller, handlers, launcher }) => {
+          handlers.fetchSessionDisclaimers.mockResolvedValue({
+            idOS: MOCK_SESSION_DISCLAIMERS.idOS,
+            kycProvider: [],
+            credentialReusabilityConsentGiven: false,
+          });
+          handlers.fetchDisclaimers.mockResolvedValue([]);
+
+          await controller.acceptTermsAndStartSession({
+            email: 'a@b.co',
+            sumsubTncSigned: true,
+            idosTncSigned: true,
+          });
+
+          expect(controller.state.phase).toBe('terms');
+          expect(controller.state.error).toMatch(
+            /missing documents for an accepted category/u,
+          );
+          expect(handlers.submitSessionDisclaimers).not.toHaveBeenCalled();
+          expect(launcher.launch).not.toHaveBeenCalled();
+        },
+      );
+    });
+
+    it('fails closed when a 409 re-GET returns an empty accepted category', async () => {
+      await withController(
+        {
+          options: {
+            state: {
+              activeVendor: 'iron',
+              disclaimers: [{ id: 'd1', display_name: 'T', url: 'u' }],
+            },
+          },
+        },
+        async ({ controller, handlers, launcher }) => {
+          handlers.fetchSessionDisclaimers
+            .mockResolvedValueOnce(MOCK_SESSION_DISCLAIMERS)
+            .mockResolvedValueOnce({
+              idOS: [],
+              kycProvider: MOCK_SESSION_DISCLAIMERS.kycProvider.map((doc) => ({
+                ...doc,
+                consented: true,
+              })),
+              credentialReusabilityConsentGiven: false,
+            });
+          handlers.submitSessionDisclaimers.mockRejectedValue(
+            new HttpError(
+              409,
+              "Fetching 'disclaimers' failed with status '409'",
+            ),
+          );
+          handlers.fetchDisclaimers.mockResolvedValue([]);
+
+          await controller.acceptTermsAndStartSession({
+            email: 'a@b.co',
+            sumsubTncSigned: true,
+            idosTncSigned: true,
+          });
+
+          expect(controller.state.phase).toBe('terms');
+          expect(controller.state.error).toMatch(/Consents session failed/u);
+          expect(controller.state.sumsub.sessionId).toBeNull();
+          expect(launcher.launch).not.toHaveBeenCalled();
+        },
+      );
+    });
+
+    it('ignores recorded session disclaimers that settle after reset', async () => {
+      await withController(
+        {
+          options: {
+            state: {
+              activeVendor: 'iron',
+              disclaimers: [{ id: 'd1', display_name: 'T', url: 'u' }],
+            },
+          },
+        },
+        async ({ controller, handlers }) => {
+          handlers.submitSessionDisclaimers.mockImplementation(async () => {
+            controller.reset();
+            return MOCK_SESSION_DISCLAIMERS;
+          });
+
+          await controller.acceptTermsAndStartSession({
+            email: 'a@b.co',
+            sumsubTncSigned: true,
+            idosTncSigned: true,
+          });
+
+          expect(controller.state.phase).toBe('idle');
+          expect(handlers.createJourney).not.toHaveBeenCalled();
+        },
+      );
+    });
+
+    it('ignores UKYC session creation that settles after reset', async () => {
+      await withController(
+        {
+          options: {
+            state: {
+              activeVendor: 'iron',
+              disclaimers: [{ id: 'd1', display_name: 'T', url: 'u' }],
+            },
+          },
+        },
+        async ({ controller, handlers }) => {
+          handlers.createUkycSession.mockImplementation(async () => {
+            controller.reset();
+            return { sessionId: 'sid' };
+          });
+
+          await controller.acceptTermsAndStartSession({
+            email: 'a@b.co',
+            sumsubTncSigned: true,
+            idosTncSigned: true,
+          });
+
+          expect(controller.state.phase).toBe('idle');
+          expect(handlers.submitSessionDisclaimers).not.toHaveBeenCalled();
+        },
+      );
+    });
+
+    it('ignores already-completed session creation after reset', async () => {
+      await withController(
+        {
+          options: {
+            state: {
+              activeVendor: 'iron',
+              disclaimers: [{ id: 'd1', display_name: 'T', url: 'u' }],
+            },
+          },
+        },
+        async ({ controller, handlers }) => {
+          handlers.createUkycSession.mockImplementation(async () => {
+            controller.reset();
+            throw new Error('session_not_in_valid_state');
+          });
+
+          await controller.acceptTermsAndStartSession({
+            email: 'a@b.co',
+            sumsubTncSigned: true,
+            idosTncSigned: true,
+          });
+
+          expect(controller.state.phase).toBe('idle');
+          expect(controller.state.userStatus).toBeNull();
         },
       );
     });
@@ -3530,6 +4330,37 @@ describe('KycController', () => {
         },
       );
     });
+
+    it('keeps phase done when the journey reports already completed after consents', async () => {
+      await withController(
+        {
+          options: {
+            state: {
+              activeVendor: 'iron',
+              disclaimers: [{ id: 'd1', display_name: 'T', url: 'u' }],
+            },
+            userStatusPollIntervalMs: 60_000,
+          },
+        },
+        async ({ controller, handlers }) => {
+          handlers.createJourney.mockRejectedValue(
+            new Error('session_not_in_valid_state'),
+          );
+
+          await controller.acceptTermsAndStartSession({
+            email: 'a@b.co',
+            sumsubTncSigned: true,
+            idosTncSigned: true,
+          });
+
+          expect(controller.state.phase).toBe('done');
+          expect(controller.state.sumsub.result).toStrictEqual({
+            alreadyCompleted: true,
+          });
+          controller.reset();
+        },
+      );
+    });
   });
 
   describe('messenger actions', () => {
@@ -3555,7 +4386,9 @@ type ServiceHandlers = {
   createSession: jest.Mock;
   checkKycRequired: jest.Mock;
   createVendorCustomer: jest.Mock;
-  submitConsents: jest.Mock;
+  submitVendorDisclaimers: jest.Mock;
+  fetchSessionDisclaimers: jest.Mock;
+  submitSessionDisclaimers: jest.Mock;
   fetchKycStatus: jest.Mock;
   getWrappingKey: jest.Mock;
   fetchJwks: jest.Mock;
@@ -3588,7 +4421,9 @@ const SERVICE_ACTIONS = [
   'KycService:createSession',
   'KycService:checkKycRequired',
   'KycService:createVendorCustomer',
-  'KycService:submitConsents',
+  'KycService:submitVendorDisclaimers',
+  'KycService:fetchSessionDisclaimers',
+  'KycService:submitSessionDisclaimers',
   'KycService:fetchKycStatus',
   'KycService:getWrappingKey',
   'KycService:fetchJwks',
@@ -3660,7 +4495,24 @@ function withController<ReturnValue>(
       email: 'a@b.co',
       status: 'SigningsRequired',
     }),
-    submitConsents: jest.fn().mockResolvedValue(undefined),
+    submitVendorDisclaimers: jest.fn().mockResolvedValue([
+      { id: 'sign-1', customer_id: 'cust-1', content_id: 'd1' },
+    ]),
+    fetchSessionDisclaimers: jest
+      .fn()
+      .mockResolvedValue(MOCK_SESSION_DISCLAIMERS),
+    submitSessionDisclaimers: jest.fn().mockResolvedValue({
+      ...MOCK_SESSION_DISCLAIMERS,
+      credentialReusabilityConsentGiven: true,
+      idOS: MOCK_SESSION_DISCLAIMERS.idOS.map((doc) => ({
+        ...doc,
+        consented: true,
+      })),
+      kycProvider: MOCK_SESSION_DISCLAIMERS.kycProvider.map((doc) => ({
+        ...doc,
+        consented: true,
+      })),
+    }),
     fetchKycStatus: jest.fn().mockResolvedValue({ status: 'pending' }),
     getWrappingKey: jest.fn().mockResolvedValue({
       id: 'wk',
@@ -3701,8 +4553,16 @@ function withController<ReturnValue>(
     handlers.createVendorCustomer,
   );
   rootMessenger.registerActionHandler(
-    'KycService:submitConsents',
-    handlers.submitConsents,
+    'KycService:submitVendorDisclaimers',
+    handlers.submitVendorDisclaimers,
+  );
+  rootMessenger.registerActionHandler(
+    'KycService:fetchSessionDisclaimers',
+    handlers.fetchSessionDisclaimers,
+  );
+  rootMessenger.registerActionHandler(
+    'KycService:submitSessionDisclaimers',
+    handlers.submitSessionDisclaimers,
   );
   rootMessenger.registerActionHandler(
     'KycService:fetchKycStatus',

--- a/packages/kyc-controller/src/KycController.test.ts
+++ b/packages/kyc-controller/src/KycController.test.ts
@@ -2813,7 +2813,9 @@ describe('KycController', () => {
           expect(handlers.createUkycSession).toHaveBeenCalledTimes(1);
           expect(
             handlers.submitVendorDisclaimers.mock.invocationCallOrder[0],
-          ).toBeLessThan(handlers.createUkycSession.mock.invocationCallOrder[0]);
+          ).toBeLessThan(
+            handlers.createUkycSession.mock.invocationCallOrder[0],
+          );
           expect(
             handlers.createUkycSession.mock.invocationCallOrder[0],
           ).toBeLessThan(
@@ -3737,7 +3739,10 @@ describe('KycController', () => {
         },
         async ({ controller, handlers }) => {
           handlers.submitSessionDisclaimers.mockRejectedValue(
-            new HttpError(500, "Fetching 'disclaimers' failed with status '500'"),
+            new HttpError(
+              500,
+              "Fetching 'disclaimers' failed with status '500'",
+            ),
           );
           handlers.fetchDisclaimers.mockResolvedValue([]);
 
@@ -4495,9 +4500,11 @@ function withController<ReturnValue>(
       email: 'a@b.co',
       status: 'SigningsRequired',
     }),
-    submitVendorDisclaimers: jest.fn().mockResolvedValue([
-      { id: 'sign-1', customer_id: 'cust-1', content_id: 'd1' },
-    ]),
+    submitVendorDisclaimers: jest
+      .fn()
+      .mockResolvedValue([
+        { id: 'sign-1', customer_id: 'cust-1', content_id: 'd1' },
+      ]),
     fetchSessionDisclaimers: jest
       .fn()
       .mockResolvedValue(MOCK_SESSION_DISCLAIMERS),

--- a/packages/kyc-controller/src/KycController.ts
+++ b/packages/kyc-controller/src/KycController.ts
@@ -19,10 +19,12 @@ import type { KycControllerMethodActions } from './KycController-method-action-t
 import type { KycServiceMethodActions } from './KycService-method-action-types.js';
 import type { CreateUkycSessionParams } from './KycService.js';
 import type {
+  KycConsentDocument,
   KycCustomerIdentity,
   KycDisclaimer,
   KycPhase,
   KycProduct,
+  KycSessionDisclaimers,
   KycSessionStatus,
   KycSumSubLauncher,
   KycSumSubStatus,
@@ -162,11 +164,24 @@ export type KycControllerState = {
    * field existed (treated as requiring reacceptance).
    */
   idosTncAccepted: boolean | null;
+  /**
+   * Whether the customer consented to reuse existing idOS credentials
+   * during this session. Applied when recording session-scoped disclaimers.
+   * Not persisted: a new UKYC session must collect reuse consent again.
+   * `null` when never set (treated as `false`).
+   */
+  credentialReusabilityConsentGiven: boolean | null;
 
   /** Disclaimers fetched for the current country. */
   disclaimers: KycDisclaimer[];
   /** Error encountered while loading disclaimers, or `null`. */
   disclaimersError: string | null;
+  /**
+   * Session-scoped idOS / KYC-provider disclaimer catalog from
+   * `GET /sessions/{sessionId}/disclaimers`. `null` until a UKYC session
+   * exists and the catalog has been fetched.
+   */
+  sessionDisclaimers: KycSessionDisclaimers | null;
 
   /** Resolved ISO 3166-1 alpha-3 country code. */
   geoCountry: string | null;
@@ -279,6 +294,12 @@ const kycControllerMetadata = {
     persist: true,
     usedInUi: false,
   },
+  credentialReusabilityConsentGiven: {
+    includeInDebugSnapshot: true,
+    includeInStateLogs: true,
+    persist: false,
+    usedInUi: false,
+  },
   disclaimers: {
     includeInDebugSnapshot: false,
     includeInStateLogs: false,
@@ -288,6 +309,12 @@ const kycControllerMetadata = {
   disclaimersError: {
     includeInDebugSnapshot: true,
     includeInStateLogs: true,
+    persist: false,
+    usedInUi: true,
+  },
+  sessionDisclaimers: {
+    includeInDebugSnapshot: false,
+    includeInStateLogs: false,
     persist: false,
     usedInUi: true,
   },
@@ -381,8 +408,10 @@ export function getDefaultKycControllerState(): KycControllerState {
     termsAcceptedVendor: null,
     sumsubTncAccepted: null,
     idosTncAccepted: null,
+    credentialReusabilityConsentGiven: null,
     disclaimers: [],
     disclaimersError: null,
+    sessionDisclaimers: null,
     geoCountry: null,
     sessionToken: null,
     accessToken: null,
@@ -415,6 +444,77 @@ export function getDefaultKycControllerState(): KycControllerState {
  */
 function isSessionAlreadyCompletedError(error: unknown): boolean {
   return String(error).includes(SESSION_NOT_IN_VALID_STATE);
+}
+
+/**
+ * Whether recording session disclaimers failed because those document
+ * versions were already consented for the session (`409 Conflict`).
+ *
+ * @param error - The caught error.
+ * @returns `true` when the error is an HTTP 409.
+ */
+function isConsentConflictError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    typeof (error as { httpStatus?: unknown }).httpStatus === 'number' &&
+    (error as { httpStatus: number }).httpStatus === 409
+  );
+}
+
+/**
+ * Maps a session-disclaimer catalog into the `{ key, version }` records the
+ * record-consents API expects, or an empty list when the user declined that
+ * category.
+ *
+ * @param documents - Catalog documents for one consent category.
+ * @param accepted - Whether the user accepted that category.
+ * @returns Consent records, or `[]` when not accepted.
+ */
+function consentRecordsFromCatalog(
+  documents: KycConsentDocument[],
+  accepted: boolean,
+): { key: string; version: string }[] {
+  if (!accepted) {
+    return [];
+  }
+  return documents
+    .filter((document) => !document.consented)
+    .map(({ key, version }) => ({ key, version }));
+}
+
+/**
+ * Whether an accepted T&C2 category has no catalog documents. An empty list
+ * would otherwise skip the POST and count as success.
+ *
+ * @param documents - Catalog documents for one consent category.
+ * @param accepted - Whether the user accepted that category.
+ * @returns `true` when the user accepted and the catalog is empty.
+ */
+function isAcceptedCategoryEmpty(
+  documents: KycConsentDocument[],
+  accepted: boolean,
+): boolean {
+  return accepted && documents.length === 0;
+}
+
+/**
+ * Whether an accepted category is still missing consent after a 409 re-GET:
+ * empty catalog or any document still unconsented.
+ *
+ * @param documents - Latest catalog documents for one consent category.
+ * @param accepted - Whether the user accepted that category.
+ * @returns `true` when accepted documents are not fully consented.
+ */
+function acceptedCategoryStillMissing(
+  documents: KycConsentDocument[],
+  accepted: boolean,
+): boolean {
+  return (
+    accepted &&
+    (documents.length === 0 ||
+      documents.some((document) => !document.consented))
+  );
 }
 
 /**
@@ -791,6 +891,8 @@ export class KycController extends BaseController<
         await this.#startConsentsSession({
           sumsubTncSigned,
           idosTncSigned,
+          credentialReusabilityConsentGiven:
+            this.state.credentialReusabilityConsentGiven ?? false,
         });
       } else {
         await this.#createSession();
@@ -906,12 +1008,16 @@ export class KycController extends BaseController<
    * Required for every vendor so callers explicitly declare acceptance.
    * @param params.idosTncSigned - Whether idOS T&C were accepted (T&C2).
    * Required for every vendor so callers explicitly declare acceptance.
+   * @param params.credentialReusabilityConsentGiven - Whether the customer
+   * consented to reuse existing idOS credentials. Used when recording
+   * session-scoped disclaimers on the consents path. Defaults to `false`.
    */
   async acceptTermsAndStartSession(params: {
     email?: string;
     product?: KycProduct;
     sumsubTncSigned: boolean;
     idosTncSigned: boolean;
+    credentialReusabilityConsentGiven?: boolean;
   }): Promise<void> {
     const sumsubTncSigned = params?.sumsubTncSigned;
     const idosTncSigned = params?.idosTncSigned;
@@ -922,6 +1028,8 @@ export class KycController extends BaseController<
       this.#fail('Missing T&C2 acceptance flags.');
       return;
     }
+    const credentialReusabilityConsentGiven =
+      params.credentialReusabilityConsentGiven ?? false;
 
     const termsAcceptedAt = new Date().toISOString();
     const disclaimerIds = this.state.disclaimers.map(
@@ -939,25 +1047,35 @@ export class KycController extends BaseController<
       state.termsAcceptedVendor = state.activeVendor;
       state.sumsubTncAccepted = sumsubTncSigned;
       state.idosTncAccepted = idosTncSigned;
+      state.credentialReusabilityConsentGiven =
+        credentialReusabilityConsentGiven;
     });
     if (usesConsentsFlow(this.state.activeVendor)) {
-      await this.#startConsentsSession({ sumsubTncSigned, idosTncSigned });
+      await this.#startConsentsSession({
+        sumsubTncSigned,
+        idosTncSigned,
+        credentialReusabilityConsentGiven,
+      });
       return;
     }
     await this.#createSession();
   }
 
   /**
-   * Consents-path vendors: post vendor signings + Sumsub/idOS ack, then
-   * launch SumSub — skipping MoonPay Check/Auth frames.
+   * Consents-path vendors: record vendor T&Cs, create a UKYC session,
+   * record session-scoped idOS / KYC-provider disclaimers, then launch
+   * SumSub — skipping MoonPay Check/Auth frames.
    *
-   * @param consents - T&C2 boolean flags.
+   * @param consents - T&C2 flags mapped onto the session disclaimer catalog.
    * @param consents.sumsubTncSigned - Whether Sumsub T&C were accepted.
    * @param consents.idosTncSigned - Whether idOS T&C were accepted.
+   * @param consents.credentialReusabilityConsentGiven - Whether credential
+   * reuse was accepted.
    */
   async #startConsentsSession(consents: {
     sumsubTncSigned: boolean;
     idosTncSigned: boolean;
+    credentialReusabilityConsentGiven: boolean;
   }): Promise<void> {
     const { email, acceptedDisclaimerIds } = this.state;
     if (!email) {
@@ -974,17 +1092,50 @@ export class KycController extends BaseController<
       state.error = null;
       state.phase = 'session';
       state.statusMessage = 'Submitting consents...';
+      state.sumsub.status = 'creatingSession';
+      state.sumsub.result = null;
+      state.sumsub.sessionStatus = null;
       // Consents-path vendors have no MoonPay session/access tokens.
       this.#clearMoonPaySession(state);
     });
 
     try {
-      await this.messenger.call('KycService:submitConsents', {
+      await this.messenger.call('KycService:submitVendorDisclaimers', {
+        vendor: this.state.activeVendor,
         disclaimerIds: acceptedDisclaimerIds,
-        sumsubTncSigned: consents.sumsubTncSigned,
-        idosTncSigned: consents.idosTncSigned,
       });
       if (this.#generation !== generation) {
+        return;
+      }
+
+      this.#updateIfCurrent(generation, (state) => {
+        state.statusMessage = 'Creating session...';
+      });
+
+      const created = await this.#createUkycSession(generation);
+      if (!created || this.#generation !== generation) {
+        return;
+      }
+
+      await this.#recordSessionDisclaimers(
+        created.sessionId,
+        consents,
+        generation,
+      );
+      if (this.#generation !== generation) {
+        return;
+      }
+
+      if (created.vendorProcessing) {
+        try {
+          await this.refreshKycStatus();
+        } catch (statusError) {
+          console.error('KYC status refresh failed:', statusError);
+        }
+        this.#updateIfCurrent(generation, (state) => {
+          state.phase = 'done';
+          state.statusMessage = VENDOR_PROCESSING_MESSAGE;
+        });
         return;
       }
       this.#applyUpdate((state) => {
@@ -1027,6 +1178,24 @@ export class KycController extends BaseController<
         }
       });
     } catch (error) {
+      if (isSessionAlreadyCompletedError(error)) {
+        if (this.#generation !== generation) {
+          return;
+        }
+        this.#applyUserStatus({
+          status: 'completed',
+          sumsubSessionId: null,
+          errorCode: null,
+        });
+        this.#updateIfCurrent(generation, (state) => {
+          state.sumsub.status = 'complete';
+          state.sumsub.result = { alreadyCompleted: true };
+          state.statusMessage = 'KYC already completed.';
+          state.phase = 'done';
+          state.error = null;
+        });
+        return;
+      }
       console.error('Consents session failed:', error);
       if (this.#generation !== generation) {
         return;
@@ -1034,12 +1203,123 @@ export class KycController extends BaseController<
       this.#applyUpdate((state) => {
         this.#clearAcceptedTerms(state);
         state.activeProduct = null;
+        state.sessionDisclaimers = null;
+        // Session create ran before recording disclaimers. Drop the leftover
+        // UKYC session so a later `startSumSub` cannot skip consent recording.
+        state.sumsub = { ...getDefaultKycControllerState().sumsub };
         state.error = `Consents session failed: ${String(error)}`;
         state.statusMessage =
           'Consent / verification failed — accept the terms to try again.';
         state.phase = 'terms';
       });
       await this.loadDisclaimers();
+    }
+  }
+
+  /**
+   * Fetches the session-scoped disclaimer catalog and records consents
+   * derived from the T&C2 flags. Already-consented catalog rows are omitted
+   * from the POST. A 409 is re-checked with a GET: continue only when every
+   * accepted document is now consented, otherwise fail closed.
+   *
+   * @param sessionId - The UKYC session id.
+   * @param consents - T&C2 flags mapped onto catalog documents.
+   * @param consents.sumsubTncSigned - Whether Sumsub T&C were accepted.
+   * @param consents.idosTncSigned - Whether idOS T&C were accepted.
+   * @param consents.credentialReusabilityConsentGiven - Whether credential
+   * reuse was accepted.
+   * @param generation - Flow generation captured by the caller.
+   */
+  async #recordSessionDisclaimers(
+    sessionId: string,
+    consents: {
+      sumsubTncSigned: boolean;
+      idosTncSigned: boolean;
+      credentialReusabilityConsentGiven: boolean;
+    },
+    generation: number,
+  ): Promise<void> {
+    const catalog = await this.messenger.call(
+      'KycService:fetchSessionDisclaimers',
+      { sessionId },
+    );
+    if (this.#generation !== generation) {
+      return;
+    }
+    this.#applyUpdate((state) => {
+      state.sessionDisclaimers = catalog;
+      state.statusMessage = 'Submitting consents...';
+    });
+
+    if (
+      isAcceptedCategoryEmpty(catalog.idOS, consents.idosTncSigned) ||
+      isAcceptedCategoryEmpty(catalog.kycProvider, consents.sumsubTncSigned)
+    ) {
+      throw new Error(
+        'Session disclaimer catalog is missing documents for an accepted category.',
+      );
+    }
+
+    const idOS = consentRecordsFromCatalog(
+      catalog.idOS,
+      consents.idosTncSigned,
+    );
+    const kycProvider = consentRecordsFromCatalog(
+      catalog.kycProvider,
+      consents.sumsubTncSigned,
+    );
+    const reuseUnchanged =
+      catalog.credentialReusabilityConsentGiven ===
+      consents.credentialReusabilityConsentGiven;
+    if (idOS.length === 0 && kycProvider.length === 0 && reuseUnchanged) {
+      return;
+    }
+
+    try {
+      const recorded = await this.messenger.call(
+        'KycService:submitSessionDisclaimers',
+        {
+          sessionId,
+          idOS,
+          kycProvider,
+          credentialReusabilityConsentGiven:
+            consents.credentialReusabilityConsentGiven,
+        },
+      );
+      this.#updateIfCurrent(generation, (state) => {
+        state.sessionDisclaimers = recorded;
+      });
+    } catch (error) {
+      if (!isConsentConflictError(error)) {
+        throw error;
+      }
+      // 409 means some document version was already recorded. Re-fetch and
+      // continue only when every document the user accepted is now consented;
+      // otherwise fail closed so a version bump cannot skip new docs.
+      const latest = await this.messenger.call(
+        'KycService:fetchSessionDisclaimers',
+        { sessionId },
+      );
+      if (this.#generation !== generation) {
+        return;
+      }
+      this.#applyUpdate((state) => {
+        state.sessionDisclaimers = latest;
+      });
+      const stillMissingIdos = acceptedCategoryStillMissing(
+        latest.idOS,
+        consents.idosTncSigned,
+      );
+      const stillMissingProvider = acceptedCategoryStillMissing(
+        latest.kycProvider,
+        consents.sumsubTncSigned,
+      );
+      const stillMissingReuse =
+        consents.credentialReusabilityConsentGiven &&
+        !latest.credentialReusabilityConsentGiven;
+      if (stillMissingIdos || stillMissingProvider || stillMissingReuse) {
+        throw error;
+      }
     }
   }
 
@@ -1137,6 +1417,7 @@ export class KycController extends BaseController<
     state.termsAcceptedVendor = null;
     state.sumsubTncAccepted = null;
     state.idosTncAccepted = null;
+    state.credentialReusabilityConsentGiven = null;
   }
 
   /**
@@ -1558,6 +1839,98 @@ export class KycController extends BaseController<
   }
 
   /**
+   * Creates a UKYC session: wrapping-key exchange, DEK wrap, capability
+   * token, and `POST /sessions`. Stores `sumsub.sessionId`. Returns `null`
+   * when a `reset()` superseded the flow.
+   *
+   * @param generation - Flow generation captured by the caller.
+   * @returns The created session, or `null` if superseded.
+   */
+  async #createUkycSession(generation: number): Promise<{
+    sessionId: string;
+    kycStatus?: string;
+    finalStatus?: string;
+    vendorProcessing: boolean;
+  } | null> {
+    const jwtToken = MOCK_JWT_TOKEN;
+
+    // Establish a per-session X25519 keypair and exchange our public half for
+    // the server's wrapping key. The private half stays on the device and is
+    // used to derive the shared secret that seals the data_encryption_key.
+    const sessionClientPrivateKey = x25519.utils.randomSecretKey();
+    const sessionClientPublicKey = x25519.getPublicKey(sessionClientPrivateKey);
+    const wrappingKey = await this.messenger.call('KycService:getWrappingKey', {
+      sessionClientPublicKey: toBase64Url(sessionClientPublicKey),
+    });
+
+    // Verify the jwtChain against Fractal's JWKS, then confirm the returned
+    // sessionServerPublicKey matches the value attested inside the verified
+    // JWT payload before trusting it for key wrapping.
+    const { keys } = await this.messenger.call('KycService:fetchJwks');
+    const jwtChainPayload = verifyJwtChain(keys, wrappingKey.jwtChain);
+    if (
+      jwtChainPayload.sessionServerPublicKeyX !==
+      wrappingKey.sessionServerPublicKey.x
+    ) {
+      throw new Error(
+        'sessionServerPublicKey does not match the verified jwtChain payload (sessionServerPublicKeyX).',
+      );
+    }
+
+    // Derive the data_encryption_key from the local_user_secret and wrap it
+    // for the session server. Only the wrapped (encrypted) key ever leaves
+    // the device.
+    const localUserSecret = await getOrCreateLocalUserSecret(
+      this.#localUserSecretStore(),
+    );
+    const clientMaterial = deriveClientMaterial(localUserSecret);
+    const wrappedEncryptionKey = {
+      sessionId: wrappingKey.id,
+      ...wrapEncryptionKey(
+        sessionClientPrivateKey,
+        wrappingKey.sessionServerPublicKey.x,
+        clientMaterial.dataEncryptionKey,
+      ),
+    };
+
+    // Mint a read-only `ukyc_capability_token` for the session. Only the
+    // client holds the signing key derived from `local_user_secret`, so only
+    // the client can mint it; scoping it to `read` means it authorizes later
+    // storage reads without granting write or delete access.
+    const ukycCapabilityToken = signStorageAccessToken({
+      material: clientMaterial,
+      operations: ['read'],
+      expiresAt: new Date(Date.now() + UKYC_CAPABILITY_TOKEN_TTL_MS),
+    });
+
+    const { sessionId, kycStatus, finalStatus } = await this.messenger.call(
+      'KycService:createUkycSession',
+      {
+        jwtToken,
+        ...this.#buildUkycSessionVendorFields(),
+        wrappedEncryptionKey,
+        ukycCapabilityToken,
+      },
+    );
+
+    const vendorProcessing =
+      kycStatus === KYC_STATUSES.approved &&
+      finalStatus === KYC_STATUSES.pending;
+
+    const stillCurrent = this.#updateIfCurrent(generation, (state) => {
+      state.sumsub.sessionId = sessionId;
+      if (vendorProcessing) {
+        state.sumsub.status = 'vendorProcessing';
+        state.statusMessage = VENDOR_PROCESSING_MESSAGE;
+      }
+    });
+    if (!stillCurrent) {
+      return null;
+    }
+    return { sessionId, kycStatus, finalStatus, vendorProcessing };
+  }
+
+  /**
    * Runs the SumSub document-verification sub-flow end to end:
    *
    *  1. requests a per-session wrapping key from the UKYC backend;
@@ -1569,6 +1942,9 @@ export class KycController extends BaseController<
    *     the UKYC session (handing over the wrapped key and the token);
    *  5. fetches the SumSub applicant access token; and
    *  6. presents the SDK via the injected launcher.
+   *
+   * If a UKYC session already exists (the consents path creates it before
+   * recording session disclaimers), steps 1–4 are skipped.
    *
    * If session creation reports the applicant is already approved on the relay
    * while the vendor is still finalizing (`kycStatus: approved`,
@@ -1602,92 +1978,35 @@ export class KycController extends BaseController<
     const generation = this.#generation;
 
     try {
-      this.#applyUpdate((state) => {
-        state.sumsub.status = 'creatingSession';
-        state.sumsub.result = null;
-        state.sumsub.sessionStatus = null;
-      });
-
-      const jwtToken = MOCK_JWT_TOKEN;
-
-      // Establish a per-session X25519 keypair and exchange our public half for
-      // the server's wrapping key. The private half stays on the device and is
-      // used to derive the shared secret that seals the data_encryption_key.
-      const sessionClientPrivateKey = x25519.utils.randomSecretKey();
-      const sessionClientPublicKey = x25519.getPublicKey(
-        sessionClientPrivateKey,
-      );
-      const wrappingKey = await this.messenger.call(
-        'KycService:getWrappingKey',
-        { sessionClientPublicKey: toBase64Url(sessionClientPublicKey) },
-      );
-
-      // Verify the jwtChain against Fractal's JWKS, then confirm the returned
-      // sessionServerPublicKey matches the value attested inside the verified
-      // JWT payload before trusting it for key wrapping.
-      const { keys } = await this.messenger.call('KycService:fetchJwks');
-      const jwtChainPayload = verifyJwtChain(keys, wrappingKey.jwtChain);
-      if (
-        jwtChainPayload.sessionServerPublicKeyX !==
-        wrappingKey.sessionServerPublicKey.x
-      ) {
-        throw new Error(
-          'sessionServerPublicKey does not match the verified jwtChain payload (sessionServerPublicKeyX).',
-        );
-      }
-
-      // Derive the data_encryption_key from the local_user_secret and wrap it
-      // for the session server. Only the wrapped (encrypted) key ever leaves
-      // the device.
-      const localUserSecret = await getOrCreateLocalUserSecret(
-        this.#localUserSecretStore(),
-      );
-      const clientMaterial = deriveClientMaterial(localUserSecret);
-      const wrappedEncryptionKey = {
-        sessionId: wrappingKey.id,
-        ...wrapEncryptionKey(
-          sessionClientPrivateKey,
-          wrappingKey.sessionServerPublicKey.x,
-          clientMaterial.dataEncryptionKey,
-        ),
-      };
-
-      // Mint a read-only `ukyc_capability_token` for the session. Only the
-      // client holds the signing key derived from `local_user_secret`, so only
-      // the client can mint it; scoping it to `read` means it authorizes later
-      // storage reads without granting write or delete access.
-      const ukycCapabilityToken = signStorageAccessToken({
-        material: clientMaterial,
-        operations: ['read'],
-        expiresAt: new Date(Date.now() + UKYC_CAPABILITY_TOKEN_TTL_MS),
-      });
-
-      const { sessionId, kycStatus, finalStatus } = await this.messenger.call(
-        'KycService:createUkycSession',
-        {
-          jwtToken,
-          ...this.#buildUkycSessionVendorFields(),
-          wrappedEncryptionKey,
-          ukycCapabilityToken,
-        },
-      );
-
-      // A user who already finished the journey can return to a session the
-      // relay has already approved (`kycStatus`) while the vendor is still
-      // finalizing its own decision (`finalStatus`). There is nothing left to
-      // verify, so stop here and surface a message rather than launching the
-      // SDK again.
-      if (
-        kycStatus === KYC_STATUSES.approved &&
-        finalStatus === KYC_STATUSES.pending
-      ) {
-        const stillCurrent = this.#updateIfCurrent(generation, (state) => {
-          state.sumsub.status = 'vendorProcessing';
-          state.sumsub.sessionId = sessionId;
-          state.statusMessage = VENDOR_PROCESSING_MESSAGE;
+      if (!this.state.sumsub.sessionId) {
+        this.#applyUpdate((state) => {
+          state.sumsub.status = 'creatingSession';
+          state.sumsub.result = null;
+          state.sumsub.sessionStatus = null;
         });
-        return stillCurrent ? { kycStatus, finalStatus } : {};
+
+        const created = await this.#createUkycSession(generation);
+        if (!created) {
+          return {};
+        }
+
+        // A user who already finished the journey can return to a session the
+        // relay has already approved (`kycStatus`) while the vendor is still
+        // finalizing its own decision (`finalStatus`). There is nothing left to
+        // verify, so stop here and surface a message rather than launching the
+        // SDK again.
+        if (created.vendorProcessing) {
+          return {
+            kycStatus: created.kycStatus,
+            finalStatus: created.finalStatus,
+          };
+        }
       }
+
+      // Empty string is a valid "no id to poll" session id used by tests and
+      // must not be coalesced away as missing.
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+      const sessionId = this.state.sumsub.sessionId || '';
 
       this.#updateIfCurrent(generation, (state) => {
         state.sumsub.status = 'fetchingToken';
@@ -2082,6 +2401,8 @@ export class KycController extends BaseController<
       state.error = null;
       state.disclaimers = [];
       state.disclaimersError = null;
+      state.sessionDisclaimers = null;
+      state.credentialReusabilityConsentGiven = null;
       state.sessionToken = null;
       state.accessToken = null;
       state.moonpayCustomerId = null;

--- a/packages/kyc-controller/src/KycService-method-action-types.ts
+++ b/packages/kyc-controller/src/KycService-method-action-types.ts
@@ -71,14 +71,48 @@ export type KycServiceCreateVendorCustomerAction = {
 };
 
 /**
- * Posts T&C1 (vendor signings) and T&C2 (Sumsub + idOS) consents for the
- * authenticated user. The API responds with 204 No Content on success.
+ * Records vendor T&C acceptance (`POST /vendors/{vendor}/disclaimers`).
+ * For Iron this creates content signings from the disclaimer ids the
+ * customer accepted. Session-scoped idOS / KYC-provider consents are
+ * recorded separately via {@link submitSessionDisclaimers}. Retries re-POST
+ * the same ids, matching the legacy `POST /consents` signing step.
+ *
+ * @param params - The parameters.
+ * @param params.vendor - Identity vendor (e.g. `iron`).
+ * @param params.disclaimerIds - Accepted vendor T&C ids.
+ * @returns The vendor signing records.
+ */
+export type KycServiceSubmitVendorDisclaimersAction = {
+  type: `KycService:submitVendorDisclaimers`;
+  handler: KycService['submitVendorDisclaimers'];
+};
+
+/**
+ * Fetches the session-scoped idOS + KYC-provider disclaimer catalog
+ * (`GET /sessions/{sessionId}/disclaimers`). Requires an existing UKYC
+ * session; vendor T&Cs continue to come from {@link fetchDisclaimers}.
+ *
+ * @param params - The parameters.
+ * @param params.sessionId - The UKYC session id.
+ * @returns The catalog, including which documents are already consented.
+ */
+export type KycServiceFetchSessionDisclaimersAction = {
+  type: `KycService:fetchSessionDisclaimers`;
+  handler: KycService['fetchSessionDisclaimers'];
+};
+
+/**
+ * Records idOS + KYC-provider consents for a UKYC session
+ * (`POST /sessions/{sessionId}/disclaimers`). `key`/`version` pairs must
+ * match the current catalog from {@link fetchSessionDisclaimers}. A 409
+ * means those document versions were already recorded for the session.
  *
  * @param params - The consent parameters.
+ * @returns The updated catalog after recording.
  */
-export type KycServiceSubmitConsentsAction = {
-  type: `KycService:submitConsents`;
-  handler: KycService['submitConsents'];
+export type KycServiceSubmitSessionDisclaimersAction = {
+  type: `KycService:submitSessionDisclaimers`;
+  handler: KycService['submitSessionDisclaimers'];
 };
 
 /**
@@ -173,7 +207,9 @@ export type KycServiceMethodActions =
   | KycServiceCreateSessionAction
   | KycServiceCheckKycRequiredAction
   | KycServiceCreateVendorCustomerAction
-  | KycServiceSubmitConsentsAction
+  | KycServiceSubmitVendorDisclaimersAction
+  | KycServiceFetchSessionDisclaimersAction
+  | KycServiceSubmitSessionDisclaimersAction
   | KycServiceFetchKycStatusAction
   | KycServiceGetWrappingKeyAction
   | KycServiceFetchJwksAction

--- a/packages/kyc-controller/src/KycService.test.ts
+++ b/packages/kyc-controller/src/KycService.test.ts
@@ -567,6 +567,71 @@ describe('KycService', () => {
     });
   });
 
+  describe('submitVendorDisclaimers', () => {
+    const signings = [
+      { id: 'sign-1', customer_id: 'cust-1', content_id: 'disc-1' },
+      { id: 'sign-2', customer_id: 'cust-1', content_id: 'disc-2' },
+    ];
+
+    it('posts accepted disclaimer ids and returns vendor signings', async () => {
+      nock(MOCK_API_URL)
+        .post('/vendors/iron/disclaimers', {
+          disclaimerIds: ['disc-1', 'disc-2'],
+        })
+        .reply(200, signings);
+      const { service } = getService();
+
+      expect(
+        await service.submitVendorDisclaimers({
+          vendor: 'iron',
+          disclaimerIds: ['disc-1', 'disc-2'],
+        }),
+      ).toStrictEqual(signings);
+    });
+
+    it('accepts extra signing fields and an omitted content_id', async () => {
+      nock(MOCK_API_URL)
+        .post('/vendors/iron/disclaimers', { disclaimerIds: ['disc-1'] })
+        .reply(200, [
+          { id: 'sign-1', customer_id: 'cust-1', signed: true },
+        ]);
+      const { service } = getService();
+
+      expect(
+        await service.submitVendorDisclaimers({
+          vendor: 'iron',
+          disclaimerIds: ['disc-1'],
+        }),
+      ).toMatchObject([{ id: 'sign-1', customer_id: 'cust-1' }]);
+    });
+
+    it('throws on a malformed response', async () => {
+      nock(MOCK_API_URL).post('/vendors/iron/disclaimers').reply(200, {});
+      const { service } = getService();
+
+      await expect(
+        service.submitVendorDisclaimers({
+          vendor: 'iron',
+          disclaimerIds: ['disc-1'],
+        }),
+      ).rejects.toThrow(
+        /Malformed response received from vendor disclaimers API/u,
+      );
+    });
+
+    it('throws an HttpError on a non-ok response', async () => {
+      nock(MOCK_API_URL).post('/vendors/iron/disclaimers').reply(500);
+      const { service } = getService();
+
+      await expect(
+        service.submitVendorDisclaimers({
+          vendor: 'iron',
+          disclaimerIds: ['disc-1'],
+        }),
+      ).rejects.toThrow(/failed with status '500'/u);
+    });
+  });
+
   describe('fetchDisclaimers for a non-MoonPay vendor', () => {
     it('returns Iron disclaimers for a country', async () => {
       const disclaimers = [
@@ -634,38 +699,148 @@ describe('KycService', () => {
     });
   });
 
-  describe('submitConsents', () => {
-    it('posts consents and accepts a 204 response', async () => {
+  describe('fetchSessionDisclaimers', () => {
+    const catalog = {
+      idOS: [
+        {
+          key: 'idos-tos',
+          version: '1',
+          title: 'idOS ToS',
+          url: 'https://idos.example/tos',
+          consented: false,
+        },
+      ],
+      kycProvider: [
+        {
+          key: 'sumsub-tos',
+          version: '1',
+          title: 'SumSub ToS',
+          url: 'https://sumsub.example/tos',
+          consented: false,
+        },
+      ],
+      credentialReusabilityConsentGiven: false,
+    };
+
+    it('returns the session-scoped disclaimer catalog', async () => {
       nock(MOCK_API_URL)
-        .post('/consents', {
-          ironDisclaimerIds: ['d1'],
-          sumsubTncSigned: true,
-          idosTncSigned: true,
-          kycLevel: 'standard',
-        })
-        .reply(204);
+        .get('/sessions/sid-1/disclaimers')
+        .reply(200, catalog);
       const { service } = getService();
 
       expect(
-        await service.submitConsents({
-          disclaimerIds: ['d1'],
-          sumsubTncSigned: true,
-          idosTncSigned: true,
-        }),
-      ).toBeUndefined();
+        await service.fetchSessionDisclaimers({ sessionId: 'sid-1' }),
+      ).toStrictEqual(catalog);
     });
 
-    it('throws an HttpError on a non-ok response', async () => {
-      nock(MOCK_API_URL).post('/consents').reply(500);
+    it('throws on a malformed response', async () => {
+      nock(MOCK_API_URL).get('/sessions/sid-1/disclaimers').reply(200, {});
       const { service } = getService();
 
       await expect(
-        service.submitConsents({
-          disclaimerIds: ['d1'],
-          sumsubTncSigned: true,
-          idosTncSigned: true,
-        }),
+        service.fetchSessionDisclaimers({ sessionId: 'sid-1' }),
+      ).rejects.toThrow(
+        /Malformed response received from session disclaimers API/u,
+      );
+    });
+
+    it('throws an HttpError on a non-ok response', async () => {
+      nock(MOCK_API_URL).get('/sessions/sid-1/disclaimers').reply(500);
+      const { service } = getService();
+
+      await expect(
+        service.fetchSessionDisclaimers({ sessionId: 'sid-1' }),
       ).rejects.toThrow(/failed with status '500'/u);
+    });
+  });
+
+  describe('submitSessionDisclaimers', () => {
+    const recorded = {
+      idOS: [
+        {
+          key: 'idos-tos',
+          version: '1',
+          title: 'idOS ToS',
+          url: 'https://idos.example/tos',
+          consented: true,
+        },
+      ],
+      kycProvider: [
+        {
+          key: 'sumsub-tos',
+          version: '1',
+          title: 'SumSub ToS',
+          url: 'https://sumsub.example/tos',
+          consented: true,
+        },
+      ],
+      credentialReusabilityConsentGiven: true,
+    };
+
+    it('posts consent records and returns the updated catalog', async () => {
+      nock(MOCK_API_URL)
+        .post('/sessions/sid-1/disclaimers', {
+          idOS: [{ key: 'idos-tos', version: '1' }],
+          kycProvider: [{ key: 'sumsub-tos', version: '1' }],
+          credentialReusabilityConsentGiven: true,
+        })
+        .reply(200, recorded);
+      const { service } = getService();
+
+      expect(
+        await service.submitSessionDisclaimers({
+          sessionId: 'sid-1',
+          idOS: [{ key: 'idos-tos', version: '1' }],
+          kycProvider: [{ key: 'sumsub-tos', version: '1' }],
+          credentialReusabilityConsentGiven: true,
+        }),
+      ).toStrictEqual(recorded);
+    });
+
+    it('throws on a malformed response', async () => {
+      nock(MOCK_API_URL).post('/sessions/sid-1/disclaimers').reply(200, {});
+      const { service } = getService();
+
+      await expect(
+        service.submitSessionDisclaimers({
+          sessionId: 'sid-1',
+          idOS: [],
+          kycProvider: [],
+          credentialReusabilityConsentGiven: false,
+        }),
+      ).rejects.toThrow(
+        /Malformed response received from session disclaimers API/u,
+      );
+    });
+
+    it('throws an HttpError on a non-ok response', async () => {
+      nock(MOCK_API_URL).post('/sessions/sid-1/disclaimers').reply(409);
+      const { service } = getService();
+
+      await expect(
+        service.submitSessionDisclaimers({
+          sessionId: 'sid-1',
+          idOS: [{ key: 'idos-tos', version: '1' }],
+          kycProvider: [],
+          credentialReusabilityConsentGiven: false,
+        }),
+      ).rejects.toThrow(/failed with status '409'/u);
+    });
+
+    it('treats a 204 response as empty and fails catalog validation', async () => {
+      nock(MOCK_API_URL).post('/sessions/sid-1/disclaimers').reply(204);
+      const { service } = getService();
+
+      await expect(
+        service.submitSessionDisclaimers({
+          sessionId: 'sid-1',
+          idOS: [],
+          kycProvider: [],
+          credentialReusabilityConsentGiven: false,
+        }),
+      ).rejects.toThrow(
+        /Malformed response received from session disclaimers API/u,
+      );
     });
   });
 

--- a/packages/kyc-controller/src/KycService.test.ts
+++ b/packages/kyc-controller/src/KycService.test.ts
@@ -592,9 +592,7 @@ describe('KycService', () => {
     it('accepts extra signing fields and an omitted content_id', async () => {
       nock(MOCK_API_URL)
         .post('/vendors/iron/disclaimers', { disclaimerIds: ['disc-1'] })
-        .reply(200, [
-          { id: 'sign-1', customer_id: 'cust-1', signed: true },
-        ]);
+        .reply(200, [{ id: 'sign-1', customer_id: 'cust-1', signed: true }]);
       const { service } = getService();
 
       expect(
@@ -723,9 +721,7 @@ describe('KycService', () => {
     };
 
     it('returns the session-scoped disclaimer catalog', async () => {
-      nock(MOCK_API_URL)
-        .get('/sessions/sid-1/disclaimers')
-        .reply(200, catalog);
+      nock(MOCK_API_URL).get('/sessions/sid-1/disclaimers').reply(200, catalog);
       const { service } = getService();
 
       expect(

--- a/packages/kyc-controller/src/KycService.ts
+++ b/packages/kyc-controller/src/KycService.ts
@@ -27,10 +27,13 @@ import type { QueryClientConfig } from '@tanstack/query-core';
 import { alpha2ToAlpha3 } from './countryCodes.js';
 import type { KycServiceMethodActions } from './KycService-method-action-types.js';
 import type {
+  KycConsentRecord,
   KycDisclaimer,
+  KycSessionDisclaimers,
   KycSessionStatus,
   KycUserStatusResponse,
   KycVendor,
+  KycVendorSigning,
 } from './types.js';
 import { UKYC_JWKS_PATH } from './ukyc/constants.js';
 import { encodeStorageAccessTokenForHeader } from './ukyc/storageAccessToken.js';
@@ -51,7 +54,9 @@ const MESSENGER_EXPOSED_METHODS = [
   'createSession',
   'checkKycRequired',
   'createVendorCustomer',
-  'submitConsents',
+  'submitVendorDisclaimers',
+  'fetchSessionDisclaimers',
+  'submitSessionDisclaimers',
   'fetchKycStatus',
   'getWrappingKey',
   'fetchJwks',
@@ -155,6 +160,13 @@ const DisclaimerStruct = type({
 });
 const DisclaimersResponseStruct = array(DisclaimerStruct);
 
+const VendorSigningStruct = type({
+  id: string(),
+  customer_id: string(),
+  content_id: optional(string()),
+});
+const VendorSigningsResponseStruct = array(VendorSigningStruct);
+
 const CreateSessionResponseStruct = type({ sessionToken: string() });
 
 // The live KYC API returns the flag under `required`; the service normalizes
@@ -237,6 +249,20 @@ const KycUserStatusResponseStruct = type({
   errorCode: optional(string()),
 });
 
+const ConsentDocumentStruct = type({
+  key: string(),
+  version: string(),
+  title: string(),
+  url: string(),
+  consented: boolean(),
+});
+
+const SessionDisclaimersResponseStruct = type({
+  idOS: array(ConsentDocumentStruct),
+  kycProvider: array(ConsentDocumentStruct),
+  credentialReusabilityConsentGiven: boolean(),
+});
+
 // === PARAM TYPES ===
 
 export type CreateSessionParams = {
@@ -267,15 +293,30 @@ export type CreateVendorCustomerParams = {
   email: string;
 };
 
-export type SubmitConsentsParams = {
-  /**
-   * Vendor disclaimer ids the customer accepted (T&C1). Mapped to the UKYC
-   * wire field `ironDisclaimerIds` for the Money/VBA consents contract.
-   */
+export type SubmitVendorDisclaimersParams = {
+  /** Identity vendor whose T&Cs were accepted (currently `iron`). */
+  vendor: KycVendor;
+  /** Disclaimer ids from {@link KycService.fetchDisclaimers}. */
   disclaimerIds: string[];
-  sumsubTncSigned: boolean;
-  idosTncSigned: boolean;
-  kycLevel?: 'standard';
+};
+
+export type FetchSessionDisclaimersParams = {
+  /** UKYC session id from {@link KycService.createUkycSession}. */
+  sessionId: string;
+};
+
+export type SubmitSessionDisclaimersParams = {
+  /** UKYC session id from {@link KycService.createUkycSession}. */
+  sessionId: string;
+  /** Consents to the idOS legal documents (`key`/`version` from the catalog). */
+  idOS: KycConsentRecord[];
+  /**
+   * Consents to the KYC provider (SumSub) legal documents (`key`/`version`
+   * from the catalog).
+   */
+  kycProvider: KycConsentRecord[];
+  /** Consent to reuse the user's existing idOS credentials. */
+  credentialReusabilityConsentGiven: boolean;
 };
 
 export type GetWrappingKeyParams = {
@@ -335,8 +376,9 @@ export type GetSessionStatusParams = {
  * `fetchQuery`: it is wrapped in the shared service policy (retries, circuit
  * breaker) and its result is exposed via the service's `QueryClient`. Read-only
  * endpoints (`fetchDisclaimers`, `fetchJwks`) are cached with a `staleTime`;
- * the session-creating and status-polling endpoints opt out of caching
- * (`staleTime`/`gcTime` of `0`) so they never serve a stale result.
+ * vendor-disclaimer, session-scoped disclaimer, session-creating, and
+ * status-polling endpoints opt out of caching (`staleTime`/`gcTime` of `0`)
+ * so they never serve a stale result.
  */
 export class KycService extends BaseDataService<
   typeof serviceName,
@@ -595,35 +637,117 @@ export class KycService extends BaseDataService<
   }
 
   /**
-   * Posts T&C1 (vendor signings) and T&C2 (Sumsub + idOS) consents for the
-   * authenticated user. The API responds with 204 No Content on success.
+   * Records vendor T&C acceptance (`POST /vendors/{vendor}/disclaimers`).
+   * For Iron this creates content signings from the disclaimer ids the
+   * customer accepted. Session-scoped idOS / KYC-provider consents are
+   * recorded separately via {@link submitSessionDisclaimers}. Retries re-POST
+   * the same ids, matching the legacy `POST /consents` signing step.
    *
-   * @param params - The consent parameters.
+   * @param params - The parameters.
+   * @param params.vendor - Identity vendor (e.g. `iron`).
+   * @param params.disclaimerIds - Accepted vendor T&C ids.
+   * @returns The vendor signing records.
    */
-  async submitConsents(params: SubmitConsentsParams): Promise<void> {
-    const url = new URL('/consents', this.#baseUrl);
-    await this.fetchQuery({
+  async submitVendorDisclaimers(
+    params: SubmitVendorDisclaimersParams,
+  ): Promise<KycVendorSigning[]> {
+    const url = new URL(
+      `/vendors/${encodeURIComponent(params.vendor)}/disclaimers`,
+      this.#baseUrl,
+    );
+    const data = await this.fetchQuery({
       queryKey: [
-        `${this.name}:submitConsents`,
+        `${this.name}:submitVendorDisclaimers`,
+        params.vendor,
         params.disclaimerIds,
-        params.sumsubTncSigned,
-        params.idosTncSigned,
-        params.kycLevel ?? 'standard',
       ],
       queryFn: async () =>
         this.#requestJson(url, {
           method: 'POST',
-          // UKYC Money/VBA consents contract still uses `ironDisclaimerIds`.
+          body: JSON.stringify({ disclaimerIds: params.disclaimerIds }),
+        }),
+      staleTime: 0,
+      gcTime: 0,
+    });
+    return this.#validateResponse(
+      data,
+      VendorSigningsResponseStruct,
+      'vendor disclaimers',
+    );
+  }
+
+  /**
+   * Fetches the session-scoped idOS + KYC-provider disclaimer catalog
+   * (`GET /sessions/{sessionId}/disclaimers`). Requires an existing UKYC
+   * session; vendor T&Cs continue to come from {@link fetchDisclaimers}.
+   *
+   * @param params - The parameters.
+   * @param params.sessionId - The UKYC session id.
+   * @returns The catalog, including which documents are already consented.
+   */
+  async fetchSessionDisclaimers(
+    params: FetchSessionDisclaimersParams,
+  ): Promise<KycSessionDisclaimers> {
+    const url = new URL(
+      `/sessions/${encodeURIComponent(params.sessionId)}/disclaimers`,
+      this.#baseUrl,
+    );
+    const data = await this.fetchQuery({
+      queryKey: [`${this.name}:fetchSessionDisclaimers`, params.sessionId],
+      queryFn: async () => this.#requestJson(url, { method: 'GET' }),
+      // Consent state can change after a POST, so always re-fetch.
+      staleTime: 0,
+      gcTime: 0,
+    });
+    return this.#validateResponse(
+      data,
+      SessionDisclaimersResponseStruct,
+      'session disclaimers',
+    );
+  }
+
+  /**
+   * Records idOS + KYC-provider consents for a UKYC session
+   * (`POST /sessions/{sessionId}/disclaimers`). `key`/`version` pairs must
+   * match the current catalog from {@link fetchSessionDisclaimers}. A 409
+   * means those document versions were already recorded for the session.
+   *
+   * @param params - The consent parameters.
+   * @returns The updated catalog after recording.
+   */
+  async submitSessionDisclaimers(
+    params: SubmitSessionDisclaimersParams,
+  ): Promise<KycSessionDisclaimers> {
+    const url = new URL(
+      `/sessions/${encodeURIComponent(params.sessionId)}/disclaimers`,
+      this.#baseUrl,
+    );
+    const data = await this.fetchQuery({
+      queryKey: [
+        `${this.name}:submitSessionDisclaimers`,
+        params.sessionId,
+        params.idOS,
+        params.kycProvider,
+        params.credentialReusabilityConsentGiven,
+      ],
+      queryFn: async () =>
+        this.#requestJson(url, {
+          method: 'POST',
           body: JSON.stringify({
-            ironDisclaimerIds: params.disclaimerIds,
-            sumsubTncSigned: params.sumsubTncSigned,
-            idosTncSigned: params.idosTncSigned,
-            kycLevel: params.kycLevel ?? 'standard',
+            idOS: params.idOS,
+            kycProvider: params.kycProvider,
+            credentialReusabilityConsentGiven:
+              params.credentialReusabilityConsentGiven,
           }),
         }),
       staleTime: 0,
       gcTime: 0,
     });
+    return this.#validateResponse(
+      data,
+      SessionDisclaimersResponseStruct,
+      'session disclaimers',
+    );
   }
 
   /**
@@ -918,7 +1042,7 @@ export class KycService extends BaseDataService<
       );
     }
 
-    // Consent (and similar) endpoints return 204 No Content.
+    // DELETE (and similar) endpoints return 204 No Content.
     if (response.status === 204) {
       return null;
     }

--- a/packages/kyc-controller/src/index.ts
+++ b/packages/kyc-controller/src/index.ts
@@ -40,6 +40,7 @@ export type {
   CreateVendorCustomerParams,
   CreateSessionParams,
   CreateUkycSessionParams,
+  FetchSessionDisclaimersParams,
   GetSessionStatusParams,
   GetWrappingKeyParams,
   VendorCustomerResponse,
@@ -51,7 +52,8 @@ export type {
   KycServiceInvalidateQueriesAction,
   KycServiceMessenger,
   KycServiceOptions,
-  SubmitConsentsParams,
+  SubmitSessionDisclaimersParams,
+  SubmitVendorDisclaimersParams,
   UkycSessionResponse,
   WrappedEncryptionKey,
   WrappingKeyResponse,
@@ -65,10 +67,12 @@ export type {
   KycServiceFetchDisclaimersAction,
   KycServiceFetchJwksAction,
   KycServiceFetchKycStatusAction,
+  KycServiceFetchSessionDisclaimersAction,
   KycServiceGetGeoCountryAction,
   KycServiceGetSessionStatusAction,
   KycServiceGetWrappingKeyAction,
-  KycServiceSubmitConsentsAction,
+  KycServiceSubmitSessionDisclaimersAction,
+  KycServiceSubmitVendorDisclaimersAction,
 } from './KycService-method-action-types.js';
 
 export {
@@ -87,10 +91,13 @@ export type {
 } from './crypto.js';
 
 export type {
+  KycConsentDocument,
+  KycConsentRecord,
   KycCustomerIdentity,
   KycDisclaimer,
   KycPhase,
   KycProduct,
+  KycSessionDisclaimers,
   KycSessionStatus,
   KycSumSubLaunchParams,
   KycSumSubLauncher,
@@ -98,6 +105,7 @@ export type {
   KycUserStatus,
   KycUserStatusResponse,
   KycVendor,
+  KycVendorSigning,
 } from './types.js';
 
 // UKYC storage-access-token utilities. Exported so a signed capability token can

--- a/packages/kyc-controller/src/types.ts
+++ b/packages/kyc-controller/src/types.ts
@@ -66,8 +66,8 @@ export type KycUserStatusResponse = {
  *
  * - `idle` — nothing started.
  * - `terms` — waiting for the customer to accept the vendor terms.
- * - `session` — creating the vendor session (MoonPay) or posting consents
- *   (non-MoonPay vendors).
+ * - `session` — creating the vendor session (MoonPay) or creating the UKYC
+ *   session and recording session-scoped disclaimers (non-MoonPay vendors).
  * - `check` — running the invisible connection-check frame (MoonPay only).
  * - `auth` — running the visible authentication (OTP) frame (MoonPay only).
  * - `form` — authenticated. When the flow is scoped to a product, the
@@ -138,8 +138,8 @@ export type KycSessionStatus = {
 };
 
 /**
- * A single disclaimer/term the customer must accept before a session is
- * created.
+ * A single disclaimer/term the customer must accept before a vendor session is
+ * created (`GET /vendors/{vendor}/disclaimers`).
  */
 export type KycDisclaimer = {
   id: string;
@@ -147,6 +147,59 @@ export type KycDisclaimer = {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   display_name: string;
   url: string;
+};
+
+/**
+ * A vendor T&C signing returned by `POST /vendors/{vendor}/disclaimers`.
+ */
+export type KycVendorSigning = {
+  /** Iron signing id. */
+  id: string;
+  // Mirrors the vendor API response field, which is snake_case.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  customer_id: string;
+  // Mirrors the vendor API response field, which is snake_case.
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  content_id?: string;
+};
+
+/**
+ * A legal document in the session-scoped idOS / KYC-provider catalog
+ * (`GET`/`POST /sessions/{sessionId}/disclaimers`).
+ */
+export type KycConsentDocument = {
+  /** Stable identifier of the legal document. */
+  key: string;
+  /** Version of the document currently in force. */
+  version: string;
+  /** Human-readable document title. */
+  title: string;
+  /** URL the document body is hosted at. */
+  url: string;
+  /** Whether this session already consented to this document version. */
+  consented: boolean;
+};
+
+/**
+ * A consent record posted for a catalog document. `key` and `version` must
+ * match the current session catalog.
+ */
+export type KycConsentRecord = {
+  key: string;
+  version: string;
+};
+
+/**
+ * Session-scoped disclaimer catalog returned by
+ * `GET`/`POST /sessions/{sessionId}/disclaimers`.
+ */
+export type KycSessionDisclaimers = {
+  /** idOS legal documents. */
+  idOS: KycConsentDocument[];
+  /** KYC provider (SumSub) legal documents. */
+  kycProvider: KycConsentDocument[];
+  /** Whether the user consented to reuse existing idOS credentials. */
+  credentialReusabilityConsentGiven: boolean;
 };
 
 /**


### PR DESCRIPTION
## Explanation

* Replace KycService.submitConsents (POST /consents) with session-scoped GET/POST /sessions/{id}/disclaimers for idOS + KYC-provider consents ({ key, version } + credentialReusabilityConsentGiven).
* Record Iron T&Cs separately via POST /vendors/{vendor}/disclaimers (submitVendorDisclaimers); those content ids are no longer sent on the session disclaimer POST.
*Consents path order: vendor T&Cs → create UKYC session → session catalog/consents → SumSub. A 409 is re-checked with a GET and only treated as success when every accepted document is consented.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking API and consent orchestration for identity/KYC flows; incorrect 409 or catalog handling could block verification or skip required legal consents.
> 
> **Overview**
> **Breaking:** Removes `KycService.submitConsents` (`POST /consents`) and replaces it with three endpoints: **`submitVendorDisclaimers`** for Iron/vendor T&C ids, **`fetchSessionDisclaimers`** / **`submitSessionDisclaimers`** for the idOS + SumSub catalog using `{ key, version }` and **`credentialReusabilityConsentGiven`**.
> 
> On the non-MoonPay consents path, **`KycController`** now runs **vendor T&Cs → UKYC session create → session disclaimers → SumSub** (vendor content ids are no longer bundled into session consent POSTs). **`acceptTermsAndStartSession`** accepts optional **`credentialReusabilityConsentGiven`**; T&C2 booleans map onto catalog documents. **409** on session disclaimer POST triggers a re-GET and only continues when every accepted item is actually consented—otherwise the flow fails closed and rewinds to **`terms`**.
> 
> UKYC session creation is extracted into **`#createUkycSession`** so the consents path can create the session before recording disclaimers; **`startSumSub`** skips wrapping-key/session steps when a session id already exists. Adds in-memory **`sessionDisclaimers`** / **`credentialReusabilityConsentGiven`** state and related types; docs and tests follow the new contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06dc3da767bbdeea2e008734e7fbf965387d88ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->