### PR TITLE
feat(kyc-controller): use debug logger

### DIFF
--- a/packages/kyc-controller/CHANGELOG.md
+++ b/packages/kyc-controller/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** Require `sumsubTncSigned` and `idosTncSigned` on `acceptTermsAndStartSession` for every vendor, so callers explicitly declare T&C2 acceptance. Zero-argument calls and omitted flags fail instead of defaulting to `true`. ([#9908](https://github.com/MetaMask/core/pull/9908))
 - Rename `CreateUkycSessionParams.vendorId` to `vendor` for consistency with other service methods. ([#9908](https://github.com/MetaMask/core/pull/9908))
 - Bump `@metamask/base-data-service` from `^0.1.3` to `^1.0.0` ([#9972](https://github.com/MetaMask/core/pull/9972))
+- Replace `KycController` `console.error` tracing with the `@metamask/utils` debug logger (`createProjectLogger` / `createModuleLogger`), so flow diagnostics are opt-in via `DEBUG=kyc-controller*` instead of always printing to the console. ([#10054](https://github.com/MetaMask/core/pull/10054))
 
 ### Fixed
 

--- a/packages/kyc-controller/src/KycController.ts
+++ b/packages/kyc-controller/src/KycController.ts
@@ -22,6 +22,7 @@ import type {
   CreateUkycSessionParams,
   EncryptionSchema,
 } from './KycService.js';
+import { controllerLog } from './logger.js';
 import type {
   KycConsentDocument,
   KycCustomerIdentity,
@@ -44,7 +45,6 @@ import {
   encodeStorageAccessTokenForHeader,
   signStorageAccessToken,
 } from './ukyc/storageAccessToken.js';
-import { controllerLog } from './logger.js';
 import { wrapEncryptionKey } from './ukyc/wrapEncryptionKey.js';
 
 // === GENERAL ===

--- a/packages/kyc-controller/src/KycController.ts
+++ b/packages/kyc-controller/src/KycController.ts
@@ -44,6 +44,7 @@ import {
   encodeStorageAccessTokenForHeader,
   signStorageAccessToken,
 } from './ukyc/storageAccessToken.js';
+import { controllerLog } from './logger.js';
 import { wrapEncryptionKey } from './ukyc/wrapEncryptionKey.js';
 
 // === GENERAL ===
@@ -1138,7 +1139,7 @@ export class KycController extends BaseController<
         try {
           await this.refreshKycStatus();
         } catch (statusError) {
-          console.error('KYC status refresh failed:', statusError);
+          controllerLog('KYC status refresh failed:', statusError);
         }
         this.#updateIfCurrent(generation, (state) => {
           state.phase = 'done';
@@ -1177,7 +1178,7 @@ export class KycController extends BaseController<
       try {
         await this.refreshKycStatus();
       } catch (statusError) {
-        console.error('KYC status refresh failed:', statusError);
+        controllerLog('KYC status refresh failed:', statusError);
       }
       this.#updateIfCurrent(generation, (state) => {
         if (state.phase !== 'error' && state.phase !== 'done') {
@@ -1204,7 +1205,7 @@ export class KycController extends BaseController<
         });
         return;
       }
-      console.error('Consents session failed:', error);
+      controllerLog('Consents session failed:', error);
       if (this.#generation !== generation) {
         return;
       }
@@ -1379,7 +1380,7 @@ export class KycController extends BaseController<
         state.statusMessage = 'Authenticating via Check frame...';
       });
     } catch (error) {
-      console.error('Session creation failed:', error);
+      controllerLog('Session creation failed:', error);
       // A reset() superseded this flow while the request was in flight; leave
       // the idle controller alone rather than forcing it back to `terms`.
       if (this.#generation !== generation) {

--- a/packages/kyc-controller/src/logger.ts
+++ b/packages/kyc-controller/src/logger.ts
@@ -1,0 +1,9 @@
+/* istanbul ignore file */
+
+import { createProjectLogger, createModuleLogger } from '@metamask/utils';
+
+export const projectLogger = createProjectLogger('kyc-controller');
+
+export const controllerLog = createModuleLogger(projectLogger, 'KycController');
+
+export { createModuleLogger };


### PR DESCRIPTION
## Explanation

Use the debug logger in the `KycController` for tracing logs to avoid polluting the terminal

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change; controller behavior and error handling are unchanged aside from logs no longer printing by default.
> 
> **Overview**
> **KycController** flow diagnostics no longer use unconditional `console.error`. They go through a new `logger.ts` module built with `@metamask/utils` (`createProjectLogger` / `createModuleLogger`), matching other core controllers.
> 
> Four error-path traces (KYC status refresh soft-fails, consents session failure, session creation failure) now call `controllerLog` instead of the console. Messages appear only when **`DEBUG=kyc-controller*`** is set, so normal runs stay quiet while developers can still trace failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8af982005d53fde0a76c08c3bb90f8de919740c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->