### PR TITLE
fix(transaction-pay-controller): use EXACT_OUTPUT for predictDepositAndOrder relay quotes

### DIFF
--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Restore `EXACT_OUTPUT` Relay quotes for `predictDepositAndOrder` flows so Predict deposit-and-order trades keep a guaranteed output amount.
+
 ## [28.0.1]
 
 ### Changed

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.test.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.test.ts
@@ -4097,6 +4097,68 @@ describe('Relay Quotes Utils', () => {
       );
     });
 
+    it('requests exact output for Predict deposit-and-order flows', async () => {
+      const predictDepositAndOrderRequest: QuoteRequest = {
+        ...QUOTE_REQUEST_MOCK,
+        targetChainId: CHAIN_ID_ARBITRUM,
+        targetTokenAddress: ARBITRUM_USDC_ADDRESS,
+      };
+
+      successfulFetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => QUOTE_MOCK,
+      } as never);
+
+      await getRelayQuotes({
+        accountSupports7702: true,
+        messenger,
+        requests: [predictDepositAndOrderRequest],
+        transaction: {
+          ...TRANSACTION_META_MOCK,
+          type: TransactionType.predictDepositAndOrder,
+        },
+      });
+
+      const body = JSON.parse(
+        successfulFetchMock.mock.calls[0][1]?.body as string,
+      );
+
+      expect(body).toStrictEqual(
+        expect.objectContaining({
+          amount: QUOTE_REQUEST_MOCK.targetAmountMinimum,
+          tradeType: 'EXACT_OUTPUT',
+        }),
+      );
+    });
+
+    it('requests exact input for Predict deposits without embedded transactions', async () => {
+      successfulFetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => QUOTE_MOCK,
+      } as never);
+
+      await getRelayQuotes({
+        accountSupports7702: true,
+        messenger,
+        requests: [QUOTE_REQUEST_MOCK],
+        transaction: {
+          ...TRANSACTION_META_MOCK,
+          type: TransactionType.predictDeposit,
+        },
+      });
+
+      const body = JSON.parse(
+        successfulFetchMock.mock.calls[0][1]?.body as string,
+      );
+
+      expect(body).toStrictEqual(
+        expect.objectContaining({
+          amount: QUOTE_REQUEST_MOCK.sourceTokenAmount,
+          tradeType: 'EXACT_INPUT',
+        }),
+      );
+    });
+
     it('requests exact input for non-Hyperliquid targets without embedded transactions', async () => {
       successfulFetchMock.mockResolvedValue({
         ok: true,

--- a/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.ts
+++ b/packages/transaction-pay-controller/src/strategy/relay/relay-quotes.ts
@@ -375,7 +375,8 @@ async function getSingleQuote(
     const hasTransactions = Boolean(body.txs?.length);
     const requiresExactOutput =
       hasTransactions ||
-      transaction.type === TransactionType.perpsDepositAndOrder;
+      transaction.type === TransactionType.perpsDepositAndOrder ||
+      transaction.type === TransactionType.predictDepositAndOrder;
     const finalBody: RelayQuoteRequest = {
       ...body,
       amount:


### PR DESCRIPTION
## Summary

- Treat `TransactionType.predictDepositAndOrder` as requiring exact-output Relay quoting.
- Keep plain `predictDeposit` flows on `EXACT_INPUT`.
- Add regression coverage and a changelog entry.

## Companion PR

- Mobile: https://github.com/MetaMask/metamask-mobile/pull/36074

## Testing

- `yarn workspaces foreach --recursive --topological-dev --from @metamask/transaction-pay-controller run build`
- `yarn jest --no-watchman packages/transaction-pay-controller/src/strategy/relay/relay-quotes.test.ts -t "Predict deposit-and-order"`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Relay quote sizing for Predict deposit-and-order flows; wrong trade type could leave follow-on orders under-funded, but the change mirrors an existing perps pattern with targeted tests.
> 
> **Overview**
> Restores **guaranteed output** Relay quoting for **Predict deposit-and-order** by treating `TransactionType.predictDepositAndOrder` like `perpsDepositAndOrder` in `requiresExactOutput`, so requests use `tradeType: EXACT_OUTPUT` and `targetAmountMinimum` instead of `EXACT_INPUT` / source amount.
> 
> Plain **`predictDeposit`** flows are unchanged and still use **`EXACT_INPUT`**. Regression tests cover both Predict transaction types, and the changelog records the fix under **[Unreleased]**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 810342aa3786abcf7ca566fa2e52ea8918245389. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->