### PR TITLE
fix(assets-controller): preserve EVM bridge exchange rates when currency has no CAIP mapping

### DIFF
--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Preserve EVM bridge exchange-rate data and omit non-EVM conversion rates when the selected currency has no CAIP mapping, instead of discarding the whole result ([#TBD](https://github.com/MetaMask/core/pull/TBD))
+- Preserve EVM bridge exchange-rate data and omit non-EVM conversion rates when the selected currency has no CAIP mapping, instead of discarding the whole result ([#10064](https://github.com/MetaMask/core/pull/10064))
 
 ## [14.0.3]
 

--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/transaction-controller` from `^69.6.1` to `^69.7.0` ([#10046](https://github.com/MetaMask/core/pull/10046))
 
+### Fixed
+
+- Preserve EVM bridge exchange-rate data and omit non-EVM conversion rates when the selected currency has no CAIP mapping, instead of discarding the whole result ([#TBD](https://github.com/MetaMask/core/pull/TBD))
+
 ## [14.0.3]
 
 ### Changed

--- a/packages/assets-controller/src/utils/formatExchangeRatesForBridge.test.ts
+++ b/packages/assets-controller/src/utils/formatExchangeRatesForBridge.test.ts
@@ -394,6 +394,129 @@ describe('formatExchangeRatesForBridge', () => {
     );
   });
 
+  describe('currencies absent from MAP_CAIP_CURRENCIES', () => {
+    // A deliberately fictional currency code: every real SupportedCurrency is
+    // now present in MAP_CAIP_CURRENCIES (see the 'gel' tests below), so this
+    // exercises the defensive path for a genuinely unmapped/invalid value.
+    const UNMAPPED_CURRENCY = 'xyz';
+
+    it('still returns EVM native marketData and currencyRates when selectedCurrency has no CAIP mapping', () => {
+      const ethNativeId = 'eip155:1/slip44:60';
+      const result = formatExchangeRatesForBridge({
+        assetsInfo: { [ethNativeId]: NATIVE_METADATA },
+        assetsPrice: {
+          [ethNativeId]: price({
+            price: 2000,
+            id: 'ethereum',
+            marketCap: 240_000_000_000,
+            lastUpdated: 1_700_000_000_000,
+          }),
+        },
+        selectedCurrency: UNMAPPED_CURRENCY,
+        nativeAssetIdentifiers: { 'eip155:1': ethNativeId },
+        networkConfigurationsByChainId: EVM_NETWORK_CONFIGS,
+      });
+
+      expect(result.currencyRates.ETH).toStrictEqual({
+        conversionDate: 1_700_000_000,
+        conversionRate: 2000,
+        usdConversionRate: 2000,
+      });
+
+      const chainData = result.marketData['0x1'];
+      expect(chainData).toBeDefined();
+      const nativeAddress = '0x0000000000000000000000000000000000000000';
+      expect(chainData[nativeAddress]).toBeDefined();
+      expect(chainData[nativeAddress].currency).toBe('ETH');
+      expect(result.currentCurrency).toBe(UNMAPPED_CURRENCY);
+    });
+
+    it('still returns EVM ERC20 marketData when selectedCurrency has no CAIP mapping', () => {
+      const ethNativeId = 'eip155:1/slip44:60';
+      const usdcId =
+        'eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+      const usdcAddress = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+      const result = formatExchangeRatesForBridge({
+        assetsInfo: {
+          [ethNativeId]: NATIVE_METADATA,
+          [usdcId]: {
+            type: 'erc20',
+            decimals: 6,
+            symbol: 'USDC',
+          } as AssetMetadata,
+        },
+        assetsPrice: {
+          [ethNativeId]: price({ price: 2000 }),
+          [usdcId]: price({ price: 1, id: 'usd-coin' }),
+        },
+        selectedCurrency: UNMAPPED_CURRENCY,
+        nativeAssetIdentifiers: { 'eip155:1': ethNativeId },
+        networkConfigurationsByChainId: EVM_NETWORK_CONFIGS,
+      });
+
+      expect(result.marketData['0x1']?.[usdcAddress]).toBeDefined();
+    });
+
+    it('omits (rather than mislabels) the non-EVM conversionRates entry when selectedCurrency has no CAIP mapping', () => {
+      // price (unlike usdPrice, which is always USD) for a non-EVM asset is
+      // already denominated in selectedCurrency, so a genuinely unmapped
+      // currency must not be silently relabeled as some other currency
+      // (e.g. USD) — that would be wrong data, not a safe fallback. It's
+      // correctly omitted instead.
+      const bitcoinAssetId = 'bip122:000000000019d6689c085ae165831e93/slip44:0';
+      const result = formatExchangeRatesForBridge({
+        assetsInfo: {},
+        assetsPrice: {
+          [bitcoinAssetId]: price({ price: 50000 }),
+        },
+        selectedCurrency: UNMAPPED_CURRENCY,
+        nativeAssetIdentifiers: {},
+      });
+
+      expect(result.conversionRates[bitcoinAssetId]).toBeUndefined();
+      expect(result.currentCurrency).toBe(UNMAPPED_CURRENCY);
+    });
+  });
+
+  describe('gel (SupportedCurrency previously missing from MAP_CAIP_CURRENCIES)', () => {
+    it('resolves EVM marketData/currencyRates for gel', () => {
+      const ethNativeId = 'eip155:1/slip44:60';
+      const result = formatExchangeRatesForBridge({
+        assetsInfo: { [ethNativeId]: NATIVE_METADATA },
+        assetsPrice: {
+          [ethNativeId]: price({ price: 5400, lastUpdated: 1_700_000_000_000 }),
+        },
+        selectedCurrency: 'gel',
+        nativeAssetIdentifiers: { 'eip155:1': ethNativeId },
+        networkConfigurationsByChainId: EVM_NETWORK_CONFIGS,
+      });
+
+      expect(result.currencyRates.ETH).toStrictEqual({
+        conversionDate: 1_700_000_000,
+        conversionRate: 5400,
+        usdConversionRate: 5400,
+      });
+    });
+
+    it('resolves the non-EVM conversionRates entry under the correct GEL CAIP currency, not USD', () => {
+      const bitcoinAssetId = 'bip122:000000000019d6689c085ae165831e93/slip44:0';
+      const result = formatExchangeRatesForBridge({
+        assetsInfo: {},
+        assetsPrice: {
+          [bitcoinAssetId]: price({ price: 135000 }),
+        },
+        selectedCurrency: 'gel',
+        nativeAssetIdentifiers: {},
+      });
+
+      expect(result.conversionRates[bitcoinAssetId]).toBeDefined();
+      expect(result.conversionRates[bitcoinAssetId].rate).toBe('135000');
+      expect(result.conversionRates[bitcoinAssetId].currency).toBe(
+        'swift:0/iso4217:GEL',
+      );
+    });
+  });
+
   describe('memoization', () => {
     afterEach(() => {
       clearFormatExchangeRatesForBridgeCacheForTesting();

--- a/packages/assets-controller/src/utils/formatExchangeRatesForBridge.ts
+++ b/packages/assets-controller/src/utils/formatExchangeRatesForBridge.ts
@@ -109,15 +109,15 @@ function computeExchangeRatesForBridge(
   const currencyRates: CurrencyRateState['currencyRates'] = {};
   const marketData: TokenRatesControllerState['marketData'] = {};
 
+  // Only consumed by the non-EVM (else) branch below to key conversionRates.
+  // An unmapped selectedCurrency must not discard EVM marketData/currencyRates,
+  // which don't depend on this lookup at all — so this bails out only the
+  // non-EVM assets (individually, below) rather than the whole function.
+  // Left undefined (not defaulted to USD) because `price` for a non-EVM
+  // asset is already denominated in `selectedCurrency` (unlike `usdPrice`,
+  // which is always USD); labeling that `price` value's currency as USD
+  // when it isn't would be wrong data, not a safe fallback.
   const currencyCaip = MAP_CAIP_CURRENCIES[selectedCurrency.toLowerCase()];
-  if (!currencyCaip) {
-    return {
-      conversionRates: {},
-      currencyRates: {},
-      marketData: {},
-      currentCurrency: selectedCurrency,
-    };
-  }
 
   const fungibleAssetsPrice = Object.entries(assetsPrice).reduce<
     Record<Caip19AssetId, FungibleAssetPrice>
@@ -195,7 +195,7 @@ function computeExchangeRatesForBridge(
             usdConversionRate: usdPrice,
           };
         }
-      } else {
+      } else if (currencyCaip) {
         conversionRates[assetId as Caip19AssetId] = {
           rate: String(price),
           currency: currencyCaip,

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Add the missing Georgian lari (`gel`) entry to `MAP_CAIP_CURRENCIES` ([#TBD](https://github.com/MetaMask/core/pull/TBD))
+- Add the missing Georgian lari (`gel`) entry to `MAP_CAIP_CURRENCIES` ([#10064](https://github.com/MetaMask/core/pull/10064))
 
 ## [111.1.3]
 

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/remote-feature-flag-controller` from `^6.0.0` to `^6.1.0` ([#9980](https://github.com/MetaMask/core/pull/9980))
 - Bump `@metamask/transaction-controller` from `^69.6.1` to `^69.7.0` ([#10046](https://github.com/MetaMask/core/pull/10046))
 
+### Fixed
+
+- Add the missing Georgian lari (`gel`) entry to `MAP_CAIP_CURRENCIES` ([#TBD](https://github.com/MetaMask/core/pull/TBD))
+
 ## [111.1.3]
 
 ### Changed

--- a/packages/assets-controllers/src/MultichainAssetsRatesController/constant.ts
+++ b/packages/assets-controllers/src/MultichainAssetsRatesController/constant.ts
@@ -57,6 +57,7 @@ export const MAP_CAIP_CURRENCIES: {
   dkk: 'swift:0/iso4217:DKK',
   eur: 'swift:0/iso4217:EUR',
   gbp: 'swift:0/iso4217:GBP',
+  gel: 'swift:0/iso4217:GEL',
   hkd: 'swift:0/iso4217:HKD',
   huf: 'swift:0/iso4217:HUF',
   idr: 'swift:0/iso4217:IDR',


### PR DESCRIPTION
## What it says on the box

`formatExchangeRatesForBridge` bailed out of the **entire** exchange-rate response — wiping EVM `marketData`/`currencyRates` too — when a currency lookup that's only needed by the non-EVM branch (to key `conversionRates`) failed to find a match in `MAP_CAIP_CURRENCIES`. This was broken today for at least one real, currently-supported currency (`gel`), and the shared map has no test coverage tying it to the actual set of supported currencies, so the gap could reopen silently.

```ts
// before — one lookup that's only used ~90 lines later, in the non-EVM branch,
// aborts the whole function including EVM output that has nothing to do with it
const currencyCaip = MAP_CAIP_CURRENCIES[selectedCurrency.toLowerCase()];
if (!currencyCaip) {
  return { conversionRates: {}, currencyRates: {}, marketData: {}, currentCurrency: selectedCurrency };
}
```

## The real gap this closes

Cross-checked `MAP_CAIP_CURRENCIES`'s keys against `packages/core-backend/src/api/shared-types.ts`'s `SupportedCurrency` type (the authoritative "currencies this backend actually supports" list) — after adding `gel`, the map is now a full superset:

```
supported but not mapped (before this PR): ["gel"]
supported but not mapped (after this PR):  []
mapped but not supported (harmless, pre-existing, untouched): ["xag", "xau", "xdr"]
```

Also confirmed live against the price API `formatExchangeRatesForBridge`'s data ultimately comes from (`https://price.api.cx.metamask.io/v1/supportedVsCurrencies`) — it returns 94 supported vs-currencies including `gel`.

## The fix

1. **`packages/assets-controllers/src/MultichainAssetsRatesController/constant.ts`** — added the missing `gel: 'swift:0/iso4217:GEL'` entry. This is the actual production gap; every other `SupportedCurrency` was already mapped.
2. **`formatExchangeRatesForBridge.ts`** — the top-level bail-out is gone. The currency lookup only affects the non-EVM (`else`) branch that actually consumes it — EVM `marketData`/`currencyRates` are computed unconditionally, regardless of whether the selected currency has a CAIP mapping.

For a *genuinely* unmapped currency (any future gap, or caller error), the fix deliberately **omits** rather than mislabels the non-EVM `conversionRates` entry — `price` for a non-EVM asset is already denominated in `selectedCurrency`, so silently falling back to e.g. `MAP_CAIP_CURRENCIES.usd` (my first draft's approach, corrected after adversarial review — see receipts) would emit a `gel`-denominated price mislabeled as USD. That's wrong data, not a safe fallback, so it's correctly left out instead.

Mirrors the same-map-consuming sibling `MultichainAssetsRatesController.ts`'s existing pattern of not letting an unmapped currency wipe out unrelated computed data.

## Testing

New tests cover:
- A genuinely unmapped (fictional `'xyz'`) currency: EVM `marketData`/`currencyRates` are still returned; the non-EVM `conversionRates` entry is correctly omitted (not mislabeled).
- `gel` specifically, end-to-end: EVM data resolves normally, and the non-EVM `conversionRates` entry resolves under the correct `swift:0/iso4217:GEL` CAIP currency (not USD).

## receipts

```
$ NODE_OPTIONS=--experimental-vm-modules npx jest src/utils/formatExchangeRatesForBridge.test.ts --coverage=false
# on unfixed source (git stash of the two source files): 4 failed, 19 passed
# restored: 23/23 passed

$ NODE_OPTIONS=--experimental-vm-modules npx jest --coverage=false   # full assets-controller package
Test Suites: 33 passed, 33 total
Tests:       986 passed, 986 total   # baseline (unmodified main): 981/981, +5 new

$ NODE_OPTIONS=--experimental-vm-modules npx jest src/MultichainAssetsRatesController --coverage=false   # sibling package, touches the same shared map
Test Suites: 1 passed, 1 total
Tests:       35 passed, 35 total (incl. 4 snapshots)

$ npx eslint <changed files>       # clean, no output
$ node_modules/.bin/oxfmt --check <changed files>   # all matched files use the correct format
$ yarn workspace @metamask/assets-controller run changelog:validate      # clean
$ yarn workspace @metamask/assets-controllers run changelog:validate     # clean
$ yarn workspace @metamask/assets-controller run build:types 2>&1 | grep -c "error TS"
53   # identical to unmodified main (53); all pre-existing, unrelated (bridge-controller, kyc-controller)
```

## Codex adversarial review

Ran `codex exec` synchronously (not backgrounded) as a second reviewer, twice.

**First pass caught a real correctness bug in my initial fix**: my first draft fell back to `MAP_CAIP_CURRENCIES.usd` for any unmapped currency — which is semantically wrong, since a non-EVM asset's `price` field is already denominated in `selectedCurrency` (only `usdPrice` is always USD), so labeling a `gel`-denominated price as `swift:0/iso4217:USD` would be incorrect data. Codex also independently ran its own cross-check (`SupportedCurrency` type vs. `MAP_CAIP_CURRENCIES` keys) and found `gel` is the *only* real gap — which reframed the fix from "add a generic fallback" to "close the actual gap directly, and make the generic fallback path correctly omit instead of mislabel." Rewrote accordingly (this PR's current state).

**Second pass** confirmed the correctness issue is fully resolved, and caught two minor follow-ups (a formatting nit, missing changelog entries in both touched packages) — both fixed before opening.

## risk

Low. `packages/assets-controllers/src/MultichainAssetsRatesController/constant.ts` gets one new key (`gel`), which is purely additive — no existing key or value changes. `formatExchangeRatesForBridge.ts`'s behavior is unchanged for every currently-supported currency (all of which are now in the map); the change only affects the previously-broken unmapped-currency path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive `gel` map entry and narrowed behavior change only for previously broken unmapped-currency paths; mapped currencies behave as before.
> 
> **Overview**
> Fixes bridge exchange-rate formatting when the selected fiat currency is missing from `MAP_CAIP_CURRENCIES` (notably **Georgian lari / `gel`**). Previously `formatExchangeRatesForBridge` returned empty `marketData` and `currencyRates` for the whole response if the CAIP lookup failed, even though that lookup is only needed for non-EVM `conversionRates`.
> 
> **`MAP_CAIP_CURRENCIES`** now includes `gel → swift:0/iso4217:GEL`. **`formatExchangeRatesForBridge`** no longer early-exits on a failed lookup; EVM `marketData` / `currencyRates` are always built, and non-EVM `conversionRates` are added only when `currencyCaip` exists—otherwise they are **omitted** (not mislabeled as USD).
> 
> Tests cover the fictional unmapped currency path and end-to-end `gel` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c934195a1f9dabb1453638f1961a3fbf6997274a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->