### PR TITLE
fix(notification-services-controller): stop gating wallet activity notifications using AUS config

### DIFF
--- a/packages/notification-services-controller/CHANGELOG.md
+++ b/packages/notification-services-controller/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Wallet-activity notifications are no longer suppressed by the `walletActivity.inAppNotificationsEnabled` and `walletActivity.pushNotificationsEnabled` toggles in Authenticated User Storage ([#10113](https://github.com/MetaMask/core/pull/10113))
+  - Both channels are now always enabled and delivery is controlled exclusively by each address's Trigger API subscription, so a stored `false` can no longer leave a subscribed address without notifications. Clients no longer expose a way to change these toggles, which made a stored `false` unrecoverable.
+  - `enablePushNotifications` no longer unregisters the device when the stored push toggle is off, `createOnChainTriggers` no longer registers an empty address list for the same reason, and `fetchAndUpdateMetamaskNotifications` no longer skips the on-chain fetch when the stored in-app toggle is off.
+  - The fields are still written when initializing a fresh preferences blob, because the Authenticated User Storage schema requires them. Nothing reads them back.
+
 ## [27.0.0]
 
 ### Changed

--- a/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.test.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.test.ts
@@ -1100,12 +1100,8 @@ describe('NotificationServicesController', () => {
         expect(mockEnablePushNotifications).not.toHaveBeenCalled();
       });
 
-      it('does not register push notifications when the wallet-activity push toggle is off', async () => {
-        const {
-          messenger,
-          mockDisablePushNotifications,
-          mockEnablePushNotifications,
-        } = arrangeMocks({
+      it('ignores the legacy wallet-activity push toggle when registering push notifications', async () => {
+        const { messenger, mockEnablePushNotifications } = arrangeMocks({
           configurePrefs: (mock) =>
             mock.mockResolvedValueOnce(
               mockPreferences({
@@ -1127,9 +1123,8 @@ describe('NotificationServicesController', () => {
         await controller.createOnChainTriggers();
 
         await waitFor(() => {
-          expect(mockDisablePushNotifications).toHaveBeenCalled();
+          expect(mockEnablePushNotifications).toHaveBeenCalled();
         });
-        expect(mockEnablePushNotifications).not.toHaveBeenCalled();
       });
 
       it('preserves user preferences when re-subscribing using enableMetamaskNotifications', async () => {
@@ -1468,7 +1463,7 @@ describe('NotificationServicesController', () => {
       expect(mocks.mockFeatureAnnouncementsAPI.isDone()).toBe(false);
     });
 
-    it('should not fetch wallet notifications if AUS wallet-activity in-app notifications are disabled', async () => {
+    it('ignores the legacy wallet-activity in-app toggle when fetching wallet notifications', async () => {
       const { messenger, ...mocks } = arrangeMocks();
       mocks.mockGetNotificationPreferences.mockResolvedValue(
         mockPreferences({
@@ -1491,8 +1486,8 @@ describe('NotificationServicesController', () => {
         result.filter(
           (notification) => notification.type === TRIGGER_TYPES.ETH_SENT,
         ),
-      ).toHaveLength(0);
-      expect(mocks.mockOnChainNotificationsAPI.isDone()).toBe(false);
+      ).toHaveLength(1);
+      expect(mocks.mockOnChainNotificationsAPI.isDone()).toBe(true);
 
       // The wallet-activity toggle must not affect other notification types.
       expect(mocks.mockFeatureAnnouncementsAPI.isDone()).toBe(true);
@@ -2002,7 +1997,7 @@ describe('NotificationServicesController', () => {
       await controller.enablePushNotifications();
 
       // Assert
-      expect(mockGetConfig).toHaveBeenCalled();
+      expect(mockGetConfig).not.toHaveBeenCalled();
       expect(mockEnablePushNotifications).toHaveBeenCalledWith([
         ADDRESS_1.toLowerCase(),
       ]);
@@ -2059,7 +2054,7 @@ describe('NotificationServicesController', () => {
       expect(mockEnablePushNotifications).not.toHaveBeenCalled();
     });
 
-    it('unregisters the device when the wallet-activity push toggle is off', async () => {
+    it('ignores the legacy wallet-activity push toggle and uses Trigger API subscriptions', async () => {
       const {
         messenger,
         mockGetConfig,
@@ -2076,6 +2071,10 @@ describe('NotificationServicesController', () => {
           },
         }),
       );
+      mockGetOnChainNotificationsConfig({
+        status: 200,
+        body: [{ address: ADDRESS_1.toLowerCase(), enabled: true }],
+      });
       const controller = new NotificationServicesController({
         messenger,
         env: { featureAnnouncements: featureAnnouncementsEnv },
@@ -2084,8 +2083,11 @@ describe('NotificationServicesController', () => {
 
       await controller.enablePushNotifications();
 
-      expect(mockDisablePushNotifications).toHaveBeenCalled();
-      expect(mockEnablePushNotifications).not.toHaveBeenCalled();
+      expect(mockGetConfig).not.toHaveBeenCalled();
+      expect(mockDisablePushNotifications).not.toHaveBeenCalled();
+      expect(mockEnablePushNotifications).toHaveBeenCalledWith([
+        ADDRESS_1.toLowerCase(),
+      ]);
     });
 
     it('handles errors gracefully when fetching the bearer token fails', async () => {

--- a/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.ts
@@ -287,13 +287,14 @@ const getEnabledAccounts = async (
 
 /**
  * Builds a fresh `NotificationPreferences` blob using hardcoded defaults for
- * Perps, Social AI, and Agentic CLI and the user's marketing/product-announcement
- * flags.
+ * Perps, Social AI, and Agentic CLI and the user's
+ * marketing/product-announcement flags.
  *
- * `walletActivity.accounts` is deliberately left empty. Addresses are scoped to a
- * keyring, but this blob is keyed by canonical profile ID, which pairing shares
- * across every SRP belonging to the same user — so storing them here pools the
- * addresses of unrelated SRPs. Subscriptions live in the Trigger API instead.
+ * `walletActivity` is written only because the blob schema requires the field;
+ * nothing reads it back. Both channels are always on, and subscriptions are
+ * held per address by the Trigger API rather than here — addresses are scoped
+ * to a keyring, but this blob is keyed by canonical profile ID, which pairing
+ * shares across every SRP belonging to the same user.
  *
  * @param hasMarketingConsent - Whether marketing push notifications should be enabled.
  * @param productAnnouncementEnabled - Whether marketing in-app notifications should be enabled.
@@ -809,29 +810,6 @@ export class NotificationServicesController extends BaseController<
   }
 
   /**
-   * Reads the global wallet-activity push toggle from
-   * {@link AuthenticatedUserStorageService}.
-   *
-   * Only the channel boolean is read. It is a user-level setting that contains
-   * no addresses, so sharing it across a paired profile is correct. The address
-   * list in the same blob is deliberately ignored — see
-   * {@link buildFreshPreferences}.
-   *
-   * A missing or unreadable blob counts as enabled, matching the API's "every
-   * toggle is on unless stated otherwise" default, so that a storage outage does
-   * not silently stop notifications.
-   *
-   * @returns Whether wallet-activity push notifications are enabled.
-   */
-  async #isWalletActivityPushEnabled(): Promise<boolean> {
-    const preferences = await this.messenger
-      .call('AuthenticatedUserStorageService:getNotificationPreferences')
-      .catch(() => null);
-
-    return preferences?.walletActivity.pushNotificationsEnabled ?? true;
-  }
-
-  /**
    * Registers this device for push notifications on the given addresses.
    *
    * An empty list cannot be sent: the push API rejects a registration with no
@@ -934,11 +912,6 @@ export class NotificationServicesController extends BaseController<
    */
   public async enablePushNotifications(): Promise<void> {
     try {
-      if (!(await this.#isWalletActivityPushEnabled())) {
-        await this.#pushNotifications.disablePushNotifications();
-        return;
-      }
-
       const { bearerToken } = await this.#getBearerToken();
       const { accounts } = this.#accounts.listAccounts();
       const enabledAddresses = await getEnabledAccounts(
@@ -1069,9 +1042,6 @@ export class NotificationServicesController extends BaseController<
 
       const isFirstTimeSetup = preferences === null;
 
-      const isPushEnabled =
-        preferences?.walletActivity.pushNotificationsEnabled ?? true;
-
       // 2. Subscribe the keyring's accounts on first-time setup only.
       //
       // This method also runs on the daily re-subscribe, so the absence of a
@@ -1127,9 +1097,7 @@ export class NotificationServicesController extends BaseController<
 
       if (opts.registerPushNotifications ?? true) {
         // Attempt FCM/device registration only; clients must request OS permission separately.
-        this.#registerPushNotifications(
-          isPushEnabled ? accountsWithNotifications : [],
-        ).catch(() => {
+        this.#registerPushNotifications(accountsWithNotifications).catch(() => {
           // Do Nothing
         });
       }
@@ -1315,10 +1283,7 @@ export class NotificationServicesController extends BaseController<
 
       // Raw On Chain Notifications
       const rawOnChainNotifications: NormalisedAPINotification[] = [];
-      const isWalletActivityInAppEnabled =
-        notificationPreferences?.walletActivity.inAppNotificationsEnabled ??
-        true;
-      if (isGlobalNotifsEnabled && isWalletActivityInAppEnabled) {
+      if (isGlobalNotifsEnabled) {
         try {
           const { bearerToken } = await this.#getBearerToken();
           // Addresses come from the keyring, so this installation can only ever


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

We're moving away from AUS as source of truth for wallet activity notification preferences. While https://github.com/MetaMask/core/pull/9985 handled most changes we missed a bug with it related to users who had disabled notifications. We should no longer be gating notification subscritions using AUS channel toggles and rely solely on the per-account config on Trigger API.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [x] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when wallet-activity notifications are delivered for users with legacy AUS `false` values, but behavior now matches Trigger API subscriptions and fixes silent suppression bugs.
> 
> **Overview**
> **Wallet-activity in-app and push delivery no longer honor legacy Authenticated User Storage channel toggles** (`walletActivity.inAppNotificationsEnabled` / `pushNotificationsEnabled`). Per-address **Trigger API** subscriptions are now the only gate, fixing users stuck with a stored `false` after clients removed UI to change those flags.
> 
> **`enablePushNotifications`** no longer reads AUS or unregisters the device when the stored push toggle is off; it registers using Trigger-enabled addresses only. **`createOnChainTriggers`** always passes the real subscribed address list to push registration instead of an empty list when the push toggle was off. **`fetchAndUpdateMetamaskNotifications`** fetches on-chain notifications whenever global notifications are on, without checking the in-app wallet-activity toggle.
> 
> The private **`#isWalletActivityPushEnabled`** helper is removed. Fresh preference blobs still **write** default `walletActivity` fields for schema compliance, but nothing reads them back. Tests and changelog are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9c906322c13b3df3e32e7a792593e22e9b57cea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->