### PR TITLE
chore: add featureIds for limit order and recurring buy

### DIFF
--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Optional `failure_phase` and `error_code` on Quotes Error and Failed event context types
   - Optional `source_hash_present` and `destination_hash_present` on Failed, Submitted, and Completed event context types
   - Submit and status classifiers live in `@metamask/bridge-status-controller`
+- Add `recurring_buy` and `limit_order` FeatureIds
 
 ### Changed
 

--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Optional `failure_phase` and `error_code` on Quotes Error and Failed event context types
   - Optional `source_hash_present` and `destination_hash_present` on Failed, Submitted, and Completed event context types
   - Submit and status classifiers live in `@metamask/bridge-status-controller`
-- Add `recurring_buy` and `limit_order` FeatureIds
+- Add `recurring_buy` and `limit_order` FeatureIds ([#10096](https://github.com/MetaMask/core/pull/10096))
 
 ### Changed
 

--- a/packages/bridge-controller/src/validators/feature-flags.ts
+++ b/packages/bridge-controller/src/validators/feature-flags.ts
@@ -22,6 +22,8 @@ export enum FeatureId {
   DAPP_SWAP = 'dapp_swap',
   BATCH_SELL = 'batch_sell',
   UNIFIED_SWAP_BRIDGE = 'unified_swap_bridge',
+  LIMIT_ORDER = 'limit_order',
+  RECURRING_BUY = 'recurring_buy',
 }
 
 export const VersionStringSchema = define<string>(


### PR DESCRIPTION
## Explanation

Adds `recurring_buy` and `limit_order` FeatureId's

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

N/A

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive enum and changelog-only change with no behavior or API contract changes beyond new allowed `feature_id` values.
> 
> **Overview**
> Extends the exported `FeatureId` enum with **`limit_order`** and **`recurring_buy`**, matching existing Segment-style `feature_id` strings used when calling bridge quote flows and unified swap/bridge analytics.
> 
> The `@metamask/bridge-controller` **Unreleased** changelog documents the addition; there is no other runtime or validation logic change in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c23f5000d3face0fa60958dd64728019e363e1fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->