### PR TITLE
feat(assets-controller): enhance spam wallet handling cleanup

### DIFF
--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Enhance spam asset cleanup to collect candidates from `assetsBalance` and remove swept assets from `assetsPrice` ([#10095](https://github.com/MetaMask/core/pull/10095))
+
 ## [15.0.0]
 
 ### Added

--- a/packages/assets-controller/src/AssetsController.spam-cleanup.test.ts
+++ b/packages/assets-controller/src/AssetsController.spam-cleanup.test.ts
@@ -28,6 +28,7 @@ import {
   OPTIMISM_USDC,
   SEI_USDCN,
   SPAM_WALLET_ASSETS_INFO,
+  SPAM_WALLET_PRICES,
   SURVIVING_ASSET_IDS,
   SWEEPABLE_ASSET_IDS,
   buildAssetsInfo,
@@ -170,7 +171,7 @@ describe('AssetsController spam cleanup', () => {
     });
   });
 
-  it('leaves prices and the imported token alone', async () => {
+  it("leaves the imported token alone and clears the swept assets' prices", async () => {
     mockSuggestedOccurrenceFloors();
     mockV3Assets();
     const state = buildSpamWalletState();
@@ -183,7 +184,9 @@ describe('AssetsController spam cleanup', () => {
         expect(controller.state.customAssets).toStrictEqual({
           [ACCOUNT_TWO_ID]: [ARBITRUM_GMX],
         });
-        expect(controller.state.assetsPrice).toStrictEqual(state.assetsPrice);
+        expect(controller.state.assetsPrice).toStrictEqual({
+          [MAINNET_USDT]: SPAM_WALLET_PRICES[MAINNET_USDT],
+        });
       });
     });
   });

--- a/packages/assets-controller/src/AssetsController.ts
+++ b/packages/assets-controller/src/AssetsController.ts
@@ -1307,7 +1307,10 @@ export class AssetsController extends BaseController<
 
       this.update((state) => {
         result.applyPatch(
-          state as Pick<AssetsControllerState, 'assetsInfo' | 'assetsBalance'>,
+          state as Pick<
+            AssetsControllerState,
+            'assetsInfo' | 'assetsBalance' | 'assetsPrice'
+          >,
           {
             spamAssetIds: result.spamAssetIds,
           },

--- a/packages/assets-controller/src/__fixtures__/spamWalletState.ts
+++ b/packages/assets-controller/src/__fixtures__/spamWalletState.ts
@@ -3,6 +3,7 @@ import { KnownCaipNamespace, getChecksumAddress } from '@metamask/utils';
 import { getDefaultTrackedAssetsForChain } from '../defaults.js';
 import type {
   AssetMetadata,
+  AssetPrice,
   AssetsControllerStateInternal,
   Caip19AssetId,
   ChainId,
@@ -238,6 +239,31 @@ export const SPAM_WALLET_ASSETS_INFO = buildAssetsInfo([
   ...SPAM_ASSET_IDS,
 ]);
 
+/**
+ * Prices are persisted next to the assets they belong to, so the airdrop spam
+ * carries quotes of its own into state.
+ */
+export const SPAM_WALLET_PRICES: Record<Caip19AssetId, AssetPrice> = {
+  [MAINNET_USDT]: {
+    assetPriceType: 'fungible',
+    price: 1.0002,
+    lastUpdated: 1_756_200_000_000,
+    usdPrice: 1.0002,
+  },
+  [MAINNET_SPAM]: {
+    assetPriceType: 'fungible',
+    price: 0.00000031,
+    lastUpdated: 1_756_200_000_000,
+    usdPrice: 0.00000031,
+  },
+  [OPTIMISM_SPAM]: {
+    assetPriceType: 'fungible',
+    price: 0.0000117,
+    lastUpdated: 1_756_200_000_000,
+    usdPrice: 0.0000117,
+  },
+};
+
 export const SPAM_WALLET_BALANCES = {
   [ACCOUNT_ONE_ID]: {
     [MAINNET_NATIVE]: { amount: '1204500000000000000' },
@@ -267,14 +293,7 @@ export function buildSpamWalletState(
   return {
     assetsInfo: { ...SPAM_WALLET_ASSETS_INFO },
     assetsBalance: structuredClone(SPAM_WALLET_BALANCES),
-    assetsPrice: {
-      [MAINNET_USDT]: {
-        assetPriceType: 'fungible',
-        price: 1.0002,
-        lastUpdated: 1_756_200_000_000,
-        usdPrice: 1.0002,
-      },
-    },
+    assetsPrice: structuredClone(SPAM_WALLET_PRICES),
     customAssets: { [ACCOUNT_TWO_ID]: [ARBITRUM_GMX] },
     assetPreferences: { [OPTIMISM_VELO]: { hidden: true } },
     selectedCurrency: 'usd',

--- a/packages/assets-controller/src/migrations/healAssetsInfoMetadata.test.ts
+++ b/packages/assets-controller/src/migrations/healAssetsInfoMetadata.test.ts
@@ -13,6 +13,7 @@ import {
   BASE_SPAM,
   BASE_USDC,
   MAINNET_NATIVE,
+  MAINNET_SPAM,
   MAINNET_USDT,
   MONAD_WMON,
   OPTIMISM_SPAM,
@@ -21,6 +22,7 @@ import {
   SEI_USDCN,
   SPAM_ASSET_IDS,
   SPAM_WALLET_ASSETS_INFO,
+  SPAM_WALLET_PRICES,
   SURVIVING_ASSET_IDS,
   SWEEPABLE_ASSET_IDS,
   buildAssetsInfo,
@@ -838,6 +840,10 @@ describe('cleanSpamAssets', () => {
         Object.keys(balances),
       ),
     ).toStrictEqual(expect.not.arrayContaining(lowercasedSpamAssetIds));
+    // Prices were written under the checksummed IDs the wallet never adopted.
+    expect(nextState.assetsPrice).toStrictEqual({
+      [MAINNET_USDT]: SPAM_WALLET_PRICES[MAINNET_USDT],
+    });
   });
 
   it('sweeps a wallet whose EVM asset IDs were never checksummed when the API answers in checksummed IDs', async () => {
@@ -885,6 +891,11 @@ describe('cleanSpamAssets', () => {
     const { scope: assetsScope } = mockV3Assets();
     const state = buildSpamWalletState({
       assetsInfo: buildAssetsInfo(OUT_OF_SCOPE_ASSET_IDS),
+      assetsBalance: {
+        [ACCOUNT_ONE_ID]: Object.fromEntries(
+          OUT_OF_SCOPE_ASSET_IDS.map((assetId) => [assetId, { amount: '1' }]),
+        ),
+      },
     });
 
     const nextState = await runCleanup(state);
@@ -899,6 +910,13 @@ describe('cleanSpamAssets', () => {
     mockV3Assets();
     const state = buildSpamWalletState({
       assetsInfo: buildAssetsInfo([MAINNET_USDT, OPTIMISM_USDC, BASE_USDC]),
+      assetsBalance: {
+        [ACCOUNT_ONE_ID]: {
+          [MAINNET_USDT]: { amount: '2500000000' },
+          [OPTIMISM_USDC]: { amount: '148230000' },
+          [BASE_USDC]: { amount: '9900000' },
+        },
+      },
     });
 
     const nextState = await runCleanup(state);
@@ -928,6 +946,75 @@ describe('cleanSpamAssets', () => {
     expect(nextState.customAssets).toStrictEqual(state.customAssets);
   });
 
+  it('sweeps a spam token that is only left in balances', async () => {
+    // Balances can outlive the `assetsInfo` entry they were tracked under, so
+    // the sweep has to consider them in their own right.
+    mockSuggestedOccurrenceFloors();
+    const { requestedBatches } = mockV3Assets();
+    const state = buildSpamWalletState({
+      assetsInfo: buildAssetsInfo([MAINNET_USDT]),
+    });
+
+    const nextState = await runCleanup(state);
+
+    expect([...requestedBatches[0]].sort()).toStrictEqual(
+      [
+        MAINNET_USDT,
+        MAINNET_SPAM,
+        OPTIMISM_USDC,
+        OPTIMISM_SPAM,
+        BASE_SPAM,
+        BASE_FARTCOIN,
+        SEI_USDCN,
+      ].sort(),
+    );
+    expect(nextState.assetsBalance).toStrictEqual({
+      [ACCOUNT_ONE_ID]: {
+        [MAINNET_NATIVE]: { amount: '1204500000000000000' },
+        [MAINNET_USDT]: { amount: '2500000000' },
+        [OPTIMISM_USDC]: { amount: '148230000' },
+        [SEI_USDCN]: { amount: '74500000' },
+      },
+      [ACCOUNT_TWO_ID]: {
+        [BASE_FARTCOIN]: { amount: '1200000000000000000000' },
+        [ARBITRUM_GMX]: { amount: '3400000000000000000' },
+      },
+    });
+  });
+
+  it('asks about an asset held under two casings only once', async () => {
+    mockSuggestedOccurrenceFloors();
+    const { requestedBatches } = mockV3Assets();
+    const state = buildSpamWalletState({
+      assetsInfo: buildAssetsInfo([MAINNET_SPAM]),
+      assetsBalance: {
+        [ACCOUNT_ONE_ID]: {
+          [MAINNET_SPAM.toLowerCase() as Caip19AssetId]: {
+            amount: '5000000000000000000000',
+          },
+        },
+      },
+    });
+
+    const nextState = await runCleanup(state);
+
+    expect(requestedBatches[0]).toHaveLength(1);
+    expect(nextState.assetsInfo).toStrictEqual({});
+    expect(nextState.assetsBalance[ACCOUNT_ONE_ID]).toStrictEqual({});
+  });
+
+  it('drops the persisted prices of the assets it sweeps', async () => {
+    mockSuggestedOccurrenceFloors();
+    mockV3Assets();
+    const state = buildSpamWalletState();
+
+    const nextState = await runCleanup(state);
+
+    expect(nextState.assetsPrice).toStrictEqual({
+      [MAINNET_USDT]: SPAM_WALLET_PRICES[MAINNET_USDT],
+    });
+  });
+
   it('does not mutate the state it was given', async () => {
     mockSuggestedOccurrenceFloors();
     mockV3Assets();
@@ -945,6 +1032,7 @@ describe('cleanSpamAssets', () => {
     const { requestedBatches } = mockV3Assets({ times: 2 });
     const state = buildSpamWalletState({
       assetsInfo: buildAssetsInfo([MAINNET_USDT]),
+      assetsBalance: {},
     });
     const apiClient = createTestApiClient();
 

--- a/packages/assets-controller/src/migrations/healAssetsInfoMetadata.ts
+++ b/packages/assets-controller/src/migrations/healAssetsInfoMetadata.ts
@@ -618,7 +618,7 @@ export type SpamTokensApiClient = Pick<ApiPlatformClient, 'tokens' | 'token'>;
 
 export type CleanSpamAssetsState = Pick<
   AssetsControllerStateInternal,
-  'assetsInfo' | 'assetsBalance' | 'customAssets'
+  'assetsInfo' | 'assetsBalance' | 'assetsPrice' | 'customAssets'
 >;
 
 export type CleanSpamAssetsOptions = {
@@ -702,13 +702,18 @@ export async function cleanSpamAssets({
  *
  * @param state - Current controller state.
  * @param state.assetsInfo - Tracked asset metadata, keyed by CAIP-19 ID.
+ * @param state.assetsBalance - Per-account balances, keyed by CAIP-19 ID.
  * @param state.customAssets - Per-account custom asset IDs.
- * @returns Candidate asset IDs.
+ * @returns Candidate asset IDs, one per asset whatever casing it is held in.
  */
 function collectSpamCleanupCandidates({
   assetsInfo,
+  assetsBalance,
   customAssets,
-}: Pick<CleanSpamAssetsState, 'assetsInfo' | 'customAssets'>): Caip19AssetId[] {
+}: Pick<
+  CleanSpamAssetsState,
+  'assetsInfo' | 'assetsBalance' | 'customAssets'
+>): Caip19AssetId[] {
   const customAssetIds = new Set(
     Object.values(customAssets)
       .flat()
@@ -719,7 +724,19 @@ function collectSpamCleanupCandidates({
     .flat()
     .map((a) => a.toLowerCase());
 
-  return (Object.keys(assetsInfo) as Caip19AssetId[]).filter((assetId) => {
+  const trackedAssetIds = new Map<string, Caip19AssetId>();
+  const assetInfoAssetIds = Object.keys(assetsInfo) as Caip19AssetId[];
+  const balanceAssetIds = Object.values(assetsBalance).flatMap((balances) =>
+    Object.keys(balances),
+  ) as Caip19AssetId[];
+  for (const assetId of [...assetInfoAssetIds, ...balanceAssetIds]) {
+    const lowerId = assetId.toLowerCase();
+    if (!trackedAssetIds.has(lowerId)) {
+      trackedAssetIds.set(lowerId, assetId);
+    }
+  }
+
+  return [...trackedAssetIds.values()].filter((assetId) => {
     const lowerId = assetId.toLowerCase();
     const [chainId, asset] = lowerId.split('/');
 
@@ -801,7 +818,10 @@ async function fetchSuggestedOccurrenceFloors(
 }
 
 function applyCleanupPatch(
-  state: Pick<CleanSpamAssetsState, 'assetsInfo' | 'assetsBalance'>,
+  state: Pick<
+    CleanSpamAssetsState,
+    'assetsInfo' | 'assetsBalance' | 'assetsPrice'
+  >,
   patch: {
     spamAssetIds: Caip19AssetId[];
   },
@@ -821,6 +841,9 @@ function applyCleanupPatch(
     for (const assetId of Object.keys(balances).filter(isSpam)) {
       delete balances[assetId as Caip19AssetId];
     }
+  }
+  for (const assetId of Object.keys(state.assetsPrice).filter(isSpam)) {
+    delete state.assetsPrice[assetId as Caip19AssetId];
   }
 
   cleanupLog('Removed spam assets', { count: spam.size });


### PR DESCRIPTION
## Explanation

- cleanup will find candidates based on balances and assetsInfo
- we will cleanup assetsInfo, assetsBalances, assetsPrices

Note - there is a ticket to fully remove this cleanup in favour for the built in `{ updateMode: 'full' }` mechanism, but this needs vetting.

## References

https://consensyssoftware.atlassian.net/browse/ASSETS-3905

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes unlock-time state mutation for balances, metadata, and persisted prices; a regression could drop legitimate tokens or skew portfolio totals, though behavior remains gated by occurrence floors and existing exclusions.
> 
> **Overview**
> **Spam asset cleanup** now considers ERC-20 holdings in **`assetsBalance`** as well as **`assetsInfo`**, so tokens that still have balances after metadata was dropped are swept. Candidate IDs are **deduped by lowercase CAIP-19** so the same token held under two casings is only sent to the Token API once.
> 
> When spam is removed, **`assetsPrice`** entries for those assets are deleted too (unlock cleanup passes `assetsPrice` through `applyCleanupPatch`). Custom-imported tokens and non-spam prices are unchanged.
> 
> Tests and spam-wallet fixtures were updated to cover balance-only spam, mixed casing, and cleared prices.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 429d2d625efc5e3f7b8928425017dd053398e410. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->