### PR TITLE
Preserve api-docs/ (not docs/) for Typedoc-generated directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,10 +17,10 @@ preview-build-message.txt
 
 examples/*/coverage
 examples/*/dist
-examples/*/docs
+examples/*/api-docs
 packages/*/coverage
 packages/*/dist
-packages/*/docs
+packages/*/api-docs
 scripts/coverage
 
 # yarn v3 (w/o zero-install)

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -59,7 +59,7 @@ const config = createConfig([
       '**/.tsc-lint-cache',
       '**/coverage/**',
       '**/dist/**',
-      '**/docs/**',
+      '**/api-docs/**',
       '.platform-api-docs/**',
       '.skills-cache/**',
       '.yarn/**',

--- a/packages/account-tree-controller/typedoc.json
+++ b/packages/account-tree-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/accounts-controller/typedoc.json
+++ b/packages/accounts-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/address-book-controller/typedoc.json
+++ b/packages/address-book-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/ai-controllers/typedoc.json
+++ b/packages/ai-controllers/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/analytics-controller/typedoc.json
+++ b/packages/analytics-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/analytics-data-regulation-controller/typedoc.json
+++ b/packages/analytics-data-regulation-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/announcement-controller/typedoc.json
+++ b/packages/announcement-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/app-metadata-controller/typedoc.json
+++ b/packages/app-metadata-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/approval-controller/typedoc.json
+++ b/packages/approval-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/assets-controller/typedoc.json
+++ b/packages/assets-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/assets-controllers/typedoc.json
+++ b/packages/assets-controllers/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/authenticated-user-storage/typedoc.json
+++ b/packages/authenticated-user-storage/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/base-controller/typedoc.json
+++ b/packages/base-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/base-data-service/typedoc.json
+++ b/packages/base-data-service/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/bitcoin-regtest-up/typedoc.json
+++ b/packages/bitcoin-regtest-up/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/bridge-controller/typedoc.json
+++ b/packages/bridge-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/bridge-status-controller/typedoc.json
+++ b/packages/bridge-status-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/build-utils/typedoc.json
+++ b/packages/build-utils/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/chain-agnostic-permission/typedoc.json
+++ b/packages/chain-agnostic-permission/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/chomp-api-service/typedoc.json
+++ b/packages/chomp-api-service/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/claims-controller/typedoc.json
+++ b/packages/claims-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/client-controller/typedoc.json
+++ b/packages/client-controller/typedoc.json
@@ -2,7 +2,7 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "plugin": ["typedoc-plugin-missing-exports"],
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/client-utils/typedoc.json
+++ b/packages/client-utils/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/compliance-controller/typedoc.json
+++ b/packages/compliance-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/composable-controller/typedoc.json
+++ b/packages/composable-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/config-registry-controller/typedoc.json
+++ b/packages/config-registry-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/connectivity-controller/typedoc.json
+++ b/packages/connectivity-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/controller-utils/typedoc.json
+++ b/packages/controller-utils/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/core-backend/docs/real-time-balance-updates-flow.md
+++ b/packages/core-backend/docs/real-time-balance-updates-flow.md
@@ -198,12 +198,10 @@ The TokenBalancesController implements intelligent polling that adapts based on 
 To prevent excessive HTTP calls during unstable connections:
 
 1. **Accumulation Window**: 5 seconds
-
    - All status changes within this window are accumulated
    - Latest status wins for each chain
 
 2. **Jitter Addition**: Random delay (0 to default interval)
-
    - Prevents synchronized requests across multiple instances
    - Reduces backend load spikes
 

--- a/packages/core-backend/typedoc.json
+++ b/packages/core-backend/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/cryptography/typedoc.json
+++ b/packages/cryptography/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/delegation-controller/typedoc.json
+++ b/packages/delegation-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/earn-controller/typedoc.json
+++ b/packages/earn-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/eip-5792-middleware/typedoc.json
+++ b/packages/eip-5792-middleware/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/eip-7702-internal-rpc-middleware/typedoc.json
+++ b/packages/eip-7702-internal-rpc-middleware/typedoc.json
@@ -1,6 +1,6 @@
 {
   "entryPoints": ["src/index.ts"],
-  "out": "docs",
+  "out": "api-docs",
   "exclude": ["**/*.test.ts"],
   "excludeExternals": true,
   "excludePrivate": true,

--- a/packages/eip1193-permission-middleware/typedoc.json
+++ b/packages/eip1193-permission-middleware/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/eth-json-rpc-middleware/typedoc.json
+++ b/packages/eth-json-rpc-middleware/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/eth-json-rpc-provider/typedoc.json
+++ b/packages/eth-json-rpc-provider/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/foundryup/typedoc.json
+++ b/packages/foundryup/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/gas-fee-controller/typedoc.json
+++ b/packages/gas-fee-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/gator-permissions-controller/typedoc.json
+++ b/packages/gator-permissions-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/geolocation-controller/typedoc.json
+++ b/packages/geolocation-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/java-tron-up/typedoc.json
+++ b/packages/java-tron-up/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/json-rpc-engine/typedoc.json
+++ b/packages/json-rpc-engine/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/json-rpc-middleware-stream/typedoc.json
+++ b/packages/json-rpc-middleware-stream/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/keyring-controller/typedoc.json
+++ b/packages/keyring-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/kyc-controller/typedoc.json
+++ b/packages/kyc-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/local-node-utils/typedoc.json
+++ b/packages/local-node-utils/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/logging-controller/typedoc.json
+++ b/packages/logging-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/message-manager/typedoc.json
+++ b/packages/message-manager/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/messenger/typedoc.json
+++ b/packages/messenger/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/money-account-api-data-service/typedoc.json
+++ b/packages/money-account-api-data-service/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/money-account-balance-service/typedoc.json
+++ b/packages/money-account-balance-service/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/money-account-controller/typedoc.json
+++ b/packages/money-account-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/money-account-upgrade-controller/typedoc.json
+++ b/packages/money-account-upgrade-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/money-account-utils/typedoc.json
+++ b/packages/money-account-utils/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/multichain-account-service/typedoc.json
+++ b/packages/multichain-account-service/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/multichain-api-middleware/typedoc.json
+++ b/packages/multichain-api-middleware/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/multichain-network-controller/typedoc.json
+++ b/packages/multichain-network-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/multichain-transactions-controller/typedoc.json
+++ b/packages/multichain-transactions-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/name-controller/typedoc.json
+++ b/packages/name-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/network-connection-banner-controller/typedoc.json
+++ b/packages/network-connection-banner-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/network-controller/typedoc.json
+++ b/packages/network-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/network-enablement-controller/typedoc.json
+++ b/packages/network-enablement-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/notification-services-controller/typedoc.json
+++ b/packages/notification-services-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/passkey-controller/typedoc.json
+++ b/packages/passkey-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/permission-controller/typedoc.json
+++ b/packages/permission-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/permission-log-controller/typedoc.json
+++ b/packages/permission-log-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/perps-controller/typedoc.json
+++ b/packages/perps-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/phishing-controller/typedoc.json
+++ b/packages/phishing-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/polling-controller/typedoc.json
+++ b/packages/polling-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/preferences-controller/typedoc.json
+++ b/packages/preferences-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/profile-metrics-controller/typedoc.json
+++ b/packages/profile-metrics-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/profile-sync-controller/typedoc.json
+++ b/packages/profile-sync-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/ramps-controller/typedoc.json
+++ b/packages/ramps-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/rate-limit-controller/typedoc.json
+++ b/packages/rate-limit-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/react-data-query/typedoc.json
+++ b/packages/react-data-query/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/remote-feature-flag-controller/typedoc.json
+++ b/packages/remote-feature-flag-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/sample-controllers/typedoc.json
+++ b/packages/sample-controllers/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/seedless-onboarding-controller/typedoc.json
+++ b/packages/seedless-onboarding-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/selected-network-controller/typedoc.json
+++ b/packages/selected-network-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/sentinel-api-service/typedoc.json
+++ b/packages/sentinel-api-service/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/shield-controller/typedoc.json
+++ b/packages/shield-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/signature-controller/typedoc.json
+++ b/packages/signature-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/smart-transactions-controller/typedoc.json
+++ b/packages/smart-transactions-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/snap-account-service/typedoc.json
+++ b/packages/snap-account-service/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/social-controllers/typedoc.json
+++ b/packages/social-controllers/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/solana-test-validator-up/typedoc.json
+++ b/packages/solana-test-validator-up/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/stellar-quickstart-up/typedoc.json
+++ b/packages/stellar-quickstart-up/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/storage-service/typedoc.json
+++ b/packages/storage-service/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/subscription-controller/typedoc.json
+++ b/packages/subscription-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/transaction-controller/typedoc.json
+++ b/packages/transaction-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/transaction-pay-controller/typedoc.json
+++ b/packages/transaction-pay-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/user-operation-controller/typedoc.json
+++ b/packages/user-operation-controller/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/wallet-framework-docs/typedoc.json
+++ b/packages/wallet-framework-docs/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/packages/wallet/typedoc.json
+++ b/packages/wallet/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }

--- a/scripts/create-package/package-template/typedoc.json
+++ b/scripts/create-package/package-template/typedoc.json
@@ -2,6 +2,6 @@
   "entryPoints": ["./src/index.ts"],
   "excludePrivate": true,
   "hideGenerator": true,
-  "out": "docs",
+  "out": "api-docs",
   "tsconfig": "./tsconfig.build.json"
 }


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

We want to use `docs/` for human-generated package-level documentation, but currently it is being gitignored. This directory path was preserved for Typedoc-generated documentation, so rename that to `api-docs/`.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling and ignore-path changes only; no runtime behavior. Anyone or CI still expecting Typedoc under `packages/*/docs` must switch to `api-docs`.
> 
> **Overview**
> Typedoc-generated API reference output moves from **`docs/`** to **`api-docs/`** across packages (and the create-package template), so **`docs/`** can be used for human-written package documentation without conflicting with gitignore rules.
> 
> **`.gitignore`** and **`eslint.config.mjs`** now ignore **`examples/*/api-docs`** and **`packages/*/api-docs`** (and ESLint skips **`**/api-docs/**`**) instead of the old **`docs`** paths. Every updated **`typedoc.json`** sets **`"out": "api-docs"`**.
> 
> There is a small whitespace-only tweak in **`packages/core-backend/docs/real-time-balance-updates-flow.md`** (blank lines removed in a numbered list).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd5562e0fa7aa6c3ae34eec1ccc6b9df5d9afb20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->