### PR TITLE
fix(compliance-controller): reconcile compliance-status writes case-insensitively

### DIFF
--- a/packages/compliance-controller/CHANGELOG.md
+++ b/packages/compliance-controller/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/messenger` from `^1.2.0` to `^2.0.0` ([#9392](https://github.com/MetaMask/core/pull/9392))
 - Bump `@metamask/superstruct` from `^3.1.0` to `^3.4.1` ([#9754](https://github.com/MetaMask/core/pull/9754))
 
+### Fixed
+
+- Fix `checkWalletCompliance`/`checkWalletsCompliance` writing a wallet's compliance status under the caller's raw address casing, which could leave a stale duplicate cache entry for a wallet already cached under a different casing (or produce two persisted entries for the same wallet if one was ever checked under two casings). Writes now reconcile with any existing case-insensitively-matching entry, healing duplicates already present in persisted state.
+
 ## [2.1.0]
 
 ### Added

--- a/packages/compliance-controller/src/ComplianceController.test.ts
+++ b/packages/compliance-controller/src/ComplianceController.test.ts
@@ -338,6 +338,94 @@ describe('ComplianceController', () => {
         });
       });
     });
+
+    it('reconciles a later write for the same address under a different casing into the existing cache entry, instead of creating a stale duplicate', async () => {
+      await withController(async ({ controller, rootMessenger }) => {
+        let blocked = false;
+        rootMessenger.registerActionHandler(
+          'ComplianceService:checkWalletCompliance',
+          async (address) => ({
+            address,
+            blocked,
+          }),
+        );
+
+        // First check: not blocked, written under the checksummed casing.
+        await controller.checkWalletCompliance(CHECKSUM_EVM_ADDRESS);
+
+        // The wallet becomes sanctioned; the second check is written under a
+        // different (lowercase) casing for the very same address.
+        blocked = true;
+        await controller.checkWalletCompliance(LOWERCASE_EVM_ADDRESS);
+
+        // The cache must reconcile to a single entry per address, not one
+        // stale entry per casing ever seen.
+        expect(
+          Object.keys(controller.state.walletComplianceStatusMap),
+        ).toHaveLength(1);
+
+        // Every casing must now resolve to the fresh, blocked status.
+        expect(
+          selectIsWalletBlocked(CHECKSUM_EVM_ADDRESS)(controller.state),
+        ).toBe(true);
+        expect(
+          selectIsWalletBlocked(LOWERCASE_EVM_ADDRESS)(controller.state),
+        ).toBe(true);
+
+        // The existing key's casing is preserved rather than being replaced
+        // by the caller's casing.
+        expect(
+          Object.prototype.hasOwnProperty.call(
+            controller.state.walletComplianceStatusMap,
+            CHECKSUM_EVM_ADDRESS,
+          ),
+        ).toBe(true);
+      });
+    });
+
+    it('heals a duplicate entry that already exists under two casings for the same address (e.g. state persisted before this reconciliation shipped)', async () => {
+      await withController(
+        {
+          options: {
+            state: {
+              walletComplianceStatusMap: {
+                [CHECKSUM_EVM_ADDRESS]: {
+                  address: CHECKSUM_EVM_ADDRESS,
+                  blocked: false,
+                  checkedAt: '2026-01-01T00:00:00.000Z',
+                },
+                [LOWERCASE_EVM_ADDRESS]: {
+                  address: LOWERCASE_EVM_ADDRESS,
+                  blocked: false,
+                  checkedAt: '2026-01-01T00:00:00.000Z',
+                },
+              },
+            },
+          },
+        },
+        async ({ controller, rootMessenger }) => {
+          rootMessenger.registerActionHandler(
+            'ComplianceService:checkWalletCompliance',
+            async (address) => ({ address, blocked: true }),
+          );
+
+          // A write under EITHER pre-existing casing must collapse both
+          // stale duplicate entries into one, not just update the one that
+          // happens to exact-match the caller's casing.
+          await controller.checkWalletCompliance(LOWERCASE_EVM_ADDRESS);
+
+          expect(
+            Object.keys(controller.state.walletComplianceStatusMap),
+          ).toHaveLength(1);
+          expect(
+            selectIsWalletBlocked(CHECKSUM_EVM_ADDRESS)(controller.state),
+          ).toBe(true);
+          expect(
+            selectIsWalletBlocked(LOWERCASE_EVM_ADDRESS)(controller.state),
+          ).toBe(true);
+        },
+      );
+    });
   });
 
   describe('ComplianceController:checkWalletsCompliance', () => {
@@ -347,6 +435,74 @@ describe('ComplianceController', () => {
 
     afterEach(() => {
       jest.useRealTimers();
+    });
+
+    it('reconciles a batch write for an address already cached under a different casing, instead of creating a stale duplicate', async () => {
+      await withController(
+        {
+          options: {
+            state: {
+              walletComplianceStatusMap: {
+                [CHECKSUM_EVM_ADDRESS]: {
+                  address: CHECKSUM_EVM_ADDRESS,
+                  blocked: false,
+                  checkedAt: '2026-01-01T00:00:00.000Z',
+                },
+              },
+            },
+          },
+        },
+        async ({ controller, rootMessenger }) => {
+          rootMessenger.registerActionHandler(
+            'ComplianceService:checkWalletsCompliance',
+            async (addresses) =>
+              addresses.map((addr) => ({ address: addr, blocked: true })),
+          );
+
+          await rootMessenger.call(
+            'ComplianceController:checkWalletsCompliance',
+            [LOWERCASE_EVM_ADDRESS],
+          );
+
+          expect(
+            Object.keys(controller.state.walletComplianceStatusMap),
+          ).toHaveLength(1);
+          expect(
+            selectIsWalletBlocked(CHECKSUM_EVM_ADDRESS)(controller.state),
+          ).toBe(true);
+          expect(
+            selectIsWalletBlocked(LOWERCASE_EVM_ADDRESS)(controller.state),
+          ).toBe(true);
+        },
+      );
+    });
+
+    it('reconciles two aliases of the same address requested within a single batch call into one entry, with the later result winning', async () => {
+      await withController(async ({ controller, rootMessenger }) => {
+        rootMessenger.registerActionHandler(
+          'ComplianceService:checkWalletsCompliance',
+          async (addresses) =>
+            addresses.map((addr) => ({
+              address: addr,
+              blocked: addr === LOWERCASE_EVM_ADDRESS,
+            })),
+        );
+
+        await rootMessenger.call(
+          'ComplianceController:checkWalletsCompliance',
+          [CHECKSUM_EVM_ADDRESS, LOWERCASE_EVM_ADDRESS],
+        );
+
+        expect(
+          Object.keys(controller.state.walletComplianceStatusMap),
+        ).toStrictEqual([CHECKSUM_EVM_ADDRESS]);
+        expect(
+          selectIsWalletBlocked(CHECKSUM_EVM_ADDRESS)(controller.state),
+        ).toBe(true);
+        expect(
+          selectIsWalletBlocked(LOWERCASE_EVM_ADDRESS)(controller.state),
+        ).toBe(true);
+      });
     });
 
     it('calls the service, persists all results to state, and returns statuses', async () => {

--- a/packages/compliance-controller/src/ComplianceController.ts
+++ b/packages/compliance-controller/src/ComplianceController.ts
@@ -12,7 +12,10 @@ import type {
   ComplianceServiceCheckWalletsComplianceAction,
 } from './ComplianceService-method-action-types.js';
 import type { WalletComplianceStatus } from './types.js';
-import { getWalletComplianceStatus } from './utils.js';
+import {
+  getWalletComplianceStatus,
+  setWalletComplianceStatus,
+} from './utils.js';
 
 // === GENERAL ===
 
@@ -203,7 +206,11 @@ export class ComplianceController extends BaseController<
       };
 
       this.update((draftState) => {
-        draftState.walletComplianceStatusMap[address] = status;
+        setWalletComplianceStatus(
+          draftState.walletComplianceStatusMap,
+          address,
+          status,
+        );
         draftState.lastCheckedAt = now;
       });
 
@@ -249,7 +256,11 @@ export class ComplianceController extends BaseController<
       this.update((draftState) => {
         for (let idx = 0; idx < statuses.length; idx++) {
           const callerAddress = addresses[idx];
-          draftState.walletComplianceStatusMap[callerAddress] = statuses[idx];
+          setWalletComplianceStatus(
+            draftState.walletComplianceStatusMap,
+            callerAddress,
+            statuses[idx],
+          );
         }
         draftState.lastCheckedAt = now;
       });

--- a/packages/compliance-controller/src/utils.ts
+++ b/packages/compliance-controller/src/utils.ts
@@ -23,3 +23,48 @@ export const getWalletComplianceStatus = (
 
   return matchingAddress ? statusMap[matchingAddress] : undefined;
 };
+
+/**
+ * Writes a wallet's compliance status into the status map, reconciling it
+ * with any existing entry (or entries) for the same address under a
+ * different casing instead of leaving or creating a stale duplicate.
+ *
+ * A wallet's cache entry can only ever live under one key at a time,
+ * regardless of the casing used across separate calls. All keys that
+ * case-insensitively match the incoming address (the exact key, if present,
+ * included) are collected; the new status is written under the FIRST such
+ * key found (preferring key insertion order, so already-persisted state
+ * keeps its existing key rather than being rekeyed under the caller's
+ * casing), and every OTHER matching key is deleted. This also heals
+ * duplicate entries that predate this reconciliation (e.g. state persisted
+ * before this fix shipped, where the same wallet could have ended up cached
+ * under two different casings) the next time either casing is written.
+ *
+ * @param statusMap - The status map to write into, in place.
+ * @param address - The wallet address being written.
+ * @param status - The compliance status to store for the address.
+ */
+export const setWalletComplianceStatus = (
+  statusMap: Record<string, WalletComplianceStatus>,
+  address: string,
+  status: WalletComplianceStatus,
+): void => {
+  if (!isValidHexAddress(address, { allowNonPrefixed: false })) {
+    statusMap[address] = status;
+    return;
+  }
+
+  const matchingAddresses = Object.keys(statusMap).filter(
+    (cachedAddress) =>
+      isValidHexAddress(cachedAddress, { allowNonPrefixed: false }) &&
+      isEqualCaseInsensitive(cachedAddress, address),
+  );
+
+  const [canonicalAddress, ...staleAddresses] = matchingAddresses;
+
+  for (const staleAddress of staleAddresses) {
+    delete statusMap[staleAddress];
+  }
+
+  statusMap[canonicalAddress ?? address] = status;
+};


### PR DESCRIPTION
## Summary

`ComplianceController` writes a wallet's compliance status to `walletComplianceStatusMap` keyed by the caller's raw address casing, but reads go through `getWalletComplianceStatus` (`src/utils.ts`, added by #8820) — which tries an exact match first, then falls back to a case-insensitive scan. That asymmetry means a second write for an already-cached wallet under a *different* casing creates a stale duplicate entry instead of updating the existing one, and a subsequent read can return either the fresh or the stale status for the same wallet depending on which casing was queried.

Rated as a stale-cache **correctness** bug on a sanctions-screening surface, not a demonstrated live OFAC-compliance bypass — see "Scope and severity" below.

## The introducing commit is the whole argument

#8820 (merged, shipped in `2.1.0`) created `utils.ts` and converted **all four read call sites** to the new case-insensitive helper. Its own PR body states the intent directly:

> "Cached EVM wallet compliance statuses now exact-match first, then fall back to case-insensitive matching."

The diff contains not one line from either `this.update(...)` write block — `git show 7645e56cb0`/the PR diff confirms only the two `catch`-block fallback reads were touched. Casing-independence was the explicit goal; the write half needed the same treatment for it to actually hold across repeated writes under different casings.

## Repro

```ts
// state starts empty
await controller.checkWalletCompliance(CHECKSUM_EVM_ADDRESS); // not blocked
// wallet gets sanctioned
await controller.checkWalletCompliance(LOWERCASE_EVM_ADDRESS); // blocked

Object.keys(controller.state.walletComplianceStatusMap)
// before this fix: [CHECKSUM_EVM_ADDRESS, LOWERCASE_EVM_ADDRESS]  <- two entries for one wallet
// after this fix:  [CHECKSUM_EVM_ADDRESS]                          <- one, casing preserved

selectIsWalletBlocked(CHECKSUM_EVM_ADDRESS)(controller.state)
// before this fix: false  <- stale, wrong
// after this fix:  true
```

The map is `persist: true, usedInUi: true`, so the stale duplicate survives app restarts and is what the UI actually reads. `lastCheckedAt` updates on every write regardless of casing, so a stale entry's presentation looks freshly-checked even while it reflects a pre-sanction verdict.

## Fix

`setWalletComplianceStatus` (new, in `utils.ts`) collects **every** key in the map that case-insensitively matches the incoming address, writes the new status under the first (existing) one — preserving that key's casing so already-persisted state migrates for free without a breaking key-shape change — and deletes the rest. This also **heals** duplicate entries that already exist from before this fix ships (a real possibility, since the bug has been live since `2.1.0`), not just prevents new ones from forming.

Both write sites in `ComplianceController.ts` (`checkWalletCompliance`, `checkWalletsCompliance`) now route through it. The batch path's loop mutates the same map object in place, so a second alias of the same address later in the same batch call correctly reconciles against an entry a prior iteration in that same call just wrote.

## Scope and severity

The two-key/stale-read mechanism is proven end-to-end inside the package by the tests in this PR. What is **not** directly observed: a real client passing two different casings for the same wallet address in production. Both known consumers ship the affected version (extension `^2.1.0`, mobile `2.1.0`), and the extension's compliance selectors forward an arbitrary `address: string` with no normalization before calling into this controller, so nothing downstream closes the gap either — meaning the bug is reachable if a caller (or two callers, e.g. an EOA reference vs. a contract-derived checksum) ever supplies inconsistent casing for the same wallet, but that hasn't been directly confirmed happening today.

## Tests

`ComplianceController.test.ts:17-18` already defines fixtures under both casings, but every existing mixed-casing test pre-seeds state with one casing then reads with the other — none of them drive a *write* under a second casing after an initial write under a different casing, which is exactly the gap this bug lived in.

Added:
- a single-check test proving a later write under a different casing reconciles into the existing entry (not a duplicate), with the existing key's casing preserved
- a batch-check test proving the same for `checkWalletsCompliance`
- a test proving **pre-existing** duplicate state (as if persisted from before this fix shipped) gets healed on the next write under either casing — this is the harder case, and an earlier draft of this fix that only reconciled the exact-match key vs. one other match missed it; a reviewer flagged the gap, I fixed it, and this test now catches the fix regressing back to that narrower version
- a test proving two aliases of the same address requested within a single batch call reconcile to one entry with the later result winning

All new tests independently confirmed to fail with the exact predicted symptom against the pre-fix code, and pass after. Full package suite: 53/53 passing (was 49), 100% statement/branch/function/line coverage maintained. `tsc --build` and `eslint` clean on all changed files.

## Dupe-check

`gh issue/pr list --repo MetaMask/core --state all --search` for `getWalletComplianceStatus`, `walletComplianceStatusMap` returns nothing beyond #8820 (the introducing PR) and merged PRs predating the helper. None of the ~20 currently open compliance-related PRs touch this package.

## receipts

```
$ NODE_OPTIONS=--experimental-vm-modules yarn jest --config packages/compliance-controller/jest.config.js
Test Suites: 2 passed, 2 total
Tests:       53 passed, 53 total
Snapshots:   5 passed, 5 total
All files | 100% Stmts | 100% Branch | 100% Funcs | 100% Lines

$ npx eslint packages/compliance-controller/src/{utils,ComplianceController,ComplianceController.test}.ts
(clean, no output)

$ npx tsc --build tsconfig.build.json   # from packages/compliance-controller/
(clean, no output)

$ yarn workspace @metamask/compliance-controller run changelog:validate
(clean, no output)
```

Reviewed adversarially with Codex across two passes. First pass (real, run to completion) caught a genuine high-severity gap in the initial version: exact-match-first meant pre-existing stale duplicates from before this fix shipped weren't healed on write, only prevented going forward. Rewrote `setWalletComplianceStatus` to collect and reconcile *all* matching keys rather than stopping at the first, added the three tests above proving it, and got a clean second pass confirming the fix and asking only for the changelog entry (added).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persisted sanctions-screening cache correctness; the change reduces stale/wrong blocked status risk rather than expanding attack surface, but wrong compliance data is safety-sensitive.
> 
> **Overview**
> Fixes a **stale-cache correctness bug** where `checkWalletCompliance` and `checkWalletsCompliance` keyed persisted cache writes by the caller’s address casing while reads already matched EVM addresses case-insensitively. A second check for the same wallet under a different casing could leave an outdated entry alongside a fresh one, so UI/selectors might report the wrong blocked state.
> 
> Writes now go through new **`setWalletComplianceStatus`**, which updates the first existing case-insensitive match (keeping that key’s casing), removes any other duplicate keys, and collapses duplicate aliases within a single batch. **Tests** cover cross-casing updates, healing pre-existing duplicate persisted state, and batch reconciliation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93213b14313c54fe5aa9e04eda026ef1f5b21f04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->