### PR TITLE
docs(perps-controller): describe package capabilities

### DIFF
--- a/packages/perps-controller/README.md
+++ b/packages/perps-controller/README.md
@@ -12,22 +12,42 @@ or
 
 ## Usage
 
+`PerpsController` provides a provider-agnostic API for perpetual trading. It
+normalizes market data, account state, trading, funding, transfers, risk
+calculations, and live subscriptions across enabled providers.
+
+Applications construct the controller with a messenger and their
+platform-specific dependencies:
+
 ```typescript
-import { PerpsController } from '@metamask/perps-controller';
+import {
+  PerpsController,
+  type PerpsControllerOptions,
+} from '@metamask/perps-controller';
+
+export async function createPerpsController(
+  options: PerpsControllerOptions,
+): Promise<PerpsController> {
+  const controller = new PerpsController(options);
+  await controller.init();
+  return controller;
+}
 ```
 
-Chase orders are client-managed post-only strategies. Use
-`controller.getChaseOrders()` to read retained lifecycle snapshots and
-`controller.suspendChaseOrders()` when the creating client leaves the
-foreground; suspension stops repricing while leaving the latest child order
-resting. Cancel a Chase through `cancelOrder` with its stable strategy handle
-and `orderType: 'chase'`. When using an aggregated provider, also pass the
-`providerId` returned with the Chase snapshot so cancellation routes to its
-owning venue. `chaseMaxDistanceBps` caps adverse movement from the arrival
-price and must be greater than 0 and less than 10,000. The stop follows the
-live touch; the final resting child can sit just inside the boundary after
-venue price-grid rounding, and `distanceChasedBps` reports that actual resting
-distance rounded to the nearest whole basis point.
+The controller registers its public operations as `PerpsController:*`
+messenger actions, and clients can call the same methods directly. Its main
+capabilities are:
+
+- Provider and network lifecycle management.
+- Normalized market, account, position, order, and history reads.
+- Trading, position, margin, deposit, and withdrawal operations with
+  preflight validation and risk calculations.
+- Callback-based live prices, positions, orders, fills, order books, and
+  candles. Each subscription returns an unsubscribe function.
+
+The package exports the controller's parameter, result, provider, and
+messenger types for client integrations. Provider availability and aggregated
+routing are controlled by client configuration and feature flags.
 
 ## Contributing
 


### PR DESCRIPTION
## Explanation

The package README presented Chase-order details as the entire usage guide. Replace that feature-specific section with a concise overview of the controller contract, construction, generic capability groups, exported integration types, and provider routing.

This changes documentation only. It does not change runtime behavior or public types.

## References

- Follow-up documentation cleanup after #9961
- The README was originally scaffolded in #7654

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate. No test changes are needed for this documentation-only PR.
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate.
- [x] I've communicated my changes to consumers by updating changelogs for packages I've changed. This PR uses `no-changelog` because it only corrects package documentation.
- [x] I've introduced breaking changes in this PR and have prepared draft pull requests for clients and consumer packages to resolve them. Not applicable: this PR has no runtime or API changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README change with no runtime, API, or type changes.
> 
> **Overview**
> The **Usage** section no longer treats Chase orders as the whole integration story. It now describes `PerpsController` as a provider-agnostic perpetuals API, shows construction via `PerpsControllerOptions` and `await controller.init()`, and summarizes capability areas (lifecycle, normalized reads, trading/risk ops, live subscriptions with unsubscribe).
> 
> The doc also notes **`PerpsController:*` messenger actions**, exported integration types, and that provider routing comes from client config and feature flags. Detailed Chase lifecycle, suspension, cancellation, and `chaseMaxDistanceBps` behavior is **removed from the README** (the APIs remain in the package).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ad22223eacec8b917380886a9ef2fb6a328024d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->