### PR TITLE
feat(ramps-controller): add NeoBankService and wallet registration HTTP client

### DIFF
--- a/packages/ramps-controller/CHANGELOG.md
+++ b/packages/ramps-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `NeoBankService` for MetaMask Ramp API neo-bank-proxy endpoints under the `/neobank` prefix on the Ramp API host, including messenger actions for `getAutoramp`, `registerPixAddress`, `getAutorampQuote`, `createAutoramp`, `getAutorampQuoteForAutoramp`, `attachAutorampQuote`, `getCustomerByExternalId`, `getMoonpayCustomerId`, `getWalletRegistrationStatus`, and `registerSelfHostedWallet`. Mutating POSTs do not retry (to avoid duplicate Pix/autoramp creates without a stable `Idempotency-Key`); GETs still retry 429/5xx/network errors. Optional `Idempotency-Key` is forwarded when callers supply one. Also exports `mapNeoBankAutorampToRemoteSnapshot`, `AutorampRemoteSnapshot`, and wallet-registration HTTP types (`WalletRegistrationError`, `RegistrationStatus`, `RegistrationOutcome`).
+
 ## [20.2.0]
 
 ### Added

--- a/packages/ramps-controller/CHANGELOG.md
+++ b/packages/ramps-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `NeoBankService` for MetaMask Ramp API neo-bank-proxy endpoints under the `/neobank` prefix on the Ramp API host, including messenger actions for `getAutoramp`, `registerPixAddress`, `getAutorampQuote`, `createAutoramp`, `getAutorampQuoteForAutoramp`, `attachAutorampQuote`, `getCustomerByExternalId`, `getMoonpayCustomerId`, `getWalletRegistrationStatus`, and `registerSelfHostedWallet`. Mutating POSTs do not retry (to avoid duplicate Pix/autoramp creates without a stable `Idempotency-Key`); GETs still retry 429/5xx/network errors. Optional `Idempotency-Key` is forwarded when callers supply one. Also exports `mapNeoBankAutorampToRemoteSnapshot`, `AutorampRemoteSnapshot`, and wallet-registration HTTP types (`WalletRegistrationError`, `RegistrationStatus`, `RegistrationOutcome`).
+- Add `NeoBankService` for MetaMask Ramp API neo-bank-proxy endpoints under the `/neobank` prefix on the Ramp API host, including messenger actions for `getAutoramp`, `registerPixAddress`, `getAutorampQuote`, `createAutoramp`, `getAutorampQuoteForAutoramp`, `attachAutorampQuote`, `getCustomerByExternalId`, `getMoonpayCustomerId`, `getWalletRegistrationStatus`, and `registerSelfHostedWallet`. Mutating POSTs do not retry (to avoid duplicate Pix/autoramp creates without a stable `Idempotency-Key`); GETs still retry 429/5xx/network errors. Optional `Idempotency-Key` is forwarded when callers supply one. Also exports `mapNeoBankAutorampToRemoteSnapshot`, `AutorampRemoteSnapshot`, and wallet-registration HTTP types (`WalletRegistrationError`, `RegistrationStatus`, `RegistrationOutcome`). ([#10031](https://github.com/MetaMask/core/pull/10031))
 
 ## [20.2.0]
 

--- a/packages/ramps-controller/src/NeoBankService-method-action-types.ts
+++ b/packages/ramps-controller/src/NeoBankService-method-action-types.ts
@@ -1,0 +1,147 @@
+/**
+ * This file is auto generated.
+ * Do not edit manually.
+ */
+
+import type { NeoBankService } from './NeoBankService.js';
+
+/**
+ * Fetches an autoramp account via neobank-proxy
+ * `GET /neobank/autoramps/{autoramp_id}` (MoonPay
+ * `GET /api/autoramps/{autoramp_id}`).
+ *
+ * @param autorampId - MoonPay / Ramp API autoramp id.
+ * @returns Remote snapshot for controller apply/refresh.
+ */
+export type NeoBankServiceGetAutorampAction = {
+  type: `NeoBankService:getAutoramp`;
+  handler: NeoBankService['getAutoramp'];
+};
+
+/**
+ * Registers a Pix address via neobank-proxy `POST /neobank/addresses/pix`.
+ * Body is forwarded as opaque JSON (MoonPay address schema).
+ *
+ * @param body - Pix address registration payload.
+ * @param options - Optional idempotency key.
+ * @returns Parsed proxy JSON response.
+ */
+export type NeoBankServiceRegisterPixAddressAction = {
+  type: `NeoBankService:registerPixAddress`;
+  handler: NeoBankService['registerPixAddress'];
+};
+
+/**
+ * Fetches an autoramp quote via neobank-proxy `GET /neobank/autoramps/quote`.
+ *
+ * @param query - Quote query params (forwarded as-is).
+ * @returns Parsed proxy JSON response.
+ */
+export type NeoBankServiceGetAutorampQuoteAction = {
+  type: `NeoBankService:getAutorampQuote`;
+  handler: NeoBankService['getAutorampQuote'];
+};
+
+/**
+ * Creates an autoramp from a signed quote via neobank-proxy
+ * `POST /neobank/autoramps` (MoonPay `POST /api/autoramps`).
+ *
+ * @param body - CreateAutoramp / signed-quote payload (forwarded as-is).
+ * @param options - Optional idempotency key.
+ * @returns Remote snapshot for controller apply/refresh.
+ */
+export type NeoBankServiceCreateAutorampAction = {
+  type: `NeoBankService:createAutoramp`;
+  handler: NeoBankService['createAutoramp'];
+};
+
+/**
+ * Fetches a quote for an existing autoramp via neobank-proxy
+ * `GET /neobank/autoramps/{autoramp_id}/quote`.
+ *
+ * @param autorampId - Autoramp id.
+ * @param query - Quote query params (forwarded as-is).
+ * @returns Parsed proxy JSON response.
+ */
+export type NeoBankServiceGetAutorampQuoteForAutorampAction = {
+  type: `NeoBankService:getAutorampQuoteForAutoramp`;
+  handler: NeoBankService['getAutorampQuoteForAutoramp'];
+};
+
+/**
+ * Attaches a signed quote to an autoramp via neobank-proxy
+ * `POST /neobank/autoramps/{autoramp_id}/quotes`.
+ *
+ * @param autorampId - Autoramp id.
+ * @param body - Quote attachment payload (forwarded as-is).
+ * @param options - Optional idempotency key.
+ * @returns Parsed proxy JSON response.
+ */
+export type NeoBankServiceAttachAutorampQuoteAction = {
+  type: `NeoBankService:attachAutorampQuote`;
+  handler: NeoBankService['attachAutorampQuote'];
+};
+
+/**
+ * Fetches a customer by partner external id via neobank-proxy
+ * `GET /neobank/customers/{external_id}/external`.
+ *
+ * @param externalId - Partner-assigned external customer id.
+ * @returns Parsed proxy JSON response.
+ */
+export type NeoBankServiceGetCustomerByExternalIdAction = {
+  type: `NeoBankService:getCustomerByExternalId`;
+  handler: NeoBankService['getCustomerByExternalId'];
+};
+
+/**
+ * Resolves Iron's internal customer id via neobank-proxy customer lookup,
+ * using the MetaMask canonical profile id as the partner `external_id`.
+ *
+ * @returns Iron's internal customer id.
+ */
+export type NeoBankServiceGetMoonpayCustomerIdAction = {
+  type: `NeoBankService:getMoonpayCustomerId`;
+  handler: NeoBankService['getMoonpayCustomerId'];
+};
+
+/**
+ * Checks whether a Monad Money Account address is already registered for the
+ * given Iron customer.
+ *
+ * @param params - Customer id and address to check.
+ * @param params.customerId - Iron / MoonPay customer UUID.
+ * @param params.address - Money Account address.
+ * @returns Active, disabled, or absent registration status.
+ */
+export type NeoBankServiceGetWalletRegistrationStatusAction = {
+  type: `NeoBankService:getWalletRegistrationStatus`;
+  handler: NeoBankService['getWalletRegistrationStatus'];
+};
+
+/**
+ * Submits a signed Monad Money Account ownership proof via neobank-proxy
+ * `POST /neobank/addresses/crypto/selfhosted`.
+ *
+ * @param params - Signed ownership proof.
+ * @returns Registered wallet record.
+ */
+export type NeoBankServiceRegisterSelfHostedWalletAction = {
+  type: `NeoBankService:registerSelfHostedWallet`;
+  handler: NeoBankService['registerSelfHostedWallet'];
+};
+
+/**
+ * Union of all NeoBankService action types.
+ */
+export type NeoBankServiceMethodActions =
+  | NeoBankServiceGetAutorampAction
+  | NeoBankServiceRegisterPixAddressAction
+  | NeoBankServiceGetAutorampQuoteAction
+  | NeoBankServiceCreateAutorampAction
+  | NeoBankServiceGetAutorampQuoteForAutorampAction
+  | NeoBankServiceAttachAutorampQuoteAction
+  | NeoBankServiceGetCustomerByExternalIdAction
+  | NeoBankServiceGetMoonpayCustomerIdAction
+  | NeoBankServiceGetWalletRegistrationStatusAction
+  | NeoBankServiceRegisterSelfHostedWalletAction;

--- a/packages/ramps-controller/src/NeoBankService.test.ts
+++ b/packages/ramps-controller/src/NeoBankService.test.ts
@@ -1,0 +1,659 @@
+import type { CreateServicePolicyOptions } from '@metamask/controller-utils';
+import { ConstantBackoff } from '@metamask/controller-utils';
+import { Messenger, MOCK_ANY_NAMESPACE } from '@metamask/messenger';
+import type { MockAnyNamespace } from '@metamask/messenger';
+import nock, { cleanAll } from 'nock';
+
+import {
+  mapNeoBankAutorampToRemoteSnapshot,
+  NeoBankService,
+} from './NeoBankService.js';
+import type { NeoBankServiceMessenger } from './NeoBankService.js';
+import { RampsEnvironment } from './RampsService.js';
+
+const STAGING_BASE = 'https://on-ramp.uat-api.cx.metamask.io';
+
+/**
+ * Builds a NeoBankService with AuthenticationController bearer auth stubbed.
+ *
+ * @param options - Optional constructor overrides.
+ * @param options.environment - Ramp environment for host selection.
+ * @param options.baseUrlOverride - Overrides the environment-derived host.
+ * @param options.omitDefaults - Pass `true` to exercise constructor defaulted
+ * parameters (`environment`, `policyOptions`).
+ * @param options.policyOptions - Retry/circuit policy overrides. Defaults to
+ * `{ maxRetries: 0 }` so tests fail fast unless they opt into retries.
+ * @param options.canonicalProfileId - Canonical profile id returned by the
+ * stubbed `AuthenticationController:getSessionProfile` (wallet registration).
+ * @returns Service instance for the test.
+ */
+function createService(options?: {
+  environment?: RampsEnvironment;
+  baseUrlOverride?: string;
+  omitDefaults?: boolean;
+  policyOptions?: CreateServicePolicyOptions;
+  canonicalProfileId?: string;
+}): NeoBankService {
+  const rootMessenger = new Messenger({
+    namespace: MOCK_ANY_NAMESPACE as MockAnyNamespace,
+  });
+  rootMessenger.registerActionHandler(
+    'AuthenticationController:getBearerToken',
+    async () => 'test-token',
+  );
+  const canonicalProfileId =
+    options?.canonicalProfileId ?? 'canonical-profile-1';
+  rootMessenger.registerActionHandler(
+    'AuthenticationController:getSessionProfile',
+    async () =>
+      ({
+        identifierId: 'id-1',
+        profileId: canonicalProfileId,
+        canonicalProfileId,
+        metaMetricsId: 'mm-1',
+      }) as never,
+  );
+
+  const messenger = new Messenger({
+    namespace: 'NeoBankService',
+    parent: rootMessenger,
+  }) as unknown as NeoBankServiceMessenger;
+  rootMessenger.delegate({
+    messenger,
+    actions: [
+      'AuthenticationController:getBearerToken',
+      'AuthenticationController:getSessionProfile',
+    ],
+  });
+
+  if (options?.omitDefaults) {
+    return new NeoBankService({
+      messenger,
+      context: 'test',
+      fetch: globalThis.fetch.bind(globalThis),
+      baseUrlOverride: options.baseUrlOverride,
+    });
+  }
+
+  return new NeoBankService({
+    messenger,
+    environment: options?.environment ?? RampsEnvironment.Staging,
+    context: 'test',
+    fetch: globalThis.fetch.bind(globalThis),
+    policyOptions: options?.policyOptions ?? { maxRetries: 0 },
+    baseUrlOverride: options?.baseUrlOverride,
+  });
+}
+
+describe('NeoBankService', () => {
+  afterEach(() => {
+    cleanAll();
+  });
+
+  describe('mapNeoBankAutorampToRemoteSnapshot', () => {
+    it('maps MoonPay-shaped fields into a remote snapshot', () => {
+      expect(
+        mapNeoBankAutorampToRemoteSnapshot({
+          id: 'ar-1',
+          customer_id: 'cust-1',
+          status: 'Approved',
+          wallet_address: '0xabc',
+          deposit_rails: [{ type: 'Iban' }],
+        }),
+      ).toStrictEqual({
+        id: 'ar-1',
+        customerId: 'cust-1',
+        walletAddress: '0xabc',
+        status: 'Approved',
+        depositRailsSummary: { ready: true },
+      });
+    });
+
+    it('falls back to recipient_account.address when wallet_address is absent', () => {
+      expect(
+        mapNeoBankAutorampToRemoteSnapshot({
+          id: 'ar-1',
+          customer_id: 'cust-1',
+          status: 'Pending',
+          recipient_account: { address: '0xfrom-recipient' },
+        }),
+      ).toMatchObject({
+        walletAddress: '0xfrom-recipient',
+        depositRailsSummary: undefined,
+      });
+    });
+
+    it('marks deposit rails not ready when Approved without rails', () => {
+      expect(
+        mapNeoBankAutorampToRemoteSnapshot({
+          id: 'ar-1',
+          customer_id: 'cust-1',
+          status: 'Approved',
+        }),
+      ).toMatchObject({
+        depositRailsSummary: { ready: false },
+      });
+    });
+  });
+
+  describe('getAutoramp', () => {
+    it('gets /neobank/autoramps/{id} with bearer auth', async () => {
+      const scope = nock(STAGING_BASE)
+        .get(/\/neobank\/autoramps\/ar-1/u)
+        .matchHeader('Authorization', 'Bearer test-token')
+        .reply(200, {
+          id: 'ar-1',
+          customer_id: 'cust-1',
+          status: 'Authorized',
+          wallet_address: '0xabc',
+        });
+
+      const service = createService();
+      const snapshot = await service.getAutoramp('ar-1');
+
+      expect(scope.isDone()).toBe(true);
+      expect(snapshot).toMatchObject({
+        id: 'ar-1',
+        customerId: 'cust-1',
+        status: 'Authorized',
+        walletAddress: '0xabc',
+      });
+    });
+
+    it('throws HttpError when the proxy returns a non-2xx status', async () => {
+      nock(STAGING_BASE)
+        .get(/\/neobank\/autoramps\/missing/u)
+        .reply(404);
+
+      const service = createService();
+      await expect(service.getAutoramp('missing')).rejects.toThrow(
+        /failed with status '404'/u,
+      );
+    });
+
+    it('retries a 429 then succeeds', async () => {
+      const scope = nock(STAGING_BASE)
+        .get(/\/neobank\/autoramps\/ar-1/u)
+        .reply(429)
+        .get(/\/neobank\/autoramps\/ar-1/u)
+        .reply(200, {
+          id: 'ar-1',
+          customer_id: 'cust-1',
+          status: 'Authorized',
+        });
+
+      const service = createService({
+        policyOptions: {
+          maxRetries: 1,
+          backoff: new ConstantBackoff(0),
+        },
+      });
+      const snapshot = await service.getAutoramp('ar-1');
+
+      expect(scope.isDone()).toBe(true);
+      expect(snapshot.id).toBe('ar-1');
+    });
+
+    it('retries a network error then succeeds', async () => {
+      const scope = nock(STAGING_BASE)
+        .get(/\/neobank\/autoramps\/ar-1/u)
+        .replyWithError('ECONNRESET')
+        .get(/\/neobank\/autoramps\/ar-1/u)
+        .reply(200, {
+          id: 'ar-1',
+          customer_id: 'cust-1',
+          status: 'Authorized',
+        });
+
+      const service = createService({
+        policyOptions: {
+          maxRetries: 1,
+          backoff: new ConstantBackoff(0),
+        },
+      });
+      const snapshot = await service.getAutoramp('ar-1');
+
+      expect(scope.isDone()).toBe(true);
+      expect(snapshot.id).toBe('ar-1');
+    });
+
+    it('throws when the response body is malformed', async () => {
+      nock(STAGING_BASE)
+        .get(/\/neobank\/autoramps\/ar-1/u)
+        .reply(200, { status: 'Authorized' });
+
+      const service = createService();
+      await expect(service.getAutoramp('ar-1')).rejects.toThrow(
+        'Malformed response received from neo-bank autoramp API',
+      );
+    });
+  });
+
+  describe('registerPixAddress', () => {
+    it('posts /neobank/addresses/pix with JSON body and bearer auth', async () => {
+      const body = {
+        type: 'Pix',
+        pix_key: 'user@example.com',
+        customer_id: 'cust-1',
+      };
+
+      const scope = nock(STAGING_BASE)
+        .post('/neobank/addresses/pix', body)
+        .query(true)
+        .matchHeader('Authorization', 'Bearer test-token')
+        .matchHeader('Content-Type', 'application/json')
+        .reply(200, { id: 'addr-1', ...body });
+
+      const service = createService();
+      const result = await service.registerPixAddress(body);
+
+      expect(scope.isDone()).toBe(true);
+      expect(result).toMatchObject({ id: 'addr-1' });
+    });
+
+    it('forwards Idempotency-Key when provided', async () => {
+      const scope = nock(STAGING_BASE)
+        .post('/neobank/addresses/pix', { pix_key: 'k' })
+        .query(true)
+        .matchHeader('Idempotency-Key', 'idem-1')
+        .reply(200, { id: 'addr-1' });
+
+      const service = createService();
+      await service.registerPixAddress(
+        { pix_key: 'k' },
+        { idempotencyKey: 'idem-1' },
+      );
+
+      expect(scope.isDone()).toBe(true);
+    });
+
+    it('does not retry a 503 POST even when maxRetries is set', async () => {
+      const scope = nock(STAGING_BASE)
+        .post('/neobank/addresses/pix')
+        .query(true)
+        .reply(503, 'unavailable');
+
+      const service = createService({
+        policyOptions: {
+          maxRetries: 3,
+          backoff: new ConstantBackoff(0),
+        },
+      });
+
+      await expect(
+        service.registerPixAddress({ pix_key: 'k' }),
+      ).rejects.toThrow(/failed with status '503'/u);
+
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
+  describe('getAutorampQuote', () => {
+    it('gets /neobank/autoramps/quote with query params', async () => {
+      const scope = nock(STAGING_BASE)
+        .get('/neobank/autoramps/quote')
+        .query((query) => {
+          return (
+            query.amount === '100' &&
+            query.currency === 'BRL' &&
+            typeof query.sdk === 'string' &&
+            typeof query.controller === 'string' &&
+            query.context === 'test'
+          );
+        })
+        .matchHeader('Authorization', 'Bearer test-token')
+        .reply(200, { quote_id: 'q-1', amount: '100' });
+
+      const service = createService();
+      const result = await service.getAutorampQuote({
+        amount: '100',
+        currency: 'BRL',
+      });
+
+      expect(scope.isDone()).toBe(true);
+      expect(result).toMatchObject({ quote_id: 'q-1' });
+    });
+  });
+
+  describe('createAutoramp', () => {
+    it('posts /neobank/autoramps and maps the Autoramp response', async () => {
+      const body = {
+        signed_quote: 'sig',
+        customer_id: 'cust-1',
+      };
+
+      const scope = nock(STAGING_BASE)
+        .post('/neobank/autoramps', body)
+        .query(true)
+        .matchHeader('Authorization', 'Bearer test-token')
+        .matchHeader('Content-Type', 'application/json')
+        .reply(201, {
+          id: 'ar-new',
+          customer_id: 'cust-1',
+          status: 'Pending',
+          wallet_address: '0xdef',
+        });
+
+      const service = createService();
+      const snapshot = await service.createAutoramp(body);
+
+      expect(scope.isDone()).toBe(true);
+      expect(snapshot).toMatchObject({
+        id: 'ar-new',
+        customerId: 'cust-1',
+        status: 'Pending',
+        walletAddress: '0xdef',
+      });
+    });
+
+    it('forwards Idempotency-Key when provided', async () => {
+      const scope = nock(STAGING_BASE)
+        .post('/neobank/autoramps', { signed_quote: 'sig' })
+        .query(true)
+        .matchHeader('Idempotency-Key', 'create-idem')
+        .reply(201, {
+          id: 'ar-2',
+          customer_id: 'cust-1',
+          status: 'Pending',
+        });
+
+      const service = createService();
+      await service.createAutoramp(
+        { signed_quote: 'sig' },
+        { idempotencyKey: 'create-idem' },
+      );
+
+      expect(scope.isDone()).toBe(true);
+    });
+
+    it('throws when the response body is malformed', async () => {
+      nock(STAGING_BASE)
+        .post('/neobank/autoramps')
+        .query(true)
+        .reply(201, { status: 'Pending' });
+
+      const service = createService();
+      await expect(
+        service.createAutoramp({ signed_quote: 'sig' }),
+      ).rejects.toThrow(
+        'Malformed response received from neo-bank autoramp API',
+      );
+    });
+  });
+
+  describe('getAutorampQuoteForAutoramp', () => {
+    it('gets /neobank/autoramps/{id}/quote with query params', async () => {
+      const scope = nock(STAGING_BASE)
+        .get('/neobank/autoramps/ar-1/quote')
+        .query((query) => {
+          return query.amount === '50' && query.context === 'test';
+        })
+        .matchHeader('Authorization', 'Bearer test-token')
+        .reply(200, { quote_id: 'q-2' });
+
+      const service = createService();
+      const result = await service.getAutorampQuoteForAutoramp('ar-1', {
+        amount: '50',
+      });
+
+      expect(scope.isDone()).toBe(true);
+      expect(result).toMatchObject({ quote_id: 'q-2' });
+    });
+  });
+
+  describe('attachAutorampQuote', () => {
+    it('posts /neobank/autoramps/{id}/quotes with JSON body', async () => {
+      const body = { signed_quote: 'attach-sig' };
+
+      const scope = nock(STAGING_BASE)
+        .post('/neobank/autoramps/ar-1/quotes', body)
+        .query(true)
+        .matchHeader('Authorization', 'Bearer test-token')
+        .matchHeader('Content-Type', 'application/json')
+        .reply(200, { quote_id: 'q-attached' });
+
+      const service = createService();
+      const result = await service.attachAutorampQuote('ar-1', body);
+
+      expect(scope.isDone()).toBe(true);
+      expect(result).toMatchObject({ quote_id: 'q-attached' });
+    });
+  });
+
+  describe('getCustomerByExternalId', () => {
+    it('gets /neobank/customers/{external_id}/external', async () => {
+      const scope = nock(STAGING_BASE)
+        .get('/neobank/customers/ext-1/external')
+        .query(true)
+        .matchHeader('Authorization', 'Bearer test-token')
+        .reply(200, { id: 'cust-1', external_id: 'ext-1' });
+
+      const service = createService();
+      const result = await service.getCustomerByExternalId('ext-1');
+
+      expect(scope.isDone()).toBe(true);
+      expect(result).toMatchObject({ id: 'cust-1', external_id: 'ext-1' });
+    });
+  });
+
+  describe('Money Account wallet registration', () => {
+    it('resolves the Iron customer id via neobank customer lookup', async () => {
+      nock(STAGING_BASE)
+        .get('/neobank/customers/canonical-profile-1/external')
+        .matchHeader('authorization', 'Bearer test-token')
+        .reply(200, {
+          id: 'iron-customer-1',
+          external_id: 'canonical-profile-1',
+        });
+
+      const service = createService();
+
+      expect(await service.getMoonpayCustomerId()).toBe('iron-customer-1');
+    });
+
+    it('checks Monad wallet registration status for a customer', async () => {
+      nock(STAGING_BASE)
+        .get('/neobank/addresses/crypto/iron-customer-1')
+        .query({ filter: 'SelfHosted' })
+        .reply(200, []);
+
+      const service = createService();
+
+      expect(
+        await service.getWalletRegistrationStatus({
+          customerId: 'iron-customer-1',
+          address: '0xabc',
+        }),
+      ).toStrictEqual({ type: 'absent' });
+    });
+
+    it('submits a signed Monad wallet ownership proof with Idempotency-Key', async () => {
+      nock(STAGING_BASE)
+        .post(
+          '/neobank/addresses/crypto/selfhosted',
+          {
+            customer_id: 'iron-customer-1',
+            address: '0xabc',
+            blockchain: 'Monad',
+            message: 'ownership message',
+            signature: '0xsig',
+          },
+          { reqheaders: { 'idempotency-key': 'idem-1' } },
+        )
+        .reply(200, {
+          id: 'wallet-1',
+          address: '0xabc',
+          disabled: false,
+        });
+
+      const service = createService();
+
+      expect(
+        await service.registerSelfHostedWallet({
+          customerId: 'iron-customer-1',
+          address: '0xabc',
+          message: 'ownership message',
+          signature: '0xsig',
+          idempotencyKey: 'idem-1',
+        }),
+      ).toMatchObject({
+        type: 'registered',
+        registration: { id: 'wallet-1', blockchain: 'Monad' },
+      });
+    });
+
+    it('uses the baseUrlOverride host for wallet routes', async () => {
+      const overrideUrl = 'https://on-ramp.dev-api.cx.metamask.io';
+      nock(overrideUrl)
+        .get('/neobank/customers/canonical-profile-1/external')
+        .reply(200, { id: 'iron-customer-1' });
+
+      const service = createService({ baseUrlOverride: overrideUrl });
+
+      expect(await service.getMoonpayCustomerId()).toBe('iron-customer-1');
+    });
+
+    it('throws when the session profile has no usable external id', async () => {
+      const service = createService({ canonicalProfileId: '' });
+
+      await expect(service.getMoonpayCustomerId()).rejects.toThrow(
+        /Unable to resolve MetaMask canonical profile id/u,
+      );
+    });
+  });
+
+  describe('environments and policy hooks', () => {
+    it.each([
+      [RampsEnvironment.Production, 'https://on-ramp.api.cx.metamask.io'],
+      [RampsEnvironment.Development, 'https://on-ramp.dev-api.cx.metamask.io'],
+      [RampsEnvironment.Local, 'http://localhost:3000'],
+    ] as const)(
+      'uses the %s host for getAutoramp',
+      async (environment, host) => {
+        const scope = nock(host)
+          .get(/\/neobank\/autoramps\/ar-1/u)
+          .reply(200, {
+            id: 'ar-1',
+            customer_id: 'cust-1',
+            status: 'Authorized',
+          });
+
+        const service = createService({ environment });
+        await service.getAutoramp('ar-1');
+
+        expect(scope.isDone()).toBe(true);
+      },
+    );
+
+    it('uses constructor defaults for environment and policyOptions', async () => {
+      const scope = nock(STAGING_BASE)
+        .get(/\/neobank\/autoramps\/ar-1/u)
+        .reply(200, {
+          id: 'ar-1',
+          customer_id: 'cust-1',
+          status: 'Authorized',
+        });
+
+      const service = createService({ omitDefaults: true });
+      await service.getAutoramp('ar-1');
+
+      expect(scope.isDone()).toBe(true);
+    });
+
+    it('calls getAutorampQuote and getAutorampQuoteForAutoramp without query', async () => {
+      const quoteScope = nock(STAGING_BASE)
+        .get('/neobank/autoramps/quote')
+        .query(true)
+        .reply(200, { quote_id: 'q-default' });
+      const forAutorampScope = nock(STAGING_BASE)
+        .get('/neobank/autoramps/ar-1/quote')
+        .query(true)
+        .reply(200, { quote_id: 'q-for-ar' });
+
+      const service = createService();
+      await service.getAutorampQuote();
+      await service.getAutorampQuoteForAutoramp('ar-1');
+
+      expect(quoteScope.isDone()).toBe(true);
+      expect(forAutorampScope.isDone()).toBe(true);
+    });
+
+    it('uses baseUrlOverride when provided', async () => {
+      const scope = nock('http://custom-neobank.test')
+        .get(/\/neobank\/autoramps\/ar-1/u)
+        .reply(200, {
+          id: 'ar-1',
+          customer_id: 'cust-1',
+          status: 'Authorized',
+        });
+
+      const service = createService({
+        baseUrlOverride: 'http://custom-neobank.test',
+      });
+      await service.getAutoramp('ar-1');
+
+      expect(scope.isDone()).toBe(true);
+    });
+
+    it('throws for an invalid environment', async () => {
+      await expect(
+        createService({
+          environment: 'bogus' as RampsEnvironment,
+        }).getAutoramp('ar-1'),
+      ).rejects.toThrow(/Invalid environment/u);
+    });
+
+    it('throws HttpError on non-2xx POST responses', async () => {
+      nock(STAGING_BASE)
+        .post('/neobank/addresses/pix')
+        .query(true)
+        .reply(422, { error: 'bad' });
+
+      const service = createService();
+      await expect(
+        service.registerPixAddress({ pix_key: 'k' }),
+      ).rejects.toThrow(/failed with status '422'/u);
+    });
+
+    it('omits nullish query values when building quote URLs', async () => {
+      const scope = nock(STAGING_BASE)
+        .get('/neobank/autoramps/quote')
+        .query((query) => {
+          return (
+            query.amount === '10' &&
+            query.currency === undefined &&
+            query.optional === undefined
+          );
+        })
+        .reply(200, { quote_id: 'q-nullish' });
+
+      const service = createService();
+      await service.getAutorampQuote({
+        amount: '10',
+        currency: undefined,
+        optional: null,
+      });
+
+      expect(scope.isDone()).toBe(true);
+    });
+
+    it('registers onRetry, onBreak, and onDegraded listeners', () => {
+      const service = createService();
+      const onRetry = jest.fn();
+      const onBreak = jest.fn();
+      const onDegraded = jest.fn();
+
+      const retrySub = service.onRetry(onRetry);
+      const breakSub = service.onBreak(onBreak);
+      const degradedSub = service.onDegraded(onDegraded);
+
+      expect(typeof retrySub.dispose).toBe('function');
+      expect(typeof breakSub.dispose).toBe('function');
+      expect(typeof degradedSub.dispose).toBe('function');
+
+      retrySub.dispose();
+      breakSub.dispose();
+      degradedSub.dispose();
+    });
+  });
+});

--- a/packages/ramps-controller/src/NeoBankService.ts
+++ b/packages/ramps-controller/src/NeoBankService.ts
@@ -1,0 +1,606 @@
+import type {
+  CreateServicePolicyOptions,
+  ServicePolicy,
+} from '@metamask/controller-utils';
+import {
+  createServicePolicy,
+  handleWhen,
+  HttpError,
+} from '@metamask/controller-utils';
+import type { Messenger } from '@metamask/messenger';
+import type { AuthenticationController } from '@metamask/profile-sync-controller';
+
+import packageJson from '../package.json';
+import type {
+  AutorampDepositRailsSummary,
+  AutorampRemoteSnapshot,
+} from './autoramp-types.js';
+import type { NeoBankServiceMethodActions } from './NeoBankService-method-action-types.js';
+import { RAMPS_SDK_VERSION, RampsEnvironment } from './RampsService.js';
+import { WalletRegistrationService } from './wallet-registration-service.js';
+import type {
+  RegistrationOutcome,
+  RegistrationStatus,
+} from './wallet-registration-service.js';
+
+/**
+ * Name of the NeoBankService messenger namespace.
+ */
+export const serviceName = 'NeoBankService';
+
+/**
+ * Determines whether a failed neo-bank request is worth re-issuing.
+ *
+ * 4xx responses describe the request or the account's state (e.g. 403
+ * "Customer is not active", 422 validation), so repeating them only multiplies
+ * the same rejection. 429 stays retryable alongside 5xx and non-HTTP
+ * network/timeout errors.
+ *
+ * @param error - Error thrown while performing the request.
+ * @returns `true` when the error is worth retrying.
+ */
+function isRetryableError(error: unknown): boolean {
+  if (error instanceof HttpError) {
+    if (error.httpStatus === 429) {
+      return true;
+    }
+    return error.httpStatus < 400 || error.httpStatus >= 500;
+  }
+  return true;
+}
+
+/**
+ * Raw autoramp payload from the MetaMask Ramp API neo-bank proxy.
+ * Shape mirrors MoonPay Enterprise `GET /api/autoramps/{autoramp_id}`.
+ * The Ramp API handles partner auth / headers; the client only sends the
+ * MetaMask bearer token.
+ */
+export type NeoBankAutorampResponse = {
+  id: string;
+  // eslint-disable-next-line @typescript-eslint/naming-convention -- MoonPay API field
+  customer_id?: string;
+  status: string;
+  /**
+   * Destination wallet when present on the proxy response.
+   * Field name may evolve with the Ramp API contract.
+   */
+  // eslint-disable-next-line @typescript-eslint/naming-convention -- MoonPay API field
+  wallet_address?: string;
+  // eslint-disable-next-line @typescript-eslint/naming-convention -- MoonPay API field
+  recipient_account?: {
+    address?: string;
+  };
+  // eslint-disable-next-line @typescript-eslint/naming-convention -- MoonPay API field
+  deposit_rails?: unknown[];
+};
+
+/**
+ * Optional headers for neo-bank mutating requests.
+ */
+export type NeoBankRequestOptions = {
+  /**
+   * Forwarded as `Idempotency-Key` when set (MoonPay requires it on some POSTs;
+   * neobank-proxy generates one when omitted).
+   */
+  idempotencyKey?: string;
+};
+
+/**
+ * Query string values accepted by neo-bank GET helpers.
+ */
+export type NeoBankQueryParams = Record<
+  string,
+  string | number | boolean | undefined | null
+>;
+
+export type GetWalletRegistrationStatusParams = {
+  customerId: string;
+  address: string;
+};
+
+export type RegisterSelfHostedWalletParams = {
+  customerId: string;
+  address: string;
+  message: string;
+  signature: string;
+  /**
+   * Forwarded as `Idempotency-Key` on the neobank-proxy POST. Prefer a stable
+   * key across retries of the same ownership body.
+   */
+  idempotencyKey?: string;
+};
+
+const MESSENGER_EXPOSED_METHODS = [
+  'getAutoramp',
+  'registerPixAddress',
+  'getAutorampQuote',
+  'createAutoramp',
+  'getAutorampQuoteForAutoramp',
+  'attachAutorampQuote',
+  'getCustomerByExternalId',
+  'getMoonpayCustomerId',
+  'getWalletRegistrationStatus',
+  'registerSelfHostedWallet',
+] as const;
+
+/**
+ * Actions that {@link NeoBankService} exposes to other consumers.
+ */
+export type NeoBankServiceActions = NeoBankServiceMethodActions;
+
+type AllowedActions =
+  | AuthenticationController.AuthenticationControllerGetBearerTokenAction
+  | AuthenticationController.AuthenticationControllerGetSessionProfileAction;
+
+export type NeoBankServiceEvents = never;
+
+type AllowedEvents = never;
+
+/**
+ * The messenger restricted to actions and events accessed by
+ * {@link NeoBankService}.
+ */
+export type NeoBankServiceMessenger = Messenger<
+  typeof serviceName,
+  NeoBankServiceActions | AllowedActions,
+  NeoBankServiceEvents | AllowedEvents
+>;
+
+/**
+ * Builds a path under the neobank-proxy global prefix.
+ *
+ * Live neobank-proxy (#1124) mounts routes at `/neobank` on the on-ramp.api
+ * host (ALB path routing, no rewrite). Prefer this over `/api/v2/...` so Core
+ * matches the proxy that ships.
+ *
+ * @param path - Path under `/neobank` (no leading slash).
+ * @returns Absolute path segment for URL join against the Ramp API host.
+ */
+function getNeoBankPath(path: string): string {
+  return `neobank/${path.replace(/^\//u, '')}`;
+}
+
+/**
+ * Resolves the Ramp API host for neo-bank calls (same hosts as {@link RampsService}).
+ *
+ * @param environment - Ramp environment.
+ * @returns Base URL.
+ */
+function getBaseUrl(environment: RampsEnvironment): string {
+  switch (environment) {
+    case RampsEnvironment.Production:
+      return 'https://on-ramp.api.cx.metamask.io';
+    case RampsEnvironment.Staging:
+      return 'https://on-ramp.uat-api.cx.metamask.io';
+    case RampsEnvironment.Development:
+      return 'https://on-ramp.dev-api.cx.metamask.io';
+    case RampsEnvironment.Local:
+      return 'http://localhost:3000';
+    default:
+      throw new Error(`Invalid environment: ${String(environment)}`);
+  }
+}
+
+/**
+ * Maps a Ramp API / MoonPay-shaped autoramp response into the local remote snapshot.
+ *
+ * @param response - Proxy response body.
+ * @returns Snapshot for the controller last-seen cursor.
+ */
+export function mapNeoBankAutorampToRemoteSnapshot(
+  response: NeoBankAutorampResponse,
+): AutorampRemoteSnapshot {
+  const depositRails = response.deposit_rails;
+  const hasDepositRails =
+    Array.isArray(depositRails) && depositRails.length > 0;
+  const depositRailsSummary: AutorampDepositRailsSummary | undefined =
+    hasDepositRails || response.status === 'Approved'
+      ? {
+          ready: response.status === 'Approved' && hasDepositRails,
+        }
+      : undefined;
+
+  return {
+    id: response.id,
+    customerId: response.customer_id,
+    walletAddress:
+      response.wallet_address !== undefined &&
+      response.wallet_address.length > 0
+        ? response.wallet_address
+        : response.recipient_account?.address,
+    status: response.status,
+    depositRailsSummary,
+  };
+}
+
+/**
+ * Client for MetaMask Ramp API neo-bank endpoints (MoonPay Enterprise proxy).
+ *
+ * Lives alongside {@link RampsService} and {@link TransakService}. Authentication
+ * and MoonPay partner headers are handled by the Ramp API; this service only
+ * attaches the MetaMask user bearer token.
+ *
+ * Paths use the neobank-proxy `/neobank` prefix on the on-ramp.api host.
+ */
+export class NeoBankService {
+  readonly name: typeof serviceName;
+
+  readonly #messenger: NeoBankServiceMessenger;
+
+  readonly #fetch: typeof fetch;
+
+  readonly #policy: ServicePolicy;
+
+  readonly #noRetryPolicy: ServicePolicy;
+
+  readonly #environment: RampsEnvironment;
+
+  readonly #context: string;
+
+  readonly #baseUrlOverride?: string;
+
+  #walletRegistrationService: WalletRegistrationService | undefined;
+
+  constructor({
+    messenger,
+    environment = RampsEnvironment.Staging,
+    context,
+    fetch: fetchFunction,
+    policyOptions = {},
+    baseUrlOverride,
+  }: {
+    messenger: NeoBankServiceMessenger;
+    environment?: RampsEnvironment;
+    context: string;
+    fetch: typeof fetch;
+    policyOptions?: CreateServicePolicyOptions;
+    baseUrlOverride?: string;
+  }) {
+    this.name = serviceName;
+    this.#messenger = messenger;
+    this.#fetch = fetchFunction;
+    this.#policy = createServicePolicy({
+      retryFilterPolicy: handleWhen(isRetryableError),
+      ...policyOptions,
+    });
+    this.#noRetryPolicy = createServicePolicy({
+      retryFilterPolicy: handleWhen(isRetryableError),
+      ...policyOptions,
+      maxRetries: 0,
+    });
+    this.#environment = environment;
+    this.#context = context;
+    this.#baseUrlOverride = baseUrlOverride;
+
+    this.#messenger.registerMethodActionHandlers(
+      this,
+      MESSENGER_EXPOSED_METHODS,
+    );
+  }
+
+  #getBaseUrl(): string {
+    if (this.#baseUrlOverride) {
+      return this.#baseUrlOverride;
+    }
+    return getBaseUrl(this.#environment);
+  }
+
+  /**
+   * Lazily builds the wallet registration client. Deferred so constructing the
+   * service never resolves the base URL eagerly (an invalid environment only
+   * throws when a request is made, matching the other neo-bank methods).
+   *
+   * @returns The wallet registration client.
+   */
+  #getWalletRegistrationService(): WalletRegistrationService {
+    this.#walletRegistrationService ??= new WalletRegistrationService({
+      fetch: this.#fetch,
+      baseUrl: this.#getBaseUrl(),
+      getAuthToken: async (): Promise<string> =>
+        this.#messenger.call('AuthenticationController:getBearerToken'),
+      getExternalId: async (): Promise<string> =>
+        this.#getCanonicalExternalId(),
+    });
+    return this.#walletRegistrationService;
+  }
+
+  async #getRequestHeaders(
+    options: NeoBankRequestOptions = {},
+  ): Promise<Record<string, string>> {
+    const bearerToken = await this.#messenger.call(
+      'AuthenticationController:getBearerToken',
+    );
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${bearerToken}`,
+    };
+    if (options.idempotencyKey) {
+      headers['Idempotency-Key'] = options.idempotencyKey;
+    }
+    return headers;
+  }
+
+  #buildUrl(path: string, query?: NeoBankQueryParams): URL {
+    const url = new URL(getNeoBankPath(path), this.#getBaseUrl());
+    url.searchParams.set('sdk', RAMPS_SDK_VERSION);
+    url.searchParams.set('controller', packageJson.version);
+    url.searchParams.set('context', this.#context);
+    if (query) {
+      for (const [key, value] of Object.entries(query)) {
+        if (value !== undefined && value !== null) {
+          url.searchParams.set(key, String(value));
+        }
+      }
+    }
+    return url;
+  }
+
+  /**
+   * Throws an {@link HttpError} that carries the upstream response body.
+   *
+   * The neobank-proxy mirrors MoonPay's status *and* body verbatim, so the
+   * body is usually the only place that explains a 4xx (e.g. which field or
+   * permission was rejected). Dropping it makes failures undiagnosable.
+   *
+   * @param url - Request URL, for context in the message.
+   * @param response - Non-OK fetch response.
+   */
+  async #throwHttpError(url: URL, response: Response): Promise<never> {
+    let detail = '';
+    try {
+      const body = (await response.text()).trim();
+      if (body) {
+        detail = ` - ${body.slice(0, 500)}`;
+      }
+    } catch {
+      // Body already consumed or unreadable; the status alone still helps.
+    }
+    throw new HttpError(
+      response.status,
+      `Fetching '${url.toString()}' failed with status '${response.status}'${detail}`,
+    );
+  }
+
+  async #getJson<ResponseBody>(
+    path: string,
+    query?: NeoBankQueryParams,
+  ): Promise<ResponseBody> {
+    const url = this.#buildUrl(path, query);
+    return this.#policy.execute(async () => {
+      const headers = await this.#getRequestHeaders();
+      const fetchResponse = await this.#fetch(url, { headers });
+      if (!fetchResponse.ok) {
+        await this.#throwHttpError(url, fetchResponse);
+      }
+      return fetchResponse.json() as Promise<ResponseBody>;
+    });
+  }
+
+  async #postJson<ResponseBody>(
+    path: string,
+    body: Record<string, unknown>,
+    options: NeoBankRequestOptions,
+  ): Promise<ResponseBody> {
+    const url = this.#buildUrl(path);
+    return this.#noRetryPolicy.execute(async () => {
+      const headers = await this.#getRequestHeaders(options);
+      headers['Content-Type'] = 'application/json';
+      const fetchResponse = await this.#fetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+      });
+      if (!fetchResponse.ok) {
+        await this.#throwHttpError(url, fetchResponse);
+      }
+      return fetchResponse.json() as Promise<ResponseBody>;
+    });
+  }
+
+  #mapAutorampResponse(
+    response: NeoBankAutorampResponse,
+  ): AutorampRemoteSnapshot {
+    if (!response || typeof response !== 'object' || !response.id) {
+      throw new Error('Malformed response received from neo-bank autoramp API');
+    }
+    return mapNeoBankAutorampToRemoteSnapshot(response);
+  }
+
+  /**
+   * Fetches an autoramp account via neobank-proxy
+   * `GET /neobank/autoramps/{autoramp_id}` (MoonPay
+   * `GET /api/autoramps/{autoramp_id}`).
+   *
+   * @param autorampId - MoonPay / Ramp API autoramp id.
+   * @returns Remote snapshot for controller apply/refresh.
+   */
+  async getAutoramp(autorampId: string): Promise<AutorampRemoteSnapshot> {
+    const response = await this.#getJson<NeoBankAutorampResponse>(
+      `autoramps/${encodeURIComponent(autorampId)}`,
+    );
+    return this.#mapAutorampResponse(response);
+  }
+
+  /**
+   * Registers a Pix address via neobank-proxy `POST /neobank/addresses/pix`.
+   * Body is forwarded as opaque JSON (MoonPay address schema).
+   *
+   * @param body - Pix address registration payload.
+   * @param options - Optional idempotency key.
+   * @returns Parsed proxy JSON response.
+   */
+  async registerPixAddress(
+    body: Record<string, unknown>,
+    options: NeoBankRequestOptions = {},
+  ): Promise<unknown> {
+    return this.#postJson('addresses/pix', body, options);
+  }
+
+  /**
+   * Fetches an autoramp quote via neobank-proxy `GET /neobank/autoramps/quote`.
+   *
+   * @param query - Quote query params (forwarded as-is).
+   * @returns Parsed proxy JSON response.
+   */
+  async getAutorampQuote(query: NeoBankQueryParams = {}): Promise<unknown> {
+    return this.#getJson('autoramps/quote', query);
+  }
+
+  /**
+   * Creates an autoramp from a signed quote via neobank-proxy
+   * `POST /neobank/autoramps` (MoonPay `POST /api/autoramps`).
+   *
+   * @param body - CreateAutoramp / signed-quote payload (forwarded as-is).
+   * @param options - Optional idempotency key.
+   * @returns Remote snapshot for controller apply/refresh.
+   */
+  async createAutoramp(
+    body: Record<string, unknown>,
+    options: NeoBankRequestOptions = {},
+  ): Promise<AutorampRemoteSnapshot> {
+    const response = await this.#postJson<NeoBankAutorampResponse>(
+      'autoramps',
+      body,
+      options,
+    );
+    return this.#mapAutorampResponse(response);
+  }
+
+  /**
+   * Fetches a quote for an existing autoramp via neobank-proxy
+   * `GET /neobank/autoramps/{autoramp_id}/quote`.
+   *
+   * @param autorampId - Autoramp id.
+   * @param query - Quote query params (forwarded as-is).
+   * @returns Parsed proxy JSON response.
+   */
+  async getAutorampQuoteForAutoramp(
+    autorampId: string,
+    query: NeoBankQueryParams = {},
+  ): Promise<unknown> {
+    return this.#getJson(
+      `autoramps/${encodeURIComponent(autorampId)}/quote`,
+      query,
+    );
+  }
+
+  /**
+   * Attaches a signed quote to an autoramp via neobank-proxy
+   * `POST /neobank/autoramps/{autoramp_id}/quotes`.
+   *
+   * @param autorampId - Autoramp id.
+   * @param body - Quote attachment payload (forwarded as-is).
+   * @param options - Optional idempotency key.
+   * @returns Parsed proxy JSON response.
+   */
+  async attachAutorampQuote(
+    autorampId: string,
+    body: Record<string, unknown>,
+    options: NeoBankRequestOptions = {},
+  ): Promise<unknown> {
+    return this.#postJson(
+      `autoramps/${encodeURIComponent(autorampId)}/quotes`,
+      body,
+      options,
+    );
+  }
+
+  /**
+   * Fetches a customer by partner external id via neobank-proxy
+   * `GET /neobank/customers/{external_id}/external`.
+   *
+   * @param externalId - Partner-assigned external customer id.
+   * @returns Parsed proxy JSON response.
+   */
+  async getCustomerByExternalId(externalId: string): Promise<unknown> {
+    return this.#getJson(
+      `customers/${encodeURIComponent(externalId)}/external`,
+    );
+  }
+
+  /**
+   * Resolves Iron's internal customer id via neobank-proxy customer lookup,
+   * using the MetaMask canonical profile id as the partner `external_id`.
+   *
+   * @returns Iron's internal customer id.
+   */
+  async getMoonpayCustomerId(): Promise<string> {
+    return await this.#getWalletRegistrationService().getMoonpayCustomerId();
+  }
+
+  /**
+   * Checks whether a Monad Money Account address is already registered for the
+   * given Iron customer.
+   *
+   * @param params - Customer id and address to check.
+   * @param params.customerId - Iron / MoonPay customer UUID.
+   * @param params.address - Money Account address.
+   * @returns Active, disabled, or absent registration status.
+   */
+  async getWalletRegistrationStatus({
+    customerId,
+    address,
+  }: GetWalletRegistrationStatusParams): Promise<RegistrationStatus> {
+    return await this.#getWalletRegistrationService().getRegistrationStatus({
+      customerId,
+      address,
+      blockchain: 'Monad',
+    });
+  }
+
+  /**
+   * Submits a signed Monad Money Account ownership proof via neobank-proxy
+   * `POST /neobank/addresses/crypto/selfhosted`.
+   *
+   * @param params - Signed ownership proof.
+   * @returns Registered wallet record.
+   */
+  async registerSelfHostedWallet(
+    params: RegisterSelfHostedWalletParams,
+  ): Promise<RegistrationOutcome> {
+    return await this.#getWalletRegistrationService().registerSelfHostedWallet({
+      ...params,
+      blockchain: 'Monad',
+    });
+  }
+
+  /**
+   * Resolves the MetaMask canonical profile id used as MoonPay's partner
+   * `external_id` for neobank customer lookup.
+   *
+   * @returns Canonical profile id.
+   */
+  async #getCanonicalExternalId(): Promise<string> {
+    const profile = await this.#messenger.call(
+      'AuthenticationController:getSessionProfile',
+    );
+    const canonical = profile?.canonicalProfileId;
+    const externalId =
+      typeof canonical === 'string' && canonical.length > 0
+        ? canonical
+        : profile?.profileId;
+    if (typeof externalId !== 'string' || externalId.length === 0) {
+      throw new Error(
+        'Unable to resolve MetaMask canonical profile id for MoonPay customer lookup',
+      );
+    }
+    return externalId;
+  }
+
+  onRetry(
+    listener: Parameters<ServicePolicy['onRetry']>[0],
+  ): ReturnType<ServicePolicy['onRetry']> {
+    return this.#policy.onRetry(listener);
+  }
+
+  onBreak(
+    listener: Parameters<ServicePolicy['onBreak']>[0],
+  ): ReturnType<ServicePolicy['onBreak']> {
+    return this.#policy.onBreak(listener);
+  }
+
+  onDegraded(
+    listener: Parameters<ServicePolicy['onDegraded']>[0],
+  ): ReturnType<ServicePolicy['onDegraded']> {
+    return this.#policy.onDegraded(listener);
+  }
+}

--- a/packages/ramps-controller/src/autoramp-types.ts
+++ b/packages/ramps-controller/src/autoramp-types.ts
@@ -1,0 +1,22 @@
+/**
+ * Non-PII deposit readiness summary from a neo-bank autoramp response.
+ * Full deposit rail details (IBAN, etc.) should be re-fetched when needed.
+ */
+export type AutorampDepositRailsSummary = {
+  /** Source currency code when known (e.g. EUR). */
+  currency?: string;
+  /** True when the autoramp is approved and deposit details may be shared. */
+  ready: boolean;
+};
+
+/**
+ * Minimal remote snapshot from `GET /neobank/autoramps/{id}` (or a push payload).
+ * Identity fields may be omitted on partial proxy responses.
+ */
+export type AutorampRemoteSnapshot = {
+  id: string;
+  customerId?: string;
+  walletAddress?: string;
+  status: string;
+  depositRailsSummary?: AutorampDepositRailsSummary;
+};

--- a/packages/ramps-controller/src/index.ts
+++ b/packages/ramps-controller/src/index.ts
@@ -231,3 +231,42 @@ export type {
   TransakServiceGeneratePaymentWidgetUrlAction,
   TransakServiceCreateWidgetUrlAction,
 } from './TransakService-method-action-types.js';
+export type {
+  AutorampDepositRailsSummary,
+  AutorampRemoteSnapshot,
+} from './autoramp-types.js';
+export type {
+  NeoBankServiceActions,
+  NeoBankServiceEvents,
+  NeoBankServiceMessenger,
+  NeoBankAutorampResponse,
+  NeoBankRequestOptions,
+  NeoBankQueryParams,
+  GetWalletRegistrationStatusParams,
+  RegisterSelfHostedWalletParams,
+} from './NeoBankService.js';
+export type {
+  NeoBankServiceGetAutorampAction,
+  NeoBankServiceRegisterPixAddressAction,
+  NeoBankServiceGetAutorampQuoteAction,
+  NeoBankServiceCreateAutorampAction,
+  NeoBankServiceGetAutorampQuoteForAutorampAction,
+  NeoBankServiceAttachAutorampQuoteAction,
+  NeoBankServiceGetCustomerByExternalIdAction,
+  NeoBankServiceGetMoonpayCustomerIdAction,
+  NeoBankServiceGetWalletRegistrationStatusAction,
+  NeoBankServiceRegisterSelfHostedWalletAction,
+} from './NeoBankService-method-action-types.js';
+export {
+  NeoBankService,
+  serviceName as neoBankServiceName,
+  mapNeoBankAutorampToRemoteSnapshot,
+} from './NeoBankService.js';
+export type {
+  Blockchain,
+  RegistrationOutcome,
+  RegistrationStatus,
+  SelfHostedRegistration,
+  WalletRegistrationErrorKind,
+} from './wallet-registration-service.js';
+export { WalletRegistrationError } from './wallet-registration-service.js';

--- a/packages/ramps-controller/src/wallet-registration-service.test.ts
+++ b/packages/ramps-controller/src/wallet-registration-service.test.ts
@@ -126,6 +126,8 @@ describe('createIdempotencyKey', () => {
     } finally {
       if (originalDescriptor) {
         Object.defineProperty(globalThis, 'crypto', originalDescriptor);
+      } else {
+        Reflect.deleteProperty(globalThis, 'crypto');
       }
     }
   });
@@ -384,7 +386,31 @@ describe('WalletRegistrationService.getRegistrationStatus', () => {
     ).rejects.toMatchObject({ kind: 'lookupUnavailable', body: 'boom' });
   });
 
-  it('throws a lookupUnavailable error when the list body is malformed', async () => {
+  it('throws a lookupUnavailable error when the error body cannot be read', async () => {
+    const fetchMock = jest.fn(
+      async (): Promise<HttpResponse> => ({
+        ...textResponse(500, ''),
+        text: async (): Promise<string> => {
+          throw new Error('stream failed');
+        },
+      }),
+    );
+    const service = buildService(fetchMock);
+
+    await expect(
+      service.getRegistrationStatus({
+        customerId: CUSTOMER_ID,
+        address: EVM_ADDRESS,
+        blockchain: 'Monad',
+      }),
+    ).rejects.toMatchObject({
+      kind: 'lookupUnavailable',
+      httpStatus: 500,
+      body: 'stream failed',
+    });
+  });
+
+  it('throws a malformedResponse error when the list body is malformed', async () => {
     const fetchMock = jest.fn(
       async (): Promise<HttpResponse> => jsonResponse(200, { nope: true }),
     );
@@ -396,7 +422,7 @@ describe('WalletRegistrationService.getRegistrationStatus', () => {
         address: EVM_ADDRESS,
         blockchain: 'Monad',
       }),
-    ).rejects.toBeInstanceOf(WalletRegistrationError);
+    ).rejects.toMatchObject({ kind: 'malformedResponse' });
   });
 
   it('never converts a network failure during lookup into "absent"', async () => {

--- a/packages/ramps-controller/src/wallet-registration-service.test.ts
+++ b/packages/ramps-controller/src/wallet-registration-service.test.ts
@@ -1,0 +1,731 @@
+import {
+  createIdempotencyKey,
+  extractErrorBody,
+  WalletRegistrationError,
+  WalletRegistrationService,
+} from './wallet-registration-service.js';
+
+const BASE_URL = 'https://on-ramp.dev-api.cx.metamask.io';
+const AUTH_TOKEN = 'session-jwt-abc';
+const EXTERNAL_ID = 'canonical-profile-1';
+const CUSTOMER_ID = '019ff69c-3039-77b0-9d5d-e4a3baefd7b7';
+
+type FetchInit = {
+  method?: string;
+  headers: Record<string, string>;
+  body?: string;
+};
+
+type HttpResponse = {
+  ok: boolean;
+  status: number;
+  json: () => Promise<unknown>;
+  text: () => Promise<string>;
+};
+
+type FetchLike = (
+  url: string,
+  init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+    signal?: unknown;
+  },
+) => Promise<HttpResponse>;
+
+const jsonResponse = (status: number, body: unknown): HttpResponse => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json: async (): Promise<unknown> => body,
+  text: async (): Promise<string> =>
+    typeof body === 'string' ? body : JSON.stringify(body),
+});
+
+const textResponse = (status: number, body: string): HttpResponse => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json: async (): Promise<unknown> => JSON.parse(body),
+  text: async (): Promise<string> => body,
+});
+
+const invalidJsonResponse = (status: number): HttpResponse => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json: async (): Promise<unknown> => {
+    throw new Error('invalid json');
+  },
+  text: async (): Promise<string> => 'not json',
+});
+
+const buildService = (fetchImpl: FetchLike): WalletRegistrationService =>
+  new WalletRegistrationService({
+    fetch: fetchImpl,
+    baseUrl: BASE_URL,
+    getAuthToken: async (): Promise<string> => AUTH_TOKEN,
+    getExternalId: async (): Promise<string> => EXTERNAL_ID,
+  });
+
+const verifiedAddress = (
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> => ({
+  id: 'addr-1',
+  wallet_address: '0xAbC0000000000000000000000000000000000001',
+  blockchain: 'Monad',
+  address_type: 'SelfHosted',
+  disabled: false,
+  is_self: true,
+  proof_message: 'I am verifying ownership...',
+  proof_signature: '0xsig',
+  created_at: '2026-08-12T10:00:00Z',
+  ...overrides,
+});
+
+const EVM_ADDRESS = '0xAbC0000000000000000000000000000000000001';
+
+describe('createIdempotencyKey', () => {
+  it('returns a non-empty string', () => {
+    expect(createIdempotencyKey().length).toBeGreaterThan(0);
+  });
+
+  // `globalThis.crypto.randomUUID` is absent under Node 18, so the preferred
+  // path has to be exercised against an installed stub rather than the ambient
+  // runtime.
+  it('prefers randomUUID when the runtime provides it', () => {
+    const originalDescriptor = Object.getOwnPropertyDescriptor(
+      globalThis,
+      'crypto',
+    );
+    Object.defineProperty(globalThis, 'crypto', {
+      configurable: true,
+      value: { randomUUID: () => 'uuid-1' },
+    });
+    try {
+      expect(createIdempotencyKey()).toBe('uuid-1');
+    } finally {
+      if (originalDescriptor) {
+        Object.defineProperty(globalThis, 'crypto', originalDescriptor);
+      } else {
+        // Node 18 exposes no own `crypto` descriptor, so the stub has to be
+        // removed rather than restored, or it leaks into later tests.
+        Reflect.deleteProperty(globalThis, 'crypto');
+      }
+    }
+  });
+
+  it('falls back when randomUUID is unavailable', () => {
+    const originalDescriptor = Object.getOwnPropertyDescriptor(
+      globalThis,
+      'crypto',
+    );
+    Object.defineProperty(globalThis, 'crypto', {
+      configurable: true,
+      value: { randomUUID: undefined },
+    });
+    try {
+      expect(createIdempotencyKey()).toMatch(/^wallet-reg-/u);
+    } finally {
+      if (originalDescriptor) {
+        Object.defineProperty(globalThis, 'crypto', originalDescriptor);
+      }
+    }
+  });
+});
+
+describe('extractErrorBody', () => {
+  it('returns whitespace-only bodies unchanged', () => {
+    expect(extractErrorBody('   ')).toBe('   ');
+    expect(extractErrorBody('')).toBe('');
+  });
+
+  it('unwraps a JSON-encoded string', () => {
+    expect(extractErrorBody(JSON.stringify('already exists'))).toBe(
+      'already exists',
+    );
+  });
+
+  it('prefers message on a JSON object', () => {
+    expect(extractErrorBody(JSON.stringify({ message: 'forbidden' }))).toBe(
+      'forbidden',
+    );
+  });
+
+  it('keeps a JSON object without message as raw text', () => {
+    const raw = JSON.stringify({ code: 'x', detail: 'nope' });
+    expect(extractErrorBody(raw)).toBe(raw);
+  });
+
+  it('returns plain text that is not JSON', () => {
+    expect(extractErrorBody('not json at all')).toBe('not json at all');
+  });
+
+  it('returns non-object JSON values as the raw trimmed text', () => {
+    expect(extractErrorBody('null')).toBe('null');
+    expect(extractErrorBody('42')).toBe('42');
+    expect(extractErrorBody('true')).toBe('true');
+  });
+});
+
+describe('WalletRegistrationService.getMoonpayCustomerId', () => {
+  it('returns Iron customer id from GET /neobank/customers/{external_id}/external', async () => {
+    const fetchMock = jest.fn(
+      async (): Promise<HttpResponse> =>
+        jsonResponse(200, {
+          id: 'iron-customer-1',
+          external_id: EXTERNAL_ID,
+          status: 'Active',
+        }),
+    );
+
+    expect(await buildService(fetchMock).getMoonpayCustomerId()).toBe(
+      'iron-customer-1',
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${BASE_URL}/neobank/customers/${EXTERNAL_ID}/external`,
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          authorization: `Bearer ${AUTH_TOKEN}`,
+        }),
+      }),
+    );
+  });
+
+  it('maps a failed customer lookup to a typed HTTP error with transparent body', async () => {
+    const fetchMock = jest.fn(
+      async (): Promise<HttpResponse> => textResponse(404, 'not found'),
+    );
+
+    await expect(
+      buildService(fetchMock).getMoonpayCustomerId(),
+    ).rejects.toMatchObject({
+      kind: 'notFound',
+      httpStatus: 404,
+      body: 'not found',
+    });
+  });
+
+  it('rejects malformed customer lookup responses', async () => {
+    await expect(
+      buildService(
+        jest.fn(async (): Promise<HttpResponse> => invalidJsonResponse(200)),
+      ).getMoonpayCustomerId(),
+    ).rejects.toMatchObject({ kind: 'malformedResponse' });
+
+    await expect(
+      buildService(
+        jest.fn(async (): Promise<HttpResponse> => jsonResponse(200, {})),
+      ).getMoonpayCustomerId(),
+    ).rejects.toMatchObject({ kind: 'malformedResponse' });
+  });
+
+  it('rejects an empty external id before calling the network', async () => {
+    const fetchMock = jest.fn();
+    const service = new WalletRegistrationService({
+      fetch: fetchMock,
+      baseUrl: BASE_URL,
+      getAuthToken: async (): Promise<string> => AUTH_TOKEN,
+      getExternalId: async (): Promise<string> => '',
+    });
+
+    await expect(service.getMoonpayCustomerId()).rejects.toMatchObject({
+      kind: 'malformedResponse',
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('WalletRegistrationService.getRegistrationStatus', () => {
+  it('lists via /neobank/addresses/crypto/{customer_id}?filter=SelfHosted', async () => {
+    const fetchMock = jest.fn(
+      async (): Promise<HttpResponse> => jsonResponse(200, []),
+    );
+    const service = buildService(fetchMock);
+
+    await service.getRegistrationStatus({
+      customerId: CUSTOMER_ID,
+      address: EVM_ADDRESS,
+      blockchain: 'Monad',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, FetchInit];
+    expect(url).toBe(
+      `${BASE_URL}/neobank/addresses/crypto/${CUSTOMER_ID}?filter=SelfHosted`,
+    );
+    expect(url).not.toContain('iron.xyz');
+    expect(url).not.toContain('/vendors/moonpay/');
+    expect(init.method).toBe('GET');
+    expect(init.headers.authorization).toBe(`Bearer ${AUTH_TOKEN}`);
+  });
+
+  it('returns an active match parsed from wallet_address (Monad filter client-side)', async () => {
+    const fetchMock = jest.fn(
+      async (): Promise<HttpResponse> =>
+        jsonResponse(200, [
+          verifiedAddress({ blockchain: 'Ethereum' }),
+          verifiedAddress(),
+        ]),
+    );
+    const service = buildService(fetchMock);
+
+    const status = await service.getRegistrationStatus({
+      customerId: CUSTOMER_ID,
+      address: '0xabc0000000000000000000000000000000000001',
+      blockchain: 'Monad',
+    });
+
+    expect(status).toMatchObject({
+      type: 'active',
+      registration: { address: EVM_ADDRESS, disabled: false },
+    });
+  });
+
+  it('returns a disabled result when the matching address is disabled', async () => {
+    const fetchMock = jest.fn(
+      async (): Promise<HttpResponse> =>
+        jsonResponse(200, [verifiedAddress({ disabled: true })]),
+    );
+    const service = buildService(fetchMock);
+
+    const status = await service.getRegistrationStatus({
+      customerId: CUSTOMER_ID,
+      address: EVM_ADDRESS,
+      blockchain: 'Monad',
+    });
+
+    expect(status.type).toBe('disabled');
+  });
+
+  it('scopes matching per blockchain (same address, different chain is absent)', async () => {
+    const fetchMock = jest.fn(
+      async (): Promise<HttpResponse> =>
+        jsonResponse(200, [verifiedAddress({ blockchain: 'Ethereum' })]),
+    );
+    const service = buildService(fetchMock);
+
+    const status = await service.getRegistrationStatus({
+      customerId: CUSTOMER_ID,
+      address: EVM_ADDRESS,
+      blockchain: 'Monad',
+    });
+
+    expect(status.type).toBe('absent');
+  });
+
+  it('skips entries whose wallet_address is not a string', async () => {
+    const fetchMock = jest.fn(
+      async (): Promise<HttpResponse> =>
+        jsonResponse(200, [
+          { id: 'junk', wallet_address: 12345, blockchain: 'Monad' },
+          verifiedAddress(),
+        ]),
+    );
+    const service = buildService(fetchMock);
+
+    const status = await service.getRegistrationStatus({
+      customerId: CUSTOMER_ID,
+      address: EVM_ADDRESS,
+      blockchain: 'Monad',
+    });
+
+    expect(status.type).toBe('active');
+  });
+
+  it('throws malformedResponse when a matching row has no id', async () => {
+    const fetchMock = jest.fn(
+      async (): Promise<HttpResponse> =>
+        jsonResponse(200, [
+          {
+            wallet_address: EVM_ADDRESS,
+            blockchain: 'Monad',
+            disabled: false,
+          },
+        ]),
+    );
+    const service = buildService(fetchMock);
+
+    await expect(
+      service.getRegistrationStatus({
+        customerId: CUSTOMER_ID,
+        address: EVM_ADDRESS,
+        blockchain: 'Monad',
+      }),
+    ).rejects.toMatchObject({ kind: 'malformedResponse' });
+  });
+
+  it('throws malformedResponse when the list body is not valid JSON', async () => {
+    const fetchMock = jest.fn(
+      async (): Promise<HttpResponse> => invalidJsonResponse(200),
+    );
+    const service = buildService(fetchMock);
+
+    await expect(
+      service.getRegistrationStatus({
+        customerId: CUSTOMER_ID,
+        address: EVM_ADDRESS,
+        blockchain: 'Monad',
+      }),
+    ).rejects.toMatchObject({ kind: 'malformedResponse' });
+  });
+
+  it('throws a lookupUnavailable error on a non-2xx list response', async () => {
+    const fetchMock = jest.fn(
+      async (): Promise<HttpResponse> => textResponse(500, 'boom'),
+    );
+    const service = buildService(fetchMock);
+
+    await expect(
+      service.getRegistrationStatus({
+        customerId: CUSTOMER_ID,
+        address: EVM_ADDRESS,
+        blockchain: 'Monad',
+      }),
+    ).rejects.toMatchObject({ kind: 'lookupUnavailable', body: 'boom' });
+  });
+
+  it('throws a lookupUnavailable error when the list body is malformed', async () => {
+    const fetchMock = jest.fn(
+      async (): Promise<HttpResponse> => jsonResponse(200, { nope: true }),
+    );
+    const service = buildService(fetchMock);
+
+    await expect(
+      service.getRegistrationStatus({
+        customerId: CUSTOMER_ID,
+        address: EVM_ADDRESS,
+        blockchain: 'Monad',
+      }),
+    ).rejects.toBeInstanceOf(WalletRegistrationError);
+  });
+
+  it('never converts a network failure during lookup into "absent"', async () => {
+    const fetchMock = jest
+      .fn<Promise<HttpResponse>, unknown[]>()
+      .mockRejectedValue(new Error('network down'));
+    const service = buildService(fetchMock);
+
+    await expect(
+      service.getRegistrationStatus({
+        customerId: CUSTOMER_ID,
+        address: EVM_ADDRESS,
+        blockchain: 'Monad',
+      }),
+    ).rejects.toMatchObject({ kind: 'lookupUnavailable' });
+  });
+
+  it('handles a non-Error thrown during lookup', async () => {
+    const fetchMock = jest
+      .fn<Promise<HttpResponse>, unknown[]>()
+      .mockRejectedValue('string failure');
+    const service = buildService(fetchMock);
+
+    await expect(
+      service.getRegistrationStatus({
+        customerId: CUSTOMER_ID,
+        address: EVM_ADDRESS,
+        blockchain: 'Monad',
+      }),
+    ).rejects.toMatchObject({ kind: 'lookupUnavailable' });
+  });
+});
+
+const registerRequest = {
+  customerId: CUSTOMER_ID,
+  address: EVM_ADDRESS,
+  blockchain: 'Monad' as const,
+  message: 'I am verifying ownership ...',
+  signature: '0xdeadbeef',
+};
+
+const selfHostedResponse = (
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> => ({
+  id: 'wallet-1',
+  address: EVM_ADDRESS,
+  customer_id: CUSTOMER_ID,
+  disabled: false,
+  signature: '0xdeadbeef',
+  created_at: '2026-08-12T10:00:00Z',
+  ...overrides,
+});
+
+describe('WalletRegistrationService.registerSelfHostedWallet', () => {
+  it('posts to /neobank/addresses/crypto/selfhosted with an idempotency key', async () => {
+    const fetchMock = jest.fn(
+      async (): Promise<HttpResponse> =>
+        jsonResponse(200, selfHostedResponse()),
+    );
+    const service = buildService(fetchMock);
+
+    const outcome = await service.registerSelfHostedWallet({
+      ...registerRequest,
+      idempotencyKey: 'idem-wallet-1',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, FetchInit];
+    expect(url).toBe(`${BASE_URL}/neobank/addresses/crypto/selfhosted`);
+    expect(url).not.toContain('iron.xyz');
+    expect(init.method).toBe('POST');
+    expect(init.headers.authorization).toBe(`Bearer ${AUTH_TOKEN}`);
+    expect(init.headers['Idempotency-Key']).toBe('idem-wallet-1');
+    expect(JSON.parse(init.body ?? '{}')).toStrictEqual({
+      customer_id: registerRequest.customerId,
+      address: registerRequest.address,
+      blockchain: 'Monad',
+      message: registerRequest.message,
+      signature: registerRequest.signature,
+    });
+    expect(outcome.registration).toMatchObject({
+      id: 'wallet-1',
+      address: registerRequest.address,
+      disabled: false,
+    });
+  });
+
+  it('generates an Idempotency-Key when the caller omits one', async () => {
+    const fetchMock = jest.fn(
+      async (): Promise<HttpResponse> =>
+        jsonResponse(200, selfHostedResponse()),
+    );
+    const service = buildService(fetchMock);
+
+    await service.registerSelfHostedWallet(registerRequest);
+
+    const [, init] = fetchMock.mock.calls[0] as [string, FetchInit];
+    expect(init.headers['Idempotency-Key']?.length).toBeGreaterThan(0);
+  });
+
+  it('maps a plain-string 409 body to an ambiguous conflict error', async () => {
+    const fetchMock = jest.fn(
+      async (): Promise<HttpResponse> =>
+        textResponse(
+          409,
+          'A crypto address with this wallet address already exists',
+        ),
+    );
+    const service = buildService(fetchMock);
+
+    await expect(
+      service.registerSelfHostedWallet(registerRequest),
+    ).rejects.toMatchObject({
+      kind: 'conflict',
+      httpStatus: 409,
+      body: 'A crypto address with this wallet address already exists',
+    });
+  });
+
+  it('maps 5xx to a transient error', async () => {
+    const fetchMock = jest.fn(
+      async (): Promise<HttpResponse> => textResponse(500, 'internal error'),
+    );
+    const service = buildService(fetchMock);
+
+    await expect(
+      service.registerSelfHostedWallet(registerRequest),
+    ).rejects.toMatchObject({ kind: 'transient', httpStatus: 500 });
+  });
+
+  it('maps a network failure / timeout to a transient error', async () => {
+    const fetchMock = jest
+      .fn<Promise<HttpResponse>, unknown[]>()
+      .mockRejectedValue(new Error('ETIMEDOUT'));
+    const service = buildService(fetchMock);
+
+    await expect(
+      service.registerSelfHostedWallet(registerRequest),
+    ).rejects.toMatchObject({ kind: 'transient' });
+  });
+
+  it('maps a non-Error thrown during registration to transient', async () => {
+    const fetchMock = jest
+      .fn<Promise<HttpResponse>, unknown[]>()
+      .mockRejectedValue('socket hang up');
+    const service = buildService(fetchMock);
+
+    await expect(
+      service.registerSelfHostedWallet(registerRequest),
+    ).rejects.toMatchObject({ kind: 'transient' });
+  });
+
+  it('maps 400 to a validation error', async () => {
+    const fetchMock = jest.fn(
+      async (): Promise<HttpResponse> => textResponse(400, 'bad message'),
+    );
+    const service = buildService(fetchMock);
+
+    await expect(
+      service.registerSelfHostedWallet(registerRequest),
+    ).rejects.toMatchObject({ kind: 'validation', httpStatus: 400 });
+  });
+
+  it('maps an unmapped 4xx (422) to a validation error', async () => {
+    const fetchMock = jest.fn(
+      async (): Promise<HttpResponse> => textResponse(422, 'unprocessable'),
+    );
+    const service = buildService(fetchMock);
+
+    await expect(
+      service.registerSelfHostedWallet(registerRequest),
+    ).rejects.toMatchObject({ kind: 'validation', httpStatus: 422 });
+  });
+
+  it('maps 401 to unauthorized', async () => {
+    const fetchMock = jest.fn(
+      async (): Promise<HttpResponse> => textResponse(401, 'session expired'),
+    );
+
+    await expect(
+      buildService(fetchMock).registerSelfHostedWallet(registerRequest),
+    ).rejects.toMatchObject({ kind: 'unauthorized' });
+  });
+
+  it('maps 403 to forbidden and 404 to notFound', async () => {
+    const forbiddenFetch = jest.fn(
+      async (): Promise<HttpResponse> => textResponse(403, 'suspended'),
+    );
+    const notFoundFetch = jest.fn(
+      async (): Promise<HttpResponse> => textResponse(404, 'not found'),
+    );
+
+    const forbidden = await buildService(forbiddenFetch)
+      .registerSelfHostedWallet(registerRequest)
+      .catch((error: unknown): WalletRegistrationError => {
+        return error as WalletRegistrationError;
+      });
+    const notFound = await buildService(notFoundFetch)
+      .registerSelfHostedWallet(registerRequest)
+      .catch((error: unknown): WalletRegistrationError => {
+        return error as WalletRegistrationError;
+      });
+
+    expect(forbidden).toMatchObject({ kind: 'forbidden' });
+    expect(notFound).toMatchObject({ kind: 'notFound' });
+  });
+
+  it('maps a JSON error object with message when present', async () => {
+    const fetchMock = jest.fn(
+      async (): Promise<HttpResponse> =>
+        jsonResponse(403, { message: 'forbidden' }),
+    );
+    const service = buildService(fetchMock);
+
+    await expect(
+      service.registerSelfHostedWallet(registerRequest),
+    ).rejects.toMatchObject({ kind: 'forbidden', body: 'forbidden' });
+  });
+
+  it('maps a JSON-encoded string error body', async () => {
+    const fetchMock = jest.fn(
+      async (): Promise<HttpResponse> =>
+        textResponse(409, JSON.stringify('already exists')),
+    );
+
+    await expect(
+      buildService(fetchMock).registerSelfHostedWallet(registerRequest),
+    ).rejects.toMatchObject({ kind: 'conflict', body: 'already exists' });
+  });
+
+  it('keeps a JSON object without message as the raw body', async () => {
+    const fetchMock = jest.fn(
+      async (): Promise<HttpResponse> =>
+        jsonResponse(400, { code: 'x', detail: 'nope' }),
+    );
+
+    await expect(
+      buildService(fetchMock).registerSelfHostedWallet(registerRequest),
+    ).rejects.toMatchObject({
+      kind: 'validation',
+      body: JSON.stringify({ code: 'x', detail: 'nope' }),
+    });
+  });
+
+  it('keeps a whitespace-only error body as-is', async () => {
+    const fetchMock = jest.fn(
+      async (): Promise<HttpResponse> => textResponse(400, '   '),
+    );
+
+    await expect(
+      buildService(fetchMock).registerSelfHostedWallet(registerRequest),
+    ).rejects.toMatchObject({ kind: 'validation', body: '   ' });
+  });
+
+  it('omits Error.message when the upstream body is empty', async () => {
+    const fetchMock = jest.fn(
+      async (): Promise<HttpResponse> => textResponse(400, ''),
+    );
+
+    await expect(
+      buildService(fetchMock).registerSelfHostedWallet(registerRequest),
+    ).rejects.toMatchObject({
+      kind: 'validation',
+      body: '',
+      message: 'wallet registration failed: validation',
+    });
+  });
+
+  it('maps an unreadable error body to malformedResponse', async () => {
+    const fetchMock = jest.fn(
+      async (): Promise<HttpResponse> => ({
+        ok: false,
+        status: 500,
+        json: async (): Promise<unknown> => {
+          throw new Error('no json');
+        },
+        text: async (): Promise<string> => {
+          throw new Error('no text');
+        },
+      }),
+    );
+
+    await expect(
+      buildService(fetchMock).registerSelfHostedWallet(registerRequest),
+    ).rejects.toMatchObject({ kind: 'malformedResponse', httpStatus: 500 });
+  });
+
+  it('maps 429 to a rateLimited error', async () => {
+    const fetchMock = jest.fn(
+      async (): Promise<HttpResponse> => textResponse(429, 'slow down'),
+    );
+    const service = buildService(fetchMock);
+
+    await expect(
+      service.registerSelfHostedWallet(registerRequest),
+    ).rejects.toMatchObject({ kind: 'rateLimited' });
+  });
+
+  it('maps a malformed 200 body to malformedResponse', async () => {
+    const fetchMock = jest.fn(
+      async (): Promise<HttpResponse> => jsonResponse(200, { nope: true }),
+    );
+    const service = buildService(fetchMock);
+
+    await expect(
+      service.registerSelfHostedWallet(registerRequest),
+    ).rejects.toMatchObject({ kind: 'malformedResponse' });
+  });
+
+  it('rejects a success body that has an id but no address', async () => {
+    const fetchMock = jest.fn(
+      async (): Promise<HttpResponse> =>
+        jsonResponse(200, { id: 'wallet-1', disabled: false }),
+    );
+    const service = buildService(fetchMock);
+
+    await expect(
+      service.registerSelfHostedWallet(registerRequest),
+    ).rejects.toMatchObject({ kind: 'malformedResponse' });
+  });
+
+  it('maps a non-JSON success body to malformedResponse', async () => {
+    const fetchMock = jest.fn(
+      async (): Promise<HttpResponse> => invalidJsonResponse(200),
+    );
+    const service = buildService(fetchMock);
+
+    await expect(
+      service.registerSelfHostedWallet(registerRequest),
+    ).rejects.toMatchObject({ kind: 'malformedResponse' });
+  });
+});

--- a/packages/ramps-controller/src/wallet-registration-service.ts
+++ b/packages/ramps-controller/src/wallet-registration-service.ts
@@ -1,0 +1,466 @@
+/** The only blockchain supported by the Money Account POC. */
+export type Blockchain = 'Monad';
+
+/** Normalized view of a single registered self-hosted address. */
+export type SelfHostedRegistration = {
+  id: string;
+  address: string;
+  blockchain: Blockchain;
+  disabled: boolean;
+  isSelf: boolean;
+};
+
+/** Result of reconciling a wallet against the customer's registered addresses. */
+export type RegistrationStatus =
+  | { type: 'active'; registration: SelfHostedRegistration }
+  | { type: 'disabled'; registration: SelfHostedRegistration }
+  | { type: 'absent' };
+
+/**
+ * Discriminated error kinds surfaced to the state machine. Every non-success
+ * path maps to exactly one of these so the machine can decide deterministically.
+ */
+export type WalletRegistrationErrorKind =
+  | 'validation'
+  | 'unauthorized'
+  | 'forbidden'
+  | 'notFound'
+  | 'conflict'
+  | 'rateLimited'
+  | 'transient'
+  | 'lookupUnavailable'
+  | 'malformedResponse';
+
+/** Minimal HTTP response shape, so the service is environment-agnostic. */
+type HttpResponse = {
+  ok: boolean;
+  status: number;
+  json: () => Promise<unknown>;
+  text: () => Promise<string>;
+};
+
+/** Minimal `fetch`-like function the service depends on. */
+type FetchLike = (
+  url: string,
+  init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+  },
+) => Promise<HttpResponse>;
+
+/** Typed error carrying enough context for state transitions. */
+export class WalletRegistrationError extends Error {
+  readonly kind: WalletRegistrationErrorKind;
+
+  readonly httpStatus?: number;
+
+  readonly body?: string;
+
+  constructor(
+    kind: WalletRegistrationErrorKind,
+    options: {
+      message?: string;
+      httpStatus?: number;
+      body?: string;
+    },
+  ) {
+    super(options.message ?? `wallet registration failed: ${kind}`);
+    this.name = 'WalletRegistrationError';
+    this.kind = kind;
+    this.httpStatus = options.httpStatus;
+    this.body = options.body;
+  }
+}
+
+export type WalletRegistrationServiceOptions = {
+  fetch: FetchLike;
+  /**
+   * Base URL of the Money Movement neobank-proxy host
+   * (e.g. `https://on-ramp.dev-api.cx.metamask.io`). Paths are under `/neobank`.
+   */
+  baseUrl: string;
+  getAuthToken: () => Promise<string>;
+  /**
+   * MetaMask profile / partner external id used as MoonPay `external_id`
+   * (typically `AuthenticationController:getSessionProfile().canonicalProfileId`).
+   */
+  getExternalId: () => Promise<string>;
+};
+
+export type GetRegistrationStatusRequest = {
+  customerId: string;
+  address: string;
+  blockchain: Blockchain;
+};
+
+export type RegisterSelfHostedWalletRequest = {
+  customerId: string;
+  address: string;
+  blockchain: Blockchain;
+  message: string;
+  signature: string;
+  /**
+   * Stable key reused across retries of the same ownership proof. Generated
+   * when omitted.
+   */
+  idempotencyKey?: string;
+};
+
+/** Successful registration outcome. */
+export type RegistrationOutcome = {
+  type: 'registered';
+  registration: SelfHostedRegistration;
+};
+
+/**
+ * Normalizes a Monad EVM address for case-insensitive comparison.
+ *
+ * @param address - Raw address string.
+ * @returns The comparison key for the address.
+ */
+function normalizeAddress(address: string): string {
+  return address.toLowerCase();
+}
+
+/**
+ * Maps an HTTP status to the typed error kind the state machine reacts to.
+ *
+ * @param status - HTTP status code from the proxy/Iron response.
+ * @returns The corresponding error kind.
+ */
+function mapStatusToKind(status: number): WalletRegistrationErrorKind {
+  switch (status) {
+    case 400:
+      return 'validation';
+    case 401:
+      return 'unauthorized';
+    case 403:
+      return 'forbidden';
+    case 404:
+      return 'notFound';
+    case 409:
+      return 'conflict';
+    case 429:
+      return 'rateLimited';
+    default:
+      return status >= 500 ? 'transient' : 'validation';
+  }
+}
+
+/**
+ * Builds a client-side Idempotency-Key for MoonPay POSTs. Prefer a stable
+ * caller-supplied key across retries of the same proof.
+ *
+ * @returns A random UUID when available, otherwise a timestamped fallback.
+ */
+export function createIdempotencyKey(): string {
+  const cryptoObj = globalThis.crypto as
+    | { randomUUID?: () => string }
+    | undefined;
+  if (typeof cryptoObj?.randomUUID === 'function') {
+    return cryptoObj.randomUUID();
+  }
+  return `wallet-reg-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+/**
+ * Extracts a human-readable error body from a transparent neobank-proxy
+ * response. Upstream may return a plain string or a JSON value; both are
+ * mirrored 1:1 (no `{ code: 'iron_error' }` envelope).
+ *
+ * @param raw - Raw response text.
+ * @returns Normalized body string for {@link WalletRegistrationError}.
+ */
+export function extractErrorBody(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return raw;
+  }
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (typeof parsed === 'string') {
+      return parsed;
+    }
+    if (parsed && typeof parsed === 'object') {
+      const { message } = parsed as { message?: unknown };
+      if (typeof message === 'string') {
+        return message;
+      }
+    }
+    return trimmed;
+  } catch {
+    return trimmed;
+  }
+}
+
+/**
+ * Data service that talks to the Money Movement neobank-proxy for MoonPay Iron
+ * self-hosted wallet registration. It never calls Iron directly, so the Iron
+ * API key never ships in the client.
+ */
+export class WalletRegistrationService {
+  readonly #fetch: FetchLike;
+
+  readonly #baseUrl: string;
+
+  readonly #getAuthToken: () => Promise<string>;
+
+  readonly #getExternalId: () => Promise<string>;
+
+  constructor(options: WalletRegistrationServiceOptions) {
+    this.#fetch = options.fetch;
+    this.#baseUrl = options.baseUrl.replace(/\/$/u, '');
+    this.#getAuthToken = options.getAuthToken;
+    this.#getExternalId = options.getExternalId;
+  }
+
+  /**
+   * Resolves Iron's internal customer id via
+   * `GET /neobank/customers/{external_id}/external`, using the MetaMask
+   * profile/canonical id as `external_id`.
+   *
+   * @returns Iron's internal customer id.
+   */
+  async getMoonpayCustomerId(): Promise<string> {
+    const [token, externalId] = await Promise.all([
+      this.#getAuthToken(),
+      this.#getExternalId(),
+    ]);
+    if (!externalId) {
+      throw new WalletRegistrationError('malformedResponse', {
+        message: 'MetaMask external id (canonical profile id) is empty',
+      });
+    }
+
+    const response = await this.#fetch(
+      `${this.#baseUrl}/neobank/customers/${encodeURIComponent(externalId)}/external`,
+      {
+        method: 'GET',
+        headers: {
+          accept: 'application/json',
+          authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
+    if (!response.ok) {
+      throw await this.#toHttpError(response);
+    }
+
+    let payload: unknown;
+    try {
+      payload = await response.json();
+    } catch {
+      throw new WalletRegistrationError('malformedResponse', {
+        message: 'MoonPay customer body was not valid JSON',
+      });
+    }
+
+    const { id } = payload as { id?: unknown };
+    if (typeof id !== 'string' || id.length === 0) {
+      throw new WalletRegistrationError('malformedResponse', {
+        message: 'MoonPay customer body missing id',
+      });
+    }
+    return id;
+  }
+
+  /**
+   * Reconciles a wallet against the customer's registered self-hosted addresses
+   * via `GET /neobank/addresses/crypto/{customer_id}?filter=SelfHosted`.
+   * Upstream returns all self-hosted chains; Monad filtering stays client-side
+   * for the POC. A failed or malformed lookup is reported as
+   * `lookupUnavailable` and never downgraded to `absent`.
+   *
+   * @param request - Customer id and Monad address to reconcile.
+   * @returns The active / disabled / absent status for the address.
+   */
+  async getRegistrationStatus(
+    request: GetRegistrationStatusRequest,
+  ): Promise<RegistrationStatus> {
+    const { customerId, address, blockchain } = request;
+
+    let response: HttpResponse;
+    try {
+      const token = await this.#getAuthToken();
+      const url = new URL(
+        `${this.#baseUrl}/neobank/addresses/crypto/${encodeURIComponent(customerId)}`,
+      );
+      url.searchParams.set('filter', 'SelfHosted');
+      response = await this.#fetch(url.toString(), {
+        method: 'GET',
+        headers: {
+          accept: 'application/json',
+          authorization: `Bearer ${token}`,
+        },
+      });
+    } catch (error) {
+      throw new WalletRegistrationError('lookupUnavailable', {
+        message: 'self-hosted address lookup failed',
+        body: error instanceof Error ? error.message : undefined,
+      });
+    }
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw new WalletRegistrationError('lookupUnavailable', {
+        httpStatus: response.status,
+        body: extractErrorBody(body),
+      });
+    }
+
+    let payload: unknown;
+    try {
+      payload = await response.json();
+    } catch {
+      throw new WalletRegistrationError('malformedResponse', {
+        message: 'self-hosted address list body was not valid JSON',
+      });
+    }
+    if (!Array.isArray(payload)) {
+      throw new WalletRegistrationError('malformedResponse', {
+        message: 'expected an array of registered addresses',
+      });
+    }
+
+    const target = normalizeAddress(address);
+    const match = payload.find((entry) => {
+      const record = entry as Record<string, unknown>;
+      const walletAddress = record.wallet_address;
+      if (typeof walletAddress !== 'string') {
+        return false;
+      }
+      return (
+        normalizeAddress(walletAddress) === target &&
+        record.blockchain === blockchain
+      );
+    }) as Record<string, unknown> | undefined;
+
+    if (!match) {
+      return { type: 'absent' };
+    }
+
+    const registration = this.#toRegistration(match);
+    return registration.disabled
+      ? { type: 'disabled', registration }
+      : { type: 'active', registration };
+  }
+
+  /**
+   * Registers a self-hosted wallet through neobank-proxy
+   * `POST /neobank/addresses/crypto/selfhosted`. The client supplies
+   * `customer_id` and an `Idempotency-Key` (generated when omitted). Every
+   * non-2xx response is mapped to a typed error; `409` is deliberately
+   * surfaced as an ambiguous `conflict` that the caller must reconcile with a
+   * follow-up status lookup.
+   *
+   * @param request - Customer id, address, blockchain, message, and signature.
+   * @returns The registered outcome on success.
+   */
+  async registerSelfHostedWallet(
+    request: RegisterSelfHostedWalletRequest,
+  ): Promise<RegistrationOutcome> {
+    const idempotencyKey = request.idempotencyKey ?? createIdempotencyKey();
+    let response: HttpResponse;
+    try {
+      const token = await this.#getAuthToken();
+      response = await this.#fetch(
+        `${this.#baseUrl}/neobank/addresses/crypto/selfhosted`,
+        {
+          method: 'POST',
+          headers: {
+            accept: 'application/json',
+            'content-type': 'application/json',
+            authorization: `Bearer ${token}`,
+            'Idempotency-Key': idempotencyKey,
+          },
+          body: JSON.stringify({
+            customer_id: request.customerId,
+            address: request.address,
+            blockchain: request.blockchain,
+            message: request.message,
+            signature: request.signature,
+          }),
+        },
+      );
+    } catch (error) {
+      throw new WalletRegistrationError('transient', {
+        message: 'self-hosted registration request failed',
+        body: error instanceof Error ? error.message : undefined,
+      });
+    }
+
+    if (!response.ok) {
+      throw await this.#toHttpError(response);
+    }
+
+    let payload: unknown;
+    try {
+      payload = await response.json();
+    } catch {
+      throw new WalletRegistrationError('malformedResponse', {
+        message: 'registration success body was not valid JSON',
+      });
+    }
+
+    const record = payload as Record<string, unknown>;
+    if (typeof record.id !== 'string' || typeof record.address !== 'string') {
+      throw new WalletRegistrationError('malformedResponse', {
+        message: 'registration success body missing id/address',
+      });
+    }
+
+    return {
+      type: 'registered',
+      registration: {
+        id: record.id,
+        address: record.address,
+        blockchain: request.blockchain,
+        disabled: Boolean(record.disabled),
+        isSelf: true,
+      },
+    };
+  }
+
+  async #toHttpError(response: HttpResponse): Promise<WalletRegistrationError> {
+    let raw = '';
+    try {
+      raw = await response.text();
+    } catch {
+      return new WalletRegistrationError('malformedResponse', {
+        httpStatus: response.status,
+        message: 'error body could not be read',
+      });
+    }
+
+    const { status } = response;
+    const kind = mapStatusToKind(status);
+    const body = extractErrorBody(raw);
+    return new WalletRegistrationError(kind, {
+      httpStatus: status,
+      body,
+      message: body || undefined,
+    });
+  }
+
+  #toRegistration(record: Record<string, unknown>): SelfHostedRegistration {
+    if (typeof record.id !== 'string' || record.id.length === 0) {
+      throw new WalletRegistrationError('malformedResponse', {
+        message: 'registered address missing id',
+      });
+    }
+    if (typeof record.wallet_address !== 'string') {
+      throw new WalletRegistrationError('malformedResponse', {
+        message: 'registered address missing wallet_address',
+      });
+    }
+    return {
+      id: record.id,
+      address: record.wallet_address,
+      blockchain: 'Monad',
+      disabled: Boolean(record.disabled),
+      isSelf: Boolean(record.is_self),
+    };
+  }
+}

--- a/packages/ramps-controller/src/wallet-registration-service.ts
+++ b/packages/ramps-controller/src/wallet-registration-service.ts
@@ -270,8 +270,9 @@ export class WalletRegistrationService {
    * Reconciles a wallet against the customer's registered self-hosted addresses
    * via `GET /neobank/addresses/crypto/{customer_id}?filter=SelfHosted`.
    * Upstream returns all self-hosted chains; Monad filtering stays client-side
-   * for the POC. A failed or malformed lookup is reported as
-   * `lookupUnavailable` and never downgraded to `absent`.
+   * for the POC. Transport failures are reported as `lookupUnavailable`;
+   * malformed successful responses are reported as `malformedResponse`.
+   * Neither is downgraded to `absent`.
    *
    * @param request - Customer id and Monad address to reconcile.
    * @returns The active / disabled / absent status for the address.
@@ -303,10 +304,15 @@ export class WalletRegistrationService {
     }
 
     if (!response.ok) {
-      const body = await response.text();
+      let body: string;
+      try {
+        body = extractErrorBody(await response.text());
+      } catch (error) {
+        body = error instanceof Error ? error.message : '';
+      }
       throw new WalletRegistrationError('lookupUnavailable', {
         httpStatus: response.status,
-        body: extractErrorBody(body),
+        body,
       });
     }
 


### PR DESCRIPTION
## Summary

- Adds `NeoBankService` (GET/POST under `/neobank`) and `WalletRegistrationService` for the neobank-proxy HTTP contract.
- POST requests do not retry (same pattern as `TransakService`), so a 5xx or network failure cannot duplicate a mutating request without an `Idempotency-Key`.
- Wallet lookup rejects a matching list row that is missing `id` (`malformedResponse`). Snapshot types live in `autoramp-types.ts` only — no `RampsController` changes.

Supersedes the client slice of #9930. Stacked follow-up: controller methods + last-seen cursor (no User Storage).

## Test plan

- [ ] `yarn workspace @metamask/ramps-controller run test`
- [ ] Confirm GET retries on 429/5xx/network; POST does not retry
- [ ] Confirm matching lookup without `id` throws `malformedResponse`


Made with [Cursor](https://cursor.com)