### PR TITLE
fix(perps-controller): keep the terminal TWAP record when a completing fill ties lastUpdated

### DIFF
--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Keep the terminal HyperLiquid TWAP record when a completing fill ties `lastUpdated` with the activation, so a finished schedule is no longer reported as live. ([#10122](https://github.com/MetaMask/core/pull/10122))
+  - The venue reports one lifecycle as several `twapHistory` entries, an activation plus a terminal record, and slice fills are looked up by `twapId` so every entry of a schedule receives the same fills. `entry.time` is a whole-second value, so when the final fill is what completed the schedule its millisecond timestamp outranks both entries' own timestamps and both derive an identical `lastUpdated`.
+  - Collapsing entries with `>=` admitted that tie. The venue returns the terminal record first, so the activation was iterated last and overwrote it, `resolveTwapOrderStatus` mapped `activated` to `Active`, and the schedule stayed listed as live carrying the activation's zero executed size while offering a cancel the venue can no longer act on. Schedules that were `terminated` stop seconds after their last fill, never tie, and were unaffected.
+  - Terminality is now decided before timestamps, and `lastUpdated` is compared strictly so an equal value keeps the record already collapsed. Termination is still only ever taken from venue status and never inferred from elapsed time, so collateral cannot be reclaimed from a live TWAP. Both the polled read and the subscription adapter are corrected.
 - Handle zero minimum order amounts and margin fractions reported by Lighter for inactive markets by omitting unusable retired rows, while keeping valid delisted metadata and active market values strict. ([#10110](https://github.com/MetaMask/core/pull/10110))
 
 ## [16.1.0]

--- a/packages/perps-controller/src/providers/HyperLiquidProvider.ts
+++ b/packages/perps-controller/src/providers/HyperLiquidProvider.ts
@@ -1233,6 +1233,37 @@ const resolveTwapOrderStatus = (
   }
 };
 
+/**
+ * Decide whether a newly adapted schedule replaces the one already collapsed
+ * under the same order id.
+ *
+ * The venue reports one lifecycle as several history entries — an activation
+ * plus a terminal record — and `lastUpdated` folds in slice fills that every
+ * entry sharing a `twapId` receives. A schedule whose final fill completed it
+ * therefore derives the same `lastUpdated` on both entries, because that fill
+ * outranks each entry's own whole-second timestamp. Ordering on `lastUpdated`
+ * alone admits that tie, letting the activation overwrite the terminal record
+ * so the schedule reads as live long after it ended. Terminality decides
+ * first, and an equal `lastUpdated` keeps the entry already collapsed.
+ *
+ * @param candidate - Schedule adapted from the current history entry.
+ * @param existing - Schedule already collapsed under this order id.
+ * @returns True when the candidate replaces the existing schedule.
+ */
+const supersedesCollapsedTwapOrder = (
+  candidate: TwapOrder,
+  existing: TwapOrder,
+): boolean => {
+  const candidateIsTerminal =
+    candidate.status !== PerpsTwapLifecycleStatus.Active;
+  const existingIsTerminal =
+    existing.status !== PerpsTwapLifecycleStatus.Active;
+  if (candidateIsTerminal !== existingIsTerminal) {
+    return candidateIsTerminal;
+  }
+  return candidate.lastUpdated > existing.lastUpdated;
+};
+
 const adaptTwapOrderFill = (
   entry: HyperLiquidTwapSliceFillEntry,
 ): TwapOrderFill => ({
@@ -7672,7 +7703,7 @@ export class HyperLiquidProvider implements PerpsProvider {
       }
 
       const existing = ordersById.get(order.orderId);
-      if (!existing || order.lastUpdated >= existing.lastUpdated) {
+      if (!existing || supersedesCollapsedTwapOrder(order, existing)) {
         ordersById.set(order.orderId, order);
       }
     }
@@ -13618,7 +13649,7 @@ export class HyperLiquidProvider implements PerpsProvider {
             continue;
           }
           const existing = ordersById.get(order.orderId);
-          if (!existing || order.lastUpdated >= existing.lastUpdated) {
+          if (!existing || supersedesCollapsedTwapOrder(order, existing)) {
             ordersById.set(order.orderId, order);
           }
         }

--- a/packages/perps-controller/tests/src/providers/HyperLiquidProvider.strategy-orders.test.ts
+++ b/packages/perps-controller/tests/src/providers/HyperLiquidProvider.strategy-orders.test.ts
@@ -2701,6 +2701,105 @@ describe('HyperLiquidProvider - strategy order types', () => {
       });
     });
 
+    describe('when a completing fill ties lastUpdated across history entries', () => {
+      // The venue reports one lifecycle as an activation plus a terminal
+      // record, and every entry sharing a twapId receives the same slice
+      // fills. A schedule finished by its last fill therefore derives an
+      // identical lastUpdated on both entries, because that fill outranks
+      // each entry's own whole-second timestamp.
+      const finishedAtSeconds = 1_700_000_600;
+      const completingFillTimestamp = finishedAtSeconds * 1_000 + 500;
+
+      const activationEntry = {
+        time: 1_700_000_000,
+        twapId: 987,
+        state: {
+          coin: 'ETH',
+          executedNtl: '0',
+          executedSz: '0',
+          minutes: 10,
+          randomize: false,
+          reduceOnly: false,
+          side: 'B',
+          sz: '1',
+          timestamp: startedAt,
+          user: userAddress,
+        },
+        status: { status: 'activated' },
+      };
+
+      const terminalEntry = {
+        time: finishedAtSeconds,
+        twapId: 987,
+        state: {
+          coin: 'ETH',
+          executedNtl: '3000',
+          executedSz: '1',
+          minutes: 10,
+          randomize: false,
+          reduceOnly: false,
+          side: 'B',
+          sz: '1',
+          timestamp: startedAt,
+          user: userAddress,
+        },
+        status: { status: 'finished' },
+      };
+
+      const completingSliceFills = [
+        {
+          twapId: 987,
+          fill: {
+            coin: 'ETH',
+            px: '3000',
+            sz: '1',
+            side: 'B',
+            time: completingFillTimestamp,
+            startPosition: '0',
+            dir: 'Open Long',
+            closedPnl: '0',
+            hash: '0xabc',
+            oid: 321,
+            crossed: true,
+            fee: '3.00',
+            tid: 456,
+            feeToken: 'USDC',
+            twapId: 987,
+          },
+        },
+      ];
+
+      it.each([
+        [
+          'venue order, terminal record first',
+          [terminalEntry, activationEntry],
+        ],
+        ['reversed, activation first', [activationEntry, terminalEntry]],
+      ])('keeps the terminal record (%s)', async (_label, history) => {
+        useStrategyClients({
+          info: {
+            twapHistory: jest.fn().mockResolvedValue(history),
+            userTwapSliceFills: jest
+              .fn()
+              .mockResolvedValue(completingSliceFills),
+          },
+        });
+
+        const orders = await provider.getTwapOrders();
+
+        expect(orders).toHaveLength(1);
+        // Reading 'active' here means the activation overwrote the terminal
+        // record, which leaves a finished schedule listed as live forever.
+        expect(orders[0]).toMatchObject({
+          orderId: '987',
+          status: 'completed',
+          executedSize: '1',
+          remainingSize: '0',
+          lastUpdated: completingFillTimestamp,
+        });
+      });
+    });
+
     it.each([
       ['negative', '-1', '0', '10', 0, 'completed_underfilled'],
       ['oversized', '11', '10', '0', 10_000, 'completed'],


### PR DESCRIPTION
## Explanation

A finished HyperLiquid TWAP could stay listed as live indefinitely.

The venue reports one lifecycle as several `twapHistory` entries — an activation plus a terminal record — and `lastUpdated` is `max(startedAt, normalizeTwapHistoryTimestamp(entry.time), ...fills)`. Slice fills are looked up by `twapId`, so **every entry of a schedule receives the same fills**, while `entry.time` is a whole-second value. When the final fill is what completed the schedule, that fill's millisecond timestamp outranks both entries' own timestamps and both entries derive an **identical** `lastUpdated`.

Collapsing with `order.lastUpdated >= existing.lastUpdated` admits that tie. The venue returns the terminal record first, so the activation was iterated last and overwrote it. `resolveTwapOrderStatus` maps `activated` → `Active`, so the schedule was reported live, carrying the activation's `executedSz: 0`, and clients offered a cancel affordance the venue can no longer act on.

Schedules that were `terminated` stop seconds *after* their last fill, so they never tie and were unaffected — which is why this presents as an intermittent subset rather than every schedule.

Observed on a real mainnet account: of 6 schedules, the 4 `terminated` ones resolved correctly and both `finished` ones were reported `active`, 74 and 18 days after they ended.

## Fix

`supersedesCollapsedTwapOrder` decides terminality first, then compares `lastUpdated` strictly so an equal timestamp keeps the record already collapsed. `Active` is the only non-terminal `PerpsTwapLifecycleStatus`, so "has a terminal record" is exactly `status !== Active`.

This keeps the module's existing stance that a schedule is terminal only when the venue says so — it never infers termination from elapsed time, so collateral still cannot be reclaimed from a live TWAP.

The polled read (`getTwapOrders`) and the subscription adapter (`subscribeToTwapOrders`) shared the comparison; both are corrected.

## References

Surfaced while investigating the mobile symptom where expired TWAPs render in the Active tab.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, `README.md`) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes TWAP lifecycle presentation and cancel affordances for a real edge case; logic is localized to history collapse but affects polled and streamed TWAP state.
> 
> **Overview**
> Fixes **finished HyperLiquid TWAPs staying in the Active list** when the activation and terminal `twapHistory` rows share the same `lastUpdated` after the completing slice fill.
> 
> Collapse logic no longer uses `lastUpdated >=`; **`supersedesCollapsedTwapOrder`** prefers a **terminal** venue status over `Active`, then uses **strict** `lastUpdated` so a tie keeps the record already merged. **`getTwapOrders`** and **`subscribeToTwapOrders`** both use this rule. Tests cover both history orderings when activation and terminal entries tie on `lastUpdated`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 912fed83087750109eacb810f272da627700da4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->