### PR TITLE
fix(assets-controller): make #start() re-entrancy safe

### DIFF
--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -7,14 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Fix `#start()` re-entrancy so a second unlock/init/state-change trigger can't run a duplicate startup asset refresh while the first one is still in flight ([#10131](https://github.com/MetaMask/core/pull/10131))
-
 ### Changed
 
 - Bump `@metamask/transaction-controller` from `^69.8.0` to `^69.8.1` ([#10124](https://github.com/MetaMask/core/pull/10124))
 - Enhance spam asset cleanup to collect candidates from `assetsBalance` and remove swept assets from `assetsPrice` ([#10095](https://github.com/MetaMask/core/pull/10095))
+
+### Fixed
+
+- Fix `#start()` re-entrancy so a second unlock/init/state-change trigger can't run a duplicate startup asset refresh while the first one is still in flight ([#10131](https://github.com/MetaMask/core/pull/10131))
 
 ## [15.0.0]
 

--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `#start()` re-entrancy so a second unlock/init/state-change trigger can't run a duplicate startup asset refresh while the first one is still in flight ([#10125](https://github.com/MetaMask/core/pull/10125))
+
 ### Changed
 
 - Bump `@metamask/transaction-controller` from `^69.8.0` to `^69.8.1` ([#10124](https://github.com/MetaMask/core/pull/10124))

--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix `#start()` re-entrancy so a second unlock/init/state-change trigger can't run a duplicate startup asset refresh while the first one is still in flight ([#10125](https://github.com/MetaMask/core/pull/10125))
+- Fix `#start()` re-entrancy so a second unlock/init/state-change trigger can't run a duplicate startup asset refresh while the first one is still in flight ([#10131](https://github.com/MetaMask/core/pull/10131))
 
 ### Changed
 

--- a/packages/assets-controller/src/AssetsController.test.ts
+++ b/packages/assets-controller/src/AssetsController.test.ts
@@ -3319,6 +3319,68 @@ describe('AssetsController', () => {
         },
       );
     });
+
+    it('does not run the startup refresh twice if a second start trigger fires before the first getAssets resolves', async () => {
+      await withController(
+        { clientControllerState: { isUiOpen: true } },
+        async ({ controller, messenger }) => {
+          let resolveGetAssets: (() => void) | undefined;
+          const getAssetsSpy = jest
+            .spyOn(controller, 'getAssets')
+            .mockImplementation(
+              () =>
+                new Promise((resolve) => {
+                  resolveGetAssets = (): void => resolve({});
+                }),
+            );
+
+          // First trigger: unlock + account tree ready. #start() kicks off
+          // #runStartupRefresh(), whose forced getAssets() call is still
+          // pending (it never resolves until we call resolveGetAssets below).
+          messenger.publish('KeyringController:unlock');
+          (messenger.publish as CallableFunction)(
+            'AccountTreeController:initialized',
+            {},
+          );
+          await flushPromises();
+
+          expect(getAssetsSpy).toHaveBeenCalledTimes(1);
+
+          // Second, independent trigger fires while the first getAssets()
+          // call is still in flight — #activeSubscriptions is still empty at
+          // this point, so only the in-flight guard can prevent a duplicate
+          // #runStartupRefresh() (and its own forced getAssets() call).
+          (
+            messenger as unknown as {
+              publish: (topic: string, payload?: unknown) => void;
+            }
+          ).publish('ClientController:stateChanged', { isUiOpen: true });
+          await flushPromises();
+
+          expect(getAssetsSpy).toHaveBeenCalledTimes(1);
+
+          resolveGetAssets?.();
+          await flushPromises();
+
+          // Once the single in-flight startup refresh settles, it also
+          // triggers one follow-up price-only getAssets() call — but a
+          // duplicate #runStartupRefresh() would double both of these (4
+          // total), not just add one. Two calls confirms no duplicate ran.
+          expect(getAssetsSpy).toHaveBeenCalledTimes(2);
+          expect(getAssetsSpy).toHaveBeenNthCalledWith(
+            1,
+            expect.anything(),
+            expect.objectContaining({ forceUpdate: true }),
+          );
+          expect(getAssetsSpy).toHaveBeenNthCalledWith(
+            2,
+            expect.anything(),
+            expect.objectContaining({ dataTypes: ['price'] }),
+          );
+          getAssetsSpy.mockRestore();
+        },
+      );
+    });
   });
 
   describe('subscribeAssetsPrice', () => {

--- a/packages/assets-controller/src/AssetsController.ts
+++ b/packages/assets-controller/src/AssetsController.ts
@@ -766,6 +766,19 @@ export class AssetsController extends BaseController<
    */
   readonly #activeSubscriptions: Map<string, SubscriptionResponse> = new Map();
 
+  /**
+   * Guards against `#start()` re-entrancy. `#activeSubscriptions` only
+   * becomes non-empty once `#runStartupRefresh()`'s forced `getAssets()`
+   * call resolves, which can take many seconds for accounts with many
+   * chains/snaps. `#start()` is invoked by `#updateActive()`, which is
+   * wired to several independent events (e.g. keyring unlock, account tree
+   * init, client state change). If a second such event fires before the
+   * first `getAssets()` call resolves, the `#activeSubscriptions.size > 0`
+   * guard alone doesn't catch it, and the whole startup refresh (including
+   * its forced `getAssets()` call) runs a second time for the same accounts.
+   */
+  #startInFlight = false;
+
   /** Currently enabled chains from NetworkEnablementController */
   #enabledChains: Set<ChainId> = new Set();
 
@@ -3081,7 +3094,7 @@ export class AssetsController extends BaseController<
       return;
     }
 
-    if (this.#activeSubscriptions.size > 0) {
+    if (this.#activeSubscriptions.size > 0 || this.#startInFlight) {
       return;
     }
 
@@ -3090,9 +3103,14 @@ export class AssetsController extends BaseController<
       enabledChainCount: chainIds.length,
     });
 
-    this.#runStartupRefresh(accounts).catch((error) => {
-      log('Failed to start asset tracking', error);
-    });
+    this.#startInFlight = true;
+    this.#runStartupRefresh(accounts)
+      .catch((error) => {
+        log('Failed to start asset tracking', error);
+      })
+      .finally(() => {
+        this.#startInFlight = false;
+      });
   }
 
   /**


### PR DESCRIPTION
## Explanation

`AssetsController#start()` guards against running twice with `#activeSubscriptions.size > 0`, but that only becomes true after the initial `#runStartupRefresh()` call resolves — including its forced `getAssets()` call, which can take many seconds for accounts with many chains/snaps.

`#start()` is triggered by several independent events (keyring unlock, account tree init, client state change). If a second one of these fires before the first `getAssets()` call resolves, the existing guard doesn't catch it, and the entire startup refresh — including its forced `getAssets()` call — runs a second time for the same accounts.

This adds a synchronous `#startInFlight` flag, set before the async work starts and cleared once it settles, so a second trigger during that window is a no-op instead of re-running the whole refresh.

## References

https://consensyssoftware.atlassian.net/browse/ASSETS-3955

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by updating changelogs for packages I've changed
- [ ] I've introduced breaking changes in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow lifecycle guard around existing startup path; behavior unchanged once the first refresh completes, with test coverage for the race.
> 
> **Overview**
> Fixes a race where **multiple lifecycle events** (unlock, account tree init, UI open) could each call `#start()` while the first startup `#runStartupRefresh()` was still waiting on a slow forced `getAssets()`. The old guard only checked `#activeSubscriptions`, which stays empty until that fetch finishes, so a second trigger could run the full startup refresh twice.
> 
> **`#startInFlight`** is set synchronously before `#runStartupRefresh()` and cleared in `.finally()`, so overlapping `#start()` calls are ignored until the in-flight startup completes. A regression test holds `getAssets` pending and asserts a second trigger does not add duplicate forced fetches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5c6d5a92670ea4900455bf0e205cb911cdf6cbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->