### PR TITLE
Fix dev-only lint errors in product-safety packages

### DIFF
--- a/packages/phishing-controller/src/PhishingController.test.ts
+++ b/packages/phishing-controller/src/PhishingController.test.ts
@@ -76,6 +76,7 @@ function getDefaultTransactionControllerState(): TransactionControllerState {
   return {
     transactions: [],
     transactionBatches: [],
+    batchTransactionCounts: {},
     methodData: {},
     lastFetchedBlockNumbers: {},
     submitHistory: [],
@@ -4837,19 +4838,23 @@ describe('Address poisoning detection', () => {
       [],
     );
 
-    rootMessenger.publish('AddressBookController:stateChange', {
-      addressBook: {
-        '0x1': {
-          [ADDRESS_BOOK_RECIPIENT]: {
-            address: ADDRESS_BOOK_RECIPIENT,
-            name: 'Known recipient',
-            chainId: '0x1',
-            memo: '',
-            isEns: false,
+    rootMessenger.publish(
+      'AddressBookController:stateChange',
+      {
+        addressBook: {
+          '0x1': {
+            [ADDRESS_BOOK_RECIPIENT]: {
+              address: ADDRESS_BOOK_RECIPIENT,
+              name: 'Known recipient',
+              chainId: '0x1',
+              memo: '',
+              isEns: false,
+            },
           },
         },
       },
-    });
+      [],
+    );
 
     await new Promise((resolve) => process.nextTick(resolve));
 

--- a/packages/phishing-controller/src/tests/utils.ts
+++ b/packages/phishing-controller/src/tests/utils.ts
@@ -116,6 +116,7 @@ export const createMockStateChangePayload = (
 ) => ({
   transactions,
   transactionBatches: [],
+  batchTransactionCounts: {},
   methodData: {},
   lastFetchedBlockNumbers: {},
   submitHistory: [],


### PR DESCRIPTION

## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

Currently, there are some type errors that exist in packages owned by `@MetaMask/product-safety`. These type errors are not present in production code, so they are not flagged by `yarn build`, but they _will_ be flagged soon by `yarn lint:tsc`, and so we need to fix them.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

https://consensyssoftware.atlassian.net/browse/WPC-1275

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only type fixes with no runtime or production code changes.
> 
> **Overview**
> Updates **phishing-controller** test helpers so they match current controller state typings ahead of stricter `yarn lint:tsc` checks—no production behavior changes.
> 
> Mock `TransactionControllerState` objects now include **`batchTransactionCounts: {}`** in `getDefaultTransactionControllerState` and `createMockStateChangePayload`, matching the field added on `TransactionController`.
> 
> The address-book integration test now publishes **`AddressBookController:stateChange`** with an empty **`[]` patches** argument as the second parameter, fixing the messenger event signature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 510410e81c0bc50f7e4880146bd87eba446d6134. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->