### PR TITLE
fix(changelog-merge): use the merge base to avoid duplicate changelog conflict entries

### DIFF
--- a/scripts/lib/changelog-conflicts.test.ts
+++ b/scripts/lib/changelog-conflicts.test.ts
@@ -452,6 +452,151 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       `[1.0.0]: ${REPO_URL}/releases/tag/${oldTagPrefix}1.0.0`,
     );
   });
+
+  it('does not re-add an entry theirs inherited unchanged from the common ancestor, even if ours has since evolved it', async () => {
+    // Regression test: "theirs" is behind and still has the original
+    // dependency-bump entry from the common ancestor; "ours" has since
+    // bumped the same dependency further (a common occurrence on a
+    // long-lived base branch). Without the common ancestor, the stale
+    // entry from "theirs" looks new (different PR numbers/description) and
+    // gets wrongly re-added, duplicating it.
+    const baseContent = buildChangelog(
+      `### Changed
+
+- Bump \`dep\` from \`1.0.0\` to \`1.0.1\` ([#10](${REPO_URL}/pull/10))`,
+    );
+    const theirContent = baseContent;
+    const ourContent = buildChangelog(
+      `### Changed
+
+- Bump \`dep\` from \`1.0.0\` to \`1.0.5\` ([#10](${REPO_URL}/pull/10), [#11](${REPO_URL}/pull/11))`,
+    );
+
+    const { content, mergedEntryCount } = await mergeChangelogs({
+      ourContent,
+      theirContent,
+      baseContent,
+      repoUrl: REPO_URL,
+      tagPrefix: TAG_PREFIX,
+    });
+
+    expect(mergedEntryCount).toBe(0);
+    expect(content.match(/Bump `dep`/gu)).toHaveLength(1);
+    expect(content).toContain('Bump `dep` from `1.0.0` to `1.0.5`');
+  });
+
+  it('does not re-add a dependency bump entry that has since been released on ours with a different target version', async () => {
+    // Regression test: "theirs" still has the original dependency-bump
+    // entry under Unreleased, unchanged since the common ancestor. Since
+    // then, "ours" cut a release: the entry moved out of Unreleased into a
+    // version section, and its target version was bumped further before
+    // release. The entry now lives in a different place (a release instead
+    // of Unreleased) with different text, so it must still be recognized as
+    // "not new" and not re-added to ours' (now-empty) Unreleased section.
+    const baseContent = `# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- Bump \`@metamask/dep\` from \`1.0.0\` to \`1.0.1\` ([#10](${REPO_URL}/pull/10))
+
+## [1.0.0]
+
+### Added
+
+- Initial release ([#1](${REPO_URL}/pull/1))
+
+[Unreleased]: ${REPO_URL}/compare/${TAG_PREFIX}1.0.0...HEAD
+[1.0.0]: ${REPO_URL}/releases/tag/${TAG_PREFIX}1.0.0
+`;
+    const theirContent = baseContent;
+    const ourContent = `# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [2.0.0]
+
+### Changed
+
+- Bump \`@metamask/dep\` from \`1.0.0\` to \`1.0.5\` ([#10](${REPO_URL}/pull/10), [#11](${REPO_URL}/pull/11))
+
+## [1.0.0]
+
+### Added
+
+- Initial release ([#1](${REPO_URL}/pull/1))
+
+[Unreleased]: ${REPO_URL}/compare/${TAG_PREFIX}2.0.0...HEAD
+[2.0.0]: ${REPO_URL}/compare/${TAG_PREFIX}1.0.0...${TAG_PREFIX}2.0.0
+[1.0.0]: ${REPO_URL}/releases/tag/${TAG_PREFIX}1.0.0
+`;
+
+    const { content, mergedEntryCount } = await mergeChangelogs({
+      ourContent,
+      theirContent,
+      baseContent,
+      repoUrl: REPO_URL,
+      tagPrefix: TAG_PREFIX,
+    });
+
+    expect(mergedEntryCount).toBe(0);
+    expect(content.match(/Bump `@metamask\/dep`/gu)).toHaveLength(1);
+    expect(content).toContain('Bump `@metamask/dep` from `1.0.0` to `1.0.5`');
+    expect(content).not.toContain('to `1.0.1`');
+    // Unreleased has nothing to merge in, so it stays empty.
+    expect(content).toMatch(/## \[Unreleased\]\s*\n\n## \[2\.0\.0\]/u);
+  });
+
+  it('still merges a genuinely new entry from theirs when a common ancestor is provided', async () => {
+    const baseContent = buildChangelog('');
+    const theirContent = buildChangelog(
+      `### Added
+
+- Added by theirs, absent from the common ancestor ([#20](${REPO_URL}/pull/20))`,
+    );
+    const ourContent = buildChangelog('');
+
+    const { content, mergedEntryCount } = await mergeChangelogs({
+      ourContent,
+      theirContent,
+      baseContent,
+      repoUrl: REPO_URL,
+      tagPrefix: TAG_PREFIX,
+    });
+
+    expect(mergedEntryCount).toBe(1);
+    expect(content).toContain(
+      'Added by theirs, absent from the common ancestor',
+    );
+  });
+
+  it('falls back to a two-way union when the common ancestor is unparseable', async () => {
+    const { content, mergedEntryCount } = await mergeChangelogs({
+      ourContent: buildChangelog(''),
+      theirContent: buildChangelog(
+        `### Added
+
+- Added by theirs ([#20](${REPO_URL}/pull/20))`,
+      ),
+      baseContent: 'this is not a valid changelog',
+      repoUrl: REPO_URL,
+      tagPrefix: TAG_PREFIX,
+    });
+
+    expect(mergedEntryCount).toBe(1);
+    expect(content).toContain('Added by theirs');
+  });
 });
 
 describe('findConflictedChangelogFiles', () => {
@@ -607,6 +752,9 @@ describe('resolveChangelogConflicts', () => {
         if (args[0] === 'show' && args[1] === `:3:${changelogPath}`) {
           return { stdout: theirsContent };
         }
+        if (args[0] === 'show' && args[1] === `:1:${changelogPath}`) {
+          return { stdout: buildChangelog('') };
+        }
         if (args[0] === 'add') {
           return { stdout: '' };
         }
@@ -635,6 +783,113 @@ describe('resolveChangelogConflicts', () => {
     );
   });
 
+  it('does not re-add an entry theirs inherited unchanged from the common ancestor', async () => {
+    // End-to-end version of the mergeChangelogs regression test above,
+    // proving the common ancestor is actually fetched and used.
+    const changelogPath = 'packages/example/CHANGELOG.md';
+    const baseContent = buildChangelog(
+      `### Changed
+
+- Bump \`dep\` from \`1.0.0\` to \`1.0.1\` ([#10](${REPO_URL}/pull/10))`,
+    );
+    const oursContent = buildChangelog(
+      `### Changed
+
+- Bump \`dep\` from \`1.0.0\` to \`1.0.5\` ([#10](${REPO_URL}/pull/10), [#11](${REPO_URL}/pull/11))`,
+    );
+    const theirsContent = baseContent;
+
+    (execa as unknown as jest.Mock).mockImplementation(
+      async (command: string, args: string[]) => {
+        if (args[0] === 'diff') {
+          return { stdout: changelogPath };
+        }
+        if (args[0] === 'show' && args[1] === `:1:${changelogPath}`) {
+          return { stdout: baseContent };
+        }
+        if (args[0] === 'show' && args[1] === `:2:${changelogPath}`) {
+          return { stdout: oursContent };
+        }
+        if (args[0] === 'show' && args[1] === `:3:${changelogPath}`) {
+          return { stdout: theirsContent };
+        }
+        if (args[0] === 'add') {
+          return { stdout: '' };
+        }
+        throw new Error(`Unexpected execa call: ${command} ${args.join(' ')}`);
+      },
+    );
+
+    jest.spyOn(fs, 'readFile').mockResolvedValue(
+      JSON.stringify({
+        name: '@metamask/example',
+        repository: { type: 'git', url: `${REPO_URL}.git` },
+      }),
+    );
+    jest.spyOn(fs, 'writeFile').mockResolvedValue();
+
+    const result = await resolveChangelogConflicts();
+
+    expect(result.resolved).toStrictEqual([
+      { path: changelogPath, mergedEntryCount: 0 },
+    ]);
+    const [, writtenContent] = (fs.writeFile as jest.Mock).mock.calls[0];
+    expect(writtenContent.match(/Bump `dep`/gu)).toHaveLength(1);
+    expect(writtenContent).toContain('Bump `dep` from `1.0.0` to `1.0.5`');
+  });
+
+  it('tolerates a missing common ancestor (e.g. both sides added the file)', async () => {
+    const changelogPath = 'packages/example/CHANGELOG.md';
+    const oursContent = buildChangelog('');
+    const theirsContent = buildChangelog(
+      `### Added
+
+- Added theirs entry ([#11](${REPO_URL}/pull/11))`,
+    );
+
+    (execa as unknown as jest.Mock).mockImplementation(
+      async (command: string, args: string[]) => {
+        if (args[0] === 'diff') {
+          return { stdout: changelogPath };
+        }
+        if (args[0] === 'show' && args[1] === `:1:${changelogPath}`) {
+          throw new Error(
+            'path exists on disk, but not in the index at stage 1',
+          );
+        }
+        if (args[0] === 'show' && args[1] === `:2:${changelogPath}`) {
+          return { stdout: oursContent };
+        }
+        if (args[0] === 'show' && args[1] === `:3:${changelogPath}`) {
+          return { stdout: theirsContent };
+        }
+        if (args[0] === 'add') {
+          return { stdout: '' };
+        }
+        throw new Error(`Unexpected execa call: ${command} ${args.join(' ')}`);
+      },
+    );
+
+    jest.spyOn(fs, 'readFile').mockResolvedValue(
+      JSON.stringify({
+        name: '@metamask/example',
+        repository: { type: 'git', url: `${REPO_URL}.git` },
+      }),
+    );
+    jest.spyOn(fs, 'writeFile').mockResolvedValue();
+
+    const result = await resolveChangelogConflicts();
+
+    expect(result.resolved).toStrictEqual([
+      { path: changelogPath, mergedEntryCount: 1 },
+    ]);
+    expect(fs.writeFile).toHaveBeenCalledWith(
+      expect.stringContaining(changelogPath),
+      expect.stringContaining('Added theirs entry'),
+      'utf8',
+    );
+  });
+
   it('skips a file that cannot be parsed and leaves it unresolved', async () => {
     const changelogPath = 'packages/example/CHANGELOG.md';
 
@@ -647,6 +902,9 @@ describe('resolveChangelogConflicts', () => {
           return { stdout: 'this is not a valid changelog' };
         }
         if (args[0] === 'show' && args[1] === `:3:${changelogPath}`) {
+          return { stdout: buildChangelog('') };
+        }
+        if (args[0] === 'show' && args[1] === `:1:${changelogPath}`) {
           return { stdout: buildChangelog('') };
         }
         throw new Error(`Unexpected execa call: ${command} ${args.join(' ')}`);

--- a/scripts/lib/changelog-conflicts.ts
+++ b/scripts/lib/changelog-conflicts.ts
@@ -196,97 +196,162 @@ function getChangeKey(change: Change): string {
 }
 
 /**
- * Merge new entries from `incoming` into `base`, mutating `base` in place.
- * Breaking changes are inserted below any existing leading breaking changes;
- * other changes are appended to the end. Relative order within `incoming` is
- * preserved.
+ * Merge entries from `theirChanges` into `ourChanges`, mutating `ourChanges`
+ * in place. An entry only counts as new if it's absent from *both*
+ * `ourChanges` and `baseChanges` (the common ancestor) — an entry `theirs`
+ * merely inherited unchanged from the common ancestor is not "their" change,
+ * so it's never re-added even if `ours` has since evolved past it (e.g. a
+ * dependency bump entry that's since been bumped further on `ours`). New
+ * breaking changes are inserted below any existing leading breaking changes;
+ * other changes are appended to the end. Relative order within
+ * `theirChanges` is preserved.
  *
- * @param baseChanges - The category's changes to merge into.
- * @param incomingChanges - The category's changes to merge from.
- * @returns The number of new entries added to `base`.
+ * @param ourChanges - The category's changes to merge into.
+ * @param theirChanges - The category's changes to merge from.
+ * @param baseChanges - The category's changes at the common ancestor, used
+ * to tell which of `theirChanges` are actually new.
+ * @returns The number of new entries added to `ourChanges`.
  */
 function mergeCategoryEntries(
+  ourChanges: Change[],
+  theirChanges: Change[],
   baseChanges: Change[],
-  incomingChanges: Change[],
 ): number {
-  const initialLength = baseChanges.length;
-  const existingKeys = new Set(baseChanges.map(getChangeKey));
+  const initialLength = ourChanges.length;
+  const ourKeys = new Set(ourChanges.map(getChangeKey));
+  const baseKeys = new Set(baseChanges.map(getChangeKey));
 
-  for (const change of incomingChanges) {
+  for (const change of theirChanges) {
     const key = getChangeKey(change);
-    if (existingKeys.has(key)) {
+    if (ourKeys.has(key) || baseKeys.has(key)) {
       continue;
     }
 
-    existingKeys.add(key);
+    ourKeys.add(key);
 
     if (isBreakingChange(change)) {
-      const firstNonBreakingIndex = baseChanges.findIndex(
+      const firstNonBreakingIndex = ourChanges.findIndex(
         (entry) => !isBreakingChange(entry),
       );
 
       const insertIndex =
         firstNonBreakingIndex === -1
-          ? baseChanges.length
+          ? ourChanges.length
           : firstNonBreakingIndex;
 
-      baseChanges.splice(insertIndex, 0, change);
+      ourChanges.splice(insertIndex, 0, change);
     } else {
-      baseChanges.push(change);
+      ourChanges.push(change);
     }
   }
 
-  return baseChanges.length - initialLength;
+  return ourChanges.length - initialLength;
 }
 
 /**
- * Merge new entries from `incoming` into `base` across every category
- * present on either side, mutating `base` in place.
+ * Merge entries from `theirReleaseChanges` into `ourReleaseChanges` across
+ * every category `theirs` has entries in, mutating `ourReleaseChanges` in
+ * place.
  *
- * @param baseReleaseChanges - The release's changes (by category) to merge
+ * @param ourReleaseChanges - The release's changes (by category) to merge
  * into.
- * @param incomingReleaseChanges - The release's changes (by category) to merge
+ * @param theirReleaseChanges - The release's changes (by category) to merge
  * from.
- * @returns The number of new entries added to `base`.
+ * @param baseReleaseChanges - The release's changes (by category) at the
+ * common ancestor, used to tell which of `theirReleaseChanges` are actually
+ * new.
+ * @returns The number of new entries added to `ourReleaseChanges`.
  */
 function mergeReleaseChanges(
+  ourReleaseChanges: ReleaseChanges,
+  theirReleaseChanges: ReleaseChanges,
   baseReleaseChanges: ReleaseChanges,
-  incomingReleaseChanges: ReleaseChanges,
 ): number {
   let addedEntriesCount = 0;
   const categories = new Set([
-    ...Object.keys(baseReleaseChanges),
-    ...Object.keys(incomingReleaseChanges),
+    ...Object.keys(ourReleaseChanges),
+    ...Object.keys(theirReleaseChanges),
   ]) as Set<Category>;
 
   for (const category of categories) {
-    const incomingEntries = incomingReleaseChanges[category] ?? [];
-    if (incomingEntries.length === 0) {
+    const theirEntries = theirReleaseChanges[category] ?? [];
+    if (theirEntries.length === 0) {
       continue;
     }
 
-    baseReleaseChanges[category] ??= [];
+    const categoryAlreadyExisted = category in ourReleaseChanges;
+    ourReleaseChanges[category] ??= [];
 
+    const ourCategoryChanges = ourReleaseChanges[category] as Change[];
     addedEntriesCount += mergeCategoryEntries(
-      baseReleaseChanges[category] as Change[],
-      incomingEntries,
+      ourCategoryChanges,
+      theirEntries,
+      baseReleaseChanges[category] ?? [],
     );
+
+    // Avoid leaving behind an empty category header (e.g. `### Changed`)
+    // when every one of `theirEntries` turned out to already be present.
+    if (!categoryAlreadyExisted && ourCategoryChanges.length === 0) {
+      delete ourReleaseChanges[category];
+    }
   }
 
   return addedEntriesCount;
 }
 
 /**
- * Merge two conflicting versions of a changelog by taking the union of their
- * entries: every entry unique to either side is kept, deduplicated by PR
- * number and description together, with new `**BREAKING:**` entries placed
- * below existing breaking entries and other new entries appended.
+ * Parse the changelog content at the common ancestor ("merge base"), so that
+ * only entries `theirs` actually added since diverging count as new. Parse
+ * failures and a missing/absent `baseContent` (e.g. the file didn't exist at
+ * the common ancestor) are tolerated by returning `undefined`, which callers
+ * treat as "no known common ancestor" — falling back to a plain two-way
+ * union of `ours` and `theirs`.
+ *
+ * @param baseContent - The changelog content at the common ancestor, if any.
+ * @param repoUrl - The GitHub repository URL for the package.
+ * @param tagPrefix - The changelog tag prefix for the package.
+ * @returns The parsed changelog, or `undefined` if unavailable/unparseable.
+ */
+function parseBaseChangelog(
+  baseContent: string | undefined,
+  repoUrl: string,
+  tagPrefix: string,
+): ReturnType<typeof parseChangelog> | undefined {
+  if (baseContent === undefined) {
+    return undefined;
+  }
+
+  try {
+    return parseChangelog({
+      changelogContent: baseContent,
+      repoUrl,
+      tagPrefix,
+      shouldExtractPrLinks: true,
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Merge two conflicting versions of a changelog via a proper three-way
+ * merge: only entries `theirs` actually added since the common ancestor
+ * (`baseContent`) are merged into `ours`, deduplicated against `ours` by PR
+ * number and description together. This means an entry `theirs` merely
+ * inherited unchanged from the common ancestor is never re-added, even if
+ * `ours` has since evolved past it (e.g. a dependency bump entry that's
+ * since been bumped further on `ours`) — avoiding the duplicate entries a
+ * plain two-way union would produce. New `**BREAKING:**` entries are placed
+ * below existing breaking entries; other new entries are appended.
  *
  * @param options - Options.
  * @param options.ourContent - The changelog content on the "ours" conflict
  * side.
  * @param options.theirContent - The changelog content on the "theirs"
  * conflict side.
+ * @param options.baseContent - The changelog content at the common
+ * ancestor ("merge base"), if available. Without it, this falls back to a
+ * plain two-way union of `ours` and `theirs`.
  * @param options.repoUrl - The GitHub repository URL for the package.
  * @param options.tagPrefix - The changelog tag prefix for the package.
  * @param options.packageRename - The package's rename properties, if it was
@@ -299,12 +364,14 @@ function mergeReleaseChanges(
 export async function mergeChangelogs({
   ourContent,
   theirContent,
+  baseContent,
   repoUrl,
   tagPrefix,
   packageRename,
 }: {
   ourContent: string;
   theirContent: string;
+  baseContent?: string;
   repoUrl: string;
   tagPrefix: string;
   packageRename?: PackageRename;
@@ -331,9 +398,12 @@ export async function mergeChangelogs({
     shouldExtractPrLinks: true,
   });
 
+  const baseChangelog = parseBaseChangelog(baseContent, repoUrl, tagPrefix);
+
   let mergedEntryCount = mergeReleaseChanges(
     ourChangelog.getUnreleasedChanges(),
     theirChangelog.getUnreleasedChanges(),
+    baseChangelog?.getUnreleasedChanges() ?? {},
   );
 
   const oursVersions = new Set(
@@ -363,10 +433,14 @@ export async function mergeChangelogs({
     const theirReleaseChanges = theirChangelog.getReleaseChanges(
       theirRelease.version,
     );
+    const baseReleaseChanges = baseChangelog?.getReleaseChanges(
+      theirRelease.version,
+    );
 
     mergedEntryCount += mergeReleaseChanges(
       ourReleaseChanges,
       theirReleaseChanges ?? {},
+      baseReleaseChanges ?? {},
     );
   }
 
@@ -396,16 +470,22 @@ export async function resolveChangelogConflicts(): Promise<ConflictResolutionRes
       const [
         oursContent,
         theirsContent,
+        baseContent,
         { repoUrl, tagPrefix, packageRename },
       ] = await Promise.all([
         readGitBlob(':2', changelogPath),
         readGitBlob(':3', changelogPath),
+        // Stage 1 (the common ancestor) doesn't exist if, e.g., both sides
+        // added the file independently — tolerate that and fall back to a
+        // two-way union in `mergeChangelogs`.
+        readGitBlob(':1', changelogPath).catch(() => undefined),
         resolvePackageMetadata(changelogPath),
       ]);
 
       const { content, mergedEntryCount } = await mergeChangelogs({
         ourContent: oursContent,
         theirContent: theirsContent,
+        baseContent,
         repoUrl,
         tagPrefix,
         packageRename,


### PR DESCRIPTION
## Explanation

`scripts/merge-changelog-conflicts.ts` (added in #9994) resolves Git merge conflicts in `packages/*/CHANGELOG.md` by taking the union of entries added on each side of the conflict. It worked by diffing `ours` and `theirs` directly, which can't distinguish a genuinely new entry from one `theirs` merely inherited unchanged from before the branches diverged.

In practice, this showed up as duplicate dependency-bump entries: if a dependency was bumped further on `ours` after a branch diverged (e.g. main regularly bumps the same dependency's target version), the branch's stale entry no longer matched the updated one by key, so it got wrongly re-added, duplicating the entry — even after the underlying PR had already been merged and released.

This PR fixes that by fetching the Git merge base (`git show :1:<path>`, the common ancestor) alongside the two conflict sides, and only merging entries `theirs` actually added _since_ that common ancestor — a proper three-way merge instead of a two-way union. An entry `theirs` inherited unchanged from the common ancestor is never re-added, even if `ours` has since evolved past it (in a different category or even after being released into a version section). When the common ancestor is unavailable (e.g. both sides added the file independently) or unparseable, it falls back to the previous two-way union behaviour.

It also fixes a small cosmetic issue this change surfaced: an empty category header (e.g. `### Changed`) could be left behind in `Unreleased` when every entry `theirs` contributed turned out to already be present.

## References

- Related to #9994

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to internal changelog merge tooling and release automation scripts, with broad test coverage and safe fallback when the merge base is unavailable.
> 
> **Overview**
> **Changelog conflict resolution** now performs a **three-way merge** instead of unioning `ours` and `theirs` only. `resolveChangelogConflicts` reads the common ancestor via `git show :1:<path>` (optional) and passes it to `mergeChangelogs` as `baseContent`.
> 
> Only entries **theirs actually added since the merge base** are merged into `ours`. Entries unchanged from the ancestor are skipped even when `ours` has evolved them (e.g. further dependency bumps) or moved them into a release section—fixing duplicate bump lines on long-lived branches. Missing or unparseable merge-base content **falls back** to the previous two-way union.
> 
> `mergeCategoryEntries` / `mergeReleaseChanges` dedupe against both `ours` and base keys. Empty `### Category` headers are removed when all of theirs’ entries were already present.
> 
> Tests cover regression cases, genuine new entries with a base, unparseable base fallback, and end-to-end `resolveChangelogConflicts` (including missing stage 1).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbc503329d05c21df50a7aa543a628d1c8686a70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->