### PR TITLE
chore: bump `uuid` from `^8.3.2` to `^9.0.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "tsx": "^4.20.5",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
     "typescript-eslint": "^8.48.0",
-    "uuid": "^8.3.2",
+    "uuid": "^9.0.1",
     "yargs": "^17.7.2"
   },
   "resolutions": {

--- a/packages/accounts-controller/CHANGELOG.md
+++ b/packages/accounts-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `uuid` from `^8.3.2` to `^9.0.1` ([#10117](https://github.com/MetaMask/core/pull/10117))
+
 ## [40.0.0]
 
 ### Changed

--- a/packages/accounts-controller/package.json
+++ b/packages/accounts-controller/package.json
@@ -66,7 +66,7 @@
     "ethereum-cryptography": "^2.1.2",
     "immer": "^9.0.6",
     "lodash-es": "^4.17.21",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^6.1.0",

--- a/packages/analytics-controller/CHANGELOG.md
+++ b/packages/analytics-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `uuid` from `^8.3.2` to `^9.0.1` ([#10117](https://github.com/MetaMask/core/pull/10117))
+
 ## [3.0.0]
 
 ### Changed

--- a/packages/analytics-controller/package.json
+++ b/packages/analytics-controller/package.json
@@ -55,12 +55,12 @@
     "@metamask/messenger": "^3.0.0",
     "@metamask/utils": "^11.12.0",
     "lodash-es": "^4.17.21",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^6.1.0",
     "@types/jest": "^30.0.0",
-    "@types/uuid": "^8.3.0",
+    "@types/uuid": "^9.0.8",
     "@typescript/native": "npm:typescript@^7.0.2",
     "deepmerge": "^4.2.2",
     "jest": "^30.4.2",

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `@types/uuid` from `^8.3.0` to `^9.0.8` ([#10117](https://github.com/MetaMask/core/pull/10117))
+- Bump `uuid` from `^8.3.2` to `^9.0.1` ([#10117](https://github.com/MetaMask/core/pull/10117))
+
 ## [112.0.0]
 
 ### Changed

--- a/packages/assets-controllers/package.json
+++ b/packages/assets-controllers/package.json
@@ -87,7 +87,7 @@
     "@metamask/utils": "^11.12.0",
     "@tanstack/query-core": "^5.62.16",
     "@types/bn.js": "^5.1.5",
-    "@types/uuid": "^8.3.0",
+    "@types/uuid": "^9.0.8",
     "async-mutex": "^0.5.0",
     "bitcoin-address-validation": "^2.2.3",
     "bn.js": "^5.2.1",
@@ -96,7 +96,7 @@
     "multiformats": "^9.9.0",
     "reselect": "^5.1.1",
     "single-call-balance-checker-abi": "^1.0.0",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@babel/runtime": "^7.23.9",

--- a/packages/bridge-controller/CHANGELOG.md
+++ b/packages/bridge-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `uuid` from `^8.3.2` to `^9.0.1` ([#10117](https://github.com/MetaMask/core/pull/10117))
+
 ## [81.0.0]
 
 ### Changed

--- a/packages/bridge-controller/package.json
+++ b/packages/bridge-controller/package.json
@@ -73,7 +73,7 @@
     "@metamask/utils": "^11.12.0",
     "bignumber.js": "^9.1.2",
     "reselect": "^5.1.1",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^6.1.0",

--- a/packages/bridge-status-controller/CHANGELOG.md
+++ b/packages/bridge-status-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `uuid` from `^8.3.2` to `^9.0.1` ([#10117](https://github.com/MetaMask/core/pull/10117))
+
 ## [76.0.0]
 
 ### Changed

--- a/packages/bridge-status-controller/package.json
+++ b/packages/bridge-status-controller/package.json
@@ -64,7 +64,7 @@
     "@metamask/transaction-controller": "^70.0.0",
     "@metamask/utils": "^11.12.0",
     "bignumber.js": "^9.1.2",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^6.1.0",

--- a/packages/core-backend/CHANGELOG.md
+++ b/packages/core-backend/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `uuid` from `^8.3.2` to `^9.0.1` ([#10117](https://github.com/MetaMask/core/pull/10117))
+
 ## [10.0.0]
 
 ### Changed

--- a/packages/core-backend/package.json
+++ b/packages/core-backend/package.json
@@ -60,7 +60,7 @@
     "@tanstack/query-core": "^5.62.16",
     "async-mutex": "^0.5.0",
     "cockatiel": "^3.1.2",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^6.1.0",

--- a/packages/eip-5792-middleware/CHANGELOG.md
+++ b/packages/eip-5792-middleware/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `uuid` from `^8.3.2` to `^9.0.1` ([#10117](https://github.com/MetaMask/core/pull/10117))
+
 ## [4.0.0]
 
 ### Changed

--- a/packages/eip-5792-middleware/package.json
+++ b/packages/eip-5792-middleware/package.json
@@ -54,7 +54,7 @@
     "@metamask/transaction-controller": "^70.0.0",
     "@metamask/utils": "^11.12.0",
     "lodash-es": "^4.17.21",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^6.1.0",

--- a/packages/gas-fee-controller/CHANGELOG.md
+++ b/packages/gas-fee-controller/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `@types/uuid` from `^8.3.0` to `^9.0.8` ([#10117](https://github.com/MetaMask/core/pull/10117))
+- Bump `uuid` from `^8.3.2` to `^9.0.1` ([#10117](https://github.com/MetaMask/core/pull/10117))
+
 ## [27.0.0]
 
 ### Changed

--- a/packages/gas-fee-controller/package.json
+++ b/packages/gas-fee-controller/package.json
@@ -59,9 +59,9 @@
     "@metamask/polling-controller": "^17.0.0",
     "@metamask/utils": "^11.12.0",
     "@types/bn.js": "^5.1.5",
-    "@types/uuid": "^8.3.0",
+    "@types/uuid": "^9.0.8",
     "bn.js": "^5.2.1",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@babel/runtime": "^7.23.9",

--- a/packages/keyring-controller/package.json
+++ b/packages/keyring-controller/package.json
@@ -85,7 +85,7 @@
     "typedoc": "^0.25.13",
     "typedoc-plugin-missing-exports": "^2.0.0",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "engines": {
     "node": "^22.14.0 || ^24"

--- a/packages/logging-controller/CHANGELOG.md
+++ b/packages/logging-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `uuid` from `^8.3.2` to `^9.0.1` ([#10117](https://github.com/MetaMask/core/pull/10117))
+
 ## [10.0.0]
 
 ### Changed

--- a/packages/logging-controller/package.json
+++ b/packages/logging-controller/package.json
@@ -53,7 +53,7 @@
     "@metamask/base-controller": "^10.0.0",
     "@metamask/messenger": "^3.0.0",
     "@metamask/utils": "^11.12.0",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^6.1.0",

--- a/packages/message-manager/CHANGELOG.md
+++ b/packages/message-manager/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `@types/uuid` from `^8.3.0` to `^9.0.8` ([#10117](https://github.com/MetaMask/core/pull/10117))
+- Bump `uuid` from `^8.3.2` to `^9.0.1` ([#10117](https://github.com/MetaMask/core/pull/10117))
+
 ## [15.0.0]
 
 ### Changed

--- a/packages/message-manager/package.json
+++ b/packages/message-manager/package.json
@@ -53,9 +53,9 @@
     "@metamask/eth-sig-util": "^9.0.0",
     "@metamask/messenger": "^3.0.0",
     "@metamask/utils": "^11.12.0",
-    "@types/uuid": "^8.3.0",
+    "@types/uuid": "^9.0.8",
     "jsonschema": "^1.4.1",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^6.1.0",

--- a/packages/multichain-account-service/package.json
+++ b/packages/multichain-account-service/package.json
@@ -77,7 +77,7 @@
     "@metamask/eth-hd-keyring": "^15.0.0",
     "@metamask/providers": "^22.1.0",
     "@types/jest": "^30.0.0",
-    "@types/uuid": "^8.3.0",
+    "@types/uuid": "^9.0.8",
     "@typescript/native": "npm:typescript@^7.0.2",
     "deepmerge": "^4.2.2",
     "jest": "^30.4.2",
@@ -87,7 +87,7 @@
     "typedoc": "^0.25.13",
     "typedoc-plugin-missing-exports": "^2.0.0",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
-    "uuid": "^8.3.2",
+    "uuid": "^9.0.1",
     "webextension-polyfill": "^0.12.0"
   },
   "peerDependencies": {

--- a/packages/multichain-network-controller/package.json
+++ b/packages/multichain-network-controller/package.json
@@ -67,7 +67,7 @@
     "@metamask/keyring-controller": "^28.0.0",
     "@types/jest": "^30.0.0",
     "@types/lodash-es": "^4.17.12",
-    "@types/uuid": "^8.3.0",
+    "@types/uuid": "^9.0.8",
     "@typescript/native": "npm:typescript@^7.0.2",
     "deepmerge": "^4.2.2",
     "immer": "^9.0.6",

--- a/packages/multichain-transactions-controller/CHANGELOG.md
+++ b/packages/multichain-transactions-controller/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `@types/uuid` from `^8.3.0` to `^9.0.8` ([#10117](https://github.com/MetaMask/core/pull/10117))
+- Bump `uuid` from `^8.3.2` to `^9.0.1` ([#10117](https://github.com/MetaMask/core/pull/10117))
+
 ## [8.0.0]
 
 ### Changed

--- a/packages/multichain-transactions-controller/package.json
+++ b/packages/multichain-transactions-controller/package.json
@@ -61,9 +61,9 @@
     "@metamask/snaps-sdk": "^11.0.0",
     "@metamask/snaps-utils": "^12.1.2",
     "@metamask/utils": "^11.12.0",
-    "@types/uuid": "^8.3.0",
+    "@types/uuid": "^9.0.8",
     "immer": "^9.0.6",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^6.1.0",

--- a/packages/network-controller/CHANGELOG.md
+++ b/packages/network-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `uuid` from `^8.3.2` to `^9.0.1` ([#10117](https://github.com/MetaMask/core/pull/10117))
+
 ## [37.0.0]
 
 ### Changed

--- a/packages/network-controller/package.json
+++ b/packages/network-controller/package.json
@@ -71,7 +71,7 @@
     "loglevel": "^1.8.1",
     "reselect": "^5.1.1",
     "uri-js": "^4.4.1",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@json-rpc-specification/meta-schema": "^1.0.6",

--- a/packages/notification-services-controller/CHANGELOG.md
+++ b/packages/notification-services-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `uuid` from `^8.3.2` to `^9.0.1` ([#10117](https://github.com/MetaMask/core/pull/10117))
+
 ## [28.0.0]
 
 ### Changed

--- a/packages/notification-services-controller/package.json
+++ b/packages/notification-services-controller/package.json
@@ -85,7 +85,7 @@
     "lodash-es": "^4.17.21",
     "loglevel": "^1.8.1",
     "semver": "^7.6.3",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^3.0.4",

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `uuid` from `^8.3.2` to `^9.0.1` ([#10117](https://github.com/MetaMask/core/pull/10117))
+
 ## [17.0.0]
 
 ### Changed

--- a/packages/perps-controller/package.json
+++ b/packages/perps-controller/package.json
@@ -75,7 +75,7 @@
     "@nktkas/hyperliquid": "^0.33.1",
     "bignumber.js": "^9.1.2",
     "reselect": "^5.1.1",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@metamask/account-tree-controller": "^10.0.0",
@@ -89,7 +89,7 @@
     "@metamask/remote-feature-flag-controller": "^7.0.0",
     "@metamask/transaction-controller": "^70.0.0",
     "@types/jest": "^30.0.0",
-    "@types/uuid": "^8.3.0",
+    "@types/uuid": "^9.0.8",
     "@typescript/native": "npm:typescript@^7.0.2",
     "deepmerge": "^4.2.2",
     "jest": "^30.4.2",

--- a/packages/polling-controller/CHANGELOG.md
+++ b/packages/polling-controller/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `@types/uuid` from `^8.3.0` to `^9.0.8` ([#10117](https://github.com/MetaMask/core/pull/10117))
+- Bump `uuid` from `^8.3.2` to `^9.0.1` ([#10117](https://github.com/MetaMask/core/pull/10117))
+
 ## [17.0.0]
 
 ### Added

--- a/packages/polling-controller/package.json
+++ b/packages/polling-controller/package.json
@@ -50,9 +50,9 @@
   "dependencies": {
     "@metamask/base-controller": "^10.0.0",
     "@metamask/utils": "^11.12.0",
-    "@types/uuid": "^8.3.0",
+    "@types/uuid": "^9.0.8",
     "fast-json-stable-stringify": "^2.1.0",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^6.1.0",

--- a/packages/profile-metrics-controller/CHANGELOG.md
+++ b/packages/profile-metrics-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `uuid` from `^8.3.2` to `^9.0.1` ([#10117](https://github.com/MetaMask/core/pull/10117))
+
 ## [5.0.0]
 
 ### Changed

--- a/packages/profile-metrics-controller/package.json
+++ b/packages/profile-metrics-controller/package.json
@@ -64,7 +64,7 @@
     "@metamask/transaction-controller": "^70.0.0",
     "@metamask/utils": "^11.12.0",
     "async-mutex": "^0.5.0",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^6.1.0",

--- a/packages/remote-feature-flag-controller/CHANGELOG.md
+++ b/packages/remote-feature-flag-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `uuid` from `^8.3.2` to `^9.0.1` ([#10117](https://github.com/MetaMask/core/pull/10117))
+
 ## [7.0.0]
 
 ### Changed

--- a/packages/remote-feature-flag-controller/package.json
+++ b/packages/remote-feature-flag-controller/package.json
@@ -54,7 +54,7 @@
     "@metamask/controller-utils": "^13.0.0",
     "@metamask/messenger": "^3.0.0",
     "@metamask/utils": "^11.12.0",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^3.0.4",

--- a/packages/shield-controller/package.json
+++ b/packages/shield-controller/package.json
@@ -77,7 +77,7 @@
     "typedoc": "^0.25.13",
     "typedoc-plugin-missing-exports": "^2.0.0",
     "typescript": "npm:@typescript/typescript6@^6.0.2",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "engines": {
     "node": "^22.14.0 || ^24"

--- a/packages/signature-controller/CHANGELOG.md
+++ b/packages/signature-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `uuid` from `^8.3.2` to `^9.0.1` ([#10117](https://github.com/MetaMask/core/pull/10117))
+
 ## [40.0.0]
 
 ### Changed

--- a/packages/signature-controller/package.json
+++ b/packages/signature-controller/package.json
@@ -63,7 +63,7 @@
     "@metamask/utils": "^11.12.0",
     "jsonschema": "^1.4.1",
     "lodash-es": "^4.17.21",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^6.1.0",

--- a/packages/transaction-controller/CHANGELOG.md
+++ b/packages/transaction-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `uuid` from `^8.3.2` to `^9.0.1` ([#10117](https://github.com/MetaMask/core/pull/10117))
+
 ## [70.0.0]
 
 ### Changed

--- a/packages/transaction-controller/package.json
+++ b/packages/transaction-controller/package.json
@@ -77,7 +77,7 @@
     "ethereum-cryptography": "^2.1.2",
     "fast-json-patch": "^3.1.1",
     "lodash-es": "^4.17.21",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@babel/runtime": "^7.23.9",

--- a/packages/user-operation-controller/CHANGELOG.md
+++ b/packages/user-operation-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `uuid` from `^8.3.2` to `^9.0.1` ([#10117](https://github.com/MetaMask/core/pull/10117))
+
 ## [42.0.0]
 
 ### Changed

--- a/packages/user-operation-controller/package.json
+++ b/packages/user-operation-controller/package.json
@@ -67,7 +67,7 @@
     "bn.js": "^5.2.1",
     "immer": "^9.0.6",
     "lodash-es": "^4.17.21",
-    "uuid": "^8.3.2"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@metamask/auto-changelog": "^6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5643,7 +5643,7 @@ __metadata:
     typedoc: "npm:^0.25.13"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:@typescript/typescript6@^6.0.2"
-    uuid: "npm:^8.3.2"
+    uuid: "npm:^9.0.1"
     webextension-polyfill: "npm:^0.12.0"
   peerDependencies:
     "@metamask/providers": ^22.0.0
@@ -5716,7 +5716,7 @@ __metadata:
     "@metamask/messenger": "npm:^3.0.0"
     "@metamask/utils": "npm:^11.12.0"
     "@types/jest": "npm:^30.0.0"
-    "@types/uuid": "npm:^8.3.0"
+    "@types/uuid": "npm:^9.0.8"
     "@typescript/native": "npm:typescript@^7.0.2"
     deepmerge: "npm:^4.2.2"
     jest: "npm:^30.4.2"
@@ -5727,7 +5727,7 @@ __metadata:
     typedoc: "npm:^0.25.13"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:@typescript/typescript6@^6.0.2"
-    uuid: "npm:^8.3.2"
+    uuid: "npm:^9.0.1"
   languageName: unknown
   linkType: soft
 
@@ -5940,7 +5940,7 @@ __metadata:
     "@types/jest": "npm:^30.0.0"
     "@types/lodash-es": "npm:^4.17.12"
     "@types/node": "npm:^22.13.14"
-    "@types/uuid": "npm:^8.3.0"
+    "@types/uuid": "npm:^9.0.8"
     "@typescript/native": "npm:typescript@^7.0.2"
     async-mutex: "npm:^0.5.0"
     bitcoin-address-validation: "npm:^2.2.3"
@@ -5960,7 +5960,7 @@ __metadata:
     typedoc: "npm:^0.25.13"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:@typescript/typescript6@^6.0.2"
-    uuid: "npm:^8.3.2"
+    uuid: "npm:^9.0.1"
     webextension-polyfill: "npm:^0.12.0"
   peerDependencies:
     "@metamask/providers": ^22.0.0
@@ -6174,7 +6174,7 @@ __metadata:
     typedoc: "npm:^0.25.13"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:@typescript/typescript6@^6.0.2"
-    uuid: "npm:^8.3.2"
+    uuid: "npm:^9.0.1"
   languageName: unknown
   linkType: soft
 
@@ -6211,7 +6211,7 @@ __metadata:
     typedoc: "npm:^0.25.13"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:@typescript/typescript6@^6.0.2"
-    uuid: "npm:^8.3.2"
+    uuid: "npm:^9.0.1"
   languageName: unknown
   linkType: soft
 
@@ -6579,7 +6579,7 @@ __metadata:
     typedoc: "npm:^0.25.13"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:@typescript/typescript6@^6.0.2"
-    uuid: "npm:^8.3.2"
+    uuid: "npm:^9.0.1"
   languageName: unknown
   linkType: soft
 
@@ -6643,7 +6643,7 @@ __metadata:
     tsx: "npm:^4.20.5"
     typescript: "npm:@typescript/typescript6@^6.0.2"
     typescript-eslint: "npm:^8.48.0"
-    uuid: "npm:^8.3.2"
+    uuid: "npm:^9.0.1"
     yargs: "npm:^17.7.2"
   languageName: unknown
   linkType: soft
@@ -6790,7 +6790,7 @@ __metadata:
     typedoc: "npm:^0.25.13"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:@typescript/typescript6@^6.0.2"
-    uuid: "npm:^8.3.2"
+    uuid: "npm:^9.0.1"
   languageName: unknown
   linkType: soft
 
@@ -7327,7 +7327,7 @@ __metadata:
     "@types/bn.js": "npm:^5.1.5"
     "@types/jest": "npm:^30.0.0"
     "@types/jest-when": "npm:^2.7.3"
-    "@types/uuid": "npm:^8.3.0"
+    "@types/uuid": "npm:^9.0.8"
     "@typescript/native": "npm:typescript@^7.0.2"
     bn.js: "npm:^5.2.1"
     deepmerge: "npm:^4.2.2"
@@ -7340,7 +7340,7 @@ __metadata:
     typedoc: "npm:^0.25.13"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:@typescript/typescript6@^6.0.2"
-    uuid: "npm:^8.3.2"
+    uuid: "npm:^9.0.1"
   peerDependencies:
     "@babel/runtime": ^7.0.0
   languageName: unknown
@@ -7560,7 +7560,7 @@ __metadata:
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:@typescript/typescript6@^6.0.2"
     ulid: "npm:^2.3.0"
-    uuid: "npm:^8.3.2"
+    uuid: "npm:^9.0.1"
   languageName: unknown
   linkType: soft
 
@@ -7724,7 +7724,7 @@ __metadata:
     typedoc: "npm:^0.25.13"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:@typescript/typescript6@^6.0.2"
-    uuid: "npm:^8.3.2"
+    uuid: "npm:^9.0.1"
   languageName: unknown
   linkType: soft
 
@@ -7739,7 +7739,7 @@ __metadata:
     "@metamask/messenger": "npm:^3.0.0"
     "@metamask/utils": "npm:^11.12.0"
     "@types/jest": "npm:^30.0.0"
-    "@types/uuid": "npm:^8.3.0"
+    "@types/uuid": "npm:^9.0.8"
     "@typescript/native": "npm:typescript@^7.0.2"
     deepmerge: "npm:^4.2.2"
     jest: "npm:^30.4.2"
@@ -7750,7 +7750,7 @@ __metadata:
     typedoc: "npm:^0.25.13"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:@typescript/typescript6@^6.0.2"
-    uuid: "npm:^8.3.2"
+    uuid: "npm:^9.0.1"
   languageName: unknown
   linkType: soft
 
@@ -7994,7 +7994,7 @@ __metadata:
     "@metamask/superstruct": "npm:^3.4.1"
     "@metamask/utils": "npm:^11.12.0"
     "@types/jest": "npm:^30.0.0"
-    "@types/uuid": "npm:^8.3.0"
+    "@types/uuid": "npm:^9.0.8"
     "@typescript/native": "npm:typescript@^7.0.2"
     async-mutex: "npm:^0.5.0"
     deepmerge: "npm:^4.2.2"
@@ -8006,7 +8006,7 @@ __metadata:
     typedoc: "npm:^0.25.13"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:@typescript/typescript6@^6.0.2"
-    uuid: "npm:^8.3.2"
+    uuid: "npm:^9.0.1"
     webextension-polyfill: "npm:^0.12.0"
   peerDependencies:
     "@metamask/providers": ^22.0.0
@@ -8066,7 +8066,7 @@ __metadata:
     "@solana/addresses": "npm:^2.0.0"
     "@types/jest": "npm:^30.0.0"
     "@types/lodash-es": "npm:^4.17.12"
-    "@types/uuid": "npm:^8.3.0"
+    "@types/uuid": "npm:^9.0.8"
     "@typescript/native": "npm:typescript@^7.0.2"
     deepmerge: "npm:^4.2.2"
     immer: "npm:^9.0.6"
@@ -8100,7 +8100,7 @@ __metadata:
     "@metamask/snaps-utils": "npm:^12.1.2"
     "@metamask/utils": "npm:^11.12.0"
     "@types/jest": "npm:^30.0.0"
-    "@types/uuid": "npm:^8.3.0"
+    "@types/uuid": "npm:^9.0.8"
     "@typescript/native": "npm:typescript@^7.0.2"
     deepmerge: "npm:^4.2.2"
     immer: "npm:^9.0.6"
@@ -8111,7 +8111,7 @@ __metadata:
     typedoc: "npm:^0.25.13"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:@typescript/typescript6@^6.0.2"
-    uuid: "npm:^8.3.2"
+    uuid: "npm:^9.0.1"
   languageName: unknown
   linkType: soft
 
@@ -8213,7 +8213,7 @@ __metadata:
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:@typescript/typescript6@^6.0.2"
     uri-js: "npm:^4.4.1"
-    uuid: "npm:^8.3.2"
+    uuid: "npm:^9.0.1"
   languageName: unknown
   linkType: soft
 
@@ -8294,7 +8294,7 @@ __metadata:
     typedoc: "npm:^0.25.13"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:@typescript/typescript6@^6.0.2"
-    uuid: "npm:^8.3.2"
+    uuid: "npm:^9.0.1"
   languageName: unknown
   linkType: soft
 
@@ -8459,7 +8459,7 @@ __metadata:
     "@metamask/utils": "npm:^11.12.0"
     "@nktkas/hyperliquid": "npm:^0.33.1"
     "@types/jest": "npm:^30.0.0"
-    "@types/uuid": "npm:^8.3.0"
+    "@types/uuid": "npm:^9.0.8"
     "@typescript/native": "npm:typescript@^7.0.2"
     bignumber.js: "npm:^9.1.2"
     deepmerge: "npm:^4.2.2"
@@ -8471,7 +8471,7 @@ __metadata:
     typedoc: "npm:^0.25.13"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:@typescript/typescript6@^6.0.2"
-    uuid: "npm:^8.3.2"
+    uuid: "npm:^9.0.1"
     viem: "npm:^2.55.8"
   languageName: unknown
   linkType: soft
@@ -8551,7 +8551,7 @@ __metadata:
     "@metamask/messenger": "npm:^3.0.0"
     "@metamask/utils": "npm:^11.12.0"
     "@types/jest": "npm:^30.0.0"
-    "@types/uuid": "npm:^8.3.0"
+    "@types/uuid": "npm:^9.0.8"
     "@typescript/native": "npm:typescript@^7.0.2"
     deepmerge: "npm:^4.2.2"
     fast-json-stable-stringify: "npm:^2.1.0"
@@ -8562,7 +8562,7 @@ __metadata:
     typedoc: "npm:^0.25.13"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:@typescript/typescript6@^6.0.2"
-    uuid: "npm:^8.3.2"
+    uuid: "npm:^9.0.1"
   languageName: unknown
   linkType: soft
 
@@ -8628,7 +8628,7 @@ __metadata:
     typedoc: "npm:^0.25.13"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:@typescript/typescript6@^6.0.2"
-    uuid: "npm:^8.3.2"
+    uuid: "npm:^9.0.1"
   languageName: unknown
   linkType: soft
 
@@ -8796,7 +8796,7 @@ __metadata:
     typedoc: "npm:^0.25.13"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:@typescript/typescript6@^6.0.2"
-    uuid: "npm:^8.3.2"
+    uuid: "npm:^9.0.1"
   languageName: unknown
   linkType: soft
 
@@ -8971,7 +8971,7 @@ __metadata:
     typedoc: "npm:^0.25.13"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:@typescript/typescript6@^6.0.2"
-    uuid: "npm:^8.3.2"
+    uuid: "npm:^9.0.1"
   languageName: unknown
   linkType: soft
 
@@ -9003,7 +9003,7 @@ __metadata:
     typedoc: "npm:^0.25.13"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:@typescript/typescript6@^6.0.2"
-    uuid: "npm:^8.3.2"
+    uuid: "npm:^9.0.1"
   languageName: unknown
   linkType: soft
 
@@ -9422,7 +9422,7 @@ __metadata:
     typedoc: "npm:^0.25.13"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:@typescript/typescript6@^6.0.2"
-    uuid: "npm:^8.3.2"
+    uuid: "npm:^9.0.1"
   peerDependencies:
     "@babel/runtime": ^7.0.0
     "@metamask/eth-block-tracker": ">=9"
@@ -9500,7 +9500,7 @@ __metadata:
     typedoc: "npm:^0.25.13"
     typedoc-plugin-missing-exports: "npm:^2.0.0"
     typescript: "npm:@typescript/typescript6@^6.0.2"
-    uuid: "npm:^8.3.2"
+    uuid: "npm:^9.0.1"
   peerDependencies:
     "@metamask/eth-block-tracker": ">=9"
   languageName: unknown
@@ -12360,13 +12360,6 @@ __metadata:
   dependencies:
     "@types/node": "npm:*"
   checksum: 10/c11c0e072556038730b218ccf8af849911ed8a1338e6db863bdf4c44d53d83dd23e3de4752322b1e19cf0205ed6eaf8746e25aa3c2b38e419da457f9d6be7b4e
-  languageName: node
-  linkType: hard
-
-"@types/uuid@npm:^8.3.0":
-  version: 8.3.4
-  resolution: "@types/uuid@npm:8.3.4"
-  checksum: 10/6f11f3ff70f30210edaa8071422d405e9c1d4e53abbe50fdce365150d3c698fe7bbff65c1e71ae080cbfb8fded860dbb5e174da96fdbbdfcaa3fb3daa474d20f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only major bump with no source edits; risk is mainly if uuid v9 behavior or bundling differs from v8 in downstream clients, though usage here is standard `v4` generation.
> 
> **Overview**
> This PR **standardizes the monorepo on `uuid` v9** by bumping `uuid` from `^8.3.2` to `^9.0.1` in the root devDependencies and across many `@metamask/*` packages that depend on it directly.
> 
> Where packages typed against UUIDs, **`@types/uuid` is updated from `^8.3.0` to `^9.0.8`**, and the lockfile drops the old `@types/uuid@^8.3.0` entry. Affected packages record the bump under **`[Unreleased]`** in their changelogs; there are **no runtime or import changes** in this diff—existing `v4` ESM imports stay as-is.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93c51bdb57b0dc3949cb4ab076a73b99628fa512. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->