### PR TITLE
fix(perps-controller): preserve categories on snapshot fallback

### DIFF
--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -62,6 +62,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Report the take profit (or stop loss) price on a `Position` when its only trigger for that direction is a partial, quantity-scoped one ([#9912](https://github.com/MetaMask/core/pull/9912))
   - `takeProfitPrice`/`stopLossPrice` were only ever scanned from position-bound triggers, so a position whose sole take profit closed it partially reported `takeProfitCount: 1` with no price, and clients rendering the scalar showed none. Applies to the REST `getPositions`, `getUserDataSnapshot`, and WebSocket position paths alike.
   - Two or more triggers in a direction still report the scanned price, because no single price describes them and clients render the count instead.
+- Map Terminal v1 `category` aliases (`pre_ipo` → `pre-ipo`, `stocks` → `stock`) when `marketType` is absent, so Pre-IPO markets such as Unitree appear under that filter without a static symbol list
+- Reclassify `xyz:CBRS` and `xyz:SPCX` from `pre-ipo` to `stock` in `HIP3_ASSET_MARKET_TYPES` now that they are public (Terminal already sends `stocks`). Leave `xyz:IPOP` as Pre-IPO
 
 ## [12.1.0]
 

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `takeProfitPrice`/`stopLossPrice` were only ever scanned from position-bound triggers, so a position whose sole take profit closed it partially reported `takeProfitCount: 1` with no price, and clients rendering the scalar showed none. Applies to the REST `getPositions`, `getUserDataSnapshot`, and WebSocket position paths alike.
   - Two or more triggers in a direction still report the scanned price, because no single price describes them and clients render the count instead.
 - Map Terminal v1 `category` aliases (`pre_ipo` → `pre-ipo`, `stocks` → `stock`) when `marketType` is absent, so Pre-IPO markets such as Unitree appear under that filter without a static symbol list
+- Clear `isNewMarket` on the v1 Terminal enrich path once a `marketType` is applied, matching the v2 snapshot rule so categorized HIP-3 markets are not also in the controller `new` bucket
 - Reclassify `xyz:CBRS` and `xyz:SPCX` from `pre-ipo` to `stock` in `HIP3_ASSET_MARKET_TYPES` now that they are public (Terminal already sends `stocks`). Leave `xyz:IPOP` as Pre-IPO
 
 ## [12.1.0]

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Map Terminal v1 `category` aliases (`pre_ipo` → `pre-ipo`, `stocks` → `stock`) when `marketType` is absent, so Pre-IPO markets such as Unitree appear under that filter without a static symbol list
 - Clear `isNewMarket` on the v1 Terminal enrich path once a `marketType` is applied, matching the v2 snapshot rule so categorized HIP-3 markets are not also in the controller `new` bucket
 - Reclassify `xyz:CBRS` and `xyz:SPCX` from `pre-ipo` to `stock` in `HIP3_ASSET_MARKET_TYPES` now that they are public (Terminal already sends `stocks`). Leave `xyz:IPOP` as Pre-IPO
+- Preserve Terminal v1 category metadata when the v2 snapshot falls back to provider prices
 
 ## [12.1.0]
 

--- a/packages/perps-controller/src/constants/hyperLiquidConfig.ts
+++ b/packages/perps-controller/src/constants/hyperLiquidConfig.ts
@@ -383,6 +383,8 @@ export const HIP3_ASSET_MARKET_TYPES: Record<string, MarketType> = {
   'xyz:ARM': MarketCategory.Stock,
   'xyz:BX': MarketCategory.Stock,
   'xyz:LITE': MarketCategory.Stock,
+  'xyz:CBRS': MarketCategory.Stock,
+  'xyz:SPCX': MarketCategory.Stock,
 
   // xyz DEX - Stocks (Korea)
   'xyz:SKHX': MarketCategory.Stock,
@@ -394,8 +396,6 @@ export const HIP3_ASSET_MARKET_TYPES: Record<string, MarketType> = {
   'xyz:KIOXIA': MarketCategory.Stock,
 
   // xyz DEX - Pre-IPO
-  'xyz:CBRS': MarketCategory.PreIpo,
-  'xyz:SPCX': MarketCategory.PreIpo,
   'xyz:IPOP': MarketCategory.PreIpo,
 
   // xyz DEX - Indices

--- a/packages/perps-controller/src/services/MarketDataService.ts
+++ b/packages/perps-controller/src/services/MarketDataService.ts
@@ -1414,8 +1414,10 @@ export class MarketDataService {
    * Merge Terminal API metadata into provider-sourced PerpsMarketData.
    * For each market, if the terminal metadata map contains an entry for its
    * symbol, override name/description/marketType and attach
-   * keywords/tags/categories. Unmatched markets keep their provider-sourced
-   * values.
+   * keywords/tags/categories. Applying a marketType clears a stale
+   * isNewMarket flag so the v1 enrich path matches the v2 snapshot rule
+   * (categorized HIP-3 is not the controller "new" bucket). Unmatched markets
+   * keep their provider-sourced values.
    *
    * @param markets - Markets from the provider.
    * @param metadata - Per-symbol metadata from the Terminal API.
@@ -1437,7 +1439,10 @@ export class MarketDataService {
         ...(meta.description !== undefined && {
           description: meta.description,
         }),
-        ...(meta.marketType !== undefined && { marketType: meta.marketType }),
+        ...(meta.marketType !== undefined && {
+          marketType: meta.marketType,
+          ...(market.isNewMarket === true && { isNewMarket: false }),
+        }),
         ...(meta.keywords !== undefined && { keywords: meta.keywords }),
         ...(meta.tags !== undefined && { tags: meta.tags }),
         ...(meta.categories !== undefined && { categories: meta.categories }),

--- a/packages/perps-controller/src/services/MarketDataService.ts
+++ b/packages/perps-controller/src/services/MarketDataService.ts
@@ -913,9 +913,9 @@ export class MarketDataService {
       });
 
       // Prefer a separately configured atomic snapshot only for an exact,
-      // still-current provider/network/DEX identity. A rejected snapshot has
-      // one lexical fallback to the provider below and is not followed by a
-      // second legacy Terminal request.
+      // still-current provider/network/DEX identity. When the snapshot cannot
+      // supply prices, retain Terminal metadata through the legacy endpoint
+      // while falling back to provider prices below.
       let snapshotAttempted = false;
       if (
         globalSnapshot &&
@@ -954,13 +954,11 @@ export class MarketDataService {
         }
       }
 
-      // Fetch Terminal API metadata before provider data when enabled.
-      // Terminal metadata enriches the provider result (name, keywords, tags,
-      // categories) but never replaces live pricing / funding data.
+      // Fetch Terminal metadata before provider data when enabled, or when the
+      // configured snapshot failed and provider prices need metadata parity.
       let terminalMetadata: Map<string, TerminalAssetMetadata> | undefined;
       if (
-        !snapshotAttempted &&
-        useTerminalApi &&
+        (useTerminalApi || snapshotAttempted) &&
         this.#deps.terminalMarketService
       ) {
         try {

--- a/packages/perps-controller/src/services/TerminalMarketService.ts
+++ b/packages/perps-controller/src/services/TerminalMarketService.ts
@@ -111,6 +111,7 @@ const TerminalPerpetualItemStruct = type({
   minimumOrderSize: optional(number()),
   keywords: optional(nullable(array(string()))),
   tags: optional(nullable(array(string()))),
+  category: optional(nullable(string())),
   categories: optional(nullable(array(string()))),
   marketType: optional(nullable(string())),
   listedAt: optional(nullable(union([number(), string()]))),
@@ -633,13 +634,9 @@ export class TerminalMarketService {
     };
   }
 
-  #marketTypeFor(
-    dex: string,
-    category: string | null,
+  #categoryToMarketType(
+    category: string | null | undefined,
   ): TerminalAssetMetadata['marketType'] | undefined {
-    if (dex === 'main') {
-      return MarketCategory.CryptoCurrency;
-    }
     if (category === 'stocks') {
       return MarketCategory.Stock;
     }
@@ -650,6 +647,16 @@ export class TerminalMarketService {
       return category as TerminalAssetMetadata['marketType'];
     }
     return undefined;
+  }
+
+  #marketTypeFor(
+    dex: string,
+    category: string | null,
+  ): TerminalAssetMetadata['marketType'] | undefined {
+    if (dex === 'main') {
+      return MarketCategory.CryptoCurrency;
+    }
+    return this.#categoryToMarketType(category);
   }
 
   #cloneGlobalSnapshotResult(
@@ -788,6 +795,11 @@ export class TerminalMarketService {
       ) {
         entry.marketType =
           item.marketType as TerminalAssetMetadata['marketType'];
+      } else {
+        const fromCategory = this.#categoryToMarketType(item.category);
+        if (fromCategory) {
+          entry.marketType = fromCategory;
+        }
       }
 
       if (item.listedAt !== null && item.listedAt !== undefined) {

--- a/packages/perps-controller/tests/src/constants/hyperLiquidConfig.test.ts
+++ b/packages/perps-controller/tests/src/constants/hyperLiquidConfig.test.ts
@@ -24,6 +24,8 @@ describe('HIP3_ASSET_MARKET_TYPES', () => {
     expect(HIP3_ASSET_MARKET_TYPES['xyz:ARM']).toBe('stock');
     expect(HIP3_ASSET_MARKET_TYPES['xyz:BX']).toBe('stock');
     expect(HIP3_ASSET_MARKET_TYPES['xyz:LITE']).toBe('stock');
+    expect(HIP3_ASSET_MARKET_TYPES['xyz:CBRS']).toBe('stock');
+    expect(HIP3_ASSET_MARKET_TYPES['xyz:SPCX']).toBe('stock');
   });
 
   it('classifies USAR as stock (USA Rare Earth)', () => {
@@ -37,8 +39,6 @@ describe('HIP3_ASSET_MARKET_TYPES', () => {
   });
 
   it('classifies pre-IPO markets correctly', () => {
-    expect(HIP3_ASSET_MARKET_TYPES['xyz:CBRS']).toBe('pre-ipo');
-    expect(HIP3_ASSET_MARKET_TYPES['xyz:SPCX']).toBe('pre-ipo');
     expect(HIP3_ASSET_MARKET_TYPES['xyz:IPOP']).toBe('pre-ipo');
   });
 

--- a/packages/perps-controller/tests/src/services/MarketDataService.test.ts
+++ b/packages/perps-controller/tests/src/services/MarketDataService.test.ts
@@ -19,6 +19,7 @@ import type {
 } from '../../../src/types/index.js';
 import type { CandleData } from '../../../src/types/perps-types.js';
 import { resetPerpsRestCacheForTests } from '../../../src/utils/coalescePerpsRestRequest.js';
+import { matchesCategory } from '../../../src/utils/marketUtils.js';
 /* eslint-disable */
 import {
   createMockHyperLiquidProvider,
@@ -1683,9 +1684,83 @@ describe('MarketDataService', () => {
         expect(result[0]?.tags).toEqual(['top-10']);
         expect(result[0]?.categories).toEqual(['crypto']);
         expect(result[0]?.marketType).toBe('crypto');
+        expect(result[0]).not.toHaveProperty('isNewMarket');
         expect(result[1]?.name).toBe('Ethereum');
         expect(result[1]?.keywords).toEqual(['defi']);
         expect(result[1]?.description).toBeUndefined();
+      });
+
+      it('clears isNewMarket when Terminal metadata supplies a marketType', async () => {
+        const unitreeMarket: PerpsMarketData = {
+          symbol: 'xyz:UNITREE',
+          name: 'xyz:UNITREE',
+          maxLeverage: '10x',
+          price: '$1.00',
+          change24h: '+$0.10',
+          change24hPercent: '+10.00%',
+          volume: '$100000',
+          isHip3: true,
+          isNewMarket: true,
+        };
+        mockTerminalService.fetchMarkets.mockResolvedValue({
+          markets: [
+            {
+              name: 'xyz:UNITREE',
+              szDecimals: 0,
+              maxLeverage: 10,
+              marginTableId: 0,
+            },
+          ],
+          metadata: new Map<string, TerminalAssetMetadata>([
+            ['xyz:UNITREE', { name: 'Unitree', marketType: 'pre-ipo' }],
+          ]),
+        });
+        mockProvider.getMarketDataWithPrices.mockResolvedValue([unitreeMarket]);
+
+        const result = await serviceWithTerminal.getMarketDataWithPrices({
+          provider: mockProvider,
+          params: { useTerminalApi: true },
+          context: mockContext,
+        });
+
+        expect(result[0]?.marketType).toBe('pre-ipo');
+        expect(result[0]?.isNewMarket).toBe(false);
+        expect(matchesCategory(result[0] as PerpsMarketData, 'pre-ipo')).toBe(
+          true,
+        );
+        expect(matchesCategory(result[0] as PerpsMarketData, 'new')).toBe(
+          false,
+        );
+      });
+
+      it('preserves isNewMarket when Terminal metadata has no marketType', async () => {
+        const unitreeMarket: PerpsMarketData = {
+          symbol: 'xyz:UNITREE',
+          name: 'xyz:UNITREE',
+          maxLeverage: '10x',
+          price: '$1.00',
+          change24h: '+$0.10',
+          change24hPercent: '+10.00%',
+          volume: '$100000',
+          isHip3: true,
+          isNewMarket: true,
+        };
+        mockTerminalService.fetchMarkets.mockResolvedValue({
+          markets: terminalMarkets,
+          metadata: new Map<string, TerminalAssetMetadata>([
+            ['xyz:UNITREE', { name: 'Unitree' }],
+          ]),
+        });
+        mockProvider.getMarketDataWithPrices.mockResolvedValue([unitreeMarket]);
+
+        const result = await serviceWithTerminal.getMarketDataWithPrices({
+          provider: mockProvider,
+          params: { useTerminalApi: true },
+          context: mockContext,
+        });
+
+        expect(result[0]?.marketType).toBeUndefined();
+        expect(result[0]?.isNewMarket).toBe(true);
       });
 
       it('preserves provider name when terminal metadata omits name', async () => {

--- a/packages/perps-controller/tests/src/services/MarketDataService.test.ts
+++ b/packages/perps-controller/tests/src/services/MarketDataService.test.ts
@@ -1268,6 +1268,10 @@ describe('MarketDataService', () => {
         clearCache: jest.fn(),
         logError: jest.fn(),
       };
+      mockTerminalService.fetchMarkets.mockResolvedValue({
+        markets: [],
+        metadata: new Map(),
+      });
 
       serviceWithTerminal = new MarketDataService({
         ...mockDeps,
@@ -1519,7 +1523,7 @@ describe('MarketDataService', () => {
         ['stale', new Error('snapshot stale')],
         ['context mismatch', new Error('snapshot identity mismatch')],
       ])(
-        'falls back to the provider exactly once on %s',
+        'falls back to Terminal metadata and provider prices on %s',
         async (_name, error) => {
           mockTerminalService.fetchGlobalSnapshot?.mockRejectedValue(error);
           mockProvider.getMarketDataWithPrices.mockResolvedValue(
@@ -1534,9 +1538,73 @@ describe('MarketDataService', () => {
 
           expect(result).toStrictEqual(providerMarketData);
           expect(mockProvider.getMarketDataWithPrices).toHaveBeenCalledTimes(1);
-          expect(mockTerminalService.fetchMarkets).not.toHaveBeenCalled();
+          expect(mockTerminalService.fetchMarkets).toHaveBeenCalledTimes(1);
         },
       );
+
+      it('applies Terminal v1 category metadata after snapshot failure', async () => {
+        const unitreeMarket: PerpsMarketData = {
+          symbol: 'xyz:UNITREE',
+          name: 'xyz:UNITREE',
+          maxLeverage: '10x',
+          price: '$1.00',
+          change24h: '+$0.10',
+          change24hPercent: '+10.00%',
+          volume: '$100000',
+          isHip3: true,
+          isNewMarket: true,
+        };
+        mockTerminalService.fetchGlobalSnapshot?.mockRejectedValue(
+          new Error('snapshot unavailable'),
+        );
+        mockTerminalService.fetchMarkets.mockResolvedValue({
+          markets: [],
+          metadata: new Map<string, TerminalAssetMetadata>([
+            ['xyz:UNITREE', { marketType: 'pre-ipo' }],
+          ]),
+        });
+        mockProvider.getMarketDataWithPrices.mockResolvedValue([unitreeMarket]);
+
+        const result = await serviceWithTerminal.getMarketDataWithPrices({
+          provider: mockProvider,
+          params: { useTerminalApi: false },
+          context: createGlobalSnapshotContext({
+            enabledDexes: ['main', 'xyz'],
+          }),
+        });
+
+        expect(result[0]?.marketType).toBe('pre-ipo');
+        expect(result[0]?.isNewMarket).toBe(false);
+        expect(mockTerminalService.fetchGlobalSnapshot).toHaveBeenCalledTimes(
+          1,
+        );
+        expect(mockTerminalService.fetchMarkets).toHaveBeenCalledTimes(1);
+        expect(mockProvider.getMarketDataWithPrices).toHaveBeenCalledTimes(1);
+      });
+
+      it('keeps provider fallback when Terminal v1 also fails', async () => {
+        mockTerminalService.fetchGlobalSnapshot?.mockRejectedValue(
+          new Error('snapshot unavailable'),
+        );
+        mockTerminalService.fetchMarkets.mockRejectedValue(
+          new Error('metadata unavailable'),
+        );
+        mockProvider.getMarketDataWithPrices.mockResolvedValue(
+          providerMarketData,
+        );
+
+        const result = await serviceWithTerminal.getMarketDataWithPrices({
+          provider: mockProvider,
+          context: createGlobalSnapshotContext(),
+        });
+
+        expect(result).toStrictEqual(providerMarketData);
+        expect(mockProvider.getMarketDataWithPrices).toHaveBeenCalledTimes(1);
+        expect(mockTerminalService.logError).toHaveBeenCalledWith(
+          expect.objectContaining({ message: 'metadata unavailable' }),
+          'getMarketDataWithPrices',
+        );
+      });
 
       it('rejects a snapshot context race without calling the captured provider', async () => {
         mockTerminalService.fetchGlobalSnapshot?.mockResolvedValue({
@@ -1654,7 +1722,8 @@ describe('MarketDataService', () => {
           provider: mockProvider,
           context: createGlobalSnapshotContext({ isCurrent }),
         });
-        await Promise.resolve();
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        expect(resolveProvider).toBeDefined();
         resolveProvider?.(providerMarketData);
 
         await expect(pending).rejects.toThrow('snapshot context changed');

--- a/packages/perps-controller/tests/src/services/TerminalMarketService.test.ts
+++ b/packages/perps-controller/tests/src/services/TerminalMarketService.test.ts
@@ -432,7 +432,11 @@ describe('TerminalMarketService', () => {
         statusText: 'OK',
         json: () =>
           Promise.resolve([
-            { symbol: 'xyz:CBRS', name: 'Cerebras Systems', category: 'stocks' },
+            {
+              symbol: 'xyz:CBRS',
+              name: 'Cerebras Systems',
+              category: 'stocks',
+            },
           ]),
       } as Response);
 

--- a/packages/perps-controller/tests/src/services/TerminalMarketService.test.ts
+++ b/packages/perps-controller/tests/src/services/TerminalMarketService.test.ts
@@ -372,6 +372,91 @@ describe('TerminalMarketService', () => {
       expect(metadata.get('FOO')?.marketType).toBeUndefined();
     });
 
+    it('maps Terminal category pre_ipo to marketType pre-ipo when marketType is absent', async () => {
+      jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: () =>
+          Promise.resolve([
+            {
+              symbol: 'xyz:UNITREE',
+              name: 'Unitree Technology',
+              category: 'pre_ipo',
+            },
+            {
+              symbol: 'xyz:CXMT',
+              name: 'ChangXin Technology',
+              category: 'pre_ipo',
+            },
+            {
+              symbol: 'xyz:SKHY',
+              name: 'SK Hynix ADR',
+              category: 'pre_ipo',
+            },
+          ]),
+      } as Response);
+
+      const { metadata } = await service.fetchMarkets();
+
+      expect(metadata.get('xyz:UNITREE')?.marketType).toBe('pre-ipo');
+      expect(metadata.get('xyz:CXMT')?.marketType).toBe('pre-ipo');
+      expect(metadata.get('xyz:SKHY')?.marketType).toBe('pre-ipo');
+    });
+
+    it('prefers explicit marketType over category pre_ipo', async () => {
+      jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: () =>
+          Promise.resolve([
+            {
+              symbol: 'xyz:UNITREE',
+              name: 'Unitree Technology',
+              category: 'pre_ipo',
+              marketType: 'stock',
+            },
+          ]),
+      } as Response);
+
+      const { metadata } = await service.fetchMarkets();
+
+      expect(metadata.get('xyz:UNITREE')?.marketType).toBe('stock');
+    });
+
+    it('maps Terminal category stocks to marketType stock when marketType is absent', async () => {
+      jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: () =>
+          Promise.resolve([
+            { symbol: 'xyz:CBRS', name: 'Cerebras Systems', category: 'stocks' },
+          ]),
+      } as Response);
+
+      const { metadata } = await service.fetchMarkets();
+
+      expect(metadata.get('xyz:CBRS')?.marketType).toBe('stock');
+    });
+
+    it('does not map an unknown Terminal category to marketType', async () => {
+      jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: () =>
+          Promise.resolve([
+            { symbol: 'xyz:FOO', name: 'Foo', category: 'unknown' },
+          ]),
+      } as Response);
+
+      const { metadata } = await service.fetchMarkets();
+
+      expect(metadata.get('xyz:FOO')?.marketType).toBeUndefined();
+    });
+
     it('uses defaults for missing numeric fields', async () => {
       jest.spyOn(globalThis, 'fetch').mockResolvedValue({
         ok: true,


### PR DESCRIPTION
## Explanation

[Core #9815](https://github.com/MetaMask/core/pull/9815) added the Terminal v2 snapshot path. That path already preserves categories when the snapshot succeeds.

Two gaps remain when Mobile uses `@metamask/perps-controller@13.0.0`:

- Terminal v1 sends `category` for some markets, but the controller only reads `marketType`. Unitree, CXMT, and SKHY can therefore miss the Pre-IPO filter.
- If the configured v2 snapshot fails, the controller falls back to provider prices without loading v1 metadata. Prices remain live, but Terminal categories can disappear.

This PR fixes both cases in one controller release. It maps Terminal v1 aliases to the client `marketType`, retains v1 metadata during snapshot fallback, clears stale `isNewMarket` when a category applies, and updates the static CBRS/SPCX classification to Stock. IPOP remains Pre-IPO.

The normal v2 path is unchanged. Mobile [#35379](https://github.com/MetaMask/metamask-mobile/pull/35379) carries the same code as a temporary Yarn patch and can remove it after this ships in `@metamask/perps-controller`.

Validation: the focused `MarketDataService`, `TerminalMarketService`, and HyperLiquid config suites pass, 169 tests total. Mobile also forced the v2 failure path on a Pixel 6 and confirmed the five affected markets kept live provider prices and the expected categories.

This PR supersedes [#9907](https://github.com/MetaMask/core/pull/9907) by including that mapping fix plus the snapshot-fallback behavior.

## References

- Mobile consumer: [MetaMask/metamask-mobile#35379](https://github.com/MetaMask/metamask-mobile/pull/35379)
- Supersedes: [#9907](https://github.com/MetaMask/core/pull/9907)
- Normal Terminal v2 path: [#9815](https://github.com/MetaMask/core/pull/9815)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

No breaking changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Terminal metadata enrichment and static market-type labels; live pricing still comes from the provider and the happy-path v2 snapshot is untouched.
> 
> **Overview**
> Fixes **market discovery filtering** when Terminal v2 snapshots fail or when v1 only sends `category` instead of `marketType`.
> 
> **Terminal v1 metadata:** Parses the optional `category` field and maps aliases (`pre_ipo` → `pre-ipo`, `stocks` → `stock`) when `marketType` is missing, so Pre-IPO markets like Unitree show up under the right filter without maintaining symbol lists. Explicit `marketType` still wins over `category`.
> 
> **Snapshot fallback:** After a failed or empty v2 global snapshot, the controller still calls Terminal v1 `fetchMarkets` and merges metadata onto **provider-sourced prices** (previously it skipped v1 and lost categories). The successful v2 path is unchanged.
> 
> **`isNewMarket`:** When v1 enrichment applies a `marketType`, **`isNewMarket` is cleared** so categorized HIP-3 markets are not also listed under the controller **new** bucket, matching v2 snapshot behavior.
> 
> **Static HIP-3 map:** **`xyz:CBRS`** and **`xyz:SPCX`** move from `pre-ipo` to **`stock`** in `HIP3_ASSET_MARKET_TYPES` (now public); **`xyz:IPOP`** stays Pre-IPO.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdf9e72e124a1914f02ecb62adf1b20233f320b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->