### PR TITLE
feat(perps-controller): funding sessions state machine (A1–A4)

### DIFF
--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **BREAKING:** Add persisted `fundingSessions` array to `PerpsControllerState`, defaulting to `[]`, alongside the new `FundingSession` and `FundingLeg` type contracts for the composed funding flow (progress tracker over Resting Points; never a custodian of funds)
+- **BREAKING:** Add persisted `fundingSessions` array to `PerpsControllerState`, defaulting to `[]`, alongside the new `FundingSession` and `FundingLeg` type contracts for the composed funding flow (progress tracker over Resting Points; never a custodian of funds) ([#9998](https://github.com/MetaMask/core/pull/9998))
   - Consumers constructing a full `PerpsControllerState` must include the new field; the default state and constructor state merge keep runtime rehydration backward-compatible with older persisted state.
 - **BREAKING:** Add persisted `selectedOrderType`, `orderBookPreferences`, and `visibleCandleCount` fields to `PerpsControllerState`, with controller methods and selectors for updating and reading each preference ([#9922](https://github.com/MetaMask/core/pull/9922))
   - `selectedOrderType` is shared across markets, order-book listed-by preferences default to USD totals, and visible candle count defaults to 30 with a supported range of 10–250.

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **BREAKING:** Add persisted `fundingSessions` array to `PerpsControllerState`, defaulting to `[]`, alongside the new `FundingSession` and `FundingLeg` type contracts for the composed funding flow (progress tracker over Resting Points; never a custodian of funds)
+  - Consumers constructing a full `PerpsControllerState` must include the new field; the default state and constructor state merge keep runtime rehydration backward-compatible with older persisted state.
 - **BREAKING:** Add persisted `selectedOrderType`, `orderBookPreferences`, and `visibleCandleCount` fields to `PerpsControllerState`, with controller methods and selectors for updating and reading each preference ([#9922](https://github.com/MetaMask/core/pull/9922))
   - `selectedOrderType` is shared across markets, order-book listed-by preferences default to USD totals, and visible candle count defaults to 30 with a supported range of 10–250.
   - Consumers constructing a full `PerpsControllerState` must include the new fields; default state, getters, and selectors remain backward-compatible with older persisted state.

--- a/packages/perps-controller/src/PerpsController.ts
+++ b/packages/perps-controller/src/PerpsController.ts
@@ -56,6 +56,17 @@ import { DataLakeService } from './services/DataLakeService.js';
 import { DepositService } from './services/DepositService.js';
 import { EligibilityService } from './services/EligibilityService.js';
 import { FeatureFlagConfigurationService } from './services/FeatureFlagConfigurationService.js';
+import {
+  completeSession as completeSessionTransition,
+  failPreflight as failPreflightTransition,
+  legEvent,
+  markPreflightPassed as markPreflightPassedTransition,
+  pauseSession as pauseSessionTransition,
+  resumeSession as resumeSessionTransition,
+  retryLeg as retryLegTransition,
+  startSession as startSessionTransition,
+} from './services/fundingSessionTransitions.js';
+import type { TransitionContext } from './services/fundingSessionTransitions.js';
 import { MarketDataService } from './services/MarketDataService.js';
 import { RewardsIntegrationService } from './services/RewardsIntegrationService.js';
 import type { ServiceContext } from './services/ServiceContext.js';
@@ -87,6 +98,7 @@ import type {
   FeeCalculationResult,
   FlipPositionParams,
   Funding,
+  FundingLeg,
   FundingSession,
   GetAccountStateParams,
   GetAvailableDexsParams,
@@ -169,6 +181,13 @@ import { wait } from './utils/wait.js';
 
 /** Derived type for logger options from PerpsLogger interface */
 type PerpsLoggerOptions = Parameters<PerpsLogger['error']>[1];
+
+/**
+ * Maximum number of terminal (completed/failed) funding sessions retained in
+ * state (D8). Excess terminal sessions are evicted oldest-first by updatedAt
+ * on every funding-session write; non-terminal sessions are never pruned.
+ */
+const MAX_TERMINAL_FUNDING_SESSIONS = 20;
 
 function cloneUserDataSnapshot(
   snapshot: PerpsUserDataSnapshot,
@@ -3139,6 +3158,266 @@ export class PerpsController extends BaseController<
     this.update((state) => {
       state.lastWithdrawResult = null;
     });
+  }
+
+  // ============================================================================
+  // Funding Sessions (composed funding flow: swap → bridge → deposit Legs)
+  // Wrappers around the pure guards in services/fundingSessionTransitions.ts.
+  // The guards own transition rules; these methods own lookup, state replace,
+  // and terminal-session pruning. No new messenger events — engine sync rides
+  // the existing stateChange.
+  // ============================================================================
+
+  /**
+   * Prune terminal (completed/failed) funding sessions down to
+   * {@link MAX_TERMINAL_FUNDING_SESSIONS}, evicting oldest-first by updatedAt.
+   * Non-terminal sessions (preflight/active/paused) are never pruned.
+   *
+   * @param state - The controller state to prune in place.
+   */
+  #pruneTerminalFundingSessions(state: PerpsControllerState): void {
+    const terminalSessions = state.fundingSessions.filter(
+      (session) =>
+        session.status === 'completed' || session.status === 'failed',
+    );
+    const excess = terminalSessions.length - MAX_TERMINAL_FUNDING_SESSIONS;
+    if (excess <= 0) {
+      return;
+    }
+    const evictedIds = new Set(
+      [...terminalSessions]
+        .sort((a, b) => a.updatedAt - b.updatedAt)
+        .slice(0, excess)
+        .map((session) => session.id),
+    );
+    state.fundingSessions = state.fundingSessions.filter(
+      (session) => !evictedIds.has(session.id),
+    );
+  }
+
+  /**
+   * Apply a pure funding-session transition to the session with the given id:
+   * find by id (throwing if unknown), apply with the controller clock, replace
+   * the entry in state, then prune terminal sessions. Mirrors how
+   * depositRequests entries are updated in place within a single update().
+   *
+   * @param sessionId - The id of the session to transition.
+   * @param transition - Pure guard applied with `{ now: Date.now() }`.
+   * @returns The updated session.
+   * @throws If no session with the given id exists in state.
+   */
+  #applyFundingTransition(
+    sessionId: string,
+    transition: (
+      session: FundingSession,
+      ctx: TransitionContext,
+    ) => FundingSession,
+  ): FundingSession {
+    let updatedSession: FundingSession | undefined;
+    this.update((state) => {
+      const sessionIndex = state.fundingSessions.findIndex(
+        (session) => session.id === sessionId,
+      );
+      const currentSession = state.fundingSessions[sessionIndex];
+      if (!currentSession) {
+        // Error style matches the pure guards in fundingSessionTransitions.ts.
+        throw new Error(`Funding session ${sessionId}: not found`);
+      }
+      updatedSession = transition(currentSession, { now: Date.now() });
+      state.fundingSessions[sessionIndex] = updatedSession;
+      this.#pruneTerminalFundingSessions(state);
+    });
+    if (!updatedSession) {
+      throw new Error(`Funding session ${sessionId}: not found`);
+    }
+    return updatedSession;
+  }
+
+  /**
+   * Start a new funding session in 'preflight' status with every Leg pending.
+   * Template legs are normalized by the pure guard (stale externalId/failure
+   * stripped).
+   *
+   * @param accountAddress - The Trading EOA the deposit will credit.
+   * @param legs - Template legs for the composed flow.
+   * @returns The newly created session.
+   */
+  startFundingSession(
+    accountAddress: string,
+    legs: FundingLeg[],
+  ): FundingSession {
+    const session = startSessionTransition(accountAddress, legs, {
+      now: Date.now(),
+    });
+    this.update((state) => {
+      // Newest-first, matching depositRequests ordering.
+      state.fundingSessions.unshift(session);
+      this.#pruneTerminalFundingSessions(state);
+    });
+    return session;
+  }
+
+  /**
+   * Transition a funding session from 'preflight' to 'active'.
+   *
+   * @param sessionId - The id of the session.
+   * @returns The updated session.
+   * @throws If the session does not exist or is not in 'preflight' status.
+   */
+  markPreflightPassed(sessionId: string): FundingSession {
+    return this.#applyFundingTransition(sessionId, (session, ctx) =>
+      markPreflightPassedTransition(session, ctx),
+    );
+  }
+
+  /**
+   * Transition a funding session from 'preflight' to 'failed' (no funds have
+   * moved). The reason is not persisted on the session (per the A2 ruling) —
+   * it is logged for diagnostics instead.
+   *
+   * @param sessionId - The id of the session.
+   * @param reason - Why preflight failed; logged, not stored.
+   * @returns The updated session.
+   * @throws If the session does not exist or is not in 'preflight' status.
+   */
+  failPreflight(sessionId: string, reason: string): FundingSession {
+    const updated = this.#applyFundingTransition(sessionId, (session, ctx) =>
+      failPreflightTransition(session, reason, ctx),
+    );
+    this.#debugLog('PerpsController: funding session preflight failed', {
+      sessionId,
+      reason,
+    });
+    return updated;
+  }
+
+  /**
+   * Mark a Leg as awaiting the user's signature.
+   *
+   * @param sessionId - The id of the session owning the leg.
+   * @param legIndex - Index of the leg.
+   * @returns The updated session.
+   * @throws If the session or leg is missing, or the leg is not 'pending'.
+   */
+  legAwaitingSignature(sessionId: string, legIndex: number): FundingSession {
+    return this.#applyFundingTransition(sessionId, (session, ctx) =>
+      legEvent(session, legIndex, { type: 'awaiting_signature' }, ctx),
+    );
+  }
+
+  /**
+   * Mark a Leg as submitted on-chain, recording the external id
+   * (BridgeStatusController txHistory key or depositRequests id).
+   *
+   * @param sessionId - The id of the session owning the leg.
+   * @param legIndex - Index of the leg.
+   * @param externalId - External tracking id for the submitted leg.
+   * @returns The updated session.
+   * @throws If the session or leg is missing, or the leg is not
+   * 'awaiting_signature'.
+   */
+  legSubmitted(
+    sessionId: string,
+    legIndex: number,
+    externalId: string,
+  ): FundingSession {
+    return this.#applyFundingTransition(sessionId, (session, ctx) =>
+      legEvent(session, legIndex, { type: 'submitted', externalId }, ctx),
+    );
+  }
+
+  /**
+   * Mark a Leg as confirmed. Confirming Leg i advances Leg i+1 to pending;
+   * confirming the last Leg does NOT complete the session (credit detection
+   * is mobile-side).
+   *
+   * @param sessionId - The id of the session owning the leg.
+   * @param legIndex - Index of the leg.
+   * @returns The updated session.
+   * @throws If the session or leg is missing, or the leg is not 'submitted'.
+   */
+  legConfirmed(sessionId: string, legIndex: number): FundingSession {
+    return this.#applyFundingTransition(sessionId, (session, ctx) =>
+      legEvent(session, legIndex, { type: 'confirmed' }, ctx),
+    );
+  }
+
+  /**
+   * Mark a Leg as failed with a reason and retryable flag.
+   *
+   * @param sessionId - The id of the session owning the leg.
+   * @param legIndex - Index of the leg.
+   * @param reason - Why the leg failed.
+   * @param retryable - Whether the leg may be retried.
+   * @returns The updated session.
+   * @throws If the session or leg is missing, or the leg is neither
+   * 'awaiting_signature' nor 'submitted'.
+   */
+  legFailed(
+    sessionId: string,
+    legIndex: number,
+    reason: string,
+    retryable: boolean,
+  ): FundingSession {
+    return this.#applyFundingTransition(sessionId, (session, ctx) =>
+      legEvent(session, legIndex, { type: 'failed', reason, retryable }, ctx),
+    );
+  }
+
+  /**
+   * Return a failed Leg to 'pending' so the composer may retry it. Only
+   * allowed for retryable failures whose predecessor Legs are confirmed.
+   *
+   * @param sessionId - The id of the session owning the leg.
+   * @param legIndex - Index of the leg.
+   * @returns The updated session.
+   * @throws If the leg is not failed, not retryable, or a predecessor is
+   * unconfirmed.
+   */
+  retryLeg(sessionId: string, legIndex: number): FundingSession {
+    return this.#applyFundingTransition(sessionId, (session, ctx) =>
+      retryLegTransition(session, legIndex, ctx),
+    );
+  }
+
+  /**
+   * Pause an active funding session (D10).
+   *
+   * @param sessionId - The id of the session.
+   * @returns The updated session.
+   * @throws If the session does not exist or is not 'active'.
+   */
+  pauseSession(sessionId: string): FundingSession {
+    return this.#applyFundingTransition(sessionId, (session, ctx) =>
+      pauseSessionTransition(session, ctx),
+    );
+  }
+
+  /**
+   * Resume a paused funding session (D10).
+   *
+   * @param sessionId - The id of the session.
+   * @returns The updated session.
+   * @throws If the session does not exist or is not 'paused'.
+   */
+  resumeSession(sessionId: string): FundingSession {
+    return this.#applyFundingTransition(sessionId, (session, ctx) =>
+      resumeSessionTransition(session, ctx),
+    );
+  }
+
+  /**
+   * Complete an active funding session. Driven by mobile-side credit
+   * detection, never by the last Leg confirming.
+   *
+   * @param sessionId - The id of the session.
+   * @returns The updated session.
+   * @throws If the session does not exist or is not 'active'.
+   */
+  completeSession(sessionId: string): FundingSession {
+    return this.#applyFundingTransition(sessionId, (session, ctx) =>
+      completeSessionTransition(session, ctx),
+    );
   }
 
   /**

--- a/packages/perps-controller/src/PerpsController.ts
+++ b/packages/perps-controller/src/PerpsController.ts
@@ -183,6 +183,16 @@ import { wait } from './utils/wait.js';
 type PerpsLoggerOptions = Parameters<PerpsLogger['error']>[1];
 
 /**
+ * Outcome applied to a funding session's deposit Leg from the deposit path
+ * (composed funding flow). Confirmation carries the depositRequests id so the
+ * Leg links to its history entry; failure carries the reason (retryable is
+ * always true — the user keeps their funds and may re-attempt the deposit).
+ */
+type DepositLegOutcome =
+  | { type: 'confirmed'; depositRequestId?: string }
+  | { type: 'failed'; reason: string };
+
+/**
  * Maximum number of terminal (completed/failed) funding sessions retained in
  * state (D8). Excess terminal sessions are evicted oldest-first by updatedAt
  * on every funding-session write; non-terminal sessions are never pruned.
@@ -2861,7 +2871,7 @@ export class PerpsController extends BaseController<
   async depositWithConfirmation(
     params: DepositWithConfirmationParams = {},
   ): Promise<{ result: Promise<string> }> {
-    const { amount, placeOrder } = params;
+    const { amount, placeOrder, fundingSessionId } = params;
 
     let currentDepositId: string | undefined;
 
@@ -2994,6 +3004,16 @@ export class PerpsController extends BaseController<
               }
             });
 
+            // Composed funding flow: confirm the session's deposit Leg and
+            // link it to the depositRequests entry. Bookkeeping only — it can
+            // never break the deposit path (errors are caught + logged).
+            if (fundingSessionId) {
+              this.#applyDepositLegOutcome(fundingSessionId, {
+                type: 'confirmed',
+                depositRequestId: currentDepositId,
+              });
+            }
+
             // Clear depositInProgress after a short delay
             setTimeout(() => {
               this.update((state) => {
@@ -3032,6 +3052,15 @@ export class PerpsController extends BaseController<
                   requestToUpdate.success = false;
                 }
               });
+
+              // Composed funding flow: the deposit Leg failed (user kept
+              // their funds, so the Leg is retryable).
+              if (fundingSessionId) {
+                this.#applyDepositLegOutcome(fundingSessionId, {
+                  type: 'failed',
+                  reason: 'cancelled',
+                });
+              }
             } else {
               // Transaction failed after confirmation - show error toast
               this.update((state) => {
@@ -3057,6 +3086,15 @@ export class PerpsController extends BaseController<
                   }
                 }
               });
+
+              // Composed funding flow: the deposit Leg failed (user kept
+              // their funds, so the Leg is retryable).
+              if (fundingSessionId) {
+                this.#applyDepositLegOutcome(fundingSessionId, {
+                  type: 'failed',
+                  reason: errorMessage,
+                });
+              }
             }
           });
       } else if (depositOrderResult) {
@@ -3073,6 +3111,16 @@ export class PerpsController extends BaseController<
                 requestToUpdate.txHash = actualTxHash;
               }
             });
+
+            // Composed funding flow: confirm the session's deposit Leg and
+            // link it to the depositRequests entry. Bookkeeping only — it can
+            // never break the deposit path (errors are caught + logged).
+            if (fundingSessionId) {
+              this.#applyDepositLegOutcome(fundingSessionId, {
+                type: 'confirmed',
+                depositRequestId: currentDepositId,
+              });
+            }
             return undefined;
           })
           .catch((error) => {
@@ -3096,6 +3144,15 @@ export class PerpsController extends BaseController<
                 requestToUpdate.success = false;
               }
             });
+
+            // Composed funding flow: the deposit Leg failed (user kept
+            // their funds, so the Leg is retryable).
+            if (fundingSessionId) {
+              this.#applyDepositLegOutcome(fundingSessionId, {
+                type: 'failed',
+                reason: isCancellation ? 'cancelled' : errorMessage,
+              });
+            }
           });
       }
 
@@ -3231,6 +3288,71 @@ export class PerpsController extends BaseController<
       throw new Error(`Funding session ${sessionId}: not found`);
     }
     return updatedSession;
+  }
+
+  /**
+   * Apply a deposit outcome to the deposit Leg of a funding session (composed
+   * funding flow). Called from the deposit lifecycle callbacks, which run
+   * outside any update(), so reusing the public session actions here is safe
+   * from nested-update hazards.
+   *
+   * Bookkeeping only: every error — including the idempotency throw from the
+   * pure guards when a confirmed Leg is re-confirmed (duplicated success
+   * application) — is caught and logged so the deposit path can never crash
+   * because of session bookkeeping.
+   *
+   * @param fundingSessionId - The session to update.
+   * @param outcome - The deposit-leg outcome to apply.
+   */
+  #applyDepositLegOutcome(
+    fundingSessionId: string,
+    outcome: DepositLegOutcome,
+  ): void {
+    try {
+      const session = this.state.fundingSessions.find(
+        (candidate) => candidate.id === fundingSessionId,
+      );
+      const depositLegIndex = session?.legs.findIndex(
+        (leg) => leg.kind === 'deposit',
+      );
+      if (!session || depositLegIndex === undefined || depositLegIndex === -1) {
+        // Exactly one deposit Leg exists by construction; a missing session
+        // or Leg is a defect state — log it, never crash the deposit path.
+        this.#debugLog(
+          'PerpsController: funding session deposit leg not found for outcome',
+          { sessionId: fundingSessionId, outcomeType: outcome.type },
+        );
+        return;
+      }
+      if (outcome.type === 'confirmed') {
+        this.legConfirmed(fundingSessionId, depositLegIndex);
+        if (outcome.depositRequestId) {
+          this.update((state) => {
+            const linked = state.fundingSessions.find(
+              (candidate) => candidate.id === fundingSessionId,
+            );
+            if (linked) {
+              linked.depositRequestId = outcome.depositRequestId;
+            }
+          });
+        }
+      } else {
+        this.legFailed(fundingSessionId, depositLegIndex, outcome.reason, true);
+      }
+    } catch (error) {
+      // Idempotency mechanism (A2): a duplicated success application throws
+      // inside the pure guard (confirmed Legs are never re-run). Swallow and
+      // log — the deposit path must never crash because of bookkeeping.
+      this.#debugLog(
+        'PerpsController: funding session deposit leg outcome skipped',
+        {
+          sessionId: fundingSessionId,
+          outcomeType: outcome.type,
+          error: ensureError(error, 'PerpsController.depositWithConfirmation')
+            .message,
+        },
+      );
+    }
   }
 
   /**

--- a/packages/perps-controller/src/PerpsController.ts
+++ b/packages/perps-controller/src/PerpsController.ts
@@ -87,6 +87,7 @@ import type {
   FeeCalculationResult,
   FlipPositionParams,
   Funding,
+  FundingSession,
   GetAccountStateParams,
   GetAvailableDexsParams,
   GetFundingParams,
@@ -405,6 +406,9 @@ export type PerpsControllerState = {
     depositId?: string;
   }[];
 
+  // Funding sessions (persistent, D8). Progress tracker over Resting Points.
+  fundingSessions: FundingSession[];
+
   // Eligibility (Geo-Blocking)
   isEligible: boolean;
 
@@ -570,6 +574,7 @@ export const getDefaultPerpsControllerState = (): PerpsControllerState => ({
     activeWithdrawalId: null,
   },
   depositRequests: [],
+  fundingSessions: [],
   lastError: null,
   lastUpdateTimestamp: 0,
   isEligible: false,
@@ -709,6 +714,12 @@ const metadata: StateMetadata<PerpsControllerState> = {
     usedInUi: true,
   },
   depositRequests: {
+    includeInStateLogs: true,
+    persist: true,
+    includeInDebugSnapshot: false,
+    usedInUi: true,
+  },
+  fundingSessions: {
     includeInStateLogs: true,
     persist: true,
     includeInDebugSnapshot: false,

--- a/packages/perps-controller/src/index.ts
+++ b/packages/perps-controller/src/index.ts
@@ -362,6 +362,16 @@ export type {
   HyperLiquidNetwork,
 } from './types/index.js';
 export type { PerpsToken } from './types/index.js';
+export type {
+  FundingSession,
+  FundingSessionStatus,
+  FundingLeg,
+  FundingLegKind,
+  FundingLegStatus,
+  FundingLegCapability,
+  FundingLegQuoteSnapshot,
+  FundingLegFailure,
+} from './types/index.js';
 
 // Constants (explicit named exports)
 export {

--- a/packages/perps-controller/src/services/fundingSessionTransitions.ts
+++ b/packages/perps-controller/src/services/fundingSessionTransitions.ts
@@ -1,0 +1,380 @@
+/**
+ * Pure transition guards for funding sessions — the state machine behind the
+ * composed funding flow (swap → bridge → deposit Legs over Resting Points).
+ *
+ * A funding session tracks progress across Legs; funds always sit in
+ * user-recoverable balances between Legs. These functions enforce:
+ * - forward-only Leg transitions (backward transitions throw),
+ * - confirmed Legs are never re-run,
+ * - 'confirmed' on Leg i advances Leg i+1 to pending,
+ * - retryLeg only on failed + retryable Legs whose predecessors are confirmed.
+ *
+ * Pure module: no side effects, no controller/Engine imports, inputs are
+ * never mutated — every accepted transition returns a new FundingSession
+ * with updatedAt = ctx.now.
+ */
+import type {
+  FundingLeg,
+  FundingSession,
+  FundingSessionStatus,
+} from '../types/index.js';
+import { generatePerpsId } from '../utils/idUtils.js';
+
+export type TransitionContext = {
+  now: number;
+};
+
+/** The leg-event union accepted by {@link legEvent}. */
+export type FundingLegEvent =
+  | { type: 'awaiting_signature' }
+  | { type: 'submitted'; externalId: string }
+  | { type: 'confirmed' }
+  | { type: 'failed'; reason: string; retryable: boolean };
+
+/**
+ * Guard helper: assert the session is in the expected status.
+ *
+ * @param session - The session to check.
+ * @param expected - The status the transition requires.
+ * @param action - Human-readable action name used in the error message.
+ * @throws If the session is not in the expected status.
+ */
+const requireStatus = (
+  session: FundingSession,
+  expected: FundingSessionStatus,
+  action: string,
+): void => {
+  if (session.status !== expected) {
+    throw new Error(
+      `Funding session ${session.id}: cannot ${action} from status '${session.status}' (expected '${expected}')`,
+    );
+  }
+};
+
+/**
+ * Guard helper: assert a leg index is in range.
+ *
+ * @param session - The session whose legs bound the index.
+ * @param legIndex - The leg index to validate.
+ * @throws If the index is not a valid leg position.
+ */
+const requireLegIndex = (session: FundingSession, legIndex: number): void => {
+  if (
+    !Number.isInteger(legIndex) ||
+    legIndex < 0 ||
+    legIndex >= session.legs.length
+  ) {
+    throw new Error(
+      `Funding session ${session.id}: invalid leg index ${legIndex} (session has ${session.legs.length} legs)`,
+    );
+  }
+};
+
+/**
+ * Copy a leg with a new status.
+ *
+ * @param leg - The leg to copy.
+ * @param status - The new leg status.
+ * @returns A new leg with the given status.
+ */
+const withLegStatus = (
+  leg: FundingLeg,
+  status: FundingLeg['status'],
+): FundingLeg => ({
+  ...leg,
+  status,
+});
+
+/**
+ * Create a new funding session in 'preflight' status with every Leg pending.
+ * Template legs are normalized: stale externalId/failure from a previous
+ * attempt are stripped. The account address is stored lowercased (Trading EOA).
+ *
+ * @param accountAddress - The Trading EOA the deposit will credit.
+ * @param legs - Template legs for the composed flow.
+ * @param ctx - Transition context providing the clock.
+ * @returns A new preflight session.
+ */
+export function startSession(
+  accountAddress: string,
+  legs: FundingLeg[],
+  ctx: TransitionContext,
+): FundingSession {
+  return {
+    id: generatePerpsId('funding'),
+    accountAddress: accountAddress.toLowerCase(),
+    createdAt: ctx.now,
+    updatedAt: ctx.now,
+    status: 'preflight',
+    legs: legs.map((leg) => ({
+      kind: leg.kind,
+      capability: leg.capability,
+      status: 'pending' as const,
+      ...(leg.quote ? { quote: leg.quote } : {}),
+    })),
+  };
+}
+
+/**
+ * Transition preflight -> active.
+ *
+ * @param session - The session in 'preflight' status.
+ * @param ctx - Transition context providing the clock.
+ * @returns A new session with status 'active'.
+ * @throws If the session is not in 'preflight' status.
+ */
+export function markPreflightPassed(
+  session: FundingSession,
+  ctx: TransitionContext,
+): FundingSession {
+  requireStatus(session, 'preflight', 'mark preflight passed');
+  return { ...session, status: 'active', updatedAt: ctx.now };
+}
+
+/**
+ * Transition preflight -> failed (no funds have moved).
+ * The reason is intentionally not persisted on FundingSession — the session
+ * type has no failure field; the controller layer owns where the reason lives.
+ *
+ * @param session - The session in 'preflight' status.
+ * @param _reason - Why preflight failed; accepted per the contract, not stored.
+ * @param ctx - Transition context providing the clock.
+ * @returns A new session with status 'failed'.
+ * @throws If the session is not in 'preflight' status.
+ */
+export function failPreflight(
+  session: FundingSession,
+  _reason: string,
+  ctx: TransitionContext,
+): FundingSession {
+  requireStatus(session, 'preflight', 'fail preflight');
+  return { ...session, status: 'failed', updatedAt: ctx.now };
+}
+
+/**
+ * Forward-only Leg event application.
+ * - pending -> awaiting_signature -> submitted -> confirmed
+ * - failed is accepted from awaiting_signature or submitted
+ * - 'confirmed' on Leg i advances Leg i+1 to pending
+ * - the last Leg being confirmed does NOT complete the session
+ *   (credit detection is mobile-side)
+ * - events on a confirmed Leg always throw (confirmed Legs are never re-run)
+ *
+ * @param session - The session owning the leg.
+ * @param legIndex - Index of the leg the event applies to.
+ * @param event - The leg event to apply.
+ * @param ctx - Transition context providing the clock.
+ * @returns A new session with the leg transition applied.
+ * @throws If the index is out of range or the event is not a forward step.
+ */
+export function legEvent(
+  session: FundingSession,
+  legIndex: number,
+  event: FundingLegEvent,
+  ctx: TransitionContext,
+): FundingSession {
+  requireLegIndex(session, legIndex);
+  const leg = session.legs[legIndex];
+  if (!leg) {
+    throw new Error(
+      `Funding session ${session.id}: missing leg at index ${legIndex}`,
+    );
+  }
+
+  switch (event.type) {
+    case 'awaiting_signature':
+      if (leg.status !== 'pending') {
+        throw new Error(
+          `Funding session ${session.id} leg ${legIndex}: cannot apply 'awaiting_signature' to leg in status '${leg.status}' (forward-only transitions)`,
+        );
+      }
+      return {
+        ...session,
+        updatedAt: ctx.now,
+        legs: session.legs.map((current, i) =>
+          i === legIndex
+            ? withLegStatus(current, 'awaiting_signature')
+            : current,
+        ),
+      };
+
+    case 'submitted':
+      if (leg.status !== 'awaiting_signature') {
+        throw new Error(
+          `Funding session ${session.id} leg ${legIndex}: cannot apply 'submitted' to leg in status '${leg.status}' (forward-only transitions)`,
+        );
+      }
+      return {
+        ...session,
+        updatedAt: ctx.now,
+        legs: session.legs.map((current, i) =>
+          i === legIndex
+            ? {
+                ...current,
+                status: 'submitted' as const,
+                externalId: event.externalId,
+              }
+            : current,
+        ),
+      };
+
+    case 'confirmed':
+      if (leg.status !== 'submitted') {
+        throw new Error(
+          `Funding session ${session.id} leg ${legIndex}: cannot apply 'confirmed' to leg in status '${leg.status}' (confirmed legs are never re-run; forward-only transitions)`,
+        );
+      }
+      return {
+        ...session,
+        updatedAt: ctx.now,
+        legs: session.legs.map((current, i) => {
+          if (i === legIndex) {
+            return withLegStatus(current, 'confirmed');
+          }
+          if (i === legIndex + 1) {
+            // Advance the next Leg to pending so the composer can start it.
+            return withLegStatus(current, 'pending');
+          }
+          return current;
+        }),
+      };
+
+    case 'failed':
+      if (leg.status !== 'awaiting_signature' && leg.status !== 'submitted') {
+        throw new Error(
+          `Funding session ${session.id} leg ${legIndex}: cannot apply 'failed' to leg in status '${leg.status}' (forward-only transitions)`,
+        );
+      }
+      return {
+        ...session,
+        updatedAt: ctx.now,
+        legs: session.legs.map((current, i) =>
+          i === legIndex
+            ? {
+                ...current,
+                status: 'failed' as const,
+                failure: {
+                  reason: event.reason,
+                  retryable: event.retryable,
+                  at: ctx.now,
+                },
+              }
+            : current,
+        ),
+      };
+
+    default:
+      // Exhaustive over FundingLegEvent; guards future event additions.
+      throw new Error(
+        `Funding session ${session.id} leg ${legIndex}: unknown leg event`,
+      );
+  }
+}
+
+/**
+ * Return a failed Leg to 'pending' so the composer may retry it
+ * (requote policy is the composer's, D7). ONLY allowed when:
+ * - the leg status is 'failed',
+ * - the failure is retryable,
+ * - every previous Leg is 'confirmed'.
+ *
+ * @param session - The session owning the leg.
+ * @param legIndex - Index of the leg to retry.
+ * @param ctx - Transition context providing the clock.
+ * @returns A new session with the leg back to 'pending'.
+ * @throws If the leg is not failed, not retryable, or a predecessor is unconfirmed.
+ */
+export function retryLeg(
+  session: FundingSession,
+  legIndex: number,
+  ctx: TransitionContext,
+): FundingSession {
+  requireLegIndex(session, legIndex);
+  const leg = session.legs[legIndex];
+  if (!leg) {
+    throw new Error(
+      `Funding session ${session.id}: missing leg at index ${legIndex}`,
+    );
+  }
+  if (leg.status !== 'failed') {
+    throw new Error(
+      `Funding session ${session.id} leg ${legIndex}: cannot retry leg in status '${leg.status}' (only failed legs can be retried)`,
+    );
+  }
+  if (!leg.failure?.retryable) {
+    throw new Error(
+      `Funding session ${session.id} leg ${legIndex}: failure is not retryable`,
+    );
+  }
+  for (let index = 0; index < legIndex; index += 1) {
+    const previous = session.legs[index];
+    if (previous?.status !== 'confirmed') {
+      throw new Error(
+        `Funding session ${session.id} leg ${legIndex}: cannot retry because previous leg ${index} is '${previous?.status}', expected 'confirmed'`,
+      );
+    }
+  }
+  return {
+    ...session,
+    updatedAt: ctx.now,
+    legs: session.legs.map((current, i) =>
+      i === legIndex
+        ? {
+            kind: current.kind,
+            capability: current.capability,
+            status: 'pending' as const,
+            ...(current.quote ? { quote: current.quote } : {}),
+          }
+        : current,
+    ),
+  };
+}
+
+/**
+ * Transition active -> paused (D10).
+ *
+ * @param session - The session in 'active' status.
+ * @param ctx - Transition context providing the clock.
+ * @returns A new session with status 'paused'.
+ * @throws If the session is not in 'active' status.
+ */
+export function pauseSession(
+  session: FundingSession,
+  ctx: TransitionContext,
+): FundingSession {
+  requireStatus(session, 'active', 'pause');
+  return { ...session, status: 'paused', updatedAt: ctx.now };
+}
+
+/**
+ * Transition paused -> active (D10).
+ *
+ * @param session - The session in 'paused' status.
+ * @param ctx - Transition context providing the clock.
+ * @returns A new session with status 'active'.
+ * @throws If the session is not in 'paused' status.
+ */
+export function resumeSession(
+  session: FundingSession,
+  ctx: TransitionContext,
+): FundingSession {
+  requireStatus(session, 'paused', 'resume');
+  return { ...session, status: 'active', updatedAt: ctx.now };
+}
+
+/**
+ * Transition active -> completed. Driven by mobile-side credit detection,
+ * never by the last Leg confirming.
+ *
+ * @param session - The session in 'active' status.
+ * @param ctx - Transition context providing the clock.
+ * @returns A new session with status 'completed'.
+ * @throws If the session is not in 'active' status.
+ */
+export function completeSession(
+  session: FundingSession,
+  ctx: TransitionContext,
+): FundingSession {
+  requireStatus(session, 'active', 'complete');
+  return { ...session, status: 'completed', updatedAt: ctx.now };
+}

--- a/packages/perps-controller/src/types/FundingSession.ts
+++ b/packages/perps-controller/src/types/FundingSession.ts
@@ -1,0 +1,63 @@
+/**
+ * A funding session is a progress tracker over Resting Points — never a
+ * custodian of funds. Funds always sit in user-recoverable balances between
+ * legs. Glossary: docs (Leg, Resting Point) in the mobile repo's CONTEXT.md.
+ */
+export type FundingLegKind = 'swap' | 'bridge' | 'deposit';
+
+/** Capabilities, not keyring types (D9): software accounts render legs silent. */
+export type FundingLegCapability = {
+  requiresDeviceSignature: boolean;
+  /** true = never rendered as a Signing Step (e.g. software-account legs) */
+  silent: boolean;
+};
+
+export type FundingLegStatus =
+  | 'pending'
+  | 'awaiting_signature'
+  | 'submitted'
+  | 'confirmed'
+  | 'failed';
+
+export type FundingLegQuoteSnapshot = {
+  srcAsset: string; // CAIP asset id
+  destAsset: string; // CAIP asset id
+  estimatedAmountOut: string; // atomic units, decimal string
+  fetchedAt: number; // ms epoch — quote freshness is composer policy (D7)
+};
+
+export type FundingLegFailure = {
+  reason: string;
+  retryable: boolean;
+  at: number;
+};
+
+export type FundingLeg = {
+  kind: FundingLegKind;
+  capability: FundingLegCapability;
+  status: FundingLegStatus;
+  /** Quote snapshot captured at leg start. Never the full quote payload. */
+  quote?: FundingLegQuoteSnapshot;
+  /** Key into BridgeStatusController txHistory (swap/bridge) or depositRequests (deposit). */
+  externalId?: string;
+  failure?: FundingLegFailure;
+};
+
+export type FundingSessionStatus =
+  | 'preflight'
+  | 'active'
+  | 'paused'
+  | 'completed'
+  | 'failed';
+
+export type FundingSession = {
+  id: string;
+  /** Trading EOA, lowercased — the account the deposit credits. */
+  accountAddress: string;
+  createdAt: number;
+  updatedAt: number;
+  status: FundingSessionStatus;
+  legs: FundingLeg[];
+  /** Links the deposit leg to the depositRequests entry for history rendering. */
+  depositRequestId?: string;
+};

--- a/packages/perps-controller/src/types/index.ts
+++ b/packages/perps-controller/src/types/index.ts
@@ -2318,6 +2318,7 @@ export function isVersionGatedFeatureFlag(
 // from the root barrel via `export * from './types.js'`.
 // ============================================================================
 export type * from './perps-types.js';
+export type * from './FundingSession.js';
 export * from './transactionTypes.js';
 // hyperliquid-types: selective export to avoid OrderType clash with main types
 export type {

--- a/packages/perps-controller/src/types/index.ts
+++ b/packages/perps-controller/src/types/index.ts
@@ -793,6 +793,11 @@ export type DepositWithConfirmationParams = {
   amount?: string;
   /** If true, uses addTransaction instead of submit to avoid navigation (e.g. deposit + place order flow) */
   placeOrder?: boolean;
+  /**
+   * Funding session whose deposit Leg this deposit fulfils (composed funding
+   * flow). Absent = plain deposit with no session bookkeeping.
+   */
+  fundingSessionId?: string;
 };
 
 export type DepositResult = {

--- a/packages/perps-controller/tests/src/PerpsController.fundingSessions.test.ts
+++ b/packages/perps-controller/tests/src/PerpsController.fundingSessions.test.ts
@@ -1,0 +1,521 @@
+/**
+ * PerpsController funding-session action tests.
+ *
+ * These cover the controller methods that wrap the pure transition guards
+ * (services/fundingSessionTransitions.ts) against `state.fundingSessions`:
+ * find-by-id, apply transition, replace in state, prune terminal sessions.
+ *
+ * Pruning policy (D8): at most 20 terminal (completed/failed) sessions are
+ * retained, evicting oldest-first by updatedAt. Non-terminal sessions
+ * (preflight/active/paused) are never pruned.
+ */
+
+import {
+  PerpsController,
+  getDefaultPerpsControllerState,
+} from '../../src/PerpsController.js';
+import { HyperLiquidProvider } from '../../src/providers/HyperLiquidProvider.js';
+import type { PerpsPlatformDependencies } from '../../src/types/index.js';
+import type { FundingLeg, FundingSession } from '../../src/types/index.js';
+import { createMockHyperLiquidProvider } from '../helpers/providerMocks.js';
+import {
+  createMockInfrastructure,
+  createMockMessenger,
+} from '../helpers/serviceMocks.js';
+
+jest.mock('@nktkas/hyperliquid', () => ({}));
+jest.mock('@myx-trade/sdk', () => ({
+  MyxClient: jest.fn(),
+  OrderStatusEnum: { Successful: 9 },
+}));
+jest.mock('../../src/providers/HyperLiquidProvider');
+jest.mock('../../src/providers/MYXProvider');
+jest.mock('@metamask/utils', () => ({
+  ...jest.requireActual('@metamask/utils'),
+  formatAccountToCaipAccountId: jest
+    .fn()
+    .mockReturnValue('eip155:1:0x1234567890123456789012345678901234567890'),
+}));
+
+const ACCOUNT_ADDRESS = '0xAbC0000000000000000000000000000000000001';
+
+/**
+ * A representative template leg as the funding composer would pass it.
+ *
+ * @param overrides - Optional leg field overrides.
+ * @returns A template leg.
+ */
+const buildTemplateLeg = (overrides: Partial<FundingLeg> = {}): FundingLeg => ({
+  kind: 'swap',
+  capability: { requiresDeviceSignature: false, silent: true },
+  status: 'pending',
+  ...overrides,
+});
+
+/**
+ * A persisted session seed for find-by-id action tests.
+ *
+ * @param overrides - Optional session field overrides.
+ * @returns A seeded session.
+ */
+const buildSeedSession = (
+  overrides: Partial<FundingSession> = {},
+): FundingSession => ({
+  id: 'funding-test-1',
+  accountAddress: ACCOUNT_ADDRESS.toLowerCase(),
+  createdAt: 1_700_000_000_000,
+  updatedAt: 1_700_000_000_000,
+  status: 'active',
+  legs: [
+    buildTemplateLeg({ status: 'confirmed' }),
+    buildTemplateLeg({ kind: 'deposit' }),
+  ],
+  ...overrides,
+});
+
+/**
+ * A terminal session seed for pruning tests, keyed by updatedAt.
+ *
+ * @param updatedAt - The updatedAt timestamp (also used to build the id).
+ * @param status - Which terminal status the session has.
+ * @returns A terminal session.
+ */
+const buildTerminalSession = (
+  updatedAt: number,
+  status: 'completed' | 'failed' = 'completed',
+): FundingSession => ({
+  id: `funding-terminal-${updatedAt}`,
+  accountAddress: ACCOUNT_ADDRESS.toLowerCase(),
+  createdAt: updatedAt - 1_000,
+  updatedAt,
+  status,
+  legs: [buildTemplateLeg({ status: 'confirmed' })],
+});
+
+describe('PerpsController funding sessions', () => {
+  let controller: PerpsController;
+  let mockInfrastructure: jest.Mocked<PerpsPlatformDependencies>;
+
+  const buildController = (fundingSessions: FundingSession[] = []): void => {
+    mockInfrastructure = createMockInfrastructure();
+    const mockProvider = createMockHyperLiquidProvider();
+    HyperLiquidProvider.mockImplementation(
+      () => mockProvider as never as InstanceType<typeof HyperLiquidProvider>,
+    );
+    controller = new PerpsController({
+      messenger: createMockMessenger(),
+      state: { ...getDefaultPerpsControllerState(), fundingSessions },
+      infrastructure: mockInfrastructure,
+    });
+  };
+
+  beforeEach(() => {
+    buildController();
+  });
+
+  describe('startFundingSession', () => {
+    it('creates a preflight session with normalized pending legs and stores it newest-first', () => {
+      // Arrange: template legs carry stale runtime fields from a prior attempt.
+      const before = Date.now();
+      const templateLegs: FundingLeg[] = [
+        buildTemplateLeg({
+          status: 'submitted',
+          externalId: 'stale-tx',
+          failure: { reason: 'stale', retryable: true, at: 1 },
+        }),
+        buildTemplateLeg({
+          kind: 'deposit',
+          capability: { requiresDeviceSignature: true, silent: false },
+        }),
+      ];
+
+      // Act
+      const session = controller.startFundingSession(
+        ACCOUNT_ADDRESS,
+        templateLegs,
+      );
+
+      // Assert
+      expect(session.status).toBe('preflight');
+      expect(session.id).toMatch(/^funding-/u);
+      expect(session.accountAddress).toBe(ACCOUNT_ADDRESS.toLowerCase());
+      expect(session.createdAt).toBeGreaterThanOrEqual(before);
+      expect(session.updatedAt).toBeGreaterThanOrEqual(before);
+      expect(session.legs).toHaveLength(2);
+      for (const leg of session.legs) {
+        expect(leg.status).toBe('pending');
+        expect(leg.externalId).toBeUndefined();
+        expect(leg.failure).toBeUndefined();
+      }
+      expect(controller.state.fundingSessions[0]).toStrictEqual(session);
+    });
+  });
+
+  describe('markPreflightPassed', () => {
+    it('transitions preflight to active and replaces the session in state', () => {
+      // Arrange
+      buildController([buildSeedSession({ status: 'preflight' })]);
+      const before = Date.now();
+
+      // Act
+      const updated = controller.markPreflightPassed('funding-test-1');
+
+      // Assert
+      expect(updated.status).toBe('active');
+      expect(updated.updatedAt).toBeGreaterThanOrEqual(before);
+      expect(controller.state.fundingSessions).toHaveLength(1);
+      expect(controller.state.fundingSessions[0]).toStrictEqual(updated);
+    });
+  });
+
+  describe('failPreflight', () => {
+    it('transitions preflight to failed without persisting the reason', () => {
+      // Arrange
+      const seed = buildSeedSession({ status: 'preflight' });
+      buildController([seed]);
+
+      // Act
+      const updated = controller.failPreflight('funding-test-1', 'geo blocked');
+
+      // Assert: the reason is accepted but never stored on the session.
+      expect(updated.status).toBe('failed');
+      expect(controller.state.fundingSessions[0]).toStrictEqual({
+        ...seed,
+        status: 'failed',
+        updatedAt: expect.any(Number),
+      });
+    });
+
+    it('logs the preflight failure reason without persisting it', () => {
+      // Arrange
+      buildController([buildSeedSession({ status: 'preflight' })]);
+
+      // Act
+      controller.failPreflight('funding-test-1', 'insufficient balance');
+
+      // Assert
+      expect(mockInfrastructure.debugLogger.log).toHaveBeenCalledWith(
+        expect.stringContaining('preflight failed'),
+        expect.objectContaining({
+          sessionId: 'funding-test-1',
+          reason: 'insufficient balance',
+        }),
+      );
+    });
+  });
+
+  describe('leg lifecycle actions', () => {
+    it('legAwaitingSignature moves a pending leg to awaiting_signature', () => {
+      // Arrange
+      buildController([buildSeedSession()]);
+
+      // Act
+      const updated = controller.legAwaitingSignature('funding-test-1', 1);
+
+      // Assert
+      expect(updated.legs[1]?.status).toBe('awaiting_signature');
+      expect(updated.legs[0]?.status).toBe('confirmed');
+    });
+
+    it('legSubmitted stores the external id on the leg', () => {
+      // Arrange
+      buildController([
+        buildSeedSession({
+          legs: [
+            buildTemplateLeg({ status: 'confirmed' }),
+            buildTemplateLeg({ status: 'awaiting_signature' }),
+          ],
+        }),
+      ]);
+
+      // Act
+      const updated = controller.legSubmitted(
+        'funding-test-1',
+        1,
+        'bridge-status-tx-9',
+      );
+
+      // Assert
+      expect(updated.legs[1]?.status).toBe('submitted');
+      expect(updated.legs[1]?.externalId).toBe('bridge-status-tx-9');
+    });
+
+    it('legConfirmed confirms the leg and keeps the session active', () => {
+      // Arrange: the last leg confirming must NOT complete the session —
+      // completion is driven by mobile-side credit detection.
+      buildController([
+        buildSeedSession({
+          legs: [
+            buildTemplateLeg({ status: 'submitted' }),
+            buildTemplateLeg({ status: 'submitted' }),
+          ],
+        }),
+      ]);
+
+      // Act
+      const updated = controller.legConfirmed('funding-test-1', 1);
+
+      // Assert
+      expect(updated.legs[1]?.status).toBe('confirmed');
+      expect(updated.status).toBe('active');
+    });
+
+    it('legFailed records the failure reason and retryable flag', () => {
+      // Arrange
+      buildController([
+        buildSeedSession({
+          legs: [buildTemplateLeg({ status: 'submitted' })],
+        }),
+      ]);
+
+      // Act
+      const updated = controller.legFailed(
+        'funding-test-1',
+        0,
+        'bridge expired',
+        true,
+      );
+
+      // Assert
+      expect(updated.legs[0]?.status).toBe('failed');
+      expect(updated.legs[0]?.failure).toStrictEqual(
+        expect.objectContaining({
+          reason: 'bridge expired',
+          retryable: true,
+        }),
+      );
+    });
+
+    it('retryLeg returns a retryable failed leg to pending and clears the failure', () => {
+      // Arrange
+      buildController([
+        buildSeedSession({
+          legs: [
+            buildTemplateLeg({ status: 'confirmed' }),
+            buildTemplateLeg({
+              status: 'failed',
+              failure: { reason: 'slippage', retryable: true, at: 1 },
+            }),
+          ],
+        }),
+      ]);
+
+      // Act
+      const updated = controller.retryLeg('funding-test-1', 1);
+
+      // Assert
+      expect(updated.legs[1]?.status).toBe('pending');
+      expect(updated.legs[1]?.failure).toBeUndefined();
+      expect(updated.legs[1]?.externalId).toBeUndefined();
+    });
+  });
+
+  describe('pause and resume', () => {
+    it('pauseSession transitions active to paused', () => {
+      // Arrange
+      buildController([buildSeedSession()]);
+
+      // Act
+      const updated = controller.pauseSession('funding-test-1');
+
+      // Assert
+      expect(updated.status).toBe('paused');
+      expect(controller.state.fundingSessions[0]?.status).toBe('paused');
+    });
+
+    it('resumeSession transitions paused to active', () => {
+      // Arrange
+      buildController([buildSeedSession({ status: 'paused' })]);
+
+      // Act
+      const updated = controller.resumeSession('funding-test-1');
+
+      // Assert
+      expect(updated.status).toBe('active');
+      expect(controller.state.fundingSessions[0]?.status).toBe('active');
+    });
+  });
+
+  describe('completeSession', () => {
+    it('transitions active to completed', () => {
+      // Arrange
+      buildController([buildSeedSession()]);
+
+      // Act
+      const updated = controller.completeSession('funding-test-1');
+
+      // Assert
+      expect(updated.status).toBe('completed');
+      expect(controller.state.fundingSessions[0]?.status).toBe('completed');
+    });
+  });
+
+  describe('unknown session ids', () => {
+    const unknownIdActions: {
+      name: string;
+      act: (target: PerpsController, id: string) => unknown;
+    }[] = [
+      {
+        name: 'markPreflightPassed',
+        act: (target, id) => target.markPreflightPassed(id),
+      },
+      {
+        name: 'failPreflight',
+        act: (target, id) => target.failPreflight(id, 'x'),
+      },
+      {
+        name: 'legAwaitingSignature',
+        act: (target, id) => target.legAwaitingSignature(id, 0),
+      },
+      {
+        name: 'legSubmitted',
+        act: (target, id) => target.legSubmitted(id, 0, 'ext'),
+      },
+      { name: 'legConfirmed', act: (target, id) => target.legConfirmed(id, 0) },
+      {
+        name: 'legFailed',
+        act: (target, id) => target.legFailed(id, 0, 'r', false),
+      },
+      { name: 'retryLeg', act: (target, id) => target.retryLeg(id, 0) },
+      { name: 'pauseSession', act: (target, id) => target.pauseSession(id) },
+      { name: 'resumeSession', act: (target, id) => target.resumeSession(id) },
+      {
+        name: 'completeSession',
+        act: (target, id) => target.completeSession(id),
+      },
+    ];
+
+    it.each(unknownIdActions)(
+      '$name throws a clear error for an unknown id',
+      ({ act }) => {
+        // Arrange: default (empty) state — no session exists.
+
+        // Act + Assert
+        expect(() => act(controller, 'funding-missing')).toThrow(
+          'Funding session funding-missing: not found',
+        );
+      },
+    );
+  });
+
+  describe('invalid transitions propagate from the pure guards', () => {
+    it('completeSession on a preflight session throws', () => {
+      // Arrange
+      buildController([buildSeedSession({ status: 'preflight' })]);
+
+      // Act + Assert
+      expect(() => controller.completeSession('funding-test-1')).toThrow(
+        /cannot complete from status 'preflight'/u,
+      );
+    });
+
+    it('legConfirmed cannot skip awaiting_signature', () => {
+      // Arrange
+      buildController([buildSeedSession()]);
+
+      // Act + Assert
+      expect(() => controller.legConfirmed('funding-test-1', 1)).toThrow(
+        /cannot apply 'confirmed' to leg in status 'pending'/u,
+      );
+    });
+
+    it('retryLeg rejects a non-retryable failure', () => {
+      // Arrange
+      buildController([
+        buildSeedSession({
+          legs: [
+            buildTemplateLeg({
+              status: 'failed',
+              failure: { reason: 'r', retryable: false, at: 1 },
+            }),
+          ],
+        }),
+      ]);
+
+      // Act + Assert
+      expect(() => controller.retryLeg('funding-test-1', 0)).toThrow(
+        /failure is not retryable/u,
+      );
+    });
+  });
+
+  describe('terminal session pruning', () => {
+    it('keeps at most 20 terminal sessions, evicting the oldest by updatedAt', () => {
+      // Arrange: 21 terminal sessions, seeded out of order so eviction is
+      // proven to depend on updatedAt, not array position (oldest is last).
+      const terminal: FundingSession[] = [];
+      for (let updatedAt = 1000; updatedAt <= 1020; updatedAt += 1) {
+        terminal.push(buildTerminalSession(updatedAt));
+      }
+      buildController([terminal[20], ...terminal.slice(0, 20)]);
+
+      // Act: any write triggers pruning.
+      controller.startFundingSession(ACCOUNT_ADDRESS, [buildTemplateLeg()]);
+
+      // Assert: the 20 newest terminals survive, fs-1000 is evicted, and the
+      // new non-terminal session is untouched.
+      const ids = controller.state.fundingSessions.map((session) => session.id);
+      expect(ids).not.toContain('funding-terminal-1000');
+      expect(ids).toContain('funding-terminal-1020');
+      expect(ids).toContain('funding-terminal-1001');
+      const terminalCount = controller.state.fundingSessions.filter(
+        (session) =>
+          session.status === 'completed' || session.status === 'failed',
+      ).length;
+      expect(terminalCount).toBe(20);
+      expect(controller.state.fundingSessions).toHaveLength(21);
+    });
+
+    it('never prunes non-terminal sessions even when over the terminal cap', () => {
+      // Arrange: 25 terminals + one session in every non-terminal status.
+      const terminal: FundingSession[] = [];
+      for (let updatedAt = 1000; updatedAt <= 1024; updatedAt += 1) {
+        terminal.push(buildTerminalSession(updatedAt));
+      }
+      buildController([
+        ...terminal,
+        buildSeedSession({ id: 'funding-active', status: 'active' }),
+        buildSeedSession({ id: 'funding-paused', status: 'paused' }),
+        buildSeedSession({ id: 'funding-preflight', status: 'preflight' }),
+      ]);
+
+      // Act
+      controller.startFundingSession(ACCOUNT_ADDRESS, [buildTemplateLeg()]);
+
+      // Assert
+      const ids = controller.state.fundingSessions.map((session) => session.id);
+      expect(ids).toContain('funding-active');
+      expect(ids).toContain('funding-paused');
+      expect(ids).toContain('funding-preflight');
+      expect(ids).not.toContain('funding-terminal-1000');
+      expect(ids).not.toContain('funding-terminal-1004');
+      expect(ids).toContain('funding-terminal-1024');
+      const terminalCount = controller.state.fundingSessions.filter(
+        (session) =>
+          session.status === 'completed' || session.status === 'failed',
+      ).length;
+      expect(terminalCount).toBe(20);
+    });
+
+    it('prunes on lifecycle writes, not only on start', () => {
+      // Arrange: 20 terminals + a preflight session (right at the cap).
+      const terminal: FundingSession[] = [];
+      for (let updatedAt = 1000; updatedAt <= 1019; updatedAt += 1) {
+        terminal.push(buildTerminalSession(updatedAt));
+      }
+      buildController([
+        ...terminal,
+        buildSeedSession({ id: 'funding-preflight', status: 'preflight' }),
+      ]);
+
+      // Act: failing the preflight creates a 21st terminal session.
+      controller.failPreflight('funding-preflight', 'user cancelled');
+
+      // Assert: the oldest seeded terminal is evicted to make room.
+      const ids = controller.state.fundingSessions.map((session) => session.id);
+      expect(ids).not.toContain('funding-terminal-1000');
+      expect(ids).toContain('funding-preflight');
+      expect(controller.state.fundingSessions).toHaveLength(20);
+    });
+  });
+});

--- a/packages/perps-controller/tests/src/PerpsController.operations.test.ts
+++ b/packages/perps-controller/tests/src/PerpsController.operations.test.ts
@@ -31,6 +31,8 @@ import type { PerpsControllerState } from '../../src/PerpsController.js';
 import { HyperLiquidProvider } from '../../src/providers/HyperLiquidProvider.js';
 import { RewardsIntegrationService } from '../../src/services/RewardsIntegrationService.js';
 import type {
+  FundingLegStatus,
+  FundingSession,
   GetAvailableDexsParams,
   PerpsProvider,
   PerpsPlatformDependencies,
@@ -1798,6 +1800,266 @@ describe('PerpsController', () => {
         expect(depositController.state.lastDepositTransactionId).toBeNull();
         expect(depositController.state.lastDepositResult).toBeNull();
       }
+    });
+
+    describe('funding session linkage', () => {
+      const fundingSessionId = 'funding-deposit-link-1';
+
+      /**
+       * A session with a confirmed swap Leg followed by the deposit Leg, as
+       * the composed funding flow would have it right before the deposit
+       * transaction is confirmed on-chain.
+       *
+       * @param depositLegStatus - Status of the deposit Leg.
+       * @returns A linked funding session.
+       */
+      const buildLinkedSession = (
+        depositLegStatus: FundingLegStatus = 'submitted',
+      ): FundingSession => ({
+        id: fundingSessionId,
+        accountAddress: '0x1234567890123456789012345678901234567890',
+        createdAt: 1_700_000_000_000,
+        updatedAt: 1_700_000_000_000,
+        status: 'active',
+        legs: [
+          {
+            kind: 'swap',
+            capability: { requiresDeviceSignature: false, silent: true },
+            status: 'confirmed',
+          },
+          {
+            kind: 'deposit',
+            capability: { requiresDeviceSignature: false, silent: true },
+            status: depositLegStatus,
+          },
+        ],
+      });
+
+      const seedFundingSession = (session: FundingSession): void => {
+        depositController.testUpdate((state) => {
+          state.fundingSessions = [session];
+        });
+      };
+
+      it('confirms the deposit leg and links the depositRequestId on success', async () => {
+        // Arrange
+        depositController.testMarkInitialized();
+        depositController.testSetProviders(
+          new Map([['hyperliquid', mockProvider]]),
+        );
+        seedFundingSession(buildLinkedSession());
+
+        // Act
+        const { result } = await depositController.depositWithConfirmation({
+          amount: '100',
+          fundingSessionId,
+        });
+        await result;
+
+        // Assert
+        const session = depositController.state.fundingSessions[0];
+        expect(session?.legs[1]?.status).toBe('confirmed');
+        expect(session?.depositRequestId).toBe(mockDepositId);
+        // The plain deposit path is unaffected by the linkage.
+        expect(depositController.state.depositRequests[0]?.status).toBe(
+          'completed',
+        );
+        expect(depositController.state.depositRequests[0]?.success).toBe(true);
+      });
+
+      it('does not crash when the deposit leg was already confirmed (duplicated success)', async () => {
+        // Arrange: the deposit Leg is already confirmed, so the second
+        // 'confirmed' application throws inside the pure guard and must be
+        // caught + logged, never propagated to the deposit path.
+        depositController.testMarkInitialized();
+        depositController.testSetProviders(
+          new Map([['hyperliquid', mockProvider]]),
+        );
+        seedFundingSession(buildLinkedSession('confirmed'));
+
+        // Act
+        const { result } = await depositController.depositWithConfirmation({
+          amount: '100',
+          fundingSessionId,
+        });
+        await result;
+
+        // Assert: the deposit still completed and session state is consistent.
+        expect(depositController.state.depositRequests[0]?.status).toBe(
+          'completed',
+        );
+        const session = depositController.state.fundingSessions[0];
+        expect(session?.legs[1]?.status).toBe('confirmed');
+        expect(session?.status).toBe('active');
+        expect(depositInfrastructure.debugLogger.log).toHaveBeenCalledWith(
+          expect.stringContaining('deposit leg outcome skipped'),
+          expect.objectContaining({ sessionId: fundingSessionId }),
+        );
+      });
+
+      it('marks the deposit leg failed as retryable when the user cancels', async () => {
+        // Arrange
+        depositController.testMarkInitialized();
+        depositController.testSetProviders(
+          new Map([['hyperliquid', mockProvider]]),
+        );
+        seedFundingSession(buildLinkedSession());
+        depositMockCall.mockImplementation(
+          (action: string, ..._args: unknown[]) => {
+            if (
+              action ===
+              'AccountTreeController:getAccountsFromSelectedAccountGroup'
+            ) {
+              return [
+                {
+                  address: '0x1234567890123456789012345678901234567890',
+                  type: 'eip155:eoa',
+                },
+              ];
+            }
+            if (action === 'TransactionController:addTransaction') {
+              return Promise.resolve({
+                result: Promise.reject(
+                  new Error('User rejected transaction signature'),
+                ),
+                transactionMeta: mockTransactionMeta,
+              });
+            }
+            if (action === 'NetworkController:findNetworkClientIdByChainId') {
+              return mockNetworkClientId;
+            }
+            if (action === 'RemoteFeatureFlagController:getState') {
+              return { remoteFeatureFlags: {} };
+            }
+            return undefined;
+          },
+        );
+
+        // Act
+        const { result } = await depositController.depositWithConfirmation({
+          amount: '100',
+          fundingSessionId,
+        });
+        await expect(result).rejects.toThrow('User rejected');
+
+        // Assert
+        const depositLeg = depositController.state.fundingSessions[0]?.legs[1];
+        expect(depositLeg?.status).toBe('failed');
+        expect(depositLeg?.failure?.reason).toBe('cancelled');
+        expect(depositLeg?.failure?.retryable).toBe(true);
+      });
+
+      it('marks the deposit leg failed as retryable when the transaction fails', async () => {
+        // Arrange
+        depositController.testMarkInitialized();
+        depositController.testSetProviders(
+          new Map([['hyperliquid', mockProvider]]),
+        );
+        seedFundingSession(buildLinkedSession());
+        depositMockCall.mockImplementation(
+          (action: string, ..._args: unknown[]) => {
+            if (
+              action ===
+              'AccountTreeController:getAccountsFromSelectedAccountGroup'
+            ) {
+              return [
+                {
+                  address: '0x1234567890123456789012345678901234567890',
+                  type: 'eip155:eoa',
+                },
+              ];
+            }
+            if (action === 'TransactionController:addTransaction') {
+              return Promise.resolve({
+                result: Promise.reject(new Error('Network error occurred')),
+                transactionMeta: mockTransactionMeta,
+              });
+            }
+            if (action === 'NetworkController:findNetworkClientIdByChainId') {
+              return mockNetworkClientId;
+            }
+            if (action === 'RemoteFeatureFlagController:getState') {
+              return { remoteFeatureFlags: {} };
+            }
+            return undefined;
+          },
+        );
+
+        // Act
+        const { result } = await depositController.depositWithConfirmation({
+          amount: '100',
+          fundingSessionId,
+        });
+        await expect(result).rejects.toThrow('Network error occurred');
+
+        // Assert
+        const depositLeg = depositController.state.fundingSessions[0]?.legs[1];
+        expect(depositLeg?.status).toBe('failed');
+        expect(depositLeg?.failure?.reason).toBe('Network error occurred');
+        expect(depositLeg?.failure?.retryable).toBe(true);
+      });
+
+      it('leaves funding sessions untouched when no fundingSessionId is provided', async () => {
+        // Arrange
+        depositController.testMarkInitialized();
+        depositController.testSetProviders(
+          new Map([['hyperliquid', mockProvider]]),
+        );
+        const seed = buildLinkedSession();
+        seedFundingSession(seed);
+
+        // Act
+        const { result } = await depositController.depositWithConfirmation({
+          amount: '100',
+        });
+        await result;
+
+        // Assert: the seeded session is byte-identical to its pre-deposit state.
+        expect(depositController.state.fundingSessions[0]).toStrictEqual(seed);
+      });
+
+      it('does not crash the deposit when the referenced session is missing', async () => {
+        // Arrange: exactly one deposit Leg exists by construction, so an
+        // unknown session id is a defect state — log it, never crash.
+        depositController.testMarkInitialized();
+        depositController.testSetProviders(
+          new Map([['hyperliquid', mockProvider]]),
+        );
+
+        // Act
+        const { result } = await depositController.depositWithConfirmation({
+          amount: '100',
+          fundingSessionId: 'funding-unknown',
+        });
+        await result;
+
+        // Assert: the deposit completed normally.
+        expect(depositController.state.depositRequests[0]?.status).toBe(
+          'completed',
+        );
+      });
+
+      it('confirms the deposit leg for the deposit+order flow on success', async () => {
+        // Arrange
+        depositController.testMarkInitialized();
+        depositController.testSetProviders(
+          new Map([['hyperliquid', mockProvider]]),
+        );
+        seedFundingSession(buildLinkedSession());
+
+        // Act
+        const { result } = await depositController.depositWithConfirmation({
+          amount: '100',
+          placeOrder: true,
+          fundingSessionId,
+        });
+        await result;
+
+        // Assert
+        const session = depositController.state.fundingSessions[0];
+        expect(session?.legs[1]?.status).toBe('confirmed');
+        expect(session?.depositRequestId).toBe(mockDepositId);
+      });
     });
   });
 

--- a/packages/perps-controller/tests/src/PerpsController.state.test.ts
+++ b/packages/perps-controller/tests/src/PerpsController.state.test.ts
@@ -32,8 +32,10 @@ import {
   firstNonEmpty,
   resolveMyxAuthConfig,
 } from '../../src/PerpsController.js';
+import type { PerpsControllerState } from '../../src/PerpsController.js';
 import { PERPS_ERROR_CODES } from '../../src/perpsErrorCodes.js';
 import { HyperLiquidProvider } from '../../src/providers/HyperLiquidProvider.js';
+import type { FundingSession } from '../../src/types/FundingSession.js';
 import { PerpsAnalyticsEvent } from '../../src/types/index.js';
 
 jest.mock('../../src/providers/HyperLiquidProvider');
@@ -613,6 +615,65 @@ describe('PerpsController', () => {
 
       await expect(controller.getPositions()).rejects.toThrow(errorMessage);
       expect(mockMarketDataServiceInstance.getPositions).toHaveBeenCalled();
+    });
+  });
+
+  describe('funding sessions', () => {
+    /** A representative session as the funding composer (A2+) would create it. */
+    const buildSampleSession = (): FundingSession => ({
+      id: 'fs-1',
+      accountAddress: '0xabc0000000000000000000000000000000000001',
+      createdAt: 1700000000000,
+      updatedAt: 1700000001000,
+      status: 'active',
+      legs: [
+        {
+          kind: 'swap',
+          capability: { requiresDeviceSignature: false, silent: true },
+          status: 'confirmed',
+          quote: {
+            srcAsset: 'eip155:1/erc20:0xeth',
+            destAsset: 'eip155:42161/erc20:0xusdc',
+            estimatedAmountOut: '100000000',
+            fetchedAt: 1700000000000,
+          },
+          externalId: 'bridge-status-tx-1',
+        },
+        {
+          kind: 'deposit',
+          capability: { requiresDeviceSignature: true, silent: false },
+          status: 'pending',
+          externalId: 'deposit-request-1',
+        },
+      ],
+      depositRequestId: 'deposit-request-1',
+    });
+
+    it('defaults fundingSessions to an empty array', () => {
+      expect(controller.state.fundingSessions).toEqual([]);
+    });
+
+    it('round-trips fundingSessions through persistence serialization', () => {
+      // Arrange: seed a session as the composer would, then serialize the
+      // state exactly like the client's persistence layer does.
+      const session = buildSampleSession();
+      controller.testUpdate((state) => {
+        state.fundingSessions = [session];
+      });
+      const persistedState = JSON.parse(
+        JSON.stringify(controller.state),
+      ) as PerpsControllerState;
+
+      // Act: rehydrate a fresh controller from the persisted state, mirroring
+      // how the client restores controller state on launch.
+      const rehydratedController = new TestablePerpsController({
+        messenger: createMockMessenger(),
+        state: persistedState,
+        infrastructure: mockInfrastructure,
+      });
+
+      // Assert: the slice survives the serialize → rehydrate round trip.
+      expect(rehydratedController.state.fundingSessions).toEqual([session]);
     });
   });
 

--- a/packages/perps-controller/tests/src/services/fundingSessionTransitions.test.ts
+++ b/packages/perps-controller/tests/src/services/fundingSessionTransitions.test.ts
@@ -1,0 +1,430 @@
+/* eslint-disable */
+import type { FundingLeg, FundingSession } from '../../../src/types/index.js';
+import {
+  completeSession,
+  failPreflight,
+  legEvent,
+  markPreflightPassed,
+  pauseSession,
+  resumeSession,
+  retryLeg,
+  startSession,
+  type TransitionContext,
+} from '../../../src/services/fundingSessionTransitions.js';
+
+const NOW = 1_700_000_000_000;
+const CTX: TransitionContext = { now: NOW };
+const ADDRESS = '0xAbC0000000000000000000000000000000000001';
+
+const makeLeg = (overrides: Partial<FundingLeg> = {}): FundingLeg => ({
+  kind: 'swap',
+  capability: { requiresDeviceSignature: false, silent: false },
+  status: 'pending',
+  ...overrides,
+});
+
+const makeLegs = (count: number): FundingLeg[] =>
+  Array.from({ length: count }, () => makeLeg());
+
+/** startSession -> markPreflightPassed => status 'active' with N pending legs. */
+const buildActiveSession = (legCount = 2): FundingSession =>
+  markPreflightPassed(startSession(ADDRESS, makeLegs(legCount), CTX), CTX);
+
+/** Drive a single leg forward through the happy path to the target status. */
+const advanceLeg = (
+  session: FundingSession,
+  legIndex: number,
+  target: 'awaiting_signature' | 'submitted' | 'confirmed' | 'failed',
+): FundingSession => {
+  let next = legEvent(session, legIndex, { type: 'awaiting_signature' }, CTX);
+  if (target === 'awaiting_signature') {
+    return next;
+  }
+  next = legEvent(
+    next,
+    legIndex,
+    { type: 'submitted', externalId: `ext-${legIndex}` },
+    CTX,
+  );
+  if (target === 'submitted') {
+    return next;
+  }
+  if (target === 'confirmed') {
+    return legEvent(next, legIndex, { type: 'confirmed' }, CTX);
+  }
+  return legEvent(
+    next,
+    legIndex,
+    { type: 'failed', reason: 'rpc timeout', retryable: true },
+    CTX,
+  );
+};
+
+describe('fundingSessionTransitions', () => {
+  describe('startSession', () => {
+    it('creates a preflight session with all legs pending', () => {
+      const result = startSession(ADDRESS, makeLegs(2), CTX);
+
+      expect(result.status).toBe('preflight');
+      expect(result.accountAddress).toBe(ADDRESS.toLowerCase());
+      expect(result.createdAt).toBe(NOW);
+      expect(result.updatedAt).toBe(NOW);
+      expect(result.id).toBeTruthy();
+      expect(result.legs.map((leg) => leg.status)).toEqual([
+        'pending',
+        'pending',
+      ]);
+      expect(result.legs.map((leg) => leg.kind)).toEqual(['swap', 'swap']);
+    });
+
+    it('normalizes template legs: strips stale externalId and failure', () => {
+      const dirtyLegs = [
+        makeLeg({
+          externalId: 'stale-tx',
+          failure: {
+            reason: 'old',
+            retryable: false,
+            at: 1,
+          },
+        }),
+      ];
+
+      const result = startSession(ADDRESS, dirtyLegs, CTX);
+
+      expect(result.legs[0]?.status).toBe('pending');
+      expect(result.legs[0]?.externalId).toBeUndefined();
+      expect(result.legs[0]?.failure).toBeUndefined();
+    });
+  });
+
+  describe('markPreflightPassed', () => {
+    it('transitions preflight -> active and stamps updatedAt', () => {
+      const session = startSession(ADDRESS, makeLegs(2), CTX);
+
+      const result = markPreflightPassed(session, { now: NOW + 10 });
+
+      expect(result.status).toBe('active');
+      expect(result.updatedAt).toBe(NOW + 10);
+    });
+
+    it('throws on any other status', () => {
+      const active = buildActiveSession();
+      const paused = pauseSession(active, CTX);
+      const completed = completeSession(active, CTX);
+      const failed = failPreflight(
+        startSession(ADDRESS, makeLegs(1), CTX),
+        'insufficient funds',
+        CTX,
+      );
+
+      expect(() => markPreflightPassed(active, CTX)).toThrow(/status 'active'/);
+      expect(() => markPreflightPassed(paused, CTX)).toThrow(/status 'paused'/);
+      expect(() => markPreflightPassed(completed, CTX)).toThrow(
+        /status 'completed'/,
+      );
+      expect(() => markPreflightPassed(failed, CTX)).toThrow(/status 'failed'/);
+    });
+  });
+
+  describe('failPreflight', () => {
+    it('transitions preflight -> failed with the reason', () => {
+      const session = startSession(ADDRESS, makeLegs(2), CTX);
+
+      const result = failPreflight(session, 'no USDC', { now: NOW + 7 });
+
+      expect(result.status).toBe('failed');
+      expect(result.updatedAt).toBe(NOW + 7);
+    });
+
+    it('throws on any other status', () => {
+      const active = buildActiveSession();
+
+      expect(() => failPreflight(active, 'nope', CTX)).toThrow(
+        /status 'active'/,
+      );
+    });
+  });
+
+  describe('legEvent', () => {
+    it('advances pending -> awaiting_signature and stamps updatedAt', () => {
+      const session = buildActiveSession();
+
+      const result = legEvent(
+        session,
+        0,
+        { type: 'awaiting_signature' },
+        {
+          now: NOW + 3,
+        },
+      );
+
+      expect(result.legs[0]?.status).toBe('awaiting_signature');
+      expect(result.updatedAt).toBe(NOW + 3);
+    });
+
+    it('advances awaiting_signature -> submitted and records externalId', () => {
+      const session = advanceLeg(buildActiveSession(), 0, 'awaiting_signature');
+
+      const result = legEvent(
+        session,
+        0,
+        { type: 'submitted', externalId: 'tx-1' },
+        { now: NOW + 4 },
+      );
+
+      expect(result.legs[0]?.status).toBe('submitted');
+      expect(result.legs[0]?.externalId).toBe('tx-1');
+      expect(result.updatedAt).toBe(NOW + 4);
+    });
+
+    it('advances submitted -> confirmed and advances the next leg to pending', () => {
+      const session = advanceLeg(buildActiveSession(), 0, 'submitted');
+
+      const result = legEvent(
+        session,
+        0,
+        { type: 'confirmed' },
+        {
+          now: NOW + 5,
+        },
+      );
+
+      expect(result.legs[0]?.status).toBe('confirmed');
+      expect(result.legs[1]?.status).toBe('pending');
+      expect(result.updatedAt).toBe(NOW + 5);
+    });
+
+    it('does NOT complete the session when the last leg is confirmed', () => {
+      let session = buildActiveSession(2);
+      session = advanceLeg(session, 0, 'confirmed');
+      session = advanceLeg(session, 1, 'confirmed');
+
+      expect(session.status).toBe('active');
+      expect(session.legs.map((leg) => leg.status)).toEqual([
+        'confirmed',
+        'confirmed',
+      ]);
+    });
+
+    it('applies failed from awaiting_signature with failure details', () => {
+      const session = advanceLeg(buildActiveSession(), 0, 'awaiting_signature');
+
+      const result = legEvent(
+        session,
+        0,
+        { type: 'failed', reason: 'user rejected', retryable: false },
+        { now: NOW + 6 },
+      );
+
+      expect(result.legs[0]?.status).toBe('failed');
+      expect(result.legs[0]?.failure).toEqual({
+        reason: 'user rejected',
+        retryable: false,
+        at: NOW + 6,
+      });
+      expect(result.updatedAt).toBe(NOW + 6);
+    });
+
+    it('applies failed from submitted', () => {
+      const session = advanceLeg(buildActiveSession(), 0, 'submitted');
+
+      const result = legEvent(
+        session,
+        0,
+        { type: 'failed', reason: 'reverted on-chain', retryable: true },
+        CTX,
+      );
+
+      expect(result.legs[0]?.status).toBe('failed');
+    });
+
+    it('throws when re-running an event on a confirmed leg', () => {
+      const session = advanceLeg(buildActiveSession(), 0, 'confirmed');
+
+      expect(() => legEvent(session, 0, { type: 'confirmed' }, CTX)).toThrow(
+        /confirmed/,
+      );
+      expect(() =>
+        legEvent(session, 0, { type: 'awaiting_signature' }, CTX),
+      ).toThrow(/confirmed/);
+      expect(() =>
+        legEvent(session, 0, { type: 'submitted', externalId: 'x' }, CTX),
+      ).toThrow(/confirmed/);
+      expect(() =>
+        legEvent(
+          session,
+          0,
+          { type: 'failed', reason: 'r', retryable: true },
+          CTX,
+        ),
+      ).toThrow(/confirmed/);
+    });
+
+    it('throws on backward transitions', () => {
+      const submitted = advanceLeg(buildActiveSession(), 0, 'submitted');
+
+      // awaiting_signature on a submitted leg is backward
+      expect(() =>
+        legEvent(submitted, 0, { type: 'awaiting_signature' }, CTX),
+      ).toThrow(/submitted/);
+
+      const awaiting = advanceLeg(
+        buildActiveSession(),
+        0,
+        'awaiting_signature',
+      );
+      // confirmed on an awaiting_signature leg skips submitted
+      expect(() => legEvent(awaiting, 0, { type: 'confirmed' }, CTX)).toThrow(
+        /awaiting_signature/,
+      );
+      // submitted on a pending leg skips awaiting_signature
+      const pendingSession = buildActiveSession();
+      expect(() =>
+        legEvent(
+          pendingSession,
+          0,
+          { type: 'submitted', externalId: 'x' },
+          CTX,
+        ),
+      ).toThrow(/pending/);
+      // failed on a pending leg that never started
+      expect(() =>
+        legEvent(
+          pendingSession,
+          0,
+          { type: 'failed', reason: 'r', retryable: true },
+          CTX,
+        ),
+      ).toThrow(/pending/);
+    });
+
+    it('throws on an out-of-range leg index', () => {
+      const session = buildActiveSession(2);
+
+      expect(() =>
+        legEvent(session, -1, { type: 'awaiting_signature' }, CTX),
+      ).toThrow(/leg index/i);
+      expect(() =>
+        legEvent(session, 2, { type: 'awaiting_signature' }, CTX),
+      ).toThrow(/leg index/i);
+    });
+  });
+
+  describe('retryLeg', () => {
+    it('returns a failed retryable leg to pending when all previous legs are confirmed', () => {
+      let session = buildActiveSession(3);
+      session = advanceLeg(session, 0, 'confirmed');
+      session = advanceLeg(session, 1, 'failed');
+
+      const result = retryLeg(session, 1, { now: NOW + 9 });
+
+      expect(result.legs[1]?.status).toBe('pending');
+      expect(result.legs[1]?.failure).toBeUndefined();
+      expect(result.updatedAt).toBe(NOW + 9);
+    });
+
+    it('allows retrying leg 0 (no previous legs)', () => {
+      const session = advanceLeg(buildActiveSession(2), 0, 'failed');
+
+      const result = retryLeg(session, 0, CTX);
+
+      expect(result.legs[0]?.status).toBe('pending');
+    });
+
+    it('throws when the leg is not failed', () => {
+      const session = buildActiveSession();
+
+      expect(() => retryLeg(session, 0, CTX)).toThrow(/pending/);
+    });
+
+    it('throws when the failure is not retryable', () => {
+      let session = buildActiveSession(2);
+      session = advanceLeg(session, 0, 'confirmed');
+      session = legEvent(session, 1, { type: 'awaiting_signature' }, CTX);
+      session = legEvent(
+        session,
+        1,
+        { type: 'failed', reason: 'permanent', retryable: false },
+        CTX,
+      );
+
+      expect(() => retryLeg(session, 1, CTX)).toThrow(/retryable/);
+    });
+
+    it('throws when an earlier leg is not confirmed', () => {
+      let session = buildActiveSession(3);
+      session = advanceLeg(session, 0, 'confirmed');
+      session = advanceLeg(session, 1, 'failed');
+      session = advanceLeg(session, 2, 'failed');
+
+      expect(() => retryLeg(session, 2, CTX)).toThrow(/confirmed/);
+    });
+
+    it('throws on an out-of-range leg index', () => {
+      const session = buildActiveSession(1);
+
+      expect(() => retryLeg(session, 5, CTX)).toThrow(/leg index/i);
+    });
+  });
+
+  describe('pauseSession / resumeSession', () => {
+    it('transitions active -> paused (D10) and stamps updatedAt', () => {
+      const session = buildActiveSession();
+
+      const result = pauseSession(session, { now: NOW + 11 });
+
+      expect(result.status).toBe('paused');
+      expect(result.updatedAt).toBe(NOW + 11);
+    });
+
+    it('throws when pausing a non-active session', () => {
+      const preflight = startSession(ADDRESS, makeLegs(1), CTX);
+
+      expect(() => pauseSession(preflight, CTX)).toThrow(/preflight/);
+      expect(() => resumeSession(preflight, CTX)).toThrow(/preflight/);
+    });
+
+    it('transitions paused -> active and stamps updatedAt', () => {
+      const paused = pauseSession(buildActiveSession(), CTX);
+
+      const result = resumeSession(paused, { now: NOW + 12 });
+
+      expect(result.status).toBe('active');
+      expect(result.updatedAt).toBe(NOW + 12);
+    });
+  });
+
+  describe('completeSession', () => {
+    it('transitions active -> completed and stamps updatedAt', () => {
+      const session = buildActiveSession();
+
+      const result = completeSession(session, { now: NOW + 13 });
+
+      expect(result.status).toBe('completed');
+      expect(result.updatedAt).toBe(NOW + 13);
+    });
+
+    it('throws when the session is not active', () => {
+      const paused = pauseSession(buildActiveSession(), CTX);
+      const preflight = startSession(ADDRESS, makeLegs(1), CTX);
+
+      expect(() => completeSession(paused, CTX)).toThrow(/paused/);
+      expect(() => completeSession(preflight, CTX)).toThrow(/preflight/);
+    });
+  });
+
+  describe('purity', () => {
+    it('never mutates the input session', () => {
+      const session = buildActiveSession(2);
+      const snapshot = JSON.stringify(session);
+
+      let driven = advanceLeg(session, 0, 'confirmed');
+      driven = retryLeg(advanceLeg(driven, 1, 'failed'), 1, CTX);
+      pauseSession(driven, CTX);
+
+      expect(JSON.stringify(session)).toBe(snapshot);
+      expect(driven).not.toBe(session);
+      expect(driven.legs[0]).not.toBe(session.legs[0]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Persistent `fundingSessions` state machine for the perps composed funding flow (mobile consumer: metamask-mobile feat/perps-composed-funding-flow, tasks B0–B11).

- **A1** `types/FundingSession.ts` — FundingSession/FundingLeg contracts (capability-tagged legs: requiresDeviceSignature/silent — silent-for-software by construction, D9), `fundingSessions: FundingSession[]` persistent state slice
- **A2** pure transition guards (`services/fundingSessionTransitions`) — forward-only per leg, confirmed legs never re-run, guarded retryLeg (failed + retryable + predecessors confirmed), pause/resume/complete, updatedAt stamping
- **A3** controller actions wrapping A2 + pruning (keep ≤20 terminal, oldest-first, never non-terminal) — method surface is the mobile contract: startFundingSession / markPreflightPassed / failPreflight / legAwaitingSignature / legSubmitted / legConfirmed / legFailed / retryLeg / pauseSession / resumeSession / completeSession
- **A4** deposit-leg linkage: `DepositWithConfirmationParams.fundingSessionId?` — success/cancel/failure map onto the session's deposit leg (idempotent via guard-throw catch+log; absent id = byte-identical legacy behavior)

Design: metamask-mobile docs/perps/perps-composed-funding-flow-design.md (D4/D7/D8/D11 locked).

## Test plan
- Full package suite: 2,872 passed / 40 skipped / 0 failed (79 suites); lint:tsc PASS; eslint + prettier clean
- New coverage: 2 state tests (A1), 27 guard tests (A2), 28 action tests incl. adversarial pruning + unknown-id table (A3), 7 linkage tests incl. duplicate-success no-crash + backward-compat (A4)

## Notes for reviewers
- Persistence is metadata-driven (no migration framework exists in the package; none invented)
- Known tolerance: TS2589 at PerpsController.ts:2577 (pre-existing method-body instantiation depth, surfaces via downstream overlay builds only)
- Hardening note for future callers: a non-retryable leg failure leaves the session active (only failPreflight sets session-level failed); current mobile callers always emit retryable=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking controller state shape and hooks into deposit lifecycle, though session updates are isolated and failures are swallowed so deposits should not regress.
> 
> **Overview**
> Introduces a **breaking** persisted `fundingSessions` slice on `PerpsControllerState` (default `[]`) plus exported `FundingSession` / `FundingLeg` types for tracking multi-step composed funding (swap → bridge → deposit) without holding funds.
> 
> Adds pure transition guards in `fundingSessionTransitions.ts` and `PerpsController` APIs to start sessions, move legs through signature/submit/confirm/fail/retry, pause/resume, complete, and fail preflight, with automatic pruning of terminal sessions (keep ≤20, oldest `updatedAt` first).
> 
> Optional `fundingSessionId` on `depositWithConfirmation` links deposit success/cancel/failure to the session’s deposit leg and `depositRequestId`; bookkeeping errors are caught so the deposit path behaves like before when the id is omitted or invalid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d12df960316024514dcc50cb486c0ab33ff84042. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->