### PR TITLE
chore: align `@types/lodash` and `@types/jest-when` ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@metamask/skills": "^0.1.0",
     "@metamask/utils": "^11.12.0",
     "@types/jest": "^30.0.0",
-    "@types/lodash": "^4.14.191",
+    "@types/lodash": "^4.17.20",
     "@types/node": "^22.13.14",
     "@types/semver": "^7",
     "@typescript-eslint/eslint-plugin": "^8.48.0",

--- a/packages/eth-json-rpc-provider/CHANGELOG.md
+++ b/packages/eth-json-rpc-provider/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `@types/lodash` from `^4.14.191` to `^4.17.20` ([#10169](https://github.com/MetaMask/core/pull/10169))
+
 ## [7.0.0]
 
 ### Added

--- a/packages/eth-json-rpc-provider/package.json
+++ b/packages/eth-json-rpc-provider/package.json
@@ -51,7 +51,7 @@
     "@metamask/json-rpc-engine": "^11.0.0",
     "@metamask/rpc-errors": "^7.0.2",
     "@metamask/utils": "^11.12.0",
-    "@types/lodash": "^4.14.191",
+    "@types/lodash": "^4.17.20",
     "lodash-es": "^4.17.21",
     "nanoid": "^3.3.8"
   },

--- a/packages/gas-fee-controller/package.json
+++ b/packages/gas-fee-controller/package.json
@@ -67,7 +67,7 @@
     "@babel/runtime": "^7.23.9",
     "@metamask/auto-changelog": "^6.1.0",
     "@types/jest": "^30.0.0",
-    "@types/jest-when": "^2.7.3",
+    "@types/jest-when": "^3.5.3",
     "@typescript/native": "npm:typescript@^7.0.2",
     "deepmerge": "^4.2.2",
     "jest": "^30.4.2",

--- a/packages/network-controller/package.json
+++ b/packages/network-controller/package.json
@@ -78,7 +78,7 @@
     "@metamask/auto-changelog": "^6.1.0",
     "@types/deep-freeze-strict": "^1.1.0",
     "@types/jest": "^30.0.0",
-    "@types/jest-when": "^2.7.3",
+    "@types/jest-when": "^3.5.3",
     "@types/lodash-es": "^4.17.12",
     "@types/node-fetch": "^2.6.12",
     "@typescript/native": "npm:typescript@^7.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6605,7 +6605,7 @@ __metadata:
     "@metamask/skills": "npm:^0.1.0"
     "@metamask/utils": "npm:^11.12.0"
     "@types/jest": "npm:^30.0.0"
-    "@types/lodash": "npm:^4.14.191"
+    "@types/lodash": "npm:^4.17.20"
     "@types/node": "npm:^22.13.14"
     "@types/semver": "npm:^7"
     "@typescript-eslint/eslint-plugin": "npm:^8.48.0"
@@ -7026,7 +7026,7 @@ __metadata:
     "@metamask/rpc-errors": "npm:^7.0.2"
     "@metamask/utils": "npm:^11.12.0"
     "@types/jest": "npm:^30.0.0"
-    "@types/lodash": "npm:^4.14.191"
+    "@types/lodash": "npm:^4.17.20"
     "@typescript/native": "npm:typescript@^7.0.2"
     deepmerge: "npm:^4.2.2"
     ethers: "npm:^6.12.0"
@@ -7326,7 +7326,7 @@ __metadata:
     "@metamask/utils": "npm:^11.12.0"
     "@types/bn.js": "npm:^5.1.5"
     "@types/jest": "npm:^30.0.0"
-    "@types/jest-when": "npm:^2.7.3"
+    "@types/jest-when": "npm:^3.5.3"
     "@types/uuid": "npm:^9.0.8"
     "@typescript/native": "npm:typescript@^7.0.2"
     bn.js: "npm:^5.2.1"
@@ -8189,7 +8189,7 @@ __metadata:
     "@metamask/utils": "npm:^11.12.0"
     "@types/deep-freeze-strict": "npm:^1.1.0"
     "@types/jest": "npm:^30.0.0"
-    "@types/jest-when": "npm:^2.7.3"
+    "@types/jest-when": "npm:^3.5.3"
     "@types/lodash-es": "npm:^4.17.12"
     "@types/node-fetch": "npm:^2.6.12"
     "@typescript/native": "npm:typescript@^7.0.2"
@@ -11974,12 +11974,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/jest-when@npm:^2.7.3":
-  version: 2.7.4
-  resolution: "@types/jest-when@npm:2.7.4"
+"@types/jest-when@npm:^3.5.3":
+  version: 3.5.5
+  resolution: "@types/jest-when@npm:3.5.5"
   dependencies:
     "@types/jest": "npm:*"
-  checksum: 10/fea5f5c9b882ee5191ef47dfbbe71ce7935d4ede7ac12c2bf7dbceead3da066930aa492fc534f8b53ef6694f30313b5669b87cb45e36ddbece42c6ff27b01364
+  checksum: 10/816c1ed5554182c43261d23c2902506c316bc0368f2ea1e632a0a93d05d8f6f2918afa6a406c2f5fdd4d277e042b8d2ba797993dc3c2fd2d5f53cda946696772
   languageName: node
   linkType: hard
 
@@ -12043,7 +12043,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/lodash@npm:*, @types/lodash@npm:^4.14.191, @types/lodash@npm:^4.17.20":
+"@types/lodash@npm:*, @types/lodash@npm:^4.17.20":
   version: 4.17.25
   resolution: "@types/lodash@npm:4.17.25"
   checksum: 10/f786e05664439cc8d327fd97c62c060d81b3c4ed52127d01fbc926139e1a669c1554bf3cd0dbb43f8fcc7d9b5c6c23c543cc36de8dc815c9f289ea852b26ebd6


### PR DESCRIPTION
## Explanation

`@types/lodash` and `@types/jest-when` were declared at different versions than the rest of the monorepo uses, which trips the constraint that all version ranges for the same non-workspace dependency must match.

`@types/jest-when` was the more meaningful of the two: `gas-fee-controller` and `network-controller` both run `jest-when@^3.7.0` against v2 type definitions. This brings the types up to v3 so they match the runtime.

Both were found while preparing `@metamask/utils` for migration into this repo, which declares `@types/lodash@^4.17.20` and `@types/jest-when@^3.5.3`. Aligning here means the port lands without constraint violations.

## References

Related to the `@metamask/utils` migration.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and lockfile-only changes with no runtime or production logic touched; main risk is minor TypeScript typing differences in tests.
> 
> **Overview**
> Aligns monorepo **dev/type dependency ranges** so the same non-workspace package is not declared at conflicting versions (needed for Yarn constraints and the upcoming `@metamask/utils` migration).
> 
> **`@types/lodash`** is raised from `^4.14.191` to `^4.17.20` on the root workspace and `@metamask/eth-json-rpc-provider`; the lockfile resolves `@types/lodash` to 4.17.25. **`eth-json-rpc-provider`** records this under its Unreleased changelog.
> 
> **`@types/jest-when`** is raised from `^2.7.3` to `^3.5.3` in **`gas-fee-controller`** and **`network-controller`**, matching their existing **`jest-when@^3.7.0`** test dependency instead of v2 typings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05680edeb67633ec7d8e2e42ef6e3ad713c8200e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->