### PR TITLE
fix(perps-controller): classify public fallback markets

### DIFF
--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Classify `xyz:CBRS` and `xyz:SPCX` as stocks in the Hyperliquid fallback market map ([#9988](https://github.com/MetaMask/core/pull/9988))
+
 ## [13.0.0]
 
 ### Added

--- a/packages/perps-controller/src/constants/hyperLiquidConfig.ts
+++ b/packages/perps-controller/src/constants/hyperLiquidConfig.ts
@@ -383,6 +383,8 @@ export const HIP3_ASSET_MARKET_TYPES: Record<string, MarketType> = {
   'xyz:ARM': MarketCategory.Stock,
   'xyz:BX': MarketCategory.Stock,
   'xyz:LITE': MarketCategory.Stock,
+  'xyz:CBRS': MarketCategory.Stock,
+  'xyz:SPCX': MarketCategory.Stock,
 
   // xyz DEX - Stocks (Korea)
   'xyz:SKHX': MarketCategory.Stock,
@@ -394,8 +396,6 @@ export const HIP3_ASSET_MARKET_TYPES: Record<string, MarketType> = {
   'xyz:KIOXIA': MarketCategory.Stock,
 
   // xyz DEX - Pre-IPO
-  'xyz:CBRS': MarketCategory.PreIpo,
-  'xyz:SPCX': MarketCategory.PreIpo,
   'xyz:IPOP': MarketCategory.PreIpo,
 
   // xyz DEX - Indices

--- a/packages/perps-controller/tests/src/constants/hyperLiquidConfig.test.ts
+++ b/packages/perps-controller/tests/src/constants/hyperLiquidConfig.test.ts
@@ -24,6 +24,8 @@ describe('HIP3_ASSET_MARKET_TYPES', () => {
     expect(HIP3_ASSET_MARKET_TYPES['xyz:ARM']).toBe('stock');
     expect(HIP3_ASSET_MARKET_TYPES['xyz:BX']).toBe('stock');
     expect(HIP3_ASSET_MARKET_TYPES['xyz:LITE']).toBe('stock');
+    expect(HIP3_ASSET_MARKET_TYPES['xyz:CBRS']).toBe('stock');
+    expect(HIP3_ASSET_MARKET_TYPES['xyz:SPCX']).toBe('stock');
   });
 
   it('classifies USAR as stock (USA Rare Earth)', () => {
@@ -37,8 +39,6 @@ describe('HIP3_ASSET_MARKET_TYPES', () => {
   });
 
   it('classifies pre-IPO markets correctly', () => {
-    expect(HIP3_ASSET_MARKET_TYPES['xyz:CBRS']).toBe('pre-ipo');
-    expect(HIP3_ASSET_MARKET_TYPES['xyz:SPCX']).toBe('pre-ipo');
     expect(HIP3_ASSET_MARKET_TYPES['xyz:IPOP']).toBe('pre-ipo');
   });
 


### PR DESCRIPTION
## Explanation

When the Terminal v2 snapshot fails, the controller falls back to Hyperliquid market data and its local category map. That map still labels `xyz:CBRS` and `xyz:SPCX` as pre-IPO, although both are public stocks.

This changes only those two fallback entries to `stock`. It does not call the deprecated Terminal v1 endpoint or change the v2 request path.

## References

No issue.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static category map correction for two symbols on the Hyperliquid fallback path only; no order, auth, or API behavior changes.
> 
> **Overview**
> When Terminal v2 market metadata is unavailable, perps still classifies HIP-3 markets via **`HIP3_ASSET_MARKET_TYPES`**. **`xyz:CBRS`** and **`xyz:SPCX`** were still mapped to **pre-IPO** even though they trade as public stocks.
> 
> This PR moves both symbols into the **stock** entries (and drops them from the pre-IPO block) so fallback-driven badges, filters, and category pills match their listing status. **`xyz:IPOP`** stays pre-IPO. Tests and the **Unreleased** changelog entry are updated accordingly; Terminal v2 routing is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 252b563ffd537398ca4d3c14ff553143314b3773. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->