### PR TITLE
fix(assets-controller): clean accountTree event handlers

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -157,7 +157,7 @@
   },
   "packages/assets-controller/src/AssetsController.ts": {
     "no-restricted-syntax": {
-      "count": 3
+      "count": 2
     }
   },
   "packages/assets-controller/src/data-sources/AccountsApiDataSource.ts": {

--- a/packages/account-tree-controller/CHANGELOG.md
+++ b/packages/account-tree-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `AccountTreeController:isInitialized` action so consumers can query whether `init()` has completed ([#10059](https://github.com/MetaMask/core/pull/10059))
+
 ### Changed
 
 - Bump `@metamask/accounts-controller` from `^39.1.0` to `^39.1.1` ([#9969](https://github.com/MetaMask/core/pull/9969))

--- a/packages/account-tree-controller/src/AccountTreeController-method-action-types.ts
+++ b/packages/account-tree-controller/src/AccountTreeController-method-action-types.ts
@@ -29,6 +29,17 @@ export type AccountTreeControllerReinitAction = {
 };
 
 /**
+ * Whether `init()` has completed and the account tree is ready to consume.
+ * Returns false after `clearState()` until the next successful `init()`.
+ *
+ * @returns True when the controller has been initialized.
+ */
+export type AccountTreeControllerIsInitializedAction = {
+  type: `AccountTreeController:isInitialized`;
+  handler: AccountTreeController['isInitialized'];
+};
+
+/**
  * Gets the account wallet object from its ID.
  *
  * @param walletId - Account wallet ID.
@@ -277,6 +288,7 @@ export type AccountTreeControllerImportStateAction = {
 export type AccountTreeControllerMethodActions =
   | AccountTreeControllerInitAction
   | AccountTreeControllerReinitAction
+  | AccountTreeControllerIsInitializedAction
   | AccountTreeControllerGetAccountWalletObjectAction
   | AccountTreeControllerGetAccountWalletObjectsAction
   | AccountTreeControllerGetAccountsFromSelectedAccountGroupAction

--- a/packages/account-tree-controller/src/AccountTreeController.test.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.test.ts
@@ -531,6 +531,18 @@ describe('AccountTreeController', () => {
       expect(controller.isInitialized()).toBe(false);
     });
 
+    it('returns true after reinit', () => {
+      const { controller } = setup({
+        accounts: [MOCK_HD_ACCOUNT_1],
+        keyrings: [MOCK_HD_KEYRING_1],
+      });
+
+      controller.init();
+      controller.reinit();
+
+      expect(controller.isInitialized()).toBe(true);
+    });
+
     it('is exposed via AccountTreeController:isInitialized', () => {
       const { controller, messenger } = setup({
         accounts: [MOCK_HD_ACCOUNT_1],

--- a/packages/account-tree-controller/src/AccountTreeController.test.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.test.ts
@@ -498,6 +498,53 @@ describe('AccountTreeController', () => {
     jest.resetAllMocks();
   });
 
+  describe('isInitialized', () => {
+    it('returns false before init', () => {
+      const { controller } = setup({
+        accounts: [MOCK_HD_ACCOUNT_1],
+        keyrings: [MOCK_HD_KEYRING_1],
+      });
+
+      expect(controller.isInitialized()).toBe(false);
+    });
+
+    it('returns true after init', () => {
+      const { controller } = setup({
+        accounts: [MOCK_HD_ACCOUNT_1],
+        keyrings: [MOCK_HD_KEYRING_1],
+      });
+
+      controller.init();
+
+      expect(controller.isInitialized()).toBe(true);
+    });
+
+    it('returns false after clearState until init is called again', () => {
+      const { controller } = setup({
+        accounts: [MOCK_HD_ACCOUNT_1],
+        keyrings: [MOCK_HD_KEYRING_1],
+      });
+
+      controller.init();
+      controller.clearState();
+
+      expect(controller.isInitialized()).toBe(false);
+    });
+
+    it('is exposed via AccountTreeController:isInitialized', () => {
+      const { controller, messenger } = setup({
+        accounts: [MOCK_HD_ACCOUNT_1],
+        keyrings: [MOCK_HD_KEYRING_1],
+      });
+
+      expect(messenger.call('AccountTreeController:isInitialized')).toBe(false);
+
+      controller.init();
+
+      expect(messenger.call('AccountTreeController:isInitialized')).toBe(true);
+    });
+  });
+
   describe('init', () => {
     it('groups accounts by entropy source, then snapId, then wallet type', () => {
       const { controller, messenger } = setup({

--- a/packages/account-tree-controller/src/AccountTreeController.ts
+++ b/packages/account-tree-controller/src/AccountTreeController.ts
@@ -51,6 +51,7 @@ import type { AccountWalletObject, AccountWalletObjectOf } from './wallet.js';
 export const controllerName = 'AccountTreeController';
 
 const MESSENGER_EXPOSED_METHODS = [
+  'isInitialized',
   'getSelectedAccountGroup',
   'setSelectedAccountGroup',
   'setSelectedAccountGroupByAccountId',
@@ -455,6 +456,16 @@ export class AccountTreeController extends BaseController<
     log('Re-initializing...');
     this.#initialized = false;
     this.init();
+  }
+
+  /**
+   * Whether `init()` has completed and the account tree is ready to consume.
+   * Returns false after `clearState()` until the next successful `init()`.
+   *
+   * @returns True when the controller has been initialized.
+   */
+  isInitialized(): boolean {
+    return this.#initialized;
   }
 
   /**

--- a/packages/account-tree-controller/src/index.ts
+++ b/packages/account-tree-controller/src/index.ts
@@ -41,6 +41,7 @@ export type {
   AccountTreeControllerSyncWithUserStorageAction,
   AccountTreeControllerSyncWithUserStorageAtLeastOnceAction,
   AccountTreeControllerInitAction,
+  AccountTreeControllerIsInitializedAction,
   AccountTreeControllerReinitAction,
   AccountTreeControllerExportStateAction,
   AccountTreeControllerImportStateAction,

--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING:** `AssetsControllerMessenger` now requires `AccountTreeController:isInitialized`, `ClientController:getState`, and `KeyringController:isUnlocked` so lifecycle checks read controller state on demand instead of mirroring it from events ([#10059](https://github.com/MetaMask/core/pull/10059))
+  - Hosts that restrict which actions flow through the `AssetsController` messenger must delegate these three actions
+  - `AccountTreeController:stateChange` is no longer subscribed to; remove it from allowed events if your messenger wiring lists events explicitly
+- Revert to `selectedAccountGroupChange` for account-group switches; snap accounts added mid-session are picked up on restart ([#10059](https://github.com/MetaMask/core/pull/10059))
 - Bump `@metamask/transaction-controller` from `^69.6.1` to `^69.7.0` ([#10046](https://github.com/MetaMask/core/pull/10046))
 
 ## [14.0.3]

--- a/packages/assets-controller/src/AssetsController.spam-cleanup.test.ts
+++ b/packages/assets-controller/src/AssetsController.spam-cleanup.test.ts
@@ -359,7 +359,7 @@ describe('AssetsController spam cleanup', () => {
         messenger as unknown as {
           publish: (topic: string, payload?: unknown) => void;
         }
-      ).publish('ClientController:stateChange', { isUiOpen: true });
+      ).publish('ClientController:stateChanged', { isUiOpen: true });
       messenger.publish('KeyringController:unlock');
       (messenger.publish as CallableFunction)(
         'AccountTreeController:initialized',

--- a/packages/assets-controller/src/AssetsController.test.ts
+++ b/packages/assets-controller/src/AssetsController.test.ts
@@ -1,3 +1,4 @@
+import { clientControllerSelectors } from '@metamask/client-controller';
 /* eslint-disable jest/unbound-method */
 import type { TraceCallback, TraceRequest } from '@metamask/controller-utils';
 import type { ApiPlatformClient } from '@metamask/core-backend';
@@ -10,6 +11,7 @@ import type {
 } from '@metamask/messenger';
 import type { NetworkState } from '@metamask/network-controller';
 
+import { registerKeyringUnlockMock } from './__fixtures__/MockAssetControllerMessenger.js';
 import {
   AssetsController,
   getDefaultAssetsControllerState,
@@ -110,7 +112,7 @@ async function activateTracking(messenger: RootMessenger): Promise<void> {
     messenger as unknown as {
       publish: (topic: string, payload?: unknown) => void;
     }
-  ).publish('ClientController:stateChange', { isUiOpen: true });
+  ).publish('ClientController:stateChanged', { isUiOpen: true });
   messenger.publish('KeyringController:unlock');
   (messenger.publish as CallableFunction)(
     'AccountTreeController:initialized',
@@ -167,9 +169,11 @@ type WithControllerOptions = {
 type WithControllerCallback<ReturnValue> = ({
   controller,
   messenger,
+  getSelectedAccountsMock,
 }: {
   controller: AssetsController;
   messenger: RootMessenger;
+  getSelectedAccountsMock: jest.Mock<InternalAccount[], []>;
 }) => Promise<ReturnValue> | ReturnValue;
 
 async function withController<ReturnValue>(
@@ -188,7 +192,7 @@ async function withController<ReturnValue>(
     {
       state = {},
       isBasicFunctionality = (): boolean => true,
-      clientControllerState,
+      clientControllerState: initialClientControllerState,
       remoteFeatureFlags = {},
       queryApiClient = createMockQueryApiClient(),
       controllerOptions = {},
@@ -217,9 +221,21 @@ async function withController<ReturnValue>(
   );
 
   // Mock AccountTreeController
+  let isAccountTreeInitialized = false;
+  messenger.registerActionHandler(
+    'AccountTreeController:isInitialized',
+    () => isAccountTreeInitialized,
+  );
+  messenger.subscribe('AccountTreeController:initialized', () => {
+    isAccountTreeInitialized = true;
+  });
+  messenger.subscribe('AccountTreeController:uninitialized', () => {
+    isAccountTreeInitialized = false;
+  });
+  const getSelectedAccountsMock = jest.fn(() => [createMockInternalAccount()]);
   messenger.registerActionHandler(
     'AccountTreeController:getAccountsFromSelectedAccountGroup',
-    () => [createMockInternalAccount()],
+    getSelectedAccountsMock,
   );
 
   // Mock NetworkEnablementController
@@ -253,16 +269,26 @@ async function withController<ReturnValue>(
     provider: {},
   }));
 
-  if (clientControllerState !== undefined) {
-    (
-      messenger as {
-        registerActionHandler: (a: string, h: () => unknown) => void;
-      }
-    ).registerActionHandler(
-      'ClientController:getState',
-      () => clientControllerState,
-    );
-  }
+  let clientControllerState = {
+    isUiOpen: initialClientControllerState?.isUiOpen ?? false,
+  };
+  (
+    messenger as {
+      registerActionHandler: (a: string, h: () => unknown) => void;
+    }
+  ).registerActionHandler(
+    'ClientController:getState',
+    () => clientControllerState,
+  );
+  messenger.subscribe(
+    'ClientController:stateChanged',
+    (open: boolean) => {
+      clientControllerState = { isUiOpen: open };
+    },
+    clientControllerSelectors.selectIsUiOpen,
+  );
+
+  registerKeyringUnlockMock(messenger);
 
   (
     messenger as {
@@ -288,7 +314,7 @@ async function withController<ReturnValue>(
   });
 
   try {
-    return await fn({ controller, messenger });
+    return await fn({ controller, messenger, getSelectedAccountsMock });
   } finally {
     await flushPromises();
     controller.destroy();
@@ -2686,7 +2712,7 @@ describe('AssetsController', () => {
             messenger as unknown as {
               publish: (topic: string, payload?: unknown) => void;
             }
-          ).publish('ClientController:stateChange', { isUiOpen: true });
+          ).publish('ClientController:stateChanged', { isUiOpen: true });
           messenger.publish('KeyringController:unlock');
           (messenger.publish as CallableFunction)(
             'AccountTreeController:initialized',
@@ -3026,7 +3052,7 @@ describe('AssetsController', () => {
             messenger as unknown as {
               publish: (topic: string, payload?: unknown) => void;
             }
-          ).publish('ClientController:stateChange', { isUiOpen: true });
+          ).publish('ClientController:stateChanged', { isUiOpen: true });
           messenger.publish('KeyringController:unlock');
           (messenger.publish as CallableFunction)(
             'AccountTreeController:initialized',
@@ -3135,7 +3161,7 @@ describe('AssetsController', () => {
             messenger as unknown as {
               publish: (topic: string, payload?: unknown) => void;
             }
-          ).publish('ClientController:stateChange', { isUiOpen: true });
+          ).publish('ClientController:stateChanged', { isUiOpen: true });
           messenger.publish('KeyringController:unlock');
           (messenger.publish as CallableFunction)(
             'AccountTreeController:initialized',
@@ -3176,7 +3202,7 @@ describe('AssetsController', () => {
             messenger as unknown as {
               publish: (topic: string, payload?: unknown) => void;
             }
-          ).publish('ClientController:stateChange', { isUiOpen: true });
+          ).publish('ClientController:stateChanged', { isUiOpen: true });
           messenger.publish('KeyringController:unlock');
           (messenger.publish as CallableFunction)(
             'AccountTreeController:initialized',
@@ -3386,10 +3412,23 @@ describe('AssetsController', () => {
         namespace: MOCK_ANY_NAMESPACE,
       });
 
+      registerKeyringUnlockMock(messenger);
+
       messenger.registerActionHandler(
         'AccountTreeController:getAccountsFromSelectedAccountGroup',
         () => [createMockInternalAccount()],
       );
+      let isAccountTreeInitialized = false;
+      messenger.registerActionHandler(
+        'AccountTreeController:isInitialized',
+        () => isAccountTreeInitialized,
+      );
+      messenger.subscribe('AccountTreeController:initialized', () => {
+        isAccountTreeInitialized = true;
+      });
+      messenger.subscribe('AccountTreeController:uninitialized', () => {
+        isAccountTreeInitialized = false;
+      });
       messenger.registerActionHandler(
         'NetworkEnablementController:getState',
         () => ({
@@ -3459,7 +3498,7 @@ describe('AssetsController', () => {
           messenger as unknown as {
             publish: (topic: string, payload?: unknown) => void;
           }
-        ).publish('ClientController:stateChange', { isUiOpen: true });
+        ).publish('ClientController:stateChanged', { isUiOpen: true });
         messenger.publish('KeyringController:unlock');
         (messenger.publish as CallableFunction)(
           'AccountTreeController:initialized',
@@ -3502,17 +3541,7 @@ describe('AssetsController', () => {
           .spyOn(controller, 'getAssets')
           .mockResolvedValue({});
 
-        (
-          messenger as unknown as {
-            publish: (topic: string, payload?: unknown) => void;
-          }
-        ).publish('ClientController:stateChange', { isUiOpen: true });
-        messenger.publish('KeyringController:unlock');
-        (messenger.publish as CallableFunction)(
-          'AccountTreeController:initialized',
-          {},
-        );
-        await flushPromises();
+        await activateTracking(messenger);
 
         getAssetsSpy.mockClear();
 
@@ -3554,11 +3583,10 @@ describe('AssetsController', () => {
           messenger as unknown as {
             publish: (topic: string, payload?: unknown) => void;
           }
-        ).publish('ClientController:stateChange', { isUiOpen: true });
+        ).publish('ClientController:stateChanged', { isUiOpen: true });
         messenger.publish('KeyringController:unlock');
         await flushPromises();
 
-        // ATC always publishes this on init, even when the group did not change.
         (messenger.publish as CallableFunction)(
           'AccountTreeController:selectedAccountGroupChange',
           'entropy:mock-keyring-id-1/0',
@@ -3585,17 +3613,7 @@ describe('AssetsController', () => {
           .spyOn(controller, 'getAssets')
           .mockResolvedValue({});
 
-        (
-          messenger as unknown as {
-            publish: (topic: string, payload?: unknown) => void;
-          }
-        ).publish('ClientController:stateChange', { isUiOpen: true });
-        messenger.publish('KeyringController:unlock');
-        (messenger.publish as CallableFunction)(
-          'AccountTreeController:initialized',
-          {},
-        );
-        await flushPromises();
+        await activateTracking(messenger);
 
         getAssetsSpy.mockClear();
 
@@ -3619,10 +3637,22 @@ describe('AssetsController', () => {
       const messenger: RootMessenger = new Messenger({
         namespace: MOCK_ANY_NAMESPACE,
       });
+      registerKeyringUnlockMock(messenger);
       messenger.registerActionHandler(
         'AccountTreeController:getAccountsFromSelectedAccountGroup',
         getAccountsMock,
       );
+      let isAccountTreeInitialized = false;
+      messenger.registerActionHandler(
+        'AccountTreeController:isInitialized',
+        () => isAccountTreeInitialized,
+      );
+      messenger.subscribe('AccountTreeController:initialized', () => {
+        isAccountTreeInitialized = true;
+      });
+      messenger.subscribe('AccountTreeController:uninitialized', () => {
+        isAccountTreeInitialized = false;
+      });
       (
         messenger as {
           registerActionHandler: (a: string, h: () => unknown) => void;
@@ -3679,7 +3709,7 @@ describe('AssetsController', () => {
         messenger as unknown as {
           publish: (topic: string, payload?: unknown) => void;
         }
-      ).publish('ClientController:stateChange', { isUiOpen: true });
+      ).publish('ClientController:stateChanged', { isUiOpen: true });
       messenger.publish('KeyringController:unlock');
       await new Promise((resolve) => setTimeout(resolve, 100));
 

--- a/packages/assets-controller/src/AssetsController.ts
+++ b/packages/assets-controller/src/AssetsController.ts
@@ -1,8 +1,8 @@
 import type {
   AccountTreeControllerGetAccountsFromSelectedAccountGroupAction,
   AccountTreeControllerInitializedEvent,
+  AccountTreeControllerIsInitializedAction,
   AccountTreeControllerSelectedAccountGroupChangeEvent,
-  AccountTreeControllerStateChangeEvent,
   AccountTreeControllerUninitializedEvent,
 } from '@metamask/account-tree-controller';
 import type { AccountsControllerGetSelectedAccountAction } from '@metamask/accounts-controller';
@@ -12,7 +12,10 @@ import type {
   ControllerStateChangeEvent,
   StateMetadata,
 } from '@metamask/base-controller';
-import type { ClientControllerStateChangeEvent } from '@metamask/client-controller';
+import type {
+  ClientControllerGetStateAction,
+  ClientControllerStateChangeEvent,
+} from '@metamask/client-controller';
 import { clientControllerSelectors } from '@metamask/client-controller';
 import type { ConfigRegistryControllerGetNetworkConfigByCaip2ChainIdAction } from '@metamask/config-registry-controller';
 import type { TraceCallback, TraceContext } from '@metamask/controller-utils';
@@ -23,6 +26,7 @@ import type {
   SupportedCurrency,
 } from '@metamask/core-backend';
 import type {
+  KeyringControllerIsUnlockedAction,
   KeyringControllerLockEvent,
   KeyringControllerUnlockEvent,
 } from '@metamask/keyring-controller';
@@ -332,6 +336,9 @@ type AllowedActions =
   // AssetsController
   | AccountsControllerGetSelectedAccountAction
   | AccountTreeControllerGetAccountsFromSelectedAccountGroupAction
+  | AccountTreeControllerIsInitializedAction
+  | ClientControllerGetStateAction
+  | KeyringControllerIsUnlockedAction
   // RpcDataSource
   | NetworkControllerGetStateAction
   | NetworkControllerGetNetworkClientByIdAction
@@ -348,9 +355,8 @@ type AllowedActions =
   | RemoteFeatureFlagControllerGetStateAction;
 
 type AllowedEvents =
-  // AssetsController
+  // AssetsController — account tree lifecycle and group switches
   | AccountTreeControllerSelectedAccountGroupChangeEvent
-  | AccountTreeControllerStateChangeEvent
   | AccountTreeControllerInitializedEvent
   | AccountTreeControllerUninitializedEvent
   | ClientControllerStateChangeEvent
@@ -747,18 +753,6 @@ export class AssetsController extends BaseController<
     });
   }
 
-  /** Whether the client (UI) is open. Combined with #keyringUnlocked for #updateActive. */
-  #uiOpen = false;
-
-  /** Whether the keyring is unlocked. Combined with #uiOpen for #updateActive. */
-  #keyringUnlocked = false;
-
-  /**
-   * Whether `AccountTreeController` has finished `init()`. Unlock / UI-open
-   * alone must not start fetches — the tree can still be mid-build.
-   */
-  #accountTreeInitialized = false;
-
   readonly #controllerMutex = new Mutex();
 
   /** Serializes account-switch fetch + subscribe to prevent overlapping races. */
@@ -774,13 +768,6 @@ export class AssetsController extends BaseController<
 
   /** Currently enabled chains from NetworkEnablementController */
   #enabledChains: Set<ChainId> = new Set();
-
-  /**
-   * Snapshot of account IDs that were active when the last subscription/fetch
-   * cycle ran. Used by #handleAccountTreeStateChange to skip redundant
-   * re-subscriptions when the account set hasn't actually changed.
-   */
-  #lastKnownAccountIds: ReadonlySet<string> = new Set();
 
   /**
    * Get the currently selected accounts from AccountTreeController.
@@ -803,6 +790,35 @@ export class AssetsController extends BaseController<
       return [selectedAccount];
     }
     return [];
+  }
+
+  /**
+   * Whether `AccountTreeController.init()` has completed and the tree is ready.
+   *
+   * @returns True when the account tree has been initialized.
+   */
+  #isAccountTreeInitialized(): boolean {
+    return this.messenger.call('AccountTreeController:isInitialized');
+  }
+
+  /**
+   * Whether the client (UI) is open, read from ClientController state.
+   *
+   * @returns True when the UI is open.
+   */
+  #isUiOpen(): boolean {
+    return clientControllerSelectors.selectIsUiOpen(
+      this.messenger.call('ClientController:getState'),
+    );
+  }
+
+  /**
+   * Whether the keyring is unlocked, read from KeyringController.
+   *
+   * @returns True when the wallet vault is unlocked.
+   */
+  #isKeyringUnlocked(): boolean {
+    return this.messenger.call('KeyringController:isUnlocked');
   }
 
   readonly #accountActivityDataSource: AccountActivityDataSource;
@@ -1114,7 +1130,6 @@ export class AssetsController extends BaseController<
   }
 
   #subscribeToEvents(): void {
-    // Subscribe to account group changes (when user switches between account groups like Account 1 -> Account 2)
     this.messenger.subscribe(
       'AccountTreeController:selectedAccountGroupChange',
       (groupId, previousGroupId) => {
@@ -1124,12 +1139,11 @@ export class AssetsController extends BaseController<
       },
     );
 
-    // Catch post-init tree mutations that change the selected account set
-    // (e.g. a snap account added to the current group) without changing
-    // the selected group id. Intermediate `:stateChange` events during
-    // `AccountTreeController.init()` are ignored until `:initialized`.
-    this.messenger.subscribe('AccountTreeController:stateChange', () => {
-      this.#handleAccountTreeStateChange();
+    this.messenger.subscribe('AccountTreeController:initialized', () => {
+      this.#updateActive();
+    });
+    this.messenger.subscribe('AccountTreeController:uninitialized', () => {
+      this.#updateActive();
     });
 
     // Subscribe to network enablement changes (only enabledNetworkMap)
@@ -1176,8 +1190,7 @@ export class AssetsController extends BaseController<
     // Client + Keyring lifecycle: only run when UI is open AND keyring is unlocked
     this.messenger.subscribe(
       'ClientController:stateChange',
-      (isUiOpen: boolean) => {
-        this.#uiOpen = isUiOpen;
+      () => {
         this.#updateActive();
       },
       clientControllerSelectors.selectIsUiOpen,
@@ -1185,14 +1198,12 @@ export class AssetsController extends BaseController<
 
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     this.messenger.subscribe('KeyringController:unlock', async () => {
-      this.#keyringUnlocked = true;
       await this.#runSpamCleanup().catch(() => {
         /* Do nothing */
       });
       this.#updateActive();
     });
     this.messenger.subscribe('KeyringController:lock', () => {
-      this.#keyringUnlocked = false;
       this.#updateActive();
     });
 
@@ -1216,17 +1227,6 @@ export class AssetsController extends BaseController<
         this.#refreshAssetsForTransaction(transactionMeta);
       },
     );
-    // Start tracking only after the account tree is fully built. Unlock can
-    // happen before `AccountTreeController.init()`, and `:stateChange` fires
-    // for intermediate mutations during that build.
-    this.messenger.subscribe('AccountTreeController:initialized', () => {
-      this.#accountTreeInitialized = true;
-      this.#updateActive();
-    });
-    this.messenger.subscribe('AccountTreeController:uninitialized', () => {
-      this.#accountTreeInitialized = false;
-      this.#updateActive();
-    });
   }
 
   /**
@@ -1276,7 +1276,7 @@ export class AssetsController extends BaseController<
   async #runSpamCleanup(): Promise<void> {
     try {
       const shouldRun =
-        this.#keyringUnlocked &&
+        this.#isKeyringUnlocked() &&
         this.#isBasicFunctionality() &&
         isUnlockCleanupEnabled(
           this.messenger.call('RemoteFeatureFlagController:getState')
@@ -1322,89 +1322,13 @@ export class AssetsController extends BaseController<
    */
   #updateActive(): void {
     const shouldRun =
-      this.#uiOpen && this.#keyringUnlocked && this.#accountTreeInitialized;
+      this.#isUiOpen() &&
+      this.#isKeyringUnlocked() &&
+      this.#isAccountTreeInitialized();
     if (shouldRun) {
       this.#start();
     } else {
       this.#stop();
-    }
-  }
-
-  /**
-   * Handle AccountTreeController state changes after the tree is initialized.
-   * Re-subscribe only when the set of selected accounts has actually changed
-   * (e.g. a snap account was added after initial startup). Intermediate
-   * `:stateChange` events during `init()` are ignored — startup is driven by
-   * `:initialized` instead, so we do not fetch on every tree mutation.
-   */
-  #handleAccountTreeStateChange(): void {
-    const shouldRun =
-      this.#uiOpen &&
-      this.#keyringUnlocked &&
-      this.#accountTreeInitialized &&
-      this.#activeSubscriptions.size > 0;
-    if (!shouldRun) {
-      return;
-    }
-    const accounts = this.#getSelectedAccounts();
-    const currentIds = new Set(accounts.map((a) => a.id));
-
-    const accountsChanged =
-      currentIds.size !== this.#lastKnownAccountIds.size ||
-      [...currentIds].some((id) => !this.#lastKnownAccountIds.has(id));
-
-    if (!accountsChanged) {
-      return;
-    }
-
-    const hasOverlap = [...currentIds].some((id) =>
-      this.#lastKnownAccountIds.has(id),
-    );
-    if (!hasOverlap && this.#lastKnownAccountIds.size > 0) {
-      return;
-    }
-
-    log('Account tree changed with new accounts, re-subscribing', {
-      previousCount: this.#lastKnownAccountIds.size,
-      currentCount: currentIds.size,
-    });
-
-    const newAccounts = accounts.filter(
-      (account) => !this.#lastKnownAccountIds.has(account.id),
-    );
-
-    this.#lastKnownAccountIds = currentIds;
-    this.#ensureNativeBalancesDefaultZero();
-    this.#ensureDefaultTrackedAssetsSeeded();
-    this.#runAccountTreeRefresh(accounts, newAccounts).catch((error) => {
-      log('Failed to refresh assets after tree change', error);
-    });
-  }
-
-  async #runAccountTreeRefresh(
-    accounts: InternalAccount[],
-    newAccounts: InternalAccount[] = [],
-  ): Promise<void> {
-    const releaseLock = await this.#accountRefreshMutex.acquire();
-    try {
-      await this.getAssets(accounts, {
-        chainIds: [...this.#enabledChains],
-        forceUpdate: true,
-      });
-      this.#subscribeAssets({ skipInitialFetch: true });
-      if (newAccounts.length > 0) {
-        await this.getAssets(newAccounts, {
-          chainIds: [...this.#enabledChains],
-          forceUpdate: true,
-        });
-      }
-      this.#fetchMissingPricesWithoutCache(accounts, [...this.#enabledChains]);
-    } catch (error) {
-      log('Failed to fetch assets after tree change', error);
-      this.#subscribeAssets({ skipInitialFetch: true });
-      this.#fetchMissingPricesWithoutCache(accounts, [...this.#enabledChains]);
-    } finally {
-      releaseLock();
     }
   }
 
@@ -1467,7 +1391,7 @@ export class AssetsController extends BaseController<
     activeChains: ChainId[],
     previousChains: ChainId[],
   ): void {
-    if (!this.#uiOpen || !this.#keyringUnlocked || !this.#isEnabled()) {
+    if (!this.#isUiOpen() || !this.#isKeyringUnlocked() || !this.#isEnabled()) {
       return;
     }
     log('Data source active chains changed', {
@@ -3152,7 +3076,6 @@ export class AssetsController extends BaseController<
       enabledChainCount: chainIds.length,
     });
 
-    this.#lastKnownAccountIds = new Set(accounts.map((a) => a.id));
     this.#runStartupRefresh(accounts).catch((error) => {
       log('Failed to start asset tracking', error);
     });
@@ -3170,7 +3093,6 @@ export class AssetsController extends BaseController<
 
     this.#firstInitFetchReported = false;
     this.#stateSizeReported = false;
-    this.#lastKnownAccountIds = new Set();
 
     // Stop price subscription first (uses direct messenger call)
     this.unsubscribeAssetsPrice();
@@ -3653,7 +3575,6 @@ export class AssetsController extends BaseController<
     groupId: string,
     previousGroupId: string = '',
   ): Promise<void> {
-    // The selected account group can be empty during onboarding or wallet reset.
     if (!groupId) {
       return;
     }
@@ -3678,8 +3599,6 @@ export class AssetsController extends BaseController<
       previousGroupId,
     });
 
-    this.#lastKnownAccountIds = new Set(accounts.map((a) => a.id));
-
     const releaseLock = await this.#accountRefreshMutex.acquire();
     try {
       if (accounts.length > 0) {
@@ -3691,8 +3610,6 @@ export class AssetsController extends BaseController<
 
       this.#ensureNativeBalancesDefaultZero();
       this.#ensureDefaultTrackedAssetsSeeded();
-      // Subscribe after seed so the price poll sees natives / defaults.
-      // Balances were just force-fetched — skip AccountsApi's subscribe-time poll.
       this.#subscribeAssets({ skipInitialFetch: true });
       this.#fetchMissingPricesWithoutCache(accounts, [...this.#enabledChains]);
     } finally {
@@ -3829,7 +3746,7 @@ export class AssetsController extends BaseController<
    * @param networkState - NetworkController state after the switch.
    */
   async #handleNetworkDidChange(networkState: NetworkState): Promise<void> {
-    if (!this.#uiOpen || !this.#keyringUnlocked || !this.#isEnabled()) {
+    if (!this.#isUiOpen() || !this.#isKeyringUnlocked() || !this.#isEnabled()) {
       return;
     }
 

--- a/packages/assets-controller/src/README.md
+++ b/packages/assets-controller/src/README.md
@@ -69,12 +69,14 @@ get selectedAccounts(): InternalAccount[]
 
 #### 1.3 Subscribe to External Events
 
-| Event                                              | Handler                          | Purpose               |
-| -------------------------------------------------- | -------------------------------- | --------------------- |
-| `AccountTreeController:selectedAccountGroupChange` | `handleAccountGroupChanged()`    | Track active accounts |
-| `NetworkEnablementController:stateChange`          | `handleEnabledNetworksChanged()` | Track enabled chains  |
-| `KeyringController:unlock`                         | `start()`                        | Start subscriptions   |
-| `KeyringController:lock`                           | `stop()`                         | Stop subscriptions    |
+| Event                                              | Handler                          | Purpose                                |
+| -------------------------------------------------- | -------------------------------- | -------------------------------------- |
+| `AccountTreeController:selectedAccountGroupChange` | `handleAccountGroupChanged()`    | Refresh when the user switches groups  |
+| `AccountTreeController:initialized`                | `updateActive()`                 | Start tracking once the tree is built  |
+| `AccountTreeController:uninitialized`              | `updateActive()`                 | Stop tracking when the tree is cleared |
+| `NetworkEnablementController:stateChange`          | `handleEnabledNetworksChanged()` | Track enabled chains                   |
+| `KeyringController:unlock`                         | `start()`                        | Start subscriptions                    |
+| `KeyringController:lock`                           | `stop()`                         | Stop subscriptions                     |
 
 #### 1.4 Register Action Handlers
 

--- a/packages/assets-controller/src/__fixtures__/MockAssetControllerMessenger.ts
+++ b/packages/assets-controller/src/__fixtures__/MockAssetControllerMessenger.ts
@@ -1,5 +1,6 @@
 import { defaultAbiCoder } from '@ethersproject/abi';
 import * as ProviderModule from '@ethersproject/providers';
+import { clientControllerSelectors } from '@metamask/client-controller';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 import {
   MOCK_ANY_NAMESPACE,
@@ -31,6 +32,42 @@ export type MockRootMessenger = Messenger<
 const MAINNET_CHAIN_ID_HEX = '0x1';
 const MOCK_CHAIN_ID_CAIP = 'eip155:1';
 
+type MessengerWithPublish = {
+  publish: (event: string, ...args: unknown[]) => void;
+  registerActionHandler: (
+    action: string,
+    handler: (...args: unknown[]) => unknown,
+  ) => void;
+};
+
+/**
+ * Register a mock `KeyringController:isUnlocked` handler. Updates unlock state
+ * before `:unlock` / `:lock` events are delivered, matching KeyringController.
+ *
+ * @param messenger - The root messenger to register handlers on.
+ * @param initialUnlocked - Initial unlock state.
+ */
+export function registerKeyringUnlockMock(
+  messenger: MessengerWithPublish,
+  initialUnlocked = false,
+): void {
+  let isKeyringUnlocked = initialUnlocked;
+  messenger.registerActionHandler(
+    'KeyringController:isUnlocked',
+    () => isKeyringUnlocked,
+  );
+
+  const originalPublish = messenger.publish.bind(messenger);
+  messenger.publish = (event: string, ...args: unknown[]): void => {
+    if (event === 'KeyringController:unlock') {
+      isKeyringUnlocked = true;
+    } else if (event === 'KeyringController:lock') {
+      isKeyringUnlocked = false;
+    }
+    return originalPublish(event, ...args);
+  };
+}
+
 export function createMockAssetControllerMessenger(options?: {
   delegateGetState?: boolean;
 }): {
@@ -54,6 +91,9 @@ export function createMockAssetControllerMessenger(options?: {
       // AssetsController
       'AccountsController:getSelectedAccount',
       'AccountTreeController:getAccountsFromSelectedAccountGroup',
+      'AccountTreeController:isInitialized',
+      'ClientController:getState',
+      'KeyringController:isUnlocked',
       ...(delegateGetState ? ['AssetsController:getState' as const] : []),
       // RpcDataSource
       'ConfigRegistryController:getNetworkConfigByCaip2ChainId',
@@ -74,7 +114,6 @@ export function createMockAssetControllerMessenger(options?: {
     events: [
       // AssetsController
       'AccountTreeController:selectedAccountGroupChange',
-      'AccountTreeController:stateChange',
       'AccountTreeController:initialized',
       'AccountTreeController:uninitialized',
       'ClientController:stateChange',
@@ -263,6 +302,8 @@ export function createMockNetworkState(
 export type RegisterAssetsControllerActionsOptions = {
   accounts?: InternalAccount[];
   selectedAccount?: InternalAccount;
+  isAccountTreeInitialized?: boolean;
+  isKeyringUnlocked?: boolean;
   enabledNetworkMap?: Record<string, Record<string, boolean>>;
   nativeAssetIdentifiers?: Record<string, string>;
   networkState?: NetworkState;
@@ -324,6 +365,20 @@ export function registerAssetsControllerActions(
     () => accounts,
   );
 
+  let isAccountTreeInitialized = opts.isAccountTreeInitialized ?? false;
+  rootMessenger.registerActionHandler(
+    'AccountTreeController:isInitialized',
+    () => isAccountTreeInitialized,
+  );
+  rootMessenger.subscribe('AccountTreeController:initialized', () => {
+    isAccountTreeInitialized = true;
+  });
+  rootMessenger.subscribe('AccountTreeController:uninitialized', () => {
+    isAccountTreeInitialized = false;
+  });
+
+  registerKeyringUnlockMock(rootMessenger, opts.isKeyringUnlocked ?? false);
+
   rootMessenger.registerActionHandler(
     'NetworkEnablementController:getState',
     () =>
@@ -364,14 +419,16 @@ export function registerAssetsControllerActions(
     () => undefined,
   );
 
-  if (opts.clientControllerState !== undefined) {
-    (
-      rootMessenger as {
-        registerActionHandler: (a: string, h: () => unknown) => void;
-      }
-    ).registerActionHandler(
-      'ClientController:getState',
-      () => opts.clientControllerState,
-    );
-  }
+  let clientControllerState = opts.clientControllerState ?? { isUiOpen: false };
+  rootMessenger.registerActionHandler(
+    'ClientController:getState',
+    () => clientControllerState,
+  );
+  rootMessenger.subscribe(
+    'ClientController:stateChanged',
+    (isUiOpen: boolean) => {
+      clientControllerState = { isUiOpen };
+    },
+    clientControllerSelectors.selectIsUiOpen,
+  );
 }


### PR DESCRIPTION
## Explanation

Mobile
- Current behavior: Same as After because `AccountTreeController:initialized` was triggered at start
- After PR:
  - Onboarding: https://www.loom.com/share/5f5cdf90bfc2499eaf882bdc33c06365
  - After onboarding: https://www.loom.com/share/e48354b4869d42fb9d7070d377ce3a55

Extension:
- Current behavior: https://www.loom.com/share/55a51f14e91f4a6480145b959869dbd8 (behavior after https://github.com/MetaMask/core/pull/9892)
- After PR: https://www.loom.com/share/befb098c25584bfba2758464cc99e65e

### Context / motivation

Mobile and extension do **not** trigger `AccountTreeController:initialized` at the same point in the lifecycle:

- **Mobile** calls `AccountTreeController.init()` at startup via `AccountTreeInitService.initializeAccountTree()` (during authentication/login), so `:initialized` fires early in the app session.
- **Extension** does **not** call `init()` during controller construction (see FIXME in `account-tree-controller-init.ts` — the keyring must be unlocked first). Instead, it calls `AccountTreeController:init` later in `#initAccountsAfterUnlock()` after unlock.

Both clients delegate `AccountTreeController:initialized` to `AssetsController`, but the event timing differs. `AssetsController` could not reliably gate asset tracking on that event alone — mirroring `#accountTreeInitialized` from it was fragile across clients.

This PR adds `AccountTreeController:isInitialized` and has `AssetsController` read lifecycle state on demand so tracking starts/stops consistently regardless of when each client runs `init()`.

### Additional cleanup

While making that change, we also removed other sources of drift and complexity:

- **Local lifecycle mirrors:** `AssetsController` previously cached `#uiOpen`, `#keyringUnlocked`, and `#accountTreeInitialized` inside event handlers. Those flags could get out of sync if events were missed, reordered, or read before handlers ran. UI open and keyring unlock now use `ClientController:getState` and `KeyringController:isUnlocked` on demand as well.
- **`AccountTreeController:stateChange` subscription:** Used to detect mid-session tree mutations (e.g. a snap account added to the current group), with `#handleAccountTreeStateChange`, `#lastKnownAccountIds`, and overlap/diff logic to avoid redundant re-subscriptions during `init()`. That path is removed; explicit group switches stay on `selectedAccountGroupChange`, and snap accounts added mid-session without a group change are picked up on the next tracking restart.

### Solution

**`@metamask/account-tree-controller`**
- Add `AccountTreeController:isInitialized` so consumers can query whether `init()` has completed (returns `false` again after `clearState()` until the next successful `init()`).

**`@metamask/assets-controller`**
- Read lifecycle state **on demand** via messenger actions:
  - `#isUiOpen()` → `ClientController:getState`
  - `#isKeyringUnlocked()` → `KeyringController:isUnlocked`
  - `#isAccountTreeInitialized()` → `AccountTreeController:isInitialized`
- Remove local lifecycle mirrors and `#handleAccountTreeStateChange` / `#lastKnownAccountIds`.
- Stop subscribing to `AccountTreeController:stateChange`.
- Keep `AccountTreeController:selectedAccountGroupChange` for explicit group switches.
- Continue using `AccountTreeController:initialized` / `:uninitialized` to trigger `#updateActive()` (but gate on authoritative state via the actions above).

**Trade-off:** Snap accounts added mid-session without a group change are no longer picked up live via `:stateChange`; they are picked up on the next tracking restart (unlock / UI open cycle).

### Non-obvious details

- `#updateActive()` still reacts to `ClientController:stateChange`, `KeyringController:lock` / `:unlock`, and account-tree init events — but each gate now re-reads authoritative controller state instead of trusting cached flags.
- `#handleAccountGroupChanged` still ignores events while `#activeSubscriptions.size === 0`, so init-time `selectedAccountGroupChange` replays do not race with `:initialized`-owned startup.
- Test mocks were updated to publish `ClientController:stateChanged` (not `:stateChange`) so `ClientController:getState` reflects UI-open during lifecycle tests.

## References

- Consumer adoption (messenger delegation):
  - Extension: `app/scripts/messenger-client-init/messengers/assets/assets-controller-messenger.ts`
  - Mobile: `app/core/Engine/messengers/assets-controller/assets-controller-messenger.ts`
- Related prior work: `AccountTreeController:initialized` / `:uninitialized` (core#9892)

## Changelog

**`@metamask/account-tree-controller`**
- **Added:** `AccountTreeController:isInitialized` action

**`@metamask/assets-controller`**
- **Changed (BREAKING):** `AssetsControllerMessenger` now requires `AccountTreeController:isInitialized`, `ClientController:getState`, and `KeyringController:isUnlocked`
- **Changed (BREAKING):** No longer subscribes to `AccountTreeController:stateChange` — remove it from delegated events if listed explicitly
- **Changed:** Revert to `selectedAccountGroupChange` for account-group switches; snap accounts added mid-session are picked up on restart

## Manual testing

1. Build extension/mobile against this core branch.
2. Unlock wallet with UI open on the portfolio/home screen.
3. Verify balances load for the selected account group.
4. Switch account groups (Account 1 → Account 2) and confirm balances refresh.
5. Lock wallet → confirm tracking stops; unlock → confirm balances reload.
6. Close UI / background extension → reopen → confirm tracking resumes.
7. (Optional) Add a snap account to the current group mid-session and confirm it appears after lock/unlock or UI close/open (not immediately on tree mutation).

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking messenger wiring for extension/mobile plus a deliberate behavior change for mid-session account-tree updates; lifecycle gating touches when balances subscribe but not auth or funds logic directly.
> 
> **Overview**
> Adds **`AccountTreeController:isInitialized`** so consumers can tell whether `init()` finished (and it flips false again after `clearState()` until the next `init()`).
> 
> **`AssetsController`** no longer caches UI open, keyring unlock, or account-tree readiness from events. **`#updateActive()`** now gates tracking by calling **`ClientController:getState`**, **`KeyringController:isUnlocked`**, and **`AccountTreeController:isInitialized`** when it runs. It still listens to **`AccountTreeController:initialized` / `:uninitialized`** and client/keyring events, but only to re-evaluate those gates.
> 
> **Breaking for hosts:** the assets messenger must delegate the three new actions and can drop **`AccountTreeController:stateChange`** from allowed events. Mid-session account-tree mutations (e.g. snap added to the current group without a group switch) no longer trigger live refresh via **`stateChange`**; **`selectedAccountGroupChange`** still refreshes on explicit group switches, with snap pickup deferred until the next tracking restart (lock/unlock or UI cycle).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc7cfd33d428e5b11b99649418f5e54e8aded5a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->