### PR TITLE
feat: DeFi force refresh behaviour change

### DIFF
--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `DeFiPositionsControllerV2.fetchDeFiPositions` now sets `forceFetchDeFiPositions` on the Accounts API request only when `forceRefresh` is true
+
 ## [111.2.0]
 
 ### Changed

--- a/packages/assets-controllers/CHANGELOG.md
+++ b/packages/assets-controllers/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `DeFiPositionsControllerV2.fetchDeFiPositions` now sets `forceFetchDeFiPositions` on the Accounts API request only when `forceRefresh` is true
+- `DeFiPositionsControllerV2.fetchDeFiPositions` now sets `forceFetchDeFiPositions` on the Accounts API request only when `forceRefresh` is true ([#10149](https://github.com/MetaMask/core/pull/10149))
 
 ## [111.2.0]
 

--- a/packages/assets-controllers/src/DeFiPositionsController/DeFiPositionsControllerV2.test.ts
+++ b/packages/assets-controllers/src/DeFiPositionsController/DeFiPositionsControllerV2.test.ts
@@ -312,7 +312,7 @@ describe('DeFiPositionsControllerV2', () => {
           network.startsWith('eip155:'),
         ),
         includeDeFiBalances: true,
-        forceFetchDeFiPositions: true,
+        forceFetchDeFiPositions: false,
         includePrices: true,
         vsCurrency: 'usd',
       },
@@ -386,7 +386,7 @@ describe('DeFiPositionsControllerV2', () => {
       {
         networks: [...expectedEvmNetworks, ...expectedSolanaNetworks],
         includeDeFiBalances: true,
-        forceFetchDeFiPositions: true,
+        forceFetchDeFiPositions: false,
         includePrices: true,
         vsCurrency: 'usd',
       },
@@ -894,8 +894,23 @@ describe('DeFiPositionsControllerV2', () => {
 
     expect(mockFetchV6MultiAccountBalances).toHaveBeenCalledWith(
       expect.any(Array),
-      expect.objectContaining({ vsCurrency: 'usd' }),
+      expect.objectContaining({
+        vsCurrency: 'usd',
+        forceFetchDeFiPositions: true,
+      }),
       { staleTime: 0 },
+    );
+  });
+
+  it('passes forceFetchDeFiPositions: false when forceRefresh is omitted', async () => {
+    const { controller, mockFetchV6MultiAccountBalances } = setupController();
+
+    await controller.fetchDeFiPositions();
+
+    expect(mockFetchV6MultiAccountBalances).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({ forceFetchDeFiPositions: false }),
+      {},
     );
   });
 

--- a/packages/assets-controllers/src/DeFiPositionsController/DeFiPositionsControllerV2.ts
+++ b/packages/assets-controllers/src/DeFiPositionsController/DeFiPositionsControllerV2.ts
@@ -266,7 +266,7 @@ export class DeFiPositionsControllerV2 extends BaseController<
     const queryOptions = {
       networks,
       includeDeFiBalances: true,
-      forceFetchDeFiPositions: true,
+      forceFetchDeFiPositions: options?.forceRefresh === true,
       includePrices: true,
       vsCurrency,
     };


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Only set `forceFetchDeFiPositions` when the user forces a refresh manually.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped behavior change to DeFi balance API query flags; manual refresh still forces a fresh fetch.
> 
> **Overview**
> **DeFi position fetches** no longer always tell the Accounts API to bypass cache. **`DeFiPositionsControllerV2.fetchDeFiPositions`** now sends **`forceFetchDeFiPositions: true`** only when callers pass **`forceRefresh: true`**; routine polls and default fetches use **`false`**.
> 
> Tests and the **Unreleased** changelog entry were updated to match. **`staleTime: 0`** on the API client when **`forceRefresh`** is true is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9f882e3037c450019773f0e7a4e403b05419d3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->