### PR TITLE
feat(perps-controller): track reduce-only trade intent

### DIFF
--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `reduce_only` intent to every `Perp Trade Transaction` lifecycle event while preserving canonical `order_type` values ([#10091](https://github.com/MetaMask/core/pull/10091))
 - Add `POSITION_NOT_FOUND` as the provider-neutral error code for operations targeting a position the venue no longer holds ([#10083](https://github.com/MetaMask/core/pull/10083))
 
 ### Changed

--- a/packages/perps-controller/src/services/TradingService.ts
+++ b/packages/perps-controller/src/services/TradingService.ts
@@ -149,6 +149,21 @@ export class TradingService {
   }
 
   /**
+   * Build properties that identify the submitted order intent.
+   *
+   * @param params - Order parameters containing placement type and reduce-only intent.
+   * @returns Properties shared by every trade lifecycle event.
+   */
+  #buildTradeIntentProperties(
+    params: Pick<OrderParams, 'orderType' | 'reduceOnly'>,
+  ): PerpsAnalyticsProperties {
+    return {
+      [PERPS_EVENT_PROPERTY.ORDER_TYPE]: params.orderType,
+      [PERPS_EVENT_PROPERTY.REDUCE_ONLY]: params.reduceOnly === true,
+    };
+  }
+
+  /**
    * Emit a transaction event with status=submitted before the provider round-trip.
    * Fired for trade, close, cancel and risk-management operations.
    *
@@ -202,7 +217,7 @@ export class TradingService {
       [PERPS_EVENT_PROPERTY.DIRECTION]: params.isBuy
         ? PERPS_EVENT_VALUE.DIRECTION.LONG
         : PERPS_EVENT_VALUE.DIRECTION.SHORT,
-      [PERPS_EVENT_PROPERTY.ORDER_TYPE]: params.orderType,
+      ...this.#buildTradeIntentProperties(params),
       [PERPS_EVENT_PROPERTY.LEVERAGE]: parseFloat(String(params.leverage ?? 1)),
       [PERPS_EVENT_PROPERTY.ORDER_SIZE]: trackedOrderSize,
       [PERPS_EVENT_PROPERTY.COMPLETION_DURATION]: duration,
@@ -612,7 +627,7 @@ export class TradingService {
         [PERPS_EVENT_PROPERTY.DIRECTION]: params.isBuy
           ? PERPS_EVENT_VALUE.DIRECTION.LONG
           : PERPS_EVENT_VALUE.DIRECTION.SHORT,
-        [PERPS_EVENT_PROPERTY.ORDER_TYPE]: params.orderType,
+        ...this.#buildTradeIntentProperties(params),
         [PERPS_EVENT_PROPERTY.LEVERAGE]: parseFloat(
           String(params.leverage ?? 1),
         ),
@@ -1262,7 +1277,7 @@ export class TradingService {
           [PERPS_EVENT_PROPERTY.DIRECTION]: params.newOrder.isBuy
             ? PERPS_EVENT_VALUE.DIRECTION.LONG
             : PERPS_EVENT_VALUE.DIRECTION.SHORT,
-          [PERPS_EVENT_PROPERTY.ORDER_TYPE]: params.newOrder.orderType,
+          ...this.#buildTradeIntentProperties(params.newOrder),
           [PERPS_EVENT_PROPERTY.LEVERAGE]: params.newOrder.leverage ?? 1,
           [PERPS_EVENT_PROPERTY.ORDER_SIZE]: params.newOrder.size,
           [PERPS_EVENT_PROPERTY.COMPLETION_DURATION]: completionDuration,
@@ -1288,7 +1303,7 @@ export class TradingService {
             [PERPS_EVENT_PROPERTY.DIRECTION]: params.newOrder.isBuy
               ? PERPS_EVENT_VALUE.DIRECTION.LONG
               : PERPS_EVENT_VALUE.DIRECTION.SHORT,
-            [PERPS_EVENT_PROPERTY.ORDER_TYPE]: params.newOrder.orderType,
+            ...this.#buildTradeIntentProperties(params.newOrder),
             [PERPS_EVENT_PROPERTY.LEVERAGE]: params.newOrder.leverage ?? 1,
             [PERPS_EVENT_PROPERTY.ORDER_SIZE]: params.newOrder.size,
             [PERPS_EVENT_PROPERTY.COMPLETION_DURATION]: completionDuration,
@@ -1311,7 +1326,7 @@ export class TradingService {
         [PERPS_EVENT_PROPERTY.DIRECTION]: params.newOrder.isBuy
           ? PERPS_EVENT_VALUE.DIRECTION.LONG
           : PERPS_EVENT_VALUE.DIRECTION.SHORT,
-        [PERPS_EVENT_PROPERTY.ORDER_TYPE]: params.newOrder.orderType,
+        ...this.#buildTradeIntentProperties(params.newOrder),
         [PERPS_EVENT_PROPERTY.LEVERAGE]: params.newOrder.leverage ?? 1,
         [PERPS_EVENT_PROPERTY.ORDER_SIZE]: params.newOrder.size,
         [PERPS_EVENT_PROPERTY.COMPLETION_DURATION]: completionDuration,
@@ -2367,6 +2382,9 @@ export class TradingService {
     const { provider, position, trackingData, context } = options;
     const traceId = uuidv4();
     const startTime = this.#deps.performance.now();
+    const flipIntentProperties = this.#buildTradeIntentProperties({
+      orderType: 'market',
+    });
 
     try {
       this.#deps.tracer.trace({
@@ -2411,7 +2429,7 @@ export class TradingService {
         [PERPS_EVENT_PROPERTY.DIRECTION]: oppositeDirection
           ? PERPS_EVENT_VALUE.DIRECTION.LONG
           : PERPS_EVENT_VALUE.DIRECTION.SHORT,
-        [PERPS_EVENT_PROPERTY.ORDER_TYPE]: 'market',
+        ...flipIntentProperties,
         [PERPS_EVENT_PROPERTY.LEVERAGE]: position.leverage?.value || 1,
         [PERPS_EVENT_PROPERTY.ORDER_SIZE]: positionSize,
         [PERPS_EVENT_PROPERTY.ACTION]: flipAction,
@@ -2449,7 +2467,7 @@ export class TradingService {
             [PERPS_EVENT_PROPERTY.DIRECTION]: oppositeDirection
               ? PERPS_EVENT_VALUE.DIRECTION.LONG
               : PERPS_EVENT_VALUE.DIRECTION.SHORT,
-            [PERPS_EVENT_PROPERTY.ORDER_TYPE]: 'market',
+            ...flipIntentProperties,
             [PERPS_EVENT_PROPERTY.LEVERAGE]: position.leverage?.value || 1,
             [PERPS_EVENT_PROPERTY.ORDER_SIZE]: positionSize,
             [PERPS_EVENT_PROPERTY.COMPLETION_DURATION]: completionDuration,
@@ -2480,6 +2498,7 @@ export class TradingService {
           {
             [PERPS_EVENT_PROPERTY.STATUS]: PERPS_EVENT_VALUE.STATUS.FAILED,
             [PERPS_EVENT_PROPERTY.ASSET]: position.symbol,
+            ...flipIntentProperties,
             [PERPS_EVENT_PROPERTY.ACTION]: flipAction,
             [PERPS_EVENT_PROPERTY.COMPLETION_DURATION]: completionDuration,
             [PERPS_EVENT_PROPERTY.ERROR_MESSAGE]:
@@ -2521,6 +2540,7 @@ export class TradingService {
       this.#deps.metrics.trackPerpsEvent(PerpsAnalyticsEvent.TradeTransaction, {
         [PERPS_EVENT_PROPERTY.STATUS]: PERPS_EVENT_VALUE.STATUS.FAILED,
         [PERPS_EVENT_PROPERTY.ASSET]: position.symbol,
+        ...flipIntentProperties,
         [PERPS_EVENT_PROPERTY.ACTION]: failFlipAction,
         [PERPS_EVENT_PROPERTY.COMPLETION_DURATION]: completionDuration,
         [PERPS_EVENT_PROPERTY.ERROR_MESSAGE]: errorMessage,

--- a/packages/perps-controller/tests/src/services/TradingService.test.ts
+++ b/packages/perps-controller/tests/src/services/TradingService.test.ts
@@ -656,6 +656,7 @@ describe('TradingService', () => {
         PerpsAnalyticsEvent.TradeTransaction,
         expect.objectContaining({
           status: 'failed',
+          reduce_only: false,
         }),
       );
     });
@@ -1002,6 +1003,7 @@ describe('TradingService', () => {
           size: '0.2',
           orderType: 'limit',
           price: '51000',
+          reduceOnly: true,
         },
       };
       const mockOrderResult: OrderResult = {
@@ -1024,6 +1026,7 @@ describe('TradingService', () => {
         PerpsAnalyticsEvent.TradeTransaction,
         expect.objectContaining({
           status: 'executed',
+          reduce_only: true,
         }),
       );
     });
@@ -1059,6 +1062,7 @@ describe('TradingService', () => {
         PerpsAnalyticsEvent.TradeTransaction,
         expect.objectContaining({
           status: 'failed',
+          reduce_only: false,
         }),
       );
     });
@@ -2842,7 +2846,8 @@ describe('TradingService', () => {
             symbol: 'BTC',
             isBuy: true,
             size: '0.1',
-            orderType: 'market',
+            orderType: 'stop_market',
+            reduceOnly: true,
           },
           context: mockContext,
           reportOrderToDataLake: mockReportOrderToDataLake,
@@ -2850,7 +2855,20 @@ describe('TradingService', () => {
 
         expect(mockDeps.metrics.trackPerpsEvent).toHaveBeenCalledWith(
           PerpsAnalyticsEvent.TradeTransaction,
-          expect.objectContaining({ status: 'submitted', asset: 'BTC' }),
+          expect.objectContaining({
+            status: 'submitted',
+            asset: 'BTC',
+            order_type: 'stop_market',
+            reduce_only: true,
+          }),
+        );
+        expect(
+          findCall(PerpsAnalyticsEvent.TradeTransaction, 'executed')?.[1],
+        ).toEqual(
+          expect.objectContaining({
+            order_type: 'stop_market',
+            reduce_only: true,
+          }),
         );
       });
 
@@ -2926,7 +2944,12 @@ describe('TradingService', () => {
 
         expect(mockDeps.metrics.trackPerpsEvent).toHaveBeenCalledWith(
           PerpsAnalyticsEvent.TradeTransaction,
-          expect.objectContaining({ status: 'submitted', asset: 'BTC' }),
+          expect.objectContaining({
+            status: 'submitted',
+            asset: 'BTC',
+            order_type: 'market',
+            reduce_only: false,
+          }),
         );
       });
 
@@ -2949,6 +2972,7 @@ describe('TradingService', () => {
             status: 'failed',
             asset: 'BTC',
             error_message: 'insufficient margin',
+            reduce_only: false,
           }),
         );
       });
@@ -3156,6 +3180,7 @@ describe('TradingService', () => {
             isBuy: true,
             size: '10',
             orderType: 'market',
+            reduceOnly: true,
           },
           context: mockContext,
           reportOrderToDataLake: mockReportOrderToDataLake,
@@ -3173,12 +3198,13 @@ describe('TradingService', () => {
             order_size: 10,
             amount_filled: 4,
             remaining_amount: 6,
+            reduce_only: true,
           }),
         );
         // The terminal executed event still fires alongside it.
         expect(
-          findCall(PerpsAnalyticsEvent.TradeTransaction, 'executed'),
-        ).toBeDefined();
+          findCall(PerpsAnalyticsEvent.TradeTransaction, 'executed')?.[1],
+        ).toEqual(expect.objectContaining({ reduce_only: true }));
       });
 
       it('does not count rejected Scale rungs as remaining fill exposure', async () => {


### PR DESCRIPTION
## Explanation

`Perp Trade Transaction` currently emits canonical placement type but does not identify whether an order was submitted with reduce-only intent. This makes Pro and triggered-order analytics incomplete.

This change centralizes `order_type` and `reduce_only` construction and includes both properties on every trade lifecycle payload: submitted, partially filled, executed, failed, edited-order terminal events, and synthetic flips. Missing `reduceOnly` values and flips are emitted as `false`.

## References

- Segment contract: https://github.com/Consensys/segment-schema/pull/725
- A Mobile dependency and integration-test PR will follow the package release.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by updating the package changelog
- [ ] I've introduced breaking changes in this PR and have prepared draft pull requests for clients and consumer packages to resolve them (not applicable; additive analytics property)

## Verification

- `yarn workspace @metamask/perps-controller run test`
- focused Jest suite (119 tests)
- targeted ESLint and Prettier checks
- full Core workspace build