### PR TITLE
fix(kyc-controller): Remove `consent` property from the `GET /disclaimers` return type

### DIFF
--- a/packages/kyc-controller/ARCHITECTURE.md
+++ b/packages/kyc-controller/ARCHITECTURE.md
@@ -136,8 +136,8 @@ Endpoints:
 | `checkKycRequired`         | `POST` | `/vendors/{vendor}/kyc-required`             | Is KYC required? (normalizes `required` → `kycRequired`)                               |
 | `createVendorCustomer`     | `POST` | `/vendors/{vendor}/customers`                | Create or resume an empty-shell vendor customer                                        |
 | `submitVendorDisclaimers`  | `POST` | `/vendors/{vendor}/disclaimers`              | Record vendor T&C signings (`disclaimerIds`)                                           |
-| `fetchDisclaimersCatalog`  | `GET`  | `/disclaimers?country=`                      | Global idOS + KYC-provider catalog (no credential-reuse flag)                          |
-| `fetchSessionDisclaimers`  | `GET`  | `/sessions/{id}/disclaimers`                 | Session-scoped idOS + KYC-provider catalog                                             |
+| `fetchDisclaimersCatalog`  | `GET`  | `/disclaimers?country=`                      | Global idOS + KYC-provider catalog (no consent state)                                  |
+| `fetchSessionDisclaimers`  | `GET`  | `/sessions/{id}/disclaimers`                 | Session-scoped catalog, with `consented` flags + credential-reuse flag                 |
 | `submitSessionDisclaimers` | `POST` | `/sessions/{id}/disclaimers`                 | Record `{ idOS, kycProvider, credentialReusabilityConsentGiven }` consents             |
 | `fetchKycStatus`           | `GET`  | `/kyc/status`                                | User-keyed simplified KYC status                                                       |
 | `fetchIdosEnclaveJwks`     | `GET`  | `{idosEnclaveBaseUrl}/.well-known/jwks.json` | idOS enclave JWKS for `encryptionDataKey` attestation                                  |

--- a/packages/kyc-controller/src/KycService-method-action-types.ts
+++ b/packages/kyc-controller/src/KycService-method-action-types.ts
@@ -89,9 +89,9 @@ export type KycServiceSubmitVendorDisclaimersAction = {
 
 /**
  * Fetches the global idOS + KYC-provider disclaimer catalog
- * (`GET /disclaimers?country=`). Does not include
- * `credentialReusabilityConsentGiven` — that is session-scoped via
- * {@link fetchSessionDisclaimers}. Vendor T&Cs continue to come from
+ * (`GET /disclaimers?country=`). Carries no consent state — per-document
+ * `consented` flags and `credentialReusabilityConsentGiven` are session-scoped
+ * via {@link fetchSessionDisclaimers}. Vendor T&Cs continue to come from
  * {@link fetchVendorDisclaimers}.
  *
  * @param params - The parameters.

--- a/packages/kyc-controller/src/KycService-method-action-types.ts
+++ b/packages/kyc-controller/src/KycService-method-action-types.ts
@@ -90,9 +90,9 @@ export type KycServiceSubmitVendorDisclaimersAction = {
 /**
  * Fetches the global idOS + KYC-provider disclaimer catalog
  * (`GET /disclaimers?country=`). Carries no consent state — per-document
- * `consented` flags and `credentialReusabilityConsentGiven` are session-scoped
- * via {@link fetchSessionDisclaimers}. Vendor T&Cs continue to come from
- * {@link fetchVendorDisclaimers}.
+ * `consented` flags and `credentialReusabilityConsentGiven` are
+ * session-scoped via {@link fetchSessionDisclaimers}. Vendor T&Cs continue to
+ * come from {@link fetchVendorDisclaimers}.
  *
  * @param params - The parameters.
  * @param params.country - ISO 3166-1 alpha-3 country code.

--- a/packages/kyc-controller/src/KycService.test.ts
+++ b/packages/kyc-controller/src/KycService.test.ts
@@ -769,7 +769,6 @@ describe('KycService', () => {
           version: '1',
           title: 'idOS ToS',
           url: 'https://idos.example/tos',
-          consented: false,
         },
       ],
       kycProvider: [
@@ -778,7 +777,6 @@ describe('KycService', () => {
           version: '1',
           title: 'SumSub ToS',
           url: 'https://sumsub.example/tos',
-          consented: false,
         },
       ],
     };
@@ -890,6 +888,30 @@ describe('KycService', () => {
       nock(MOCK_API_URL)
         .get('/sessions/sid-1/disclaimers')
         .reply(200, documents);
+      const { service } = getService();
+
+      await expect(
+        service.fetchSessionDisclaimers({ sessionId: 'sid-1' }),
+      ).rejects.toThrow(
+        /Malformed response received from session disclaimers API/u,
+      );
+    });
+
+    it('throws when a session document omits consented', async () => {
+      nock(MOCK_API_URL)
+        .get('/sessions/sid-1/disclaimers')
+        .reply(200, {
+          idOS: [
+            {
+              key: 'idos-tos',
+              version: '1',
+              title: 'idOS ToS',
+              url: 'https://idos.example/tos',
+            },
+          ],
+          kycProvider: [],
+          credentialReusabilityConsentGiven: false,
+        });
       const { service } = getService();
 
       await expect(

--- a/packages/kyc-controller/src/KycService.ts
+++ b/packages/kyc-controller/src/KycService.ts
@@ -255,25 +255,34 @@ const KycUserStatusResponseStruct = type({
   errorCode: optional(string()),
 });
 
-const ConsentDocumentStruct = type({
+const CatalogDocumentFields = {
   key: string(),
   version: string(),
   title: string(),
   url: string(),
+} as const;
+
+const CatalogDocumentStruct = type(CatalogDocumentFields);
+
+// Session documents also report whether that version was already consented to.
+const ConsentDocumentStruct = type({
+  ...CatalogDocumentFields,
   consented: boolean(),
 });
 
-const DisclaimersCatalogFields = {
-  idOS: array(ConsentDocumentStruct),
-  kycProvider: array(ConsentDocumentStruct),
-} as const;
-
-/** Global catalog from `GET /disclaimers` (no credential-reuse flag). */
-const GlobalDisclaimersResponseStruct = type(DisclaimersCatalogFields);
+/**
+ * Global catalog from `GET /disclaimers` (no per-document `consented` flag and
+ * no credential-reuse flag).
+ */
+const GlobalDisclaimersResponseStruct = type({
+  idOS: array(CatalogDocumentStruct),
+  kycProvider: array(CatalogDocumentStruct),
+});
 
 /** Session catalog from `GET`/`POST /sessions/{id}/disclaimers`. */
 const SessionDisclaimersResponseStruct = type({
-  ...DisclaimersCatalogFields,
+  idOS: array(ConsentDocumentStruct),
+  kycProvider: array(ConsentDocumentStruct),
   credentialReusabilityConsentGiven: boolean(),
 });
 
@@ -668,10 +677,10 @@ export class KycService extends BaseDataService<
 
   /**
    * Fetches the global idOS + KYC-provider disclaimer catalog
-   * (`GET /disclaimers?country=`). Does not include
-   * `credentialReusabilityConsentGiven` — that is session-scoped via
-   * {@link fetchSessionDisclaimers}. Vendor T&Cs continue to come from
-   * {@link fetchVendorDisclaimers}.
+   * (`GET /disclaimers?country=`). Carries no consent state — per-document
+   * `consented` flags and `credentialReusabilityConsentGiven` are
+   * session-scoped via {@link fetchSessionDisclaimers}. Vendor T&Cs continue to
+   * come from {@link fetchVendorDisclaimers}.
    *
    * @param params - The parameters.
    * @param params.country - ISO 3166-1 alpha-3 country code.

--- a/packages/kyc-controller/src/index.ts
+++ b/packages/kyc-controller/src/index.ts
@@ -94,6 +94,7 @@ export type {
 } from './crypto.js';
 
 export type {
+  KycCatalogDocument,
   KycConsentDocument,
   KycConsentRecord,
   KycCustomerIdentity,

--- a/packages/kyc-controller/src/types.ts
+++ b/packages/kyc-controller/src/types.ts
@@ -164,10 +164,11 @@ export type KycVendorSigning = {
 };
 
 /**
- * A legal document in the idOS / KYC-provider catalog
- * (`GET /disclaimers`, or `GET`/`POST /sessions/{sessionId}/disclaimers`).
+ * A legal document in the global idOS / KYC-provider catalog
+ * (`GET /disclaimers`). Carries no consent state, which only exists within a
+ * session.
  */
-export type KycConsentDocument = {
+export type KycCatalogDocument = {
   /** Stable identifier of the legal document. */
   key: string;
   /** Version of the document currently in force. */
@@ -176,10 +177,14 @@ export type KycConsentDocument = {
   title: string;
   /** URL the document body is hosted at. */
   url: string;
-  /**
-   * Whether the document version has already been consented to (session-scoped
-   * fetches). For the global catalog this is typically `false`.
-   */
+};
+
+/**
+ * A legal document in the session-scoped idOS / KYC-provider catalog
+ * (`GET`/`POST /sessions/{sessionId}/disclaimers`).
+ */
+export type KycConsentDocument = KycCatalogDocument & {
+  /** Whether the document version has already been consented to. */
   consented: boolean;
 };
 
@@ -198,16 +203,21 @@ export type KycConsentRecord = {
  */
 export type KycDisclaimersCatalog = {
   /** idOS legal documents. */
-  idOS: KycConsentDocument[];
+  idOS: KycCatalogDocument[];
   /** KYC provider (SumSub) legal documents. */
-  kycProvider: KycConsentDocument[];
+  kycProvider: KycCatalogDocument[];
 };
 
 /**
  * Session-scoped disclaimer catalog returned by
- * `GET`/`POST /sessions/{sessionId}/disclaimers`.
+ * `GET`/`POST /sessions/{sessionId}/disclaimers`. Documents additionally report
+ * whether that version was already consented to for the session.
  */
-export type KycSessionDisclaimers = KycDisclaimersCatalog & {
+export type KycSessionDisclaimers = {
+  /** idOS legal documents. */
+  idOS: KycConsentDocument[];
+  /** KYC provider (SumSub) legal documents. */
+  kycProvider: KycConsentDocument[];
   /** Whether the user consented to reuse existing idOS credentials. */
   credentialReusabilityConsentGiven: boolean;
 };


### PR DESCRIPTION
## Explanation

Fixes incorrect typing causing validation to fail when fetching session disclaimers

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking public types and response validation for disclaimer flows; incorrect assumptions about `consented` on the global catalog could break compile-time or runtime consumers until they adopt `KycCatalogDocument`.
> 
> **Overview**
> **Separates global disclaimer catalog documents from session-scoped consent documents** so `GET /disclaimers` no longer implies per-document `consented` state.
> 
> Introduces **`KycCatalogDocument`** (key, version, title, url only) and types **`KycDisclaimersCatalog`** with `KycCatalogDocument[]`. **`KycConsentDocument`** is now `KycCatalogDocument & { consented: boolean }`, and **`KycSessionDisclaimers`** explicitly uses consent documents plus `credentialReusabilityConsentGiven`.
> 
> **Runtime validation** in `KycService` matches the API: `GlobalDisclaimersResponseStruct` validates catalog fields only; session responses still require `consented` on each document (new test when `consented` is omitted). Docs and tests are updated accordingly.
> 
> **Breaking for TypeScript consumers** that treated global catalog entries as `KycConsentDocument` with `consented`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33c8851cb3a10c46d82baeec5ba588dfb03eeaa3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->