### PR TITLE
fix(multichain-account-service): stop BaseBip44AccountProvider leaking removed accounts and stale account IDs

### DIFF
--- a/packages/multichain-account-service/CHANGELOG.md
+++ b/packages/multichain-account-service/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `BaseBip44AccountProvider` leaking removed accounts and stale account IDs ([#PR_NUMBER](https://github.com/MetaMask/core/pull/PR_NUMBER))
+  - `getAccounts()` now filters out entries the `AccountsController` no longer knows about instead of returning them as if they were real accounts.
+  - `init()` now replaces the tracked account set instead of adding to it, so a re-init after an account removal (e.g. on unlock) no longer leaves the removed account's ID tracked forever.
+
 ### Changed
 
 - Bump `@metamask/accounts-controller` from `^39.1.0` to `^39.1.1` ([#9969](https://github.com/MetaMask/core/pull/9969))

--- a/packages/multichain-account-service/CHANGELOG.md
+++ b/packages/multichain-account-service/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix `BaseBip44AccountProvider` leaking removed accounts and stale account IDs ([#PR_NUMBER](https://github.com/MetaMask/core/pull/PR_NUMBER))
+- Fix `BaseBip44AccountProvider` leaking removed accounts and stale account IDs ([#10069](https://github.com/MetaMask/core/pull/10069))
   - `getAccounts()` now filters out entries the `AccountsController` no longer knows about instead of returning them as if they were real accounts.
   - `init()` now replaces the tracked account set instead of adding to it, so a re-init after an account removal (e.g. on unlock) no longer leaves the removed account's ID tracked forever.
 

--- a/packages/multichain-account-service/src/providers/BaseBip44AccountProvider.test.ts
+++ b/packages/multichain-account-service/src/providers/BaseBip44AccountProvider.test.ts
@@ -1,0 +1,168 @@
+import type {
+  CreateAccountOptions,
+  KeyringAccount,
+  KeyringCapabilities,
+} from '@metamask/keyring-api';
+import type { Bip44Account } from '@metamask/account-api';
+import type { InternalAccount } from '@metamask/keyring-internal-api';
+
+import {
+  getMultichainAccountServiceMessenger,
+  getRootMessenger,
+  MOCK_HD_ACCOUNT_1,
+  MOCK_HD_ACCOUNT_2,
+} from '../tests/index.js';
+import type { RootMessenger } from '../tests/index.js';
+import { BaseBip44AccountProvider } from './BaseBip44AccountProvider.js';
+
+/**
+ * Minimal concrete subclass so we can exercise the abstract base class
+ * directly, matching the pattern used to test other abstract collaborators
+ * in this package.
+ */
+class TestAccountProvider extends BaseBip44AccountProvider<
+  Bip44Account<KeyringAccount>
+> {
+  get capabilities(): KeyringCapabilities {
+    return { supportsEnabling: true } as unknown as KeyringCapabilities;
+  }
+
+  getName(): string {
+    return 'TestAccountProvider';
+  }
+
+  async resyncAccounts(): Promise<void> {
+    // No-op for this test double.
+  }
+
+  isAccountCompatible(): boolean {
+    return true;
+  }
+
+  async createAccounts(
+    _options: CreateAccountOptions,
+  ): Promise<Bip44Account<KeyringAccount>[]> {
+    return [];
+  }
+
+  async deleteAccount(): Promise<void> {
+    // No-op for this test double.
+  }
+
+  async discoverAccounts(): Promise<Bip44Account<KeyringAccount>[]> {
+    return [];
+  }
+}
+
+/**
+ * Sets up a provider wired to a messenger whose
+ * `AccountsController:getAccounts` handler mirrors the real
+ * `AccountsController.getAccounts` contract: one slot per requested ID,
+ * `undefined` in place for any ID the controller no longer knows about
+ * (rather than omitting it, which would silently shrink the array).
+ *
+ * @param knownAccounts - The accounts the mocked AccountsController knows
+ * about.
+ * @returns The provider under test and its messenger.
+ */
+function setup(knownAccounts: InternalAccount[] = []): {
+  provider: TestAccountProvider;
+  messenger: RootMessenger;
+} {
+  const rootMessenger = getRootMessenger();
+  const messenger = getMultichainAccountServiceMessenger(rootMessenger);
+
+  rootMessenger.registerActionHandler(
+    'AccountsController:getAccounts',
+    (accountIds: string[]) =>
+      accountIds.map((id) =>
+        knownAccounts.find((account) => account.id === id),
+      ),
+  );
+
+  return {
+    provider: new TestAccountProvider(messenger),
+    messenger: rootMessenger,
+  };
+}
+
+describe('BaseBip44AccountProvider', () => {
+  describe('getAccounts', () => {
+    it('filters out accounts the AccountsController no longer knows about', () => {
+      // Only account 1 is "known" -- account 2 has been removed from the
+      // AccountsController's perspective, but is still tracked by this
+      // provider (e.g. before a reconciling init() call happens).
+      const { provider } = setup([MOCK_HD_ACCOUNT_1]);
+      provider.init([MOCK_HD_ACCOUNT_1.id, MOCK_HD_ACCOUNT_2.id]);
+
+      const accounts = provider.getAccounts();
+
+      expect(accounts).toStrictEqual([MOCK_HD_ACCOUNT_1]);
+      expect(accounts).not.toContain(undefined);
+    });
+
+    it('returns an empty array when none of the tracked accounts exist anymore', () => {
+      const { provider } = setup([]);
+      provider.init([MOCK_HD_ACCOUNT_1.id, MOCK_HD_ACCOUNT_2.id]);
+
+      expect(provider.getAccounts()).toStrictEqual([]);
+    });
+
+    it('returns all accounts unchanged when every tracked account still exists', () => {
+      const { provider } = setup([MOCK_HD_ACCOUNT_1, MOCK_HD_ACCOUNT_2]);
+      provider.init([MOCK_HD_ACCOUNT_1.id, MOCK_HD_ACCOUNT_2.id]);
+
+      expect(provider.getAccounts()).toStrictEqual([
+        MOCK_HD_ACCOUNT_1,
+        MOCK_HD_ACCOUNT_2,
+      ]);
+    });
+  });
+
+  describe('init', () => {
+    it('does not leave stale account IDs behind after a re-init with a smaller set', () => {
+      const { provider } = setup([MOCK_HD_ACCOUNT_1, MOCK_HD_ACCOUNT_2]);
+
+      // First init: both accounts are tracked.
+      provider.init([MOCK_HD_ACCOUNT_1.id, MOCK_HD_ACCOUNT_2.id]);
+      expect(
+        provider.isAligned({ entropySource: 'x', groupIndex: 0 }, [
+          MOCK_HD_ACCOUNT_2.id,
+        ]),
+      ).toBe(true);
+
+      // Account 2 gets removed upstream; a real caller (e.g. the mobile
+      // app's Authentication flow, which calls
+      // MultichainAccountService.init() -> provider.init() on every
+      // unlock) re-initializes the provider with only the surviving
+      // account.
+      provider.init([MOCK_HD_ACCOUNT_1.id]);
+
+      // The stale ID for the removed account must not still be tracked.
+      expect(
+        provider.isAligned({ entropySource: 'x', groupIndex: 0 }, [
+          MOCK_HD_ACCOUNT_2.id,
+        ]),
+      ).toBe(false);
+      expect(
+        provider.isAligned({ entropySource: 'x', groupIndex: 0 }, [
+          MOCK_HD_ACCOUNT_1.id,
+        ]),
+      ).toBe(true);
+    });
+
+    it('is idempotent when called repeatedly with the same accounts', () => {
+      const { provider } = setup([MOCK_HD_ACCOUNT_1]);
+
+      provider.init([MOCK_HD_ACCOUNT_1.id]);
+      provider.init([MOCK_HD_ACCOUNT_1.id]);
+      provider.init([MOCK_HD_ACCOUNT_1.id]);
+
+      expect(
+        provider.isAligned({ entropySource: 'x', groupIndex: 0 }, [
+          MOCK_HD_ACCOUNT_1.id,
+        ]),
+      ).toBe(true);
+    });
+  });
+});

--- a/packages/multichain-account-service/src/providers/BaseBip44AccountProvider.test.ts
+++ b/packages/multichain-account-service/src/providers/BaseBip44AccountProvider.test.ts
@@ -1,8 +1,8 @@
 import type {
   CreateAccountOptions,
   KeyringAccount,
-  KeyringCapabilities,
 } from '@metamask/keyring-api';
+import type { KeyringCapabilities } from '@metamask/keyring-api/v2';
 import type { Bip44Account } from '@metamask/account-api';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 

--- a/packages/multichain-account-service/src/providers/BaseBip44AccountProvider.ts
+++ b/packages/multichain-account-service/src/providers/BaseBip44AccountProvider.ts
@@ -138,16 +138,18 @@ export abstract class BaseBip44AccountProvider<
   }
 
   /**
-   * Add accounts to the provider.
+   * Initialize the provider with the given accounts.
    *
    * Note: There's an implicit assumption that the accounts are BIP-44 compatible.
    *
-   * @param accounts - The accounts to add.
+   * This replaces the provider's internal account list rather than adding to
+   * it, so a re-init (e.g. after an account has been removed) does not leave
+   * stale IDs behind from a previous call.
+   *
+   * @param accounts - The accounts to initialize the provider with.
    */
   init(accounts: Account['id'][]): void {
-    for (const account of accounts) {
-      this.accounts.add(account);
-    }
+    this.accounts = new Set(accounts);
   }
 
   /**
@@ -170,8 +172,14 @@ export abstract class BaseBip44AccountProvider<
       'AccountsController:getAccounts',
       accountsIds,
     );
-    // we cast here because we know that the accounts are BIP-44 compatible
-    return internalAccounts as unknown as Account[];
+    // `AccountsController:getAccounts` returns `undefined` for any ID it no
+    // longer knows about (e.g. the account was removed but this provider's
+    // internal ID list hasn't been reconciled yet). Filter those out rather
+    // than casting them through as if they were real accounts.
+    // we cast here because we know that the remaining accounts are BIP-44 compatible
+    return internalAccounts.filter(
+      (account): account is NonNullable<typeof account> => Boolean(account),
+    ) as unknown as Account[];
   }
 
   /**

--- a/packages/multichain-account-service/src/tests/providers.ts
+++ b/packages/multichain-account-service/src/tests/providers.ts
@@ -111,7 +111,9 @@ export function setupBip44AccountProvider({
   mocks.createAccounts.mockResolvedValue([]);
   mocks.init.mockImplementation(
     (accountIds: Bip44Account<KeyringAccount>['id'][]) => {
-      accountIds.forEach((id) => mocks.accounts.add(id));
+      // Mirrors the real BaseBip44AccountProvider#init(), which replaces
+      // (rather than adds to) the tracked account set on every call.
+      mocks.accounts = new Set(accountIds);
     },
   );
 


### PR DESCRIPTION
## What it says on the box

`BaseBip44AccountProvider` has two related bugs that both stem from the same root cause: its internal account-ID tracking (`this.accounts`) can silently drift from what the `AccountsController` actually knows about.

### 1. `getAccounts()` returns `undefined` entries cast as if they were real accounts

`AccountsController.getAccounts(accountIds)` is documented as returning `(InternalAccount | undefined)[]` — one slot per requested ID, `undefined` for any ID it doesn't recognize (e.g. the account was removed). `BaseBip44AccountProvider#getAccounts()` cast this straight through:

```ts
const internalAccounts = this.messenger.call('AccountsController:getAccounts', accountsIds);
return internalAccounts as unknown as Account[]; // could contain `undefined`
```

The sibling `MultichainAccountGroup#getAccounts()` already guards this exact case (`if (account) { ... } // might mean it has been deleted`), but `BaseBip44AccountProvider`'s own batch method didn't.

### 2. `init()` is purely additive, so a re-init after a removal leaves stale IDs forever

```ts
init(accounts: Account['id'][]): void {
  for (const account of accounts) {
    this.accounts.add(account);
  }
}
```

`MultichainAccountService#init()` calls `provider.init(state)` on every provider, computed fresh from current account state, every time it runs. It's not a one-shot boot call — `metamask-mobile`'s `Authentication.ts` calls `MultichainAccountService.init()` on every unlock:

```ts
// app/core/Authentication/Authentication.ts
const { MultichainAccountService } = Engine.context;
await MultichainAccountService.init();
```

So: remove an account, lock, unlock — the provider re-inits with a fresh (smaller) list, but the old ID is still in `this.accounts` because `init()` only ever adds.

## Receipts

Real regression tests added (`BaseBip44AccountProvider.test.ts`), using a mock `AccountsController:getAccounts` handler that mirrors the real `.map()`-based contract (same-length array, `undefined` in place for missing IDs — not a shorter, filtered array, which is what happened to make this invisible to `EvmAccountProvider.test.ts`'s existing mock).

Genuine red-before/green-after via `git stash` on the source fix alone:

```
$ git stash push -- .../BaseBip44AccountProvider.ts
$ yarn jest BaseBip44AccountProvider.test.ts
Tests: 3 failed, 2 passed, 5 total
$ git stash pop
$ yarn jest BaseBip44AccountProvider.test.ts
Tests: 5 passed, 5 total
```

Full package suite: `Test Suites: 17 passed, 17 total` / `Tests: 353 passed, 353 total`, 100% statement/function/line coverage, 96.85% branch (unchanged from baseline).

`yarn lint:tsc` (the real monorepo-wide `tsc --build`, not a scoped package check, which silently no-ops for this package since it has no local `lint:tsc` script) and `yarn eslint` on all changed files both clean.

Also updated the shared `tests/providers.ts` mock provider's `init()` implementation to match the real replace-not-add semantics — it's used by higher-level `MultichainAccountService`/`MultichainAccountWallet` tests, and was otherwise silently modeling the old buggy behavior even after this fix. Full suite re-confirmed green after that change too (nothing relied on the old mock behavior).

## Fix

- Filter `undefined` entries out of `getAccounts()` instead of casting them through.
- `init()` now does `this.accounts = new Set(accounts)` — replaces rather than adds.

## Review

Reviewed adversarially with Codex (`codex exec`, synchronous). It found no production correctness bug in the intended fix, but caught two real issues in my first pass, both fixed:
- The new test imported `KeyringCapabilities` from the wrong subpath (`@metamask/keyring-api` instead of `@metamask/keyring-api/v2`) — a real `TS2305`, only visible under the monorepo's real `tsc --build`, not the scoped package check I'd run first.
- The shared `tests/providers.ts` mock's `init()` was still additive, inconsistent with the fix (described above, fixed).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core multichain account ID tracking used on every unlock/re-init; behavior change is intentional but could affect alignment or account listing if callers relied on additive init or undefined entries.
> 
> **Overview**
> Fixes **account drift** in `BaseBip44AccountProvider` when the `AccountsController` drops an account but the provider’s internal ID set has not caught up yet (e.g. after remove + lock/unlock re-init).
> 
> **`getAccounts()`** now drops `undefined` slots from `AccountsController:getAccounts` instead of casting them through as real accounts.
> 
> **`init()`** **replaces** the tracked ID set (`new Set(accounts)`) instead of only adding IDs, so repeated inits with a smaller list no longer leave removed IDs tracked (including `isAligned` false positives).
> 
> Adds **`BaseBip44AccountProvider.test.ts`** with a mock that mirrors the controller’s per-ID `undefined` contract, and aligns the shared test mock’s **`init`** with replace semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fae227a8d3cabe153578ac83ea3d56edfb7e99a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->