### PR TITLE
test(sample-controllers): demonstrate messenger interactions

### DIFF
--- a/packages/sample-controllers/src/sample-gas-prices-controller.test.ts
+++ b/packages/sample-controllers/src/sample-gas-prices-controller.test.ts
@@ -335,6 +335,28 @@ describe('SampleGasPricesController', () => {
         });
       });
     });
+
+    it('calls the gas prices service through the messenger', async () => {
+      await withController(async ({ controller, rootMessenger, messenger }) => {
+        const chainId = '0x42';
+        rootMessenger.registerActionHandler(
+          'SampleGasPricesService:fetchGasPrices',
+          async () => ({
+            low: 5,
+            average: 10,
+            high: 15,
+          }),
+        );
+        const messengerCall = jest.spyOn(messenger, 'call');
+
+        await controller.updateGasPrices({ chainId });
+
+        expect(messengerCall).toHaveBeenCalledWith(
+          'SampleGasPricesService:fetchGasPrices',
+          chainId,
+        );
+      });
+    });
   });
 
   describe('metadata', () => {

--- a/packages/sample-controllers/src/sample-petnames-controller.test.ts
+++ b/packages/sample-controllers/src/sample-petnames-controller.test.ts
@@ -190,6 +190,28 @@ describe('SamplePetnamesController', () => {
         },
       );
     });
+
+    it('publishes state changes through the messenger', async () => {
+      await withController(({ controller, controllerMessenger }) => {
+        const stateChangeListener = jest.fn();
+        controllerMessenger.subscribe(
+          // eslint-disable-next-line no-restricted-syntax
+          'SamplePetnamesController:stateChange',
+          stateChangeListener,
+        );
+
+        controller.assignPetname('0x1', '0xAAAAAA', 'Account 1');
+
+        expect(stateChangeListener).toHaveBeenCalledTimes(1);
+        expect(stateChangeListener.mock.calls[0][0]).toStrictEqual({
+          namesByChainIdAndAddress: {
+            '0x1': {
+              '0xaaaaaa': 'Account 1',
+            },
+          },
+        });
+      });
+    });
   });
 
   describe('metadata', () => {


### PR DESCRIPTION
## Explanation

Adds focused examples to the sample controller tests showing how to:

- spy on a controller messenger and assert an external action call
- subscribe to a controller event and assert the published state

This keeps production behavior unchanged and addresses #6766.

## References

Fixes #6766

## Changelog

No changelog entry is needed because this only changes test examples.

## Checklist

- [x] Focused sample-controller tests pass (28 tests)
- [x] Modified files pass ESLint and oxfmt checks
- [x] The monorepo and sample-controller package build successfully

## Test commands

- `corepack yarn workspace @metamask/sample-controllers run jest --no-coverage packages/sample-controllers/src/sample-gas-prices-controller.test.ts packages/sample-controllers/src/sample-petnames-controller.test.ts`
- `corepack yarn eslint packages/sample-controllers/src/sample-gas-prices-controller.test.ts packages/sample-controllers/src/sample-petnames-controller.test.ts`
- `corepack yarn oxfmt --check packages/sample-controllers/src/sample-gas-prices-controller.test.ts packages/sample-controllers/src/sample-petnames-controller.test.ts`
- `corepack yarn build`

Made with [Cursor](https://cursor.com)