### PR TITLE
fix(perps-controller): revalidate TP/SL cache misses

### DIFF
--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Revalidate HyperLiquid positions over HTTP before reporting a WebSocket cache miss during a TP/SL update.
+- Revalidate HyperLiquid positions over HTTP before reporting a WebSocket cache miss during a TP/SL update ([#10101](https://github.com/MetaMask/core/pull/10101)).
 
 ## [16.0.0]
 

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Revalidate HyperLiquid positions over HTTP before reporting a WebSocket cache miss during a TP/SL update ([#10101](https://github.com/MetaMask/core/pull/10101)).
+  - A current DEX slice is stamped with the connection epoch, which proves it belongs to the live subscription but not that it has caught up with the most recent fill. `updatePositionTPSL` therefore treated the post-fill window, where the position exists on the venue but has not yet been published, as identical to a position that was closed, and returned `POSITION_NOT_FOUND` without making a request.
+  - Only `updatePositionTPSL` opts in. `closePosition`, `closePositions` and the margin operations keep failing closed on a cache miss, because they act on a position the user is looking at: an unpublished position is not rendered, so those flows cannot reach the post-fill window. TP/SL attachment is the one path a client fires automatically within milliseconds of placing an order, with no human in the loop. Keeping the opt-in narrow also keeps the added REST traffic off the batch paths.
+  - A cache hit still returns the WebSocket slice untouched, so a stale size on a symbol that is present is resolved exactly as before, and the reduce-only sizing guarantees added in [#10037](https://github.com/MetaMask/core/pull/10037) are unaffected.
 
 ## [16.0.0]
 

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Revalidate HyperLiquid positions over HTTP before reporting a WebSocket cache miss during a TP/SL update.
+
 ## [16.0.0]
 
 ### Added

--- a/packages/perps-controller/src/providers/HyperLiquidProvider.ts
+++ b/packages/perps-controller/src/providers/HyperLiquidProvider.ts
@@ -9493,6 +9493,7 @@ export class HyperLiquidProvider implements PerpsProvider {
       // side/size reduce-only rejection this method is meant to prevent.
       const currentPositions = await this.#getPositionsForOperation(
         parseAssetName(symbol).dex ?? '',
+        { revalidateMissingSymbol: symbol },
       );
       const position = currentPositions.find((pos) => pos.symbol === symbol);
 
@@ -10717,8 +10718,11 @@ export class HyperLiquidProvider implements PerpsProvider {
    *
    * A symbol-specific caller can use its current-connection DEX slice directly.
    * The current-epoch slice wins before any REST request because it is the
-   * provider's live subscription source for that exact DEX. If the target DEX
-   * has not published, the caller uses REST instead of a stale aggregate.
+   * provider's live subscription source for that exact DEX. A caller may opt
+   * into one targeted REST revalidation when a required symbol is absent, which
+   * covers the post-fill window before the next WebSocket position update. If
+   * the target DEX has not published, the caller uses REST instead of a stale
+   * aggregate.
    *
    * A whole-list caller uses one shallow-copied WebSocket snapshot only when
    * every configured DEX is current. Otherwise it falls back to REST. No path
@@ -10727,20 +10731,43 @@ export class HyperLiquidProvider implements PerpsProvider {
    *
    * @param targetDex - DEX for a single-symbol lookup, or undefined for a full
    * position list.
+   * @param options - Optional lookup behavior for a symbol-specific operation.
+   * @param options.revalidateMissingSymbol - Query the target DEX over REST when
+   * its current WebSocket slice does not contain this symbol.
    * @returns Positions from one provenance-safe cache/REST path.
    */
-  async #getPositionsForOperation(targetDex?: string): Promise<Position[]> {
+  async #getPositionsForOperation(
+    targetDex?: string,
+    options: { revalidateMissingSymbol?: string } = {},
+  ): Promise<Position[]> {
     if (targetDex !== undefined) {
       const targetPositions =
         this.#subscriptionService.getCachedPositionsForDex(targetDex);
-      if (targetPositions !== null) {
-        return [...targetPositions];
+      if (targetPositions === null) {
+        this.#deps.debugLogger.log(
+          'Target DEX position cache unavailable: fetching REST positions',
+          { dex: targetDex || 'main' },
+        );
+      } else {
+        const { revalidateMissingSymbol } = options;
+        const shouldRevalidate =
+          revalidateMissingSymbol !== undefined &&
+          targetPositions.find(
+            (position) => position.symbol === revalidateMissingSymbol,
+          ) === undefined;
+        if (shouldRevalidate) {
+          this.#deps.debugLogger.log(
+            'Target symbol missing from position cache: revalidating REST positions',
+            {
+              dex: targetDex || 'main',
+              symbol: revalidateMissingSymbol,
+            },
+          );
+        } else {
+          return [...targetPositions];
+        }
       }
 
-      this.#deps.debugLogger.log(
-        'Target DEX position cache unavailable: fetching REST positions',
-        { dex: targetDex || 'main' },
-      );
       const { answered, positions } = await this.#queryDexPositions(
         targetDex || null,
       );

--- a/packages/perps-controller/tests/src/providers/HyperLiquidProvider.advanced-orders.test.ts
+++ b/packages/perps-controller/tests/src/providers/HyperLiquidProvider.advanced-orders.test.ts
@@ -2246,6 +2246,58 @@ describe('HyperLiquidProvider', () => {
         ).not.toHaveBeenCalled();
       });
 
+      it('stops revalidating once the slice publishes the filled position', async () => {
+        // The post-fill window is transient: the first update runs before the
+        // subscription publishes the new position and pays for one HTTP read,
+        // and the next one must be served from the slice alone. Asserting the
+        // second call makes no request is what keeps this fix from becoming
+        // steady REST traffic on a hot path.
+        mockSubscriptionService.getCachedPositionsForDex = jest
+          .fn()
+          .mockReturnValueOnce([])
+          .mockReturnValue([{ ...position, size: '0.04' }]);
+        const clearinghouseState = jest.fn().mockResolvedValue({
+          marginSummary: { totalMarginUsed: '200', accountValue: '10200' },
+          withdrawable: '10000',
+          assetPositions: [
+            {
+              position: {
+                coin: 'BTC',
+                szi: '0.04',
+                entryPx: '50000',
+                positionValue: '2000',
+                unrealizedPnl: '20',
+                marginUsed: '200',
+                leverage: { type: 'cross', value: 10 },
+                liquidationPx: '45000',
+              },
+              type: 'oneWay',
+            },
+          ],
+        });
+        mockClientService.getInfoClient.mockReturnValue(
+          createMockInfoClient({ clearinghouseState }),
+        );
+
+        const duringWindow = await provider.updatePositionTPSL({
+          symbol: 'BTC',
+          takeProfitPrice: '60000',
+          position,
+        });
+        const revalidationCalls = clearinghouseState.mock.calls.length;
+
+        const afterWindow = await provider.updatePositionTPSL({
+          symbol: 'BTC',
+          takeProfitPrice: '60000',
+          position,
+        });
+
+        expect(duringWindow.success).toBe(true);
+        expect(revalidationCalls).toBe(1);
+        expect(afterWindow.success).toBe(true);
+        expect(clearinghouseState).toHaveBeenCalledTimes(1);
+      });
+
       it('reports provider unavailable instead of trusting a snapshot when REST fails', async () => {
         mockSubscriptionService.getCachedPositionsForDex.mockReturnValue([]);
         mockClientService.getInfoClient.mockReturnValue(

--- a/packages/perps-controller/tests/src/providers/HyperLiquidProvider.advanced-orders.test.ts
+++ b/packages/perps-controller/tests/src/providers/HyperLiquidProvider.advanced-orders.test.ts
@@ -2010,6 +2010,9 @@ describe('HyperLiquidProvider', () => {
         mockSubscriptionService.getCachedPositionsForDex = jest
           .fn()
           .mockReturnValue([{ ...position, size: '0.04' }]);
+        const infoClient = mockClientService.getInfoClient();
+        const clearinghouseState = infoClient.clearinghouseState as jest.Mock;
+        clearinghouseState.mockClear();
 
         await provider.updatePositionTPSL({
           symbol: 'BTC',
@@ -2025,6 +2028,7 @@ describe('HyperLiquidProvider', () => {
         // The stop loss carries no explicit size, so it covers the position —
         // the live 0.04, not the snapshot's 0.1.
         expect(request.orders[1].s).toBe('0.04');
+        expect(clearinghouseState).not.toHaveBeenCalled();
       });
 
       it('re-reads the live position while the aggregate flag is still false', async () => {
@@ -2122,10 +2126,33 @@ describe('HyperLiquidProvider', () => {
         });
       });
 
-      it('does not submit TP/SL for a position the current DEX slice reports closed', async () => {
+      it('revalidates a current empty DEX slice before reporting no position', async () => {
         mockSubscriptionService.getCachedPositionsForDex = jest
           .fn()
           .mockReturnValue([]);
+        mockClientService.getInfoClient.mockReturnValue(
+          createMockInfoClient({
+            clearinghouseState: jest.fn().mockResolvedValue({
+              marginSummary: { totalMarginUsed: '200', accountValue: '10200' },
+              withdrawable: '10000',
+              assetPositions: [
+                {
+                  position: {
+                    coin: 'BTC',
+                    szi: '0.04',
+                    entryPx: '50000',
+                    positionValue: '2000',
+                    unrealizedPnl: '20',
+                    marginUsed: '200',
+                    leverage: { type: 'cross', value: 10 },
+                    liquidationPx: '45000',
+                  },
+                  type: 'oneWay',
+                },
+              ],
+            }),
+          }),
+        );
 
         const result = await provider.updatePositionTPSL({
           symbol: 'BTC',
@@ -2135,15 +2162,92 @@ describe('HyperLiquidProvider', () => {
           position,
         });
 
-        expect(result.success).toBe(false);
-        expect(result.error).toBe(PERPS_ERROR_CODES.POSITION_NOT_FOUND);
+        expect(result.success).toBe(true);
+        expect(mockClientService.getInfoClient).toHaveBeenCalledWith({
+          useHttp: true,
+        });
+        const request = (
+          mockClientService.getExchangeClient().order as jest.Mock
+        ).mock.calls[0][0];
+        expect(request.orders[1].s).toBe('0.04');
+      });
+
+      it('revalidates when the current DEX slice contains only another market', async () => {
+        mockSubscriptionService.getCachedPositionsForDex = jest
+          .fn()
+          .mockReturnValue([{ ...position, symbol: 'ETH' }]);
+        mockClientService.getInfoClient.mockReturnValue(
+          createMockInfoClient({
+            clearinghouseState: jest.fn().mockResolvedValue({
+              marginSummary: { totalMarginUsed: '200', accountValue: '10200' },
+              withdrawable: '10000',
+              assetPositions: [
+                {
+                  position: {
+                    coin: 'BTC',
+                    szi: '-0.04',
+                    entryPx: '50000',
+                    positionValue: '2000',
+                    unrealizedPnl: '20',
+                    marginUsed: '200',
+                    leverage: { type: 'cross', value: 10 },
+                    liquidationPx: '55000',
+                  },
+                  type: 'oneWay',
+                },
+              ],
+            }),
+          }),
+        );
+
+        const result = await provider.updatePositionTPSL({
+          symbol: 'BTC',
+          takeProfitPrice: '40000',
+          takeProfitSize: '0.04',
+          position,
+        });
+
+        expect(result.success).toBe(true);
+        const request = (
+          mockClientService.getExchangeClient().order as jest.Mock
+        ).mock.calls[0][0];
+        expect(request.orders[0].b).toBe(true);
+      });
+
+      it('reports no position when target-DEX REST confirms the cache miss', async () => {
+        mockSubscriptionService.getCachedPositionsForDex = jest
+          .fn()
+          .mockReturnValue([]);
+        mockClientService.getInfoClient.mockReturnValue(
+          createMockInfoClient({
+            clearinghouseState: jest.fn().mockResolvedValue({
+              marginSummary: { totalMarginUsed: '0', accountValue: '10000' },
+              withdrawable: '10000',
+              assetPositions: [],
+            }),
+          }),
+        );
+
+        const result = await provider.updatePositionTPSL({
+          symbol: 'BTC',
+          takeProfitPrice: '60000',
+          position,
+        });
+
+        expect(result).toStrictEqual({
+          success: false,
+          error: PERPS_ERROR_CODES.POSITION_NOT_FOUND,
+        });
+        expect(mockClientService.getInfoClient).toHaveBeenCalledWith({
+          useHttp: true,
+        });
         expect(
           mockClientService.getExchangeClient().order,
         ).not.toHaveBeenCalled();
       });
 
       it('reports provider unavailable instead of trusting a snapshot when REST fails', async () => {
-        mockSubscriptionService.getCachedPositionsForDex.mockReturnValue(null);
+        mockSubscriptionService.getCachedPositionsForDex.mockReturnValue([]);
         mockClientService.getInfoClient.mockReturnValue(
           createMockInfoClient({
             clearinghouseState: jest


### PR DESCRIPTION
## Explanation

Immediately after a HyperLiquid position fills, the current WebSocket DEX slice can still omit the new symbol until the next `clearinghouseState` update. `updatePositionTPSL` treated that cache miss as authoritative and returned `POSITION_NOT_FOUND`, so post-order protection could fail even though the position existed on the venue.

This change lets only `updatePositionTPSL` opt into one target-DEX HTTP revalidation when its requested symbol is absent from the current WebSocket slice. A cache hit remains WebSocket-only. The HTTP response is used as a complete replacement rather than merged with cached data, and an unavailable response fails closed with `PROVIDER_NOT_AVAILABLE`.

Close and margin operations keep their existing cache-miss behavior, avoiding broader REST traffic and 429 pressure.

## References

- Related Mobile coordination fix: https://github.com/MetaMask/metamask-mobile/pull/35707
- HyperLiquid position state: https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/info-endpoint/perpetuals
- HyperLiquid WebSocket recovery guidance: https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/websocket

## Test plan

- `yarn workspace @metamask/perps-controller run jest --no-coverage tests/src/providers/HyperLiquidProvider.advanced-orders.test.ts`
- `yarn workspace @metamask/perps-controller run test`
- `yarn build`
- Changed-file ESLint and formatting checks
- `yarn workspace @metamask/perps-controller run changelog:validate`

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

Made with [Cursor](https://cursor.com)