### PR TITLE
fix(perps): implement the TPSL false failure fix

### DIFF
--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Stop reporting `TPSL_UPDATE_FAILED` from `updatePositionTPSL` when HyperLiquid accepts a trigger with `waitingForTrigger`; accepted triggers without response order IDs are reconciled before mixed-failure cleanup
+- Stop reporting `TPSL_UPDATE_FAILED` from `updatePositionTPSL` when HyperLiquid accepts a trigger with `waitingForTrigger`; accepted triggers without response order IDs are reconciled before mixed-failure cleanup ([#9995](https://github.com/MetaMask/core/pull/9995))
 
 ## [13.1.0]
 

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Stop reporting `TPSL_UPDATE_FAILED` from `updatePositionTPSL` when HyperLiquid accepts a trigger with `waitingForTrigger`; accepted triggers without response order IDs are reconciled before mixed-failure cleanup
+
 ## [13.1.0]
 
 ### Added

--- a/packages/perps-controller/src/providers/HyperLiquidProvider.ts
+++ b/packages/perps-controller/src/providers/HyperLiquidProvider.ts
@@ -7789,32 +7789,6 @@ export class HyperLiquidProvider implements PerpsProvider {
   }
 
   /**
-   * Capture open orders without turning a read failure into a placement
-   * failure. The snapshot is needed only if an accepted trigger later needs an
-   * ID for cleanup after another leg fails.
-   *
-   * @param dexName - DEX to query, or null for the main DEX.
-   * @returns The open orders, or undefined when the snapshot failed.
-   */
-  async #captureTpslOpenOrders(
-    dexName: string | null,
-  ): Promise<FrontendOrder[] | undefined> {
-    try {
-      return await this.#fetchOpenOrders({ dexName });
-    } catch (error) {
-      this.#deps.debugLogger.log(
-        'Could not capture open orders before TP/SL placement',
-        {
-          error: ensureError(error, 'HyperLiquidProvider.captureTpslOpenOrders')
-            .message,
-          dex: dexName ?? 'main',
-        },
-      );
-      return undefined;
-    }
-  }
-
-  /**
    * Recover IDs omitted from waiting trigger acknowledgements.
    *
    * HyperLiquid does not preserve submission order in `frontendOpenOrders`, so
@@ -7824,7 +7798,7 @@ export class HyperLiquidProvider implements PerpsProvider {
    * @param params - Reconciliation parameters.
    * @param params.outcomes - Classified placement responses.
    * @param params.orders - Submitted TP/SL orders.
-   * @param params.previousOrders - Orders resting before submission.
+   * @param params.previousOrderIds - Order IDs observed before submission.
    * @param params.dexName - DEX queried for the placement.
    * @param params.symbol - Market the triggers protect.
    * @returns Outcomes enriched with unambiguous exchange order IDs.
@@ -7832,16 +7806,14 @@ export class HyperLiquidProvider implements PerpsProvider {
   async #reconcileTpslOrderPlacementOutcomes(params: {
     outcomes: TpslOrderPlacementOutcome[];
     orders: SDKOrderParams[];
-    previousOrders: FrontendOrder[] | undefined;
+    previousOrderIds: ReadonlySet<string>;
     dexName: string | null;
     symbol: string;
   }): Promise<TpslOrderPlacementOutcome[]> {
     if (
-      params.previousOrders === undefined ||
       !params.outcomes.some(
         (outcome) =>
-          (outcome.state === 'waitingForTrigger' ||
-            outcome.state === 'unknown') &&
+          outcome.state === 'waitingForTrigger' &&
           outcome.orderId === undefined,
       )
     ) {
@@ -7849,9 +7821,6 @@ export class HyperLiquidProvider implements PerpsProvider {
     }
 
     try {
-      const previousOrderIds = new Set(
-        params.previousOrders.map((order) => order.oid.toString()),
-      );
       const appearedOrders = (
         await this.#fetchOpenOrders({ dexName: params.dexName })
       ).filter(
@@ -7859,14 +7828,14 @@ export class HyperLiquidProvider implements PerpsProvider {
           order.coin === params.symbol &&
           order.reduceOnly &&
           order.isTrigger &&
-          !previousOrderIds.has(order.oid.toString()),
+          !params.previousOrderIds.has(order.oid.toString()),
       );
       const claimedOrderIds = new Set<number>();
 
       return params.outcomes.map((outcome, index) => {
         if (
           outcome.orderId !== undefined ||
-          (outcome.state !== 'waitingForTrigger' && outcome.state !== 'unknown')
+          outcome.state !== 'waitingForTrigger'
         ) {
           return outcome;
         }
@@ -9093,6 +9062,7 @@ export class HyperLiquidProvider implements PerpsProvider {
       // OPTIMIZATION: Use WebSocket cache first (0 weight), fall back to single-DEX REST (20 weight)
       // Previously: queryUserDataAcrossDexs queried ALL DEXs (20 weight × N DEXs = 40+ weight)
       let cancelRequests: ExchangeCancelRequest[] = [];
+      const orderIdsBeforePlacement = new Set<string>();
       const restorablePositionTpslOrders: RestorableTpslOrder[] = [];
       const restorableStandaloneTpslOrders: RestorableTpslOrder[] = [];
 
@@ -9198,6 +9168,9 @@ export class HyperLiquidProvider implements PerpsProvider {
           user: userAddress,
           dex: dexName ?? undefined,
         });
+        openOrders.forEach((order) =>
+          orderIdsBeforePlacement.add(order.oid.toString()),
+        );
 
         // Orders that belong to a pending parent order (normalTpsl children) are
         // also listed at the top level, so collect their IDs to exclude them:
@@ -9233,6 +9206,9 @@ export class HyperLiquidProvider implements PerpsProvider {
         this.#deps.debugLogger.log(
           'Using WebSocket cache for TP/SL orders lookup',
           { cachedOrdersCount: cachedOrders.length },
+        );
+        cachedOrders.forEach((order) =>
+          orderIdsBeforePlacement.add(order.orderId),
         );
 
         // Filter using normalized Order type properties, matching the REST fallback criteria:
@@ -9359,8 +9335,6 @@ export class HyperLiquidProvider implements PerpsProvider {
           }
 
           try {
-            const openOrdersBeforeRestoration =
-              await this.#captureTpslOpenOrders(dexName);
             const result = await exchangeClient.order({
               orders: entries.map((entry) => entry.order),
               grouping: protection.grouping,
@@ -9374,7 +9348,10 @@ export class HyperLiquidProvider implements PerpsProvider {
             const outcomes = await this.#reconcileTpslOrderPlacementOutcomes({
               outcomes: rawOutcomes,
               orders: entries.map((entry) => entry.order),
-              previousOrders: openOrdersBeforeRestoration,
+              previousOrderIds: new Set([
+                ...orderIdsBeforePlacement,
+                ...Array.from(cancelledOrderIds, String),
+              ]),
               dexName,
               symbol,
             });
@@ -9510,8 +9487,6 @@ export class HyperLiquidProvider implements PerpsProvider {
       }
 
       let result: Awaited<ReturnType<ExchangeClient['order']>>;
-      const openOrdersBeforePlacement =
-        await this.#captureTpslOpenOrders(dexName);
       try {
         result = await exchangeClient.order({
           orders,
@@ -9554,15 +9529,17 @@ export class HyperLiquidProvider implements PerpsProvider {
         {
           outcomes: initialPlacementOutcomes,
           orders,
-          previousOrders: openOrdersBeforePlacement,
+          previousOrderIds: new Set([
+            ...orderIdsBeforePlacement,
+            ...Array.from(confirmedCancelledOldOrderIds, String),
+          ]),
           dexName,
           symbol,
         },
       );
       const restingReplacementOrderIds = placementOutcomes.flatMap((outcome) =>
         (outcome.state === 'resting' ||
-          outcome.state === 'waitingForTrigger' ||
-          outcome.state === 'unknown') &&
+          outcome.state === 'waitingForTrigger') &&
         outcome.orderId
           ? [outcome.orderId]
           : [],
@@ -9570,14 +9547,11 @@ export class HyperLiquidProvider implements PerpsProvider {
       const filledReplacementOrderIds = placementOutcomes.flatMap((outcome) =>
         outcome.state === 'filled' && outcome.orderId ? [outcome.orderId] : [],
       );
-      const hasUnresolvedPlacement =
-        placementStatuses.length !== orders.length ||
-        placementOutcomes.some(
-          (outcome) =>
-            (outcome.state === 'waitingForTrigger' ||
-              outcome.state === 'unknown') &&
-            outcome.orderId === undefined,
-        );
+      const hasUnresolvedWaitingTrigger = placementOutcomes.some(
+        (outcome) =>
+          outcome.state === 'waitingForTrigger' &&
+          outcome.orderId === undefined,
+      );
       const remainingReplacementIds = await this.#cancelOrderRequests(
         exchangeClient,
         restingReplacementOrderIds.map((orderId) => ({
@@ -9589,7 +9563,7 @@ export class HyperLiquidProvider implements PerpsProvider {
         ...filledReplacementOrderIds,
         ...remainingReplacementIds.map(String),
       ];
-      if (hasUnresolvedPlacement) {
+      if (hasUnresolvedWaitingTrigger) {
         return createProtectionLostResult(recoverableOrderIds);
       }
       if (recoverableOrderIds.length === 0) {

--- a/packages/perps-controller/src/providers/HyperLiquidProvider.ts
+++ b/packages/perps-controller/src/providers/HyperLiquidProvider.ts
@@ -352,6 +352,11 @@ type OrderPlacementOutcome = {
   state: 'resting' | 'filled';
 };
 
+type TpslOrderPlacementOutcome = {
+  orderId?: string;
+  state: 'resting' | 'filled' | 'waitingForTrigger' | 'rejected' | 'unknown';
+};
+
 type RestorableTpslOrder = {
   orderId: number;
   order: SDKOrderParams;
@@ -7760,6 +7765,161 @@ export class HyperLiquidProvider implements PerpsProvider {
   }
 
   /**
+   * Classify one TP/SL placement response.
+   *
+   * HyperLiquid acknowledges a resting trigger with the bare
+   * `waitingForTrigger` string, which is successful but carries no order ID.
+   * Other placement paths still require a resting or filled ID.
+   *
+   * @param status - A single status from the exchange response.
+   * @returns The TP/SL-specific placement outcome.
+   */
+  #readTpslOrderPlacementOutcome(status: unknown): TpslOrderPlacementOutcome {
+    const placement = this.#readOrderPlacementOutcome(status);
+    if (placement) {
+      return placement;
+    }
+    if (status === 'waitingForTrigger') {
+      return { state: 'waitingForTrigger' };
+    }
+    if (isStatusObject(status) && hasProperty(status, 'error')) {
+      return { state: 'rejected' };
+    }
+    return { state: 'unknown' };
+  }
+
+  /**
+   * Capture open orders without turning a read failure into a placement
+   * failure. The snapshot is needed only if an accepted trigger later needs an
+   * ID for cleanup after another leg fails.
+   *
+   * @param dexName - DEX to query, or null for the main DEX.
+   * @returns The open orders, or undefined when the snapshot failed.
+   */
+  async #captureTpslOpenOrders(
+    dexName: string | null,
+  ): Promise<FrontendOrder[] | undefined> {
+    try {
+      return await this.#fetchOpenOrders({ dexName });
+    } catch (error) {
+      this.#deps.debugLogger.log(
+        'Could not capture open orders before TP/SL placement',
+        {
+          error: ensureError(error, 'HyperLiquidProvider.captureTpslOpenOrders')
+            .message,
+          dex: dexName ?? 'main',
+        },
+      );
+      return undefined;
+    }
+  }
+
+  /**
+   * Recover IDs omitted from waiting trigger acknowledgements.
+   *
+   * HyperLiquid does not preserve submission order in `frontendOpenOrders`, so
+   * each unresolved leg is matched by its submitted trigger attributes and
+   * accepted only when exactly one new order qualifies.
+   *
+   * @param params - Reconciliation parameters.
+   * @param params.outcomes - Classified placement responses.
+   * @param params.orders - Submitted TP/SL orders.
+   * @param params.previousOrders - Orders resting before submission.
+   * @param params.dexName - DEX queried for the placement.
+   * @param params.symbol - Market the triggers protect.
+   * @returns Outcomes enriched with unambiguous exchange order IDs.
+   */
+  async #reconcileTpslOrderPlacementOutcomes(params: {
+    outcomes: TpslOrderPlacementOutcome[];
+    orders: SDKOrderParams[];
+    previousOrders: FrontendOrder[] | undefined;
+    dexName: string | null;
+    symbol: string;
+  }): Promise<TpslOrderPlacementOutcome[]> {
+    if (
+      params.previousOrders === undefined ||
+      !params.outcomes.some(
+        (outcome) =>
+          (outcome.state === 'waitingForTrigger' ||
+            outcome.state === 'unknown') &&
+          outcome.orderId === undefined,
+      )
+    ) {
+      return params.outcomes;
+    }
+
+    try {
+      const previousOrderIds = new Set(
+        params.previousOrders.map((order) => order.oid.toString()),
+      );
+      const appearedOrders = (
+        await this.#fetchOpenOrders({ dexName: params.dexName })
+      ).filter(
+        (order) =>
+          order.coin === params.symbol &&
+          order.reduceOnly &&
+          order.isTrigger &&
+          !previousOrderIds.has(order.oid.toString()),
+      );
+      const claimedOrderIds = new Set<number>();
+
+      return params.outcomes.map((outcome, index) => {
+        if (
+          outcome.orderId !== undefined ||
+          (outcome.state !== 'waitingForTrigger' && outcome.state !== 'unknown')
+        ) {
+          return outcome;
+        }
+
+        const submittedOrder = params.orders[index];
+        const trigger = hasProperty(submittedOrder.t, 'trigger')
+          ? submittedOrder.t.trigger
+          : undefined;
+        if (
+          !isStatusObject(trigger) ||
+          !hasProperty(trigger, 'triggerPx') ||
+          (typeof trigger.triggerPx !== 'string' &&
+            typeof trigger.triggerPx !== 'number') ||
+          !hasProperty(trigger, 'tpsl') ||
+          (trigger.tpsl !== 'tp' && trigger.tpsl !== 'sl')
+        ) {
+          return outcome;
+        }
+        const submittedSize = parseFloat(String(submittedOrder.s));
+        const submittedTriggerPrice = parseFloat(String(trigger.triggerPx));
+        const expectedOrderType =
+          trigger.tpsl === 'tp' ? 'Take Profit' : 'Stop';
+        const candidates = appearedOrders.filter(
+          (order) =>
+            !claimedOrderIds.has(order.oid) &&
+            (order.side === 'B') === submittedOrder.b &&
+            parseFloat(order.sz) === submittedSize &&
+            parseFloat(order.triggerPx) === submittedTriggerPrice &&
+            order.orderType.includes(expectedOrderType),
+        );
+        if (candidates.length !== 1) {
+          return outcome;
+        }
+
+        claimedOrderIds.add(candidates[0].oid);
+        return { ...outcome, orderId: candidates[0].oid.toString() };
+      });
+    } catch (error) {
+      this.#deps.debugLogger.log(
+        'Could not reconcile TP/SL placement order IDs',
+        {
+          error: ensureError(
+            error,
+            'HyperLiquidProvider.reconcileTpslOrderPlacementOutcomes',
+          ).message,
+          symbol: params.symbol,
+        },
+      );
+      return params.outcomes;
+    }
+  }
+
+  /**
    * Read a valid order ID from a resting or filled placement status.
    *
    * @param status - A single status from the exchange response.
@@ -9199,6 +9359,8 @@ export class HyperLiquidProvider implements PerpsProvider {
           }
 
           try {
+            const openOrdersBeforeRestoration =
+              await this.#captureTpslOpenOrders(dexName);
             const result = await exchangeClient.order({
               orders: entries.map((entry) => entry.order),
               grouping: protection.grouping,
@@ -9206,18 +9368,28 @@ export class HyperLiquidProvider implements PerpsProvider {
                 builderOrderContext && { builder: builderOrderContext }),
             });
             const statuses = result.response?.data?.statuses ?? [];
-            const outcomes = statuses
+            const rawOutcomes = statuses
               .slice(0, entries.length)
-              .map((status) => this.#readOrderPlacementOutcome(status));
+              .map((status) => this.#readTpslOrderPlacementOutcome(status));
+            const outcomes = await this.#reconcileTpslOrderPlacementOutcomes({
+              outcomes: rawOutcomes,
+              orders: entries.map((entry) => entry.order),
+              previousOrders: openOrdersBeforeRestoration,
+              dexName,
+              symbol,
+            });
             restoredOrderIds.push(
               ...outcomes.flatMap((outcome) =>
-                outcome ? [outcome.orderId] : [],
+                outcome.orderId ? [outcome.orderId] : [],
               ),
             );
             if (
               result.status !== 'ok' ||
               statuses.length !== entries.length ||
-              outcomes.some((outcome) => outcome === undefined)
+              outcomes.some(
+                (outcome) =>
+                  outcome.state === 'rejected' || outcome.state === 'unknown',
+              )
             ) {
               success = false;
               this.#deps.logger.error(
@@ -9338,6 +9510,8 @@ export class HyperLiquidProvider implements PerpsProvider {
       }
 
       let result: Awaited<ReturnType<ExchangeClient['order']>>;
+      const openOrdersBeforePlacement =
+        await this.#captureTpslOpenOrders(dexName);
       try {
         result = await exchangeClient.order({
           orders,
@@ -9356,65 +9530,93 @@ export class HyperLiquidProvider implements PerpsProvider {
       }
 
       const placementStatuses = result.response?.data?.statuses ?? [];
-      const placementOutcomes = placementStatuses
+      const initialPlacementOutcomes = placementStatuses
         .slice(0, orders.length)
-        .map((status) => this.#readOrderPlacementOutcome(status));
-      const replacementOrderIds = placementOutcomes.flatMap((outcome) =>
-        outcome ? [outcome.orderId] : [],
-      );
-      const restingReplacementOrderIds = placementOutcomes.flatMap((outcome) =>
-        outcome?.state === 'resting' ? [outcome.orderId] : [],
-      );
-      const filledReplacementOrderIds = placementOutcomes.flatMap((outcome) =>
-        outcome?.state === 'filled' ? [outcome.orderId] : [],
-      );
-      if (
-        result.status !== 'ok' ||
-        placementStatuses.length !== orders.length ||
-        replacementOrderIds.length !== orders.length
-      ) {
-        const remainingReplacementIds = await this.#cancelOrderRequests(
-          exchangeClient,
-          restingReplacementOrderIds.map((orderId) => ({
-            a: assetId,
-            o: Number(orderId),
-          })),
+        .map((status) => this.#readTpslOrderPlacementOutcome(status));
+      const placementAccepted =
+        result.status === 'ok' &&
+        placementStatuses.length === orders.length &&
+        initialPlacementOutcomes.every(
+          (outcome) =>
+            outcome.state === 'resting' ||
+            outcome.state === 'filled' ||
+            outcome.state === 'waitingForTrigger',
         );
-        const recoverableOrderIds = [
-          ...filledReplacementOrderIds,
-          ...remainingReplacementIds.map(String),
-        ];
-        if (recoverableOrderIds.length === 0) {
-          const restoration = await restoreCancelledProtection(
-            confirmedCancelledOldOrderIds,
-          );
-          if (!restoration.success) {
-            return createProtectionLostResult(restoration.restoredOrderIds);
-          }
-        }
-        // A filled replacement may have changed or closed the position, while
-        // an uncancelled replacement may still protect it. Restoring the old
-        // whole-position triggers in either case risks stale or duplicate
-        // protection, so return those IDs for caller reconciliation instead.
-        if (recoverableOrderIds.length > 0) {
-          if (!isPartialTpsl) {
-            return createProtectionLostResult(recoverableOrderIds);
-          }
-          return createErrorResult(
-            new Error(PERPS_ERROR_CODES.TPSL_UPDATE_FAILED),
-            {
-              success: false,
-              childOrderIds: recoverableOrderIds,
-            },
-          );
-        }
-        throw new Error(PERPS_ERROR_CODES.TPSL_UPDATE_FAILED);
+
+      if (placementAccepted) {
+        return {
+          success: true,
+          orderId: 'TP/SL orders placed',
+        };
       }
 
-      return {
-        success: true,
-        orderId: 'TP/SL orders placed',
-      };
+      const placementOutcomes = await this.#reconcileTpslOrderPlacementOutcomes(
+        {
+          outcomes: initialPlacementOutcomes,
+          orders,
+          previousOrders: openOrdersBeforePlacement,
+          dexName,
+          symbol,
+        },
+      );
+      const restingReplacementOrderIds = placementOutcomes.flatMap((outcome) =>
+        (outcome.state === 'resting' ||
+          outcome.state === 'waitingForTrigger' ||
+          outcome.state === 'unknown') &&
+        outcome.orderId
+          ? [outcome.orderId]
+          : [],
+      );
+      const filledReplacementOrderIds = placementOutcomes.flatMap((outcome) =>
+        outcome.state === 'filled' && outcome.orderId ? [outcome.orderId] : [],
+      );
+      const hasUnresolvedPlacement =
+        placementStatuses.length !== orders.length ||
+        placementOutcomes.some(
+          (outcome) =>
+            (outcome.state === 'waitingForTrigger' ||
+              outcome.state === 'unknown') &&
+            outcome.orderId === undefined,
+        );
+      const remainingReplacementIds = await this.#cancelOrderRequests(
+        exchangeClient,
+        restingReplacementOrderIds.map((orderId) => ({
+          a: assetId,
+          o: Number(orderId),
+        })),
+      );
+      const recoverableOrderIds = [
+        ...filledReplacementOrderIds,
+        ...remainingReplacementIds.map(String),
+      ];
+      if (hasUnresolvedPlacement) {
+        return createProtectionLostResult(recoverableOrderIds);
+      }
+      if (recoverableOrderIds.length === 0) {
+        const restoration = await restoreCancelledProtection(
+          confirmedCancelledOldOrderIds,
+        );
+        if (!restoration.success) {
+          return createProtectionLostResult(restoration.restoredOrderIds);
+        }
+      }
+      // A filled replacement may have changed or closed the position, while
+      // an uncancelled replacement may still protect it. Restoring the old
+      // whole-position triggers in either case risks stale or duplicate
+      // protection, so return those IDs for caller reconciliation instead.
+      if (recoverableOrderIds.length > 0) {
+        if (!isPartialTpsl) {
+          return createProtectionLostResult(recoverableOrderIds);
+        }
+        return createErrorResult(
+          new Error(PERPS_ERROR_CODES.TPSL_UPDATE_FAILED),
+          {
+            success: false,
+            childOrderIds: recoverableOrderIds,
+          },
+        );
+      }
+      throw new Error(PERPS_ERROR_CODES.TPSL_UPDATE_FAILED);
     } catch (error) {
       this.#deps.logger.error(
         ensureError(error, 'HyperLiquidProvider.updatePositionTPSL'),

--- a/packages/perps-controller/tests/src/providers/HyperLiquidProvider.strategy-orders.test.ts
+++ b/packages/perps-controller/tests/src/providers/HyperLiquidProvider.strategy-orders.test.ts
@@ -1612,7 +1612,8 @@ describe('HyperLiquidProvider - strategy order types', () => {
     });
 
     it('accepts waitingForTrigger for a combined TP/SL placement', async () => {
-      const { exchangeClient } = useStrategyClients({
+      mockSubscriptionService.getOrdersCacheIfInitialized.mockReturnValue([]);
+      const { exchangeClient, infoClient } = useStrategyClients({
         exchange: {
           order: jest.fn().mockResolvedValue({
             status: 'ok',
@@ -1632,6 +1633,7 @@ describe('HyperLiquidProvider - strategy order types', () => {
         symbol: 'ETH',
         takeProfitPrice: '3500',
         stopLossPrice: '2500',
+        position: createMockPosition({ symbol: 'ETH', size: '1.5' }),
       });
 
       expect(result).toStrictEqual({
@@ -1639,6 +1641,7 @@ describe('HyperLiquidProvider - strategy order types', () => {
         orderId: 'TP/SL orders placed',
       });
       expect(exchangeClient.cancel).not.toHaveBeenCalled();
+      expect(infoClient.frontendOpenOrders).not.toHaveBeenCalled();
     });
 
     it('accepts mixed resting and waitingForTrigger placement statuses', async () => {
@@ -1669,27 +1672,24 @@ describe('HyperLiquidProvider - strategy order types', () => {
     });
 
     it('replaces existing protection when the trigger waits for activation', async () => {
-      const frontendOpenOrders = jest
-        .fn()
-        .mockResolvedValueOnce([
-          {
-            coin: 'ETH',
-            side: 'A',
-            limitPx: '3400',
-            sz: '0',
-            origSz: '0',
-            oid: 456,
-            timestamp: 1_700_000_000_000,
-            reduceOnly: true,
-            isTrigger: true,
-            isPositionTpsl: true,
-            triggerCondition: 'Price above 3400',
-            triggerPx: '3400',
-            orderType: 'Take Profit Limit',
-            children: [],
-          },
-        ])
-        .mockResolvedValueOnce([]);
+      const frontendOpenOrders = jest.fn().mockResolvedValueOnce([
+        {
+          coin: 'ETH',
+          side: 'A',
+          limitPx: '3400',
+          sz: '0',
+          origSz: '0',
+          oid: 456,
+          timestamp: 1_700_000_000_000,
+          reduceOnly: true,
+          isTrigger: true,
+          isPositionTpsl: true,
+          triggerCondition: 'Price above 3400',
+          triggerPx: '3400',
+          orderType: 'Take Profit Limit',
+          children: [],
+        },
+      ]);
       const { exchangeClient } = useStrategyClients({
         exchange: {
           order: jest.fn().mockResolvedValue({
@@ -1717,7 +1717,6 @@ describe('HyperLiquidProvider - strategy order types', () => {
     it('reconciles a waiting trigger before cleaning up a mixed failure', async () => {
       const frontendOpenOrders = jest
         .fn()
-        .mockResolvedValueOnce([])
         .mockResolvedValueOnce([])
         .mockResolvedValueOnce([
           {
@@ -1809,18 +1808,45 @@ describe('HyperLiquidProvider - strategy order types', () => {
       expect(exchangeClient.cancel).not.toHaveBeenCalled();
     });
 
-    it('reports lost protection for an unknown placement status', async () => {
+    it.each([
+      ['an unknown placement status', ['futureTriggerStatus']],
+      ['an incomplete placement response', []],
+    ])('restores old protection after %s', async (_label, statuses) => {
+      const order = jest
+        .fn()
+        .mockResolvedValueOnce({
+          status: 'ok',
+          response: {
+            data: { statuses },
+          },
+        })
+        .mockResolvedValueOnce({
+          status: 'ok',
+          response: {
+            data: { statuses: [{ resting: { oid: 902 } }] },
+          },
+        });
       const { exchangeClient } = useStrategyClients({
-        exchange: {
-          order: jest.fn().mockResolvedValue({
-            status: 'ok',
-            response: {
-              data: { statuses: ['futureTriggerStatus'] },
-            },
-          }),
-        },
+        exchange: { order },
         info: {
-          frontendOpenOrders: jest.fn().mockResolvedValue([]),
+          frontendOpenOrders: jest.fn().mockResolvedValue([
+            {
+              coin: 'ETH',
+              side: 'A',
+              limitPx: '2450',
+              sz: '0',
+              origSz: '0',
+              oid: 456,
+              timestamp: 1_700_000_000_000,
+              reduceOnly: true,
+              isTrigger: true,
+              isPositionTpsl: true,
+              triggerCondition: 'Price below 2450',
+              triggerPx: '2450',
+              orderType: 'Stop Market',
+              children: [],
+            },
+          ]),
         },
       });
 
@@ -1832,10 +1858,16 @@ describe('HyperLiquidProvider - strategy order types', () => {
 
       expect(result).toStrictEqual({
         success: false,
-        error: PERPS_ERROR_CODES.TPSL_PROTECTION_LOST,
-        childOrderIds: [],
+        error: PERPS_ERROR_CODES.TPSL_UPDATE_FAILED,
       });
-      expect(exchangeClient.cancel).not.toHaveBeenCalled();
+      expect(exchangeClient.cancel).toHaveBeenCalledWith({
+        cancels: [{ a: 1, o: 456 }],
+      });
+      expect(order).toHaveBeenCalledTimes(2);
+      expect(order.mock.calls[1][0]).toMatchObject({
+        grouping: 'positionTpsl',
+        orders: [expect.objectContaining({ p: '2450', s: '0' })],
+      });
     });
 
     it('cancels old protection before placing partial TP/SL', async () => {

--- a/packages/perps-controller/tests/src/providers/HyperLiquidProvider.strategy-orders.test.ts
+++ b/packages/perps-controller/tests/src/providers/HyperLiquidProvider.strategy-orders.test.ts
@@ -1611,6 +1611,233 @@ describe('HyperLiquidProvider - strategy order types', () => {
       expect(exchangeClient.order.mock.calls[0][0].orders).toHaveLength(2);
     });
 
+    it('accepts waitingForTrigger for a combined TP/SL placement', async () => {
+      const { exchangeClient } = useStrategyClients({
+        exchange: {
+          order: jest.fn().mockResolvedValue({
+            status: 'ok',
+            response: {
+              data: {
+                statuses: ['waitingForTrigger', 'waitingForTrigger'],
+              },
+            },
+          }),
+        },
+        info: {
+          frontendOpenOrders: jest.fn().mockResolvedValue([]),
+        },
+      });
+
+      const result = await provider.updatePositionTPSL({
+        symbol: 'ETH',
+        takeProfitPrice: '3500',
+        stopLossPrice: '2500',
+      });
+
+      expect(result).toStrictEqual({
+        success: true,
+        orderId: 'TP/SL orders placed',
+      });
+      expect(exchangeClient.cancel).not.toHaveBeenCalled();
+    });
+
+    it('accepts mixed resting and waitingForTrigger placement statuses', async () => {
+      const { exchangeClient } = useStrategyClients({
+        exchange: {
+          order: jest.fn().mockResolvedValue({
+            status: 'ok',
+            response: {
+              data: {
+                statuses: [{ resting: { oid: 123 } }, 'waitingForTrigger'],
+              },
+            },
+          }),
+        },
+        info: {
+          frontendOpenOrders: jest.fn().mockResolvedValue([]),
+        },
+      });
+
+      const result = await provider.updatePositionTPSL({
+        symbol: 'ETH',
+        takeProfitPrice: '3500',
+        stopLossPrice: '2500',
+      });
+
+      expect(result.success).toBe(true);
+      expect(exchangeClient.cancel).not.toHaveBeenCalled();
+    });
+
+    it('replaces existing protection when the trigger waits for activation', async () => {
+      const frontendOpenOrders = jest
+        .fn()
+        .mockResolvedValueOnce([
+          {
+            coin: 'ETH',
+            side: 'A',
+            limitPx: '3400',
+            sz: '0',
+            origSz: '0',
+            oid: 456,
+            timestamp: 1_700_000_000_000,
+            reduceOnly: true,
+            isTrigger: true,
+            isPositionTpsl: true,
+            triggerCondition: 'Price above 3400',
+            triggerPx: '3400',
+            orderType: 'Take Profit Limit',
+            children: [],
+          },
+        ])
+        .mockResolvedValueOnce([]);
+      const { exchangeClient } = useStrategyClients({
+        exchange: {
+          order: jest.fn().mockResolvedValue({
+            status: 'ok',
+            response: {
+              data: { statuses: ['waitingForTrigger'] },
+            },
+          }),
+        },
+        info: { frontendOpenOrders },
+      });
+
+      const result = await provider.updatePositionTPSL({
+        symbol: 'ETH',
+        takeProfitPrice: '3500',
+        position: createMockPosition({ symbol: 'ETH', size: '1.5' }),
+      });
+
+      expect(result.success).toBe(true);
+      expect(exchangeClient.cancel).toHaveBeenCalledWith({
+        cancels: [{ a: 1, o: 456 }],
+      });
+    });
+
+    it('reconciles a waiting trigger before cleaning up a mixed failure', async () => {
+      const frontendOpenOrders = jest
+        .fn()
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([
+          {
+            coin: 'ETH',
+            side: 'A',
+            limitPx: '3500',
+            sz: '0.4',
+            origSz: '0.4',
+            oid: 901,
+            timestamp: 1_700_000_000_000,
+            reduceOnly: true,
+            isTrigger: true,
+            isPositionTpsl: false,
+            triggerCondition: 'Price above 3500',
+            triggerPx: '3500',
+            orderType: 'Take Profit Limit',
+            children: [],
+          },
+        ]);
+      const { exchangeClient } = useStrategyClients({
+        exchange: {
+          order: jest.fn().mockResolvedValue({
+            status: 'ok',
+            response: {
+              data: {
+                statuses: [
+                  'waitingForTrigger',
+                  { error: 'Rejected stop loss' },
+                ],
+              },
+            },
+          }),
+        },
+        info: { frontendOpenOrders },
+      });
+
+      const result = await provider.updatePositionTPSL({
+        symbol: 'ETH',
+        takeProfitPrice: '3500',
+        takeProfitSize: '0.4',
+        stopLossPrice: '2500',
+        stopLossSize: '0.6',
+        position: createMockPosition({ symbol: 'ETH', size: '1.5' }),
+      });
+
+      expect(result).toMatchObject({
+        success: false,
+        error: PERPS_ERROR_CODES.TPSL_UPDATE_FAILED,
+      });
+      expect(exchangeClient.cancel).toHaveBeenCalledWith({
+        cancels: [{ a: 1, o: 901 }],
+      });
+    });
+
+    it('reports lost protection when a waiting trigger cannot be reconciled after a mixed failure', async () => {
+      const { exchangeClient } = useStrategyClients({
+        exchange: {
+          order: jest.fn().mockResolvedValue({
+            status: 'ok',
+            response: {
+              data: {
+                statuses: [
+                  'waitingForTrigger',
+                  { error: 'Rejected stop loss' },
+                ],
+              },
+            },
+          }),
+        },
+        info: {
+          frontendOpenOrders: jest.fn().mockResolvedValue([]),
+        },
+      });
+
+      const result = await provider.updatePositionTPSL({
+        symbol: 'ETH',
+        takeProfitPrice: '3500',
+        takeProfitSize: '0.4',
+        stopLossPrice: '2500',
+        stopLossSize: '0.6',
+        position: createMockPosition({ symbol: 'ETH', size: '1.5' }),
+      });
+
+      expect(result).toStrictEqual({
+        success: false,
+        error: PERPS_ERROR_CODES.TPSL_PROTECTION_LOST,
+        childOrderIds: [],
+      });
+      expect(exchangeClient.cancel).not.toHaveBeenCalled();
+    });
+
+    it('reports lost protection for an unknown placement status', async () => {
+      const { exchangeClient } = useStrategyClients({
+        exchange: {
+          order: jest.fn().mockResolvedValue({
+            status: 'ok',
+            response: {
+              data: { statuses: ['futureTriggerStatus'] },
+            },
+          }),
+        },
+        info: {
+          frontendOpenOrders: jest.fn().mockResolvedValue([]),
+        },
+      });
+
+      const result = await provider.updatePositionTPSL({
+        symbol: 'ETH',
+        takeProfitPrice: '3500',
+        position: createMockPosition({ symbol: 'ETH', size: '1.5' }),
+      });
+
+      expect(result).toStrictEqual({
+        success: false,
+        error: PERPS_ERROR_CODES.TPSL_PROTECTION_LOST,
+        childOrderIds: [],
+      });
+      expect(exchangeClient.cancel).not.toHaveBeenCalled();
+    });
+
     it('cancels old protection before placing partial TP/SL', async () => {
       const { exchangeClient } = useStrategyClients({
         info: {


### PR DESCRIPTION
## Explanation

`@metamask/perps-controller` v13 treated HyperLiquid's valid `waitingForTrigger` TP/SL acknowledgement as a failure because it has no order ID. The trigger was created, but Mobile displayed `TPSL_UPDATE_FAILED`.

This change accepts `waitingForTrigger` and reconciles its order ID only when needed to clean up a mixed-result batch. It reuses existing REST/cache order IDs to avoid an extra happy-path request, while preserving rollback for rejected, unknown, and incomplete responses. No dependencies or other packages changed, and there are no breaking changes.

## References

- Related to TAT-3846

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes failure/rollback paths for `updatePositionTPSL` and open-order reconciliation; incorrect matching could mis-cancel triggers or mis-report protection loss, though matching requires a single unambiguous candidate.
> 
> **Overview**
> **Fixes false `TPSL_UPDATE_FAILED` when HyperLiquid accepts position TP/SL with a bare `waitingForTrigger` acknowledgement (no order ID in the response).**
> 
> `updatePositionTPSL` now classifies TP/SL placement via `#readTpslOrderPlacementOutcome`, treating `waitingForTrigger` as success alongside resting and filled. On the happy path it returns success without requiring an order ID for every leg. When a mixed batch fails, `#reconcileTpslOrderPlacementOutcomes` can match new trigger orders from `frontendOpenOrders` (size, trigger price, side, TP vs SL) using a pre-placement order ID snapshot so cleanup can cancel reconciled legs; unreconciled `waitingForTrigger` legs surface `TPSL_PROTECTION_LOST` instead of a generic update failure. Restoration after partial failure uses the same TP/SL outcome logic. Tests cover combined/mixed statuses, replacement with cancel, reconciliation before mixed-failure cleanup, and restore-on-unknown/incomplete responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3cffdad3c095f2495fbc1b17a28eafa2d0bf4e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->