### PR TITLE
fix: reuse adaptOrderFromSDK for historical orders

### DIFF
--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Preserve trigger prices and normalized trigger order types in HyperLiquid historical orders while retaining their lifecycle and execution semantics ([#9982](https://github.com/MetaMask/core/pull/9982)).
 - Classify `xyz:CBRS` and `xyz:SPCX` as stocks in the Hyperliquid fallback market map ([#9988](https://github.com/MetaMask/core/pull/9988))
 
 ## [13.0.0]

--- a/packages/perps-controller/src/providers/HyperLiquidProvider.ts
+++ b/packages/perps-controller/src/providers/HyperLiquidProvider.ts
@@ -10535,9 +10535,7 @@ export class HyperLiquidProvider implements PerpsProvider {
         const adaptedOrder = adaptOrderFromSDK(order, undefined);
         let historicalOrderType = adaptedOrder.orderType;
         if (!adaptedOrder.triggerOrderType) {
-          historicalOrderType = order.orderType
-            ?.toLowerCase()
-            .includes('limit')
+          historicalOrderType = order.orderType?.toLowerCase().includes('limit')
             ? 'limit'
             : 'market';
         }

--- a/packages/perps-controller/src/providers/HyperLiquidProvider.ts
+++ b/packages/perps-controller/src/providers/HyperLiquidProvider.ts
@@ -10493,8 +10493,6 @@ export class HyperLiquidProvider implements PerpsProvider {
       // Transform HyperLiquid orders to abstract Order type
       const orders: Order[] = (rawOrders || []).map((rawOrder) => {
         const { order, status, statusTimestamp } = rawOrder;
-        // Normalize side: HyperLiquid uses 'A' (Ask/Sell) and 'B' (Bid/Buy)
-        const normalizedSide = order.side === 'B' ? 'buy' : 'sell';
 
         // Normalize status
         let normalizedStatus: Order['status'];
@@ -10534,24 +10532,26 @@ export class HyperLiquidProvider implements PerpsProvider {
         const currentSize = parseFloat(order.sz);
         const filledSize = originalSize - currentSize;
 
-        return {
-          orderId: order.oid?.toString() || '',
-          symbol: order.coin,
-          side: normalizedSide,
-          orderType: order.orderType?.toLowerCase().includes('limit')
+        const adaptedOrder = adaptOrderFromSDK(order, undefined);
+        let historicalOrderType = adaptedOrder.orderType;
+        if (!adaptedOrder.triggerOrderType) {
+          historicalOrderType = order.orderType
+            ?.toLowerCase()
+            .includes('limit')
             ? 'limit'
-            : 'market',
+            : 'market';
+        }
+
+        return {
+          ...adaptedOrder,
+          orderType: historicalOrderType,
           size: order.sz,
           originalSize: order.origSz || order.sz,
-          price: order.limitPx || '0',
           filledSize: filledSize.toString(),
           remainingSize: currentSize.toString(),
           status: normalizedStatus,
           timestamp: statusTimestamp,
           lastUpdated: statusTimestamp,
-          detailedOrderType: order.orderType, // Full order type from exchange (e.g., 'Take Profit Limit', 'Stop Market')
-          isTrigger: order.isTrigger,
-          reduceOnly: order.reduceOnly,
         };
       });
 

--- a/packages/perps-controller/src/providers/HyperLiquidProvider.ts
+++ b/packages/perps-controller/src/providers/HyperLiquidProvider.ts
@@ -32,6 +32,7 @@ import {
   USDC_DECIMALS,
   USDC_SYMBOL,
 } from '../constants/hyperLiquidConfig.js';
+import { DETAILED_ORDER_TYPES } from '../constants/orderTypes.js';
 import {
   CHASE_ORDER_CONFIG,
   CHASE_ORDER_STATUS,
@@ -59,6 +60,7 @@ import {
 } from '../services/TradingReadinessCache.js';
 import type {
   FrontendOrder,
+  OrderType as HyperLiquidOrderType,
   SDKOrderParams,
   MetaResponse,
   PerpsAssetCtx,
@@ -223,6 +225,15 @@ import {
 } from '../utils/standaloneInfoClient.js';
 import { parseBoundedNonNegativeDecimal } from '../utils/stringParseUtils.js';
 // getStreamManagerInstance removed: use this.#deps.streamManager instead
+
+const HISTORICAL_ORDER_TYPE_BY_DETAILED_TYPE = {
+  [DETAILED_ORDER_TYPES.LIMIT]: 'limit',
+  [DETAILED_ORDER_TYPES.MARKET]: 'market',
+  [DETAILED_ORDER_TYPES.STOP_LIMIT]: 'limit',
+  [DETAILED_ORDER_TYPES.STOP_MARKET]: 'market',
+  [DETAILED_ORDER_TYPES.TAKE_PROFIT_LIMIT]: 'limit',
+  [DETAILED_ORDER_TYPES.TAKE_PROFIT_MARKET]: 'market',
+} as const satisfies Record<HyperLiquidOrderType, Order['orderType']>;
 
 /**
  * Type guard to check if a status is an object (not a string literal like "waitingForFill")
@@ -10530,10 +10541,11 @@ export class HyperLiquidProvider implements PerpsProvider {
         const adaptedOrder = adaptOrderFromSDK(order, undefined);
         // limitPx is also populated as a slippage cap for market orders, so the
         // exchange's detailed type is the reliable execution-mode source.
-        const historicalOrderType = order.orderType
-          ?.toLowerCase()
-          .includes('limit')
-          ? 'limit'
+        const historicalOrderType = hasProperty(
+          HISTORICAL_ORDER_TYPE_BY_DETAILED_TYPE,
+          order.orderType,
+        )
+          ? HISTORICAL_ORDER_TYPE_BY_DETAILED_TYPE[order.orderType]
           : 'market';
 
         return {

--- a/packages/perps-controller/src/providers/HyperLiquidProvider.ts
+++ b/packages/perps-controller/src/providers/HyperLiquidProvider.ts
@@ -10527,26 +10527,19 @@ export class HyperLiquidProvider implements PerpsProvider {
             normalizedStatus = 'queued';
         }
 
-        // Calculate filled and remaining size
-        const originalSize = parseFloat(order.origSz || order.sz);
-        const currentSize = parseFloat(order.sz);
-        const filledSize = originalSize - currentSize;
-
         const adaptedOrder = adaptOrderFromSDK(order, undefined);
-        let historicalOrderType = adaptedOrder.orderType;
-        if (!adaptedOrder.triggerOrderType) {
-          historicalOrderType = order.orderType?.toLowerCase().includes('limit')
-            ? 'limit'
-            : 'market';
-        }
+        // limitPx is also populated as a slippage cap for market orders, so the
+        // exchange's detailed type is the reliable execution-mode source.
+        const historicalOrderType = order.orderType
+          ?.toLowerCase()
+          .includes('limit')
+          ? 'limit'
+          : 'market';
 
         return {
           ...adaptedOrder,
           orderType: historicalOrderType,
-          size: order.sz,
-          originalSize: order.origSz || order.sz,
-          filledSize: filledSize.toString(),
-          remainingSize: currentSize.toString(),
+          remainingSize: parseFloat(order.sz).toString(),
           status: normalizedStatus,
           timestamp: statusTimestamp,
           lastUpdated: statusTimestamp,

--- a/packages/perps-controller/src/utils/hyperLiquidAdapter.ts
+++ b/packages/perps-controller/src/utils/hyperLiquidAdapter.ts
@@ -277,7 +277,7 @@ export function adaptOrderFromSDK(
   );
 
   // Extract basic fields with appropriate conversions
-  const orderId = rawOrder.oid.toString();
+  const orderId = rawOrder.oid?.toString() || '';
   const symbol = rawOrder.coin;
   const side: 'buy' | 'sell' = rawOrder.side === 'B' ? 'buy' : 'sell';
   const detailedOrderType = rawOrder.orderType;
@@ -293,7 +293,7 @@ export function adaptOrderFromSDK(
     // source for how the order actually executes.
     orderType = getTriggerExecution(triggerOrderType);
   } else if (
-    detailedOrderType.toLowerCase().includes('limit') ||
+    detailedOrderType?.toLowerCase().includes('limit') ||
     rawOrder.limitPx
   ) {
     orderType = 'limit';

--- a/packages/perps-controller/tests/src/providers/HyperLiquidProvider.history.test.ts
+++ b/packages/perps-controller/tests/src/providers/HyperLiquidProvider.history.test.ts
@@ -559,6 +559,7 @@ describe('HyperLiquidProvider', () => {
             sz: '0.0',
             origSz: '2.0',
             limitPx: '3500',
+            triggerPx: '3450',
             orderType: 'Take Profit Limit',
             reduceOnly: true,
             isTrigger: true,
@@ -574,12 +575,29 @@ describe('HyperLiquidProvider', () => {
             sz: '0.1',
             origSz: '0.1',
             limitPx: '45000',
+            triggerPx: '45500',
             orderType: 'Stop Market',
             reduceOnly: true,
             isTrigger: true,
           },
           status: 'triggered',
           statusTimestamp: 1640995400000,
+        },
+        {
+          order: {
+            oid: 126,
+            coin: 'ETH',
+            side: 'B',
+            sz: '0.0',
+            origSz: '1.0',
+            limitPx: '3600',
+            triggerPx: '',
+            orderType: 'Market',
+            reduceOnly: false,
+            isTrigger: false,
+          },
+          status: 'filled',
+          statusTimestamp: 1640995500000,
         },
       ];
       mockClientService.getInfoClient = jest.fn().mockReturnValue({
@@ -596,7 +614,7 @@ describe('HyperLiquidProvider', () => {
 
       const result = await provider.getOrders();
 
-      expect(result).toHaveLength(3);
+      expect(result).toHaveLength(4);
 
       // Check first order - regular limit order (not closing)
       expect(result[0]).toMatchObject({
@@ -622,7 +640,13 @@ describe('HyperLiquidProvider', () => {
         size: '0.0',
         originalSize: '2.0',
         price: '3500',
+        triggerPrice: '3450',
+        triggerOrderType: 'take_profit_limit',
+        filledSize: '2',
+        remainingSize: '0',
         status: 'filled',
+        timestamp: 1640995300000,
+        lastUpdated: 1640995300000,
         detailedOrderType: 'Take Profit Limit',
         reduceOnly: true,
         isTrigger: true,
@@ -637,10 +661,35 @@ describe('HyperLiquidProvider', () => {
         size: '0.1',
         originalSize: '0.1',
         price: '45000',
+        triggerPrice: '45500',
+        triggerOrderType: 'stop_market',
+        filledSize: '0',
+        remainingSize: '0.1',
         status: 'triggered',
+        timestamp: 1640995400000,
+        lastUpdated: 1640995400000,
         detailedOrderType: 'Stop Market',
         reduceOnly: true,
         isTrigger: true,
+      });
+
+      // Check fourth order - regular market order with a slippage-cap price
+      expect(result[3]).toMatchObject({
+        orderId: '126',
+        symbol: 'ETH',
+        side: 'buy',
+        orderType: 'market',
+        size: '0.0',
+        originalSize: '1.0',
+        price: '3600',
+        filledSize: '1',
+        remainingSize: '0',
+        status: 'filled',
+        timestamp: 1640995500000,
+        lastUpdated: 1640995500000,
+        detailedOrderType: 'Market',
+        reduceOnly: false,
+        isTrigger: false,
       });
     });
 

--- a/packages/perps-controller/tests/src/providers/HyperLiquidProvider.history.test.ts
+++ b/packages/perps-controller/tests/src/providers/HyperLiquidProvider.history.test.ts
@@ -581,6 +581,41 @@ describe('HyperLiquidProvider', () => {
       });
     });
 
+    it.each([
+      ['Limit', 'limit'],
+      ['Market', 'market'],
+      ['Stop Limit', 'limit'],
+      ['Stop Market', 'market'],
+      ['Take Profit Limit', 'limit'],
+      ['Take Profit Market', 'market'],
+      ['Unexpected Limit', 'market'],
+    ])(
+      'maps the exact historical order type %s to %s',
+      async (orderType, expected) => {
+        mockClientService.fetchHistoricalOrders = jest.fn().mockResolvedValue([
+          {
+            order: {
+              oid: 123,
+              coin: 'BTC',
+              side: 'B',
+              sz: '0.1',
+              origSz: '0.1',
+              limitPx: '50000',
+              orderType,
+              reduceOnly: false,
+              isTrigger: false,
+            },
+            status: 'open',
+            statusTimestamp: 1640995200000,
+          },
+        ]);
+
+        const result = await provider.getOrders();
+
+        expect(result[0].orderType).toBe(expected);
+      },
+    );
+
     it('properly transform getOrders with reduceOnly and isTrigger fields', async () => {
       const historicalOrdersData = [
         {

--- a/packages/perps-controller/tests/src/providers/HyperLiquidProvider.history.test.ts
+++ b/packages/perps-controller/tests/src/providers/HyperLiquidProvider.history.test.ts
@@ -534,6 +534,53 @@ describe('HyperLiquidProvider', () => {
       expect(result).toEqual([]);
     });
 
+    it('preserves history when an order is missing runtime-required fields', async () => {
+      mockClientService.fetchHistoricalOrders = jest.fn().mockResolvedValue([
+        {
+          order: {
+            oid: 123,
+            coin: 'BTC',
+            side: 'A',
+            sz: '0.5',
+            origSz: '1.0',
+            limitPx: '50000',
+            orderType: 'Limit',
+            reduceOnly: false,
+            isTrigger: false,
+          },
+          status: 'filled',
+          statusTimestamp: 1640995200000,
+        },
+        {
+          order: {
+            oid: undefined,
+            coin: 'ETH',
+            side: 'B',
+            sz: '0.1',
+            origSz: '0.1',
+            limitPx: '',
+            orderType: undefined,
+            reduceOnly: false,
+            isTrigger: false,
+          },
+          status: 'open',
+          statusTimestamp: 1640995300000,
+        },
+      ]);
+
+      const result = await provider.getOrders();
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject({
+        orderId: '123',
+        orderType: 'limit',
+      });
+      expect(result[1]).toMatchObject({
+        orderId: '',
+        orderType: 'market',
+      });
+    });
+
     it('properly transform getOrders with reduceOnly and isTrigger fields', async () => {
       const historicalOrdersData = [
         {
@@ -691,6 +738,8 @@ describe('HyperLiquidProvider', () => {
         reduceOnly: false,
         isTrigger: false,
       });
+      expect(result[3].triggerPrice).toBeUndefined();
+      expect(result[3].triggerOrderType).toBeUndefined();
     });
 
     it('properly transform getOpenOrders with reduceOnly and isTrigger fields', async () => {

--- a/packages/perps-controller/tests/src/utils/hyperLiquidAdapter.advanced-orders.test.ts
+++ b/packages/perps-controller/tests/src/utils/hyperLiquidAdapter.advanced-orders.test.ts
@@ -117,6 +117,23 @@ describe('hyperLiquidAdapter - advanced order types', () => {
 
       expect(result.triggerOrderType).toBeUndefined();
     });
+
+    it('tolerates runtime orders without an id or detailed type', () => {
+      const malformedOrder = buildFrontendOrder({
+        oid: undefined,
+        orderType: undefined,
+        limitPx: '',
+      } as unknown as Partial<FrontendOrder>);
+
+      const result = adaptOrderFromSDK(malformedOrder);
+
+      expect(result).toMatchObject({
+        orderId: '',
+        orderType: 'market',
+      });
+      expect(result.detailedOrderType).toBeUndefined();
+      expect(result.triggerOrderType).toBeUndefined();
+    });
   });
 
   describe('adaptOrderToSDK', () => {


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Hyperliquid historical orders were mapped through a separate inline path that dropped `triggerPx` and the normalized trigger order type. Consumers therefore received trigger orders without `Order.triggerPrice`, preventing clients such as MetaMask Mobile from displaying the trigger price in order history.

This change reuses the existing `adaptOrderFromSDK` mapping used for open orders, then overlays historical lifecycle fields such as status, timestamps, and filled/remaining size. It also preserves ordinary historical market-order classification when Hyperliquid supplies a non-empty `limitPx` as a slippage cap.

Provider tests now cover distinct trigger and limit prices for Take Profit Limit and Stop Market orders, plus a regular market order carrying a slippage-cap price. There are no public type changes or breaking changes.

Validation:
- `yarn workspace @metamask/perps-controller run test`
- `yarn eslint packages/perps-controller/src/providers/HyperLiquidProvider.ts packages/perps-controller/tests/src/providers/HyperLiquidProvider.history.test.ts`
- `yarn build`

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

- Related to [MetaMask/metamask-mobile#35118](https://github.com/MetaMask/metamask-mobile/pull/35118)
- Addresses [the production history boundary review finding](https://github.com/MetaMask/metamask-mobile/pull/35118#discussion_r3868602007)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized to HyperLiquid historical order mapping and adapter edge cases; no public API or breaking type changes, with expanded unit tests.
> 
> **Overview**
> **HyperLiquid order history** now goes through the same `adaptOrderFromSDK` path as open orders, instead of a separate inline mapper that dropped trigger metadata.
> 
> Historical rows still get lifecycle overlays (`status`, `statusTimestamp` / `lastUpdated`, and `remainingSize` from the exchange’s current `sz`). **`orderType`** for history is derived from HyperLiquid’s detailed type via `HISTORICAL_ORDER_TYPE_BY_DETAILED_TYPE`, so trigger and market orders are not mislabeled as limits when `limitPx` is only a slippage cap.
> 
> **`adaptOrderFromSDK`** tolerates missing `oid`, `orderType`, and empty `limitPx` so partial history payloads still map instead of failing silently.
> 
> Tests cover trigger/limit price preservation for TP/SL history, market orders with slippage-cap prices, and the detailed-type → limit/market mapping table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdd11cd0639a4f9fd143d2fa546f159f371b48c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->