### PR TITLE
chore: break AuthenticationController constructor dependency on KeyringController

### DIFF
--- a/packages/profile-sync-controller/CHANGELOG.md
+++ b/packages/profile-sync-controller/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resolve HD entropy source IDs from `KeyringController` instead of the message-signing snap (`getBearerToken` primary ID, `performSignIn` SRP enumeration) ([#9794](https://github.com/MetaMask/core/pull/9794))
 - Bump `@metamask/keyring-controller` from `^27.1.0` to `^27.1.1` ([#9791](https://github.com/MetaMask/core/pull/9791))
 - Add `@metamask/key-tree` and `@noble/curves`; remove unused `@metamask/snaps-controllers`, `@metamask/snaps-sdk`, and `@metamask/snaps-utils` dependencies ([#9824](https://github.com/MetaMask/core/pull/9824))
-- Bump `@metamask/utils` from `^11.11.0` to `^11.12.0` ([#10076](https://github.com/MetaMask/core/pull/10076))
+- Bump `@metamask/utils` from `^11.11.0` to `^11.12.0` ([#10076](10076))
+- `AuthenticationControllerMessenger` does not require `KeyringController:unlock` or `KeyringController:lock` events anymore ([#0000](https://github.com/MetaMask/core/pull/0000))
 
 ## [29.0.0]
 

--- a/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.ts
@@ -159,7 +159,7 @@ type AllowedActions =
   | KeyringControllerWithKeyringV2UnsafeAction
   | SeedlessOnboardingControllerGetStateAction;
 
-type AllowedEvents = KeyringControllerLockEvent | KeyringControllerUnlockEvent;
+type AllowedEvents = never;
 
 // Messenger
 export type AuthenticationControllerMessenger = Messenger<
@@ -185,27 +185,10 @@ export class AuthenticationController extends BaseController<
     env: Env.PRD,
   };
 
-  #isUnlocked = false;
-
   // Bumped by `requestProfilePairing`. `performSignIn` snapshots this
   // before its first await; if it changes mid-flight we must NOT clear
   // `needsProfilePairing` (the rearm signal wins).
   #profilePairingRequestEpoch = 0;
-
-  readonly #keyringController = {
-    setupLockedStateSubscriptions: () => {
-      const { isUnlocked } = this.messenger.call('KeyringController:getState');
-      this.#isUnlocked = isUnlocked;
-
-      this.messenger.subscribe('KeyringController:unlock', () => {
-        this.#isUnlocked = true;
-      });
-
-      this.messenger.subscribe('KeyringController:lock', () => {
-        this.#isUnlocked = false;
-      });
-    },
-  };
 
   constructor({
     messenger,
@@ -261,8 +244,6 @@ export class AuthenticationController extends BaseController<
       },
     );
 
-    this.#keyringController.setupLockedStateSubscriptions();
-
     this.messenger.registerMethodActionHandlers(
       this,
       MESSENGER_EXPOSED_METHODS,
@@ -301,7 +282,8 @@ export class AuthenticationController extends BaseController<
   }
 
   #assertIsUnlocked(methodName: string): void {
-    if (!this.#isUnlocked) {
+    const { isUnlocked } = this.messenger.call('KeyringController:getState');
+    if (!isUnlocked) {
       throw new Error(`${methodName} - unable to proceed, wallet is locked`);
     }
   }


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->
`AuthenticationController` calls `KeyringController:getState` in its constructor in order to keep an internal variable for `isUnlocked`. This constructor call and the two event subscriptions can be substituted by `KeyringController:getState` calls whenever the `isUnlocked` value is needed.

This makes it easier for `AuthenticationController` to be included in the `@metamask/wallet` package.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->
N/A

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Messenger contract change requires consumer updates, and auth gating now depends on live keyring state reads instead of event-driven caching (behavior should be equivalent but is on the authentication critical path).
> 
> **Overview**
> **AuthenticationController** no longer mirrors wallet lock state in the constructor. It removes the cached `#isUnlocked` flag, the `KeyringController:lock` / `KeyringController:unlock` subscriptions, and the constructor-time `KeyringController:getState` call used to seed that cache.
> 
> Unlock checks in `#assertIsUnlocked` now read **`KeyringController:getState`** when auth methods run, so lock gating follows current keyring state instead of subscribed updates. **`AuthenticationControllerMessenger`** types **`AllowedEvents`** as **`never`**, so integrators can stop wiring those keyring events on this messenger (documented in the changelog).
> 
> This is aimed at easing inclusion of **AuthenticationController** in **`@metamask/wallet`** by avoiding constructor coupling to keyring lifecycle events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe8ba53852c399b6e2f0ed06ae8b35002433b37b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->