### PR TITLE
fix(perps): reject incomplete order reads and preserve protection IDs

### DIFF
--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **BREAKING:** Replace the placeholder HyperLiquid TP/SL success `orderId` with confirmed venue IDs in `OrderResult.childOrderIds`. Resolve acknowledgements without IDs by their submitted client order ID; accepted protection remains successful when its venue ID is unavailable.
-- **BREAKING:** Reject failed or incomplete open-order fetches from HyperLiquid, Lighter, and aggregated providers instead of reporting empty or partial success. Callers must handle rejections and retain prior order state. HyperLiquid order classification now requires complete position context for the requested account.
+- **BREAKING:** Replace the placeholder HyperLiquid TP/SL success `orderId` with confirmed venue IDs in `OrderResult.childOrderIds`. Resolve acknowledgements without IDs by their submitted client order ID; accepted protection remains successful when its venue ID is unavailable. ([#10135](https://github.com/MetaMask/core/pull/10135))
+- **BREAKING:** Reject failed or incomplete open-order fetches from HyperLiquid, Lighter, and aggregated providers instead of reporting empty or partial success. Callers must handle rejections and retain prior order state. HyperLiquid order classification now requires complete position context for the requested account. ([#10135](https://github.com/MetaMask/core/pull/10135))
 - Handle zero minimum order amounts and margin fractions reported by Lighter for inactive markets by omitting unusable retired rows, while keeping valid delisted metadata and active market values strict. ([#10110](https://github.com/MetaMask/core/pull/10110))
 
 ## [16.1.0]

--- a/packages/perps-controller/CHANGELOG.md
+++ b/packages/perps-controller/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **BREAKING:** Replace the placeholder HyperLiquid TP/SL success `orderId` with confirmed venue IDs in `OrderResult.childOrderIds`. Resolve acknowledgements without IDs by their submitted client order ID; accepted protection remains successful when its venue ID is unavailable.
+- **BREAKING:** Reject failed or incomplete open-order fetches from HyperLiquid, Lighter, and aggregated providers instead of reporting empty or partial success. Callers must handle rejections and retain prior order state. HyperLiquid order classification now requires complete position context for the requested account.
 - Handle zero minimum order amounts and margin fractions reported by Lighter for inactive markets by omitting unusable retired rows, while keeping valid delisted metadata and active market values strict. ([#10110](https://github.com/MetaMask/core/pull/10110))
 
 ## [16.1.0]

--- a/packages/perps-controller/src/providers/AggregatedPerpsProvider.ts
+++ b/packages/perps-controller/src/providers/AggregatedPerpsProvider.ts
@@ -465,14 +465,14 @@ export class AggregatedPerpsProvider implements PerpsProvider {
   }
 
   async getOpenOrders(params?: GetOrdersParams): Promise<Order[]> {
-    const results = await Promise.allSettled(
+    const results = await Promise.all(
       this.#getActiveProviders().map(async ([id, provider]) => {
         const orders = await provider.getOpenOrders(params);
         return orders.map((order) => ({ ...order, providerId: id }));
       }),
     );
 
-    return this.#extractSuccessfulResults(results, 'getOpenOrders').flat();
+    return results.flat();
   }
 
   async getFunding(

--- a/packages/perps-controller/src/providers/HyperLiquidProvider.ts
+++ b/packages/perps-controller/src/providers/HyperLiquidProvider.ts
@@ -3010,9 +3010,12 @@ export class HyperLiquidProvider implements PerpsProvider {
    * Unlike ordinary discovery, this uses HTTP and never degrades to main-only
    * when HIP-3 discovery fails.
    *
+   * @param client - Optional standalone read client.
    * @returns The validated DEX set.
    */
-  async #getValidatedDexsStrict(): Promise<(string | null)[]> {
+  async #getValidatedDexsStrict(
+    client?: InfoClient,
+  ): Promise<(string | null)[]> {
     if (!this.#hip3Enabled) {
       return [null];
     }
@@ -3022,7 +3025,8 @@ export class HyperLiquidProvider implements PerpsProvider {
     }
 
     const lifecycleGeneration = this.#lifecycleGeneration;
-    const infoClient = this.#clientService.getInfoClient({ useHttp: true });
+    const infoClient =
+      client ?? this.#clientService.getInfoClient({ useHttp: true });
     let allDexs;
     try {
       allDexs = await infoClient.perpDexs();
@@ -9841,6 +9845,7 @@ export class HyperLiquidProvider implements PerpsProvider {
       if (takeProfitPrice) {
         const tpOrder: SDKOrderParams = {
           a: assetId,
+          c: `0x${uuidv4().replace(/-/gu, '')}`,
           b: !isLong, // Opposite side to close position
           p: formatHyperLiquidPrice({
             price: parseFloat(takeProfitPrice),
@@ -9866,6 +9871,7 @@ export class HyperLiquidProvider implements PerpsProvider {
       if (stopLossPrice) {
         const slOrder: SDKOrderParams = {
           a: assetId,
+          c: `0x${uuidv4().replace(/-/gu, '')}`,
           b: !isLong, // Opposite side to close position
           p: formatHyperLiquidPrice({
             price: parseFloat(stopLossPrice),
@@ -10117,9 +10123,53 @@ export class HyperLiquidProvider implements PerpsProvider {
         );
 
       if (placementAccepted) {
+        const childOrderIds = await Promise.all(
+          initialPlacementOutcomes.map(async (outcome, index) => {
+            if (outcome.orderId !== undefined) {
+              return outcome.orderId;
+            }
+            const clientOrderId = orders[index].c;
+            if (!clientOrderId) {
+              return undefined;
+            }
+            try {
+              const status = await infoClient.orderStatus({
+                user: userAddress,
+                oid: clientOrderId,
+              });
+              if (status.status === 'order') {
+                const venueOrder = status.order.order;
+                if (
+                  venueOrder.cloid?.toLowerCase() ===
+                    clientOrderId.toLowerCase() &&
+                  venueOrder.coin === symbol &&
+                  Number.isSafeInteger(venueOrder.oid) &&
+                  venueOrder.oid >= 0
+                ) {
+                  return String(venueOrder.oid);
+                }
+              }
+            } catch (error) {
+              this.#deps.debugLogger.log(
+                'Accepted TP/SL order ID unavailable',
+                {
+                  symbol,
+                  error: ensureError(
+                    error,
+                    'HyperLiquidProvider.updatePositionTPSL',
+                  ).message,
+                },
+              );
+            }
+            // Acceptance does not depend on the order-status index catching up.
+            return undefined;
+          }),
+        );
         return {
           success: true,
-          orderId: 'TP/SL orders placed',
+          childOrderIds: childOrderIds.filter(
+            (orderId): orderId is string => orderId !== undefined,
+          ),
         };
       }
 
@@ -11460,7 +11510,7 @@ export class HyperLiquidProvider implements PerpsProvider {
         const standaloneInfoClient = createStandaloneInfoClient({
           isTestnet: this.#clientService.isTestnetMode(),
         });
-        const dexs = await this.#getStandaloneValidatedDexs();
+        const dexs = await this.#getValidatedDexsStrict(standaloneInfoClient);
         const orderResults = await queryStandaloneOpenOrders(
           standaloneInfoClient,
           userAddress,
@@ -11512,29 +11562,50 @@ export class HyperLiquidProvider implements PerpsProvider {
         params?.accountId,
       );
 
-      // Query orders across all enabled DEXs in parallel
+      const dexs = await this.#getValidatedDexsStrict();
       const { results: orderResults, failedDexs } =
         await this.#queryUserDataAcrossDexs(
           { user: userAddress },
           (userParam) => infoClient.frontendOpenOrders(userParam),
+          dexs,
         );
 
       if (failedDexs.length > 0) {
         this.#deps.debugLogger.log(
-          'Partial multi-DEX open order fetch completed with failures',
+          'Complete multi-DEX open order fetch unavailable',
           {
             failedDexs: failedDexs.map(
               ({ dex, error }) => `${dex ?? 'main'}:${error.message}`,
             ),
           },
         );
+        throw new Error(PERPS_ERROR_CODES.PROVIDER_NOT_AVAILABLE);
       }
 
       // Combine all orders from all DEXs
       const rawOrders = orderResults.flatMap((result) => result.data);
+      if (rawOrders.length === 0) {
+        return [];
+      }
 
-      // Get positions for order context (already multi-DEX aware)
-      const positions = await this.getPositions();
+      // Order classification needs complete position context for the same account.
+      const { results: stateResults, failedDexs: failedStateDexs } =
+        await this.#queryUserDataAcrossDexs(
+          { user: userAddress },
+          (userParam) => infoClient.clearinghouseState(userParam),
+          dexs,
+        );
+      if (
+        failedStateDexs.length > 0 ||
+        stateResults.some(({ data }) => !Array.isArray(data.assetPositions))
+      ) {
+        throw new Error(PERPS_ERROR_CODES.PROVIDER_NOT_AVAILABLE);
+      }
+      const positions = stateResults.flatMap(({ data }) =>
+        data.assetPositions
+          .filter((assetPos) => assetPos.position.szi !== '0')
+          .map((assetPos) => adaptPositionFromSDK(assetPos)),
+      );
 
       this.#deps.debugLogger.log('Currently open orders received (all DEXs):', {
         count: rawOrders.length,
@@ -11551,7 +11622,7 @@ export class HyperLiquidProvider implements PerpsProvider {
       return orders;
     } catch (error) {
       this.#deps.debugLogger.log('Error getting currently open orders:', error);
-      return [];
+      throw error;
     }
   }
 

--- a/packages/perps-controller/src/providers/LighterProvider.ts
+++ b/packages/perps-controller/src/providers/LighterProvider.ts
@@ -4934,7 +4934,7 @@ export class LighterProvider implements PerpsProvider {
         error: String(wrappedError),
         ...this.#getErrorContext('getOpenOrders'),
       });
-      return [];
+      throw wrappedError;
     }
   }
 
@@ -4965,8 +4965,7 @@ export class LighterProvider implements PerpsProvider {
       );
       // Full lifecycle: open orders first, then the historical states.
       const open = await this.getOpenOrders(params);
-      // getOpenOrders swallows its own cancellation into []; the merge must
-      // still refuse to pair A's history with B's session.
+      // Never pair one account's history with another account's open orders.
       this.#assertSession(generation);
       return [...open, ...historical];
     } catch (caughtError) {

--- a/packages/perps-controller/src/types/index.ts
+++ b/packages/perps-controller/src/types/index.ts
@@ -1972,6 +1972,7 @@ export type PerpsProvider = {
    * Purpose: Show orders that are currently open/pending execution (not historical states).
    * Different from getOrders() which returns complete historical order lifecycle.
    * Example: Shows only orders that are actually open right now in the exchange.
+   * Rejects failed or incomplete fetches; callers should retain prior order state on error.
    */
   getOpenOrders(params?: GetOrdersParams): Promise<Order[]>;
 

--- a/packages/perps-controller/src/utils/standaloneInfoClient.ts
+++ b/packages/perps-controller/src/utils/standaloneInfoClient.ts
@@ -70,6 +70,7 @@ export const queryStandaloneClearinghouseStates = async (
 /**
  * Query frontendOpenOrders across multiple DEXs in parallel.
  * Used by standalone mode to fetch open orders across HIP-3 DEXs.
+ * Rejects if any DEX request fails.
  *
  * @param infoClient - The HyperLiquid InfoClient instance to use for queries.
  * @param userAddress - The user's wallet address to query orders for.
@@ -81,7 +82,7 @@ export const queryStandaloneOpenOrders = async (
   userAddress: string,
   dexs: (string | null)[],
 ): Promise<FrontendOpenOrdersResponse[]> => {
-  const results = await Promise.allSettled(
+  return Promise.all(
     dexs.map(async (dex) => {
       const queryParams: { user: string; dex?: string } = {
         user: userAddress,
@@ -92,11 +93,4 @@ export const queryStandaloneOpenOrders = async (
       return infoClient.frontendOpenOrders(queryParams);
     }),
   );
-
-  return results
-    .filter(
-      (result): result is PromiseFulfilledResult<FrontendOpenOrdersResponse> =>
-        result.status === 'fulfilled',
-    )
-    .map((result) => result.value);
 };

--- a/packages/perps-controller/tests/src/providers/AggregatedPerpsProvider.test.ts
+++ b/packages/perps-controller/tests/src/providers/AggregatedPerpsProvider.test.ts
@@ -525,6 +525,11 @@ describe('AggregatedPerpsProvider', () => {
       expect(result).toContainEqual(
         expect.objectContaining({ orderId: '1', providerId: 'hyperliquid' }),
       );
+
+      mockHLProvider.getOpenOrders.mockRejectedValue(new Error('Unavailable'));
+      await expect(aggregatedProvider.getOpenOrders()).rejects.toThrow(
+        'Unavailable',
+      );
     });
   });
 

--- a/packages/perps-controller/tests/src/providers/HyperLiquidProvider.history.test.ts
+++ b/packages/perps-controller/tests/src/providers/HyperLiquidProvider.history.test.ts
@@ -1375,7 +1375,7 @@ describe('HyperLiquidProvider', () => {
   });
 
   describe('getOpenOrders additional coverage', () => {
-    it('returns empty array when frontendOpenOrders throws error', async () => {
+    it('rejects when frontendOpenOrders throws error', async () => {
       // Arrange
       mockClientService.getInfoClient = jest.fn().mockReturnValue({
         frontendOpenOrders: jest.fn().mockRejectedValue(new Error('API Error')),
@@ -1386,10 +1386,9 @@ describe('HyperLiquidProvider', () => {
       });
 
       // Act
-      const result = await provider.getOpenOrders({ skipCache: true });
-
-      // Assert
-      expect(result).toEqual([]);
+      await expect(provider.getOpenOrders({ skipCache: true })).rejects.toThrow(
+        PERPS_ERROR_CODES.PROVIDER_NOT_AVAILABLE,
+      );
     });
 
     it('returns cached orders when cache is initialized', async () => {
@@ -1561,8 +1560,7 @@ describe('HyperLiquidProvider', () => {
       // Assert
       expect(result).toHaveLength(1);
       expect(result[0].symbol).toBe('ETH');
-      // Note: frontendOpenOrders is called twice - once for getOpenOrders and once for getPositions
-      expect(mockFrontendOpenOrders).toHaveBeenCalled();
+      expect(mockFrontendOpenOrders).toHaveBeenCalledTimes(1);
     });
 
     it('queries multiple DEXs when HIP-3 enabled', async () => {

--- a/packages/perps-controller/tests/src/providers/HyperLiquidProvider.standalone.test.ts
+++ b/packages/perps-controller/tests/src/providers/HyperLiquidProvider.standalone.test.ts
@@ -1420,20 +1420,17 @@ describe('HyperLiquidProvider', () => {
         });
       });
 
-      it('returns empty array when standalone client fails', async () => {
-        // Arrange
+      it('rejects when standalone open orders fail', async () => {
         mockStandaloneInfoClient.frontendOpenOrders.mockRejectedValue(
           new Error('API unavailable'),
         );
 
-        // Act
-        const orders = await provider.getOpenOrders({
-          standalone: true,
-          userAddress: mockUserAddress,
-        });
-
-        // Assert — all DEX queries failed, flatMap([]) returns empty
-        expect(orders).toEqual([]);
+        await expect(
+          provider.getOpenOrders({
+            standalone: true,
+            userAddress: mockUserAddress,
+          }),
+        ).rejects.toThrow('API unavailable');
       });
     });
 

--- a/packages/perps-controller/tests/src/providers/HyperLiquidProvider.strategy-orders.test.ts
+++ b/packages/perps-controller/tests/src/providers/HyperLiquidProvider.strategy-orders.test.ts
@@ -1343,7 +1343,7 @@ describe('HyperLiquidProvider - strategy order types', () => {
 
       expect(result).toStrictEqual({
         success: true,
-        orderId: 'TP/SL orders placed',
+        childOrderIds: ['123'],
       });
       expect(exchangeClient.cancel.mock.invocationCallOrder[0]).toBeLessThan(
         exchangeClient.order.mock.invocationCallOrder[0],
@@ -1664,7 +1664,7 @@ describe('HyperLiquidProvider - strategy order types', () => {
 
       expect(result).toStrictEqual({
         success: true,
-        orderId: 'TP/SL orders placed',
+        childOrderIds: [],
       });
       expect(exchangeClient.cancel).not.toHaveBeenCalled();
       expect(infoClient.frontendOpenOrders).not.toHaveBeenCalled();

--- a/packages/perps-controller/tests/src/providers/HyperLiquidProvider.trading.test.ts
+++ b/packages/perps-controller/tests/src/providers/HyperLiquidProvider.trading.test.ts
@@ -4849,7 +4849,7 @@ describe('HyperLiquidProvider', () => {
       const result = await provider.updatePositionTPSL(updateParams);
 
       expect(result.success).toBe(true);
-      expect(result.orderId).toBeDefined();
+      expect(result.childOrderIds).toEqual(['123', '124']);
     });
 
     it('handles update with only take profit price', async () => {

--- a/packages/perps-controller/tests/src/providers/LighterProvider.test.ts
+++ b/packages/perps-controller/tests/src/providers/LighterProvider.test.ts
@@ -5348,7 +5348,9 @@ describe('LighterProvider', () => {
       const venueB = setupTriggerVenue(second.clientInstance, second.bridge);
       venueB.setVenueNonce(venueA.getVenueNonce());
       venueB.setNextIndex(venueA.getNextIndex());
-      await second.provider.getOpenOrders();
+      await expect(second.provider.getOpenOrders()).rejects.toThrow(
+        'unresolved outcome',
+      );
       await new Promise((resolve) => setTimeout(resolve, 500));
       // The obligation is retained (unexpired + venue-confirmed nothing).
       expect(journalKeysOf(disk)).toHaveLength(1);
@@ -10157,7 +10159,7 @@ describe('LighterProvider', () => {
       expect(result.totalBalance).toBe('0');
     });
 
-    it('getOpenOrders returns nothing when the account switches between index and token', async () => {
+    it('getOpenOrders rejects when the account switches between index and token', async () => {
       const { provider, clientInstance, getUserAddressMock, bridge } =
         buildProvider({ configuredAccountIndex: null });
       clientInstance.getAccountsByL1Address.mockImplementation(
@@ -10185,8 +10187,7 @@ describe('LighterProvider', () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
       getUserAddressMock.mockReturnValue('0xbbbb');
       releaseToken();
-      const orders = await readUnderA;
-      expect(orders).toStrictEqual([]);
+      await expect(readUnderA).rejects.toThrow('Operation cancelled');
       // The A index + fresh token pairing never reached the venue.
       expect(clientInstance.getActiveOrders).not.toHaveBeenCalled();
     });

--- a/packages/perps-controller/tests/src/utils/standaloneInfoClient.test.ts
+++ b/packages/perps-controller/tests/src/utils/standaloneInfoClient.test.ts
@@ -278,30 +278,32 @@ describe('standaloneInfoClient', () => {
       expect(mockInfoClient.frontendOpenOrders).toHaveBeenCalledTimes(2);
     });
 
-    it('returns only fulfilled results when some DEX queries fail', async () => {
+    it('rejects when some open-order DEX queries fail', async () => {
       const ordersA = [{ oid: 1, coin: 'BTC', side: 'A' }];
 
       mockInfoClient.frontendOpenOrders
         .mockResolvedValueOnce(ordersA)
         .mockRejectedValueOnce(new Error('DEX timeout'));
 
-      const results = await queryStandaloneOpenOrders(
-        mockInfoClient as unknown as InfoClient,
-        userAddress,
-        [null, 'failing-dex'],
-      );
-
-      expect(results).toEqual([ordersA]);
+      await expect(
+        queryStandaloneOpenOrders(
+          mockInfoClient as unknown as InfoClient,
+          userAddress,
+          [null, 'failing-dex'],
+        ),
+      ).rejects.toThrow('DEX timeout');
     });
 
     it('omits dex param when DEX is null', async () => {
       mockInfoClient.frontendOpenOrders.mockResolvedValue([]);
 
-      await queryStandaloneOpenOrders(
-        mockInfoClient as unknown as InfoClient,
-        userAddress,
-        [null],
-      );
+      await expect(
+        queryStandaloneOpenOrders(
+          mockInfoClient as unknown as InfoClient,
+          userAddress,
+          [null],
+        ),
+      ).resolves.toEqual([[]]);
 
       expect(mockInfoClient.frontendOpenOrders).toHaveBeenCalledWith({
         user: userAddress,


### PR DESCRIPTION
## Explanation

Failed or incomplete open-order reads could appear successfully empty. HyperLiquid now rejects failed DEX discovery, order requests and required position context; Lighter and aggregated reads preserve failures. Genuine empty results remain successful, and nonempty orders use complete position context for the requested account.

Successful HyperLiquid TP/SL updates now return confirmed venue IDs in `childOrderIds`. Each submitted leg receives a CLOID; acknowledgements without IDs get an exact CLOID lookup. Unresolved IDs stay absent without changing accepted placement to failure. Existing failure/restoration behavior remains unchanged.

Breaking changes: callers must handle rejected open-order reads and retain prior state. TP/SL success no longer returns the placeholder `orderId` string; consumers use `childOrderIds`, whose presence does not prove protection is still live.

## Validation

- Read-safety changes: 1,061 existing checks passed, one skipped. TP/SL follow-up: 25 existing scoped checks passed.
- TypeScript/package build, ESLint, formatting and changelog validation passed. Private archives passed entrypoint and dependency checks.
- Mobile 8.12 controlled transport-fault checks confirmed real empty results, partial/all-DEX rejection, and retention of an accepted order in controller cache through errors. A subsequent real read returned the same ID; exact-order cancellation completed later. No paired screenshot UI-retention claim.
- Mobile 8.12 protected BTC market-order proof passed: the entry filled, returned `childOrderIds` identified the exact TP limit and SL market triggers, and both configured protections were verified. Exact protections were cancelled and the position closed. Independent final reads showed no orders, positions, pending entries or owned unsigned requests. Mismatched-account cleanup was refused before mutation.

## References

No linked issue found. Locally retained evidence, not committed Core files:

- Mobile: `temp/provider-read-safety/normal-read-fault.result.json`, `http-read-fault.result.json`, `normal-read-fault-nonempty-59587470472.result.json`.
- Harness narratives: `temp/limit-receipt-device/report.md` and `temp/protected-receipt-device/report.md`.

## Checklist

- [x] I've updated existing tests for the changed behavior.
- [x] I've updated relevant documentation.
- [x] I've updated the package changelog.
- [ ] I've completed consumer migration and validation for the breaking changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking API behavior for open-order reads and TP/SL success payloads requires consumer migration; changes affect trading UI state retention and order classification across multi-DEX HyperLiquid paths.
> 
> **Overview**
> **Breaking read safety:** `getOpenOrders` no longer masks transport or partial multi-DEX failures as an empty book. HyperLiquid, Lighter, standalone HIP-3 helpers, and the aggregated provider now **reject** failed or incomplete fetches so callers should catch errors and keep showing prior order state. On HyperLiquid, open orders are classified only after a **complete** per-account position snapshot across the same validated DEX set (via `clearinghouseState`), not a best-effort `getPositions` that could silently drop a DEX.
> 
> **Breaking TP/SL receipts:** Successful HyperLiquid `updatePositionTPSL` no longer returns the placeholder success string in `orderId`. It returns confirmed venue IDs in **`OrderResult.childOrderIds`**, assigning client order IDs (CLOIDs) to each TP/SL leg and backfilling missing acknowledgement IDs with an exact `orderStatus` lookup when possible. Accepted placement can still succeed with an empty or partial `childOrderIds` list when the index has not caught up.
> 
> Tests and changelog document the new reject-vs-empty behavior and updated success shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c69d98aa0fcc6092ddb01d04ac5ef15e15681887. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->