### PR TITLE
ci: disable fail-fast on lint-build-test matrix jobs

### DIFF
--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -78,6 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: prepare
     strategy:
+      fail-fast: false
       matrix:
         node-version: [24.x]
         script:
@@ -152,6 +153,7 @@ jobs:
     if: needs.prepare.outputs.package-names != '[]'
     needs: prepare
     strategy:
+      fail-fast: false
       matrix:
         node-version: [24.x]
         package-name: ${{ fromJson(needs.prepare.outputs.package-names) }}
@@ -273,6 +275,7 @@ jobs:
     if: needs.prepare.outputs.package-names != '[]'
     needs: prepare
     strategy:
+      fail-fast: false
       matrix:
         package-name: ${{ fromJson(needs.prepare.outputs.package-names) }}
     steps:
@@ -299,6 +302,7 @@ jobs:
     if: needs.prepare.outputs.package-names != '[]'
     needs: prepare
     strategy:
+      fail-fast: false
       matrix:
         package-name: ${{ fromJson(needs.prepare.outputs.package-names) }}
     steps:

--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -329,6 +329,7 @@ jobs:
     if: needs.prepare.outputs.package-names != '[]'
     needs: prepare
     strategy:
+      fail-fast: false
       matrix:
         package-name: ${{ fromJson(needs.prepare.outputs.package-names) }}
     steps:
@@ -375,6 +376,7 @@ jobs:
     if: contains(fromJson(needs.prepare.outputs.package-names), '@metamask/wallet-cli')
     needs: prepare
     strategy:
+      fail-fast: false
       matrix:
         node-version: [20.x, 22.x, 24.x]
     steps:


### PR DESCRIPTION
## Explanation

Currently, the lint, build, and test matrix jobs in `lint-build-test.yml` cancel all other in-progress matrix combinations as soon as one fails, because `fail-fast` defaults to `true`. This means a single failing package can hide the results of other packages in the same run, making it harder to see the full picture of what's broken.

This PR sets `fail-fast: false` on all matrix strategies in the workflow, so every matrix combination runs to completion regardless of whether another one fails.

## References

N/A

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only CI behavior change; no application code, security, or release paths affected.
> 
> **Overview**
> Sets **`fail-fast: false`** on matrix strategies in `lint-build-test.yml` so one failing combination no longer cancels the rest of the matrix.
> 
> This applies to **`lint`** (per lint script), **`validate-changelog`** (per package), **`test-18`**, **`test-20`**, and **`test-22`** (per changed workspace package), and **`test-wallet-cli-e2e`** (per Node version). CI runs may take slightly longer when something fails, but PR checks should surface **all** failing lint scripts, changelog validations, and package tests in a single run instead of stopping after the first failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 175ba85db2e118459d1cdc429939d082e5cdab97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->