### PR TITLE
Fix partial build step in CI to pass correct args to tsc

### DIFF
--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -220,7 +220,7 @@ jobs:
               echo "Building changed packages:"
               jq -r '"- " + (.references[].path | ltrimstr("./") | rtrimstr("/tsconfig.build.json"))' "$TSCONFIG"
               echo ""
-              yarn tsc --build --project "$TSCONFIG" --verbose
+              yarn tsc --build "$TSCONFIG" --verbose
             else
               echo "No packages to build."
             fi


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

The step in CI which only builds changed packages is not working because `tsc` is called with both `--build` and `--project`. Supplying both seems to have allowed prior to TypeScript 7, but this no longer works. The fix is to remove `--project`, as `--build` fills the same role.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line CI workflow change with no runtime or application code impact.
> 
> **Overview**
> Fixes the **partial package build** step in `lint-build-test.yml` so changed-package CI builds work again under current TypeScript.
> 
> When a merge base is available and the change set is not a full-repo build, the workflow generates a temporary solution-style tsconfig and runs `yarn tsc --build` against it. The command previously used **both** `--build` and `--project`, which TypeScript no longer accepts (it worked before TS 7). The fix drops `--project` and passes the generated config path as the positional argument to `--build`, matching how full builds invoke `tsc` elsewhere in the repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb56c93bbf7d3d8d95758161bc8ad353c0fb9607. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->