### PR TITLE
fix(eth-json-rpc-middleware): allow null for optional transaction params

### DIFF
--- a/packages/eth-json-rpc-middleware/CHANGELOG.md
+++ b/packages/eth-json-rpc-middleware/CHANGELOG.md
@@ -7,14 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `@metamask/eth-sig-util` from `^8.2.0` to `^9.0.0` ([#9999](https://github.com/MetaMask/core/pull/9999))
+
 ### Fixed
 
 - Allow `null` values for optional fields in `eth_sendTransaction` / `eth_signTransaction` params ([#10039](https://github.com/MetaMask/core/pull/10039))
   - Fields like `maxFeePerGas`, `maxPriorityFeePerGas`, `gasPrice`, `gas`, `value`, `data`, `to`, `nonce`, `chainId`, `type`, `gasLimit`, `accessList`, and `authorizationList` now accept `null` in addition to `undefined`, which is how some dApps signal an absent value in JSON
-
-### Changed
-
-- Bump `@metamask/eth-sig-util` from `^8.2.0` to `^9.0.0` ([#9999](https://github.com/MetaMask/core/pull/9999))
 
 ## [24.0.1]
 

--- a/packages/eth-json-rpc-middleware/CHANGELOG.md
+++ b/packages/eth-json-rpc-middleware/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow `null` values for optional fields in `eth_sendTransaction` / `eth_signTransaction` params ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
+  - Fields like `maxFeePerGas`, `maxPriorityFeePerGas`, `gasPrice`, `gas`, `value`, `data`, `to`, `nonce`, `chainId`, `type`, `gasLimit`, `accessList`, and `authorizationList` now accept `null` in addition to `undefined`, which is how some dApps signal an absent value in JSON
+
 ### Changed
 
 - Bump `@metamask/eth-sig-util` from `^8.2.0` to `^9.0.0` ([#9999](https://github.com/MetaMask/core/pull/9999))

--- a/packages/eth-json-rpc-middleware/CHANGELOG.md
+++ b/packages/eth-json-rpc-middleware/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Allow `null` values for optional fields in `eth_sendTransaction` / `eth_signTransaction` params ([#XXXX](https://github.com/MetaMask/core/pull/XXXX))
+- Allow `null` values for optional fields in `eth_sendTransaction` / `eth_signTransaction` params ([#10039](https://github.com/MetaMask/core/pull/10039))
   - Fields like `maxFeePerGas`, `maxPriorityFeePerGas`, `gasPrice`, `gas`, `value`, `data`, `to`, `nonce`, `chainId`, `type`, `gasLimit`, `accessList`, and `authorizationList` now accept `null` in addition to `undefined`, which is how some dApps signal an absent value in JSON
 
 ### Changed

--- a/packages/eth-json-rpc-middleware/src/utils/validation.test.ts
+++ b/packages/eth-json-rpc-middleware/src/utils/validation.test.ts
@@ -368,6 +368,70 @@ describe('Validation Utils', () => {
       ).not.toThrow();
     });
 
+    it('does not throw when optional quantity fields are null', () => {
+      expect(() =>
+        validateTransactionParams({
+          from: VALID_FROM,
+          to: VALID_TO,
+          chainId: null,
+          gas: null,
+          gasLimit: null,
+          gasPrice: null,
+          maxFeePerGas: null,
+          maxPriorityFeePerGas: null,
+          nonce: null,
+          value: null,
+        }),
+      ).not.toThrow();
+    });
+
+    it('does not throw when optional string fields are null', () => {
+      expect(() =>
+        validateTransactionParams({
+          from: VALID_FROM,
+          to: null,
+          data: null,
+          type: null,
+        }),
+      ).not.toThrow();
+    });
+
+    it('does not throw when accessList is null', () => {
+      expect(() =>
+        validateTransactionParams({
+          from: VALID_FROM,
+          accessList: null,
+        }),
+      ).not.toThrow();
+    });
+
+    it('does not throw when authorizationList is null', () => {
+      expect(() =>
+        validateTransactionParams({
+          from: VALID_FROM,
+          authorizationList: null,
+        }),
+      ).not.toThrow();
+    });
+
+    it('does not throw when authorizationList entry fields are null', () => {
+      expect(() =>
+        validateTransactionParams({
+          from: VALID_FROM,
+          authorizationList: [
+            {
+              address: VALID_TO,
+              chainId: null,
+              nonce: null,
+              r: null,
+              s: null,
+              yParity: null,
+            },
+          ],
+        }),
+      ).not.toThrow();
+    });
+
     it.each([
       ['null', null],
       ['undefined', undefined],

--- a/packages/eth-json-rpc-middleware/src/utils/validation.ts
+++ b/packages/eth-json-rpc-middleware/src/utils/validation.ts
@@ -250,7 +250,9 @@ const QuantityStruct = union([string(), number()]);
 
 export const TransactionParamsStruct = object({
   accessList: optional(
-    nullable(array(object({ address: string(), storageKeys: array(string()) }))),
+    nullable(
+      array(object({ address: string(), storageKeys: array(string()) })),
+    ),
   ),
   authorizationList: optional(
     nullable(

--- a/packages/eth-json-rpc-middleware/src/utils/validation.ts
+++ b/packages/eth-json-rpc-middleware/src/utils/validation.ts
@@ -3,6 +3,7 @@ import { providerErrors, rpcErrors } from '@metamask/rpc-errors';
 import type { Struct, StructError } from '@metamask/superstruct';
 import {
   array,
+  nullable,
   number,
   object,
   optional,
@@ -249,32 +250,34 @@ const QuantityStruct = union([string(), number()]);
 
 export const TransactionParamsStruct = object({
   accessList: optional(
-    array(object({ address: string(), storageKeys: array(string()) })),
+    nullable(array(object({ address: string(), storageKeys: array(string()) }))),
   ),
   authorizationList: optional(
-    array(
-      object({
-        address: string(),
-        chainId: optional(QuantityStruct),
-        nonce: optional(QuantityStruct),
-        r: optional(string()),
-        s: optional(string()),
-        yParity: optional(QuantityStruct),
-      }),
+    nullable(
+      array(
+        object({
+          address: string(),
+          chainId: optional(nullable(QuantityStruct)),
+          nonce: optional(nullable(QuantityStruct)),
+          r: optional(nullable(string())),
+          s: optional(nullable(string())),
+          yParity: optional(nullable(QuantityStruct)),
+        }),
+      ),
     ),
   ),
-  chainId: optional(QuantityStruct),
-  data: optional(string()),
+  chainId: optional(nullable(QuantityStruct)),
+  data: optional(nullable(string())),
   from: string(),
-  gas: optional(QuantityStruct),
-  gasLimit: optional(QuantityStruct),
-  gasPrice: optional(QuantityStruct),
-  maxFeePerGas: optional(QuantityStruct),
-  maxPriorityFeePerGas: optional(QuantityStruct),
-  nonce: optional(QuantityStruct),
-  to: optional(string()),
-  type: optional(string()),
-  value: optional(QuantityStruct),
+  gas: optional(nullable(QuantityStruct)),
+  gasLimit: optional(nullable(QuantityStruct)),
+  gasPrice: optional(nullable(QuantityStruct)),
+  maxFeePerGas: optional(nullable(QuantityStruct)),
+  maxPriorityFeePerGas: optional(nullable(QuantityStruct)),
+  nonce: optional(nullable(QuantityStruct)),
+  to: optional(nullable(string())),
+  type: optional(nullable(string())),
+  value: optional(nullable(QuantityStruct)),
 });
 
 // Upper bound derived from the largest valid eth_sendTransaction payload:


### PR DESCRIPTION
## Summary

Some dApps send `null` for optional transaction fields like `maxFeePerGas` and `maxPriorityFeePerGas` instead of omitting them. This is natural in JSON, where `null` is the standard way to express "no value", but our validator was rejecting these requests with an `Invalid params` error.

This change updates all optional fields in `TransactionParamsStruct` to accept both `undefined` (field omitted) and `null` (field explicitly set to null).

## Changes

- Wrapped all `optional(...)` fields in `TransactionParamsStruct` with `nullable()` so both `undefined` and `null` are accepted
- Added `nullable` to the superstruct imports
- Added tests for all affected fields

## Affected fields

`maxFeePerGas`, `maxPriorityFeePerGas`, `gasPrice`, `gas`, `gasLimit`, `value`, `nonce`, `chainId`, `data`, `to`, `type`, `accessList`, `authorizationList`, and the nested fields inside `authorizationList` entries.

## Testing

All 448 existing tests pass. New tests cover null values for every affected field.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows validation only by accepting JSON `null` on optional transaction fields; required `from` and structural checks are unchanged.
> 
> **Overview**
> **Fixes `Invalid params` for dApps that send `null` on optional `eth_sendTransaction` / `eth_signTransaction` fields** instead of omitting them.
> 
> `TransactionParamsStruct` now wraps each optional field with `nullable()` (including `accessList`, `authorizationList`, and nested authorization entry fields), so validation treats explicit `null` like a missing value. New unit tests cover null for quantity, string, list, and authorization fields; the changelog documents the fix under **Unreleased**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfa443f0e47f95551fd41d83458e98400373e947. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->