### PR TITLE
Ignore TS2589 error in MultichainTransactionController

### DIFF
--- a/packages/multichain-transactions-controller/src/MultichainTransactionsController.ts
+++ b/packages/multichain-transactions-controller/src/MultichainTransactionsController.ts
@@ -313,6 +313,10 @@ export class MultichainTransactionsController extends BaseController<
           }
 
           chainUpdates.forEach(({ chain, entry }) => {
+            // Using `@ts-ignore` instead of `@ts-expect-error` since this error
+            // comes and goes after unrelated changes.
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            // @ts-ignore: TS2589: Type instantiation is excessively deep and possibly infinite.
             state.nonEvmTransactions[account.id][chain as CaipChainId] = entry;
           });
         });


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

For some reason, we are getting a "Type instantiation is excessively deep and possibly infinite" error in `MultichainTransactionController` when we attempt to update state. This is a common error we've received in other controllers, and we have yet to determine the cause. In the meantime we use `@ts-ignore` to bypass it so that it doesn't cause build issues.


## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Unblocks https://github.com/MetaMask/core/pull/10121.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only TypeScript suppression with no logic or data-handling changes.
> 
> **Overview**
> Adds a **`@ts-ignore`** (with eslint exemption and a short comment) on the nested **`nonEvmTransactions`** assignment inside **`updateTransactionsForAccount`**, where TypeScript intermittently reports **TS2589** (“Type instantiation is excessively deep and possibly infinite”) on Immer **`Draft`** state writes.
> 
> The comment explains **`@ts-ignore`** is used instead of **`@ts-expect-error`** because the diagnostic appears and disappears with unrelated edits—a pattern already used in other controllers until the root cause is understood. **Runtime behavior is unchanged**; this only unblocks builds (e.g. related core PR **#10121**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0791215a7bd81b920bee4f7c8624f69a764b234. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->