### PR TITLE
fix: keep persisted feature flags for empty segmentation id

### DIFF
--- a/packages/remote-feature-flag-controller/CHANGELOG.md
+++ b/packages/remote-feature-flag-controller/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Keep the previously selected value for a threshold feature flag when the segmentation identifier is unavailable, instead of exposing the unresolved threshold array ([#0000](https://github.com/MetaMask/core/pull/0000))
+- Keep the previously selected value for a threshold feature flag when the segmentation identifier is unavailable, instead of exposing the unresolved threshold array ([#10123](https://github.com/MetaMask/core/pull/10123))
   - `getMetaMetricsId` and `getCanonicalProfileId` may legitimately return an empty string, as they do when `init` runs before whatever backs them is ready. Previously `init` would then replace resolved threshold values with the raw arrays, flipping those flags for the end user until the next fetch. Flags with no previously selected value, as on a fresh install, still fall back to the raw array.
 
 ## [6.1.0]

--- a/packages/remote-feature-flag-controller/CHANGELOG.md
+++ b/packages/remote-feature-flag-controller/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/utils` from `^11.11.0` to `^11.12.0` ([#10076](https://github.com/MetaMask/core/pull/10076))
 
+### Fixed
+
+- Keep the previously selected value for a threshold feature flag when the segmentation identifier is unavailable, instead of exposing the unresolved threshold array ([#0000](https://github.com/MetaMask/core/pull/0000))
+  - `getMetaMetricsId` and `getCanonicalProfileId` may legitimately return an empty string, as they do when `init` runs before whatever backs them is ready. Previously `init` would then replace resolved threshold values with the raw arrays, flipping those flags for the end user until the next fetch. Flags with no previously selected value, as on a fresh install, still fall back to the raw array.
+
 ## [6.1.0]
 
 ### Added

--- a/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.test.ts
+++ b/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.test.ts
@@ -884,6 +884,37 @@ describe('RemoteFeatureFlagController', () => {
         controller.state.remoteFeatureFlags.canonicalThresholdFlag,
       ).toStrictEqual(mockFlags.canonicalThresholdFlag);
     });
+
+    it('keeps the previously selected value when canonical profile id is empty', async () => {
+      const rawRemoteFeatureFlags = {
+        canonicalThresholdFlag: [
+          {
+            name: 'groupA',
+            scope: { type: 'threshold', value: 1.0 },
+            value: 'canonicalA',
+          },
+        ],
+      };
+      // A returning user whose identifier is not available yet, as when `init`
+      // runs before the controller backing `getCanonicalProfileId`.
+      const { controller } = createController({
+        state: {
+          rawRemoteFeatureFlags,
+          remoteFeatureFlags: { canonicalThresholdFlag: 'canonicalA' },
+          featureFlagThresholdGroups: { canonicalThresholdFlag: 'groupA' },
+        },
+        getCanonicalProfileId: () => '',
+      });
+
+      await controller.init();
+
+      expect(controller.state.remoteFeatureFlags.canonicalThresholdFlag).toBe(
+        'canonicalA',
+      );
+      expect(controller.state.featureFlagThresholdGroups).toStrictEqual({
+        canonicalThresholdFlag: 'groupA',
+      });
+    });
   });
 
   describe('metaMetricsIds explicit targeting', () => {

--- a/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.ts
+++ b/packages/remote-feature-flag-controller/src/remote-feature-flag-controller.ts
@@ -4,7 +4,7 @@ import {
 } from '@metamask/base-controller';
 import type { ControllerStateChangeEvent } from '@metamask/base-controller';
 import type { Messenger } from '@metamask/messenger';
-import { isValidSemVerVersion } from '@metamask/utils';
+import { hasProperty, isValidSemVerVersion } from '@metamask/utils';
 import type { Json, SemVerVersion } from '@metamask/utils';
 
 import type { AbstractClientConfigApiService } from './client-config-api-service/abstract-client-config-api-service.js';
@@ -491,6 +491,30 @@ export class RemoteFeatureFlagController extends BaseController<
           const segmentationId = this.#getSegmentationId(remoteFeatureFlagName);
 
           if (!segmentationId) {
+            // The identifier needed to group this flag is unavailable, as it
+            // is when `init` runs before whatever backs these getters is
+            // ready. Exposing the unresolved threshold array would
+            // flip the flag for the end user until the next fetch.
+            if (
+              hasProperty(
+                this.#processedRemoteFeatureFlags,
+                remoteFeatureFlagName,
+              )
+            ) {
+              processedFlags[remoteFeatureFlagName] =
+                this.#processedRemoteFeatureFlags[remoteFeatureFlagName];
+              // Keep the group name alongside the value it was selected with,
+              // so consumers segmenting on it do not see a value with no group.
+              const previousGroup =
+                this.state.featureFlagThresholdGroups?.[remoteFeatureFlagName];
+              if (previousGroup) {
+                featureFlagThresholdGroups[remoteFeatureFlagName] =
+                  previousGroup;
+              }
+              continue;
+            }
+
+            // No previous value to preserve, as on a fresh install.
             processedFlags[remoteFeatureFlagName] = processedValue;
             continue;
           }


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->
`init()` re-derives the effective flags from the persisted `rawRemoteFeatureFlags`. For threshold flags that means grouping the user by `getMetaMetricsId` or `getCanonicalProfileId`, and both are documented as returning an empty string when the identifier isn't available. When that happened we stored the raw threshold array as the flag value, so a flag that had a resolved value last session came back unresolved.

That isn't hypothetical. On the extension, `wallet.init()` runs before the controllers backing both getters are registered, so both return an empty string on every startup, and consumers reading a threshold flag get an array instead of a value until the next fetch.

With this change, when there's no identifier we keep the value from the previous session rather than the array, plus its entry in `featureFlagThresholdGroups` so the value and its group stay in sync. Flags with nothing to preserve, as on a fresh install, still fall back to the array. Same reasoning already applied to the no-raw-flags branch in #9816: leaving a flag ungrouped beats flipping it for the end user.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->
See: https://github.com/MetaMask/metamask-extension/pull/45749#discussion_r3947558519

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes threshold flag resolution during `init`, which affects effective flag values for all consumers until the next fetch, though the behavior is intentionally conservative.
> 
> **Overview**
> Fixes a startup bug where **`init()`** could replace resolved threshold feature flag values with the raw threshold **array** when `getMetaMetricsId` or `getCanonicalProfileId` return an empty string (common before their backing controllers are ready).
> 
> During threshold processing, if there is no segmentation id the controller now **reuses the last persisted resolved value** from `#processedRemoteFeatureFlags` and restores the matching **`featureFlagThresholdGroups`** entry so value and group stay aligned. Fresh installs with nothing to preserve still get the unresolved array.
> 
> Adds a regression test for empty canonical profile id on `init` and documents the fix in the package changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 652a1b81e8416b44455b736548d08f8985aec627. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->