### PR TITLE
feat(core-backend): add timeout to retrieve auth token

### DIFF
--- a/packages/core-backend/CHANGELOG.md
+++ b/packages/core-backend/CHANGELOG.md
@@ -9,11 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `authTokenTimeout` to `ApiPlatformClientOptions` and export `DEFAULT_AUTH_TOKEN_TIMEOUT` ([#10104](https://github.com/MetaMask/core/pull/10104))
+  - Requests wait at most this long (default 500ms) for `getBearerToken`. If the token is not ready, the request is sent unauthenticated while the in-flight `fetchQuery` continues so later requests can attach the token. Set `authTokenTimeout` to `0` to wait indefinitely.
+  - Bearer-token `fetchQuery` uses `staleTime: 0` so concurrent requests are de-duplicated without a second JWT cache; token lifetime stays with AuthenticationController.
 - Add `bypassServerCache` option to `FetchOptions` ([#10068](https://github.com/MetaMask/core/pull/10068))
   - When true, the v5/v6 multi-account balances requests skip the client-side query cache (stale time defaults to 0) and append a random `bypassServerCache` query param so the Accounts API's server-side cache (keyed on the full URL) misses. Intended for hard refreshes only, e.g. right after a transaction confirms.
 
 ### Changed
 
+- Bearer-token `fetchQuery` no longer uses a 5-minute `STALE_TIMES.AUTH_TOKEN`; `STALE_TIMES.AUTH_TOKEN` is removed ([#10104](https://github.com/MetaMask/core/pull/10104))
 - Bump `@metamask/remote-feature-flag-controller` from `^6.0.0` to `^6.1.0` ([#9980](https://github.com/MetaMask/core/pull/9980))
 - Bump `@metamask/utils` from `^11.11.0` to `^11.12.0` ([#10076](https://github.com/MetaMask/core/pull/10076))
 - Bump `@metamask/account-tree-controller` from `^8.0.0` to `^8.1.0` ([#10088](https://github.com/MetaMask/core/pull/10088))

--- a/packages/core-backend/src/api/base-client.test.ts
+++ b/packages/core-backend/src/api/base-client.test.ts
@@ -6,6 +6,21 @@ import { QueryClient } from '@tanstack/query-core';
 
 import { AccountsApiClient } from './accounts/index.js';
 import { authQueryKeys } from './base-client.js';
+import { createMockResponse, mockFetch } from './test-utils.js';
+
+/**
+ * Reads the Authorization header from a recorded fetch call.
+ *
+ * @param callIndex - Index of the fetch call to inspect.
+ * @returns The Authorization header, or undefined if it was not sent.
+ */
+function authorizationHeaderOfCall(callIndex: number): string | undefined {
+  const headers = mockFetch.mock.calls[callIndex]?.[1]?.headers as Record<
+    string,
+    string
+  >;
+  return headers.Authorization;
+}
 
 describe('BaseApiClient', () => {
   describe('invalidateAuthToken', () => {
@@ -58,6 +73,96 @@ describe('BaseApiClient', () => {
       // The default version is '1.0.0' - we can verify this indirectly
       // by checking the client was created successfully
       expect(client.queryClient).toBeInstanceOf(QueryClient);
+    });
+  });
+
+  describe('bearer token timeout', () => {
+    /**
+     * Creates a client whose token provider only resolves when told to.
+     *
+     * @param authTokenTimeout - Timeout to configure on the client.
+     * @returns The client and a function that resolves the pending token.
+     */
+    function setup(authTokenTimeout?: number): {
+      client: AccountsApiClient;
+      getBearerToken: jest.Mock<Promise<string>, []>;
+      resolveToken: (token: string) => void;
+    } {
+      let resolvedToken: string | undefined;
+      let pending: Promise<string> | undefined;
+      let settleToken: (token: string) => void = () => undefined;
+      const getBearerToken = jest.fn(async (): Promise<string> => {
+        if (resolvedToken !== undefined) {
+          return resolvedToken;
+        }
+        pending ??= new Promise<string>((resolve) => {
+          settleToken = (token: string): void => {
+            resolvedToken = token;
+            resolve(token);
+          };
+        });
+        return await pending;
+      });
+      const client = new AccountsApiClient({
+        clientProduct: 'test-product',
+        getBearerToken,
+        authTokenTimeout,
+        queryClient: new QueryClient({
+          defaultOptions: { queries: { retry: false, gcTime: 0 } },
+        }),
+      });
+      return {
+        client,
+        getBearerToken,
+        resolveToken: (token: string): void => settleToken(token),
+      };
+    }
+
+    beforeEach(() => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(
+        createMockResponse({ supportedNetworks: [] }),
+      );
+    });
+
+    it('de-duplicates concurrent getBearerToken calls while the token is in flight', async () => {
+      const { client, getBearerToken } = setup(1);
+
+      await Promise.all([
+        client.fetchV1SupportedNetworks(),
+        client.fetchV1SupportedNetworks(),
+      ]);
+
+      expect(getBearerToken).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends the request unauthenticated when the token is not ready in time', async () => {
+      const { client } = setup(1);
+
+      await client.fetchV1SupportedNetworks();
+
+      expect(authorizationHeaderOfCall(0)).toBeUndefined();
+    });
+
+    it('authenticates later requests once the pending token resolves', async () => {
+      const { client, resolveToken } = setup(1);
+
+      await client.fetchV1SupportedNetworks();
+      resolveToken('late-token');
+      // staleTime 0 so the endpoint cache does not short-circuit the request
+      await client.fetchV1SupportedNetworks({ staleTime: 0 });
+
+      expect(authorizationHeaderOfCall(1)).toBe('Bearer late-token');
+    });
+
+    it('waits for the token when the timeout is disabled', async () => {
+      const { client, resolveToken } = setup(0);
+
+      const request = client.fetchV1SupportedNetworks();
+      resolveToken('slow-token');
+      await request;
+
+      expect(authorizationHeaderOfCall(0)).toBe('Bearer slow-token');
     });
   });
 });

--- a/packages/core-backend/src/api/base-client.ts
+++ b/packages/core-backend/src/api/base-client.ts
@@ -9,6 +9,7 @@ import {
   API_URLS,
   STALE_TIMES,
   GC_TIMES,
+  DEFAULT_AUTH_TOKEN_TIMEOUT,
   calculateRetryDelay,
   shouldRetry,
   HttpError,
@@ -44,6 +45,8 @@ export class BaseApiClient {
 
   protected readonly getBearerToken?: () => Promise<string | undefined>;
 
+  protected readonly authTokenTimeout: number;
+
   readonly #queryClientInstance: QueryClient;
 
   /**
@@ -73,6 +76,8 @@ export class BaseApiClient {
     this.clientProduct = options.clientProduct;
     this.clientVersion = options.clientVersion;
     this.getBearerToken = options.getBearerToken;
+    this.authTokenTimeout =
+      options.authTokenTimeout ?? DEFAULT_AUTH_TOKEN_TIMEOUT;
 
     this.#queryClientInstance =
       options.queryClient ??
@@ -88,6 +93,55 @@ export class BaseApiClient {
           },
         },
       });
+  }
+
+  /**
+   * Resolve the bearer token, giving up after `authTokenTimeout` so that a slow
+   * token provider does not delay the request. When the wait times out the
+   * request goes out unauthenticated (lower rate limit) while the in-flight
+   * `fetchQuery` keeps resolving `getBearerToken` for later requests.
+   *
+   * @returns The bearer token, or undefined if unavailable in time.
+   */
+  async #fetchBearerToken(): Promise<string | undefined> {
+    const { getBearerToken } = this;
+    if (!getBearerToken) {
+      return undefined;
+    }
+
+    // fetchQuery de-duplicates concurrent callers. staleTime is 0 so we do not
+    // cache the JWT here — AuthenticationController already owns token lifetime.
+    const tokenPromise = this.#queryClientInstance
+      .fetchQuery({
+        queryKey: authQueryKeys.bearerToken(),
+        queryFn: async () => {
+          const result = await getBearerToken();
+          // Throw if no token - prevents caching null/undefined
+          // so subsequent requests can retry (e.g., after user logs in)
+          if (!result) {
+            throw new Error('No bearer token available');
+          }
+          return result;
+        },
+        staleTime: 0,
+        retry: false, // Don't retry auth failures
+      })
+      .catch(() => undefined);
+
+    if (this.authTokenTimeout <= 0) {
+      return await tokenPromise;
+    }
+
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const timeoutPromise = new Promise<undefined>((resolve) => {
+      timeoutId = setTimeout(() => resolve(undefined), this.authTokenTimeout);
+    });
+
+    try {
+      return await Promise.race([tokenPromise, timeoutPromise]);
+    } finally {
+      clearTimeout(timeoutId);
+    }
   }
 
   /**
@@ -128,32 +182,9 @@ export class BaseApiClient {
       headers['x-metamask-clientversion'] = this.clientVersion;
     }
 
-    // Get bearer token using fetchQuery for automatic deduplication
-    if (this.getBearerToken) {
-      const queryKey = authQueryKeys.bearerToken();
-      const { getBearerToken } = this;
-
-      try {
-        // fetchQuery handles caching and deduplicates concurrent requests
-        const token = await this.#queryClientInstance.fetchQuery({
-          queryKey,
-          queryFn: async () => {
-            const result = await getBearerToken();
-            // Throw if no token - prevents caching null/undefined
-            // so subsequent requests can retry (e.g., after user logs in)
-            if (!result) {
-              throw new Error('No bearer token available');
-            }
-            return result;
-          },
-          staleTime: STALE_TIMES.AUTH_TOKEN,
-          retry: false, // Don't retry auth failures
-        });
-
-        headers.Authorization = `Bearer ${token}`;
-      } catch {
-        // No token available - continue without auth header
-      }
+    const token = await this.#fetchBearerToken();
+    if (token) {
+      headers.Authorization = `Bearer ${token}`;
     }
 
     const response = await fetch(url.toString(), {

--- a/packages/core-backend/src/api/index.ts
+++ b/packages/core-backend/src/api/index.ts
@@ -15,6 +15,7 @@ export {
   API_URLS,
   STALE_TIMES,
   GC_TIMES,
+  DEFAULT_AUTH_TOKEN_TIMEOUT,
   RETRY_CONFIG,
   calculateRetryDelay,
   getQueryOptionsOverrides,

--- a/packages/core-backend/src/api/shared-types.ts
+++ b/packages/core-backend/src/api/shared-types.ts
@@ -136,6 +136,13 @@ export type ApiPlatformClientOptions = {
   clientVersion?: string;
   /** Function to get bearer token for authenticated requests */
   getBearerToken?: () => Promise<string | undefined>;
+  /**
+   * Max time (ms) to wait for `getBearerToken` before sending the request
+   * unauthenticated. The token keeps resolving in the background and is used by
+   * later requests. Set to `0` to always wait for the token.
+   * Defaults to {@link DEFAULT_AUTH_TOKEN_TIMEOUT}.
+   */
+  authTokenTimeout?: number;
   /** Optional custom QueryClient instance */
   queryClient?: QueryClient;
 };
@@ -211,7 +218,6 @@ export const API_URLS = {
 
 /** Stale times for different data types (ms) */
 export const STALE_TIMES = {
-  AUTH_TOKEN: 5 * 60 * 1000, // 5 minutes - cache the auth token
   PRICES: 30 * 1000, // 30 seconds
   BALANCES: 60 * 1000, // 1 minute
   NETWORKS: 10 * 60 * 1000, // 10 minutes
@@ -223,6 +229,12 @@ export const STALE_TIMES = {
   TRANSACTIONS: 30 * 1000, // 30 seconds
   DEFAULT: 30 * 1000, // 30 seconds
 } as const;
+
+/**
+ * Default max time (ms) to wait for the bearer token before falling back to an
+ * unauthenticated request.
+ */
+export const DEFAULT_AUTH_TOKEN_TIMEOUT = 500;
 
 /** Garbage collection times (ms) */
 export const GC_TIMES = {


### PR DESCRIPTION
## Explanation

Current Behavior: https://www.loom.com/share/a6884ecd42d7475780838f4c9fdd2a7d

After PR: https://www.loom.com/share/aed73a550d934ac3ab319ba5d4a93a6d

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when API calls are authenticated versus sent unauthenticated, which can affect rate limits and data visibility until a token arrives; behavior is configurable via `authTokenTimeout`.
> 
> **Overview**
> Adds **`authTokenTimeout`** on `ApiPlatformClientOptions` (default **`DEFAULT_AUTH_TOKEN_TIMEOUT`** = 500ms, exported from the package). `BaseApiClient` now resolves the bearer token via `#fetchBearerToken`, which races `getBearerToken` against that limit so slow token providers no longer block HTTP calls.
> 
> If the token is not ready in time, the request is sent **without** an `Authorization` header while the in-flight TanStack `fetchQuery` keeps running; once it resolves, later requests can attach the token. Set **`authTokenTimeout` to `0`** to restore blocking wait-for-token behavior.
> 
> Bearer-token lookup still uses `fetchQuery` for concurrent de-duplication, but **`staleTime` is now `0`** instead of the removed **`STALE_TIMES.AUTH_TOKEN`** (5-minute JWT cache), leaving token lifetime to AuthenticationController. Tests cover de-duplication, unauthenticated fallback, late auth, and infinite wait.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34ffa74c7859129796e41bfa13cf17454b49f13e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->