### PR TITLE
feat(kyc-controller): move moonpay keypair generation out of constructor

### DIFF
--- a/packages/kyc-controller/src/KycController.test.ts
+++ b/packages/kyc-controller/src/KycController.test.ts
@@ -954,7 +954,9 @@ describe('KycController', () => {
           },
         },
         async ({ controller, handlers }) => {
-          const envelope = await envelopeFor(controller, { accessToken: 'access-1' });
+          const envelope = await envelopeFor(controller, {
+            accessToken: 'access-1',
+          });
 
           await controller.handleFrameMessage({
             message: {
@@ -984,7 +986,9 @@ describe('KycController', () => {
         },
         async ({ controller, handlers, launcher }) => {
           handlers.checkKycRequired.mockResolvedValue({ kycRequired: false });
-          const envelope = await envelopeFor(controller, { accessToken: 'access-1' });
+          const envelope = await envelopeFor(controller, {
+            accessToken: 'access-1',
+          });
 
           await controller.handleFrameMessage({
             message: {
@@ -1024,7 +1028,9 @@ describe('KycController', () => {
             onStatusChange?.('InProgress', 'Completed');
             return { ok: true };
           });
-          const envelope = await envelopeFor(controller, { accessToken: 'access-2' });
+          const envelope = await envelopeFor(controller, {
+            accessToken: 'access-2',
+          });
 
           await controller.handleFrameMessage({
             message: {
@@ -1056,7 +1062,9 @@ describe('KycController', () => {
         async ({ controller, handlers, launcher }) => {
           handlers.checkKycRequired.mockResolvedValue({ kycRequired: true });
           launcher.isAvailable.mockReturnValue(false);
-          const envelope = await envelopeFor(controller, { accessToken: 'access-1' });
+          const envelope = await envelopeFor(controller, {
+            accessToken: 'access-1',
+          });
 
           const result = await controller.handleFrameMessage({
             message: {
@@ -1101,7 +1109,9 @@ describe('KycController', () => {
             onStatusChange?.('InProgress', 'Completed');
             return { ok: true };
           });
-          const envelope = await envelopeFor(controller, { accessToken: 'access-1' });
+          const envelope = await envelopeFor(controller, {
+            accessToken: 'access-1',
+          });
           const message = {
             kind: 'complete',
             meta: { channelId: 'ch_2' },
@@ -1208,7 +1218,9 @@ describe('KycController', () => {
         },
         async ({ controller, handlers, launcher }) => {
           handlers.checkKycRequired.mockRejectedValue(new Error('down'));
-          const envelope = await envelopeFor(controller, { accessToken: 'access-1' });
+          const envelope = await envelopeFor(controller, {
+            accessToken: 'access-1',
+          });
 
           await controller.handleFrameMessage({
             message: {

--- a/packages/kyc-controller/src/KycController.test.ts
+++ b/packages/kyc-controller/src/KycController.test.ts
@@ -106,14 +106,31 @@ function makeEnvelope(
  * @param credentials - The plaintext credentials to encrypt.
  * @returns The encrypted envelope.
  */
-function envelopeFor(
+async function envelopeFor(
   controller: KycController,
   credentials: Record<string, unknown>,
-): { ephemeralPublicKey: string; iv: string; ciphertext: string } {
-  const url = controller.buildCheckFrameUrl();
-  const publicKeyHex = new URL(url as string).searchParams.get(
-    'publicKey',
-  ) as string;
+): Promise<{ ephemeralPublicKey: string; iv: string; ciphertext: string }> {
+  let url = controller.buildCheckFrameUrl();
+  if (!url) {
+    const inProgressPhases: KycController['state']['phase'][] = [
+      'session',
+      'check',
+      'auth',
+      'form',
+      'submit',
+    ];
+    if (!inProgressPhases.includes(controller.state.phase)) {
+      throw new Error(
+        'Controller needs a MoonPay frame keypair; call initialize({ vendor: "moonpay" }) first',
+      );
+    }
+    await controller.initialize({ vendor: 'moonpay' });
+    url = controller.buildCheckFrameUrl();
+  }
+  if (!url) {
+    throw new Error('Could not build Check frame URL for envelope');
+  }
+  const publicKeyHex = new URL(url).searchParams.get('publicKey') as string;
   return makeEnvelope(hexToBytes(publicKeyHex), credentials);
 }
 
@@ -431,7 +448,7 @@ describe('KycController', () => {
           });
 
           // Establish an auth-frame client token from a prior authentication.
-          const envelope = envelopeFor(controller, {
+          const envelope = await envelopeFor(controller, {
             clientToken: 'old-client',
           });
           await controller.handleFrameMessage({
@@ -496,6 +513,7 @@ describe('KycController', () => {
           await pending;
 
           expect(controller.state.sessionToken).toBe('new-session');
+          await controller.initialize({ vendor: 'moonpay' });
           expect(controller.buildCheckFrameUrl()).toContain(
             'sessionToken=new-session',
           );
@@ -713,14 +731,13 @@ describe('KycController', () => {
       await withController(
         { options: { state: { phase: 'done', sessionToken: 'tok' } } },
         async ({ controller }) => {
-          const envelope = envelopeFor(controller, { accessToken: 'access-1' });
           const result = await controller.handleFrameMessage({
             message: {
               kind: 'complete',
               meta: { channelId: 'ch_1' },
               payload: {
                 status: 'active',
-                credentials: envelope,
+                credentials: 'not-used',
                 customer: { id: 'cust-late' },
               },
             },
@@ -770,6 +787,7 @@ describe('KycController', () => {
       await withController(
         { options: { state: { phase: 'check', sessionToken: 'tok' } } },
         async ({ controller }) => {
+          await controller.initialize({ vendor: 'moonpay' });
           await controller.handleFrameMessage({
             message: {
               kind: 'complete',
@@ -788,7 +806,7 @@ describe('KycController', () => {
         await withController(
           { options: { state: { phase: 'check', sessionToken: 'tok' } } },
           async ({ controller }) => {
-            const envelope = envelopeFor(controller, {
+            const envelope = await envelopeFor(controller, {
               accessToken: 'access-1',
             });
             await controller.handleFrameMessage({
@@ -808,7 +826,7 @@ describe('KycController', () => {
         await withController(
           { options: { state: { phase: 'check', sessionToken: 'tok' } } },
           async ({ controller }) => {
-            const envelope = envelopeFor(controller, {
+            const envelope = await envelopeFor(controller, {
               clientToken: 'client-1',
             });
             await controller.handleFrameMessage({
@@ -877,7 +895,7 @@ describe('KycController', () => {
         await withController(
           { options: { state: { phase: 'auth', sessionToken: 'tok' } } },
           async ({ controller }) => {
-            const envelope = envelopeFor(controller, {
+            const envelope = await envelopeFor(controller, {
               accessToken: 'access-2',
             });
             await controller.handleFrameMessage({
@@ -936,7 +954,7 @@ describe('KycController', () => {
           },
         },
         async ({ controller, handlers }) => {
-          const envelope = envelopeFor(controller, { accessToken: 'access-1' });
+          const envelope = await envelopeFor(controller, { accessToken: 'access-1' });
 
           await controller.handleFrameMessage({
             message: {
@@ -966,7 +984,7 @@ describe('KycController', () => {
         },
         async ({ controller, handlers, launcher }) => {
           handlers.checkKycRequired.mockResolvedValue({ kycRequired: false });
-          const envelope = envelopeFor(controller, { accessToken: 'access-1' });
+          const envelope = await envelopeFor(controller, { accessToken: 'access-1' });
 
           await controller.handleFrameMessage({
             message: {
@@ -1006,7 +1024,7 @@ describe('KycController', () => {
             onStatusChange?.('InProgress', 'Completed');
             return { ok: true };
           });
-          const envelope = envelopeFor(controller, { accessToken: 'access-2' });
+          const envelope = await envelopeFor(controller, { accessToken: 'access-2' });
 
           await controller.handleFrameMessage({
             message: {
@@ -1038,7 +1056,7 @@ describe('KycController', () => {
         async ({ controller, handlers, launcher }) => {
           handlers.checkKycRequired.mockResolvedValue({ kycRequired: true });
           launcher.isAvailable.mockReturnValue(false);
-          const envelope = envelopeFor(controller, { accessToken: 'access-1' });
+          const envelope = await envelopeFor(controller, { accessToken: 'access-1' });
 
           const result = await controller.handleFrameMessage({
             message: {
@@ -1083,7 +1101,7 @@ describe('KycController', () => {
             onStatusChange?.('InProgress', 'Completed');
             return { ok: true };
           });
-          const envelope = envelopeFor(controller, { accessToken: 'access-1' });
+          const envelope = await envelopeFor(controller, { accessToken: 'access-1' });
           const message = {
             kind: 'complete',
             meta: { channelId: 'ch_2' },
@@ -1122,14 +1140,8 @@ describe('KycController', () => {
           },
         },
         async ({ controller, handlers }) => {
-          // The keypair is stable across reset, so both envelopes can be built
-          // up front while the session token (used only to derive the public
-          // key here) is still present.
-          const envelope1 = envelopeFor(controller, {
+          const envelope1 = await envelopeFor(controller, {
             accessToken: 'access-1',
-          });
-          const envelope2 = envelopeFor(controller, {
-            accessToken: 'access-2',
           });
           const messageFor = (
             credentials: unknown,
@@ -1169,6 +1181,9 @@ describe('KycController', () => {
           // returns to phase `check`) and confirm the next completion continues
           // again rather than being blocked forever by a stuck guard.
           await controller.initialize({ product: 'ramps' });
+          const envelope2 = await envelopeFor(controller, {
+            accessToken: 'access-2',
+          });
           handlers.checkKycRequired.mockResolvedValue({ kycRequired: false });
           await controller.handleFrameMessage({
             message: messageFor(envelope2),
@@ -1193,7 +1208,7 @@ describe('KycController', () => {
         },
         async ({ controller, handlers, launcher }) => {
           handlers.checkKycRequired.mockRejectedValue(new Error('down'));
-          const envelope = envelopeFor(controller, { accessToken: 'access-1' });
+          const envelope = await envelopeFor(controller, { accessToken: 'access-1' });
 
           await controller.handleFrameMessage({
             message: {
@@ -1220,7 +1235,8 @@ describe('KycController', () => {
     it('builds the check frame URL with a session', async () => {
       await withController(
         { options: { state: { sessionToken: 'tok' } } },
-        ({ controller }) => {
+        async ({ controller }) => {
+          await controller.initialize({ vendor: 'moonpay' });
           const url = controller.buildCheckFrameUrl() as string;
           expect(url).toContain('sessionToken=tok');
           expect(url).toContain('channelId=ch_1');
@@ -2432,7 +2448,7 @@ describe('KycController', () => {
       await withController(
         { options: { state: { phase: 'check', sessionToken: 'tok' } } },
         async ({ controller }) => {
-          const envelope = envelopeFor(controller, {
+          const envelope = await envelopeFor(controller, {
             clientToken: 'client-1',
           });
           await controller.handleFrameMessage({

--- a/packages/kyc-controller/src/KycController.ts
+++ b/packages/kyc-controller/src/KycController.ts
@@ -663,8 +663,8 @@ export class KycController extends BaseController<
 > {
   readonly #sumsubLauncher: KycSumSubLauncher;
 
-  /** Ephemeral X25519 keypair for the frame key exchange (never persisted). */
-  readonly #keypair: X25519KeyPair;
+  /** MoonPay Check/Auth frame X25519 keypair (never persisted). */
+  #moonpayFrameKeypair: X25519KeyPair | null = null;
 
   /** Auth-frame client token, kept out of state. */
   #authClientToken: string | null = null;
@@ -739,7 +739,6 @@ export class KycController extends BaseController<
     this.#sumsubLauncher = sumsubLauncher;
     this.#sessionStatusPollIntervalMs = sessionStatusPollIntervalMs;
     this.#userStatusPollIntervalMs = userStatusPollIntervalMs;
-    this.#keypair = generateKeyPair();
 
     this.messenger.registerMethodActionHandlers(
       this,
@@ -803,11 +802,18 @@ export class KycController extends BaseController<
     // forces `phase` back through `session`/`check`, breaking an in-flight
     // Check/Auth frame flow. Leave the active flow untouched and let the
     // consumer drive it (or call `reset` first to start over).
+    const vendor = params?.vendor ?? 'moonpay';
+
     if (IN_PROGRESS_PHASES.includes(this.state.phase)) {
       return;
     }
 
-    const vendor = params?.vendor ?? 'moonpay';
+    if (vendor === 'moonpay') {
+      this.#moonpayFrameKeypair = generateKeyPair();
+    } else {
+      this.#moonpayFrameKeypair = null;
+    }
+
 
     // `initialize` starts a fresh flow, so `activeProduct` is always reset to
     // this call's product (or `null`). Otherwise a prior run's product could
@@ -943,6 +949,7 @@ export class KycController extends BaseController<
       state.activeVendor = params.vendor;
       if (params.vendor !== 'moonpay') {
         this.#authClientToken = null;
+        this.#moonpayFrameKeypair = null;
         this.#clearMoonPaySession(state);
       }
     });
@@ -1542,11 +1549,11 @@ export class KycController extends BaseController<
 
     let accessToken: string | undefined;
     let clientToken: string | undefined;
-    if (credsEnvelope) {
+    if (credsEnvelope && this.#moonpayFrameKeypair) {
       try {
         const { credentials } = decryptCredentials(
           credsEnvelope,
-          this.#keypair.privateKey,
+          this.#moonpayFrameKeypair.privateKey,
         );
         accessToken = credentials.accessToken;
         clientToken = credentials.clientToken;
@@ -1687,12 +1694,16 @@ export class KycController extends BaseController<
    * @returns The Check-frame URL or `null`.
    */
   buildCheckFrameUrl(): string | null {
-    if (this.state.activeVendor !== 'moonpay' || !this.state.sessionToken) {
+    if (
+      this.state.activeVendor !== 'moonpay' ||
+      !this.state.sessionToken ||
+      !this.#moonpayFrameKeypair
+    ) {
       return null;
     }
     const url = new URL(`${FRAMES_BASE_URL}/check-connection`);
     url.searchParams.set('sessionToken', this.state.sessionToken);
-    url.searchParams.set('publicKey', this.#keypair.publicKeyHex);
+    url.searchParams.set('publicKey', this.#moonpayFrameKeypair.publicKeyHex);
     url.searchParams.set('channelId', CHANNEL_CHECK);
     url.searchParams.set('skipKyc', 'true');
     return url.toString();
@@ -1704,12 +1715,16 @@ export class KycController extends BaseController<
    * @returns The Auth-frame URL or `null`.
    */
   buildAuthFrameUrl(): string | null {
-    if (this.state.activeVendor !== 'moonpay' || !this.#authClientToken) {
+    if (
+      this.state.activeVendor !== 'moonpay' ||
+      !this.#authClientToken ||
+      !this.#moonpayFrameKeypair
+    ) {
       return null;
     }
     const url = new URL(`${FRAMES_BASE_URL}/auth`);
     url.searchParams.set('clientToken', this.#authClientToken);
-    url.searchParams.set('publicKey', this.#keypair.publicKeyHex);
+    url.searchParams.set('publicKey', this.#moonpayFrameKeypair.publicKeyHex);
     url.searchParams.set('channelId', CHANNEL_AUTH);
     return url.toString();
   }

--- a/packages/kyc-controller/src/KycController.ts
+++ b/packages/kyc-controller/src/KycController.ts
@@ -805,6 +805,9 @@ export class KycController extends BaseController<
     const vendor = params?.vendor ?? 'moonpay';
 
     if (IN_PROGRESS_PHASES.includes(this.state.phase)) {
+      if (vendor === 'moonpay' && !this.#moonpayFrameKeypair) {
+        this.#moonpayFrameKeypair = generateKeyPair();
+      }
       return;
     }
 
@@ -813,7 +816,6 @@ export class KycController extends BaseController<
     } else {
       this.#moonpayFrameKeypair = null;
     }
-
 
     // `initialize` starts a fresh flow, so `activeProduct` is always reset to
     // this call's product (or `null`). Otherwise a prior run's product could


### PR DESCRIPTION
## Explanation

* Moves moonpay keypair generation out of the constructor and into `initialize()` when moonpay is passed as the vendor

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when MoonPay frame keys exist and how encrypted frame credentials are decrypted—callers must `initialize` with MoonPay before building Check/Auth URLs, which may be a breaking integration change.
> 
> **Overview**
> **MoonPay Check/Auth frame crypto is no longer created in the constructor.** The controller keeps a nullable `#moonpayFrameKeypair` that is generated on `initialize()` when the vendor is MoonPay (or lazily on a repeat `initialize` mid-flow if the keypair was missing), and cleared when switching to a non-MoonPay vendor via `initialize` or `createVendorCustomer`.
> 
> **Frame URLs and credential handling now depend on that keypair.** `buildCheckFrameUrl` and `buildAuthFrameUrl` return `null` without it; frame credential decryption runs only when both an envelope and the MoonPay keypair are present.
> 
> Tests were updated so helpers call `initialize({ vendor: 'moonpay' })` where needed, `envelopeFor` is async, and stale-completion cases no longer rely on a constructor-time key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cce8585b89b61d78757423711b6227700a70fcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->