### PR TITLE
Move MockNetwork to `tests` in `network-controller`

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -336,10 +336,10 @@ const config = createConfig([
       'packages/message-manager/src/AbstractMessageManager.ts',
       'packages/message-manager/src/DecryptMessageManager.ts',
       'packages/message-manager/src/EncryptionPublicKeyManager.ts',
+      'packages/network-controller/tests/mock-network.ts',
       'packages/permission-log-controller/src/PermissionLogController.ts',
       'packages/phishing-controller/src/PhishingController.ts',
       'packages/rate-limit-controller/src/RateLimitController.ts',
-      'tests/mock-network.ts',
     ],
     rules: {
       // TODO: Re-enable this rule

--- a/packages/assets-controllers/src/AssetsContractController.test.ts
+++ b/packages/assets-controllers/src/AssetsContractController.test.ts
@@ -28,8 +28,8 @@ import { getDefaultPreferencesState } from '@metamask/preferences-controller';
 import assert from 'assert';
 
 import { SECONDS } from '../../../tests/constants.js';
-import { mockNetwork } from '../../../tests/mock-network.js';
 import { buildInfuraNetworkClientConfiguration } from '../../network-controller/tests/helpers.js';
+import { mockNetwork } from '../../network-controller/tests/mock-network.js';
 import type { AssetsContractControllerMessenger } from './AssetsContractController.js';
 import {
   AssetsContractController,

--- a/packages/network-controller/src/create-auto-managed-network-client.test.ts
+++ b/packages/network-controller/src/create-auto-managed-network-client.test.ts
@@ -1,8 +1,8 @@
 import { BUILT_IN_NETWORKS, NetworkType } from '@metamask/controller-utils';
 import { PollingBlockTrackerOptions } from '@metamask/eth-block-tracker';
 
-import { mockNetwork } from '../../../tests/mock-network.js';
 import { buildNetworkControllerMessenger } from '../tests/helpers.js';
+import { mockNetwork } from '../tests/mock-network.js';
 import { createAutoManagedNetworkClient } from './create-auto-managed-network-client.js';
 import * as createNetworkClientModule from './create-network-client.js';
 import { RpcServiceOptions } from './rpc-service/rpc-service.js';

--- a/packages/network-controller/tests/mock-network.ts
+++ b/packages/network-controller/tests/mock-network.ts
@@ -1,8 +1,8 @@
 import type { JsonRpcRequest, JsonRpcResponse } from '@metamask/utils';
 import nock from 'nock';
 
-import type { NetworkClientConfiguration } from '../packages/network-controller/src/types.js';
-import { NetworkClientType } from '../packages/network-controller/src/types.js';
+import type { NetworkClientConfiguration } from '../src/types.js';
+import { NetworkClientType } from '../src/types.js';
 
 /**
  * An object which instructs the MockedNetwork class which JSON-RPC request

--- a/packages/transaction-controller/src/TransactionControllerIntegration.test.ts
+++ b/packages/transaction-controller/src/TransactionControllerIntegration.test.ts
@@ -35,12 +35,12 @@ import assert from 'assert';
 import { v4 as uuidV4 } from 'uuid';
 
 import { jestAdvanceTime } from '../../../tests/helpers.js';
-import { mockNetwork } from '../../../tests/mock-network.js';
 import {
   buildAddNetworkFields,
   buildCustomNetworkClientConfiguration,
   buildUpdateNetworkCustomRpcEndpointFields,
 } from '../../network-controller/tests/helpers.js';
+import { mockNetwork } from '../../network-controller/tests/mock-network.js';
 import { getDefaultRemoteFeatureFlagControllerState } from '../../remote-feature-flag-controller/src/remote-feature-flag-controller.js';
 import {
   buildEthGasPriceRequestMock,

--- a/packages/transaction-controller/tests/JsonRpcRequestMocks.ts
+++ b/packages/transaction-controller/tests/JsonRpcRequestMocks.ts
@@ -1,6 +1,6 @@
 import type { Hex } from '@metamask/utils';
 
-import type { JsonRpcRequestMock } from '../../../tests/mock-network.js';
+import type { JsonRpcRequestMock } from '../../network-controller/tests/mock-network.js';
 
 /**
  * Builds mock eth_gasPrice request.


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

`MockNetwork` is a class that can be used in tests to easily mock requests that go through NetworkController network clients.

Because the file where this class lives (`mock-network.ts`) relies on `network-controller` types, any package that wants to use this class needs to declare a development dependency on `network-controller`. This confuses TypeScript and its project reference resolution logic. In fact, currently, `mock-network.ts` exhibits type errors that look something like thsi:

```
File '~/core/packages/network-controller/src/types.ts' is not listed within the file list of project '~/core/packages/json-rpc-engine/tsconfig.json'. Projects must list all files or use an 'include' pattern.
     The file is in the program because:
       Imported via '../packages/network-controller/src/types.js' from file '~/core/tests/mock-network.ts'
       Imported via '../packages/network-controller/src/types.js' from file '~/core/tests/mock-network.ts'
```

This commit moves the file inside of `network-controller`, resolving the type errors.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

Related to https://consensyssoftware.atlassian.net/browse/WPC-1275.

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only relocation and import path updates; no production runtime behavior changes.
> 
> **Overview**
> Relocates the shared **`mockNetwork`** test helper from the repo-root **`tests/`** tree into **`packages/network-controller/tests/mock-network.ts`**, so it lives alongside the **`network-controller`** types it imports instead of pulling those types across unrelated TypeScript projects.
> 
> The helper’s internal imports now use **`../src/types.js`**. Consumer tests and **`JsonRpcRequestMocks`** update their import paths accordingly (e.g. **`assets-controllers`**, **`transaction-controller`**, and in-package **`create-auto-managed-network-client`** tests). **ESLint**’s **`jsdoc/check-tag-names`** file override list is updated to reference the new path instead of **`tests/mock-network.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2287872d7f5fd710c3c0120ef9e4fd91ac7b4127. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->