### PR TITLE
Release 1250.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/core-monorepo",
-  "version": "1249.0.0",
+  "version": "1250.0.0",
   "private": true,
   "description": "Monorepo for packages shared between MetaMask clients",
   "repository": {

--- a/packages/transaction-pay-controller/CHANGELOG.md
+++ b/packages/transaction-pay-controller/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [28.0.2]
+
 ### Fixed
 
 - Restore `EXACT_OUTPUT` Relay quotes for `predictDepositAndOrder` flows so Predict deposit-and-order trades keep a guaranteed output amount.
@@ -1538,7 +1540,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release ([#6820](https://github.com/MetaMask/core/pull/6820))
 
-[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/transaction-pay-controller@28.0.1...HEAD
+[Unreleased]: https://github.com/MetaMask/core/compare/@metamask/transaction-pay-controller@28.0.2...HEAD
+[28.0.2]: https://github.com/MetaMask/core/compare/@metamask/transaction-pay-controller@28.0.1...@metamask/transaction-pay-controller@28.0.2
 [28.0.1]: https://github.com/MetaMask/core/compare/@metamask/transaction-pay-controller@28.0.0...@metamask/transaction-pay-controller@28.0.1
 [28.0.0]: https://github.com/MetaMask/core/compare/@metamask/transaction-pay-controller@27.1.2...@metamask/transaction-pay-controller@28.0.0
 [27.1.2]: https://github.com/MetaMask/core/compare/@metamask/transaction-pay-controller@27.1.1...@metamask/transaction-pay-controller@27.1.2

--- a/packages/transaction-pay-controller/package.json
+++ b/packages/transaction-pay-controller/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/transaction-pay-controller",
-  "version": "28.0.1",
+  "version": "28.0.2",
   "description": "Manages alternate payment strategies to provide required funds for transactions in MetaMask",
   "keywords": [
     "Ethereum",


### PR DESCRIPTION
Release PR for @metamask/transaction-pay-controller 28.0.2.

Includes the fix from #10173 restoring EXACT_OUTPUT Relay quotes for predictDepositAndOrder flows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> The diff is version and changelog updates only; behavioral risk comes from the already-merged relay quote fix when clients upgrade to 28.0.2.
> 
> **Overview**
> This is a **release-only** PR: it bumps the monorepo to **1250.0.0** and publishes **`@metamask/transaction-pay-controller` 28.0.2** (package version and changelog only—no new source changes in the diff).
> 
> The **28.0.2** notes document the shipped fix from #10173: **`predictDepositAndOrder`** flows again request **`EXACT_OUTPUT`** Relay quotes (alongside embedded txs and **`perpsDepositAndOrder`**), so Predict deposit-and-order trades keep a **guaranteed output amount** instead of falling back to **`EXACT_INPUT`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee4a5ee0ce8b744c7b3d41e77a38e89cb728e237. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->