### PR TITLE
fix: linea gas fee flow and user-op gas buffer truncate fractional muln multipliers

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `LineaGasFeeFlow` silently under-computing fee estimates for the `medium` and `high` levels ([#CHANGEME](https://github.com/MetaMask/core/pull/CHANGEME))
+  - `BN.muln()` was called with the fractional multipliers (`1.35`, `1.7`, `1.05`, `1.1`) used to derive Linea gas fee levels; `muln` truncates non-integer input per 26-bit word instead of throwing, so the previous implementation silently returned an under-computed value (e.g. `1 gwei * 1.05` returned `1003023795` instead of `1050000000`).
+
 ### Changed
 
 - Bump `@metamask/remote-feature-flag-controller` from `^6.0.0` to `^6.1.0` ([#9980](https://github.com/MetaMask/core/pull/9980))

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix `LineaGasFeeFlow` silently under-computing fee estimates for the `medium` and `high` levels ([#CHANGEME](https://github.com/MetaMask/core/pull/CHANGEME))
+- Fix `LineaGasFeeFlow` silently under-computing fee estimates for the `medium` and `high` levels ([#10045](https://github.com/MetaMask/core/pull/10045))
   - `BN.muln()` was called with the fractional multipliers (`1.35`, `1.7`, `1.05`, `1.1`) used to derive Linea gas fee levels; `muln` truncates non-integer input per 26-bit word instead of throwing, so the previous implementation silently returned an under-computed value (e.g. `1 gwei * 1.05` returned `1003023795` instead of `1050000000`).
 
 ### Changed

--- a/packages/transaction-controller/src/gas-flows/LineaGasFeeFlow.test.ts
+++ b/packages/transaction-controller/src/gas-flows/LineaGasFeeFlow.test.ts
@@ -110,8 +110,8 @@ describe('LineaGasFeeFlow', () => {
 
       expect(priorityFees).toStrictEqual([
         LINEA_RESPONSE_MOCK.priorityFeePerGas,
-        '0x23a3d70a3',
-        '0x25658bf25',
+        '0x23d70a3d6',
+        '0x258bf258b',
       ]);
 
       expect(rpcRequestMock).toHaveBeenCalledTimes(1);
@@ -138,9 +138,39 @@ describe('LineaGasFeeFlow', () => {
 
       expect(maxFees).toStrictEqual([
         '0x333333333',
-        '0x3a7ae1479',
-        '0x42428f5c1',
+        '0x3ae147ae0',
+        '0x428f5c28e',
       ]);
+    });
+
+    it('applies fractional multipliers without integer truncation', async () => {
+      // Values chosen so a naive `BN.muln(1.35)` truncates to the wrong
+      // integer per 26-bit word instead of throwing - proving the
+      // implementation multiplies via an arbitrary-precision path.
+      const basePerGas = 30_000_000_000n; // 30 gwei
+      const priorityPerGas = 1_000_000_000n; // 1 gwei
+
+      rpcRequestMock.mockResolvedValue({
+        baseFeePerGas: `0x${basePerGas.toString(16)}`,
+        priorityFeePerGas: `0x${priorityPerGas.toString(16)}`,
+      });
+
+      const flow = new LineaGasFeeFlow();
+      const response = await flow.getGasFees(request);
+      const estimates = response.estimates as FeeMarketGasFeeEstimates;
+
+      expect(BigInt(estimates.medium.maxPriorityFeePerGas)).toBe(
+        (priorityPerGas * 105n) / 100n,
+      );
+      expect(BigInt(estimates.high.maxPriorityFeePerGas)).toBe(
+        (priorityPerGas * 110n) / 100n,
+      );
+      expect(BigInt(estimates.medium.maxFeePerGas)).toBe(
+        (basePerGas * 135n) / 100n + (priorityPerGas * 105n) / 100n,
+      );
+      expect(BigInt(estimates.high.maxFeePerGas)).toBe(
+        (basePerGas * 170n) / 100n + (priorityPerGas * 110n) / 100n,
+      );
     });
 
     it('uses default flow if error', async () => {

--- a/packages/transaction-controller/src/gas-flows/LineaGasFeeFlow.ts
+++ b/packages/transaction-controller/src/gas-flows/LineaGasFeeFlow.ts
@@ -1,4 +1,9 @@
-import { ChainId, hexToBN, toHex } from '@metamask/controller-utils';
+import {
+  ChainId,
+  fractionBN,
+  hexToBN,
+  toHex,
+} from '@metamask/controller-utils';
 import type { NetworkClientId } from '@metamask/network-controller';
 import { createModuleLogger } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
@@ -27,6 +32,16 @@ type FeesByLevel = {
 };
 
 const log = createModuleLogger(projectLogger, 'linea-gas-fee-flow');
+
+/**
+ * Precision used to convert a decimal multiplier (e.g. 1.35) into an integer
+ * numerator/denominator pair for `fractionBN`, which does the multiplication
+ * as an arbitrary-precision BN operation. `BN.muln` cannot be used directly
+ * with a fractional multiplier: it silently truncates to the integer part on
+ * a per-26-bit-word basis instead of throwing, so `base.muln(1.35)` returns a
+ * wrong, under-computed result rather than failing loudly.
+ */
+const MULTIPLIER_PRECISION = 100;
 
 const LINEA_CHAIN_IDS: Hex[] = [
   ChainId['linea-mainnet'],
@@ -150,15 +165,34 @@ export class LineaGasFeeFlow implements GasFeeFlow {
     multipliers: { low: number; medium: number; high: number },
   ): FeesByLevel {
     const base = hexToBN(value);
-    const low = base.muln(multipliers.low);
-    const medium = base.muln(multipliers.medium);
-    const high = base.muln(multipliers.high);
+    const low = this.#applyMultiplier(base, multipliers.low);
+    const medium = this.#applyMultiplier(base, multipliers.medium);
+    const high = this.#applyMultiplier(base, multipliers.high);
 
     return {
       low,
       medium,
       high,
     };
+  }
+
+  /**
+   * Multiplies a BN value by a decimal multiplier, quantized to
+   * `MULTIPLIER_PRECISION` decimal places, without `BN.muln`'s word-boundary
+   * truncation. All multipliers this flow uses have at most two decimal
+   * places, so this is exact for them; it is not a general-purpose
+   * arbitrary-precision decimal multiply.
+   *
+   * @param value - The value to multiply.
+   * @param multiplier - The decimal multiplier (e.g. 1.35).
+   * @returns The multiplied value.
+   */
+  #applyMultiplier(value: BN, multiplier: number): BN {
+    return fractionBN(
+      value,
+      Math.round(multiplier * MULTIPLIER_PRECISION),
+      MULTIPLIER_PRECISION,
+    );
   }
 
   #getMaxFees(

--- a/packages/user-operation-controller/CHANGELOG.md
+++ b/packages/user-operation-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix `normalizeGasEstimate` silently under-computing the gas buffer for estimates that need more than one 26-bit `BN` word (values at or above ~67.1M) ([#CHANGEME](https://github.com/MetaMask/core/pull/CHANGEME))
+- Fix `normalizeGasEstimate` silently under-computing the gas buffer for estimates that need more than one 26-bit `BN` word (values at or above ~67.1M) ([#10045](https://github.com/MetaMask/core/pull/10045))
   - Same root cause as the `LineaGasFeeFlow` fix in `@metamask/transaction-controller`: `BN.muln(1.5)` truncates instead of throwing once the value crosses the 26-bit-word boundary (~67.1M), e.g. `100000000 * 1.5` previously returned `116445568` instead of `150000000`.
 
 ## [41.2.9]

--- a/packages/user-operation-controller/CHANGELOG.md
+++ b/packages/user-operation-controller/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `normalizeGasEstimate` silently under-computing the gas buffer for estimates that need more than one 26-bit `BN` word (values at or above ~67.1M) ([#CHANGEME](https://github.com/MetaMask/core/pull/CHANGEME))
+  - Same root cause as the `LineaGasFeeFlow` fix in `@metamask/transaction-controller`: `BN.muln(1.5)` truncates instead of throwing once the value crosses the 26-bit-word boundary (~67.1M), e.g. `100000000 * 1.5` previously returned `116445568` instead of `150000000`.
+
 ## [41.2.9]
 
 ### Changed

--- a/packages/user-operation-controller/src/utils/gas.test.ts
+++ b/packages/user-operation-controller/src/utils/gas.test.ts
@@ -123,6 +123,26 @@ describe('gas', () => {
         );
       });
 
+      it('applies the gas buffer multiplier without integer truncation for large estimates', async () => {
+        // 100_000_000 is above the 2^26 threshold at which `BN.muln` with a
+        // fractional multiplier silently truncates instead of throwing -
+        // `muln(1.5)` on this value previously returned 116445568 instead of
+        // the correct 150000000.
+        bundlerMock.estimateUserOperationGas.mockResolvedValue({
+          callGasLimit: 100_000_000,
+          preVerificationGas: 456,
+          verificationGasLimit: 789,
+        });
+
+        await callUpdateGas();
+
+        expect(metadata.userOperation).toStrictEqual(
+          expect.objectContaining({
+            callGasLimit: '0x8f0d180',
+          }),
+        );
+      });
+
       it('if estimates are hexadecimal strings', async () => {
         bundlerMock.estimateUserOperationGas.mockResolvedValue(
           ESTIMATE_RESPONSE_HEX_MOCK,

--- a/packages/user-operation-controller/src/utils/gas.ts
+++ b/packages/user-operation-controller/src/utils/gas.ts
@@ -1,4 +1,4 @@
-import { hexToBN } from '@metamask/controller-utils';
+import { fractionBN, hexToBN } from '@metamask/controller-utils';
 import { add0x } from '@metamask/utils';
 import BN from 'bn.js';
 
@@ -16,6 +16,18 @@ const log = createModuleLogger(projectLogger, 'gas');
  * A multiplier to apply to all gas estimate values returned from the bundler.
  */
 const GAS_ESTIMATE_MULTIPLIER = 1.5;
+
+/**
+ * Precision used to convert `GAS_ESTIMATE_MULTIPLIER` into an integer
+ * numerator/denominator pair for `fractionBN`. `BN.muln` cannot be used
+ * directly with a fractional multiplier: it silently truncates to the
+ * integer part on a per-26-bit-word basis instead of throwing, so
+ * `value.muln(1.5)` can return a wrong, under-computed result once the gas
+ * estimate needs more than one 26-bit word (values at or above ~67.1M, i.e.
+ * 2^26, are susceptible, though not every value above that boundary is
+ * actually affected).
+ */
+const GAS_ESTIMATE_MULTIPLIER_PRECISION = 100;
 
 /**
  * Populates the gas properties for a user operation.
@@ -87,7 +99,11 @@ function normalizeGasEstimate(rawValue: string | number): string {
   const value =
     typeof rawValue === 'string' ? hexToBN(rawValue) : new BN(rawValue);
 
-  const bufferedValue = value.muln(GAS_ESTIMATE_MULTIPLIER);
+  const bufferedValue = fractionBN(
+    value,
+    Math.round(GAS_ESTIMATE_MULTIPLIER * GAS_ESTIMATE_MULTIPLIER_PRECISION),
+    GAS_ESTIMATE_MULTIPLIER_PRECISION,
+  );
 
   return add0x(bufferedValue.toString(16));
 }


### PR DESCRIPTION
## What

`LineaGasFeeFlow` (`@metamask/transaction-controller`) and `normalizeGasEstimate` (`@metamask/user-operation-controller`) both apply a decimal multiplier to a `BN` via `BN.muln(fractionalNumber)`. `bn.js`'s `imuln` requires an **integer** multiplier but never validates that — it does `w & 0x3ffffff` per 26-bit word, so a fractional multiplier gets silently truncated instead of throwing. The value that comes out the other end is wrong and *under-computed*, and on the Linea side it reaches what actually gets **signed** by default (`RandomisedEstimationsGasFeeFlow` only supersedes this flow behind a remote feature flag).

## Repro (pinned `bn.js@5.2.2`, exactly what ships in this repo)

```
1 gwei  x1.05 (muln) -> 1003023795   (exact 1050000000, short 46976205 wei = 4.47% low)
30 gwei x1.35 (muln) -> 40469801011  (exact 40500000000)
100000000 x1.5 (muln) -> 116445568  (exact 150000000)
```

The transaction-controller side is live right now: `LineaGasFeeFlow.test.ts`'s existing pinned expectations (`0x23a3d70a3`, `0x25658bf25` for priority fees, `0x3a7ae1479`, `0x42428f5c1` for max fees) are snapshots **of the buggy output**, not independently-verified correct values — I confirmed this by computing the old `muln` output directly and it matches the pinned hex exactly.

The user-operation-controller side (`GAS_ESTIMATE_MULTIPLIER = 1.5`) needs the estimate to cross 2^26 (~67.1M) before it's wrong, which is above typical UserOperation gas but not impossible (heavy calldata/batched ops, chains with higher gas costs). Included as the same bug class with the same trivial fix, not as the headline issue.

## Fix

Both now use `fractionBN` (already exported from `@metamask/controller-utils`, and already used correctly for exactly this purpose at `packages/transaction-controller/src/utils/gas.ts:401`) instead of `muln`. `fractionBN` does `target.mul(numerator).div(denominator)` — full-precision `BN` multiplication, not the fixed-width `imuln` path — so it has no truncation boundary. The decimal multiplier is converted to an integer numerator/denominator pair via `Math.round(multiplier * PRECISION)` / `PRECISION` (guards against `multiplier * 100` landing on a non-integer float, e.g. `1.1 * 100 === 110.00000000000001` in JS).

## Tests

- Recomputed and corrected the two pinned hex expectations in `LineaGasFeeFlow.test.ts` that were snapshotting the buggy output (see repro above for how I know the old values were wrong, not just different).
- Added a new test to each affected suite that doesn't rely on a pinned snapshot — it computes the expected value independently via `BigInt`/exact decimal math and uses an input magnitude chosen specifically to fail against the old `muln` implementation. Verified this directly: stashed just the source fix (kept the new tests) and confirmed 3 tests fail with the exact truncated values shown above; restored the fix and all pass.

```
$ yarn jest LineaGasFeeFlow --no-coverage
Test Suites: 1 passed, 1 total
Tests:       8 passed, 8 total

$ yarn jest (full transaction-controller package)
Test Suites: 44 passed, 44 total
Tests:       1141 passed, 1141 total

$ yarn jest gas.test.ts --no-coverage (user-operation-controller)
Test Suites: 1 passed, 1 total
Tests:       6 passed, 6 total

$ yarn jest (full user-operation-controller package)
Test Suites: 10 passed, 10 total
Tests:       217 passed, 217 total

$ yarn lint:tsc   -> clean, no output
$ yarn eslint <4 changed files>  -> clean, no output
```

## Risk

Low — this only ever *increases* the previously-under-computed medium/high estimates toward the mathematically-intended value; it never changes the `low` level (multiplier `1`, unaffected either way) and never produces a value the code wasn't already trying to produce.

## Scope note

Kept to the two `muln`-with-fractional-multiplier call sites found via `rg`. Did not touch other `BN` arithmetic in either package.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Linea default gas fees and user-op gas buffers increase toward previously intended values, affecting what users see and sign; behavior is corrective but touches fee-critical paths.
> 
> **Overview**
> Fixes **silent under-estimation** when applying decimal gas multipliers with `BN.muln`, which truncates fractional inputs per 26-bit word instead of multiplying correctly.
> 
> **`LineaGasFeeFlow`** now scales base and priority fees for medium/high via `fractionBN` through a new `#applyMultiplier` helper (replacing `base.muln(1.35)`, `1.7`, `1.05`, `1.1`). Medium and high **max fee** and **priority fee** values increase toward the intended math; low (multiplier `1`) is unchanged. Tests update previously wrong pinned hex expectations and add a case that asserts exact fractional math.
> 
> **`normalizeGasEstimate`** in user-operation-controller applies the same pattern for the **1.5× gas buffer**, fixing wrong buffered limits when estimates exceed ~67M gas. A regression test covers a large `callGasLimit`.
> 
> Changelogs document both fixes ([#10045](https://github.com/MetaMask/core/pull/10045)).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a6d23052fd0bdcfc80830968554e4e37600356d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->