### PR TITLE
feat(ai-controllers): make AiDigestController a cache-free passthrough

### DIFF
--- a/packages/ai-controllers/CHANGELOG.md
+++ b/packages/ai-controllers/CHANGELOG.md
@@ -9,14 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** `AiDigestController` no longer caches `fetchMarketInsights` or `fetchMarketOverview` results (no TTL, eviction, or persisted `marketInsights` / `marketOverview` state). Each call is a passthrough to `AiDigestService`. Clients must own freshness.
+- **BREAKING:** `AiDigestController` no longer caches `fetchMarketInsights` or `fetchMarketOverview` results (no TTL, eviction, or persisted `marketInsights` / `marketOverview` state). Each call is a passthrough to `AiDigestService`. Clients must own freshness. ([#10020](https://github.com/MetaMask/core/pull/10020))
   - `AiDigestControllerState` is now an empty object (`Record<string, never>`).
   - The constructor no longer accepts a `state` option.
 - Bump `@metamask/superstruct` from `^3.1.0` to `^3.4.1` ([#9754](https://github.com/MetaMask/core/pull/9754))
 
 ### Removed
 
-- **BREAKING:** Remove `MarketInsightsEntry`, `MarketOverviewEntry`, `CACHE_DURATION_MS`, and `MAX_CACHE_ENTRIES`. Cache policy belongs to clients.
+- **BREAKING:** Remove `MarketInsightsEntry`, `MarketOverviewEntry`, `CACHE_DURATION_MS`, and `MAX_CACHE_ENTRIES`. Cache policy belongs to clients. ([#10020](https://github.com/MetaMask/core/pull/10020))
 
 ## [0.8.0]
 

--- a/packages/ai-controllers/CHANGELOG.md
+++ b/packages/ai-controllers/CHANGELOG.md
@@ -9,7 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING:** `AiDigestController` no longer caches `fetchMarketInsights` or `fetchMarketOverview` results (no TTL, eviction, or persisted `marketInsights` / `marketOverview` state). Each call is a passthrough to `AiDigestService`. Clients must own freshness.
+  - `AiDigestControllerState` is now an empty object (`Record<string, never>`).
+  - The constructor no longer accepts a `state` option.
 - Bump `@metamask/superstruct` from `^3.1.0` to `^3.4.1` ([#9754](https://github.com/MetaMask/core/pull/9754))
+
+### Removed
+
+- **BREAKING:** Remove `MarketInsightsEntry`, `MarketOverviewEntry`, `CACHE_DURATION_MS`, and `MAX_CACHE_ENTRIES`. Cache policy belongs to clients.
 
 ## [0.8.0]
 

--- a/packages/ai-controllers/src/AiDigestController-method-action-types.ts
+++ b/packages/ai-controllers/src/AiDigestController-method-action-types.ts
@@ -7,11 +7,10 @@ import type { AiDigestController } from './AiDigestController.js';
 
 /**
  * Fetches market insights for a given asset identifier.
- * Passthrough to the digest service; clients own freshness.
  *
  * Accepts either a CAIP-19 asset type (e.g. `eip155:1/slip44:60`) or a perps
  * market symbol (e.g. `ETH`). The service handles choosing the correct API
- * query parameter automatically.
+ * query parameter automatically. Clients own freshness/caching.
  *
  * @param assetIdentifier - The asset identifier (CAIP-19 ID or perps market symbol).
  * @returns The market insights report, or `null` if none exists.
@@ -23,7 +22,8 @@ export type AiDigestControllerFetchMarketInsightsAction = {
 
 /**
  * Fetches the market overview report.
- * Passthrough to the digest service; clients own freshness.
+ *
+ * Clients own freshness/caching.
  *
  * @returns The market overview report, or `null` if none exists.
  */

--- a/packages/ai-controllers/src/AiDigestController-method-action-types.ts
+++ b/packages/ai-controllers/src/AiDigestController-method-action-types.ts
@@ -7,7 +7,7 @@ import type { AiDigestController } from './AiDigestController.js';
 
 /**
  * Fetches market insights for a given asset identifier.
- * Returns cached data if still fresh, otherwise calls the service.
+ * Passthrough to the digest service; clients own freshness.
  *
  * Accepts either a CAIP-19 asset type (e.g. `eip155:1/slip44:60`) or a perps
  * market symbol (e.g. `ETH`). The service handles choosing the correct API
@@ -23,7 +23,7 @@ export type AiDigestControllerFetchMarketInsightsAction = {
 
 /**
  * Fetches the market overview report.
- * Returns cached data if still fresh, otherwise calls the service.
+ * Passthrough to the digest service; clients own freshness.
  *
  * @returns The market overview report, or `null` if none exists.
  */

--- a/packages/ai-controllers/src/AiDigestController.test.ts
+++ b/packages/ai-controllers/src/AiDigestController.test.ts
@@ -4,8 +4,6 @@ import {
   AiDigestController,
   getDefaultAiDigestControllerState,
   AiDigestControllerErrorMessage,
-  CACHE_DURATION_MS,
-  MAX_CACHE_ENTRIES,
 } from './index.js';
 import type {
   AiDigestControllerMessenger,
@@ -16,6 +14,7 @@ import type {
 } from './index.js';
 
 const mockReport: MarketInsightsReport = {
+  digestId: 'digest-1',
   version: '1.0',
   asset: 'btc',
   generatedAt: '2026-02-11T10:32:52.403Z',
@@ -59,16 +58,8 @@ const createService = (overrides?: Partial<DigestService>): DigestService => ({
 });
 
 describe('AiDigestController (market insights)', () => {
-  it('returns default state', () => {
-    expect(getDefaultAiDigestControllerState()).toStrictEqual({
-      marketInsights: {},
-      marketOverview: null,
-    });
-  });
-
-  it('uses expected cache constants', () => {
-    expect(CACHE_DURATION_MS).toBe(10 * 60 * 1000);
-    expect(MAX_CACHE_ENTRIES).toBe(50);
+  it('returns default empty state', () => {
+    expect(getDefaultAiDigestControllerState()).toStrictEqual({});
   });
 
   it('registers fetch action on messenger', async () => {
@@ -82,10 +73,10 @@ describe('AiDigestController (market insights)', () => {
     );
 
     expect(result).toStrictEqual(mockReport);
-    expect(controller.state.marketInsights['eip155:1/slip44:0']).toBeDefined();
+    expect(controller.state).toStrictEqual({});
   });
 
-  it('caches successful response and returns cache while fresh', async () => {
+  it('does not cache; each call hits the service', async () => {
     const digestService = createService();
     const controller = new AiDigestController({
       messenger: createMessenger(),
@@ -93,25 +84,9 @@ describe('AiDigestController (market insights)', () => {
     });
 
     await controller.fetchMarketInsights('eip155:1/slip44:0');
-    await controller.fetchMarketInsights('eip155:1/slip44:0');
-
-    expect(digestService.searchDigest).toHaveBeenCalledTimes(1);
-  });
-
-  it('refetches after cache expiration', async () => {
-    jest.useFakeTimers();
-    const digestService = createService();
-    const controller = new AiDigestController({
-      messenger: createMessenger(),
-      digestService,
-    });
-
-    await controller.fetchMarketInsights('eip155:1/slip44:0');
-    jest.advanceTimersByTime(CACHE_DURATION_MS + 1);
     await controller.fetchMarketInsights('eip155:1/slip44:0');
 
     expect(digestService.searchDigest).toHaveBeenCalledTimes(2);
-    jest.useRealTimers();
   });
 
   it('throws for empty asset identifier', async () => {
@@ -139,10 +114,9 @@ describe('AiDigestController (market insights)', () => {
 
     expect(result).toStrictEqual(mockReport);
     expect(digestService.searchDigest).toHaveBeenCalledWith(perpsSymbol);
-    expect(controller.state.marketInsights[perpsSymbol]).toBeDefined();
   });
 
-  it('caches perps and CAIP-19 identifiers independently', async () => {
+  it('treats perps and CAIP-19 identifiers as independent service calls', async () => {
     const digestService = createService();
     const controller = new AiDigestController({
       messenger: createMessenger(),
@@ -155,57 +129,22 @@ describe('AiDigestController (market insights)', () => {
     await controller.fetchMarketInsights(caip19Id);
 
     expect(digestService.searchDigest).toHaveBeenCalledTimes(2);
-    expect(controller.state.marketInsights[perpsSymbol]).toBeDefined();
-    expect(controller.state.marketInsights[caip19Id]).toBeDefined();
+    expect(digestService.searchDigest).toHaveBeenNthCalledWith(1, perpsSymbol);
+    expect(digestService.searchDigest).toHaveBeenNthCalledWith(2, caip19Id);
   });
 
-  it('removes stale entry when service returns null', async () => {
-    const digestService = createService();
+  it('returns null when the service returns null', async () => {
+    const digestService = createService({
+      searchDigest: jest.fn().mockResolvedValue(null),
+    });
     const controller = new AiDigestController({
       messenger: createMessenger(),
       digestService,
     });
 
-    await controller.fetchMarketInsights('eip155:1/slip44:0');
-    (digestService.searchDigest as jest.Mock).mockResolvedValue(null);
-    jest.useFakeTimers();
-    jest.advanceTimersByTime(CACHE_DURATION_MS + 1);
     const result = await controller.fetchMarketInsights('eip155:1/slip44:0');
-    jest.useRealTimers();
 
     expect(result).toBeNull();
-    expect(
-      controller.state.marketInsights['eip155:1/slip44:0'],
-    ).toBeUndefined();
-  });
-
-  it('evicts stale and oldest entries', async () => {
-    jest.useFakeTimers();
-    const digestService = createService();
-    const controller = new AiDigestController({
-      messenger: createMessenger(),
-      digestService,
-    });
-
-    await controller.fetchMarketInsights('eip155:1/slip44:1');
-    jest.advanceTimersByTime(CACHE_DURATION_MS + 1);
-    await controller.fetchMarketInsights('eip155:1/slip44:2');
-    expect(
-      controller.state.marketInsights['eip155:1/slip44:1'],
-    ).toBeUndefined();
-
-    for (let i = 0; i < MAX_CACHE_ENTRIES + 1; i++) {
-      await controller.fetchMarketInsights(`eip155:1/slip44:${100 + i}`);
-      jest.advanceTimersByTime(1);
-    }
-
-    expect(Object.keys(controller.state.marketInsights)).toHaveLength(
-      MAX_CACHE_ENTRIES,
-    );
-    expect(
-      controller.state.marketInsights['eip155:1/slip44:100'],
-    ).toBeUndefined();
-    jest.useRealTimers();
   });
 });
 
@@ -220,10 +159,10 @@ describe('AiDigestController (market overview)', () => {
     );
 
     expect(result).toStrictEqual(mockOverview);
-    expect(controller.state.marketOverview?.data).toStrictEqual(mockOverview);
+    expect(controller.state).toStrictEqual({});
   });
 
-  it('persists fetched overview in state', async () => {
+  it('does not cache; each call hits the service', async () => {
     const digestService = createService();
     const controller = new AiDigestController({
       messenger: createMessenger(),
@@ -231,40 +170,12 @@ describe('AiDigestController (market overview)', () => {
     });
 
     await controller.fetchMarketOverview();
-
-    expect(controller.state.marketOverview?.data).toStrictEqual(mockOverview);
-  });
-
-  it('caches successful response and returns cache while fresh', async () => {
-    const digestService = createService();
-    const controller = new AiDigestController({
-      messenger: createMessenger(),
-      digestService,
-    });
-
-    await controller.fetchMarketOverview();
-    await controller.fetchMarketOverview();
-
-    expect(digestService.fetchMarketOverview).toHaveBeenCalledTimes(1);
-  });
-
-  it('refetches after cache expiration', async () => {
-    jest.useFakeTimers();
-    const digestService = createService();
-    const controller = new AiDigestController({
-      messenger: createMessenger(),
-      digestService,
-    });
-
-    await controller.fetchMarketOverview();
-    jest.advanceTimersByTime(CACHE_DURATION_MS + 1);
     await controller.fetchMarketOverview();
 
     expect(digestService.fetchMarketOverview).toHaveBeenCalledTimes(2);
-    jest.useRealTimers();
   });
 
-  it('clears state and returns null when service returns null', async () => {
+  it('returns null when the service returns null', async () => {
     const digestService = createService({
       fetchMarketOverview: jest.fn().mockResolvedValue(null),
     });
@@ -276,7 +187,6 @@ describe('AiDigestController (market overview)', () => {
     const result = await controller.fetchMarketOverview();
 
     expect(result).toBeNull();
-    expect(controller.state.marketOverview).toBeNull();
   });
 });
 
@@ -295,11 +205,7 @@ describe('AiDigestController (front page)', () => {
     expect(digestService.fetchFrontPageItem).toHaveBeenCalledWith(
       mockFrontPage.id,
     );
-    // The front page is not cached, so controller state is left untouched.
-    expect(controller.state).toStrictEqual({
-      marketInsights: {},
-      marketOverview: null,
-    });
+    expect(controller.state).toStrictEqual({});
   });
 
   it('delegates to the service and returns the front page', async () => {

--- a/packages/ai-controllers/src/AiDigestController.ts
+++ b/packages/ai-controllers/src/AiDigestController.ts
@@ -9,16 +9,12 @@ import type { Messenger } from '@metamask/messenger';
 import {
   AiDigestControllerErrorMessage,
   controllerName,
-  CACHE_DURATION_MS,
-  MAX_CACHE_ENTRIES,
 } from './ai-digest-constants.js';
 import type {
   AiDigestControllerState,
   DigestService,
   MarketInsightsReport,
-  MarketInsightsEntry,
   MarketOverview,
-  MarketOverviewEntry,
   MarketOverviewFrontPage,
 } from './ai-digest-types.js';
 import type { AiDigestControllerMethodActions } from './AiDigestController-method-action-types.js';
@@ -47,31 +43,14 @@ export type AiDigestControllerMessenger = Messenger<
 
 export type AiDigestControllerOptions = {
   messenger: AiDigestControllerMessenger;
-  state?: Partial<AiDigestControllerState>;
   digestService: DigestService;
 };
 
 export function getDefaultAiDigestControllerState(): AiDigestControllerState {
-  return {
-    marketInsights: {},
-    marketOverview: null,
-  };
+  return {};
 }
 
-const aiDigestControllerMetadata: StateMetadata<AiDigestControllerState> = {
-  marketInsights: {
-    persist: true,
-    includeInDebugSnapshot: true,
-    includeInStateLogs: true,
-    usedInUi: true,
-  },
-  marketOverview: {
-    persist: true,
-    includeInDebugSnapshot: true,
-    includeInStateLogs: true,
-    usedInUi: true,
-  },
-};
+const aiDigestControllerMetadata: StateMetadata<AiDigestControllerState> = {};
 
 const MESSENGER_EXPOSED_METHODS = [
   'fetchMarketInsights',
@@ -86,14 +65,11 @@ export class AiDigestController extends BaseController<
 > {
   readonly #digestService: DigestService;
 
-  constructor({ messenger, state, digestService }: AiDigestControllerOptions) {
+  constructor({ messenger, digestService }: AiDigestControllerOptions) {
     super({
       name: controllerName,
       metadata: aiDigestControllerMetadata,
-      state: {
-        ...getDefaultAiDigestControllerState(),
-        ...state,
-      },
+      state: getDefaultAiDigestControllerState(),
       messenger,
     });
 
@@ -106,11 +82,10 @@ export class AiDigestController extends BaseController<
 
   /**
    * Fetches market insights for a given asset identifier.
-   * Returns cached data if still fresh, otherwise calls the service.
    *
    * Accepts either a CAIP-19 asset type (e.g. `eip155:1/slip44:60`) or a perps
    * market symbol (e.g. `ETH`). The service handles choosing the correct API
-   * query parameter automatically.
+   * query parameter automatically. Clients own freshness/caching.
    *
    * @param assetIdentifier - The asset identifier (CAIP-19 ID or perps market symbol).
    * @returns The market insights report, or `null` if none exists.
@@ -122,72 +97,18 @@ export class AiDigestController extends BaseController<
       throw new Error(AiDigestControllerErrorMessage.INVALID_ASSET_IDENTIFIER);
     }
 
-    const existing = this.state.marketInsights[assetIdentifier];
-    if (existing) {
-      const age = Date.now() - existing.fetchedAt;
-      if (age < CACHE_DURATION_MS) {
-        return existing.data;
-      }
-    }
-
-    const data = await this.#digestService.searchDigest(assetIdentifier);
-
-    if (data === null) {
-      // No insights available for this asset — clear any stale cache entry
-      this.update((state) => {
-        delete state.marketInsights[assetIdentifier];
-      });
-      return null;
-    }
-
-    const entry: MarketInsightsEntry = {
-      assetIdentifier,
-      fetchedAt: Date.now(),
-      data,
-    };
-
-    this.update((state) => {
-      state.marketInsights[assetIdentifier] = entry;
-      this.#evictStaleCachedEntries(state.marketInsights);
-    });
-
-    return data;
+    return this.#digestService.searchDigest(assetIdentifier);
   }
 
   /**
    * Fetches the market overview report.
-   * Returns cached data if still fresh, otherwise calls the service.
+   *
+   * Clients own freshness/caching.
    *
    * @returns The market overview report, or `null` if none exists.
    */
   async fetchMarketOverview(): Promise<MarketOverview | null> {
-    const existing = this.state.marketOverview;
-    if (existing) {
-      const age = Date.now() - existing.fetchedAt;
-      if (age < CACHE_DURATION_MS) {
-        return existing.data;
-      }
-    }
-
-    const data = await this.#digestService.fetchMarketOverview();
-
-    if (data === null) {
-      this.update((state) => {
-        state.marketOverview = null;
-      });
-      return null;
-    }
-
-    const entry: MarketOverviewEntry = {
-      fetchedAt: Date.now(),
-      data,
-    };
-
-    this.update((state) => {
-      state.marketOverview = entry;
-    });
-
-    return data;
+    return this.#digestService.fetchMarketOverview();
   }
 
   /**
@@ -208,39 +129,5 @@ export class AiDigestController extends BaseController<
     }
 
     return this.#digestService.fetchFrontPageItem(id);
-  }
-
-  /**
-   * Evicts stale (TTL expired) and oldest entries (FIFO) if cache exceeds max size.
-   *
-   * @param cache - The cache record to evict entries from.
-   */
-  #evictStaleCachedEntries<EntryType extends { fetchedAt: number }>(
-    cache: Record<string, EntryType>,
-  ): void {
-    const now = Date.now();
-    const entries = Object.entries(cache);
-    const keysToDelete: string[] = [];
-    const freshEntries: [string, EntryType][] = [];
-
-    for (const [key, entry] of entries) {
-      if (now - entry.fetchedAt >= CACHE_DURATION_MS) {
-        keysToDelete.push(key);
-      } else {
-        freshEntries.push([key, entry]);
-      }
-    }
-
-    if (freshEntries.length > MAX_CACHE_ENTRIES) {
-      freshEntries.sort((a, b) => a[1].fetchedAt - b[1].fetchedAt);
-      const entriesToRemove = freshEntries.length - MAX_CACHE_ENTRIES;
-      for (let i = 0; i < entriesToRemove; i++) {
-        keysToDelete.push(freshEntries[i][0]);
-      }
-    }
-
-    for (const key of keysToDelete) {
-      delete cache[key];
-    }
   }
 }

--- a/packages/ai-controllers/src/ai-digest-constants.ts
+++ b/packages/ai-controllers/src/ai-digest-constants.ts
@@ -1,9 +1,5 @@
 export const controllerName = 'AiDigestController';
 
-export const CACHE_DURATION_MS = 10 * 60 * 1000; // 10 minutes
-
-export const MAX_CACHE_ENTRIES = 50;
-
 export const AiDigestControllerErrorMessage = {
   API_REQUEST_FAILED: 'API request failed',
   API_INVALID_RESPONSE: 'API returned invalid response',

--- a/packages/ai-controllers/src/ai-digest-types.ts
+++ b/packages/ai-controllers/src/ai-digest-types.ts
@@ -101,28 +101,6 @@ export type MarketInsightsReport = {
   metadata?: AIResponseMetadata[];
 };
 
-/**
- * A cached market insights entry.
- */
-export type MarketInsightsEntry = {
-  /** Asset identifier — either a CAIP-19 ID (e.g. "eip155:1/slip44:60") or a perps market symbol (e.g. "ETH") */
-  assetIdentifier: string;
-  /** Timestamp when the entry was fetched */
-  fetchedAt: number;
-  /** The market insights report data */
-  data: MarketInsightsReport;
-};
-
-/**
- * A cached market overview entry.
- */
-export type MarketOverviewEntry = {
-  /** Timestamp when the entry was fetched */
-  fetchedAt: number;
-  /** The market overview data */
-  data: MarketOverview;
-};
-
 // ---------------------------------------------------------------------------
 // Market Overview types (non-asset-specific)
 // ---------------------------------------------------------------------------
@@ -219,10 +197,11 @@ export type MarketOverviewFrontPage = {
 // Controller state
 // ---------------------------------------------------------------------------
 
-export type AiDigestControllerState = {
-  marketInsights: Record<string, MarketInsightsEntry>;
-  marketOverview: MarketOverviewEntry | null;
-};
+/**
+ * AiDigestController has no persisted cache. Digest freshness is owned by
+ * clients (e.g. React Query).
+ */
+export type AiDigestControllerState = Record<string, never>;
 
 // ---------------------------------------------------------------------------
 // Service interface

--- a/packages/ai-controllers/src/index.ts
+++ b/packages/ai-controllers/src/index.ts
@@ -25,13 +25,11 @@ export type {
   Article,
   DigestService,
   MarketInsightsArticle,
-  MarketInsightsEntry,
   MarketInsightsReport,
   MarketInsightsSource,
   MarketInsightsTrend,
   MarketInsightsTweet,
   MarketOverview,
-  MarketOverviewEntry,
   MarketOverviewFrontPage,
   MarketOverviewItem,
   MarketOverviewTrend,
@@ -42,7 +40,5 @@ export type {
 
 export {
   controllerName as aiDigestControllerName,
-  CACHE_DURATION_MS,
-  MAX_CACHE_ENTRIES,
   AiDigestControllerErrorMessage,
 } from './ai-digest-constants.js';


### PR DESCRIPTION
## Explanation

`AiDigestController` currently owns a persisted 10-minute TTL cache for market insights and market overview. Mobile What's Happening and Market Insights already coordinate requests with React Query, so freshness lived in two places and was hard to debug.

This PR makes the controller a passthrough to `AiDigestService`: validate args, call the service, return. No `fetchedAt`, TTL, eviction, or persisted digest payloads. `fetchFrontPageItem` was already uncached.

**BREAKING** for `@metamask/ai-controllers`:
- `AiDigestControllerState` is now an empty object (`Record<string, never>`).
- The constructor no longer accepts a `state` option.
- Removed public exports `MarketInsightsEntry`, `MarketOverviewEntry`, `CACHE_DURATION_MS`, and `MAX_CACHE_ENTRIES`.
- `fetchMarketInsights` / `fetchMarketOverview` always hit the service; clients must own freshness.

## References

NA

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

[TSA-1055]: https://consensyssoftware.atlassian.net/browse/TSA-1055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking API and state shape changes require consumer updates; behavior change means more network calls unless clients already cache, but no auth or payment logic is touched.
> 
> **Overview**
> **BREAKING:** `AiDigestController` no longer caches or persists market insights or market overview. `fetchMarketInsights` and `fetchMarketOverview` validate inputs and delegate straight to `AiDigestService` on every call; freshness is the client’s responsibility (e.g. React Query).
> 
> Controller state is now an empty object (`Record<string, never>`), the constructor drops the optional `state` argument, and persisted state metadata for `marketInsights` / `marketOverview` is removed. Public exports `MarketInsightsEntry`, `MarketOverviewEntry`, `CACHE_DURATION_MS`, and `MAX_CACHE_ENTRIES` are deleted along with TTL/FIFO eviction logic. Docs, generated action JSDoc, changelog, and tests are updated to match passthrough behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d769537191f372b6598c16db6da569f4ee744a18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->