### PR TITLE
feat(profile-sync-controller): add `clearState` to `AuthenticationController`

### DIFF
--- a/packages/profile-sync-controller/CHANGELOG.md
+++ b/packages/profile-sync-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `AuthenticationController.clearState()` to reset the controller to `defaultState` (unsigned, both pairing gates re-armed). Clients call this on wallet reset.
+
 ## [31.0.0]
 
 ### Changed

--- a/packages/profile-sync-controller/CHANGELOG.md
+++ b/packages/profile-sync-controller/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `AuthenticationController.clearState()` to reset the controller to `defaultState` (unsigned, both pairing gates re-armed). Clients call this on wallet reset.
+- Add `AuthenticationController.clearState()` to reset the controller to `defaultState` (unsigned, both pairing gates re-armed). Clients call this on wallet reset ([#10165](https://github.com/MetaMask/core/pull/10165))
 
 ## [31.0.0]
 

--- a/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController-method-action-types.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController-method-action-types.ts
@@ -26,6 +26,15 @@ export type AuthenticationControllerPerformSignOutAction = {
 };
 
 /**
+ * Resets the controller to `defaultState`. Clients call this on wallet reset
+ * so the next wallet starts unsigned with both pairing gates re-armed.
+ */
+export type AuthenticationControllerClearStateAction = {
+  type: `AuthenticationController:clearState`;
+  handler: AuthenticationController['clearState'];
+};
+
+/**
  * Returns a bearer token for the specified SRP, logging in if needed.
  *
  * When called without `entropySourceId`, returns the primary (first) SRP's
@@ -113,6 +122,7 @@ export type AuthenticationControllerMethodActions =
   | AuthenticationControllerPerformSignInAction
   | AuthenticationControllerRequestProfilePairingAction
   | AuthenticationControllerPerformSignOutAction
+  | AuthenticationControllerClearStateAction
   | AuthenticationControllerGetBearerTokenAction
   | AuthenticationControllerGetSessionProfileAction
   | AuthenticationControllerRefreshCanonicalProfileIdAction

--- a/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.test.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.test.ts
@@ -1689,6 +1689,23 @@ describe('AuthenticationController', () => {
       expect(mockEndpoints.mockPairSocialIdentifierUrl.isDone()).toBe(true);
       expect(controller.state.needsSocialPairing).toBe(false);
     });
+
+    it('keeps needsProfilePairing true when clearState lands during an in-flight /pair', async () => {
+      const metametrics = createMockAuthMetaMetrics();
+      arrangeAuthAPIs({ mockPairProfilesDelayMs: 50 });
+      const { messenger } = createMockAuthenticationMessenger();
+      const controller = new AuthenticationController({
+        messenger,
+        state: mockSignedInState({ needsProfilePairing: true }),
+        metametrics,
+      });
+
+      const performSignInPromise = controller.performSignIn();
+      controller.clearState();
+      await performSignInPromise;
+
+      expect(controller.state.needsProfilePairing).toBe(true);
+    });
   });
 
   describe('getBearerToken', () => {

--- a/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.test.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.test.ts
@@ -1631,6 +1631,7 @@ describe('AuthenticationController', () => {
       controller.clearState();
 
       expect(controller.state).toStrictEqual(defaultState);
+      expect(populatedState).not.toStrictEqual(defaultState);
     });
 
     it('is exposed via the messenger registry', () => {

--- a/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.test.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.test.ts
@@ -18,7 +18,10 @@ import {
   getMessageSigningPublicKey,
   signMessageWithMessageSigningKey,
 } from '../../shared/utils/message-signing.js';
-import { AuthenticationController } from './AuthenticationController.js';
+import {
+  AuthenticationController,
+  defaultState,
+} from './AuthenticationController.js';
 import type {
   AuthenticationControllerMessenger,
   AuthenticationControllerState,
@@ -1603,6 +1606,88 @@ describe('AuthenticationController', () => {
       controller.performSignOut();
       expect(controller.state.isSignedIn).toBe(false);
       expect(controller.state.srpSessionData).toBeUndefined();
+      // Sign-out is not a wallet reset: pairing gates stay cleared.
+      expect(controller.state.needsProfilePairing).toBe(false);
+      expect(controller.state.needsSocialPairing).toBe(false);
+    });
+  });
+
+  describe('clearState', () => {
+    it('resets a fully populated state to defaultState', () => {
+      const metametrics = createMockAuthMetaMetrics();
+      const { messenger } = createMockAuthenticationMessenger();
+      const populatedState = mockSignedInState({
+        needsProfilePairing: false,
+        needsSocialPairing: false,
+      });
+      const controller = new AuthenticationController({
+        messenger,
+        state: populatedState,
+        metametrics,
+      });
+
+      expect(controller.state).toStrictEqual(populatedState);
+
+      controller.clearState();
+
+      expect(controller.state).toStrictEqual(defaultState);
+    });
+
+    it('is exposed via the messenger registry', () => {
+      const metametrics = createMockAuthMetaMetrics();
+      const { messenger, baseMessenger } = createMockAuthenticationMessenger();
+      const controller = new AuthenticationController({
+        messenger,
+        state: mockSignedInState({
+          needsProfilePairing: false,
+          needsSocialPairing: false,
+        }),
+        metametrics,
+      });
+
+      baseMessenger.call('AuthenticationController:clearState');
+      expect(controller.state).toStrictEqual(defaultState);
+    });
+
+    it('re-arms social pairing so the next performSignIn calls pair/identifier', async () => {
+      const metametrics = createMockAuthMetaMetrics();
+      const mockEndpoints = arrangeAuthAPIs();
+      const {
+        messenger,
+        mockKeyringControllerGetState,
+        mockSeedlessOnboardingGetState,
+        mockSeedlessOnboardingGetAccessToken,
+      } = createMockAuthenticationMessenger();
+      mockKeyringControllerGetState.mockReturnValue({
+        isUnlocked: true,
+        keyrings: mockHdKeyrings(MOCK_ENTROPY_SOURCE_IDS[0]),
+      });
+      mockSeedlessOnboardingGetState.mockReturnValue({
+        vault: 'encrypted',
+        authConnection: 'google',
+        socialLoginEmail: MOCK_SOCIAL_EMAIL,
+      });
+      mockSeedlessOnboardingGetAccessToken.mockResolvedValue(MOCK_SOCIAL_JWT);
+
+      const controller = new AuthenticationController({
+        messenger,
+        metametrics,
+        config: SOCIAL_PAIRING_ENABLED,
+        state: mockSignedInState({
+          needsProfilePairing: false,
+          needsSocialPairing: false,
+        }),
+      });
+
+      expect(controller.state.needsSocialPairing).toBe(false);
+
+      controller.clearState();
+      expect(controller.state).toStrictEqual(defaultState);
+
+      await controller.performSignIn();
+
+      expect(mockEndpoints.mockPairSocialIdentifierUrl.isDone()).toBe(true);
+      expect(controller.state.needsSocialPairing).toBe(false);
     });
   });
 

--- a/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.ts
@@ -151,6 +151,7 @@ const MESSENGER_EXPOSED_METHODS = [
   'getCustomerServiceToken',
   'isSignedIn',
   'requestProfilePairing',
+  'clearState',
 ] as const;
 
 export type Actions =
@@ -729,6 +730,14 @@ export class AuthenticationController extends BaseController<
       state.isSignedIn = false;
       state.srpSessionData = undefined;
     });
+  }
+
+  /**
+   * Resets the controller to `defaultState`. Clients call this on wallet reset
+   * so the next wallet starts unsigned with both pairing gates re-armed.
+   */
+  public clearState(): void {
+    this.update(() => ({ ...defaultState }));
   }
 
   /**

--- a/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/AuthenticationController.ts
@@ -220,9 +220,10 @@ export class AuthenticationController extends BaseController<
 
   #isUnlocked = false;
 
-  // Bumped by `requestProfilePairing`. `performSignIn` snapshots this
-  // before its first await; if it changes mid-flight we must NOT clear
-  // `needsProfilePairing` (the rearm signal wins).
+  /**
+   * Bumped by `requestProfilePairing` and `clearState` so an in-flight
+   * `performSignIn` can't clear `needsProfilePairing` afterwards.
+   */
   #profilePairingRequestEpoch = 0;
 
   readonly #keyringController = {
@@ -737,6 +738,7 @@ export class AuthenticationController extends BaseController<
    * so the next wallet starts unsigned with both pairing gates re-armed.
    */
   public clearState(): void {
+    this.#profilePairingRequestEpoch += 1;
     this.update(() => ({ ...defaultState }));
   }
 

--- a/packages/profile-sync-controller/src/controllers/authentication/index.ts
+++ b/packages/profile-sync-controller/src/controllers/authentication/index.ts
@@ -14,4 +14,5 @@ export type {
   AuthenticationControllerGetUserProfileLineageAction,
   AuthenticationControllerIsSignedInAction,
   AuthenticationControllerRequestProfilePairingAction,
+  AuthenticationControllerClearStateAction,
 } from './AuthenticationController-method-action-types.js';

--- a/packages/profile-sync-controller/src/sdk/__fixtures__/auth.ts
+++ b/packages/profile-sync-controller/src/sdk/__fixtures__/auth.ts
@@ -59,17 +59,19 @@ export const handleMockPairIdentifiers = (
   return mockPairIdentifiersEndpoint;
 };
 
-export const handleMockPairProfiles = (mockReply?: MockReply): nock.Scope => {
+export const handleMockPairProfiles = (
+  mockReply?: MockReply,
+  delayMs?: number,
+): nock.Scope => {
   const reply = mockReply ?? {
     status: 200,
     body: MOCK_PAIR_PROFILES_RESPONSE,
   };
-  const mockPairProfilesEndpoint = nock(MOCK_PAIR_PROFILES_URL)
-    .persist()
-    .post('')
-    .reply(reply.status, reply.body);
-
-  return mockPairProfilesEndpoint;
+  const interceptor = nock(MOCK_PAIR_PROFILES_URL).persist().post('');
+  if (delayMs !== undefined && delayMs > 0) {
+    interceptor.delay(delayMs);
+  }
+  return interceptor.reply(reply.status, reply.body);
 };
 
 export const handleMockPairSocialIdentifier = (
@@ -160,6 +162,7 @@ export const arrangeAuthAPIs = (options?: {
   mockCustomerServiceTokenUrl?: MockReply;
   onSrpLoginBody?: (body: unknown) => void;
   onPairSocialIdentifierBody?: (body: unknown) => void;
+  mockPairProfilesDelayMs?: number;
 }): {
   mockNonceUrl: nock.Scope;
   mockOAuth2TokenUrl: nock.Scope;
@@ -181,7 +184,10 @@ export const arrangeAuthAPIs = (options?: {
   const mockPairIdentifiersUrl = handleMockPairIdentifiers(
     options?.mockPairIdentifiers,
   );
-  const mockPairProfilesUrl = handleMockPairProfiles(options?.mockPairProfiles);
+  const mockPairProfilesUrl = handleMockPairProfiles(
+    options?.mockPairProfiles,
+    options?.mockPairProfilesDelayMs,
+  );
   const mockPairSocialIdentifierUrl = handleMockPairSocialIdentifier(
     options?.mockPairSocialIdentifier,
     options?.onPairSocialIdentifierBody,


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

Related to: https://consensyssoftware.atlassian.net/browse/MUL-2240

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication lifecycle on wallet reset (session wipe and re-arming pairing gates); incorrect client wiring could leave stale auth state or skip required pairing on the next wallet.
> 
> **Overview**
> Adds **`AuthenticationController.clearState()`** (and **`AuthenticationController:clearState`**) so hosts can wipe auth state on **wallet reset**, not just on sign-out. **`clearState`** replaces persisted state with **`defaultState`**: signed out, no **`srpSessionData`**, and both **`needsProfilePairing`** / **`needsSocialPairing`** set back to **`true`**.
> 
> **`performSignOut`** is unchanged in behavior; new tests document that sign-out still leaves pairing gates cleared, unlike a full reset.
> 
> **`clearState`** also bumps **`#profilePairingRequestEpoch`** (same mechanism as **`requestProfilePairing`**) so an in-flight **`performSignIn`** cannot clear **`needsProfilePairing`** after a reset mid-**`/pair`**. Test helpers gain optional delayed **`/pair`** mocks to cover that race.
> 
> Changelog and exported **`AuthenticationControllerClearStateAction`** are updated; consumers must allow the new messenger action if they call it through the registry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2ed73ffc699c6a107a9f962e8982ddef03be114. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->