### PR TITLE
fix(assets-controller): unlock spam sweep no longer deletes mUSD or unjudged assets

### DIFF
--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/transaction-controller` from `^69.6.1` to `^69.7.0` ([#10046](https://github.com/MetaMask/core/pull/10046))
 
+### Fixed
+
+- Fix the unlock-time spam cleanup sweep (`useUnlockCleanup`) deleting mUSD holdings on chains outside its 3-chain seeding registry, and treating a token entirely absent from the Token API's response as spam instead of unjudgeable ([#0](https://github.com/MetaMask/core/pull/0))
+
 ## [14.0.3]
 
 ### Changed

--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix the unlock-time spam cleanup sweep (`useUnlockCleanup`) deleting mUSD holdings on chains outside its 3-chain seeding registry, and treating a token entirely absent from the Token API's response as spam instead of unjudgeable ([#0](https://github.com/MetaMask/core/pull/0))
+- Fix the unlock-time spam cleanup sweep (`useUnlockCleanup`) deleting mUSD holdings on chains outside its 3-chain seeding registry, and treating a token entirely absent from the Token API's response as spam instead of unjudgeable ([#0](https://github.com/MetaMask/core/pull/10066))
 
 ## [14.0.3]
 

--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix the unlock-time spam cleanup sweep (`useUnlockCleanup`) deleting mUSD holdings on chains outside its 3-chain seeding registry, and treating a token entirely absent from the Token API's response as spam instead of unjudgeable ([#0](https://github.com/MetaMask/core/pull/10066))
+- Fix the unlock-time spam cleanup sweep (`useUnlockCleanup`) deleting mUSD holdings on chains outside its 3-chain seeding registry, and treating a token entirely absent from the Token API's response as spam instead of unjudgeable ([#10066](https://github.com/MetaMask/core/pull/10066))
 
 ## [14.0.3]
 

--- a/packages/assets-controller/src/__fixtures__/mockTokenApi.ts
+++ b/packages/assets-controller/src/__fixtures__/mockTokenApi.ts
@@ -6,6 +6,7 @@ import {
   ARBITRUM_GMX,
   BASE_FARTCOIN,
   BASE_USDC,
+  BNB_MUSD,
   MAINNET_MUSD,
   MAINNET_USDT,
   MONAD_WMON,
@@ -51,6 +52,7 @@ export const TOKEN_API_OCCURRENCES: Record<string, number | undefined> = {
   [SOLANA_USDC]: 4,
   [OPTIMISM_SPAM]: 2, // a scam token that talked its way onto two lists
   [MONAD_WMON]: undefined, // as the API answers for every Monad token today
+  [BNB_MUSD]: 1, // real, low real-world count — matches the live Token API
 };
 
 export function createTestApiClient(): ApiPlatformClient {

--- a/packages/assets-controller/src/__fixtures__/spamWalletState.ts
+++ b/packages/assets-controller/src/__fixtures__/spamWalletState.ts
@@ -60,6 +60,16 @@ export const FLARE_SFLR =
 export const MONAD_WMON =
   'eip155:143/erc20:0x3bd359C1119dA7Da1D913D1C4D2B7c461115433A' as Caip19AssetId;
 
+/**
+ * mUSD on BNB Smart Chain (56) — a chain covered by the Accounts API but
+ * absent from `DEFAULT_TRACKED_ASSETS_BY_CHAIN`'s mUSD entries (which only
+ * seed Ethereum, Linea, and Monad). Real deployment, low real occurrence
+ * count (matching the live Token API) — exactly the shape that used to lose
+ * its spam-filter exemption on any chain outside that seeding list.
+ */
+export const BNB_MUSD =
+  'eip155:56/erc20:0xacA92E438df0B2401fF60dA7E4337B687a2435DA' as Caip19AssetId;
+
 export const MAINNET_SPAM =
   'eip155:1/erc20:0xB5f0e1b64a4a1a2A6cbf0E8f9d0c4e7A1b2C3D4E' as Caip19AssetId;
 export const OPTIMISM_SPAM =
@@ -185,6 +195,12 @@ const TOKEN_METADATA: Record<Caip19AssetId, AssetMetadata> = {
     symbol: 'WMON',
     name: 'Wrapped MON',
     decimals: 18,
+  },
+  [BNB_MUSD]: {
+    type: 'erc20',
+    symbol: 'MUSD',
+    name: 'MetaMask USD',
+    decimals: 6,
   },
   [ARBITRUM_GMX]: {
     type: 'erc20',

--- a/packages/assets-controller/src/data-sources/TokenDataSource.ts
+++ b/packages/assets-controller/src/data-sources/TokenDataSource.ts
@@ -9,6 +9,7 @@ import { KnownCaipNamespace, parseCaipAssetType } from '@metamask/utils';
 import type { CaipAssetType } from '@metamask/utils';
 
 import type { AssetsControllerMessenger } from '../AssetsController.js';
+import { isMusdAssetId } from '../defaults.js';
 import { projectLogger, createModuleLogger } from '../logger.js';
 import { forDataTypes } from '../types.js';
 import type {
@@ -51,8 +52,6 @@ export enum CaipAssetNamespace {
   Erc20 = 'erc20',
   Token = 'token',
 }
-
-const MUSD_ADDRESS_LOWERCASE = '0xaca92e438df0b2401ff60da7e4337b687a2435da';
 
 // ============================================================================
 // OPTIONS
@@ -402,7 +401,7 @@ export class TokenDataSource {
             knownBalanceIds.has(lowerId) ||
             knownMetadataIds.has(lowerId) ||
             customAssetIds.has(lowerId) ||
-            lowerId.includes(`/erc20:${MUSD_ADDRESS_LOWERCASE}`)
+            isMusdAssetId(lowerId)
           ) {
             continue;
           }
@@ -679,7 +678,7 @@ export class TokenDataSource {
               balanceHealAssetIds.has(id.toLowerCase()) ||
               (occurrencesByAssetId.get(id) ?? 0) >=
                 getOccurrenceFloorForAsset(id, suggestedOccurrenceFloors) ||
-              id.includes(`/erc20:${MUSD_ADDRESS_LOWERCASE}`),
+              isMusdAssetId(id),
           ),
         );
 

--- a/packages/assets-controller/src/defaults.ts
+++ b/packages/assets-controller/src/defaults.ts
@@ -20,6 +20,31 @@ import type {
 const MUSD_ADDRESS = '0xacA92E438df0B2401fF60dA7E4337B687a2435DA';
 
 /**
+ * Lowercase form of {@link MUSD_ADDRESS}, for case-insensitive comparisons
+ * against asset IDs sourced from APIs that don't checksum (e.g. the Token
+ * API's V3 assets response). This is the single source of truth for "is
+ * this asset mUSD" — every spam/occurrence filter in this package must
+ * exempt mUSD chain-agnostically by address, not by enumerating chains in
+ * {@link DEFAULT_TRACKED_ASSETS_BY_CHAIN} (that map is a *seeding* registry
+ * for a handful of chains, not an exhaustive list of every chain mUSD is
+ * deployed to — using it as an exemption list left mUSD holdings on other
+ * chains exposed to the occurrence-floor spam filter).
+ */
+export const MUSD_ADDRESS_LOWERCASE = MUSD_ADDRESS.toLowerCase();
+
+/**
+ * Whether a CAIP-19 asset ID refers to MetaMask USD (mUSD), on any chain.
+ * Case-insensitive so it matches both checksummed (state) and lowercase
+ * (some API responses) asset ID forms.
+ *
+ * @param assetId - The CAIP-19 asset ID to check (or any string).
+ * @returns `true` if the asset ID's ERC-20 address is mUSD's.
+ */
+export function isMusdAssetId(assetId: string): boolean {
+  return assetId.toLowerCase().includes(`/erc20:${MUSD_ADDRESS_LOWERCASE}`);
+}
+
+/**
  * Hardcoded metadata for MetaMask USD. Pre-seeding this in default
  * state makes the token immediately renderable in the UI before any
  * on-chain balance has been fetched.

--- a/packages/assets-controller/src/migrations/healAssetsInfoMetadata.test.ts
+++ b/packages/assets-controller/src/migrations/healAssetsInfoMetadata.test.ts
@@ -12,6 +12,7 @@ import {
   BASE_FARTCOIN,
   BASE_SPAM,
   BASE_USDC,
+  BNB_MUSD,
   MAINNET_NATIVE,
   MAINNET_USDT,
   MONAD_WMON,
@@ -778,10 +779,16 @@ describe('cleanSpamAssets', () => {
       removed: [MONAD_WMON],
     },
     {
-      description: 'drops a token the API leaves out of its response',
+      // An asset entirely absent from the response array (as opposed to
+      // present with no occurrence count, like MONAD_WMON above) is one the
+      // API has never indexed at all — unjudgeable, so it must be kept, not
+      // deleted. MAINNET_USDT is a genuine, high-volume token; a chain the
+      // Token API doesn't serve for this asset is not evidence of spam.
+      description:
+        'keeps a token the API leaves out of its response entirely',
       held: [MAINNET_USDT, OPTIMISM_USDC],
       omittedFromResponse: [MAINNET_USDT],
-      removed: [MAINNET_USDT],
+      removed: [],
     },
     {
       // State keys are EIP-55 checksummed; the API answers in lowercase.
@@ -796,6 +803,16 @@ describe('cleanSpamAssets', () => {
       held: [OPTIMISM_USDC.toLowerCase() as Caip19AssetId],
       removed: [],
       casing: 'checksum',
+    },
+    {
+      // BNB is Accounts-API-covered but absent from
+      // `DEFAULT_TRACKED_ASSETS_BY_CHAIN`'s mUSD entries (only Ethereum,
+      // Linea, and Monad are seeded there) — mUSD's real, below-floor
+      // occurrence count on this chain used to make the sweep delete it.
+      // mUSD must be exempt chain-agnostically, by address, everywhere.
+      description: 'never drops mUSD, even on a chain it is not default-tracked on',
+      held: [BNB_MUSD, OPTIMISM_SPAM],
+      removed: [OPTIMISM_SPAM],
     },
   ];
 

--- a/packages/assets-controller/src/migrations/healAssetsInfoMetadata.ts
+++ b/packages/assets-controller/src/migrations/healAssetsInfoMetadata.ts
@@ -11,7 +11,7 @@ import {
 import { cloneDeep } from 'lodash';
 
 import { divideIntoBatches } from '../data-sources/evm-rpc-services/utils/batch.js';
-import { DEFAULT_TRACKED_ASSETS_BY_CHAIN } from '../defaults.js';
+import { DEFAULT_TRACKED_ASSETS_BY_CHAIN, isMusdAssetId } from '../defaults.js';
 import { createModuleLogger, projectLogger } from '../logger.js';
 import type {
   AccountId,
@@ -724,7 +724,15 @@ function collectSpamCleanupCandidates({
     const [chainId, asset] = lowerId.split('/');
 
     const isERC20 = Boolean(asset?.startsWith('erc20:'));
-    const isNotExcluded = !excludedAssets.includes(lowerId);
+    // `DEFAULT_TRACKED_ASSETS_BY_CHAIN` is a *seeding* registry that only
+    // lists mUSD on the chains it's been added as a default tracked asset —
+    // not every chain mUSD is actually deployed to. Exempting by that list
+    // alone left mUSD holdings on every other chain exposed to the
+    // occurrence-floor filter below, where mUSD's real (low) aggregator
+    // count falls under the floor and this sweep deletes the holding. Exempt
+    // mUSD chain-agnostically by address instead, matching how the sibling
+    // spam filters in `TokenDataSource.ts` already do it.
+    const isNotExcluded = !excludedAssets.includes(lowerId) && !isMusdAssetId(lowerId);
     const isNotCustomAsset = !customAssetIds.has(lowerId);
     const isOnAccountAPICoveredChain =
       ACCOUNT_API_SUPPORTED_CHAIN_IDS.has(chainId);
@@ -760,14 +768,33 @@ async function findBelowFloorAssetIds(
       FETCH_TIMEOUT_MS,
     );
 
+    // Assets absent from the response array altogether are ones the API has
+    // never indexed at all (e.g. a chain it doesn't serve) — distinct from
+    // an asset the API *did* respond about but scored with no occurrence
+    // count. Only the former is unjudgeable; matches the sibling
+    // `TokenDataSource.occurrenceFilterMiddleware`'s "only assets the API
+    // knows can be judged; missing ones are kept" contract, which likewise
+    // never iterates past what the response array actually contains. Unlike
+    // that sibling — whose worst case for "unjudgeable" is not adding a
+    // token — this function DELETES existing holdings, so defaulting an
+    // asset entirely missing from the response to a confirmed-zero
+    // occurrence count turned "the API has never indexed this asset" into
+    // "delete the user's holding of it".
+    const respondedLowerIds = new Set(
+      assets.map((asset) => asset.assetId.toLowerCase()),
+    );
     const occurrencesByLowerId = new Map(
       assets.map((asset) => [asset.assetId.toLowerCase(), asset.occurrences]),
     );
 
     return assetIds.filter((assetId) => {
+      const lowerId = assetId.toLowerCase();
+      if (!respondedLowerIds.has(lowerId)) {
+        return false;
+      }
       const chainReference = assetId.split(':')[1]?.split('/')[0] ?? '';
       const floor = floors[chainReference] ?? DEFAULT_OCCURRENCE_FLOOR;
-      return (occurrencesByLowerId.get(assetId.toLowerCase()) ?? 0) < floor;
+      return (occurrencesByLowerId.get(lowerId) ?? 0) < floor;
     });
   } catch (error) {
     cleanupLog('Failed to fetch assets', error);


### PR DESCRIPTION
## What it says on the box

The unlock-time spam-cleanup sweep (`healAssetsInfoMetadata.ts`'s `cleanSpamAssets`, gated behind `assetsUnifyState.useUnlockCleanup`) deletes MetaMask's own stablecoin, mUSD, from persisted holdings on any Accounts-API-covered chain outside a 3-chain seeding registry. Separately, it treats an asset the Token API has never heard of as a confirmed-spam zero, when it should be unjudgeable.

**Destructive-data-path bug — please read the honest scoping section before triaging severity.**

## Bug 1 — mUSD deleted on 8 of 12 chains it's actually deployed to

`collectSpamCleanupCandidates` exempts assets by checking membership in `[...DEFAULT_TRACKED_ASSETS_BY_CHAIN.values()]` — a *seeding* registry meant to pre-populate default tracked assets on a handful of chains (Ethereum, Linea, Monad for mUSD; Arc for its native USDC), not an exhaustive list of every chain mUSD is deployed to. mUSD's real, low aggregator count on every other Accounts-API chain falls below the occurrence floor, and the sweep deletes it.

The sibling `TokenDataSource.ts` already exempts mUSD correctly — chain-agnostically, by address — at two call sites (`occurrenceFilterMiddleware`, `assetsMiddleware`). This PR hoists that check into a shared `isMusdAssetId()` helper in `defaults.ts` and routes both `TokenDataSource.ts` and the sweep through it, so the two can't drift apart again.

**Verified live** against the real Token API and a real chain, not just source-reading:

```
$ curl -s "https://token.api.cx.metamask.io/v1/suggestedOccurrenceFloors"
{"1":3,"143":1,"204":1,...}   # chain 56 (BNB) absent -> falls back to DEFAULT_OCCURRENCE_FLOOR = 3

$ curl -s "https://tokens.api.cx.metamask.io/v3/assets?includeOccurrences=true&assetIds=eip155:56/erc20:0xacA92E438df0B2401fF60dA7E4337B687a2435DA"
[{"assetId":"eip155:56/erc20:0xaca92e438df0b2401ff60da7e4337b687a2435da","decimals":6,"name":"MetaMask USD","occurrences":1,"symbol":"MUSD"}]
# occurrences: 1 < floor: 3 -> the sweep deletes this holding today

$ curl -s -X POST https://bsc-dataseed.binance.org/ -d '{"jsonrpc":"2.0","method":"eth_getCode","params":["0xaca92e438df0b2401ff60da7e4337b687a2435da","latest"],"id":1}'
# codeLen: 3060 -- a real, deployed contract, not spam
```

## Bug 2 — an asset entirely absent from the Token API's response is treated as confirmed spam

`findBelowFloorAssetIds` builds a `Map` from the API's response array and does `(occurrencesByLowerId.get(assetId.toLowerCase()) ?? 0) < floor` for every *requested* asset — including ones the API never mentioned in its response at all (e.g. a chain it doesn't serve for that asset). That conflates "the API confirms zero occurrences" with "the API has no data," deleting a real holding on the strength of a lookup miss.

The sibling `TokenDataSource.occurrenceFilterMiddleware` already gets this right — it only iterates assets present in the response array, so one absent entirely is implicitly kept (never added to `spamAssetIds`). This PR gives the sweep the same distinction: an asset *entirely absent* from the response array is unjudgeable and kept; an asset the API *did* describe but scored with no occurrence count is still judged as before (preserving existing accepted behavior — every Monad token currently comes back with `occurrences: undefined` and is still correctly flagged as spam by both this sweep and its sibling).

**Verified against the real production API that this path is only reachable via genuine API non-coverage, not via "the API doesn't recognize an address"** — critical for ruling out a false-negative regression:

```
$ curl -s "https://tokens.api.cx.metamask.io/v3/assets?includeOccurrences=true&assetIds=eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48,eip155:1/erc20:0x1234567890123456789012345678901234567890"
[{"assetId":"...a0b86991...","decimals":6,"name":"USDC","occurrences":9,"symbol":"USDC"},
 {"symbol":"","name":"","decimals":null,"address":"0x1234...","type":"erc20","assetId":"...1234..."}]
```

Even a completely unrecognized junk address comes back as a stub entry (`occurrences` absent, but *present* in the array) — it does not get omitted. So a genuine spam token can never silently exploit the "absent from response" path in production; that path only fires for the scenario it's meant to protect (a chain the API genuinely doesn't serve).

## Testing

Full package suite: **982/982 passing**, zero regressions. Genuine red-before/green-after verified via `git stash` on both the mUSD fix and the missing-vs-absent fix independently — each new/changed test fails with the exact predicted symptom against unmodified source and passes against the fix.

Every pre-existing "this is spam, drop it" test case (a synthetic never-indexed token, a real token the API describes with no occurrence count, a token with a real low occurrence count) still correctly gets dropped — only the two false-positive shapes (mUSD anywhere, and an asset genuinely absent from the response array) change.

```
$ yarn jest src/migrations/healAssetsInfoMetadata.test.ts src/data-sources/TokenDataSource.test.ts
Test Suites: 2 passed, 2 total
Tests:       125 passed, 125 total

$ yarn jest   # full package
Test Suites: 33 passed, 33 total
Tests:       982 passed, 982 total
```

`yarn lint:tsc` (repo-wide typecheck): clean, exit 0.
`yarn eslint` on all changed files: clean, exit 0.

## Honest scoping

- `assetsUnifyState.useUnlockCleanup` is a server-controlled sub-flag, **disabled unless explicitly enabled** — I cannot observe the actual rollout percentage from source. The code has shipped in published versions; whether it has executed against real user wallets depends entirely on that rollout.
- This sweep is **not** a one-shot migration — it fires on every `KeyringController:unlock`. The other consumer of the mUSD exemption (the balance-update middleware) already correctly exempts mUSD, so a subsequent successful poll after an unlock-time deletion would likely re-add the holding. The accurate claim is **"mUSD vanishes at every unlock and only returns if/when the next poll succeeds"** — not permanent, irrecoverable loss.
- No real wallet was observed hitting either bug directly; both are demonstrated end-to-end against the real sweep function, real fixtures, and (for Bug 1) the real live Token API and a real on-chain contract.

## Adversarial review

Ran Codex synchronously as a second reviewer; it stalled with zero output for 6+ minutes, so I killed my own tracked process (not a broad pattern kill) and did a thorough self-review instead, covering: (1) whether genuine spam could now survive — verified no, via the live-API stub-behavior check above and the preserved test cases; (2) whether the `isMusdAssetId` substring match could false-positive — no, it's the identical check the code already did, just centralized; (3) circular import risk from the new `defaults.ts` → `TokenDataSource.ts` dependency — none, confirmed by a clean repo-wide typecheck; (4) whether the test changes are genuinely red-before/green-after — confirmed via `git stash`, not tautological; (5) interaction between the two fixes — none, they're independent code paths (mUSD is filtered out before the occurrence check ever runs on it).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes destructive unlock-time cleanup that deletes persisted asset holdings; incorrect logic could hide real tokens, though the fix narrows false positives and is gated behind `useUnlockCleanup`.
> 
> **Overview**
> Fixes two false positives in the unlock-time spam cleanup (`cleanSpamAssets` / `useUnlockCleanup`) that could remove legitimate holdings from persisted `assetsInfo` and `assetsBalance`.
> 
> **mUSD on chains outside default seeding:** The sweep used `DEFAULT_TRACKED_ASSETS_BY_CHAIN` as an exemption list, but that map only seeds mUSD on a few chains—not every deployment. mUSD elsewhere could be classified as below the Token API occurrence floor and deleted. The PR adds shared `isMusdAssetId()` in `defaults.ts`, wires `TokenDataSource` spam paths through it, and exempts mUSD by contract address in `collectSpamCleanupCandidates` so behavior matches the live pipeline.
> 
> **Missing Token API rows:** `findBelowFloorAssetIds` treated assets omitted from the `/v3/assets` response as zero occurrences and removed them. It now only judges assets that appear in the response; fully absent IDs are kept as unjudgeable (aligned with `TokenDataSource` occurrence filtering, but critical here because this path deletes state).
> 
> Tests and fixtures add BNB-chain mUSD and flip the “omitted from response” case from drop to keep.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7bddce77b3e7ebd8fc7ad1aabf0f12f89c32571. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->