### PR TITLE
ci: fix changelog checks for fork pull requests

### DIFF
--- a/.github/actions/check-merge-queue-changelogs/action.yml
+++ b/.github/actions/check-merge-queue-changelogs/action.yml
@@ -40,23 +40,27 @@ runs:
           const number = parseInt(match[1], 10);
           core.setOutput('pr-number', number);
 
-    - name: Get pull request branch
-      id: pr-branch
+    - name: Fetch pull request head commit
+      id: pr-head
       shell: bash
       env:
-        REPOSITORY: ${{ github.repository }}
         PR_NUMBER: ${{ steps.pr-number.outputs.pr-number }}
-        GH_TOKEN: ${{ inputs.github-token }}
       run: |
-        BRANCH=$(gh api "/repos/${REPOSITORY}/pulls/${PR_NUMBER}" --jq=.head.ref)
-        echo "pr-branch=$BRANCH" >> "$GITHUB_OUTPUT"
+        set -euo pipefail
+
+        # The head branch of a fork pull request does not exist in this
+        # repository, so the head commit is only reachable through the pull
+        # request ref.
+        PR_REF="refs/remotes/pr/${PR_NUMBER}/head"
+        git fetch --no-tags origin "+refs/pull/${PR_NUMBER}/head:${PR_REF}"
+        echo "pr-ref=$PR_REF" >> "$GITHUB_OUTPUT"
 
     - name: Check changelog changes
       id: changelog-check
       shell: bash
       env:
         BASE_REF: ${{ github.event.pull_request.base.ref || github.event.merge_group.base_ref }}
-        PR_BRANCH: ${{ steps.pr-branch.outputs.pr-branch }}
+        PR_REF: ${{ steps.pr-head.outputs.pr-ref }}
         ACTION_PATH: ${{ github.action_path }}
       run: |
         set -euo pipefail
@@ -69,10 +73,10 @@ runs:
           BASE_REF="${BASH_REMATCH[1]}"
         fi
 
-        TARGET_REF=$(git merge-base "origin/$BASE_REF" "origin/$PR_BRANCH")
+        TARGET_REF=$(git merge-base "origin/$BASE_REF" "$PR_REF")
         git fetch origin "$TARGET_REF"
 
-        UPDATED_CHANGELOGS=$(git diff --name-only "$TARGET_REF" "origin/$PR_BRANCH" | grep -E 'CHANGELOG\.md$' || true)
+        UPDATED_CHANGELOGS=$(git diff --name-only "$TARGET_REF" "$PR_REF" | grep -E 'CHANGELOG\.md$' || true)
         if [ -n "$UPDATED_CHANGELOGS" ]; then
           for FILE in $UPDATED_CHANGELOGS; do
             if [ ! -f "$FILE" ]; then
@@ -87,7 +91,7 @@ runs:
 
             echo "Checking changelog file: $FILE"
             git show "$TARGET_REF":"$FILE" > /tmp/base-changelog.md
-            git show origin/"$PR_BRANCH":"$FILE" > /tmp/pr-changelog.md
+            git show "$PR_REF":"$FILE" > /tmp/pr-changelog.md
 
             node "${ACTION_PATH}/check-changelog-diff.cjs" \
               /tmp/base-changelog.md \

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -16,7 +16,10 @@ jobs:
         uses: MetaMask/github-tools/.github/actions/check-changelog@v1
         with:
           base-branch: ${{ github.event.pull_request.base.ref }}
-          head-ref: ${{ github.head_ref }}
+          # The head branch of a fork pull request does not exist in this
+          # repository, but its head commit is always reachable through the
+          # pull request ref.
+          head-ref: refs/pull/${{ github.event.pull_request.number }}/head
           labels: ${{ toJSON(github.event.pull_request.labels) }}
           pr-number: ${{ github.event.pull_request.number }}
           repo: ${{ github.repository }}


### PR DESCRIPTION
## Explanation

### Summary

Resolve the pull request head commit through `refs/pull/<number>/head` in both changelog checks, so they work for pull requests opened from a fork.

### Problem

Both changelog checks assume the pull request head branch exists in `MetaMask/core`. That is false for a pull request opened from a fork, so both jobs fail before running any changelog validation. This currently blocks [#9875](https://github.com/MetaMask/core/pull/9875), which comes from `wzrdk3lly/core`.

**`Check Changelog`** passes `head-ref: ${{ github.head_ref }}` (a bare branch name) together with `repo: ${{ github.repository }}` to [`MetaMask/github-tools/.github/actions/check-changelog@v1`](https://github.com/MetaMask/github-tools/blob/v1/.github/actions/check-changelog/action.yml). That action checks out `inputs.repo` at `inputs.head-ref`, so `actions/checkout` looks for a branch or tag of that name in this repository and fails:

```
git branch --list --remote origin/feat/phishing-controller-extract-signature-addresses
git tag --list feat/phishing-controller-extract-signature-addresses
##[error]A branch or tag with the name 'feat/phishing-controller-extract-signature-addresses' could not be found
```

**`Lint, build, and test / Validate changelog diffs`** resolves the head via `gh api .../pulls/<n> --jq=.head.ref` and then references it as `origin/$PR_BRANCH`. That remote-tracking ref does not exist either:

```
fatal: Not a valid object name origin/feat/phishing-controller-extract-signature-addresses
```

### Solution

GitHub populates `refs/pull/<number>/head` in the base repository for every pull request, including forks, so it is a single ref that both checks can resolve without knowing where the head branch lives.

- **`changelog-check.yml`**: pass `head-ref: refs/pull/${{ github.event.pull_request.number }}/head`. `actions/checkout` special-cases `refs/pull/` refs and fetches them into `refs/remotes/pull/*` instead of trying to resolve a branch or tag name ([`ref-helper.ts`](https://github.com/actions/checkout/blob/v6/src/ref-helper.ts)). `repo` stays as `github.repository` so that `origin` remains this repository and the action's own `git fetch origin <base-branch>` plus `git diff origin/<base-branch>...HEAD` still resolve.
- **`check-merge-queue-changelogs`**: fetch `refs/pull/<number>/head` into a local `refs/remotes/pr/<number>/head` ref and use it in place of `origin/$PR_BRANCH`. This replaces the `gh api` lookup, since the pull request number the action already derives is enough to name the ref.

Both checks keep working for same-repository pull requests and for `merge_group` events, because `refs/pull/<number>/head` is populated for those pull requests too.

### Risk

- The new `git fetch` runs against a checkout created with `persist-credentials: false`. `MetaMask/core` is public, so the anonymous fetch of `refs/pull/*` succeeds. If this repository ever becomes private, that fetch would need credentials.
- `MetaMask/metamask-mobile` wires `check-changelog` up the same way and has the same latent problem, but it is out of scope here.

### Verification

Replayed the `check-merge-queue-changelogs` script locally against [#9875](https://github.com/MetaMask/core/pull/9875) (a fork pull request). Before the change it fails at `git merge-base`; after the change the ref resolves and the script proceeds to real changelog validation:

```
* [new ref]  refs/pull/9875/head -> pr/9875/head
resolved PR_REF -> 541dff0d9dd7d1bc164a9b2cc5b7a9100d1fc125
TARGET_REF -> fcfa4a5cf6db1adf70fb52e2b8009c61319a1596
UPDATED_CHANGELOGS -> [packages/phishing-controller/CHANGELOG.md]
Checking changelog file: packages/phishing-controller/CHANGELOG.md
```

## References

- Unblocks #9875
- Upstream action that consumes `head-ref`: https://github.com/MetaMask/github-tools/blob/v1/.github/actions/check-changelog/action.yml
- `refs/pull/` handling in `actions/checkout`: https://github.com/actions/checkout/blob/v6/src/ref-helper.ts

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them
