### PR TITLE
fix: force RPC slow pipeline to update balances

### DIFF
--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/transaction-controller` from `^69.6.1` to `^69.7.0` ([#10046](https://github.com/MetaMask/core/pull/10046))
 
+### Fixed
+
+- Fix stale ARC USDC/EURC balances after confirmed swaps by running an authoritative RPC balance refresh for post-transaction asset updates ([#10058](https://github.com/MetaMask/core/pull/10058))
+
 ## [14.0.3]
 
 ### Changed

--- a/packages/assets-controller/src/AssetsController.test.ts
+++ b/packages/assets-controller/src/AssetsController.test.ts
@@ -21,6 +21,8 @@ import type {
 import type { AccountsApiDataSourceConfig } from './data-sources/AccountsApiDataSource.js';
 import type { PriceDataSourceConfig } from './data-sources/PriceDataSource.js';
 import { PriceDataSource } from './data-sources/PriceDataSource.js';
+import { RpcDataSource } from './data-sources/RpcDataSource.js';
+import { SnapDataSource } from './data-sources/SnapDataSource.js';
 import { TokenDataSource } from './data-sources/TokenDataSource.js';
 import { buildDefaultAssetsInfo } from './defaults.js';
 import type { Assets3346MigrationState } from './migrations/healAssetsInfoMetadata.js';
@@ -1498,6 +1500,117 @@ describe('AssetsController', () => {
         );
       });
 
+      it('uses RPC as the authoritative slow pipeline after a transaction', async () => {
+        const arcNativeAssetId = 'eip155:5042/slip44:5042' as Caip19AssetId;
+        const arcEurcAssetId =
+          'eip155:5042/erc20:0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE' as Caip19AssetId;
+        const arcAccount = createMockInternalAccount({
+          scopes: ['eip155:5042'],
+        });
+        const initialState: Partial<AssetsControllerState> = {
+          assetsInfo: {
+            [arcNativeAssetId]: {
+              type: 'native',
+              symbol: 'USDC',
+              name: 'USDC',
+              decimals: 18,
+            },
+            [arcEurcAssetId]: {
+              type: 'erc20',
+              symbol: 'EURC',
+              name: 'EURC',
+              decimals: 6,
+            },
+          },
+          assetsBalance: {
+            [MOCK_ACCOUNT_ID]: {
+              [arcNativeAssetId]: { amount: '1' },
+              [arcEurcAssetId]: { amount: '5' },
+            },
+          },
+        };
+
+        const snapActiveChainsSpy = jest
+          .spyOn(SnapDataSource.prototype, 'getActiveChainsSync')
+          .mockReturnValue(['eip155:5042']);
+        const rpcActiveChainsSpy = jest
+          .spyOn(RpcDataSource.prototype, 'getActiveChainsSync')
+          .mockReturnValue(['eip155:5042']);
+        const snapMiddleware = jest.fn(async (ctx, next) =>
+          next({
+            ...ctx,
+            response: {
+              assetsBalance: {
+                [MOCK_ACCOUNT_ID]: {
+                  [arcNativeAssetId]: { amount: '1' },
+                  [arcEurcAssetId]: { amount: '5' },
+                },
+              },
+            },
+          }),
+        );
+        const rpcMiddleware = jest.fn(async (ctx, next) =>
+          next({
+            ...ctx,
+            response: {
+              assetsBalance: {
+                [MOCK_ACCOUNT_ID]: {
+                  [arcNativeAssetId]: { amount: '2' },
+                  [arcEurcAssetId]: { amount: '0' },
+                },
+              },
+            },
+          }),
+        );
+        const snapMiddlewareSpy = jest
+          .spyOn(SnapDataSource.prototype, 'assetsMiddleware', 'get')
+          .mockReturnValue(snapMiddleware);
+        const rpcMiddlewareSpy = jest
+          .spyOn(RpcDataSource.prototype, 'assetsMiddleware', 'get')
+          .mockReturnValue(rpcMiddleware);
+
+        try {
+          await withController(
+            { state: initialState },
+            async ({ controller }) => {
+              await controller.getAssets([arcAccount], {
+                chainIds: ['eip155:5042'],
+                forceUpdate: true,
+                postTransaction: true,
+              });
+              await flushPromises();
+
+              expect(snapMiddleware).not.toHaveBeenCalled();
+              expect(rpcMiddleware).toHaveBeenCalled();
+              expect(rpcMiddleware).toHaveBeenCalledWith(
+                expect.objectContaining({
+                  request: expect.objectContaining({
+                    chainIds: ['eip155:5042'],
+                    customAssets: expect.arrayContaining([arcEurcAssetId]),
+                  }),
+                }),
+                expect.any(Function),
+              );
+              expect(
+                controller.state.assetsBalance[MOCK_ACCOUNT_ID]?.[
+                  arcNativeAssetId
+                ],
+              ).toStrictEqual({ amount: '2' });
+              expect(
+                controller.state.assetsBalance[MOCK_ACCOUNT_ID]?.[
+                  arcEurcAssetId
+                ],
+              ).toStrictEqual({ amount: '0' });
+            },
+          );
+        } finally {
+          snapActiveChainsSpy.mockRestore();
+          rpcActiveChainsSpy.mockRestore();
+          snapMiddlewareSpy.mockRestore();
+          rpcMiddlewareSpy.mockRestore();
+        }
+      });
+
       it('getAssets resolves without error when isBasicFunctionality is false', async () => {
         await withController(
           { isBasicFunctionality: () => false },
@@ -2846,6 +2959,7 @@ describe('AssetsController', () => {
           {
             chainIds: ['eip155:42161'],
             forceUpdate: true,
+            postTransaction: true,
           },
         );
 
@@ -2878,7 +2992,7 @@ describe('AssetsController', () => {
       });
     });
 
-    it('does not force refresh assets on transaction events for AccountActivity-active chains', async () => {
+    it('does not force refresh assets for unapproved transactions on AccountActivity-active chains', async () => {
       await withController(async ({ controller, messenger }) => {
         const getAssetsSpy = jest
           .spyOn(controller, 'getAssets')
@@ -2895,6 +3009,28 @@ describe('AssetsController', () => {
           chainId: '0xa4b1',
           txParams: { from: '0x1234567890123456789012345678901234567890' },
         });
+
+        await flushPromises();
+
+        expect(getAssetsSpy).not.toHaveBeenCalled();
+
+        getAssetsSpy.mockRestore();
+      });
+    });
+
+    it('force refreshes confirmed transactions on AccountActivity-active chains', async () => {
+      await withController(async ({ controller, messenger }) => {
+        const getAssetsSpy = jest
+          .spyOn(controller, 'getAssets')
+          .mockResolvedValue({});
+
+        messenger.publish('AccountActivityService:statusChanged', {
+          chainIds: ['eip155:42161'],
+          status: 'up',
+        });
+
+        await flushPromises();
+
         messenger.publish('TransactionController:transactionConfirmed', {
           chainId: '0xa4b1',
           txParams: { from: '0x1234567890123456789012345678901234567890' },
@@ -2902,7 +3038,14 @@ describe('AssetsController', () => {
 
         await flushPromises();
 
-        expect(getAssetsSpy).not.toHaveBeenCalled();
+        expect(getAssetsSpy).toHaveBeenCalledWith(
+          [expect.objectContaining({ id: MOCK_ACCOUNT_ID })],
+          {
+            chainIds: ['eip155:42161'],
+            forceUpdate: true,
+            postTransaction: true,
+          },
+        );
 
         getAssetsSpy.mockRestore();
       });

--- a/packages/assets-controller/src/AssetsController.ts
+++ b/packages/assets-controller/src/AssetsController.ts
@@ -1718,7 +1718,11 @@ export class AssetsController extends BaseController<
         const stateBalances = this.state.assetsBalance[account.id] ?? {};
         for (const assetId of Object.keys(stateBalances) as Caip19AssetId[]) {
           const assetChainId = assetId.split('/')[0] as ChainId;
-          if (chainIdSet.has(assetChainId) && !customAssets.includes(assetId)) {
+          if (
+            chainIdSet.has(assetChainId) &&
+            !isStakingContractAssetId(assetId) &&
+            !customAssets.includes(assetId)
+          ) {
             customAssets.push(assetId);
           }
         }

--- a/packages/assets-controller/src/AssetsController.ts
+++ b/packages/assets-controller/src/AssetsController.ts
@@ -114,6 +114,7 @@ import {
   createParallelBalanceMiddleware,
   createParallelMiddleware,
 } from './middlewares/ParallelMiddleware.js';
+import type { BalanceSource } from './middlewares/ParallelMiddleware.js';
 import { RpcFallbackMiddleware } from './middlewares/RpcFallbackMiddleware.js';
 import type { Assets3346MigrationState } from './migrations/healAssetsInfoMetadata.js';
 import {
@@ -1213,7 +1214,9 @@ export class AssetsController extends BaseController<
     this.messenger.subscribe(
       'TransactionController:transactionConfirmed',
       (transactionMeta: TransactionMeta) => {
-        this.#refreshAssetsForTransaction(transactionMeta);
+        this.#refreshAssetsForTransaction(transactionMeta, {
+          postTransaction: true,
+        });
       },
     );
     // Start tracking only after the account tree is fully built. Unlock can
@@ -1234,8 +1237,15 @@ export class AssetsController extends BaseController<
    * chain is already covered by AccountActivity (real-time WebSocket balances).
    *
    * @param transactionMeta - The transaction that triggered the refresh.
+   * @param options - Additional options for the refresh.
+   * @param options.postTransaction - When true, forces the RPC slow pipeline for
+   * all chains so that potentially stale Accounts API cache data is overridden
+   * with authoritative on-chain values immediately after the transaction mines.
    */
-  #refreshAssetsForTransaction(transactionMeta: TransactionMeta): void {
+  #refreshAssetsForTransaction(
+    transactionMeta: TransactionMeta,
+    options?: { postTransaction?: boolean },
+  ): void {
     const hexChainId = transactionMeta.chainId;
     if (!hexChainId) {
       return;
@@ -1244,8 +1254,11 @@ export class AssetsController extends BaseController<
     const caipChainId = `eip155:${parseInt(hexChainId, 16)}` as ChainId;
 
     // AccountActivity pushes live balance updates for its active chains; a
-    // force getAssets would be redundant and can race the WebSocket path.
+    // pre-confirmation force getAssets would be redundant and can race the
+    // WebSocket path. After confirmation, still run the post-transaction RPC
+    // pass because AccountActivity may update only part of a swap pair.
     if (
+      !options?.postTransaction &&
       this.#accountActivityDataSource
         .getActiveChainsSync()
         .includes(caipChainId)
@@ -1268,6 +1281,7 @@ export class AssetsController extends BaseController<
     this.getAssets([matchedAccount], {
       chainIds: [caipChainId],
       forceUpdate: true,
+      postTransaction: options?.postTransaction,
     }).catch((error) => {
       log('Failed to refresh assets after transaction event', { error });
     });
@@ -1671,6 +1685,12 @@ export class AssetsController extends BaseController<
       assetsForPriceUpdate?: Caip19AssetId[];
       /** When set to `'merge'`, fetch result is merged with existing state instead of replacing. Use for partial fetches (e.g. newly added chains). */
       updateMode?: AssetsUpdateMode;
+      /**
+       * When true, forces the RPC slow pipeline for all chains regardless of
+       * Accounts API coverage. Use after a transaction confirms to override
+       * potentially stale API cache with authoritative on-chain values.
+       */
+      postTransaction?: boolean;
     },
   ): Promise<Record<AccountId, Record<Caip19AssetId, Asset>>> {
     const chainIds = options?.chainIds ?? [...this.#enabledChains];
@@ -1683,9 +1703,26 @@ export class AssetsController extends BaseController<
 
     // Collect custom assets for all requested accounts
     const customAssets: Caip19AssetId[] = [];
+    const chainIdSet = new Set(chainIds);
     for (const account of accounts) {
       const accountCustomAssets = this.getCustomAssets(account.id);
       customAssets.push(...accountCustomAssets);
+
+      // When refreshing after a confirmed transaction, also include graduated
+      // tokens — ERC-20s currently in assetsBalance but removed from
+      // customAssets by CustomAssetGraduationMiddleware. The Accounts API
+      // indexes incoming transfers (received tokens) slower than outgoing
+      // ones, so without a direct RPC query the "to" token in a swap keeps
+      // the stale API-cached balance until the next polling cycle.
+      if (options?.postTransaction) {
+        const stateBalances = this.state.assetsBalance[account.id] ?? {};
+        for (const assetId of Object.keys(stateBalances) as Caip19AssetId[]) {
+          const assetChainId = assetId.split('/')[0] as ChainId;
+          if (chainIdSet.has(assetChainId) && !customAssets.includes(assetId)) {
+            customAssets.push(assetId);
+          }
+        }
+      }
     }
 
     if (options?.forceUpdate) {
@@ -1800,12 +1837,16 @@ export class AssetsController extends BaseController<
       const slowPipelineChainIds = this.#getSlowPipelineChainIds(
         chainIds,
         response,
+        { forceAll: options?.postTransaction === true },
       );
 
       if (slowPipelineChainIds.length > 0) {
-        const slowSources = this.#isBasicFunctionality()
-          ? [this.#snapDataSource, this.#rpcDataSource]
-          : [this.#rpcDataSource];
+        let slowSources: BalanceSource[];
+        if (options?.postTransaction || !this.#isBasicFunctionality()) {
+          slowSources = [this.#rpcDataSource];
+        } else {
+          slowSources = [this.#snapDataSource, this.#rpcDataSource];
+        }
 
         const slowRequest = { ...request, chainIds: slowPipelineChainIds };
 
@@ -2589,12 +2630,23 @@ export class AssetsController extends BaseController<
    *
    * @param chainIds - Chains requested by the caller.
    * @param fastResponse - Response committed by the fast pipeline.
+   * @param options - Additional options.
+   * @param options.forceAll - When true, bypasses the Accounts API coverage
+   * check and returns all chain IDs so the RPC slow pipeline runs for every
+   * chain. Use after a transaction confirms to override potentially stale API
+   * cache data with authoritative on-chain values.
    * @returns Chain IDs that still need the slow pipeline.
    */
   #getSlowPipelineChainIds(
     chainIds: ChainId[],
     fastResponse: DataResponse,
+    options?: { forceAll?: boolean },
   ): ChainId[] {
+    // Post-transaction: always run RPC to override potentially stale Accounts API data.
+    if (options?.forceAll) {
+      return chainIds;
+    }
+
     const accountsApiChains = new Set(
       this.#accountsApiDataSource.getActiveChainsSync(),
     );


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Fixes stale ARC USDC/EURC balances after confirmed swaps by ensuring post-transaction asset refreshes use an authoritative RPC balance pass.
Previously, confirmed transaction refreshes could be skipped on AccountActivity-active chains. 
This meant one side of a swap could update while the other remained stale until switching accounts forced a full refresh.

This change:

- Marks confirmed transaction refreshes as post-transaction refreshes
- Allows confirmed transaction refreshes to run even when AccountActivity is active
- Forces the post-transaction slow pipeline to use RPC
- Includes already-tracked balance assets in post-transaction RPC requests, so graduated ERC-20s are refreshed too
- Keeps unapproved transaction refreshes skipped on AccountActivity-active chains

### Tests

Added regression coverage in `AssetsController.test.ts` for:
- RPC being used as the authoritative post-transaction slow pipeline
- tracked ARC EURC being included in the RPC request
- ARC native USDC and EURC balances updating from the RPC response
- unapproved transactions still being skipped on AccountActivity-active chains
- confirmed transactions refreshing even on AccountActivity-active chains

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Fixes: [WPN-1954](https://consensyssoftware.atlassian.net/browse/WPN-1954)

## Checklist

- [X] I've updated the test suite for new or updated code as appropriate
- [X] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


[WPN-1954]: https://consensyssoftware.atlassian.net/browse/WPN-1954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes balance refresh timing and data-source precedence after confirmations on live chains; incorrect RPC or merge behavior could show wrong balances, but scope is limited to post-confirmation refresh paths with regression tests.
> 
> **Overview**
> Fixes **stale swap balances** (e.g. ARC USDC/EURC) by treating **confirmed** transaction refreshes differently from pre-confirmation ones.
> 
> **Confirmed transactions** now call `getAssets` with `postTransaction: true`. That flag still runs a force refresh on **AccountActivity-active** chains (only unapproved txs keep skipping those chains), forces the **slow pipeline to RPC-only** (no Snap), and makes `#getSlowPipelineChainIds` run RPC on **all** requested chains instead of skipping chains the Accounts API already “covered.” Post-transaction fetches also add **graduated ERC-20s** from existing `assetsBalance` into the RPC `customAssets` list so the “receive” side of a swap is queried on-chain.
> 
> Tests cover the ARC RPC path, `postTransaction` on `transactionConfirmed`, and the split behavior for unapproved vs confirmed on AccountActivity chains. Changelog notes the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64bce4b11ea9494ff4a6c840e3dd667ed57069bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->