### PR TITLE
Release/1216.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "1215.0.0",
+  "version": "1216.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {

--- a/packages/ramps-controller/CHANGELOG.md
+++ b/packages/ramps-controller/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [20.2.0]
+
 ### Added
 
 - Add optional `clientProduct` and `clientVersion` constructor options on `RampsService` and `TransakService`, sent on every on-ramp API fetch as `clientProduct` / `clientVersion` query params so the API can evaluate version-gated feature flags per client. Identity travels in the URL (not headers) because the on-ramp CDN cache key is the URL. Also exports the `RampsClientIdentity` type, the `addRampsClientIdentityParams` helper, and the param name constants. ([#9983](https://github.com/MetaMask/core/pull/9983))
@@ -544,7 +546,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add `OnRampService` for interacting with the OnRamp API
   - Add geolocation detection via IP address lookup
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/ramps-controller@20.1.0...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/ramps-controller@20.2.0...HEAD
+[20.2.0]: https://github.com/MetaMask/core/compare/@metamask/ramps-controller@20.1.0...@metamask/ramps-controller@20.2.0
 [20.1.0]: https://github.com/MetaMask/core/compare/@metamask/ramps-controller@20.0.0...@metamask/ramps-controller@20.1.0
 [20.0.0]: https://github.com/MetaMask/core/compare/@metamask/ramps-controller@19.0.0...@metamask/ramps-controller@20.0.0
 [19.0.0]: https://github.com/MetaMask/core/compare/@metamask/ramps-controller@18.0.1...@metamask/ramps-controller@19.0.0

--- a/packages/ramps-controller/package.json
+++ b/packages/ramps-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/ramps-controller",
-  "version": "20.1.0",
+  "version": "20.2.0",
   "description": "A controller for managing cryptocurrency on/off ramps functionality",
   "keywords": [
     "Ethereum",

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -11,9 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/sentinel-api-service` from `^1.0.0` to `^1.0.1` ([#9972](https://github.com/MetaMask/core/pull/9972))
 - Bump `@metamask/remote-feature-flag-controller` from `^6.0.0` to `^6.1.0` ([#9980](https://github.com/MetaMask/core/pull/9980))
-- Bump `@metamask/ramps-controller` from `^20.1.0` to `^20.2.0`
 - Bump `@metamask/ramps-controller` from `^20.0.0` to `^20.1.0` ([#10004](https://github.com/MetaMask/core/pull/10004))
-- Bump `@metamask/ramps-controller` from `^20.1.0` to `^20.2.0`
+- Bump `@metamask/ramps-controller` from `^20.1.0` to `^20.2.0` ([#10005](https://github.com/MetaMask/core/pull/10005))
 
 ## [27.0.0]
 

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -11,7 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/sentinel-api-service` from `^1.0.0` to `^1.0.1` ([#9972](https://github.com/MetaMask/core/pull/9972))
 - Bump `@metamask/remote-feature-flag-controller` from `^6.0.0` to `^6.1.0` ([#9980](https://github.com/MetaMask/core/pull/9980))
+- Bump `@metamask/ramps-controller` from `^20.1.0` to `^20.2.0`
 - Bump `@metamask/ramps-controller` from `^20.0.0` to `^20.1.0` ([#10004](https://github.com/MetaMask/core/pull/10004))
+- Bump `@metamask/ramps-controller` from `^20.1.0` to `^20.2.0`
 
 ## [27.0.0]
 

--- a/packages/transaction-pay-controller/package.json
+++ b/packages/transaction-pay-controller/package.json
@@ -68,7 +68,7 @@
     "@metamask/messenger": "^2.0.0",
     "@metamask/metamask-eth-abis": "^3.1.1",
     "@metamask/network-controller": "^36.0.0",
-    "@metamask/ramps-controller": "^20.1.0",
+    "@metamask/ramps-controller": "^20.2.0",
     "@metamask/remote-feature-flag-controller": "^6.1.0",
     "@metamask/sentinel-api-service": "^1.0.1",
     "@metamask/transaction-controller": "^69.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8673,7 +8673,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/ramps-controller@npm:^20.1.0, @metamask/ramps-controller@workspace:packages/ramps-controller":
+"@metamask/ramps-controller@npm:^20.2.0, @metamask/ramps-controller@workspace:packages/ramps-controller":
   version: 0.0.0-use.local
   resolution: "@metamask/ramps-controller@workspace:packages/ramps-controller"
   dependencies:
@@ -9395,7 +9395,7 @@ __metadata:
     "@metamask/messenger": "npm:^2.0.0"
     "@metamask/metamask-eth-abis": "npm:^3.1.1"
     "@metamask/network-controller": "npm:^36.0.0"
-    "@metamask/ramps-controller": "npm:^20.1.0"
+    "@metamask/ramps-controller": "npm:^20.2.0"
     "@metamask/remote-feature-flag-controller": "npm:^6.1.0"
     "@metamask/sentinel-api-service": "npm:^1.0.1"
     "@metamask/transaction-controller": "npm:^69.6.1"


### PR DESCRIPTION
## Explanation

Releases `@metamask/ramps-controller` 20.1.0 to 20.2.0 so Mobile and Extension can consume the client-identity query params from [#9983](https://github.com/MetaMask/core/pull/9983). The monorepo version goes 1215.0.0 to 1216.0.0.

No other package is being published. `@metamask/transaction-pay-controller` only tightens its workspace range to `^20.2.0` (same pattern as [Release/1215.0.0](https://github.com/MetaMask/core/pull/10004)). Unreleased deps of ramps-controller (`base-controller`, `controller-utils`, `messenger`, `profile-sync-controller`) are intentionally skipped — this release does not rely on those unreleased changes.

The bump is **minor**. The new section is additive and nothing in it is marked `**BREAKING:**`:

- **Added** optional `clientProduct` and `clientVersion` constructor options on `RampsService` and `TransakService`, sent as `clientProduct` / `clientVersion` query params on every on-ramp API fetch so the API can evaluate version-gated feature flags per client. Identity travels in the URL (not headers) because the on-ramp CDN cache key is the URL. Also exports `RampsClientIdentity`, `addRampsClientIdentityParams`, and the param name constants ([#9983](https://github.com/MetaMask/core/pull/9983)).

Jira: [TRAM-3828](https://consensyssoftware.atlassian.net/browse/TRAM-3828)

## Changelog

Updated `packages/ramps-controller/CHANGELOG.md` (Unreleased → 20.2.0) and recorded the workspace bump in `packages/transaction-pay-controller/CHANGELOG.md`.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by updating changelogs for packages I've changed
- [x] No breaking changes introduced


Made with [Cursor](https://cursor.com)

[TRAM-3828]: https://consensyssoftware.atlassian.net/browse/TRAM-3828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ