### PR TITLE
fix(perps): tighten Scale ladder contract

### DIFF
--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add provider-routed Scale price normalization through `PerpsController:getScalePriceLadder`, the optional `PerpsProvider.getScalePriceLadder` hook, and their exported action, parameter, and result types ([#10021](https://github.com/MetaMask/core/pull/10021))
+- Add provider-routed Scale price normalization through `PerpsController:getScalePriceLadder`, the optional `PerpsProvider.getScalePriceLadder` hook, and their exported action, parameter, and result types. `ScalePriceLadderUnavailableReason` limits unavailable results to routing, market, and provider failures ([#10021](https://github.com/MetaMask/core/pull/10021))
 - Add an optional batch-level `error` to `ClosePositionsResult` for an operation-level close failure, including cases that also populate per-position results ([#10037](https://github.com/MetaMask/core/pull/10037))
 
 ### Fixed

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add provider-routed Scale price normalization through `PerpsController:getScalePriceLadder`, the optional `PerpsProvider.getScalePriceLadder` hook, and their exported action, parameter, and result types. `ScalePriceLadderUnavailableReason` limits unavailable results to routing, market, and provider failures ([#10021](https://github.com/MetaMask/core/pull/10021), [#10065](https://github.com/MetaMask/core/pull/10065))
+- Add provider-routed Scale price normalization through `PerpsController:getScalePriceLadder`, the optional `PerpsProvider.getScalePriceLadder` hook, and their exported action, parameter, and result types. `DirectProviderScalePriceLadderUnavailableReason` and `ScalePriceLadderUnavailableReason` limit unavailable results to direct-provider and routed failures respectively ([#10021](https://github.com/MetaMask/core/pull/10021), [#10065](https://github.com/MetaMask/core/pull/10065))
 - Add an optional batch-level `error` to `ClosePositionsResult` for an operation-level close failure, including cases that also populate per-position results ([#10037](https://github.com/MetaMask/core/pull/10037))
 
 ### Fixed

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add provider-routed Scale price normalization through `PerpsController:getScalePriceLadder`, the optional `PerpsProvider.getScalePriceLadder` hook, and their exported action, parameter, and result types. `ScalePriceLadderUnavailableReason` limits unavailable results to routing, market, and provider failures ([#10021](https://github.com/MetaMask/core/pull/10021))
+- Add provider-routed Scale price normalization through `PerpsController:getScalePriceLadder`, the optional `PerpsProvider.getScalePriceLadder` hook, and their exported action, parameter, and result types. `ScalePriceLadderUnavailableReason` limits unavailable results to routing, market, and provider failures ([#10021](https://github.com/MetaMask/core/pull/10021), [#10065](https://github.com/MetaMask/core/pull/10065))
 - Add an optional batch-level `error` to `ClosePositionsResult` for an operation-level close failure, including cases that also populate per-position results ([#10037](https://github.com/MetaMask/core/pull/10037))
 
 ### Fixed

--- a/packages/perps-controller/src/PerpsController.ts
+++ b/packages/perps-controller/src/PerpsController.ts
@@ -117,6 +117,7 @@ import type {
   PerpsMarketData,
   PerpsOrderCapabilities,
   PerpsScalePriceLadder,
+  ScalePriceLadderUnavailableReason,
   PerpsPendingManualRecovery,
   PerpsRecoveredDispatch,
   Position,
@@ -2984,7 +2985,7 @@ export class PerpsController extends BaseController<
   }
 
   #getUnavailableScalePriceLadder(
-    reason: OrderCapabilitiesUnavailableReason,
+    reason: ScalePriceLadderUnavailableReason,
     providerId: PerpsProviderType | undefined,
   ): PerpsScalePriceLadder {
     return providerId

--- a/packages/perps-controller/src/index.ts
+++ b/packages/perps-controller/src/index.ts
@@ -294,6 +294,7 @@ export type {
   OrderCapabilitiesUnavailableReason,
   DirectProviderOrderCapabilitiesUnavailableReason,
   RoutedOrderCapabilitiesUnavailableReason,
+  ScalePriceLadderUnavailableReason,
   DirectProviderOrderCapabilities,
   PerpsOrderCapabilities,
   PerpsScalePriceLadder,

--- a/packages/perps-controller/src/index.ts
+++ b/packages/perps-controller/src/index.ts
@@ -294,6 +294,7 @@ export type {
   OrderCapabilitiesUnavailableReason,
   DirectProviderOrderCapabilitiesUnavailableReason,
   RoutedOrderCapabilitiesUnavailableReason,
+  DirectProviderScalePriceLadderUnavailableReason,
   ScalePriceLadderUnavailableReason,
   DirectProviderOrderCapabilities,
   PerpsOrderCapabilities,

--- a/packages/perps-controller/src/providers/HyperLiquidProvider.ts
+++ b/packages/perps-controller/src/providers/HyperLiquidProvider.ts
@@ -110,6 +110,7 @@ import type {
   InitializeResult,
   PerpsPlatformDependencies,
   PerpsProvider,
+  PerpsProviderType,
   PerpsScalePriceLadder,
   LiquidationPriceParams,
   LiveDataConfig,
@@ -125,6 +126,7 @@ import type {
   ScaleOrderChild,
   PerpsMarketData,
   DirectProviderOrderCapabilities,
+  DirectProviderOrderCapabilitiesUnavailableReason,
   Position,
   PositionTriggerOrder,
   ReadyToTradeResult,
@@ -1266,7 +1268,14 @@ const normalizeHyperLiquidScalePriceLadder = (params: {
 /** Capability lookup result that carries resolved market metadata when ready. */
 type HyperLiquidOrderCapabilityMarket =
   | Readonly<{ status: 'ready'; market: MarketInfo }>
-  | Extract<DirectProviderOrderCapabilities, { status: 'unavailable' }>;
+  | Readonly<{
+      status: 'unavailable';
+      providerId?: PerpsProviderType;
+      reason: Exclude<
+        DirectProviderOrderCapabilitiesUnavailableReason,
+        'strategy_market_unsupported'
+      >;
+    }>;
 
 /**
  * HyperLiquid provider implementation

--- a/packages/perps-controller/src/providers/HyperLiquidProvider.ts
+++ b/packages/perps-controller/src/providers/HyperLiquidProvider.ts
@@ -126,7 +126,7 @@ import type {
   ScaleOrderChild,
   PerpsMarketData,
   DirectProviderOrderCapabilities,
-  DirectProviderOrderCapabilitiesUnavailableReason,
+  DirectProviderScalePriceLadderUnavailableReason,
   Position,
   PositionTriggerOrder,
   ReadyToTradeResult,
@@ -1271,10 +1271,7 @@ type HyperLiquidOrderCapabilityMarket =
   | Readonly<{
       status: 'unavailable';
       providerId?: PerpsProviderType;
-      reason: Exclude<
-        DirectProviderOrderCapabilitiesUnavailableReason,
-        'strategy_market_unsupported'
-      >;
+      reason: DirectProviderScalePriceLadderUnavailableReason;
     }>;
 
 /**

--- a/packages/perps-controller/src/types/index.ts
+++ b/packages/perps-controller/src/types/index.ts
@@ -1617,11 +1617,16 @@ export type PerpsOrderCapabilities =
       reason: OrderCapabilitiesUnavailableReason;
     }>;
 
-/** Reasons a provider-routed Scale price ladder cannot be produced. */
-export type ScalePriceLadderUnavailableReason = Exclude<
-  OrderCapabilitiesUnavailableReason,
+/** Reasons a direct provider cannot produce a Scale price ladder. */
+export type DirectProviderScalePriceLadderUnavailableReason = Exclude<
+  DirectProviderOrderCapabilitiesUnavailableReason,
   'strategy_market_unsupported'
 >;
+
+/** Reasons a provider-routed Scale price ladder cannot be produced. */
+export type ScalePriceLadderUnavailableReason =
+  | DirectProviderScalePriceLadderUnavailableReason
+  | RoutedOrderCapabilitiesUnavailableReason;
 
 /** Result of provider-routed Scale price normalization. */
 export type PerpsScalePriceLadder =

--- a/packages/perps-controller/src/types/index.ts
+++ b/packages/perps-controller/src/types/index.ts
@@ -1617,6 +1617,12 @@ export type PerpsOrderCapabilities =
       reason: OrderCapabilitiesUnavailableReason;
     }>;
 
+/** Reasons a provider-routed Scale price ladder cannot be produced. */
+export type ScalePriceLadderUnavailableReason = Exclude<
+  OrderCapabilitiesUnavailableReason,
+  'strategy_market_unsupported'
+>;
+
 /** Result of provider-routed Scale price normalization. */
 export type PerpsScalePriceLadder =
   | Readonly<{
@@ -1627,7 +1633,7 @@ export type PerpsScalePriceLadder =
   | Readonly<{
       status: 'unavailable';
       providerId?: PerpsProviderType;
-      reason: OrderCapabilitiesUnavailableReason;
+      reason: ScalePriceLadderUnavailableReason;
     }>;
 
 export type FeeCalculationParams = {

--- a/packages/perps-controller/tests/src/providers/HyperLiquidProvider.strategy-orders.test.ts
+++ b/packages/perps-controller/tests/src/providers/HyperLiquidProvider.strategy-orders.test.ts
@@ -3030,6 +3030,37 @@ describe('HyperLiquidProvider - strategy order types', () => {
       ).toStrictEqual(['2000', '2500', '3000']);
     });
 
+    it('submits the provider preview prices for fractional bounds', async () => {
+      const { exchangeClient } = useStrategyClients({
+        exchange: { order: jest.fn().mockResolvedValue(scaleStatuses) },
+      });
+      const minPrice = 1234.567;
+      const maxPrice = 1234.767;
+      const count = 3;
+      const preview = await provider.getScalePriceLadder({
+        symbol: 'BTC',
+        minPrice,
+        maxPrice,
+        count,
+      });
+      if (preview.status !== 'ready') {
+        throw new Error('Expected Scale price ladder preview to be ready');
+      }
+
+      await provider.placeOrder({
+        ...baseOrder,
+        orderType: 'scale',
+        scaleMinPrice: minPrice.toString(),
+        scaleMaxPrice: maxPrice.toString(),
+        scaleNumOrders: count,
+      } satisfies OrderParams);
+
+      const submitted = exchangeClient.order.mock.calls[0][0];
+      expect(
+        submitted.orders.map((order: { p: string }) => order.p),
+      ).toStrictEqual(preview.prices);
+    });
+
     it('splits the size across the rungs so the total is preserved', async () => {
       const { exchangeClient } = useStrategyClients({
         exchange: { order: jest.fn().mockResolvedValue(scaleStatuses) },

--- a/packages/perps-controller/tests/src/providers/HyperLiquidProvider.strategy-orders.test.ts
+++ b/packages/perps-controller/tests/src/providers/HyperLiquidProvider.strategy-orders.test.ts
@@ -3034,11 +3034,12 @@ describe('HyperLiquidProvider - strategy order types', () => {
       const { exchangeClient } = useStrategyClients({
         exchange: { order: jest.fn().mockResolvedValue(scaleStatuses) },
       });
-      const minPrice = 1234.567;
-      const maxPrice = 1234.767;
+      const { symbol } = baseOrder;
+      const minPrice = 12.341;
+      const maxPrice = 12.381;
       const count = 3;
       const preview = await provider.getScalePriceLadder({
-        symbol: 'BTC',
+        symbol,
         minPrice,
         maxPrice,
         count,
@@ -3046,9 +3047,13 @@ describe('HyperLiquidProvider - strategy order types', () => {
       if (preview.status !== 'ready') {
         throw new Error('Expected Scale price ladder preview to be ready');
       }
+      expect(preview.prices).toStrictEqual(['12.34', '12.36', '12.38']);
 
       await provider.placeOrder({
         ...baseOrder,
+        symbol,
+        currentPrice: 12.36,
+        usdAmount: '300',
         orderType: 'scale',
         scaleMinPrice: minPrice.toString(),
         scaleMaxPrice: maxPrice.toString(),


### PR DESCRIPTION
## Explanation

The Scale price ladder API introduced in #10021 reused `OrderCapabilitiesUnavailableReason`, which exposed `strategy_market_unsupported` even though no ladder path can return that reason. This made exhaustive consumer handling include an impossible state. The original tests also verified fractional preview formatting and integer placement separately, but did not directly prove that fractional preview prices match submitted wire prices.

This PR:

- Adds and exports `ScalePriceLadderUnavailableReason`, excluding the capability-only `strategy_market_unsupported` reason.
- Uses the narrower reason type for `PerpsScalePriceLadder` and the controller's Scale-specific unavailable response helper.
- Adds a fractional-price parity test that compares `getScalePriceLadder` output with the prices sent by Scale placement.
- Updates the Unreleased changelog entry for the new public type.

Runtime behavior and dependencies are unchanged.

## References

- Follow-up to #10021
- [Scale unavailable reason review comment](https://github.com/MetaMask/core/pull/10021#discussion_r3908860311)
- [Fractional preview and placement parity review comment](https://github.com/MetaMask/core/pull/10021#discussion_r3908860314)

## Validation

- Focused HyperLiquid strategy-order suite: 288 tests passed
- Full `@metamask/perps-controller` test suite
- TypeScript validation
- Scoped ESLint and formatting checks
- Changelog validation
- Diff checks

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-level contract tightening and tests only; placement and routing behavior are unchanged, with minor compile-time impact for exhaustive handling of ladder unavailable reasons.
> 
> **Overview**
> Tightens the **Scale price ladder** public contract so unavailable results no longer reuse the broader order-capabilities reason union.
> 
> **`PerpsScalePriceLadder`** and **`PerpsController`** Scale-specific unavailable helpers now use **`ScalePriceLadderUnavailableReason`** and **`DirectProviderScalePriceLadderUnavailableReason`**, which drop the capability-only **`strategy_market_unsupported`** reason that ladder APIs cannot return. The new types are exported from the package entry; HyperLiquid’s internal capability lookup typing is aligned with the direct-provider ladder reason.
> 
> Adds a HyperLiquid strategy-order test that **`getScalePriceLadder`** preview prices for fractional bounds match the prices submitted on **`placeOrder`** for a scale ladder. Updates the Unreleased changelog to document the exported reason types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caa9bfebb801c74cca6d86cab3a4bc81f8844484. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->