### PR TITLE
Place TypeDoc config files under Core Platform ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -175,195 +175,260 @@
 /packages/account-tree-controller/package.json                 @MetaMask/accounts-engineers @MetaMask/core-platform
 /packages/account-tree-controller/CHANGELOG.md                 @MetaMask/accounts-engineers @MetaMask/core-platform
 /packages/account-tree-controller/tsconfig.*                   @MetaMask/accounts-engineers @MetaMask/core-platform
+/packages/account-tree-controller/typedoc.json                 @MetaMask/accounts-engineers @MetaMask/core-platform
 /packages/accounts-controller/package.json                     @MetaMask/accounts-engineers @MetaMask/core-platform
 /packages/accounts-controller/CHANGELOG.md                     @MetaMask/accounts-engineers @MetaMask/core-platform
 /packages/accounts-controller/tsconfig.*                       @MetaMask/accounts-engineers @MetaMask/core-platform
+/packages/accounts-controller/typedoc.json                     @MetaMask/accounts-engineers @MetaMask/core-platform
 /packages/analytics-controller/package.json                    @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/core-platform
 /packages/analytics-controller/CHANGELOG.md                    @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/core-platform
 /packages/analytics-controller/tsconfig.*                      @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/core-platform
+/packages/analytics-controller/typedoc.json                    @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/core-platform
 /packages/analytics-data-regulation-controller/package.json    @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/core-platform
 /packages/analytics-data-regulation-controller/CHANGELOG.md    @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/core-platform
 /packages/analytics-data-regulation-controller/tsconfig.*      @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/core-platform
+/packages/analytics-data-regulation-controller/typedoc.json    @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/core-platform
 /packages/address-book-controller/package.json                 @MetaMask/confirmations @MetaMask/core-platform
 /packages/address-book-controller/CHANGELOG.md                 @MetaMask/confirmations @MetaMask/core-platform
 /packages/address-book-controller/tsconfig.*                   @MetaMask/confirmations @MetaMask/core-platform
+/packages/address-book-controller/typedoc.json                 @MetaMask/confirmations @MetaMask/core-platform
 /packages/announcement-controller/package.json                 @MetaMask/core-extension-ux @MetaMask/mobile-core-ux @MetaMask/core-platform
 /packages/announcement-controller/CHANGELOG.md                 @MetaMask/core-extension-ux @MetaMask/mobile-core-ux @MetaMask/core-platform
 /packages/announcement-controller/tsconfig.*                   @MetaMask/core-extension-ux @MetaMask/mobile-core-ux @MetaMask/core-platform
+/packages/announcement-controller/typedoc.json                 @MetaMask/core-extension-ux @MetaMask/mobile-core-ux @MetaMask/core-platform
 /packages/client-utils/package.json                            @MetaMask/core-extension-ux @MetaMask/mobile-core-ux @MetaMask/core-platform
 /packages/client-utils/CHANGELOG.md                            @MetaMask/core-extension-ux @MetaMask/mobile-core-ux @MetaMask/core-platform
 /packages/client-utils/tsconfig.*                              @MetaMask/core-extension-ux @MetaMask/mobile-core-ux @MetaMask/core-platform
+/packages/client-utils/typedoc.json                            @MetaMask/core-extension-ux @MetaMask/mobile-core-ux @MetaMask/core-platform
 /packages/approval-controller/package.json                     @MetaMask/confirmations @MetaMask/core-platform
 /packages/approval-controller/CHANGELOG.md                     @MetaMask/confirmations @MetaMask/core-platform
 /packages/approval-controller/tsconfig.*                       @MetaMask/confirmations @MetaMask/core-platform
+/packages/approval-controller/typedoc.json                     @MetaMask/confirmations @MetaMask/core-platform
 /packages/assets-controllers/package.json                      @MetaMask/metamask-assets @MetaMask/core-platform
 /packages/assets-controllers/CHANGELOG.md                      @MetaMask/metamask-assets @MetaMask/core-platform
 /packages/assets-controllers/tsconfig.*                        @MetaMask/metamask-assets @MetaMask/core-platform
+/packages/assets-controllers/typedoc.json                      @MetaMask/metamask-assets @MetaMask/core-platform
 /packages/assets-controller/package.json                       @MetaMask/metamask-assets @MetaMask/core-platform
 /packages/assets-controller/CHANGELOG.md                       @MetaMask/metamask-assets @MetaMask/core-platform
 /packages/assets-controller/tsconfig.*                         @MetaMask/metamask-assets @MetaMask/core-platform
+/packages/assets-controller/typedoc.json                       @MetaMask/metamask-assets @MetaMask/core-platform
 /packages/config-registry-controller/package.json              @MetaMask/networks @MetaMask/emerging-opportunities @MetaMask/core-platform
 /packages/config-registry-controller/CHANGELOG.md              @MetaMask/networks @MetaMask/emerging-opportunities @MetaMask/core-platform
 /packages/config-registry-controller/tsconfig.*                @MetaMask/networks @MetaMask/emerging-opportunities @MetaMask/core-platform
+/packages/config-registry-controller/typedoc.json              @MetaMask/networks @MetaMask/emerging-opportunities @MetaMask/core-platform
 /packages/delegation-controller/package.json                   @MetaMask/delegation @MetaMask/core-platform
 /packages/delegation-controller/CHANGELOG.md                   @MetaMask/delegation @MetaMask/core-platform
 /packages/delegation-controller/tsconfig.*                     @MetaMask/delegation @MetaMask/core-platform
+/packages/delegation-controller/typedoc.json                   @MetaMask/delegation @MetaMask/core-platform
 /packages/earn-controller/package.json                         @MetaMask/earn @MetaMask/core-platform
 /packages/earn-controller/CHANGELOG.md                         @MetaMask/earn @MetaMask/core-platform
 /packages/earn-controller/tsconfig.*                           @MetaMask/earn @MetaMask/core-platform
+/packages/earn-controller/typedoc.json                         @MetaMask/earn @MetaMask/core-platform
 /packages/money-account-balance-service/package.json           @MetaMask/earn @MetaMask/core-platform
 /packages/money-account-balance-service/CHANGELOG.md           @MetaMask/earn @MetaMask/core-platform
 /packages/money-account-balance-service/tsconfig.*             @MetaMask/earn @MetaMask/core-platform
+/packages/money-account-balance-service/typedoc.json           @MetaMask/earn @MetaMask/core-platform
 /packages/money-account-api-data-service/package.json          @MetaMask/earn @MetaMask/core-platform
 /packages/money-account-api-data-service/CHANGELOG.md          @MetaMask/earn @MetaMask/core-platform
 /packages/money-account-api-data-service/tsconfig.*            @MetaMask/earn @MetaMask/core-platform
+/packages/money-account-api-data-service/typedoc.json          @MetaMask/earn @MetaMask/core-platform
 /packages/gas-fee-controller/package.json                      @MetaMask/confirmations @MetaMask/core-platform
 /packages/gas-fee-controller/CHANGELOG.md                      @MetaMask/confirmations @MetaMask/core-platform
 /packages/gas-fee-controller/tsconfig.*                        @MetaMask/confirmations @MetaMask/core-platform
+/packages/gas-fee-controller/typedoc.json                      @MetaMask/confirmations @MetaMask/core-platform
 /packages/gator-permissions-controller/package.json            @MetaMask/delegation @MetaMask/core-platform
 /packages/gator-permissions-controller/CHANGELOG.md            @MetaMask/delegation @MetaMask/core-platform
 /packages/gator-permissions-controller/tsconfig.*              @MetaMask/delegation @MetaMask/core-platform
+/packages/gator-permissions-controller/typedoc.json            @MetaMask/delegation @MetaMask/core-platform
 /packages/geolocation-controller/package.json                  @MetaMask/mobile-platform @MetaMask/core-platform
 /packages/geolocation-controller/CHANGELOG.md                  @MetaMask/mobile-platform @MetaMask/core-platform
 /packages/geolocation-controller/tsconfig.*                    @MetaMask/mobile-platform @MetaMask/core-platform
+/packages/geolocation-controller/typedoc.json                  @MetaMask/mobile-platform @MetaMask/core-platform
 /packages/keyring-controller/package.json                      @MetaMask/accounts-engineers @MetaMask/core-platform
 /packages/keyring-controller/CHANGELOG.md                      @MetaMask/accounts-engineers @MetaMask/core-platform
 /packages/keyring-controller/tsconfig.*                        @MetaMask/accounts-engineers @MetaMask/core-platform
+/packages/keyring-controller/typedoc.json                      @MetaMask/accounts-engineers @MetaMask/core-platform
 /packages/passkey-controller/package.json                      @MetaMask/web3auth @MetaMask/core-platform
 /packages/passkey-controller/CHANGELOG.md                      @MetaMask/web3auth @MetaMask/core-platform
 /packages/passkey-controller/tsconfig.*                        @MetaMask/web3auth @MetaMask/core-platform
+/packages/passkey-controller/typedoc.json                      @MetaMask/web3auth @MetaMask/core-platform
 /packages/logging-controller/package.json                      @MetaMask/confirmations @MetaMask/core-platform
 /packages/logging-controller/CHANGELOG.md                      @MetaMask/confirmations @MetaMask/core-platform
 /packages/logging-controller/tsconfig.*                        @MetaMask/confirmations @MetaMask/core-platform
+/packages/logging-controller/typedoc.json                      @MetaMask/confirmations @MetaMask/core-platform
 /packages/message-manager/package.json                         @MetaMask/confirmations @MetaMask/core-platform
 /packages/message-manager/CHANGELOG.md                         @MetaMask/confirmations @MetaMask/core-platform
 /packages/message-manager/tsconfig.*                           @MetaMask/confirmations @MetaMask/core-platform
+/packages/message-manager/typedoc.json                         @MetaMask/confirmations @MetaMask/core-platform
 /packages/multichain-account-service/package.json              @MetaMask/accounts-engineers @MetaMask/core-platform
 /packages/multichain-account-service/CHANGELOG.md              @MetaMask/accounts-engineers @MetaMask/core-platform
 /packages/multichain-account-service/tsconfig.*                @MetaMask/accounts-engineers @MetaMask/core-platform
+/packages/multichain-account-service/typedoc.json              @MetaMask/accounts-engineers @MetaMask/core-platform
 /packages/name-controller/package.json                         @MetaMask/confirmations @MetaMask/core-platform
 /packages/name-controller/CHANGELOG.md                         @MetaMask/confirmations @MetaMask/core-platform
 /packages/name-controller/tsconfig.*                           @MetaMask/confirmations @MetaMask/core-platform
+/packages/name-controller/typedoc.json                         @MetaMask/confirmations @MetaMask/core-platform
 /packages/notification-services-controller/package.json        @MetaMask/engagement @MetaMask/core-platform
 /packages/notification-services-controller/CHANGELOG.md        @MetaMask/engagement @MetaMask/core-platform
 /packages/notification-services-controller/tsconfig.*          @MetaMask/engagement @MetaMask/core-platform
+/packages/notification-services-controller/typedoc.json        @MetaMask/engagement @MetaMask/core-platform
 /packages/compliance-controller/package.json                   @MetaMask/perps @MetaMask/core-platform
 /packages/compliance-controller/CHANGELOG.md                   @MetaMask/perps @MetaMask/core-platform
 /packages/compliance-controller/tsconfig.*                     @MetaMask/perps @MetaMask/core-platform
+/packages/compliance-controller/typedoc.json                   @MetaMask/perps @MetaMask/core-platform
 /packages/perps-controller/package.json                        @MetaMask/perps @MetaMask/core-platform
 /packages/perps-controller/CHANGELOG.md                        @MetaMask/perps @MetaMask/core-platform
 /packages/perps-controller/tsconfig.*                          @MetaMask/perps @MetaMask/core-platform
+/packages/perps-controller/typedoc.json                        @MetaMask/perps @MetaMask/core-platform
 /packages/phishing-controller/package.json                     @MetaMask/product-safety @MetaMask/core-platform
 /packages/phishing-controller/CHANGELOG.md                     @MetaMask/product-safety @MetaMask/core-platform
 /packages/phishing-controller/tsconfig.*                       @MetaMask/product-safety @MetaMask/core-platform
+/packages/phishing-controller/typedoc.json                     @MetaMask/product-safety @MetaMask/core-platform
 /packages/ramps-controller/package.json                        @MetaMask/money-movement @MetaMask/core-platform
 /packages/ramps-controller/CHANGELOG.md                        @MetaMask/money-movement @MetaMask/core-platform
 /packages/ramps-controller/tsconfig.*                          @MetaMask/money-movement @MetaMask/core-platform
+/packages/ramps-controller/typedoc.json                        @MetaMask/money-movement @MetaMask/core-platform
 /packages/authenticated-user-storage/package.json              @MetaMask/auth-engineers @MetaMask/core-platform
 /packages/authenticated-user-storage/CHANGELOG.md              @MetaMask/auth-engineers @MetaMask/core-platform
 /packages/authenticated-user-storage/tsconfig.*                @MetaMask/auth-engineers @MetaMask/core-platform
+/packages/authenticated-user-storage/typedoc.json              @MetaMask/auth-engineers @MetaMask/core-platform
 /packages/profile-metrics-controller/package.json              @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/core-platform
 /packages/profile-metrics-controller/CHANGELOG.md              @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/core-platform
 /packages/profile-metrics-controller/tsconfig.*                @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/core-platform
+/packages/profile-metrics-controller/typedoc.json              @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/core-platform
 /packages/profile-sync-controller/package.json                 @MetaMask/accounts-engineers @MetaMask/core-platform
 /packages/profile-sync-controller/CHANGELOG.md                 @MetaMask/accounts-engineers @MetaMask/core-platform
 /packages/profile-sync-controller/tsconfig.*                   @MetaMask/accounts-engineers @MetaMask/core-platform
+/packages/profile-sync-controller/typedoc.json                 @MetaMask/accounts-engineers @MetaMask/core-platform
 /packages/signature-controller/package.json                    @MetaMask/confirmations @MetaMask/core-platform
 /packages/signature-controller/CHANGELOG.md                    @MetaMask/confirmations @MetaMask/core-platform
 /packages/signature-controller/tsconfig.*                      @MetaMask/confirmations @MetaMask/core-platform
+/packages/signature-controller/typedoc.json                    @MetaMask/confirmations @MetaMask/core-platform
 /packages/smart-transactions-controller/package.json           @MetaMask/transactions @MetaMask/core-platform
 /packages/smart-transactions-controller/CHANGELOG.md           @MetaMask/transactions @MetaMask/core-platform
 /packages/smart-transactions-controller/tsconfig.*             @MetaMask/transactions @MetaMask/core-platform
+/packages/smart-transactions-controller/typedoc.json           @MetaMask/transactions @MetaMask/core-platform
 /packages/sentinel-api-service/package.json                    @MetaMask/confirmations @MetaMask/transactions @MetaMask/core-platform
 /packages/sentinel-api-service/CHANGELOG.md                    @MetaMask/confirmations @MetaMask/transactions @MetaMask/core-platform
 /packages/sentinel-api-service/tsconfig.*                      @MetaMask/confirmations @MetaMask/transactions @MetaMask/core-platform
+/packages/sentinel-api-service/typedoc.json                    @MetaMask/confirmations @MetaMask/transactions @MetaMask/core-platform
 /packages/transaction-controller/package.json                  @MetaMask/confirmations @MetaMask/core-platform
 /packages/transaction-controller/CHANGELOG.md                  @MetaMask/confirmations @MetaMask/core-platform
 /packages/transaction-controller/tsconfig.*                    @MetaMask/confirmations @MetaMask/core-platform
+/packages/transaction-controller/typedoc.json                  @MetaMask/confirmations @MetaMask/core-platform
 /packages/transaction-pay-controller/package.json              @MetaMask/confirmations @MetaMask/core-platform
 /packages/transaction-pay-controller/CHANGELOG.md              @MetaMask/confirmations @MetaMask/core-platform
 /packages/transaction-pay-controller/tsconfig.*                @MetaMask/confirmations @MetaMask/core-platform
+/packages/transaction-pay-controller/typedoc.json              @MetaMask/confirmations @MetaMask/core-platform
 /packages/user-operation-controller/package.json               @MetaMask/confirmations @MetaMask/core-platform
 /packages/user-operation-controller/CHANGELOG.md               @MetaMask/confirmations @MetaMask/core-platform
 /packages/user-operation-controller/tsconfig.*                 @MetaMask/confirmations @MetaMask/core-platform
+/packages/user-operation-controller/typedoc.json               @MetaMask/confirmations @MetaMask/core-platform
 /packages/multichain-transactions-controller/package.json      @MetaMask/accounts-engineers @MetaMask/core-platform
 /packages/multichain-transactions-controller/CHANGELOG.md      @MetaMask/accounts-engineers @MetaMask/core-platform
 /packages/multichain-transactions-controller/tsconfig.*        @MetaMask/accounts-engineers @MetaMask/core-platform
+/packages/multichain-transactions-controller/typedoc.json      @MetaMask/accounts-engineers @MetaMask/core-platform
 /packages/bridge-controller/package.json                       @MetaMask/swaps-engineers @MetaMask/core-platform
 /packages/bridge-controller/CHANGELOG.md                       @MetaMask/swaps-engineers @MetaMask/core-platform
 /packages/bridge-controller/tsconfig.*                         @MetaMask/swaps-engineers @MetaMask/core-platform
+/packages/bridge-controller/typedoc.json                       @MetaMask/swaps-engineers @MetaMask/core-platform
 /packages/remote-feature-flag-controller/package.json          @MetaMask/extension-platform @MetaMask/mobile-platform @MetaMask/core-platform
 /packages/remote-feature-flag-controller/CHANGELOG.md          @MetaMask/extension-platform @MetaMask/mobile-platform @MetaMask/core-platform
 /packages/remote-feature-flag-controller/tsconfig.*            @MetaMask/extension-platform @MetaMask/mobile-platform @MetaMask/core-platform
+/packages/remote-feature-flag-controller/typedoc.json          @MetaMask/extension-platform @MetaMask/mobile-platform @MetaMask/core-platform
 /packages/storage-service/package.json                         @MetaMask/extension-platform @MetaMask/mobile-platform @MetaMask/core-platform
 /packages/storage-service/CHANGELOG.md                         @MetaMask/extension-platform @MetaMask/mobile-platform @MetaMask/core-platform
 /packages/storage-service/tsconfig.*                           @MetaMask/extension-platform @MetaMask/mobile-platform @MetaMask/core-platform
+/packages/storage-service/typedoc.json                         @MetaMask/extension-platform @MetaMask/mobile-platform @MetaMask/core-platform
 /packages/bridge-status-controller/package.json                @MetaMask/swaps-engineers @MetaMask/core-platform
 /packages/bridge-status-controller/CHANGELOG.md                @MetaMask/swaps-engineers @MetaMask/core-platform
 /packages/bridge-status-controller/tsconfig.*                  @MetaMask/swaps-engineers @MetaMask/core-platform
+/packages/bridge-status-controller/typedoc.json                @MetaMask/swaps-engineers @MetaMask/core-platform
 /packages/app-metadata-controller/package.json                 @MetaMask/mobile-platform @MetaMask/core-platform
 /packages/app-metadata-controller/CHANGELOG.md                 @MetaMask/mobile-platform @MetaMask/core-platform
 /packages/app-metadata-controller/tsconfig.*                   @MetaMask/mobile-platform @MetaMask/core-platform
+/packages/app-metadata-controller/typedoc.json                 @MetaMask/mobile-platform @MetaMask/core-platform
 /packages/foundryup/package.json                               @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/core-platform
 /packages/foundryup/CHANGELOG.md                               @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/core-platform
 /packages/foundryup/tsconfig.*                                 @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/core-platform
+/packages/foundryup/typedoc.json                               @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/core-platform
 /packages/bitcoin-regtest-up/package.json                      @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/networks @MetaMask/emerging-opportunities @MetaMask/core-platform
 /packages/bitcoin-regtest-up/CHANGELOG.md                      @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/networks @MetaMask/emerging-opportunities @MetaMask/core-platform
 /packages/bitcoin-regtest-up/tsconfig.*                        @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/networks @MetaMask/emerging-opportunities @MetaMask/core-platform
+/packages/bitcoin-regtest-up/typedoc.json                      @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/networks @MetaMask/emerging-opportunities @MetaMask/core-platform
 /packages/java-tron-up/package.json                            @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/networks @MetaMask/emerging-opportunities @MetaMask/core-platform
 /packages/java-tron-up/CHANGELOG.md                            @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/networks @MetaMask/emerging-opportunities @MetaMask/core-platform
 /packages/java-tron-up/tsconfig.*                              @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/networks @MetaMask/emerging-opportunities @MetaMask/core-platform
+/packages/java-tron-up/typedoc.json                            @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/networks @MetaMask/emerging-opportunities @MetaMask/core-platform
 /packages/local-node-utils/package.json                        @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/networks @MetaMask/emerging-opportunities @MetaMask/core-platform
 /packages/local-node-utils/CHANGELOG.md                        @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/networks @MetaMask/emerging-opportunities @MetaMask/core-platform
 /packages/local-node-utils/tsconfig.*                          @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/networks @MetaMask/emerging-opportunities @MetaMask/core-platform
+/packages/local-node-utils/typedoc.json                        @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/networks @MetaMask/emerging-opportunities @MetaMask/core-platform
 /packages/solana-test-validator-up/package.json                @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/networks @MetaMask/emerging-opportunities @MetaMask/core-platform
 /packages/solana-test-validator-up/CHANGELOG.md                @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/networks @MetaMask/emerging-opportunities @MetaMask/core-platform
 /packages/solana-test-validator-up/tsconfig.*                  @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/networks @MetaMask/emerging-opportunities @MetaMask/core-platform
+/packages/solana-test-validator-up/typedoc.json                @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/networks @MetaMask/emerging-opportunities @MetaMask/core-platform
 /packages/stellar-quickstart-up/package.json                   @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/networks @MetaMask/emerging-opportunities @MetaMask/core-platform
 /packages/stellar-quickstart-up/CHANGELOG.md                   @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/networks @MetaMask/emerging-opportunities @MetaMask/core-platform
 /packages/stellar-quickstart-up/tsconfig.*                     @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/networks @MetaMask/emerging-opportunities @MetaMask/core-platform
+/packages/stellar-quickstart-up/typedoc.json                   @MetaMask/mobile-platform @MetaMask/extension-platform @MetaMask/networks @MetaMask/emerging-opportunities @MetaMask/core-platform
 /packages/seedless-onboarding-controller/package.json          @MetaMask/web3auth @MetaMask/core-platform
 /packages/seedless-onboarding-controller/CHANGELOG.md          @MetaMask/web3auth @MetaMask/core-platform
 /packages/seedless-onboarding-controller/tsconfig.*            @MetaMask/web3auth @MetaMask/core-platform
+/packages/seedless-onboarding-controller/typedoc.json          @MetaMask/web3auth @MetaMask/core-platform
 /packages/shield-controller/package.json                       @MetaMask/web3auth @MetaMask/core-platform
 /packages/shield-controller/CHANGELOG.md                       @MetaMask/web3auth @MetaMask/core-platform
 /packages/shield-controller/tsconfig.*                         @MetaMask/web3auth @MetaMask/core-platform
+/packages/shield-controller/typedoc.json                       @MetaMask/web3auth @MetaMask/core-platform
 /packages/network-enablement-controller/package.json           @MetaMask/metamask-assets @MetaMask/core-platform
 /packages/network-enablement-controller/CHANGELOG.md           @MetaMask/metamask-assets @MetaMask/core-platform
 /packages/network-enablement-controller/tsconfig.*             @MetaMask/metamask-assets @MetaMask/core-platform
+/packages/network-enablement-controller/typedoc.json           @MetaMask/metamask-assets @MetaMask/core-platform
 /packages/subscription-controller/package.json                 @MetaMask/web3auth @MetaMask/core-platform
 /packages/subscription-controller/CHANGELOG.md                 @MetaMask/web3auth @MetaMask/core-platform
 /packages/subscription-controller/tsconfig.*                   @MetaMask/web3auth @MetaMask/core-platform
+/packages/subscription-controller/typedoc.json                 @MetaMask/web3auth @MetaMask/core-platform
 /packages/core-backend/package.json                            @MetaMask/core-platform @MetaMask/metamask-assets
 /packages/core-backend/CHANGELOG.md                            @MetaMask/core-platform @MetaMask/metamask-assets
 /packages/core-backend/tsconfig.*                              @MetaMask/core-platform @MetaMask/metamask-assets
+/packages/core-backend/typedoc.json                            @MetaMask/core-platform @MetaMask/metamask-assets
 /packages/claims-controller/package.json                       @MetaMask/web3auth @MetaMask/core-platform
 /packages/claims-controller/CHANGELOG.md                       @MetaMask/web3auth @MetaMask/core-platform
 /packages/claims-controller/tsconfig.*                         @MetaMask/web3auth @MetaMask/core-platform
+/packages/claims-controller/typedoc.json                       @MetaMask/web3auth @MetaMask/core-platform
 /packages/ai-controllers/package.json                          @MetaMask/social-ai @MetaMask/core-platform
 /packages/ai-controllers/CHANGELOG.md                          @MetaMask/social-ai @MetaMask/core-platform
 /packages/ai-controllers/tsconfig.*                            @MetaMask/social-ai @MetaMask/core-platform
+/packages/ai-controllers/typedoc.json                          @MetaMask/social-ai @MetaMask/core-platform
 /packages/client-controller/package.json                       @MetaMask/core-platform @MetaMask/extension-platform @MetaMask/mobile-platform
 /packages/client-controller/CHANGELOG.md                       @MetaMask/core-platform @MetaMask/extension-platform @MetaMask/mobile-platform
 /packages/client-controller/tsconfig.*                         @MetaMask/core-platform @MetaMask/extension-platform @MetaMask/mobile-platform
+/packages/client-controller/typedoc.json                       @MetaMask/core-platform @MetaMask/extension-platform @MetaMask/mobile-platform
 /packages/social-controllers/package.json                      @MetaMask/social-ai @MetaMask/core-platform
 /packages/social-controllers/CHANGELOG.md                      @MetaMask/social-ai @MetaMask/core-platform
 /packages/social-controllers/tsconfig.*                        @MetaMask/social-ai @MetaMask/core-platform
+/packages/social-controllers/typedoc.json                      @MetaMask/social-ai @MetaMask/core-platform
 /packages/money-account-controller/package.json                @MetaMask/accounts-engineers @MetaMask/core-platform
 /packages/money-account-controller/CHANGELOG.md                @MetaMask/accounts-engineers @MetaMask/core-platform
 /packages/money-account-controller/tsconfig.*                  @MetaMask/accounts-engineers @MetaMask/core-platform
+/packages/money-account-controller/typedoc.json                @MetaMask/accounts-engineers @MetaMask/core-platform
 /packages/chomp-api-service/package.json                       @MetaMask/earn @MetaMask/delegation @MetaMask/core-platform
 /packages/chomp-api-service/CHANGELOG.md                       @MetaMask/earn @MetaMask/delegation @MetaMask/core-platform
 /packages/chomp-api-service/tsconfig.*                         @MetaMask/earn @MetaMask/delegation @MetaMask/core-platform
+/packages/chomp-api-service/typedoc.json                       @MetaMask/earn @MetaMask/delegation @MetaMask/core-platform
 /packages/money-account-upgrade-controller/package.json        @MetaMask/earn @MetaMask/delegation @MetaMask/core-platform
 /packages/money-account-upgrade-controller/CHANGELOG.md        @MetaMask/earn @MetaMask/delegation @MetaMask/core-platform
 /packages/money-account-upgrade-controller/tsconfig.*          @MetaMask/earn @MetaMask/delegation @MetaMask/core-platform
+/packages/money-account-upgrade-controller/typedoc.json        @MetaMask/earn @MetaMask/delegation @MetaMask/core-platform
 /packages/money-account-utils/package.json                     @MetaMask/earn @MetaMask/core-platform
 /packages/money-account-utils/CHANGELOG.md                     @MetaMask/earn @MetaMask/core-platform
 /packages/money-account-utils/tsconfig.*                       @MetaMask/earn @MetaMask/core-platform
+/packages/money-account-utils/typedoc.json                     @MetaMask/earn @MetaMask/core-platform
 /packages/snap-account-service/package.json                    @MetaMask/accounts-engineers @MetaMask/core-platform
 /packages/snap-account-service/CHANGELOG.md                    @MetaMask/accounts-engineers @MetaMask/core-platform
 /packages/snap-account-service/tsconfig.*                      @MetaMask/accounts-engineers @MetaMask/core-platform
+/packages/snap-account-service/typedoc.json                    @MetaMask/accounts-engineers @MetaMask/core-platform
 /packages/kyc-controller/package.json                          @MetaMask/universal-kyc @MetaMask/core-platform
 /packages/kyc-controller/CHANGELOG.md                          @MetaMask/universal-kyc @MetaMask/core-platform
 /packages/kyc-controller/tsconfig.*                            @MetaMask/universal-kyc @MetaMask/core-platform
+/packages/kyc-controller/typedoc.json                          @MetaMask/universal-kyc @MetaMask/core-platform

--- a/codeowners.ts
+++ b/codeowners.ts
@@ -740,6 +740,7 @@ function buildPackageReleaseSection(): CodeownersSection {
         { pattern: `${workspacePath}/package.json`, owners },
         { pattern: `${workspacePath}/CHANGELOG.md`, owners },
         { pattern: `${workspacePath}/tsconfig.*`, owners },
+        { pattern: `${workspacePath}/typedoc.json`, owners },
       ];
     }),
   };


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Each package has a `typedoc.json` file which is used to configure TypeDoc. These files are a part of the the monorepo architecture and tooling, and therefore only the Core Platform team should need to approve modifications to them. This commit updates CODEOWNERS to place `typedoc.json` files under Core Platform ownership.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Process-only change to GitHub CODEOWNERS generation; no runtime or application behavior is affected.
> 
> **Overview**
> Extends the autogenerated **Package Release related** CODEOWNERS rules so each listed workspace package now includes `typedoc.json` alongside `package.json`, `CHANGELOG.md`, and `tsconfig.*`.
> 
> The generator in `codeowners.ts` gains a fourth pattern in `buildPackageReleaseSection`, so regenerating CODEOWNERS adds the matching lines for every package in that list. Reviewers are the same as for other release/tooling files for that package (domain team(s) plus `@MetaMask/core-platform` where that section already adds it).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07ee4015f745ebe6ba16c2f71acd501177988a3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->