### PR TITLE
feat(kyc-controller): add write to capability token operations

### DIFF
--- a/packages/kyc-controller/src/KycController.ts
+++ b/packages/kyc-controller/src/KycController.ts
@@ -1794,7 +1794,8 @@ export class KycController extends BaseController<
     // authorizes later storage reads without granting write or delete access.
     const ukycCapabilityToken = signStorageAccessToken({
       material: clientMaterial,
-      operations: ['read'],
+      // TODO: Confirm with idOS when this can be switched back to read and a separate token is sent for write
+      operations: ['read', 'write'],
       expiresAt: new Date(Date.now() + UKYC_CAPABILITY_TOKEN_TTL_MS),
     });
     const wrappedUkycCapabilityToken = wrapEncryptionKey(


### PR DESCRIPTION
## Explanation

Temporarily add `write` to the capability token's operations array. This does not match the sequence diagram in the architecture docs and is temporary to unblock us until next week or so

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them
