### PR TITLE
fix(perps): tpsl builder fee readiness

### DIFF
--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Prevent transient HyperLiquid WebSocket disconnects from failing the first TP/SL update by checking builder-fee approval over HTTP
+
 ## [13.1.0]
 
 ### Added

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Prevent transient HyperLiquid WebSocket disconnects from failing the first TP/SL update by checking builder-fee approval over HTTP
+- Prevent transient HyperLiquid WebSocket disconnects from failing the first TP/SL update by checking builder-fee approval over HTTP ([#9997](https://github.com/MetaMask/core/pull/9997))
 
 ## [13.1.0]
 

--- a/packages/perps-controller/src/providers/HyperLiquidProvider.ts
+++ b/packages/perps-controller/src/providers/HyperLiquidProvider.ts
@@ -3779,7 +3779,7 @@ export class HyperLiquidProvider implements PerpsProvider {
     builder: string,
     userAddress: string,
   ): Promise<number | null> {
-    const infoClient = this.#clientService.getInfoClient();
+    const infoClient = this.#clientService.getInfoClient({ useHttp: true });
 
     return infoClient.maxBuilderFee({
       user: userAddress,

--- a/packages/perps-controller/tests/src/providers/HyperLiquidProvider.builder-fees.test.ts
+++ b/packages/perps-controller/tests/src/providers/HyperLiquidProvider.builder-fees.test.ts
@@ -1090,6 +1090,50 @@ describe('HyperLiquidProvider', () => {
       expect(result.success).toBe(true);
     });
 
+    it('uses HTTP for builder fee reads during a cold-start TP/SL update', async () => {
+      const webSocketMaxBuilderFee = jest
+        .fn()
+        .mockRejectedValue(
+          Object.assign(
+            new Error(
+              'WebSocket connection closed before the request was sent',
+            ),
+            { name: 'WebSocketRequestError' },
+          ),
+        );
+      const httpMaxBuilderFee = jest
+        .fn()
+        .mockResolvedValue(BUILDER_FEE_CONFIG.MaxFeeDecimal);
+      const webSocketInfoClient = createMockInfoClient({
+        maxBuilderFee: webSocketMaxBuilderFee,
+      });
+      const httpInfoClient = createMockInfoClient({
+        maxBuilderFee: httpMaxBuilderFee,
+      });
+      mockClientService.getInfoClient.mockImplementation((options) =>
+        options?.useHttp ? httpInfoClient : webSocketInfoClient,
+      );
+
+      const result = await provider.updatePositionTPSL({
+        symbol: 'BTC',
+        takeProfitPrice: '55000',
+        stopLossPrice: '45000',
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockClientService.getInfoClient).toHaveBeenCalledWith({
+        useHttp: true,
+      });
+      expect(httpMaxBuilderFee).toHaveBeenCalledWith({
+        user: '0x1234567890123456789012345678901234567890',
+        builder: BUILDER_FEE_CONFIG.MainnetBuilder,
+      });
+      expect(webSocketMaxBuilderFee).not.toHaveBeenCalled();
+      expect(mockClientService.getExchangeClient().order).toHaveBeenCalledWith(
+        expect.objectContaining({ grouping: 'positionTpsl' }),
+      );
+    });
+
     it('uses a builder approval completed while acquiring the global lock', async () => {
       const mockedCache = PerpsSigningCache as jest.Mocked<
         typeof PerpsSigningCache


### PR DESCRIPTION
## Explanation

The first TP/SL edit after Mobile reload could fail before cancellation or placement because the builder-fee approval lookup sent the one-off `maxBuilderFee` request over a reconnecting WebSocket. HyperLiquid rejected it with `WebSocketRequestError`, which `updatePositionTPSL` surfaced as `TPSL_UPDATE_FAILED`; a later retry succeeded after reconnection.

This routes builder-fee approval reads through the existing HTTP `InfoClient`, which is designed for request/response operations and remains available during WebSocket churn. `maxBuilderFee` was not a subscription, so this does not remove live updates or change existing approval-cache semantics. Genuine approval failures still block replacement before existing protection is cancelled.

Adds regression coverage with distinct WebSocket and HTTP clients and updates the perps-controller changelog. No dependencies or other packages are changed.

Validation:
- Full `@metamask/perps-controller` test suite
- Builder-fee and strategy-order suites
- Monorepo build
- Changelog validation and scoped lint/format checks
- Mobile simulator: first `+50/-50` TP/SL edit succeeded after reload

## References

- Discovered while validating [#9995](https://github.com/MetaMask/core/pull/9995)

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow transport change for a read-only approval lookup on an existing HTTP code path; regression test covers the TP/SL cold-start scenario.
> 
> **Overview**
> Fixes a case where the **first position TP/SL update after app reload** could fail with `TPSL_UPDATE_FAILED` because the builder-fee approval check (`maxBuilderFee`) went over a reconnecting HyperLiquid WebSocket and threw `WebSocketRequestError`.
> 
> `#checkBuilderFeeApproval` in `HyperLiquidProvider` now requests the info client with **`useHttp: true`**, so that read uses the HTTP `InfoClient` path that stays usable during socket churn. Approval caching and real approval/signing behavior are unchanged; only the lookup transport changes.
> 
> Adds a regression test that simulates a failing WebSocket `maxBuilderFee` and asserts cold-start `updatePositionTPSL` succeeds via HTTP, plus an **Unreleased** changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e2cffb3c470bdd918c2d270c461d6a51ce05660. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->