### PR TITLE
Remove lint rule that deprecates use of :stateChange events

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -16,9 +16,6 @@
     },
     "no-negated-condition": {
       "count": 3
-    },
-    "no-restricted-syntax": {
-      "count": 1
     }
   },
   "packages/account-tree-controller/src/backup-and-sync/analytics/segment.ts": {
@@ -40,11 +37,6 @@
   "packages/account-tree-controller/src/backup-and-sync/service/index.ts": {
     "@typescript-eslint/explicit-function-return-type": {
       "count": 1
-    }
-  },
-  "packages/account-tree-controller/src/backup-and-sync/syncing/group.test.ts": {
-    "no-restricted-syntax": {
-      "count": 3
     }
   },
   "packages/account-tree-controller/src/backup-and-sync/syncing/metadata.ts": {
@@ -88,19 +80,6 @@
   "packages/account-tree-controller/tests/mockMessenger.ts": {
     "@typescript-eslint/explicit-function-return-type": {
       "count": 1
-    },
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "packages/accounts-controller/src/AccountsController.test.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "packages/accounts-controller/src/AccountsController.ts": {
-    "no-restricted-syntax": {
-      "count": 1
     }
   },
   "packages/accounts-controller/src/index.ts": {
@@ -124,19 +103,9 @@
       "count": 2
     }
   },
-  "packages/analytics-controller/src/AnalyticsController.test.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "packages/analytics-controller/src/index.ts": {
     "no-restricted-syntax": {
       "count": 1
-    }
-  },
-  "packages/analytics-data-regulation-controller/src/AnalyticsDataRegulationController.test.ts": {
-    "no-restricted-syntax": {
-      "count": 2
     }
   },
   "packages/approval-controller/src/ApprovalController.test.ts": {
@@ -155,29 +124,14 @@
       "count": 6
     }
   },
-  "packages/assets-controller/src/AssetsController.ts": {
-    "no-restricted-syntax": {
-      "count": 2
-    }
-  },
   "packages/assets-controller/src/data-sources/AccountsApiDataSource.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "packages/assets-controller/src/data-sources/RpcDataSource.ts": {
     "no-restricted-syntax": {
       "count": 1
     }
   },
   "packages/assets-controller/src/data-sources/SnapDataSource.ts": {
     "no-restricted-syntax": {
-      "count": 2
-    }
-  },
-  "packages/assets-controller/src/data-sources/StakedBalanceDataSource.ts": {
-    "no-restricted-syntax": {
-      "count": 2
+      "count": 1
     }
   },
   "packages/assets-controller/src/selectors/balance.ts": {
@@ -217,9 +171,6 @@
     },
     "id-length": {
       "count": 1
-    },
-    "no-restricted-syntax": {
-      "count": 1
     }
   },
   "packages/assets-controllers/src/AssetsContractController.ts": {
@@ -256,11 +207,6 @@
       "count": 2
     }
   },
-  "packages/assets-controllers/src/MultichainAssetsRatesController/MultichainAssetsRatesController.test.ts": {
-    "no-restricted-syntax": {
-      "count": 3
-    }
-  },
   "packages/assets-controllers/src/MultichainAssetsRatesController/MultichainAssetsRatesController.ts": {
     "@typescript-eslint/explicit-function-return-type": {
       "count": 2
@@ -269,7 +215,7 @@
       "count": 1
     },
     "no-restricted-syntax": {
-      "count": 2
+      "count": 1
     }
   },
   "packages/assets-controllers/src/MultichainBalancesController/MultichainBalancesController.test.ts": {
@@ -294,9 +240,6 @@
     },
     "id-denylist": {
       "count": 1
-    },
-    "no-restricted-syntax": {
-      "count": 5
     }
   },
   "packages/assets-controllers/src/NftController.ts": {
@@ -325,17 +268,12 @@
       "count": 2
     },
     "no-restricted-syntax": {
-      "count": 7
-    }
-  },
-  "packages/assets-controllers/src/NftDetectionController.test.ts": {
-    "no-restricted-syntax": {
-      "count": 2
+      "count": 6
     }
   },
   "packages/assets-controllers/src/NftDetectionController.ts": {
     "no-restricted-syntax": {
-      "count": 2
+      "count": 1
     }
   },
   "packages/assets-controllers/src/RatesController/RatesController.test.ts": {
@@ -393,32 +331,12 @@
       "count": 2
     }
   },
-  "packages/assets-controllers/src/TokenBalancesController.test.ts": {
-    "no-restricted-syntax": {
-      "count": 3
-    }
-  },
   "packages/assets-controllers/src/TokenBalancesController.ts": {
     "no-restricted-syntax": {
-      "count": 4
-    }
-  },
-  "packages/assets-controllers/src/TokenDetectionController.test.ts": {
-    "no-restricted-syntax": {
-      "count": 1
+      "count": 2
     }
   },
   "packages/assets-controllers/src/TokenDetectionController.ts": {
-    "no-restricted-syntax": {
-      "count": 3
-    }
-  },
-  "packages/assets-controllers/src/TokenListController.test.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "packages/assets-controllers/src/TokenListController.ts": {
     "no-restricted-syntax": {
       "count": 2
     }
@@ -426,17 +344,11 @@
   "packages/assets-controllers/src/TokenRatesController.test.ts": {
     "@typescript-eslint/explicit-function-return-type": {
       "count": 4
-    },
-    "no-restricted-syntax": {
-      "count": 2
     }
   },
   "packages/assets-controllers/src/TokenRatesController.ts": {
     "@typescript-eslint/explicit-function-return-type": {
       "count": 7
-    },
-    "no-restricted-syntax": {
-      "count": 2
     }
   },
   "packages/assets-controllers/src/TokenSearchDiscoveryDataController/TokenSearchDiscoveryDataController.test.ts": {
@@ -455,9 +367,6 @@
   "packages/assets-controllers/src/TokensController.test.ts": {
     "@typescript-eslint/explicit-function-return-type": {
       "count": 6
-    },
-    "no-restricted-syntax": {
-      "count": 3
     }
   },
   "packages/assets-controllers/src/TokensController.ts": {
@@ -477,9 +386,6 @@
       "count": 3
     },
     "no-param-reassign": {
-      "count": 1
-    },
-    "no-restricted-syntax": {
       "count": 1
     },
     "require-atomic-updates": {
@@ -770,24 +676,9 @@
       "count": 1
     }
   },
-  "packages/composable-controller/src/ComposableController.test.ts": {
-    "no-restricted-syntax": {
-      "count": 14
-    }
-  },
   "packages/composable-controller/src/ComposableController.ts": {
     "no-restricted-syntax": {
       "count": 3
-    }
-  },
-  "packages/config-registry-controller/src/ConfigRegistryController.test.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "packages/config-registry-controller/src/ConfigRegistryController.ts": {
-    "no-restricted-syntax": {
-      "count": 1
     }
   },
   "packages/config-registry-controller/src/index.ts": {
@@ -815,11 +706,6 @@
       "count": 4
     }
   },
-  "packages/core-backend/src/ws/AccountActivityService.test.ts": {
-    "no-restricted-syntax": {
-      "count": 2
-    }
-  },
   "packages/core-backend/src/ws/AccountActivityService.ts": {
     "no-restricted-syntax": {
       "count": 1
@@ -827,7 +713,7 @@
   },
   "packages/core-backend/src/ws/BackendWebSocketService.ts": {
     "no-restricted-syntax": {
-      "count": 5
+      "count": 4
     }
   },
   "packages/core-backend/src/ws/ohlcv/OHLCVService.test.ts": {
@@ -835,9 +721,6 @@
       "count": 2
     },
     "id-length": {
-      "count": 1
-    },
-    "no-restricted-syntax": {
       "count": 1
     }
   },
@@ -856,20 +739,12 @@
       "count": 3
     }
   },
-  "packages/earn-controller/src/EarnController.test.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "packages/earn-controller/src/EarnController.ts": {
     "@typescript-eslint/explicit-function-return-type": {
       "count": 4
     },
     "no-negated-condition": {
       "count": 3
-    },
-    "no-restricted-syntax": {
-      "count": 1
     }
   },
   "packages/earn-controller/src/selectors.ts": {
@@ -953,22 +828,12 @@
       "count": 1
     }
   },
-  "packages/eth-block-tracker/tests/withBlockTracker.ts": {
-    "no-restricted-syntax": {
-      "count": 3
-    }
-  },
   "packages/eth-json-rpc-middleware/src/fetch.ts": {
     "no-restricted-syntax": {
       "count": 1
     }
   },
   "packages/eth-json-rpc-middleware/src/inflight-cache.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "packages/eth-json-rpc-provider/src/internal-provider.test.ts": {
     "no-restricted-syntax": {
       "count": 1
     }
@@ -1077,11 +942,6 @@
       "count": 1
     }
   },
-  "packages/geolocation-controller/src/GeolocationController.test.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "packages/json-rpc-engine/src/JsonRpcEngine.ts": {
     "no-restricted-syntax": {
       "count": 1
@@ -1097,19 +957,9 @@
       "count": 1
     }
   },
-  "packages/json-rpc-engine/src/v2/compatibility-utils.test.ts": {
-    "no-restricted-syntax": {
-      "count": 2
-    }
-  },
   "packages/json-rpc-engine/src/v2/utils.ts": {
     "no-restricted-syntax": {
       "count": 1
-    }
-  },
-  "packages/keyring-controller/src/KeyringController.test.ts": {
-    "no-restricted-syntax": {
-      "count": 5
     }
   },
   "packages/keyring-controller/src/KeyringController.ts": {
@@ -1173,9 +1023,6 @@
   "packages/multichain-account-service/src/MultichainAccountWallet.test.ts": {
     "id-length": {
       "count": 2
-    },
-    "no-restricted-syntax": {
-      "count": 1
     }
   },
   "packages/multichain-account-service/src/MultichainAccountWallet.ts": {
@@ -1428,11 +1275,6 @@
       "count": 6
     }
   },
-  "packages/network-controller/src/create-auto-managed-network-client.test.ts": {
-    "no-restricted-syntax": {
-      "count": 23
-    }
-  },
   "packages/network-controller/src/create-auto-managed-network-client.ts": {
     "no-restricted-syntax": {
       "count": 4
@@ -1448,26 +1290,6 @@
       "count": 3
     }
   },
-  "packages/network-controller/tests/NetworkController.provider.test.ts": {
-    "no-restricted-syntax": {
-      "count": 5
-    }
-  },
-  "packages/network-controller/tests/NetworkController.test.ts": {
-    "no-restricted-syntax": {
-      "count": 4
-    }
-  },
-  "packages/network-controller/tests/network-client/helpers.ts": {
-    "no-restricted-syntax": {
-      "count": 3
-    }
-  },
-  "packages/network-enablement-controller/src/NetworkEnablementController.test.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "packages/network-enablement-controller/src/NetworkEnablementController.ts": {
     "no-restricted-syntax": {
       "count": 1
@@ -1481,16 +1303,6 @@
       "count": 2
     }
   },
-  "packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.test.ts": {
-    "no-restricted-syntax": {
-      "count": 2
-    }
-  },
-  "packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "packages/permission-controller/src/SubjectMetadataController.ts": {
     "no-restricted-syntax": {
       "count": 1
@@ -1498,16 +1310,11 @@
   },
   "packages/perps-controller/src/PerpsController.ts": {
     "no-restricted-syntax": {
-      "count": 2
+      "count": 1
     }
   },
   "packages/perps-controller/src/utils/perpsConnectionAttemptContext.ts": {
     "require-atomic-updates": {
-      "count": 1
-    }
-  },
-  "packages/perps-controller/tests/defer-eligibility.test.ts": {
-    "no-restricted-syntax": {
       "count": 1
     }
   },
@@ -1516,9 +1323,6 @@
       "count": 2
     },
     "@typescript-eslint/naming-convention": {
-      "count": 1
-    },
-    "no-restricted-syntax": {
       "count": 1
     }
   },
@@ -1894,16 +1698,6 @@
       "count": 1
     }
   },
-  "packages/ramps-controller/src/RampsController.test.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "packages/ramps-controller/src/TransakService.test.ts": {
-    "no-restricted-syntax": {
-      "count": 4
-    }
-  },
   "packages/ramps-controller/src/index.ts": {
     "no-restricted-syntax": {
       "count": 1
@@ -1924,16 +1718,6 @@
       "count": 1
     }
   },
-  "packages/sample-controllers/src/sample-gas-prices-controller.test.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "packages/sample-controllers/src/sample-gas-prices-controller.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "packages/seedless-onboarding-controller/src/SecretMetadata.ts": {
     "no-restricted-syntax": {
       "count": 2
@@ -1944,17 +1728,12 @@
       "count": 10
     }
   },
-  "packages/seedless-onboarding-controller/tests/mocks/vaultEncryptor.ts": {
-    "no-restricted-syntax": {
-      "count": 5
-    }
-  },
   "packages/selected-network-controller/src/SelectedNetworkController.ts": {
     "@typescript-eslint/explicit-function-return-type": {
       "count": 4
     },
     "no-restricted-syntax": {
-      "count": 5
+      "count": 3
     }
   },
   "packages/selected-network-controller/src/SelectedNetworkMiddleware.ts": {
@@ -1965,24 +1744,6 @@
   "packages/selected-network-controller/tests/SelectedNetworkController.test.ts": {
     "@typescript-eslint/explicit-function-return-type": {
       "count": 4
-    },
-    "no-restricted-syntax": {
-      "count": 2
-    }
-  },
-  "packages/shield-controller/src/ShieldController.test.ts": {
-    "no-restricted-syntax": {
-      "count": 2
-    }
-  },
-  "packages/shield-controller/src/ShieldController.ts": {
-    "no-restricted-syntax": {
-      "count": 2
-    }
-  },
-  "packages/shield-controller/tests/mocks/messenger.ts": {
-    "no-restricted-syntax": {
-      "count": 2
     }
   },
   "packages/signature-controller/src/SignatureController.test.ts": {
@@ -2055,9 +1816,6 @@
     },
     "@typescript-eslint/no-explicit-any": {
       "count": 3
-    },
-    "no-restricted-syntax": {
-      "count": 12
     }
   },
   "packages/smart-transactions-controller/src/SmartTransactionsController.ts": {
@@ -2068,7 +1826,7 @@
       "count": 4
     },
     "no-restricted-syntax": {
-      "count": 3
+      "count": 1
     }
   },
   "packages/smart-transactions-controller/src/featureFlags/feature-flags.ts": {
@@ -2119,32 +1877,7 @@
       "count": 2
     }
   },
-  "packages/snap-account-service/src/SnapAccountService.test.ts": {
-    "no-restricted-syntax": {
-      "count": 2
-    }
-  },
-  "packages/snap-account-service/src/SnapPlatformWatcher.test.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "packages/snap-account-service/src/SnapPlatformWatcher.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "packages/subscription-controller/src/SubscriptionController.test.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "packages/subscription-controller/src/errors.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "packages/transaction-controller/src/TransactionControllerIntegration.test.ts": {
     "no-restricted-syntax": {
       "count": 1
     }
@@ -2159,11 +1892,6 @@
       "count": 1
     }
   },
-  "packages/transaction-pay-controller/src/helpers/QuoteRefresher.ts": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "packages/transaction-pay-controller/src/strategy/across/across-actions.ts": {
     "no-restricted-syntax": {
       "count": 2
@@ -2172,11 +1900,6 @@
   "packages/transaction-pay-controller/src/strategy/relay/hyperliquid-withdraw.ts": {
     "no-restricted-syntax": {
       "count": 1
-    }
-  },
-  "packages/transaction-pay-controller/src/utils/transaction.ts": {
-    "no-restricted-syntax": {
-      "count": 6
     }
   },
   "packages/user-operation-controller/src/BlockTrackerPollingController.test.ts": {
@@ -2286,21 +2009,6 @@
     },
     "@typescript-eslint/naming-convention": {
       "count": 1
-    }
-  },
-  "tests/fake-provider.ts": {
-    "no-restricted-syntax": {
-      "count": 7
-    }
-  },
-  "tests/helpers.ts": {
-    "no-restricted-syntax": {
-      "count": 2
-    }
-  },
-  "tests/mock-network.ts": {
-    "no-restricted-syntax": {
-      "count": 10
     }
   }
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,25 +7,6 @@ import node from 'eslint-plugin-n';
 const NODE_LTS_VERSION = 22;
 
 /**
- * Arguments to the `no-restricted` syntax rule that advises use of
- * `${Controller}:stateChanged` instead of `:stateChange`.
- */
-const NO_CONTROLLER_STATE_CHANGE_SELECTOR_OBJECTS = [
-  {
-    selector:
-      'CallExpression[callee.property.name="subscribe"] > Literal[value=/^.+:stateChange$/]',
-    message:
-      "Subscribing to ':stateChange' events is deprecated. Use ':stateChanged' instead.",
-  },
-  {
-    selector:
-      'CallExpression[callee.property.name="delegate"] Property[key.name="events"] ArrayExpression > Literal[value=/^.+:stateChange$/]',
-    message:
-      "Delegating ':stateChange' events is deprecated. Use ':stateChanged' instead.",
-  },
-];
-
-/**
  * Arguments to the `no-restricted-syntax` rule that prevents messsenger actions
  * from being called in constructors.
  */
@@ -159,17 +140,6 @@ const config = createConfig([
       // do not work very well.
       'jsdoc/check-tag-names': 'off',
       'jsdoc/require-jsdoc': 'off',
-
-      // Add custom rule for deprecating `${Controller}:stateChange` in favor of
-      // `:stateChanged`.
-      'no-restricted-syntax': [
-        'error',
-        ...collectExistingRuleOptions('no-restricted-syntax', [
-          base,
-          typescript,
-        ]),
-        ...NO_CONTROLLER_STATE_CHANGE_SELECTOR_OBJECTS,
-      ],
     },
   },
   {
@@ -252,7 +222,6 @@ const config = createConfig([
           base,
           typescript,
         ]),
-        ...NO_CONTROLLER_STATE_CHANGE_SELECTOR_OBJECTS,
         ...NO_MESSENGER_ACTIONS_IN_CONSTRUCTORS_SELECTOR_OBJECTS,
       ],
     },
@@ -268,7 +237,6 @@ const config = createConfig([
           base,
           typescript,
         ]),
-        ...NO_CONTROLLER_STATE_CHANGE_SELECTOR_OBJECTS,
         ...NO_MESSENGER_ACTIONS_IN_CONSTRUCTORS_SELECTOR_OBJECTS,
         {
           selector:

--- a/packages/assets-controller/src/__fixtures__/MockAssetControllerMessenger.ts
+++ b/packages/assets-controller/src/__fixtures__/MockAssetControllerMessenger.ts
@@ -110,7 +110,7 @@ export function createMockAssetControllerMessenger(options?: {
       // AccountsApiDataSource
       'RemoteFeatureFlagController:getState',
     ],
-    /* eslint-disable no-restricted-syntax */
+
     events: [
       // AssetsController
       'AccountTreeController:selectedAccountGroupChange',
@@ -139,7 +139,6 @@ export function createMockAssetControllerMessenger(options?: {
       // AccountsApiDataSource
       'RemoteFeatureFlagController:stateChange',
     ],
-    /* eslint-enable no-restricted-syntax */
   });
 
   return {

--- a/packages/assets-controller/src/data-sources/AccountsApiDataSource.test.ts
+++ b/packages/assets-controller/src/data-sources/AccountsApiDataSource.test.ts
@@ -184,7 +184,7 @@ async function setupController(
   rootMessenger.delegate({
     messenger: controllerMessenger,
     actions: ['RemoteFeatureFlagController:getState'],
-    // eslint-disable-next-line no-restricted-syntax
+
     events: ['RemoteFeatureFlagController:stateChange'],
   });
 

--- a/packages/assets-controller/src/data-sources/AccountsApiDataSource.ts
+++ b/packages/assets-controller/src/data-sources/AccountsApiDataSource.ts
@@ -248,7 +248,6 @@ export class AccountsApiDataSource extends AbstractDataSource<
     // react to remote feature flag changes so newly-enabled chains are picked up
     // (and disabled ones dropped) without waiting for the periodic refresh.
     this.#messenger.subscribe(
-      // eslint-disable-next-line no-restricted-syntax
       'RemoteFeatureFlagController:stateChange',
       // Promise result intentionally not awaited
       // eslint-disable-next-line @typescript-eslint/no-misused-promises

--- a/packages/base-data-service/tests/ExampleDataService.ts
+++ b/packages/base-data-service/tests/ExampleDataService.ts
@@ -145,10 +145,8 @@ export class ExampleDataService extends BaseDataService<
             `${this.#accountsBaseUrl}/v4/multiaccount/transactions?limit=3&accountAddresses=${caipAddress}`,
           );
 
-          // eslint-disable-next-line no-restricted-syntax
           if (pageParam && 'after' in pageParam) {
             url.searchParams.set('after', pageParam.after);
-            // eslint-disable-next-line no-restricted-syntax
           } else if (pageParam && 'before' in pageParam) {
             url.searchParams.set('before', pageParam.before);
           }

--- a/packages/core-backend/src/ws/AccountActivityService.test.ts
+++ b/packages/core-backend/src/ws/AccountActivityService.test.ts
@@ -142,7 +142,7 @@ const getMessenger = (): {
     events: [
       'AccountTreeController:selectedAccountGroupChange',
       'BackendWebSocketService:connectionStateChanged',
-      // eslint-disable-next-line no-restricted-syntax
+
       'RemoteFeatureFlagController:stateChange',
     ],
     messenger,

--- a/packages/core-backend/src/ws/AccountActivityService.ts
+++ b/packages/core-backend/src/ws/AccountActivityService.ts
@@ -289,7 +289,6 @@ export class AccountActivityService {
         this.#handleWebSocketStateChange(connectionInfo),
     );
     this.#messenger.subscribe(
-      // eslint-disable-next-line no-restricted-syntax
       'RemoteFeatureFlagController:stateChange',
       // Promise result intentionally not awaited
       // eslint-disable-next-line @typescript-eslint/no-misused-promises

--- a/packages/core-backend/src/ws/BackendWebSocketService.test.ts
+++ b/packages/core-backend/src/ws/BackendWebSocketService.test.ts
@@ -233,7 +233,6 @@ const getMessenger = (): {
   rootMessenger.delegate({
     actions: ['AuthenticationController:getBearerToken'],
     events: [
-      // eslint-disable-next-line no-restricted-syntax -- AuthenticationController messenger types still expose stateChange
       'AuthenticationController:stateChange',
       'KeyringController:lock',
       'KeyringController:unlock',

--- a/packages/messenger/src/Messenger.test.ts
+++ b/packages/messenger/src/Messenger.test.ts
@@ -2078,7 +2078,7 @@ describe('Messenger', () => {
 
       // Child can now subscribe to the delegated event
       const subscriber = jest.fn();
-      // eslint-disable-next-line no-restricted-syntax
+
       childMessenger.subscribe('Source:stateChange', subscriber);
       sourceMessenger.publish('Source:stateChange', { value: 1 });
       expect(subscriber).toHaveBeenCalledWith({ value: 1 });

--- a/packages/money-account-balance-service/src/money-account-balance-service.test.ts
+++ b/packages/money-account-balance-service/src/money-account-balance-service.test.ts
@@ -266,7 +266,7 @@ function createService({
       'RemoteFeatureFlagController:getState',
       'MoneyAccountApiDataService:fetchPositions',
     ],
-    // eslint-disable-next-line no-restricted-syntax
+
     events: ['RemoteFeatureFlagController:stateChange'],
     messenger,
   });

--- a/packages/money-account-balance-service/src/money-account-balance-service.ts
+++ b/packages/money-account-balance-service/src/money-account-balance-service.ts
@@ -351,7 +351,6 @@ export class MoneyAccountBalanceService extends BaseDataService<
       });
 
     this.messenger.subscribe(
-      // eslint-disable-next-line no-restricted-syntax
       'RemoteFeatureFlagController:stateChange',
       (state) => this.#onRemoteFeatureFlagChange(state.remoteFeatureFlags),
     );

--- a/packages/network-connection-banner-controller/src/NetworkConnectionBannerController.test.ts
+++ b/packages/network-connection-banner-controller/src/NetworkConnectionBannerController.test.ts
@@ -1837,13 +1837,12 @@ async function withController<ReturnValue>(
       'ConnectivityController:getState',
     ],
     events: [
-      // eslint-disable-next-line no-restricted-syntax -- awaiting upstream :stateChanged migration
       'NetworkController:stateChange',
-      // eslint-disable-next-line no-restricted-syntax -- awaiting upstream :stateChanged migration
+
       'NetworkEnablementController:stateChange',
-      // eslint-disable-next-line no-restricted-syntax -- awaiting upstream :stateChanged migration
+
       'ConnectivityController:stateChange',
-      // eslint-disable-next-line no-restricted-syntax -- awaiting upstream :stateChanged migration
+
       'ClientController:stateChange',
       'KeyringController:unlock',
       'KeyringController:lock',

--- a/packages/network-connection-banner-controller/src/NetworkConnectionBannerController.ts
+++ b/packages/network-connection-banner-controller/src/NetworkConnectionBannerController.ts
@@ -464,7 +464,6 @@ export class NetworkConnectionBannerController extends BaseController<
     // Lifecycle: evaluate RPC health (and run the banner escalation timers)
     // only while the client UI is open on an unlocked wallet.
     this.messenger.subscribe(
-      // eslint-disable-next-line no-restricted-syntax -- awaiting upstream :stateChanged migration
       'ClientController:stateChange',
       (isUiOpen) => {
         this.#isUiOpen = isUiOpen;

--- a/packages/network-controller/src/NetworkController.ts
+++ b/packages/network-controller/src/NetworkController.ts
@@ -1427,7 +1427,6 @@ export class NetworkController extends BaseController<
     );
 
     this.messenger.subscribe(
-      // eslint-disable-next-line no-restricted-syntax
       'RemoteFeatureFlagController:stateChange',
       (rpcFailoverMode) => {
         this.#updateRpcFailover(rpcFailoverMode);

--- a/packages/network-controller/tests/helpers.ts
+++ b/packages/network-controller/tests/helpers.ts
@@ -207,7 +207,6 @@ export function buildNetworkControllerMessenger(
       'AnalyticsController:trackEvent',
     ],
     events: [
-      // eslint-disable-next-line no-restricted-syntax
       'RemoteFeatureFlagController:stateChange',
       'ConfigRegistryController:stateChanged',
     ],

--- a/packages/phishing-controller/src/PhishingController.test.ts
+++ b/packages/phishing-controller/src/PhishingController.test.ts
@@ -139,9 +139,8 @@ function setupMessenger(options: SetupMessengerOptions = {}): {
       'TransactionController:getState',
     ],
     events: [
-      // eslint-disable-next-line no-restricted-syntax
       'AddressBookController:stateChange',
-      // eslint-disable-next-line no-restricted-syntax
+
       'TransactionController:stateChange',
     ],
     messenger,

--- a/packages/phishing-controller/src/PhishingController.ts
+++ b/packages/phishing-controller/src/PhishingController.ts
@@ -619,7 +619,6 @@ export class PhishingController extends BaseController<
 
   #subscribeToAddressBookControllerStateChange(): void {
     this.messenger.subscribe(
-      // eslint-disable-next-line no-restricted-syntax
       'AddressBookController:stateChange',
       this.#addressBookControllerStateChangeHandler,
     );
@@ -627,7 +626,6 @@ export class PhishingController extends BaseController<
 
   #subscribeToTransactionControllerStateChange(): void {
     this.messenger.subscribe(
-      // eslint-disable-next-line no-restricted-syntax
       'TransactionController:stateChange',
       this.#transactionControllerStateChangeHandler,
     );

--- a/packages/transaction-controller/src/utils/batch.ts
+++ b/packages/transaction-controller/src/utils/batch.ts
@@ -606,7 +606,7 @@ function waitForTransactionStatus(
     };
 
     messenger.subscribe(
-      'TransactionController:stateChange', // eslint-disable-line no-restricted-syntax
+      'TransactionController:stateChange',
       handler,
       (state: TransactionControllerState) =>
         state.transactions.find((tx) => tx.id === transactionId),

--- a/packages/wallet/src/Wallet.test.ts
+++ b/packages/wallet/src/Wallet.test.ts
@@ -63,7 +63,6 @@ describe('Wallet', () => {
     // eslint-disable-next-line n/no-unsupported-features/node-builtins
     globalThis.crypto ??= webcrypto as typeof globalThis.crypto;
 
-    // eslint-disable-next-line no-restricted-syntax
     if (!('CryptoKey' in globalThis)) {
       Object.defineProperty(globalThis, 'CryptoKey', {
         value: webcrypto.CryptoKey,

--- a/packages/wallet/src/initialization/instances/accounts-controller/accounts-controller.ts
+++ b/packages/wallet/src/initialization/instances/accounts-controller/accounts-controller.ts
@@ -37,7 +37,7 @@ export const accountsController: InitializationConfiguration<
       events: [
         // AccountsController subscribes to :stateChange internally; the
         // delegation must match until that package migrates to :stateChanged.
-        // eslint-disable-next-line no-restricted-syntax
+
         'KeyringController:stateChange',
         'SnapAccountService:accountAssetListUpdated',
         'SnapAccountService:accountBalancesUpdated',

--- a/packages/wallet/src/initialization/instances/config-registry-controller/config-registry-controller.ts
+++ b/packages/wallet/src/initialization/instances/config-registry-controller/config-registry-controller.ts
@@ -34,7 +34,7 @@ export const configRegistryController: InitializationConfiguration<
       events: [
         'KeyringController:unlock',
         'KeyringController:lock',
-        // eslint-disable-next-line no-restricted-syntax
+
         'RemoteFeatureFlagController:stateChange',
       ],
     });

--- a/packages/wallet/src/initialization/instances/keyring-controller/encryptor.test.ts
+++ b/packages/wallet/src/initialization/instances/keyring-controller/encryptor.test.ts
@@ -8,7 +8,6 @@ describe('encryptorFactory', () => {
     // eslint-disable-next-line n/no-unsupported-features/node-builtins
     globalThis.crypto ??= webcrypto as typeof globalThis.crypto;
 
-    // eslint-disable-next-line no-restricted-syntax
     if (!('CryptoKey' in globalThis)) {
       Object.defineProperty(globalThis, 'CryptoKey', {
         value: webcrypto.CryptoKey,

--- a/packages/wallet/src/initialization/instances/network-controller/network-controller.ts
+++ b/packages/wallet/src/initialization/instances/network-controller/network-controller.ts
@@ -39,7 +39,7 @@ export const networkController: InitializationConfiguration<
 
       events: [
         'ConfigRegistryController:stateChanged',
-        // eslint-disable-next-line no-restricted-syntax
+
         'RemoteFeatureFlagController:stateChange',
       ],
     });

--- a/packages/wallet/src/initialization/instances/shield-controller/shield-controller.ts
+++ b/packages/wallet/src/initialization/instances/shield-controller/shield-controller.ts
@@ -36,9 +36,9 @@ export const shieldController: InitializationConfiguration<
       events: [
         // ShieldController subscribes to :stateChange internally; the
         // delegation must match until those controllers migrate to :stateChanged.
-        // eslint-disable-next-line no-restricted-syntax
+
         'TransactionController:stateChange',
-        // eslint-disable-next-line no-restricted-syntax
+
         'SignatureController:stateChange',
       ],
     });

--- a/packages/wallet/src/initialization/instances/transaction-controller/transaction-controller.ts
+++ b/packages/wallet/src/initialization/instances/transaction-controller/transaction-controller.ts
@@ -47,7 +47,7 @@ export const transactionController: InitializationConfiguration<
       events: [
         'AccountActivityService:transactionUpdated',
         // TODO: Replace with `NetworkController:stateChanged` once TransactionController migrates.
-        // eslint-disable-next-line no-restricted-syntax
+
         'NetworkController:stateChange',
       ],
     });

--- a/scripts/manage-codeowners/main.ts
+++ b/scripts/manage-codeowners/main.ts
@@ -90,7 +90,7 @@ function generateCodeownersFileContent(): string {
     const lines: string[] = [];
 
     // This is useful to discriminate the union.
-    // eslint-disable-next-line no-restricted-syntax
+
     if ('title' in section) {
       lines.push(`## ${section.title}`);
     }


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Eventually we want to rename the `:stateChange` event across all controllers to `:stateChanged`. To encourage engineers to switch, we added a lint rule to prevent engineers from subscribing to `:stateChange`. However, that hasn't really happened, and engineers often disable this rule inline. We need to carry out this migration explicitly and then we can introduce this lint rule. In the meantime, we remove it.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint and suppression cleanup only; no intentional runtime or API behavior changes.
> 
> **Overview**
> Stops enforcing migration from messenger **`:stateChange`** events to **`:stateChanged`** by deleting the custom `no-restricted-syntax` selectors from `eslint.config.mjs` (while keeping other restricted-syntax rules such as messenger calls in constructors and index export bans).
> 
> **`eslint-suppressions.json`** is trimmed accordingly—many file-level `no-restricted-syntax` suppressions tied only to that rule are removed, and remaining counts are updated. Across controllers, services, tests, and wallet initialization, inline **`eslint-disable`** comments that existed solely to allow subscribing or delegating `:stateChange` are dropped; subscription/delegation strings are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d22d86f08f721e7908bd626eb2cd0ee149bf4a24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->