### PR TITLE
Fix dev-only lint errors in delegation packages

### DIFF
--- a/packages/gator-permissions-controller/src/GatorPermissionsController.test.ts
+++ b/packages/gator-permissions-controller/src/GatorPermissionsController.test.ts
@@ -306,8 +306,8 @@ describe('GatorPermissionsController', () => {
         frameworkContracts;
 
       const delegation = {
-        delegate: '0x4f71DA06987BfeDE90aF0b33E1e3e4ffDCEE7a63',
-        delegator: '0xB68c70159E9892DdF5659ec42ff9BD2bbC23e778',
+        delegate: '0x4f71DA06987BfeDE90aF0b33E1e3e4ffDCEE7a63' as Hex,
+        delegator: '0xB68c70159E9892DdF5659ec42ff9BD2bbC23e778' as Hex,
         authority: ROOT_AUTHORITY,
         caveats: [
           {
@@ -318,7 +318,7 @@ describe('GatorPermissionsController', () => {
               amountPerSecond: hexToBigInt('0x6f05b59d3b20000'),
               startTime: 1747699200,
             }),
-            args: '0x',
+            args: '0x' as Hex,
           },
         ],
         salt: 0n,
@@ -372,8 +372,8 @@ describe('GatorPermissionsController', () => {
         frameworkContracts;
 
       const delegation = {
-        delegate: '0x4f71DA06987BfeDE90aF0b33E1e3e4ffDCEE7a63',
-        delegator: '0xB68c70159E9892DdF5659ec42ff9BD2bbC23e778',
+        delegate: '0x4f71DA06987BfeDE90aF0b33E1e3e4ffDCEE7a63' as Hex,
+        delegator: '0xB68c70159E9892DdF5659ec42ff9BD2bbC23e778' as Hex,
         authority: ROOT_AUTHORITY,
         caveats: [
           {
@@ -384,7 +384,7 @@ describe('GatorPermissionsController', () => {
               amountPerSecond: hexToBigInt('0x6f05b59d3b20000'),
               startTime: 1747699200,
             }),
-            args: '0x',
+            args: '0x' as Hex,
           },
         ],
         salt: 0n,

--- a/packages/gator-permissions-controller/src/decodePermission/utils.test.ts
+++ b/packages/gator-permissions-controller/src/decodePermission/utils.test.ts
@@ -372,7 +372,7 @@ describe('extractExpiryFromCaveatTerms', () => {
   });
 
   it('throws if timestampBeforeThreshold is zero', () => {
-    const terms = `0x${'0'.repeat(64)}`;
+    const terms = `0x${'0'.repeat(64)}` as const;
 
     expect(() => extractExpiryFromCaveatTerms(terms)).toThrow(
       'Invalid expiry: timestampBeforeThreshold must be greater than 0',


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Currently, there are some type errors that exist in packages owned by `@MetaMask/delegation`. These type errors are not present in production code, so they are not flagged by `yarn build`, but they _will_ be flagged soon by `yarn lint:tsc`, and so we need to fix them.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

https://consensyssoftware.atlassian.net/browse/WPC-1275

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only type annotations with no runtime or production code changes.
> 
> **Overview**
> Addresses upcoming **`yarn lint:tsc`** failures in delegation-owned packages by tightening types in **tests only**—no production behavior changes.
> 
> In **`GatorPermissionsController.test.ts`**, mock delegation objects passed to **`encodeDelegations`** now assert **`delegate`**, **`delegator`**, and caveat **`args`** as **`Hex`**, matching stricter delegation typing.
> 
> In **`decodePermission/utils.test.ts`**, the all-zero expiry caveat **`terms`** fixture is annotated so it satisfies the **`Hex`** parameter expected by **`extractExpiryFromCaveatTerms`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9888c9b19f127b5ae763882963aeb339b312889. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->