### PR TITLE
Exclude lint:tsc emitted files from ESLint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -75,7 +75,7 @@ const config = createConfig([
   {
     ignores: [
       '**/.docusaurus',
-      '**/.lint-tsc-cache',
+      '**/.tsc-lint-cache',
       '**/coverage/**',
       '**/dist/**',
       '**/docs/**',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -75,6 +75,7 @@ const config = createConfig([
   {
     ignores: [
       '**/.docusaurus',
+      '**/.lint-tsc-cache',
       '**/coverage/**',
       '**/dist/**',
       '**/docs/**',


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

When `lint:tsc` runs, it will emit files to package-specific `.lint-tsc-cache` directories. However, running `yarn lint` after running `yarn lint:tsc` currently fails because ESLint is attempting to process these directories. We don't need ESLint to do this.


## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> ESLint ignore-only change for generated cache output; no runtime or application logic affected.
> 
> **Overview**
> **Fixes `yarn lint` failing after `yarn lint:tsc`** by adding `**/.tsc-lint-cache` to the root ESLint `ignores` list alongside other build/cache paths.
> 
> `lint:tsc` writes compiled output under package-local `.tsc-lint-cache` directories (via `tsconfig.lint.json`). Without this ignore, a subsequent full lint pass tries to lint those emitted files and errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ceb159351c273919bfa3f4520a25af7252d6f13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->