### PR TITLE
fix(perps-controller): correct significant-figure counting for sub-$1 HyperLiquid prices

### DIFF
--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix sub-$1 HyperLiquid price rounding miscounting significant figures, needlessly clipping precision on limit/TP/SL/trigger/chase prices and mispricing post-only order chases ([#PR_NUMBER](https://github.com/MetaMask/core/pull/PR_NUMBER))
+- Fix sub-$1 HyperLiquid price rounding miscounting significant figures, needlessly clipping precision on limit/TP/SL/trigger/chase prices and mispricing post-only order chases ([#10052](https://github.com/MetaMask/core/pull/10052))
 
 ## [15.0.0]
 

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix sub-$1 HyperLiquid price rounding miscounting significant figures, needlessly clipping precision on limit/TP/SL/trigger/chase prices and mispricing post-only order chases ([#PR_NUMBER](https://github.com/MetaMask/core/pull/PR_NUMBER))
+
 ## [15.0.0]
 
 ### Added

--- a/packages/perps-controller/src/utils/significantFigures.ts
+++ b/packages/perps-controller/src/utils/significantFigures.ts
@@ -19,15 +19,21 @@ export const countSignificantFigures = (priceString: string): number => {
   }
 
   const normalized = number.toString();
-  const [integerPart, decimalPart = ''] = normalized.split('.');
-  const trimmedInteger = integerPart.replace(/^-?0*/u, '') || '';
+  // Strip the sign and decimal point so leading zeros are counted across the
+  // *whole* number, not just the integer part — "0.001234" has to lose its
+  // "0" integer part and its two leading fractional zeros to land on the
+  // correct 4 significant figures ("1234"), not 6.
+  const digitsOnly = normalized.replace(/^-/u, '').replace('.', '');
+  const withoutLeadingZeros = digitsOnly.replace(/^0+/u, '') || '0';
 
-  const effectiveIntegerLength = decimalPart
-    ? trimmedInteger.length
-    : trimmedInteger.replace(/0+$/u, '').length ||
-      (trimmedInteger.length > 0 ? 1 : 0);
+  // Trailing zeros are only ambiguous (not significant) for an integer with
+  // no decimal point (e.g. "1000" could be 1-4 sig figs); once there's a
+  // decimal point, every digit already present is significant.
+  if (!normalized.includes('.')) {
+    return withoutLeadingZeros.replace(/0+$/u, '').length || 1;
+  }
 
-  return effectiveIntegerLength + decimalPart.length;
+  return withoutLeadingZeros.length;
 };
 
 /**
@@ -80,26 +86,20 @@ export const roundToSignificantFigures = (
     return priceString;
   }
 
-  const normalized = number.toString();
-  const [integerPart, decimalPart = ''] = normalized.split('.');
-
-  const trimmedInteger = integerPart.replace(/^-?0*/u, '') || '';
-  const integerSigFigs = trimmedInteger.length;
-
-  if (!decimalPart) {
-    return normalized;
+  if (countSignificantFigures(cleaned) <= maxSigFigs) {
+    return number.toString();
   }
 
-  const allowedDecimalDigits = maxSigFigs - integerSigFigs;
+  // Same order-of-magnitude approach as getPriceTick (orderCalculations.ts) —
+  // keep the two significant-figures rules in sync instead of maintaining
+  // two independent implementations of the same HyperLiquid precision rule.
+  const magnitude = Math.floor(Math.log10(Math.abs(number)));
+  const decimalPlaces = maxSigFigs - 1 - magnitude;
 
-  if (allowedDecimalDigits <= 0) {
+  if (decimalPlaces <= 0) {
     return Math.round(number).toString();
   }
 
-  if (decimalPart.length <= allowedDecimalDigits) {
-    return normalized;
-  }
-
-  const rounded = number.toFixed(allowedDecimalDigits);
+  const rounded = number.toFixed(decimalPlaces);
   return Number.parseFloat(rounded).toString();
 };

--- a/packages/perps-controller/tests/src/utils/formatHyperLiquidPrice.test.ts
+++ b/packages/perps-controller/tests/src/utils/formatHyperLiquidPrice.test.ts
@@ -1,0 +1,33 @@
+import { formatHyperLiquidPrice } from '../../../src/utils/hyperLiquidAdapter.js';
+
+describe('formatHyperLiquidPrice', () => {
+  it('returns an integer price unchanged', () => {
+    expect(formatHyperLiquidPrice({ price: 50000, szDecimals: 3 })).toBe(
+      '50000',
+    );
+  });
+
+  it('rounds a price >= 1 to the decimal-place grid, then to 5 significant figures', () => {
+    expect(
+      formatHyperLiquidPrice({ price: 2999.14159, szDecimals: 4 }),
+    ).toBe('2999.1');
+  });
+
+  // Regression: countSignificantFigures used to miscount every sub-$1 price
+  // as having far more significant figures than it does, so a price that was
+  // already within HyperLiquid's 5-significant-figure limit got needlessly
+  // re-rounded and lost a real digit of precision.
+  it.each([
+    ['0.001234', 0],
+    ['0.000463', 0],
+    ['0.000171', 0],
+  ])('preserves full precision for %s (szDecimals=%s)', (price, szDecimals) => {
+    expect(formatHyperLiquidPrice({ price, szDecimals })).toBe(price);
+  });
+
+  it('still rounds a sub-$1 price that genuinely exceeds 5 significant figures', () => {
+    expect(
+      formatHyperLiquidPrice({ price: '0.00123456', szDecimals: 0 }),
+    ).toBe('0.001235');
+  });
+});

--- a/packages/perps-controller/tests/src/utils/orderCalculations.scale-ladder.test.ts
+++ b/packages/perps-controller/tests/src/utils/orderCalculations.scale-ladder.test.ts
@@ -279,12 +279,44 @@ describe('orderCalculations - scale ladder', () => {
         }),
       ).toBe('50001');
     });
+
+    // Regression: formatHyperLiquidPrice used to miscount a sub-$1 price's
+    // significant figures and re-round it back down onto a coarser grid than
+    // getPriceTick (used two lines above to compute `improved`) had just
+    // produced. A post-only buy chase meant to rest one tick above the best
+    // bid came back AT the best bid instead — resting behind the whole
+    // queue — and a sell chase came back BELOW the best bid, which the venue
+    // treats as crossing the book and rejects for a post-only (ALO) order.
+    it('rests strictly inside the spread for a sub-$1 book (HMSTR-shaped)', () => {
+      const bestBid = 0.000171;
+      const bestAsk = 0.000175;
+
+      const buyChase = computeChaseQuotePrice({
+        bestBid,
+        bestAsk,
+        isBuy: true,
+        szDecimals: 0,
+      });
+      expect(buyChase).toBe('0.000172');
+      expect(Number(buyChase)).toBeGreaterThan(bestBid);
+
+      const sellChase = computeChaseQuotePrice({
+        bestBid,
+        bestAsk,
+        isBuy: false,
+        szDecimals: 0,
+      });
+      expect(sellChase).toBe('0.000174');
+      expect(Number(sellChase)).toBeLessThan(bestAsk);
+      expect(Number(sellChase)).toBeGreaterThan(bestBid);
+    });
   });
 
   describe('getPriceTick', () => {
     it.each([
       ['decimal-bound at a low price', 12, 4, 0.01],
       ['significant-figure-bound at a high price', 50000, 3, 1],
+      ['significant-figure-bound at a sub-$1 price', 0.000171, 0, 0.000001],
     ])('is %s', (_label, price, szDecimals, expected) => {
       expect(getPriceTick({ price, szDecimals })).toBeCloseTo(expected, 10);
     });

--- a/packages/perps-controller/tests/src/utils/significantFigures.test.ts
+++ b/packages/perps-controller/tests/src/utils/significantFigures.test.ts
@@ -11,7 +11,13 @@ describe('significantFigures utilities', () => {
       ['0', 0],
       ['not-a-number', 0],
       ['$1,230.4500', 6],
-      ['0.001234', 6],
+      // Sub-$1 values: leading zeros before the first nonzero digit are not
+      // significant, whether they sit in the integer part or the fraction.
+      // 0.001234 is HyperLiquid's own canonical example of a valid perp
+      // price (4 significant figures) — see https://hyperliquid.gitbook.io.
+      ['0.001234', 4],
+      ['0.000463', 3],
+      ['0.000171', 3],
       ['1000', 1],
       ['-12.340', 4],
     ])('counts %s as %s', (input, expected) => {
@@ -30,6 +36,14 @@ describe('significantFigures utilities', () => {
       expect(hasExceededSignificantFigures('123.456', 5)).toBe(true);
       expect(hasExceededSignificantFigures('123.45', 5)).toBe(false);
     });
+
+    it('does not flag a valid sub-$1 price as exceeding the limit', () => {
+      // Regression: countSignificantFigures used to inflate 0.001234's 4 real
+      // significant figures to 6 by counting the leading fractional zeros,
+      // which made this documented-valid HyperLiquid price look invalid.
+      expect(hasExceededSignificantFigures('0.001234', 5)).toBe(false);
+      expect(hasExceededSignificantFigures('0.00123456', 5)).toBe(true);
+    });
   });
 
   describe('roundToSignificantFigures', () => {
@@ -43,6 +57,20 @@ describe('significantFigures utilities', () => {
       expect(roundToSignificantFigures('123.4567', 5)).toBe('123.46');
       expect(roundToSignificantFigures('123.4', 5)).toBe('123.4');
       expect(roundToSignificantFigures('12345.67', 3)).toBe('12346');
+    });
+
+    it('leaves a sub-$1 price within the significant-figure budget untouched', () => {
+      // Regression: these used to be misclassified as 6 significant figures
+      // and rounded down to 5 decimal places (0.00046/0.00017), destroying a
+      // real digit of precision on a price that was already valid.
+      expect(roundToSignificantFigures('0.001234', 5)).toBe('0.001234');
+      expect(roundToSignificantFigures('0.000463', 5)).toBe('0.000463');
+      expect(roundToSignificantFigures('0.000171', 5)).toBe('0.000171');
+    });
+
+    it('rounds a sub-$1 price that genuinely exceeds the budget', () => {
+      expect(roundToSignificantFigures('0.00123456', 5)).toBe('0.0012346');
+      expect(roundToSignificantFigures('0.00012345', 4)).toBe('0.0001234');
     });
   });
 });


### PR DESCRIPTION
## Explanation

`countSignificantFigures` (`packages/perps-controller/src/utils/significantFigures.ts`) only stripped leading zeros from the **integer part** of a number, then added the full decimal-part length. For any HyperLiquid perp price under $1, the integer part is always `"0"`, so its two/three leading fractional zeros got counted as significant figures too:

```ts
const trimmedInteger = integerPart.replace(/^-?0*/u, '') || '';
const effectiveIntegerLength = decimalPart ? trimmedInteger.length : ...;
return effectiveIntegerLength + decimalPart.length;
```

`0.001234` — HyperLiquid's own canonical example of a **valid** perp price (4 significant figures) — was miscounted as **6**. That fed into `roundToSignificantFigures`, whose `allowedDecimalDigits = maxSigFigs - integerSigFigs` degenerates into a fixed-decimal-places round when `integerSigFigs` is 0, needlessly re-rounding an already-valid price down to `0.00123` and destroying a real digit of precision.

**The package already implements the correct rule elsewhere, and the two disagree.** `getPriceTick` (`orderCalculations.ts:330-347`) computes HyperLiquid's precision rule correctly via `Math.floor(Math.log10(price))` — magnitude-based, so it doesn't care whether the price is above or below 1. `computeChaseQuotePrice` calls `getPriceTick` for the correct tick size, then routes the resulting price through the broken `formatHyperLiquidPrice` → `countSignificantFigures` path. For a sub-$1 book this is a real functional failure, not just a display nit:

```
$ node repro (HMSTR-shaped book, bestBid 0.000171 / bestAsk 0.000175, szDecimals 0)
tick (getPriceTick, correct):  0.000001
buyChase  (before fix): 0.00017   -- NOT > bestBid (0.000171) -- rests behind the whole queue
sellChase (before fix): 0.00017   -- NOT > bestBid            -- crosses the book; an ALO order gets rejected
buyChase  (after fix):  0.000172  -- > bestBid, correct
sellChase (after fix):  0.000174  -- between bestBid and bestAsk, correct
```

## Fix

- `countSignificantFigures`: strip leading zeros from the **combined** integer+decimal digit string, not just the integer part.
- `roundToSignificantFigures`: switched from the ad-hoc `maxSigFigs - integerSigFigs` decimal budget to the same order-of-magnitude approach `getPriceTick` already uses correctly, so the package has one significant-figures rule instead of two independently-maintained (and disagreeing) copies.
- Fixed `significantFigures.test.ts`'s existing assertion pinning `'0.001234'` at **6** significant figures — that expectation was captured from the buggy implementation, not derived; the correct value is 4.
- Added real coverage for the previously-untested `< 1` branch across `countSignificantFigures`, `hasExceededSignificantFigures`, `roundToSignificantFigures`, and `formatHyperLiquidPrice` (which had **zero** unit tests before this PR), plus the `computeChaseQuotePrice`/`getPriceTick` sub-$1 regression above.

## Receipts

**Genuine red-before/green-after** — reverted just the source fix and reran the new tests against the old logic:
```
FAIL formatHyperLiquidPrice.test.ts
  ✕ preserves full precision for 0.000463 (szDecimals=0): Expected "0.000463", Received "0.00046"
  ✕ preserves full precision for 0.000171 (szDecimals=0): Expected "0.000171", Received "0.00017"
  ✕ still rounds a sub-$1 price that genuinely exceeds 5 significant figures: Expected "0.001235", Received "0.00123"
FAIL orderCalculations.scale-ladder.test.ts
  ✕ rests strictly inside the spread for a sub-$1 book (HMSTR-shaped): Expected "0.000172", Received "0.00017"
Tests: 5 failed, 47 passed, 52 total
```
Restored the fix — same tests, plus the full package suite:
```
$ yarn jest --testPathPatterns='formatHyperLiquidPrice|orderCalculations.scale-ladder|significantFigures'
Tests: 68 passed, 68 total

$ yarn jest   (full perps-controller package)
Test Suites: 85 passed, 85 total
Tests:       40 skipped, 3697 passed, 3737 total

$ yarn lint:tsc   (monorepo-wide tsc --build)
$ echo $?
0

$ yarn eslint <changed files>
$ echo $?
0

$ yarn changelog:validate
$ echo $?
0
```

## Risk / scope

Low. Two pure functions and their one downstream consumer (`formatHyperLiquidPrice`); no change to `getPriceTick` itself, which was already correct and is now the reference the other function follows.

**Known limitation, unaffected by this PR** — `countSignificantFigures`/`roundToSignificantFigures` are exported as general-purpose pure functions, and neither the old nor the new implementation correctly parses a raw exponential-notation string (e.g. `"1.23e-7"`) if called directly with one — both mishandle it identically. This is unreachable via the actual price-formatting pipeline: `formatHyperLiquidPrice` bounds its input through `toFixed(maxDecimalPlaces)` (max 6 decimal places) before these functions ever see it, and `(0.000001).toString()` stays in decimal notation — JS only switches to exponential below `1e-6`. Not fixing full scientific-notation support here since it's pre-existing, unregressed, and outside the price-formatting domain this package actually exercises.

Codex reviewed the diff adversarially but didn't return a verdict inside a reasonable time budget (~9 minutes of visible, genuine progress — not a stall); killed the process (targeting only its own PID) and substituted the two specific things it was mid-investigation on myself: the exponential-notation question above, and whether `toFixed`'s IEEE-754 rounding behavior (e.g. `(0.123455).toFixed(5)` rounding down due to `0.123455` not being exactly representable) is a new regression — it isn't; `toFixed` was already used by the pre-fix code and this is an inherent floating-point property, not something this diff introduces.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure math utilities in perps-controller with no auth or persistence changes; main effect is more accurate HyperLiquid price strings for sub-$1 assets and chase orders.
> 
> **Overview**
> Fixes HyperLiquid price formatting for **sub-$1** markets by correcting how significant figures are counted and rounded in `significantFigures.ts`.
> 
> **`countSignificantFigures`** now strips leading zeros from the full digit string (integer + fraction), so values like `0.001234` count as **4** sig figs instead of **6**. **`roundToSignificantFigures`** no longer uses the broken integer-part decimal budget; it uses the same **order-of-magnitude** rule as `getPriceTick`, and returns prices unchanged when they already fit within the cap.
> 
> That stops `formatHyperLiquidPrice` from over-rounding valid limit/TP/SL/trigger prices and fixes **post-only chase** quotes on penny books: chase prices stay one tick inside the spread instead of resting at or through the touch (ALO rejections). Changelog and regression tests cover `formatHyperLiquidPrice`, chase ladder behavior, and the sig-fig helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7547eff89c68569748f411bcc6da6f8e3e3c9b24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->