### PR TITLE
fix(notification-services-controller): prevent unsibscribing if keyring is locked

### DIFF
--- a/packages/notification-services-controller/CHANGELOG.md
+++ b/packages/notification-services-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Leave existing push registration in place when the keyring has no accounts yet
+- Leave existing push registration in place when the keyring has no accounts yet ([#10143](https://github.com/MetaMask/core/pull/10143))
   - `createOnChainTriggers` and `enablePushNotifications` no longer treat an empty keyring as "every account disabled", which previously unregistered the device. An empty keyring is skipped so a later run can still seed first-time preferences and keep push links.
 
 ## [27.0.2]

--- a/packages/notification-services-controller/CHANGELOG.md
+++ b/packages/notification-services-controller/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Leave existing push registration in place when the keyring has no accounts yet
+  - `createOnChainTriggers` and `enablePushNotifications` no longer treat an empty keyring as "every account disabled", which previously unregistered the device. An empty keyring is skipped so a later run can still seed first-time preferences and keep push links.
+
 ## [27.0.2]
 
 ### Changed

--- a/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.test.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.test.ts
@@ -1025,6 +1025,36 @@ describe('NotificationServicesController', () => {
           ADDRESS_1,
         ]);
       });
+
+      it('does not write preferences or unregister push when the keyring has no accounts', async () => {
+        const {
+          messenger,
+          mockDisablePushNotifications,
+          mockEnablePushNotifications,
+          mockUpdateNotifications,
+          mockKeyringControllerGetState,
+        } = arrangeMocks({
+          configurePrefs: (mock) => mock.mockResolvedValueOnce(null),
+        });
+
+        mockKeyringControllerGetState.mockReturnValue({
+          isUnlocked: true,
+          keyrings: [],
+        });
+
+        const controller = new NotificationServicesController({
+          messenger,
+          env: { featureAnnouncements: featureAnnouncementsEnv },
+        });
+
+        await controller.createOnChainTriggers();
+
+        // Writing the blob here would make the next run a re-subscribe with no
+        // chance to seed accounts; unregistering would drop an existing device.
+        expect(mockUpdateNotifications).not.toHaveBeenCalled();
+        expect(mockDisablePushNotifications).not.toHaveBeenCalled();
+        expect(mockEnablePushNotifications).not.toHaveBeenCalled();
+      });
     });
 
     describe('when AUS preferences are fully initialized', () => {
@@ -1052,6 +1082,37 @@ describe('NotificationServicesController', () => {
         expect(mockUpdateNotifications).not.toHaveBeenCalled();
         expect(mockTriggerUpdate.isDone()).toBe(false);
         expect(mockEnablePushNotifications).toHaveBeenCalled();
+      });
+
+      it('leaves existing push links alone on re-subscribe when the keyring has no accounts', async () => {
+        const {
+          messenger,
+          mockDisablePushNotifications,
+          mockEnablePushNotifications,
+          mockUpdateNotifications,
+          mockKeyringControllerGetState,
+        } = arrangeMocks({
+          configurePrefs: (mock) =>
+            mock.mockResolvedValueOnce(mockPreferences()),
+        });
+
+        mockKeyringControllerGetState.mockReturnValue({
+          isUnlocked: true,
+          keyrings: [],
+        });
+        const mockTriggerUpdate = mockUpdateOnChainNotifications();
+
+        const controller = new NotificationServicesController({
+          messenger,
+          env: { featureAnnouncements: featureAnnouncementsEnv },
+        });
+
+        await controller.createOnChainTriggers();
+
+        expect(mockTriggerUpdate.isDone()).toBe(false);
+        expect(mockUpdateNotifications).not.toHaveBeenCalled();
+        expect(mockDisablePushNotifications).not.toHaveBeenCalled();
+        expect(mockEnablePushNotifications).not.toHaveBeenCalled();
       });
 
       it('does not re-subscribe accounts on the daily re-subscribe when the user disabled them all', async () => {
@@ -2001,6 +2062,31 @@ describe('NotificationServicesController', () => {
       expect(mockEnablePushNotifications).toHaveBeenCalledWith([
         ADDRESS_1.toLowerCase(),
       ]);
+    });
+
+    it('leaves existing push links alone when the keyring has no accounts', async () => {
+      const {
+        messenger,
+        mockEnablePushNotifications,
+        mockDisablePushNotifications,
+        mockKeyringControllerGetState,
+      } = arrangeMocks();
+      mockKeyringControllerGetState.mockReturnValue({
+        isUnlocked: true,
+        keyrings: [],
+      });
+      const controller = new NotificationServicesController({
+        messenger,
+        env: { featureAnnouncements: featureAnnouncementsEnv },
+        state: { isNotificationServicesEnabled: true },
+      });
+
+      await controller.enablePushNotifications();
+
+      // An empty keyring is not "every account disabled": unregistering here
+      // would drop the device until the next successful re-subscribe.
+      expect(mockDisablePushNotifications).not.toHaveBeenCalled();
+      expect(mockEnablePushNotifications).not.toHaveBeenCalled();
     });
 
     it('unregisters the device when no account has notifications enabled', async () => {

--- a/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.test.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.test.ts
@@ -630,6 +630,7 @@ describe('NotificationServicesController', () => {
           messenger,
           env: { featureAnnouncements: featureAnnouncementsEnv },
         });
+        controller.init();
 
         await controller.createOnChainTriggers({
           hasMarketingConsent: true,
@@ -690,6 +691,7 @@ describe('NotificationServicesController', () => {
           messenger,
           env: { featureAnnouncements: featureAnnouncementsEnv },
         });
+        controller.init();
 
         await controller.createOnChainTriggers({
           registerPushNotifications: false,
@@ -738,6 +740,7 @@ describe('NotificationServicesController', () => {
           messenger,
           env: { featureAnnouncements: featureAnnouncementsEnv },
         });
+        controller.init();
 
         await controller.createOnChainTriggers();
 
@@ -786,6 +789,7 @@ describe('NotificationServicesController', () => {
           messenger,
           env: { featureAnnouncements: featureAnnouncementsEnv },
         });
+        controller.init();
 
         await expect(controller.createOnChainTriggers()).rejects.toThrow(
           'Failed to create On Chain triggers',
@@ -831,6 +835,7 @@ describe('NotificationServicesController', () => {
           messenger,
           env: { featureAnnouncements: featureAnnouncementsEnv },
         });
+        controller.init();
 
         await controller.createOnChainTriggers();
 
@@ -850,6 +855,7 @@ describe('NotificationServicesController', () => {
           messenger,
           env: { featureAnnouncements: featureAnnouncementsEnv },
         });
+        controller.init();
 
         await controller.createOnChainTriggers();
 
@@ -870,6 +876,7 @@ describe('NotificationServicesController', () => {
           messenger,
           env: { featureAnnouncements: featureAnnouncementsEnv },
         });
+        controller.init();
 
         await controller.createOnChainTriggers({
           productAnnouncementEnabled: true,
@@ -919,6 +926,7 @@ describe('NotificationServicesController', () => {
           messenger,
           env: { featureAnnouncements: featureAnnouncementsEnv },
         });
+        controller.init();
 
         await controller.createOnChainTriggers();
 
@@ -971,6 +979,7 @@ describe('NotificationServicesController', () => {
           messenger,
           env: { featureAnnouncements: featureAnnouncementsEnv },
         });
+        controller.init();
 
         await controller.createOnChainTriggers();
 
@@ -1015,6 +1024,7 @@ describe('NotificationServicesController', () => {
           messenger,
           env: { featureAnnouncements: featureAnnouncementsEnv },
         });
+        controller.init();
 
         await controller.createOnChainTriggers();
 
@@ -1046,11 +1056,47 @@ describe('NotificationServicesController', () => {
           messenger,
           env: { featureAnnouncements: featureAnnouncementsEnv },
         });
+        controller.init();
 
         await controller.createOnChainTriggers();
 
         // Writing the blob here would make the next run a re-subscribe with no
         // chance to seed accounts; unregistering would drop an existing device.
+        expect(mockUpdateNotifications).not.toHaveBeenCalled();
+        expect(mockDisablePushNotifications).not.toHaveBeenCalled();
+        expect(mockEnablePushNotifications).not.toHaveBeenCalled();
+      });
+
+      it('does not write preferences or unregister push when the keyring is locked', async () => {
+        const {
+          messenger,
+          mockDisablePushNotifications,
+          mockEnablePushNotifications,
+          mockUpdateNotifications,
+          mockKeyringControllerGetState,
+        } = arrangeMocks({
+          configurePrefs: (mock) => mock.mockResolvedValueOnce(null),
+        });
+
+        mockKeyringControllerGetState.mockReturnValue({
+          isUnlocked: false,
+          keyrings: [
+            {
+              accounts: [ADDRESS_1, ADDRESS_2],
+              type: KeyringTypes.hd,
+              metadata: { id: 'srp-1', name: 'SRP 1' },
+            },
+          ],
+        });
+
+        const controller = new NotificationServicesController({
+          messenger,
+          env: { featureAnnouncements: featureAnnouncementsEnv },
+        });
+        controller.init();
+
+        await controller.createOnChainTriggers();
+
         expect(mockUpdateNotifications).not.toHaveBeenCalled();
         expect(mockDisablePushNotifications).not.toHaveBeenCalled();
         expect(mockEnablePushNotifications).not.toHaveBeenCalled();
@@ -1075,6 +1121,7 @@ describe('NotificationServicesController', () => {
           messenger,
           env: { featureAnnouncements: featureAnnouncementsEnv },
         });
+        controller.init();
 
         await controller.createOnChainTriggers();
 
@@ -1106,6 +1153,45 @@ describe('NotificationServicesController', () => {
           messenger,
           env: { featureAnnouncements: featureAnnouncementsEnv },
         });
+        controller.init();
+
+        await controller.createOnChainTriggers();
+
+        expect(mockTriggerUpdate.isDone()).toBe(false);
+        expect(mockUpdateNotifications).not.toHaveBeenCalled();
+        expect(mockDisablePushNotifications).not.toHaveBeenCalled();
+        expect(mockEnablePushNotifications).not.toHaveBeenCalled();
+      });
+
+      it('leaves existing push links alone on re-subscribe when the keyring is locked', async () => {
+        const {
+          messenger,
+          mockDisablePushNotifications,
+          mockEnablePushNotifications,
+          mockUpdateNotifications,
+          mockKeyringControllerGetState,
+        } = arrangeMocks({
+          configurePrefs: (mock) =>
+            mock.mockResolvedValueOnce(mockPreferences()),
+        });
+
+        mockKeyringControllerGetState.mockReturnValue({
+          isUnlocked: false,
+          keyrings: [
+            {
+              accounts: [ADDRESS_1, ADDRESS_2],
+              type: KeyringTypes.hd,
+              metadata: { id: 'srp-1', name: 'SRP 1' },
+            },
+          ],
+        });
+        const mockTriggerUpdate = mockUpdateOnChainNotifications();
+
+        const controller = new NotificationServicesController({
+          messenger,
+          env: { featureAnnouncements: featureAnnouncementsEnv },
+        });
+        controller.init();
 
         await controller.createOnChainTriggers();
 
@@ -1149,6 +1235,7 @@ describe('NotificationServicesController', () => {
           messenger,
           env: { featureAnnouncements: featureAnnouncementsEnv },
         });
+        controller.init();
 
         await controller.createOnChainTriggers();
 
@@ -1180,6 +1267,7 @@ describe('NotificationServicesController', () => {
           messenger,
           env: { featureAnnouncements: featureAnnouncementsEnv },
         });
+        controller.init();
 
         await controller.createOnChainTriggers();
 
@@ -1199,6 +1287,7 @@ describe('NotificationServicesController', () => {
             mock.mockResolvedValueOnce(mockPreferences()),
         });
         mockGetOnChainNotificationsConfig();
+        mockGetOnChainNotificationsConfig();
 
         const controller = new NotificationServicesController({
           messenger,
@@ -1208,6 +1297,7 @@ describe('NotificationServicesController', () => {
             isFeatureAnnouncementsEnabled: false,
           },
         });
+        controller.init();
 
         await controller.enableMetamaskNotifications();
 
@@ -1226,6 +1316,7 @@ describe('NotificationServicesController', () => {
         messenger: mocks.messenger,
         env: { featureAnnouncements: featureAnnouncementsEnv },
       });
+      controller.init();
 
       const testScenarios = {
         ...arrangeFailureAuthAssertions(mocks),
@@ -1867,6 +1958,7 @@ describe('NotificationServicesController', () => {
         messenger: mocks.messenger,
         env: { featureAnnouncements: featureAnnouncementsEnv },
       });
+      controller.init();
 
       await controller.enableMetamaskNotifications();
 
@@ -1886,6 +1978,7 @@ describe('NotificationServicesController', () => {
         messenger: mocks.messenger,
         env: { featureAnnouncements: featureAnnouncementsEnv },
       });
+      controller.init();
 
       const promise = controller.enableMetamaskNotifications();
 
@@ -1913,6 +2006,7 @@ describe('NotificationServicesController', () => {
         messenger: mocks.messenger,
         env: { featureAnnouncements: featureAnnouncementsEnv },
       });
+      controller.init();
 
       await controller.enableMetamaskNotifications({
         registerPushNotifications: false,
@@ -1936,6 +2030,7 @@ describe('NotificationServicesController', () => {
         messenger: mocks.messenger,
         env: { featureAnnouncements: featureAnnouncementsEnv },
       });
+      controller.init();
 
       await controller.enableMetamaskNotifications();
 
@@ -2051,8 +2146,8 @@ describe('NotificationServicesController', () => {
       const controller = new NotificationServicesController({
         messenger,
         env: { featureAnnouncements: featureAnnouncementsEnv },
-        state: { isNotificationServicesEnabled: true },
       });
+      controller.init();
 
       // Act
       await controller.enablePushNotifications();
@@ -2078,13 +2173,42 @@ describe('NotificationServicesController', () => {
       const controller = new NotificationServicesController({
         messenger,
         env: { featureAnnouncements: featureAnnouncementsEnv },
-        state: { isNotificationServicesEnabled: true },
       });
+      controller.init();
 
       await controller.enablePushNotifications();
 
       // An empty keyring is not "every account disabled": unregistering here
       // would drop the device until the next successful re-subscribe.
+      expect(mockDisablePushNotifications).not.toHaveBeenCalled();
+      expect(mockEnablePushNotifications).not.toHaveBeenCalled();
+    });
+
+    it('leaves existing push links alone when the keyring is locked', async () => {
+      const {
+        messenger,
+        mockEnablePushNotifications,
+        mockDisablePushNotifications,
+        mockKeyringControllerGetState,
+      } = arrangeMocks();
+      mockKeyringControllerGetState.mockReturnValue({
+        isUnlocked: false,
+        keyrings: [
+          {
+            accounts: [ADDRESS_1, ADDRESS_2],
+            type: KeyringTypes.hd,
+            metadata: { id: 'srp-1', name: 'SRP 1' },
+          },
+        ],
+      });
+      const controller = new NotificationServicesController({
+        messenger,
+        env: { featureAnnouncements: featureAnnouncementsEnv },
+      });
+      controller.init();
+
+      await controller.enablePushNotifications();
+
       expect(mockDisablePushNotifications).not.toHaveBeenCalled();
       expect(mockEnablePushNotifications).not.toHaveBeenCalled();
     });
@@ -2105,8 +2229,8 @@ describe('NotificationServicesController', () => {
       const controller = new NotificationServicesController({
         messenger,
         env: { featureAnnouncements: featureAnnouncementsEnv },
-        state: { isNotificationServicesEnabled: true },
       });
+      controller.init();
 
       await controller.enablePushNotifications();
 
@@ -2129,8 +2253,8 @@ describe('NotificationServicesController', () => {
       const controller = new NotificationServicesController({
         messenger,
         env: { featureAnnouncements: featureAnnouncementsEnv },
-        state: { isNotificationServicesEnabled: true },
       });
+      controller.init();
 
       await controller.enablePushNotifications();
 
@@ -2164,8 +2288,8 @@ describe('NotificationServicesController', () => {
       const controller = new NotificationServicesController({
         messenger,
         env: { featureAnnouncements: featureAnnouncementsEnv },
-        state: { isNotificationServicesEnabled: true },
       });
+      controller.init();
 
       await controller.enablePushNotifications();
 
@@ -2186,6 +2310,7 @@ describe('NotificationServicesController', () => {
         env: { featureAnnouncements: featureAnnouncementsEnv },
         state: { isNotificationServicesEnabled: true },
       });
+      controller.init();
 
       // Should not throw error
       await controller.enablePushNotifications();

--- a/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.ts
@@ -913,7 +913,7 @@ export class NotificationServicesController extends BaseController<
   public async enablePushNotifications(): Promise<void> {
     try {
       const { accounts } = this.#accounts.listAccounts();
-      if (accounts.length === 0) {
+      if (!this.#keyringController.isUnlocked || accounts.length === 0) {
         // no keyring accounts could be caused by calling this function while keyring is locked
         // it does not mean the user does not have any enabled accounts on Trigger API
         return;
@@ -1032,7 +1032,7 @@ export class NotificationServicesController extends BaseController<
       this.#setIsUpdatingMetamaskNotifications(true);
 
       const { accounts } = this.#accounts.listAccounts();
-      if (accounts.length === 0) {
+      if (!this.#keyringController.isUnlocked || accounts.length === 0) {
         // no keyring accounts could be caused by calling this function while keyring is locked
         // it does not mean the user does not have any enabled accounts on Trigger API
         return;

--- a/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.ts
+++ b/packages/notification-services-controller/src/NotificationServicesController/NotificationServicesController.ts
@@ -912,8 +912,14 @@ export class NotificationServicesController extends BaseController<
    */
   public async enablePushNotifications(): Promise<void> {
     try {
-      const { bearerToken } = await this.#getBearerToken();
       const { accounts } = this.#accounts.listAccounts();
+      if (accounts.length === 0) {
+        // no keyring accounts could be caused by calling this function while keyring is locked
+        // it does not mean the user does not have any enabled accounts on Trigger API
+        return;
+      }
+
+      const { bearerToken } = await this.#getBearerToken();
       const enabledAddresses = await getEnabledAccounts(
         bearerToken,
         accounts,
@@ -1025,9 +1031,14 @@ export class NotificationServicesController extends BaseController<
     try {
       this.#setIsUpdatingMetamaskNotifications(true);
 
-      const { bearerToken } = await this.#getBearerToken();
-
       const { accounts } = this.#accounts.listAccounts();
+      if (accounts.length === 0) {
+        // no keyring accounts could be caused by calling this function while keyring is locked
+        // it does not mean the user does not have any enabled accounts on Trigger API
+        return;
+      }
+
+      const { bearerToken } = await this.#getBearerToken();
 
       // 1. Read existing AUS notification preferences. Their absence is what
       // marks a first-time setup, and they are initialized in step 3.


### PR DESCRIPTION
## Explanation

Prevents calls to NSC when keyring is locked from unwillingly unsubscribing the authenticated user from wallet activity notifications.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References
Fixes https://consensyssoftware.atlassian.net/browse/GE-478

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when wallet-activity push registration and on-chain trigger setup run; incorrect guards could delay setup, but the change is defensive and avoids silent push unregister during lock/empty keyring.
> 
> **Overview**
> **`createOnChainTriggers`** and **`enablePushNotifications`** now return early when the keyring is locked or yields no accounts, instead of treating that as “no enabled addresses” and unregistering push or writing AUS preferences prematurely.
> 
> That keeps existing device push links and leaves first-time preference seeding for a later run when accounts are readable (fixes unwanted unsubscription while locked or before the keyring is populated).
> 
> Tests call **`controller.init()`** so keyring unlock state is wired like production, and add coverage for locked/empty keyring paths on both methods. The package changelog records the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9509a238a630c7b3e300cbeab22ef59e7e9a0256. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->