### PR TITLE
ci: run update-changelogs on comment for non-release PRs

### DIFF
--- a/.github/workflows/update-changelogs.yml
+++ b/.github/workflows/update-changelogs.yml
@@ -92,7 +92,7 @@ jobs:
   react-to-comment:
     name: React to the comment
     needs: is-release
-    if: needs.is-release.outputs.is-release == 'true' && github.event_name == 'issue_comment'
+    if: github.event_name == 'issue_comment'
     runs-on: ubuntu-latest
     environment: default-branch
     permissions:
@@ -123,7 +123,7 @@ jobs:
   update-changelogs:
     name: Update changelogs
     needs: is-release
-    if: ${{ needs.is-release.outputs.is-release == 'true' }}
+    if: needs.is-release.outputs.is-release == 'true' || github.event_name == 'issue_comment'
     runs-on: ubuntu-latest
     environment: default-branch
     permissions:

--- a/docs/processes/updating-changelogs.md
+++ b/docs/processes/updating-changelogs.md
@@ -17,9 +17,9 @@ We will offer more guidance here in the future, but in general:
 - Split disparate changes from the same pull request into multiple entries if necessary.
 - Omit reverted changes from the changelog.
 
-## Updating changelogs automatically
+## Generating changelog entries for dependency bumps
 
-Some changelog entries are mechanical, such as the entries that record dependency bumps across packages. You can get these written for you instead of writing them by hand:
+Recording dependency bumps within package changelogs can be tedious. You can have these entries generated for you instead of writing them by hand:
 
 1. Post a comment on your pull request with the text `@metamaskbot update-changelogs`.
 2. The `Update Changelogs` GitHub action reacts to your comment with a 👍 and kicks off.
@@ -28,5 +28,5 @@ Some changelog entries are mechanical, such as the entries that record dependenc
 A few things to know:
 
 - This works on any pull request, not just release pull requests. Release pull requests also get this automatically when they are opened.
-- If the action pushes a commit, remember to pull it before you push again.
+- If the action pushes a commit to your branch, remember to pull it locally before you push again.
 - This only works on pull requests opened from a branch in this repo. Pull requests from forks are skipped, so if you are an outside contributor you will need to update changelogs by hand.

--- a/docs/processes/updating-changelogs.md
+++ b/docs/processes/updating-changelogs.md
@@ -16,3 +16,17 @@ We will offer more guidance here in the future, but in general:
 - Combine like changes from multiple pull requests into a single changelog entry if necessary.
 - Split disparate changes from the same pull request into multiple entries if necessary.
 - Omit reverted changes from the changelog.
+
+## Updating changelogs automatically
+
+Some changelog entries are mechanical, such as the entries that record dependency bumps across packages. You can get these written for you instead of writing them by hand:
+
+1. Post a comment on your pull request with the text `@metamaskbot update-changelogs`.
+2. The `Update Changelogs` GitHub action reacts to your comment with a 👍 and kicks off.
+3. After a few minutes you will see a new comment saying either that the changelogs were updated and pushed to your branch, or that no changes were needed. If validation errors remain that the action cannot fix, the comment links to the workflow run so you can see them.
+
+A few things to know:
+
+- This works on any pull request, not just release pull requests. Release pull requests also get this automatically when they are opened.
+- If the action pushes a commit, remember to pull it before you push again.
+- This only works on pull requests opened from a branch in this repo. Pull requests from forks are skipped, so if you are an outside contributor you will need to update changelogs by hand.


### PR DESCRIPTION
## Explanation

`@metamaskbot update-changelogs` never worked outside release PRs. #8443 documented it as working on any non fork PR, but shipped both comment jobs gated on `is-release == 'true'`, so commenting on a normal PR did nothing. This makes the comment trigger actually work.

| Job | Before | After | Why |
| --- | --- | --- | --- |
| `react-to-comment` | `is-release == 'true' && issue_comment` | `issue_comment` | react to every command comment, not just ones on release PRs |
| `update-changelogs` | `is-release == 'true'` | `is-release == 'true' \|\| issue_comment` | run on demand on any PR, while release PRs keep running automatically |

Release PR behavior is unchanged. Opening a non release PR still triggers nothing automatically, you have to ask for it. Fork PRs are still skipped.

Also documented the command in `docs/processes/updating-changelogs.md`, since it was undiscoverable.

## References

Related to #8443

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow condition changes and documentation only; no runtime application or security-sensitive logic.
> 
> **Overview**
> Fixes **`@metamaskbot update-changelogs`** so it works on ordinary PRs, not only release PRs. Previously both comment-related jobs required `is-release == 'true'`, so commenting on a non-release PR did nothing despite earlier docs implying it should work.
> 
> **`react-to-comment`** now runs on any `issue_comment` (drops the release check) so the bot can 👍 every command comment. **`update-changelogs`** runs when the PR is a release **or** when triggered via `issue_comment`, preserving automatic updates on release PRs while enabling on-demand runs elsewhere. Fork PRs remain unsupported per existing behavior.
> 
> Adds a **Generating changelog entries for dependency bumps** section in `docs/processes/updating-changelogs.md` describing the comment flow, timing, and limitations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1d87058f7c81e5cdd01c3f60c40c880f37680bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->