### PR TITLE
Infer NetworkController RPC endpoint types from URLs

### DIFF
--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Infer RPC endpoint types from their URLs when initializing, adding, or updating network configurations.
 - Bump `@metamask/remote-feature-flag-controller` from `^6.0.0` to `^6.1.0` ([#9980](https://github.com/MetaMask/core/pull/9980))
 
 ## [36.0.0]
@@ -1281,7 +1282,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial release
+
   - As a result of converting our shared controllers repo into a monorepo ([#831](https://github.com/MetaMask/core/pull/831)), we've created this package from select parts of [`@metamask/controllers` v33.0.0](https://github.com/MetaMask/core/tree/v33.0.0), namely:
+
     - Everything in `src/network` (minus `NetworkType` and `NetworksChainId`, which were placed in `@metamask/controller-utils`)
 
     All changes listed after this point were applied to this package following the monorepo conversion.

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -1282,9 +1282,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial release
-
   - As a result of converting our shared controllers repo into a monorepo ([#831](https://github.com/MetaMask/core/pull/831)), we've created this package from select parts of [`@metamask/controllers` v33.0.0](https://github.com/MetaMask/core/tree/v33.0.0), namely:
-
     - Everything in `src/network` (minus `NetworkType` and `NetworksChainId`, which were placed in `@metamask/controller-utils`)
 
     All changes listed after this point were applied to this package following the monorepo conversion.

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -1191,6 +1191,7 @@ function deriveInfuraNetworkNameFromRpcEndpointUrl(
     return match.groups.networkName;
   }
 
+  /* istanbul ignore next -- The URL is matched before this function is called. */
   throw new Error('Could not derive Infura network from RPC endpoint URL');
 }
 
@@ -1305,6 +1306,7 @@ function normalizeNetworkConfiguration(
       infuraProjectId,
     );
 
+    /* istanbul ignore if -- State endpoint IDs are required by the public state type. */
     if (!hasNetworkClientId(inferredRpcEndpoint)) {
       throw new Error(
         `Network configuration '${networkConfiguration.name}' has an RPC endpoint without a network client ID`,

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -1211,6 +1211,33 @@ type InferredRpcEndpoint =
       type: RpcEndpointType.Custom;
     });
 
+function isInfuraRpcEndpoint(
+  rpcEndpointFields: RpcEndpointFields,
+): rpcEndpointFields is Extract<
+  InferredRpcEndpoint,
+  { type: RpcEndpointType.Infura }
+> {
+  return (
+    rpcEndpointFields.type === RpcEndpointType.Infura &&
+    rpcEndpointFields.networkClientId !== undefined
+  );
+}
+
+function isCustomRpcEndpoint(
+  rpcEndpointFields: RpcEndpointFields,
+): rpcEndpointFields is Extract<
+  InferredRpcEndpoint,
+  { type: RpcEndpointType.Custom }
+> {
+  return rpcEndpointFields.type === RpcEndpointType.Custom;
+}
+
+function hasNetworkClientId(
+  rpcEndpoint: InferredRpcEndpoint,
+): rpcEndpoint is RpcEndpoint {
+  return rpcEndpoint.networkClientId !== undefined;
+}
+
 /**
  * Checks whether an RPC URL is a MetaMask Infura endpoint. The URL may contain
  * either the placeholder persisted in built-in network configurations or the
@@ -1237,10 +1264,7 @@ function inferRpcEndpointType(
   infuraProjectId: string,
 ): InferredRpcEndpoint {
   if (isInfuraEndpointUrl(rpcEndpointFields.url, infuraProjectId)) {
-    if (
-      rpcEndpointFields.type === RpcEndpointType.Infura &&
-      rpcEndpointFields.networkClientId !== undefined
-    ) {
+    if (isInfuraRpcEndpoint(rpcEndpointFields)) {
       return rpcEndpointFields;
     }
 
@@ -1253,7 +1277,7 @@ function inferRpcEndpointType(
     };
   }
 
-  if (rpcEndpointFields.type === RpcEndpointType.Custom) {
+  if (isCustomRpcEndpoint(rpcEndpointFields)) {
     return rpcEndpointFields;
   }
 
@@ -1281,7 +1305,7 @@ function normalizeNetworkConfiguration(
       infuraProjectId,
     );
 
-    if (inferredRpcEndpoint.networkClientId === undefined) {
+    if (!hasNetworkClientId(inferredRpcEndpoint)) {
       throw new Error(
         `Network configuration '${networkConfiguration.name}' has an RPC endpoint without a network client ID`,
       );
@@ -1318,7 +1342,6 @@ function getInitialState(
     state?.networkConfigurationsByChainId ??
     defaultState.networkConfigurationsByChainId;
 
-  let hasChanges = false;
   const normalizedNetworkConfigurationsByChainId = Object.entries(
     networkConfigurationsByChainId,
   ).reduce<Record<Hex, NetworkConfiguration>>(
@@ -1327,7 +1350,6 @@ function getInitialState(
         networkConfiguration,
         infuraProjectId,
       );
-      hasChanges ||= normalizedNetworkConfiguration !== networkConfiguration;
       normalizedConfigurations[chainId as Hex] = normalizedNetworkConfiguration;
       return normalizedConfigurations;
     },
@@ -1337,9 +1359,7 @@ function getInitialState(
   return {
     ...defaultState,
     ...state,
-    networkConfigurationsByChainId: hasChanges
-      ? normalizedNetworkConfigurationsByChainId
-      : networkConfigurationsByChainId,
+    networkConfigurationsByChainId: normalizedNetworkConfigurationsByChainId,
   };
 }
 

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -97,7 +97,7 @@ import type {
 const debugLog = createModuleLogger(projectLogger, 'NetworkController');
 
 const INFURA_URL_REGEX =
-  /^https:\/\/(?<networkName>[^.]+)\.infura\.io\/v\d+\/(?<apiKey>.+)$/u;
+  /^https:\/\/(?<networkName>[^./]+)\.infura\.io\/v3\/(?<projectId>[^/]+)$/u;
 
 export type Block = {
   baseFeePerGas?: string;
@@ -168,7 +168,7 @@ export type InfuraRpcEndpoint = {
    * `{infuraProjectId}`, which will get replaced with the Infura project ID
    * when the network client is created.
    */
-  url: `https://${InfuraNetworkType}.infura.io/v3/{infuraProjectId}`;
+  url: string;
 };
 
 /**
@@ -277,8 +277,20 @@ export type NetworkConfiguration = {
  */
 export type AddNetworkCustomRpcEndpointFields = Omit<
   CustomRpcEndpoint,
-  'networkClientId'
->;
+  'networkClientId' | 'type'
+> & {
+  /**
+   * The type of the endpoint. If omitted, it is inferred from the URL.
+   */
+  type?: RpcEndpointType;
+};
+
+type AddNetworkInfuraRpcEndpointFields = Omit<InfuraRpcEndpoint, 'type'> & {
+  /**
+   * The type of the endpoint. If omitted, it is inferred from the URL.
+   */
+  type?: RpcEndpointType;
+};
 
 /**
  * A new network configuration that `addNetwork` takes.
@@ -288,7 +300,10 @@ export type AddNetworkCustomRpcEndpointFields = Omit<
  * network clients yet.
  */
 export type AddNetworkFields = Omit<NetworkConfiguration, 'rpcEndpoints'> & {
-  rpcEndpoints: (InfuraRpcEndpoint | AddNetworkCustomRpcEndpointFields)[];
+  rpcEndpoints: (
+    | AddNetworkInfuraRpcEndpointFields
+    | AddNetworkCustomRpcEndpointFields
+  )[];
 };
 
 /**
@@ -299,10 +314,22 @@ export type AddNetworkFields = Omit<NetworkConfiguration, 'rpcEndpoints'> & {
  * assumed that they have not already been added and therefore network clients
  * do not exist for them yet (and hence IDs need to be generated).
  */
-export type UpdateNetworkCustomRpcEndpointFields = Partialize<
-  CustomRpcEndpoint,
-  'networkClientId'
->;
+export type UpdateNetworkCustomRpcEndpointFields = Omit<
+  Partialize<CustomRpcEndpoint, 'networkClientId'>,
+  'type'
+> & {
+  /**
+   * The type of the endpoint. If omitted, it is inferred from the URL.
+   */
+  type?: RpcEndpointType;
+};
+
+type UpdateNetworkInfuraRpcEndpointFields = Omit<InfuraRpcEndpoint, 'type'> & {
+  /**
+   * The type of the endpoint. If omitted, it is inferred from the URL.
+   */
+  type?: RpcEndpointType;
+};
 
 /**
  * An updated representation of an existing network configuration that
@@ -313,8 +340,44 @@ export type UpdateNetworkCustomRpcEndpointFields = Partialize<
  * assumed that they are new and are not represented by network clients yet.
  */
 export type UpdateNetworkFields = Omit<NetworkConfiguration, 'rpcEndpoints'> & {
-  rpcEndpoints: (InfuraRpcEndpoint | UpdateNetworkCustomRpcEndpointFields)[];
+  rpcEndpoints: (
+    | UpdateNetworkInfuraRpcEndpointFields
+    | UpdateNetworkCustomRpcEndpointFields
+  )[];
 };
+
+type RpcEndpointWithOptionalType =
+  | (Omit<InfuraRpcEndpoint, 'type'> & {
+      type?: RpcEndpointType;
+    })
+  | (Omit<CustomRpcEndpoint, 'type'> & {
+      type?: RpcEndpointType;
+    });
+
+type NetworkConfigurationWithOptionalRpcEndpointType = Omit<
+  NetworkConfiguration,
+  'rpcEndpoints'
+> & {
+  rpcEndpoints: RpcEndpointWithOptionalType[];
+};
+
+type NetworkStateWithOptionalRpcEndpointType = Omit<
+  NetworkState,
+  'networkConfigurationsByChainId'
+> & {
+  networkConfigurationsByChainId: Record<
+    Hex,
+    NetworkConfigurationWithOptionalRpcEndpointType
+  >;
+};
+
+function hasRpcEndpointTypes(
+  networkConfiguration: NetworkConfigurationWithOptionalRpcEndpointType,
+): networkConfiguration is NetworkConfiguration {
+  return networkConfiguration.rpcEndpoints.every(
+    (rpcEndpoint) => rpcEndpoint.type !== undefined,
+  );
+}
 
 /**
  * `Object.keys()` is intentionally generic: it returns the keys of an object,
@@ -772,7 +835,7 @@ export type NetworkControllerOptions = {
    * specified, `networkConfigurationsByChainId` will default to a basic set of
    * network configurations (see {@link InfuraNetworkType} for the list).
    */
-  state?: Partial<NetworkState>;
+  state?: Partial<NetworkStateWithOptionalRpcEndpointType>;
   /**
    * A `loglevel` logger object.
    */
@@ -1131,6 +1194,155 @@ function deriveInfuraNetworkNameFromRpcEndpointUrl(
   throw new Error('Could not derive Infura network from RPC endpoint URL');
 }
 
+type RpcEndpointFields = {
+  failoverUrls?: string[];
+  name?: string;
+  networkClientId?: NetworkClientId;
+  type?: RpcEndpointType;
+  url: string;
+};
+
+type InferredRpcEndpoint =
+  | (Omit<InfuraRpcEndpoint, 'type'> & {
+      type: RpcEndpointType.Infura;
+    })
+  | (Omit<CustomRpcEndpoint, 'networkClientId' | 'type'> & {
+      networkClientId?: CustomNetworkClientId;
+      type: RpcEndpointType.Custom;
+    });
+
+/**
+ * Checks whether an RPC URL is a MetaMask Infura endpoint. The URL may contain
+ * either the placeholder persisted in built-in network configurations or the
+ * controller's Infura project ID.
+ *
+ * @param url - The RPC URL to check.
+ * @param infuraProjectId - The controller's Infura project ID.
+ * @returns Whether the URL is a MetaMask Infura endpoint.
+ */
+function isInfuraEndpointUrl(url: string, infuraProjectId: string): boolean {
+  const projectId = INFURA_URL_REGEX.exec(url)?.groups?.projectId;
+  return projectId === '{infuraProjectId}' || projectId === infuraProjectId;
+}
+
+/**
+ * Infers the type of an RPC endpoint from its URL.
+ *
+ * @param rpcEndpointFields - The RPC endpoint fields.
+ * @param infuraProjectId - The controller's Infura project ID.
+ * @returns The RPC endpoint fields with an inferred type.
+ */
+function inferRpcEndpointType(
+  rpcEndpointFields: RpcEndpointFields,
+  infuraProjectId: string,
+): InferredRpcEndpoint {
+  if (isInfuraEndpointUrl(rpcEndpointFields.url, infuraProjectId)) {
+    if (
+      rpcEndpointFields.type === RpcEndpointType.Infura &&
+      rpcEndpointFields.networkClientId !== undefined
+    ) {
+      return rpcEndpointFields;
+    }
+
+    return {
+      ...rpcEndpointFields,
+      networkClientId:
+        rpcEndpointFields.networkClientId ??
+        deriveInfuraNetworkNameFromRpcEndpointUrl(rpcEndpointFields.url),
+      type: RpcEndpointType.Infura,
+    };
+  }
+
+  if (rpcEndpointFields.type === RpcEndpointType.Custom) {
+    return rpcEndpointFields;
+  }
+
+  return {
+    ...rpcEndpointFields,
+    type: RpcEndpointType.Custom,
+  };
+}
+
+/**
+ * Normalizes the endpoint types in a network configuration.
+ *
+ * @param networkConfiguration - The network configuration to normalize.
+ * @param infuraProjectId - The controller's Infura project ID.
+ * @returns The normalized network configuration.
+ */
+function normalizeNetworkConfiguration(
+  networkConfiguration: NetworkConfigurationWithOptionalRpcEndpointType,
+  infuraProjectId: string,
+): NetworkConfiguration {
+  let hasChanges = false;
+  const rpcEndpoints = networkConfiguration.rpcEndpoints.map((rpcEndpoint) => {
+    const inferredRpcEndpoint = inferRpcEndpointType(
+      rpcEndpoint,
+      infuraProjectId,
+    );
+
+    if (inferredRpcEndpoint.networkClientId === undefined) {
+      throw new Error(
+        `Network configuration '${networkConfiguration.name}' has an RPC endpoint without a network client ID`,
+      );
+    }
+
+    hasChanges ||= inferredRpcEndpoint !== rpcEndpoint;
+    return inferredRpcEndpoint;
+  });
+
+  if (!hasChanges && hasRpcEndpointTypes(networkConfiguration)) {
+    return networkConfiguration;
+  }
+
+  return {
+    ...networkConfiguration,
+    rpcEndpoints,
+  };
+}
+
+/**
+ * Constructs the initial NetworkController state and infers RPC endpoint
+ * types in any provided network configurations.
+ *
+ * @param state - The desired initial state.
+ * @param infuraProjectId - The controller's Infura project ID.
+ * @returns The complete normalized initial state.
+ */
+function getInitialState(
+  state: NetworkControllerOptions['state'],
+  infuraProjectId: string,
+): NetworkState {
+  const defaultState = getDefaultNetworkControllerState();
+  const networkConfigurationsByChainId =
+    state?.networkConfigurationsByChainId ??
+    defaultState.networkConfigurationsByChainId;
+
+  let hasChanges = false;
+  const normalizedNetworkConfigurationsByChainId = Object.entries(
+    networkConfigurationsByChainId,
+  ).reduce<Record<Hex, NetworkConfiguration>>(
+    (normalizedConfigurations, [chainId, networkConfiguration]) => {
+      const normalizedNetworkConfiguration = normalizeNetworkConfiguration(
+        networkConfiguration,
+        infuraProjectId,
+      );
+      hasChanges ||= normalizedNetworkConfiguration !== networkConfiguration;
+      normalizedConfigurations[chainId as Hex] = normalizedNetworkConfiguration;
+      return normalizedConfigurations;
+    },
+    {},
+  );
+
+  return {
+    ...defaultState,
+    ...state,
+    networkConfigurationsByChainId: hasChanges
+      ? normalizedNetworkConfigurationsByChainId
+      : networkConfigurationsByChainId,
+  };
+}
+
 /**
  * Performs a series of checks that the given NetworkController state is
  * internally consistent — that all parts of state that are supposed to match in
@@ -1330,16 +1542,14 @@ export class NetworkController extends BaseController<
       getBlockTrackerOptions,
       analyticsOptions,
     } = options;
-    const initialState = {
-      ...getDefaultNetworkControllerState(),
-      ...state,
-    };
+    const initialState = getInitialState(state, infuraProjectId);
     validateInitialState(initialState);
-    const correctedInitialState = correctInitialState(initialState, messenger);
 
     if (!infuraProjectId || typeof infuraProjectId !== 'string') {
       throw new Error('Invalid Infura project ID');
     }
+
+    const correctedInitialState = correctInitialState(initialState, messenger);
 
     super({
       name: controllerName,
@@ -2119,14 +2329,21 @@ export class NetworkController extends BaseController<
    * @see {@link NetworkConfiguration}
    */
   addNetwork(fields: AddNetworkFields): NetworkConfiguration {
-    const { rpcEndpoints: setOfRpcEndpointFields } = fields;
+    const fieldsWithInferredRpcEndpointTypes = {
+      ...fields,
+      rpcEndpoints: fields.rpcEndpoints.map((rpcEndpointFields) =>
+        inferRpcEndpointType(rpcEndpointFields, this.#infuraProjectId),
+      ),
+    };
+    const { rpcEndpoints: setOfRpcEndpointFields } =
+      fieldsWithInferredRpcEndpointTypes;
 
     const autoManagedNetworkClientRegistry =
       this.#ensureAutoManagedNetworkClientRegistryPopulated();
 
     this.#validateNetworkFields({
       mode: 'add',
-      networkFields: fields,
+      networkFields: fieldsWithInferredRpcEndpointTypes,
       autoManagedNetworkClientRegistry,
     });
 
@@ -2148,11 +2365,11 @@ export class NetworkController extends BaseController<
 
     const newNetworkConfiguration =
       this.#determineNetworkConfigurationToPersist({
-        networkFields: fields,
+        networkFields: fieldsWithInferredRpcEndpointTypes,
         networkClientOperations,
       });
     this.#registerNetworkClientsAsNeeded({
-      networkFields: fields,
+      networkFields: fieldsWithInferredRpcEndpointTypes,
       networkClientOperations,
       autoManagedNetworkClientRegistry,
     });
@@ -2160,7 +2377,7 @@ export class NetworkController extends BaseController<
       this.#updateNetworkConfigurations({
         state,
         mode: 'add',
-        networkFields: fields,
+        networkFields: fieldsWithInferredRpcEndpointTypes,
         networkConfigurationToPersist: newNetworkConfiguration,
       });
     });
@@ -2214,15 +2431,21 @@ export class NetworkController extends BaseController<
     }
 
     const existingChainId = chainId;
+    const fieldsWithInferredRpcEndpointTypes = {
+      ...fields,
+      rpcEndpoints: fields.rpcEndpoints.map((rpcEndpointFields) =>
+        inferRpcEndpointType(rpcEndpointFields, this.#infuraProjectId),
+      ),
+    };
     const { chainId: newChainId, rpcEndpoints: setOfNewRpcEndpointFields } =
-      fields;
+      fieldsWithInferredRpcEndpointTypes;
 
     const autoManagedNetworkClientRegistry =
       this.#ensureAutoManagedNetworkClientRegistryPopulated();
 
     this.#validateNetworkFields({
       mode: 'update',
-      networkFields: fields,
+      networkFields: fieldsWithInferredRpcEndpointTypes,
       existingNetworkConfiguration,
       autoManagedNetworkClientRegistry,
     });
@@ -2352,7 +2575,7 @@ export class NetworkController extends BaseController<
 
     const updatedNetworkConfiguration =
       this.#determineNetworkConfigurationToPersist({
-        networkFields: fields,
+        networkFields: fieldsWithInferredRpcEndpointTypes,
         networkClientOperations,
       });
 
@@ -2379,7 +2602,7 @@ export class NetworkController extends BaseController<
     }
 
     this.#registerNetworkClientsAsNeeded({
-      networkFields: fields,
+      networkFields: fieldsWithInferredRpcEndpointTypes,
       networkClientOperations,
       autoManagedNetworkClientRegistry,
     });
@@ -2423,7 +2646,7 @@ export class NetworkController extends BaseController<
           this.#updateNetworkConfigurations({
             state,
             mode: 'update',
-            networkFields: fields,
+            networkFields: fieldsWithInferredRpcEndpointTypes,
             networkConfigurationToPersist: updatedNetworkConfiguration,
             existingNetworkConfiguration,
           });
@@ -2434,7 +2657,7 @@ export class NetworkController extends BaseController<
         this.#updateNetworkConfigurations({
           state,
           mode: 'update',
-          networkFields: fields,
+          networkFields: fieldsWithInferredRpcEndpointTypes,
           networkConfigurationToPersist: updatedNetworkConfiguration,
           existingNetworkConfiguration,
         });

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -3441,8 +3441,7 @@ export class NetworkController extends BaseController<
                 type: RpcEndpointType.Infura,
                 networkClientId:
                   registryNetworkConfig.rpcProviders.default.networkClientId,
-                url: registryNetworkConfig.rpcProviders.default
-                  .url as InfuraRpcEndpoint['url'],
+                url: registryNetworkConfig.rpcProviders.default.url,
               }
             : {
                 type: RpcEndpointType.Custom,

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -421,7 +421,10 @@ describe('NetworkController', () => {
       );
     });
 
-    it('corrects RPC endpoint types based on their URLs', async () => {
+    it.each([
+      'https://mainnet.infura.io/v3/{infuraProjectId}',
+      'https://mainnet.infura.io/v3/infura-project-id',
+    ])('corrects RPC endpoint types based on their URLs', async (url) => {
       await withController(
         {
           state: {
@@ -429,7 +432,7 @@ describe('NetworkController', () => {
               '0x1337': buildCustomNetworkConfiguration({
                 rpcEndpoints: [
                   buildCustomRpcEndpoint({
-                    url: 'https://mainnet.infura.io/v3/{infuraProjectId}',
+                    url,
                   }),
                 ],
               }),
@@ -4315,6 +4318,27 @@ describe('NetworkController', () => {
         expect(result.rpcEndpoints[0]).toMatchObject({
           type: RpcEndpointType.Custom,
           url: 'https://custom.endpoint',
+        });
+      });
+    });
+
+    it('infers an Infura RPC endpoint when adding a network', async () => {
+      const rpcEndpoint = {
+        networkClientId: 'some-network',
+        url: 'https://some-network.infura.io/v3/{infuraProjectId}',
+      };
+
+      await withController(({ controller }) => {
+        const result = controller.addNetwork(
+          buildAddNetworkFields({
+            rpcEndpoints: [rpcEndpoint],
+          }),
+        );
+
+        expect(result.rpcEndpoints[0]).toStrictEqual({
+          networkClientId: 'some-network',
+          type: RpcEndpointType.Infura,
+          url: 'https://some-network.infura.io/v3/{infuraProjectId}',
         });
       });
     });

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -421,6 +421,57 @@ describe('NetworkController', () => {
       );
     });
 
+    it('corrects RPC endpoint types based on their URLs', async () => {
+      await withController(
+        {
+          state: {
+            networkConfigurationsByChainId: {
+              '0x1337': buildCustomNetworkConfiguration({
+                rpcEndpoints: [
+                  buildCustomRpcEndpoint({
+                    url: 'https://mainnet.infura.io/v3/{infuraProjectId}',
+                  }),
+                ],
+              }),
+            },
+          },
+        },
+        ({ controller }) => {
+          expect(
+            controller.state.networkConfigurationsByChainId['0x1337']
+              .rpcEndpoints[0].type,
+          ).toBe(RpcEndpointType.Infura);
+        },
+      );
+    });
+
+    it('infers the type of RPC endpoints missing a type in the initial state', async () => {
+      const { type: _, ...rpcEndpoint } = buildCustomRpcEndpoint({
+        url: 'https://custom.endpoint',
+      });
+
+      await withController(
+        {
+          state: {
+            networkConfigurationsByChainId: {
+              '0x1337': buildCustomNetworkConfiguration({
+                rpcEndpoints: [rpcEndpoint],
+              }),
+            },
+          },
+        },
+        ({ controller }) => {
+          expect(
+            controller.state.networkConfigurationsByChainId['0x1337']
+              .rpcEndpoints[0],
+          ).toMatchObject({
+            type: RpcEndpointType.Custom,
+            url: 'https://custom.endpoint',
+          });
+        },
+      );
+    });
+
     it('removes invalid network client IDs from networksMetadata, logging this fact', () => {
       const messenger = buildRootMessenger();
       const captureExceptionSpy = jest.spyOn(messenger, 'captureException');
@@ -4248,6 +4299,26 @@ describe('NetworkController', () => {
       });
     });
 
+    it('infers the type of an RPC endpoint when adding a network', async () => {
+      const { type: _, ...rpcEndpoint } =
+        buildAddNetworkCustomRpcEndpointFields({
+          url: 'https://custom.endpoint',
+        });
+
+      await withController(({ controller }) => {
+        const result = controller.addNetwork(
+          buildAddNetworkFields({
+            rpcEndpoints: [rpcEndpoint],
+          }),
+        );
+
+        expect(result.rpcEndpoints[0]).toMatchObject({
+          type: RpcEndpointType.Custom,
+          url: 'https://custom.endpoint',
+        });
+      });
+    });
+
     it('throws if the rpcEndpoints field is an empty array', async () => {
       await withController(({ controller }) => {
         expect(() =>
@@ -5449,6 +5520,41 @@ describe('NetworkController', () => {
               'Could not update network: `rpcEndpoints` must be a non-empty array',
             ),
           );
+        },
+      );
+    });
+
+    it('infers the type of an RPC endpoint when updating a network', async () => {
+      const networkConfigurationToUpdate = buildCustomNetworkConfiguration({
+        chainId: '0x1337',
+      });
+      const { type: _, ...rpcEndpoint } =
+        buildUpdateNetworkCustomRpcEndpointFields({
+          url: 'https://custom.endpoint',
+        });
+
+      await withController(
+        {
+          state: {
+            networkConfigurationsByChainId: {
+              '0x1337': networkConfigurationToUpdate,
+            },
+          },
+        },
+        async ({ controller }) => {
+          const result = await controller.updateNetwork(
+            '0x1337',
+            {
+              ...networkConfigurationToUpdate,
+              rpcEndpoints: [rpcEndpoint],
+            },
+            { replacementSelectedRpcEndpointIndex: 0 },
+          );
+
+          expect(result.rpcEndpoints[0]).toMatchObject({
+            type: RpcEndpointType.Custom,
+            url: 'https://custom.endpoint',
+          });
         },
       );
     });

--- a/packages/network-controller/tests/NetworkController.test.ts
+++ b/packages/network-controller/tests/NetworkController.test.ts
@@ -4324,7 +4324,6 @@ describe('NetworkController', () => {
 
     it('infers an Infura RPC endpoint when adding a network', async () => {
       const rpcEndpoint = {
-        networkClientId: 'some-network',
         url: 'https://some-network.infura.io/v3/{infuraProjectId}',
       };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Explanation

`NetworkController` previously required callers and persisted state to include an RPC endpoint type. This change makes the type derived from the endpoint URL instead. Infura URLs matching the controller project ID or `{infuraProjectId}` are normalized to `infura`; all other URLs are normalized to `custom`.

The normalization runs for initial state, `addNetwork`, and `updateNetwork`, so existing state is corrected on the next initialization and mutation validation/client registration use the normalized endpoint shape. Infura network client IDs can also be derived from the URL when an inferred Infura endpoint does not provide one. The endpoint URL type is widened to support dynamically configured Infura subdomains.

## References

None.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-37414cdc-2894-45da-886e-be9144b08f15?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37414cdc-2894-45da-886e-be9144b08f15&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

