### PR TITLE
docs: correct the changelog validation command in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,7 @@ For more on these commands, see:
 ### Linting and formatting
 
 - Run `yarn lint` to check for code quality issues across the monorepo.
-- Run `yarn validate:changelog` to check for formatting issues in changelogs.
+- Run `yarn changelog:validate` to check for formatting issues in changelogs.
 - Run `yarn lint:fix` to automatically fix fixable violations.
 
 ### Building packages
@@ -158,7 +158,7 @@ Each consumer-facing change to a package should be accompanied by one or more en
   - Do not simply reuse the PR title in the entry, but describe exact changes to the API or usable surface area of the project.
   - When there are multiple upgrades to a package in the same release, combine them into a single entry.
   - Each changelog entry should describe one kind of change; if an entry describes too many things, split it up.
-- After updating a changelog, run `yarn validate:changelog` and fix any errors reported.
+- After updating a changelog, run `yarn changelog:validate` and fix any errors reported.
 
 ## Creating releases
 


### PR DESCRIPTION
## Description

`yarn validate:changelog` does not exist. The script is `changelog:validate`, both at the root and per package. AGENTS.md had the two halves the wrong way round in both places it mentions it.

Running the documented command just errors with `Couldn't find a script named "validate:changelog"`, which is easy to misread as "nothing to validate" rather than "you ran the wrong thing".

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only correction with no runtime or API impact.
> 
> **Overview**
> **AGENTS.md** now documents the real Yarn script for changelog checks: both mentions of the linting/formatting and post-update changelog steps use **`yarn changelog:validate`** instead of the non-existent **`yarn validate:changelog`**.
> 
> That aligns agent and contributor docs with the root **`package.json`** script and workspace usage elsewhere in the repo, so following the guide no longer fails with a missing-script error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc5f8bb630402c73599262ebd2cd4746b872612f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->