### PR TITLE
Feat/subs cancellation reason

### DIFF
--- a/packages/subscription-controller/CHANGELOG.md
+++ b/packages/subscription-controller/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add stable cancellation reason codes and optional free-text feedback to the subscription cancellation request ([#10189](https://github.com/MetaMask/core/pull/10189))
+
 ### Changed
 
+- Refresh subscriptions, product entitlements, and benefits after a successful subscription cancellation ([#10189](https://github.com/MetaMask/core/pull/10189))
 - Bump `@metamask/profile-sync-controller` from `^32.0.0` to `^32.1.0` ([#10184](https://github.com/MetaMask/core/pull/10184))
 
 ## [9.0.1]

--- a/packages/subscription-controller/src/SubscriptionController.test.ts
+++ b/packages/subscription-controller/src/SubscriptionController.test.ts
@@ -15,6 +15,7 @@ import type { Hex } from '@metamask/utils';
 import { jestAdvanceTime } from '../../../tests/helpers.js';
 import { generateMockTxMeta } from '../tests/utils.js';
 import {
+  CANCELLATION_REASONS,
   controllerName,
   SubscriptionControllerErrorMessage,
 } from './constants.js';
@@ -1744,26 +1745,45 @@ describe('SubscriptionController', () => {
           },
         },
         async ({ controller, rootMessenger, mockService }) => {
-          mockService.cancelSubscription.mockResolvedValue({
+          const cancellationRequest = {
+            subscriptionId: MOCK_SUBSCRIPTION.id,
+            cancellationReason: CANCELLATION_REASONS.OTHER,
+            cancellationFeedback: 'Not good for me',
+          };
+          const cancelledSubscription = {
             ...MOCK_SUBSCRIPTION,
             status: SUBSCRIPTION_STATUSES.canceled,
+          };
+          mockService.cancelSubscription.mockResolvedValue(
+            cancelledSubscription,
+          );
+          mockService.getSubscriptions.mockResolvedValue({
+            customerId: 'cus_1',
+            subscriptions: [cancelledSubscription, mockSubscription2],
+            trialedProducts: [],
+            productEntitlements: MOCK_PRODUCT_ENTITLEMENTS,
           });
           expect(
             await rootMessenger.call(
               'SubscriptionController:cancelSubscription',
-              {
-                subscriptionId: MOCK_SUBSCRIPTION.id,
-              },
+              cancellationRequest,
             ),
           ).toBeUndefined();
           expect(controller.state.subscriptions).toStrictEqual([
-            { ...MOCK_SUBSCRIPTION, status: SUBSCRIPTION_STATUSES.canceled },
+            cancelledSubscription,
             mockSubscription2,
           ]);
+          expect(controller.state.productEntitlements).toStrictEqual(
+            MOCK_PRODUCT_ENTITLEMENTS,
+          );
           expect(mockService.cancelSubscription).toHaveBeenCalledWith({
-            subscriptionId: MOCK_SUBSCRIPTION.id,
+            ...cancellationRequest,
           });
           expect(mockService.cancelSubscription).toHaveBeenCalledTimes(1);
+          expect(mockService.getSubscriptions).toHaveBeenCalledTimes(1);
+          expect(JSON.stringify(controller.state)).not.toContain(
+            cancellationRequest.cancellationFeedback,
+          );
         },
       );
     });
@@ -1832,6 +1852,7 @@ describe('SubscriptionController', () => {
             subscriptionId: 'sub_123456789',
           });
           expect(mockService.cancelSubscription).toHaveBeenCalledTimes(1);
+          expect(mockService.getSubscriptions).not.toHaveBeenCalled();
         },
       );
     });
@@ -1845,9 +1866,18 @@ describe('SubscriptionController', () => {
           },
         },
         async ({ controller, rootMessenger, mockService }) => {
-          mockService.cancelSubscription.mockResolvedValue({
+          const cancelledSubscription = {
             ...MOCK_MONEY_ACCOUNT_SUBSCRIPTION,
             status: SUBSCRIPTION_STATUSES.canceled,
+          };
+          mockService.cancelSubscription.mockResolvedValue(
+            cancelledSubscription,
+          );
+          mockService.getSubscriptions.mockResolvedValue({
+            customerId: 'cus_1',
+            subscriptions: [cancelledSubscription],
+            trialedProducts: [],
+            productEntitlements: {},
           });
 
           await rootMessenger.call(
@@ -1865,6 +1895,7 @@ describe('SubscriptionController', () => {
           ]);
           expect(controller.state.benefits).toBeUndefined();
           expect(mockService.getBenefits).not.toHaveBeenCalled();
+          expect(mockService.getSubscriptions).toHaveBeenCalledTimes(1);
         },
       );
     });
@@ -1878,9 +1909,21 @@ describe('SubscriptionController', () => {
           },
         },
         async ({ controller, rootMessenger, mockService }) => {
-          mockService.cancelSubscription.mockResolvedValue({
+          const cancelledSubscription = {
             ...MOCK_SUBSCRIPTION,
             status: SUBSCRIPTION_STATUSES.canceled,
+          };
+          mockService.cancelSubscription.mockResolvedValue(
+            cancelledSubscription,
+          );
+          mockService.getSubscriptions.mockResolvedValue({
+            customerId: 'cus_1',
+            subscriptions: [
+              cancelledSubscription,
+              MOCK_MONEY_ACCOUNT_SUBSCRIPTION,
+            ],
+            trialedProducts: [],
+            productEntitlements: MOCK_PRODUCT_ENTITLEMENTS,
           });
           mockService.getBenefits.mockRejectedValue(
             new SubscriptionServiceError('Failed to get benefits'),
@@ -1901,6 +1944,40 @@ describe('SubscriptionController', () => {
           ]);
           expect(controller.state.benefits).toStrictEqual(MOCK_BENEFITS_STATE);
           expect(mockService.getBenefits).toHaveBeenCalledTimes(1);
+          expect(mockService.getSubscriptions).toHaveBeenCalledTimes(1);
+        },
+      );
+    });
+
+    it('should preserve the cancelled subscription when the subscription refresh fails', async () => {
+      await withController(
+        {
+          state: {
+            subscriptions: [MOCK_SUBSCRIPTION],
+          },
+        },
+        async ({ controller, rootMessenger, mockService }) => {
+          const cancelledSubscription = {
+            ...MOCK_SUBSCRIPTION,
+            status: SUBSCRIPTION_STATUSES.canceled,
+          };
+          mockService.cancelSubscription.mockResolvedValue(
+            cancelledSubscription,
+          );
+          mockService.getSubscriptions.mockRejectedValue(
+            new SubscriptionServiceError('Failed to refresh subscriptions'),
+          );
+
+          await expect(
+            rootMessenger.call('SubscriptionController:cancelSubscription', {
+              subscriptionId: MOCK_SUBSCRIPTION.id,
+            }),
+          ).resolves.toBeUndefined();
+
+          expect(controller.state.subscriptions).toStrictEqual([
+            cancelledSubscription,
+          ]);
+          expect(mockService.getSubscriptions).toHaveBeenCalledTimes(1);
         },
       );
     });

--- a/packages/subscription-controller/src/SubscriptionController.test.ts
+++ b/packages/subscription-controller/src/SubscriptionController.test.ts
@@ -1968,11 +1968,14 @@ describe('SubscriptionController', () => {
             new SubscriptionServiceError('Failed to refresh subscriptions'),
           );
 
-          await expect(
-            rootMessenger.call('SubscriptionController:cancelSubscription', {
-              subscriptionId: MOCK_SUBSCRIPTION.id,
-            }),
-          ).resolves.toBeUndefined();
+          expect(
+            await rootMessenger.call(
+              'SubscriptionController:cancelSubscription',
+              {
+                subscriptionId: MOCK_SUBSCRIPTION.id,
+              },
+            ),
+          ).toBeUndefined();
 
           expect(controller.state.subscriptions).toStrictEqual([
             cancelledSubscription,

--- a/packages/subscription-controller/src/SubscriptionController.ts
+++ b/packages/subscription-controller/src/SubscriptionController.ts
@@ -507,7 +507,15 @@ export class SubscriptionController extends StaticIntervalPollingController()<
       );
     });
 
-    await this.#refreshBenefitsIfActive();
+    try {
+      await this.#getSubscriptions();
+    } catch (error) {
+      log('Failed to refresh subscriptions after cancellation', error);
+
+      // Preserve the existing best-effort benefits refresh behavior if the
+      // canonical subscription refresh is unavailable.
+      await this.#refreshBenefitsIfActive();
+    }
 
     this.triggerAccessTokenRefresh();
   }

--- a/packages/subscription-controller/src/SubscriptionService.test.ts
+++ b/packages/subscription-controller/src/SubscriptionService.test.ts
@@ -1132,7 +1132,9 @@ describe('SubscriptionService', () => {
 
         await expect(
           service.cancelSubscription({ subscriptionId: 'sub_123456789' }),
-        ).rejects.toThrow();
+        ).rejects.toThrow(
+          'At path: id -- Expected a string, but received: undefined',
+        );
       });
     });
   });

--- a/packages/subscription-controller/src/SubscriptionService.test.ts
+++ b/packages/subscription-controller/src/SubscriptionService.test.ts
@@ -8,6 +8,7 @@ import type {
 import { create } from '@metamask/superstruct';
 
 import {
+  CANCELLATION_REASONS,
   Env,
   getEnvUrls,
   SubscriptionControllerErrorMessage,
@@ -991,7 +992,7 @@ describe('SubscriptionService', () => {
   describe('cancelSubscription', () => {
     it('should cancel subscription successfully', async () => {
       await withMockSubscriptionService(
-        async ({ service, fetchMock, getBearerToken }) => {
+        async ({ service, fetchMock, getBearerToken, env }) => {
           fetchMock.mockResolvedValue(
             createMockResponse({ jsonData: MOCK_SUBSCRIPTION }),
           );
@@ -1002,8 +1003,98 @@ describe('SubscriptionService', () => {
 
           expect(result).toStrictEqual(MOCK_SUBSCRIPTION);
           expect(getBearerToken).toHaveBeenCalledTimes(1);
+          expect(fetchMock).toHaveBeenCalledWith(
+            SUBSCRIPTION_URL(env, 'subscriptions/sub_123456789/cancel'),
+            {
+              method: 'POST',
+              headers: MOCK_HEADERS,
+              body: JSON.stringify({}),
+            },
+          );
         },
       );
+    });
+
+    it('should serialize cancellation reason and feedback without subscriptionId in the body', async () => {
+      await withMockSubscriptionService(async ({ service, fetchMock, env }) => {
+        fetchMock.mockResolvedValue(
+          createMockResponse({ jsonData: MOCK_SUBSCRIPTION }),
+        );
+
+        await service.cancelSubscription({
+          subscriptionId: 'sub_123456789',
+          cancelAtPeriodEnd: true,
+          cancellationReason: CANCELLATION_REASONS.OTHER,
+          cancellationFeedback: 'Not good for me',
+        });
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          SUBSCRIPTION_URL(env, 'subscriptions/sub_123456789/cancel'),
+          {
+            method: 'POST',
+            headers: MOCK_HEADERS,
+            body: JSON.stringify({
+              cancelAtPeriodEnd: true,
+              cancellationReason: CANCELLATION_REASONS.OTHER,
+              cancellationFeedback: 'Not good for me',
+            }),
+          },
+        );
+      });
+    });
+
+    it.each(Object.values(CANCELLATION_REASONS))(
+      'should serialize cancellation reason %s',
+      async (cancellationReason) => {
+        await withMockSubscriptionService(
+          async ({ service, fetchMock, env }) => {
+            fetchMock.mockResolvedValue(
+              createMockResponse({ jsonData: MOCK_SUBSCRIPTION }),
+            );
+
+            await service.cancelSubscription({
+              subscriptionId: 'sub_123456789',
+              cancellationReason,
+            });
+
+            expect(fetchMock).toHaveBeenCalledWith(
+              SUBSCRIPTION_URL(env, 'subscriptions/sub_123456789/cancel'),
+              expect.objectContaining({
+                body: JSON.stringify({ cancellationReason }),
+              }),
+            );
+          },
+        );
+      },
+    );
+
+    it('should not include cancellation feedback in the query key', async () => {
+      await withMockSubscriptionService(async ({ service }) => {
+        const fetchQuerySpy = jest
+          .spyOn(
+            service as unknown as {
+              fetchQuery: SubscriptionService['fetchQuery'];
+            },
+            'fetchQuery',
+          )
+          .mockResolvedValue(MOCK_SUBSCRIPTION);
+        const feedback = 'private cancellation feedback';
+
+        await service.cancelSubscription({
+          subscriptionId: 'sub_123456789',
+          cancelAtPeriodEnd: true,
+          cancellationReason: CANCELLATION_REASONS.OTHER,
+          cancellationFeedback: feedback,
+        });
+
+        const queryKey = fetchQuerySpy.mock.calls[0]?.[0].queryKey;
+        expect(JSON.stringify(queryKey)).not.toContain(feedback);
+        expect(queryKey).toContainEqual({
+          subscriptionId: 'sub_123456789',
+          cancelAtPeriodEnd: true,
+          cancellationReason: CANCELLATION_REASONS.OTHER,
+        });
+      });
     });
 
     it('should throw SubscriptionServiceError for network errors', async () => {
@@ -1033,6 +1124,16 @@ describe('SubscriptionService', () => {
           expect(captureExceptionMock).toHaveBeenCalledTimes(1);
         },
       );
+    });
+
+    it('should throw when the cancellation response is invalid', async () => {
+      await withMockSubscriptionService(async ({ service, fetchMock }) => {
+        fetchMock.mockResolvedValue(createMockResponse({ jsonData: {} }));
+
+        await expect(
+          service.cancelSubscription({ subscriptionId: 'sub_123456789' }),
+        ).rejects.toThrow();
+      });
     });
   });
 

--- a/packages/subscription-controller/src/SubscriptionService.ts
+++ b/packages/subscription-controller/src/SubscriptionService.ts
@@ -240,11 +240,17 @@ export class SubscriptionService extends BaseDataService<
       profileKey,
       bearerToken,
       methodName: 'cancelSubscription',
-      requestParams: params,
+      requestParams: {
+        subscriptionId: params.subscriptionId,
+        cancelAtPeriodEnd: params.cancelAtPeriodEnd,
+        cancellationReason: params.cancellationReason,
+      },
       path,
       method: 'POST',
       body: {
         cancelAtPeriodEnd: params.cancelAtPeriodEnd,
+        cancellationReason: params.cancellationReason,
+        cancellationFeedback: params.cancellationFeedback,
       },
       errorMessage: SubscriptionServiceErrorMessage.FailedToCancelSubscription,
     });

--- a/packages/subscription-controller/src/constants.ts
+++ b/packages/subscription-controller/src/constants.ts
@@ -2,6 +2,24 @@ import { SUBSCRIPTION_STATUSES } from './types.js';
 
 export const controllerName = 'SubscriptionController';
 
+/**
+ * API cancellation reason values and their client-facing text.
+ */
+export const CANCELLATION_REASONS = {
+  // Costs more than it's worth
+  TOO_EXPENSIVE: 'too_expensive',
+  // I wasn't using the benefits
+  NOT_USING_BENEFITS: 'not_using_benefits',
+  // The benefits weren't what I expected
+  BENEFITS_NOT_AS_EXPECTED: 'benefits_not_as_expected',
+  // Something didn't work
+  SOMETHING_DID_NOT_WORK: 'something_did_not_work',
+  // Unhappy with support
+  UNHAPPY_WITH_SUPPORT: 'unhappy_with_support',
+  // Other
+  OTHER: 'other',
+} as const;
+
 export enum Env {
   DEV = 'dev',
   UAT = 'uat',

--- a/packages/subscription-controller/src/index.ts
+++ b/packages/subscription-controller/src/index.ts
@@ -48,6 +48,7 @@ export type {
   AuthUtils,
   CancelSubscriptionRequest,
   CancelType,
+  CancellationReasonCode,
   ISubscriptionService,
   StartCryptoSubscriptionRequest,
   StartDelegationCryptoSubscriptionRequest,
@@ -105,6 +106,7 @@ export type {
 } from './types.js';
 export {
   CANCEL_TYPES,
+  CANCELLATION_REASONS,
   CRYPTO_PAYMENT_METHOD_ERRORS,
   SUBSCRIPTION_STATUSES,
   PRODUCT_TYPES,

--- a/packages/subscription-controller/src/index.ts
+++ b/packages/subscription-controller/src/index.ts
@@ -106,7 +106,6 @@ export type {
 } from './types.js';
 export {
   CANCEL_TYPES,
-  CANCELLATION_REASONS,
   CRYPTO_PAYMENT_METHOD_ERRORS,
   SUBSCRIPTION_STATUSES,
   PRODUCT_TYPES,
@@ -120,6 +119,7 @@ export {
   MoneyAccountFeature,
   ShieldFeature,
 } from './types.js';
+export { CANCELLATION_REASONS } from './constants.js';
 export {
   selectHasEntitlement,
   selectIsActiveSubscriber,

--- a/packages/subscription-controller/src/types.ts
+++ b/packages/subscription-controller/src/types.ts
@@ -1,6 +1,8 @@
 import type { TransactionMeta } from '@metamask/transaction-controller';
 import type { CaipAccountId, Hex } from '@metamask/utils';
 
+import type { CANCELLATION_REASONS } from './constants.js';
+
 /**
  * Error response from the Subscription API.
  */
@@ -127,24 +129,6 @@ export const CANCEL_TYPES = {
 } as const;
 
 export type CancelType = (typeof CANCEL_TYPES)[keyof typeof CANCEL_TYPES];
-
-/**
- * API cancellation reason values and their client-facing text.
- */
-export const CANCELLATION_REASONS = {
-  // Costs more than it's worth
-  TOO_EXPENSIVE: 'too_expensive',
-  // I wasn't using the benefits
-  NOT_USING_BENEFITS: 'not_using_benefits',
-  // The benefits weren't what I expected
-  BENEFITS_NOT_AS_EXPECTED: 'benefits_not_as_expected',
-  // Something didn't work
-  SOMETHING_DID_NOT_WORK: 'something_did_not_work',
-  // Unhappy with support
-  UNHAPPY_WITH_SUPPORT: 'unhappy_with_support',
-  // Other
-  OTHER: 'other',
-} as const;
 
 export type CancellationReasonCode =
   (typeof CANCELLATION_REASONS)[keyof typeof CANCELLATION_REASONS];

--- a/packages/subscription-controller/src/types.ts
+++ b/packages/subscription-controller/src/types.ts
@@ -128,6 +128,27 @@ export const CANCEL_TYPES = {
 
 export type CancelType = (typeof CANCEL_TYPES)[keyof typeof CANCEL_TYPES];
 
+/**
+ * API cancellation reason values and their client-facing text.
+ */
+export const CANCELLATION_REASONS = {
+  // Costs more than it's worth
+  TOO_EXPENSIVE: 'too_expensive',
+  // I wasn't using the benefits
+  NOT_USING_BENEFITS: 'not_using_benefits',
+  // The benefits weren't what I expected
+  BENEFITS_NOT_AS_EXPECTED: 'benefits_not_as_expected',
+  // Something didn't work
+  SOMETHING_DID_NOT_WORK: 'something_did_not_work',
+  // Unhappy with support
+  UNHAPPY_WITH_SUPPORT: 'unhappy_with_support',
+  // Other
+  OTHER: 'other',
+} as const;
+
+export type CancellationReasonCode =
+  (typeof CANCELLATION_REASONS)[keyof typeof CANCELLATION_REASONS];
+
 export const CRYPTO_PAYMENT_METHOD_ERRORS = {
   APPROVAL_TRANSACTION_TOO_OLD: 'approval_transaction_too_old',
   APPROVAL_TRANSACTION_REVERTED: 'approval_transaction_reverted',
@@ -375,6 +396,10 @@ export type CancelSubscriptionRequest = {
   subscriptionId: string;
   /** Whether to cancel at the end of the current period */
   cancelAtPeriodEnd?: boolean;
+  /** Stable reason code for the cancellation. */
+  cancellationReason?: CancellationReasonCode;
+  /** Optional free-text feedback for the cancellation. */
+  cancellationFeedback?: string;
 };
 
 export type AuthUtils = {


### PR DESCRIPTION
# Extend subscription cancellation with reason and feedback

## Summary

Extend `@metamask/subscription-controller` cancellation requests with stable cancellation reason codes and optional free-text feedback.

After a successful cancellation, refresh the canonical subscription state, product entitlements, and benefits.

## Changes

- Add and export `CANCELLATION_REASONS` and `CancellationReasonCode`.
- Extend `CancelSubscriptionRequest` with optional `cancellationReason` and `cancellationFeedback` fields.
- Serialize the new fields only in the Subscription API cancellation request body.
- Keep `subscriptionId` in the URL and omit it from the request body.
- Exclude free-text feedback from data-service query keys and controller state.
- Preserve the immediate local cancellation update while making the canonical refresh best effort.
- Keep access-token refresh behavior unchanged.

## API example

```json
{
  "subscriptionId": "sub_123456789",
  "cancelAtPeriodEnd": true,
  "cancellationReason": "other",
  "cancellationFeedback": "Not good for me"
}
```

The Subscription API receives:

```json
{
  "cancelAtPeriodEnd": true,
  "cancellationReason": "other",
  "cancellationFeedback": "Not good for me"
}
```

When the new fields are omitted, the existing cancellation payload remains unchanged.

## Privacy and rollout

- Free-text feedback is not persisted, logged, included in cache identity, or sent to refresh endpoints.
- Both new fields are optional for compatibility with existing callers and backend rollout stages.
- `cancellationFeedback` should only be populated after Product/Legal approval.
- No fallback retry that strips the new fields is added; that behavior requires an explicit unsupported-field response and idempotency guarantees.

## Tests

- Add request serialization coverage for the legacy payload, full payload, every reason code, URL, headers, and body shape.
- Verify free-text feedback is excluded from query keys.
- Add malformed-response coverage for the cancellation service.
- Verify controller forwarding, subscription/entitlement/benefit refreshes, cancellation failures, and refresh failures.

## JIRA

https://consensyssoftware.atlassian.net/browse/SUB-1025?atlOrigin=eyJpIjoiY2IwZGVkNzJmM2ZjNDMwNDk0ZGE1NmQ3YzI4ZGQ4OTkiLCJwIjoiaiJ9

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes post-cancellation state synchronization and sends new optional user feedback to the Subscription API, which can affect entitlements and benefits timing if refresh fails.
> 
> **Overview**
> Extends **subscription cancellation** with optional stable reason codes (`CANCELLATION_REASONS` / `CancellationReasonCode`) and optional free-text **feedback**, exported for UI callers. The service sends `cancelAtPeriodEnd`, `cancellationReason`, and `cancellationFeedback` in the **POST body** only (still keyed by `subscriptionId` in the URL); **feedback is omitted from data-service query keys** and does not land in controller state.
> 
> After a successful cancel, the controller still applies the immediate local subscription update, then runs a **full `#getSubscriptions()` refresh** so entitlements and benefits stay in sync. If that refresh fails, it **falls back** to the prior best-effort `#refreshBenefitsIfActive()` path while keeping the cancelled subscription in state. Tests cover body serialization for every reason code, privacy of feedback, malformed cancel responses, and refresh success/failure paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9f406b84493ed533539e8f34a1290cda5acf56a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->