### PR TITLE
fix(transaction-controller): harden gas fee token preflight

### DIFF
--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -9,8 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Prevent clearing a selected gas fee token when native gas estimates are still pending ([#10071](https://github.com/MetaMask/core/pull/10071))
-- Avoid leaving `isExternalSign` enabled when gas fee token preflight validation fails ([#10071](https://github.com/MetaMask/core/pull/10071))
+- Harden gas fee token preflight by not treating pending gas estimates as zero-cost native gas, and by resetting `isExternalSign` when preflight validation fails ([#10071](https://github.com/MetaMask/core/pull/10071))
 
 ## [69.8.0]
 

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Prevent clearing a selected gas fee token when native gas estimates are still pending ([#TBD](https://github.com/MetaMask/core/pull/TBD))
-- Avoid leaving `isExternalSign` enabled when gas fee token preflight validation fails ([#TBD](https://github.com/MetaMask/core/pull/TBD))
+- Prevent clearing a selected gas fee token when native gas estimates are still pending ([#10071](https://github.com/MetaMask/core/pull/10071))
+- Avoid leaving `isExternalSign` enabled when gas fee token preflight validation fails ([#10071](https://github.com/MetaMask/core/pull/10071))
 
 ## [69.8.0]
 

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Prevent clearing a selected gas fee token when native gas estimates are still pending ([#TBD](https://github.com/MetaMask/core/pull/TBD))
+- Avoid leaving `isExternalSign` enabled when gas fee token preflight validation fails ([#TBD](https://github.com/MetaMask/core/pull/TBD))
+
 ## [69.8.0]
 
 ### Added

--- a/packages/transaction-controller/src/utils/balance.test.ts
+++ b/packages/transaction-controller/src/utils/balance.test.ts
@@ -75,5 +75,40 @@ describe('Balance Utils', () => {
 
       expect(result).toBe(false);
     });
+
+    it('returns false if gas estimate is missing', async () => {
+      const result = await isNativeBalanceSufficientForGas(
+        {
+          ...TRANSACTION_META_MOCK,
+          txParams: {
+            ...TRANSACTION_META_MOCK.txParams,
+            gas: undefined,
+          },
+        },
+        MESSENGER_MOCK,
+        NETWORK_CLIENT_ID_MOCK,
+      );
+
+      expect(result).toBe(false);
+      expect(rpcRequestMock).not.toHaveBeenCalled();
+    });
+
+    it('returns false if max fee per gas is missing', async () => {
+      const result = await isNativeBalanceSufficientForGas(
+        {
+          ...TRANSACTION_META_MOCK,
+          txParams: {
+            ...TRANSACTION_META_MOCK.txParams,
+            maxFeePerGas: undefined,
+            gasPrice: undefined,
+          },
+        },
+        MESSENGER_MOCK,
+        NETWORK_CLIENT_ID_MOCK,
+      );
+
+      expect(result).toBe(false);
+      expect(rpcRequestMock).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/transaction-controller/src/utils/balance.ts
+++ b/packages/transaction-controller/src/utils/balance.ts
@@ -52,12 +52,18 @@ export async function isNativeBalanceSufficientForGas(
   networkClientId: NetworkClientId,
 ): Promise<boolean> {
   const from = transaction.txParams.from as Hex;
+  const gas = transaction.txParams.gas;
+  const maxFeePerGas =
+    transaction.txParams.maxFeePerGas ?? transaction.txParams.gasPrice;
 
-  const gasCostRawValue = new BigNumber(
-    transaction.txParams.gas ?? '0x0',
-  ).multipliedBy(
-    transaction.txParams.maxFeePerGas ?? transaction.txParams.gasPrice ?? '0x0',
-  );
+  // Gas estimates can still be in flight (e.g. skipInitialGasEstimate). Treating
+  // missing fee fields as zero makes every balance look sufficient and clears a
+  // selected gas fee token before publish.
+  if (!gas || !maxFeePerGas) {
+    return false;
+  }
+
+  const gasCostRawValue = new BigNumber(gas).multipliedBy(maxFeePerGas);
 
   const { balanceRaw } = await getNativeBalance(
     from,

--- a/packages/transaction-controller/src/utils/balance.ts
+++ b/packages/transaction-controller/src/utils/balance.ts
@@ -51,22 +51,22 @@ export async function isNativeBalanceSufficientForGas(
   messenger: TransactionControllerMessenger,
   networkClientId: NetworkClientId,
 ): Promise<boolean> {
-  const from = transaction.txParams.from as Hex;
-  const gas = transaction.txParams.gas;
-  const maxFeePerGas =
-    transaction.txParams.maxFeePerGas ?? transaction.txParams.gasPrice;
+  const {
+    txParams: { from, gas, maxFeePerGas, gasPrice },
+  } = transaction;
+  const maxFeePerGasValue = maxFeePerGas ?? gasPrice;
 
   // Gas estimates can still be in flight (e.g. skipInitialGasEstimate). Treating
   // missing fee fields as zero makes every balance look sufficient and clears a
   // selected gas fee token before publish.
-  if (!gas || !maxFeePerGas) {
+  if (!gas || !maxFeePerGasValue) {
     return false;
   }
 
-  const gasCostRawValue = new BigNumber(gas).multipliedBy(maxFeePerGas);
+  const gasCostRawValue = new BigNumber(gas).multipliedBy(maxFeePerGasValue);
 
   const { balanceRaw } = await getNativeBalance(
-    from,
+    from as Hex,
     messenger,
     networkClientId,
   );

--- a/packages/transaction-controller/src/utils/gas-fee-tokens.test.ts
+++ b/packages/transaction-controller/src/utils/gas-fee-tokens.test.ts
@@ -411,10 +411,20 @@ describe('Gas Fee Tokens Utils', () => {
       request.transaction.isGasFeeTokenIgnoredIfBalance = true;
       request.transaction.selectedGasFeeToken = TOKEN_ADDRESS_1_MOCK;
       request.transaction.gasFeeTokens = [];
+      request.transaction.isExternalSign = true;
+
+      jest.mocked(request.fetchGasFeeTokens).mockResolvedValueOnce([]);
 
       await expect(checkGasFeeTokenBeforePublish(request)).rejects.toThrow(
         'Gas fee token not found and insufficient native balance',
       );
+
+      jest
+        .mocked(request.updateTransaction)
+        .mock.calls[0][1](request.transaction);
+
+      expect(request.transaction.isExternalSign).toBe(false);
+      expect(request.transaction.gasFeeTokens).toStrictEqual([]);
     });
 
     it('updates gas fee tokens', async () => {

--- a/packages/transaction-controller/src/utils/gas-fee-tokens.ts
+++ b/packages/transaction-controller/src/utils/gas-fee-tokens.ts
@@ -187,6 +187,20 @@ export async function checkGasFeeTokenBeforePublish({
     isExternalSign: true,
   });
 
+  const isSelectedGasFeeTokenAvailable = gasFeeTokens?.some(
+    (token) =>
+      token.tokenAddress.toLowerCase() === selectedGasFeeToken.toLowerCase(),
+  );
+
+  if (!isSelectedGasFeeTokenAvailable) {
+    updateTransaction(transaction.id, (tx) => {
+      tx.gasFeeTokens = gasFeeTokens;
+      tx.isExternalSign = false;
+    });
+
+    throw new Error('Gas fee token not found and insufficient native balance');
+  }
+
   updateTransaction(transaction.id, (tx) => {
     tx.gasFeeTokens = gasFeeTokens;
     tx.isExternalSign = true;
@@ -194,16 +208,6 @@ export async function checkGasFeeTokenBeforePublish({
   });
 
   log('Updated gas fee tokens before publish', gasFeeTokens);
-
-  if (
-    !gasFeeTokens?.some(
-      (token) =>
-        token.tokenAddress.toLowerCase() === selectedGasFeeToken.toLowerCase(),
-    )
-  ) {
-    throw new Error('Gas fee token not found and insufficient native balance');
-  }
-
   log('Publishing with selected gas fee token', { selectedGasFeeToken });
 }
 


### PR DESCRIPTION
## Explanation

Predict claim on Mobile (Polygon Safe wallets) can fail during gas-station preflight when a gas fee token (e.g. pUSD) is pre-selected but Sentinel returns an empty `gasFeeTokens` list and native POL is insufficient.

Two controller bugs contribute to confusing failures and bad publish fallbacks:

1. **`isNativeBalanceSufficientForGas`** treated missing `maxFeePerGas`/`gasPrice` as zero, so `gas × 0 = 0` made every wallet look able to pay native gas. That could clear `selectedGasFeeToken` while gas estimates were still in flight (common with `skipInitialGasEstimate`), leading to publishes with **`intrinsic gas too low: gas 0`**.
2. **`checkGasFeeTokenBeforePublish`** set `isExternalSign: true` and cleared nonce **before** validating the selected token. When validation failed (`Gas fee token not found and insufficient native balance`), transaction metadata could remain in external-sign mode even though signing was never completed.

This PR hardens both paths:

- **`balance.ts`**: return insufficient when `gas` or fee fields are unset, so pre-selected gas fee tokens are not cleared prematurely.
- **`gas-fee-tokens.ts`**: only enable external sign after the selected token is confirmed in freshly fetched `gasFeeTokens`; on failure, persist refreshed tokens but reset `isExternalSign` to `false` before throwing.

No breaking API changes. Scope is limited to `@metamask/transaction-controller` publish-time gas-fee-token gating.

## References

https://consensyssoftware.atlassian.net/browse/CONF-1725

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes publish-path balance and gas-fee-token validation; incorrect behavior could block valid publishes or alter signing mode, but scope is limited to preflight gating with targeted tests.
> 
> **Overview**
> Hardens publish-time gas fee token gating in `@metamask/transaction-controller` so pre-selected tokens are not dropped and external-sign state is not left inconsistent when preflight fails.
> 
> **`isNativeBalanceSufficientForGas`** now returns insufficient when `gas` or fee fields (`maxFeePerGas` / `gasPrice`) are unset, instead of treating missing values as zero. That stops in-flight gas estimates (e.g. with `skipInitialGasEstimate`) from looking like free native gas and clearing a selected gas fee token too early.
> 
> **`checkGasFeeTokenBeforePublish`** only sets `isExternalSign: true` and clears nonce after confirming the selected token appears in freshly fetched `gasFeeTokens`. If the token is missing, it persists the refreshed token list, resets **`isExternalSign` to `false`**, then throws—avoiding metadata stuck in external-sign mode after a failed preflight.
> 
> Tests and an Unreleased changelog entry cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35560024abdb86375f58f4b8087b2698baca3bee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->