### PR TITLE
fix: exclude assets without metadata from aggregated balance

### DIFF
--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Exclude assets that have no `assetsInfo` metadata from the aggregated balance selectors ([#10083](https://github.com/MetaMask/core/pull/10083))
+- Exclude assets that have no `assetsInfo` metadata from the aggregated balance selectors ([#10084](https://github.com/MetaMask/core/pull/10084))
   - `getAggregatedBalanceForAccount`, `getAggregatedBalanceForAccountIds`, `calculateBalanceForAllWallets`, and `calculateBalanceChangeForAccountGroup` previously included such assets in `entries` (without `symbol`/`name`/`decimals`) and in fiat totals; a balance now only counts once its metadata is known
 - Run `RpcFallbackMiddleware` on Accounts API poll updates (`handleAssetsUpdate`), not only in the forced `getAssets` fast pipeline, so a stale amount for tokens omitted from poll responses no longer survives between forced refreshes while the wallet sits open ([#10078](https://github.com/MetaMask/core/pull/10078))
   - WebSocket, RPC, and Snap updates are excluded: WebSocket pushes are incremental single-asset updates where absence is not staleness, and RPC/Snap updates must not re-trigger RPC

--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Exclude assets that have no `assetsInfo` metadata from the aggregated balance selectors ([#10083](https://github.com/MetaMask/core/pull/10083))
+  - `getAggregatedBalanceForAccount`, `getAggregatedBalanceForAccountIds`, `calculateBalanceForAllWallets`, and `calculateBalanceChangeForAccountGroup` previously included such assets in `entries` (without `symbol`/`name`/`decimals`) and in fiat totals; a balance now only counts once its metadata is known
 - Run `RpcFallbackMiddleware` on Accounts API poll updates (`handleAssetsUpdate`), not only in the forced `getAssets` fast pipeline, so a stale amount for tokens omitted from poll responses no longer survives between forced refreshes while the wallet sits open ([#10078](https://github.com/MetaMask/core/pull/10078))
   - WebSocket, RPC, and Snap updates are excluded: WebSocket pushes are incremental single-asset updates where absence is not staleness, and RPC/Snap updates must not re-trigger RPC
 - Fix stale balances shown right after a transaction confirms: the post-confirmation refresh now calls `getAssets` with `bypassServerCache: true`, since WebSocket events do not invalidate the Accounts API's server-side cache and a plain refetch within its 60s window returns the pre-transaction snapshot ([#10068](https://github.com/MetaMask/core/pull/10068))

--- a/packages/assets-controller/src/selectors/balance.test.ts
+++ b/packages/assets-controller/src/selectors/balance.test.ts
@@ -309,6 +309,50 @@ describe('balance selectors', () => {
       expect(result.totalBalanceInFiat).toBeCloseTo(54060000000 * 2.5634e-11);
     });
 
+    it('excludes assets that have a balance but no assetsInfo metadata', () => {
+      const state = arrangeAssetsControllerState({
+        assetsBalance: {
+          [accountId1]: {
+            [assetEth]: { amount: '1' },
+            [assetUsdc]: { amount: '100' },
+          },
+        },
+        assetsInfo: {
+          [assetEth]: assetInfoEth,
+          // no entry for assetUsdc
+        },
+      });
+
+      const result = getAggregatedBalanceForAccount(state, selectedAccount);
+
+      expect(result.entries).toHaveLength(1);
+      expect(result.entries[0].assetId).toBe(assetEth);
+    });
+
+    it('excludes assets without assetsInfo metadata from fiat totals', () => {
+      const state = arrangeAssetsControllerState({
+        assetsBalance: {
+          [accountId1]: {
+            [assetEth]: { amount: '1' },
+            [assetUsdc]: { amount: '100' },
+          },
+        },
+        assetsInfo: {
+          [assetEth]: assetInfoEth,
+          // no entry for assetUsdc
+        },
+        assetsPrice: {
+          [assetEth]: testFungibleAssetPrice(2000, 0),
+          [assetUsdc]: testFungibleAssetPrice(1, 0),
+        },
+      });
+
+      const result = getAggregatedBalanceForAccount(state, selectedAccount);
+
+      expect(result.entries).toHaveLength(1);
+      expect(result.totalBalanceInFiat).toBe(2000);
+    });
+
     it('excludes hidden assets', () => {
       const state = arrangeAssetsControllerState({
         assetsBalance: {

--- a/packages/assets-controller/src/selectors/balance.ts
+++ b/packages/assets-controller/src/selectors/balance.ts
@@ -241,6 +241,13 @@ function mergeBalancesIntoMap(args: {
       continue;
     }
 
+    // Balances without a matching `assetsInfo` entry are not renderable
+    // (no symbol/name/decimals), so they are excluded from aggregation.
+    const meta = metadata[typedAssetId];
+    if (!meta) {
+      continue;
+    }
+
     const info = getAssetInfo(assetInfoCache, typedAssetId);
     if (!isChainEnabledByMap(enabledNetworkMap, info.chainId)) {
       continue;
@@ -248,7 +255,6 @@ function mergeBalancesIntoMap(args: {
 
     const amountStr = getAmountFromBalance(accountBalances[typedAssetId]);
     const amountBn = toBigNumberOrZero(amountStr);
-    const meta = metadata[typedAssetId];
     if (amountBn.isZero()) {
       continue; // skip zeros early to reduce map pressure
     }
@@ -261,9 +267,9 @@ function mergeBalancesIntoMap(args: {
 
     out.set(typedAssetId, {
       amount: amountBn,
-      decimals: meta?.decimals,
-      symbol: meta?.symbol,
-      name: meta?.name,
+      decimals: meta.decimals,
+      symbol: meta.symbol,
+      name: meta.name,
     });
   }
 }


### PR DESCRIPTION
Assets that have an entry in `assetsBalance` but no matching `assetsInfo` metadata were included in the aggregated balance selectors, producing entries with no symbol/name/decimals and contributing to fiat totals. Such balances are now skipped until their metadata is known.

## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow selector fix with tests; portfolio totals may decrease slightly when metadata lags balances, which is the intended behavior.
> 
> **Overview**
> Aggregated balance selectors no longer count holdings that exist in `assetsBalance` but lack a matching `assetsInfo` entry. Those rows were not renderable (no symbol, name, or decimals) yet still appeared in `entries` and could inflate fiat totals when prices existed.
> 
> **`mergeBalancesIntoMap`** in `balance.ts` now skips an asset when `metadata[assetId]` is missing, before chain enablement and amount checks. Metadata fields on aggregated rows are required (non-optional) once an asset is included. The same path backs `getAggregatedBalanceForAccount`, `getAggregatedBalanceForAccountIds`, `calculateBalanceForAllWallets`, and `calculateBalanceChangeForAccountGroup`.
> 
> Tests cover exclusion from `entries` and from `totalBalanceInFiat`; the changelog documents the fix under **Fixed**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e12b5ece67b713dc6d25104cb228fd82bed17fa2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->