### PR TITLE
feat(perps-controller): persist direction on pending trade drafts

### DIFF
--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Include `direction` on pending trade configurations so a 30-second draft restores long/short with size
+- Include `direction` on pending trade configurations so a 30-second draft restores long/short with size ([#9992](https://github.com/MetaMask/core/pull/9992))
 
 ### Fixed
 

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Include `direction` on pending trade configurations so a 30-second draft restores long/short with size
+
 ### Fixed
 
 - Classify `xyz:CBRS` and `xyz:SPCX` as stocks in the Hyperliquid fallback market map ([#9988](https://github.com/MetaMask/core/pull/9988))

--- a/packages/perps-controller/src/PerpsController-method-action-types.ts
+++ b/packages/perps-controller/src/PerpsController-method-action-types.ts
@@ -978,6 +978,7 @@ export type PerpsControllerSaveTradeConfigurationAction = {
  * @param config.limitPrice - The limit price.
  * @param config.orderType - The order type.
  * @param config.reduceOnly - Whether the order may only reduce a position.
+ * @param config.direction - Long or short.
  * @param config.selectedPaymentToken - The selected payment token.
  */
 export type PerpsControllerSavePendingTradeConfigurationAction = {

--- a/packages/perps-controller/src/PerpsController.ts
+++ b/packages/perps-controller/src/PerpsController.ts
@@ -106,6 +106,7 @@ import type {
   MarketInfo,
   Order,
   OrderCapabilitiesUnavailableReason,
+  OrderDirection,
   OrderFill,
   OrderParams,
   OrderResult,
@@ -456,6 +457,7 @@ export type PerpsControllerState = {
           limitPrice?: string; // Limit price (for limit orders)
           orderType?: OrderType; // Market vs limit
           reduceOnly?: boolean; // Whether the order may only reduce a position
+          direction?: OrderDirection; // Long vs short
           timestamp: number; // When the config was saved (for expiration check)
         };
       };
@@ -473,6 +475,7 @@ export type PerpsControllerState = {
           limitPrice?: string; // Limit price (for limit orders)
           orderType?: OrderType; // Market vs limit
           reduceOnly?: boolean; // Whether the order may only reduce a position
+          direction?: OrderDirection; // Long vs short
           timestamp: number; // When the config was saved (for expiration check)
         };
       };
@@ -6049,6 +6052,7 @@ export class PerpsController extends BaseController<
    * @param config.limitPrice - The limit price.
    * @param config.orderType - The order type.
    * @param config.reduceOnly - Whether the order may only reduce a position.
+   * @param config.direction - Long or short.
    * @param config.selectedPaymentToken - The selected payment token.
    */
   savePendingTradeConfiguration(
@@ -6061,6 +6065,7 @@ export class PerpsController extends BaseController<
       limitPrice?: string;
       orderType?: OrderType;
       reduceOnly?: boolean;
+      direction?: OrderDirection;
       /** When user used pay-with-token in PerpsPayRow: minimal token shape to restore selection */
       selectedPaymentToken?: PerpsSelectedPaymentToken | null;
     },
@@ -6109,6 +6114,7 @@ export class PerpsController extends BaseController<
         limitPrice?: string;
         orderType?: OrderType;
         reduceOnly?: boolean;
+        direction?: OrderDirection;
         selectedPaymentToken?: PerpsSelectedPaymentToken | null;
       }
     | undefined {

--- a/packages/perps-controller/src/selectors.ts
+++ b/packages/perps-controller/src/selectors.ts
@@ -17,6 +17,7 @@ import type {
 } from './constants/perpsConfig.js';
 import type { PerpsControllerState } from './PerpsController.js';
 import type {
+  OrderDirection,
   OrderType,
   PerpsSelectedPaymentToken,
   SortDirection,
@@ -149,6 +150,7 @@ type PendingTradeConfiguration = {
   limitPrice?: string;
   orderType?: OrderType;
   reduceOnly?: boolean;
+  direction?: OrderDirection;
   selectedPaymentToken?: PerpsSelectedPaymentToken | null;
 };
 

--- a/packages/perps-controller/tests/src/PerpsController.configuration.test.ts
+++ b/packages/perps-controller/tests/src/PerpsController.configuration.test.ts
@@ -1118,6 +1118,7 @@ describe('PerpsController', () => {
         limitPrice: '45000',
         orderType: 'limit' as const,
         reduceOnly: true,
+        direction: 'short' as const,
       };
 
       controller.savePendingTradeConfiguration('BTC', config);
@@ -1125,6 +1126,20 @@ describe('PerpsController', () => {
       const result = controller.getPendingTradeConfiguration('BTC');
       expect(result).toEqual(config);
       expect(controller.getSelectedOrderType()).toBe('limit');
+    });
+
+    it('restores a short direction from a pending trade configuration', () => {
+      controller.savePendingTradeConfiguration('BTC', {
+        amount: '100',
+        direction: 'short',
+      });
+
+      const result = controller.getPendingTradeConfiguration('BTC');
+
+      expect(result).toEqual({
+        amount: '100',
+        direction: 'short',
+      });
     });
 
     it('returns undefined for non-existent pending configuration', () => {

--- a/packages/perps-controller/tests/src/selectors.test.ts
+++ b/packages/perps-controller/tests/src/selectors.test.ts
@@ -347,6 +347,7 @@ describe('PerpsController selectors', () => {
                 limitPrice: '45000',
                 orderType: 'limit',
                 reduceOnly: true,
+                direction: 'short',
                 timestamp: now,
               },
             },
@@ -365,6 +366,7 @@ describe('PerpsController selectors', () => {
         limitPrice: '45000',
         orderType: 'limit',
         reduceOnly: true,
+        direction: 'short',
       });
     });
 


### PR DESCRIPTION
## Explanation

Pending trade drafts currently restore amount, leverage, TP/SL, limit price, order type, and reduce-only, but not long/short. Clients that restore a sized draft therefore reopen a short as a long (the form default). That is an accidental-trade risk once Pro starts restoring drafts ([MetaMask/metamask-mobile#35367](https://github.com/MetaMask/metamask-mobile/pull/35367)).

This adds an optional `direction` (`'long' | 'short'`) to `savePendingTradeConfiguration` / `getPendingTradeConfiguration` and to the pending-config selector. Older drafts without the field still restore as today. Direction is not a global preference; it lives only on the 30-second per-market draft and is not copied onto `selectedOrderType`.

## References

* Related to [MetaMask/metamask-mobile#35367](https://github.com/MetaMask/metamask-mobile/pull/35367)
* Related to [#9922](https://github.com/MetaMask/core/pull/9922)
* Related to [TAT-3706](https://consensyssoftware.atlassian.net/browse/TAT-3706)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

Made with [Cursor](https://cursor.com)

[TAT-3706]: https://consensyssoftware.atlassian.net/browse/TAT-3706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ