### PR TITLE
feat(core-backend): overide APIs with env var

### DIFF
--- a/packages/core-backend/CHANGELOG.md
+++ b/packages/core-backend/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add optional `apiUrls` option to `ApiPlatformClientOptions`, allowing API base URLs (accounts, prices, token, tokens) to be overridden per client instance, e.g. from client env vars; unspecified services fall back to the production `API_URLS` ([#10196](https://github.com/MetaMask/core/pull/10196))
+
 ### Changed
 
 - **BREAKING:** Accounts API `V2SupportedNetworksResponse` now uses CAIP-2 string arrays for both `fullSupport` and `partialSupport`, replacing decimal `fullSupport` and object-shaped `partialSupport.balances` ([#10144](https://github.com/MetaMask/core/pull/10144))

--- a/packages/core-backend/src/api/accounts/client.ts
+++ b/packages/core-backend/src/api/accounts/client.ts
@@ -17,12 +17,7 @@ import type {
   QueryFunctionContext,
 } from '@tanstack/query-core';
 
-import {
-  BaseApiClient,
-  API_URLS,
-  STALE_TIMES,
-  GC_TIMES,
-} from '../base-client.js';
+import { BaseApiClient, STALE_TIMES, GC_TIMES } from '../base-client.js';
 import { getQueryOptionsOverrides } from '../shared-types.js';
 import type { FetchOptions } from '../shared-types.js';
 import type {
@@ -97,7 +92,7 @@ export class AccountsApiClient extends BaseApiClient {
       queryKey: ['accounts', 'v1SupportedNetworks'],
       queryFn: ({ signal }: QueryFunctionContext) =>
         this.fetch<V1SupportedNetworksResponse>(
-          API_URLS.ACCOUNTS,
+          this.apiUrls.ACCOUNTS,
           '/v1/supportedNetworks',
           { signal },
         ),
@@ -134,7 +129,7 @@ export class AccountsApiClient extends BaseApiClient {
       queryKey: ['accounts', 'v2SupportedNetworks'],
       queryFn: ({ signal }: QueryFunctionContext) =>
         this.fetch<V2SupportedNetworksResponse>(
-          API_URLS.ACCOUNTS,
+          this.apiUrls.ACCOUNTS,
           '/v2/supportedNetworks',
           { signal },
         ),
@@ -198,7 +193,7 @@ export class AccountsApiClient extends BaseApiClient {
           return { activeNetworks: [] };
         }
         return this.fetch<V2ActiveNetworksResponse>(
-          API_URLS.ACCOUNTS,
+          this.apiUrls.ACCOUNTS,
           '/v2/activeNetworks',
           {
             signal,
@@ -289,7 +284,7 @@ export class AccountsApiClient extends BaseApiClient {
           return { count: 0, balances: [], unprocessedNetworks: [] };
         }
         return this.fetch<V2BalancesResponse>(
-          API_URLS.ACCOUNTS,
+          this.apiUrls.ACCOUNTS,
           `/v2/accounts/${address}/balances`,
           {
             signal,
@@ -373,7 +368,7 @@ export class AccountsApiClient extends BaseApiClient {
           return { count: 0, balances: [], unprocessedNetworks: [] };
         }
         return this.fetch<V4BalancesResponse>(
-          API_URLS.ACCOUNTS,
+          this.apiUrls.ACCOUNTS,
           '/v4/multiaccount/balances',
           {
             signal,
@@ -457,7 +452,7 @@ export class AccountsApiClient extends BaseApiClient {
           return { count: 0, unprocessedNetworks: [], balances: [] };
         }
         return this.fetch<V5BalancesResponse>(
-          API_URLS.ACCOUNTS,
+          this.apiUrls.ACCOUNTS,
           '/v5/multiaccount/balances',
           {
             signal,
@@ -584,7 +579,7 @@ export class AccountsApiClient extends BaseApiClient {
           };
         }
         return this.fetch<V6BalancesResponse>(
-          API_URLS.ACCOUNTS,
+          this.apiUrls.ACCOUNTS,
           '/v6/multiaccount/balances',
           {
             signal,
@@ -709,7 +704,7 @@ export class AccountsApiClient extends BaseApiClient {
       ],
       queryFn: ({ signal }: QueryFunctionContext) =>
         this.fetch<V1TransactionByHashResponse>(
-          API_URLS.ACCOUNTS,
+          this.apiUrls.ACCOUNTS,
           `/v1/networks/${chainId}/transactions/${txHash}`,
           {
             signal,
@@ -806,7 +801,7 @@ export class AccountsApiClient extends BaseApiClient {
           return { data: [], pageInfo: { count: 0, hasNextPage: false } };
         }
         return this.fetch<V1AccountTransactionsResponse>(
-          API_URLS.ACCOUNTS,
+          this.apiUrls.ACCOUNTS,
           `/v1/accounts/${address}/transactions`,
           {
             signal,
@@ -914,7 +909,7 @@ export class AccountsApiClient extends BaseApiClient {
       ],
       queryFn: ({ signal }: QueryFunctionContext) =>
         this.fetch<V4MultiAccountTransactionsResponse>(
-          API_URLS.ACCOUNTS,
+          this.apiUrls.ACCOUNTS,
           '/v4/multiaccount/transactions',
           {
             signal,
@@ -1006,7 +1001,7 @@ export class AccountsApiClient extends BaseApiClient {
         signal?: AbortSignal;
       }) =>
         this.fetch<V4MultiAccountTransactionsResponse>(
-          API_URLS.ACCOUNTS,
+          this.apiUrls.ACCOUNTS,
           '/v4/multiaccount/transactions',
           {
             signal,
@@ -1106,7 +1101,7 @@ export class AccountsApiClient extends BaseApiClient {
         signal,
       }: QueryFunctionContext): Promise<V1AccountRelationshipResult> =>
         this.fetch<V1AccountRelationshipResult>(
-          API_URLS.ACCOUNTS,
+          this.apiUrls.ACCOUNTS,
           `/v1/networks/${chainId}/accounts/${from}/relationships/${to}`,
           { signal },
         ),
@@ -1175,7 +1170,7 @@ export class AccountsApiClient extends BaseApiClient {
           return { data: [], pageInfo: { count: 0, hasNextPage: false } };
         }
         return this.fetch<V2NftsResponse>(
-          API_URLS.ACCOUNTS,
+          this.apiUrls.ACCOUNTS,
           `/v2/accounts/${address}/nfts`,
           {
             signal,
@@ -1253,7 +1248,7 @@ export class AccountsApiClient extends BaseApiClient {
           return { data: [] };
         }
         return this.fetch<V2TokensResponse>(
-          API_URLS.ACCOUNTS,
+          this.apiUrls.ACCOUNTS,
           `/v2/accounts/${address}/tokens`,
           {
             signal,

--- a/packages/core-backend/src/api/base-client.test.ts
+++ b/packages/core-backend/src/api/base-client.test.ts
@@ -76,6 +76,40 @@ describe('BaseApiClient', () => {
     });
   });
 
+  describe('API URL overrides', () => {
+    beforeEach(() => {
+      mockFetch.mockReset();
+      mockFetch.mockResolvedValue(
+        createMockResponse({ supportedNetworks: [] }),
+      );
+    });
+
+    it('uses the production URL by default', async () => {
+      const client = new AccountsApiClient({
+        clientProduct: 'test-product',
+      });
+
+      await client.fetchV1SupportedNetworks();
+
+      expect(String(mockFetch.mock.calls[0]?.[0])).toMatch(
+        'https://accounts.api.cx.metamask.io/',
+      );
+    });
+
+    it('uses the overridden URL when apiUrls is provided', async () => {
+      const client = new AccountsApiClient({
+        clientProduct: 'test-product',
+        apiUrls: { ACCOUNTS: 'https://accounts.dev-api.cx.metamask.io' },
+      });
+
+      await client.fetchV1SupportedNetworks();
+
+      expect(String(mockFetch.mock.calls[0]?.[0])).toMatch(
+        'https://accounts.dev-api.cx.metamask.io/',
+      );
+    });
+  });
+
   describe('bearer token timeout', () => {
     /**
      * Creates a client whose token provider only resolves when told to.

--- a/packages/core-backend/src/api/base-client.ts
+++ b/packages/core-backend/src/api/base-client.ts
@@ -14,7 +14,7 @@ import {
   shouldRetry,
   HttpError,
 } from './shared-types.js';
-import type { ApiPlatformClientOptions } from './shared-types.js';
+import type { ApiPlatformClientOptions, ApiUrls } from './shared-types.js';
 
 // Auth query keys - shared for token management across clients
 export const authQueryKeys = {
@@ -47,6 +47,9 @@ export class BaseApiClient {
 
   protected readonly authTokenTimeout: number;
 
+  /** Resolved API base URLs (production defaults merged with any overrides). */
+  readonly apiUrls: ApiUrls;
+
   readonly #queryClientInstance: QueryClient;
 
   /**
@@ -78,6 +81,7 @@ export class BaseApiClient {
     this.getBearerToken = options.getBearerToken;
     this.authTokenTimeout =
       options.authTokenTimeout ?? DEFAULT_AUTH_TOKEN_TIMEOUT;
+    this.apiUrls = { ...API_URLS, ...options.apiUrls };
 
     this.#queryClientInstance =
       options.queryClient ??
@@ -213,5 +217,5 @@ export class BaseApiClient {
   }
 }
 
-// Re-export constants for use by API clients
-export { API_URLS, STALE_TIMES, GC_TIMES, HttpError };
+// Re-export cache timings for use by API clients
+export { STALE_TIMES, GC_TIMES };

--- a/packages/core-backend/src/api/index.ts
+++ b/packages/core-backend/src/api/index.ts
@@ -9,6 +9,7 @@ export type {
   SupportedCurrency,
   MarketDataDetails,
   ApiPlatformClientOptions,
+  ApiUrls,
   FetchOptions,
 } from './shared-types.js';
 export {

--- a/packages/core-backend/src/api/prices/client.ts
+++ b/packages/core-backend/src/api/prices/client.ts
@@ -14,12 +14,7 @@ import type {
   QueryFunctionContext,
 } from '@tanstack/query-core';
 
-import {
-  BaseApiClient,
-  API_URLS,
-  STALE_TIMES,
-  GC_TIMES,
-} from '../base-client.js';
+import { BaseApiClient, STALE_TIMES, GC_TIMES } from '../base-client.js';
 import { getQueryOptionsOverrides } from '../shared-types.js';
 import type {
   FetchOptions,
@@ -70,7 +65,7 @@ export class PricesApiClient extends BaseApiClient {
       queryKey: ['prices', 'v1SupportedNetworks'],
       queryFn: ({ signal }: QueryFunctionContext) =>
         this.fetch<PriceSupportedNetworksResponse>(
-          API_URLS.PRICES,
+          this.apiUrls.PRICES,
           '/v1/supportedNetworks',
           { signal },
         ),
@@ -107,7 +102,7 @@ export class PricesApiClient extends BaseApiClient {
       queryKey: ['prices', 'v2SupportedNetworks'],
       queryFn: ({ signal }: QueryFunctionContext) =>
         this.fetch<PriceSupportedNetworksResponse>(
-          API_URLS.PRICES,
+          this.apiUrls.PRICES,
           '/v2/supportedNetworks',
           { signal },
         ),
@@ -155,7 +150,7 @@ export class PricesApiClient extends BaseApiClient {
           return {};
         }
         return this.fetch<V1ExchangeRatesResponse>(
-          API_URLS.PRICES,
+          this.apiUrls.PRICES,
           '/v1/exchange-rates',
           {
             signal,
@@ -201,7 +196,7 @@ export class PricesApiClient extends BaseApiClient {
       queryKey: ['prices', 'v1FiatExchangeRates'],
       queryFn: ({ signal }: QueryFunctionContext) =>
         this.fetch<V1ExchangeRatesResponse>(
-          API_URLS.PRICES,
+          this.apiUrls.PRICES,
           '/v1/exchange-rates/fiat',
           { signal },
         ),
@@ -238,7 +233,7 @@ export class PricesApiClient extends BaseApiClient {
       queryKey: ['prices', 'v1CryptoExchangeRates'],
       queryFn: ({ signal }: QueryFunctionContext) =>
         this.fetch<V1ExchangeRatesResponse>(
-          API_URLS.PRICES,
+          this.apiUrls.PRICES,
           '/v1/exchange-rates/crypto',
           { signal },
         ),
@@ -290,7 +285,7 @@ export class PricesApiClient extends BaseApiClient {
           return {};
         }
         return this.fetch<Record<string, CoinGeckoSpotPrice>>(
-          API_URLS.PRICES,
+          this.apiUrls.PRICES,
           '/v1/spot-prices',
           {
             signal,
@@ -345,7 +340,7 @@ export class PricesApiClient extends BaseApiClient {
           return { id: '', price: 0 };
         }
         return this.fetch<CoinGeckoSpotPrice>(
-          API_URLS.PRICES,
+          this.apiUrls.PRICES,
           `/v1/spot-prices/${coinId}`,
           {
             signal,
@@ -423,7 +418,7 @@ export class PricesApiClient extends BaseApiClient {
           return {};
         }
         return this.fetch<Record<string, Record<string, number>>>(
-          API_URLS.PRICES,
+          this.apiUrls.PRICES,
           `/v1/chains/${chainIdDecimal}/spot-prices`,
           {
             signal,
@@ -496,7 +491,7 @@ export class PricesApiClient extends BaseApiClient {
         signal,
       }: QueryFunctionContext): Promise<MarketDataDetails> => {
         return this.fetch<MarketDataDetails>(
-          API_URLS.PRICES,
+          this.apiUrls.PRICES,
           `/v1/chains/${chainIdDecimal}/spot-prices/${tokenAddress}`,
           {
             signal,
@@ -580,7 +575,7 @@ export class PricesApiClient extends BaseApiClient {
           return {};
         }
         return this.fetch<Record<string, MarketDataDetails>>(
-          API_URLS.PRICES,
+          this.apiUrls.PRICES,
           `/v2/chains/${chainIdDecimal}/spot-prices`,
           {
             signal,
@@ -676,7 +671,7 @@ export class PricesApiClient extends BaseApiClient {
           return {};
         }
         return this.fetch<V3SpotPricesResponse>(
-          API_URLS.PRICES,
+          this.apiUrls.PRICES,
           '/v3/spot-prices',
           {
             signal,
@@ -753,7 +748,7 @@ export class PricesApiClient extends BaseApiClient {
       queryKey: ['prices', 'v1HistoricalByCoinId', coinId, queryOptions],
       queryFn: ({ signal }: QueryFunctionContext) =>
         this.fetch<V1HistoricalPricesResponse>(
-          API_URLS.PRICES,
+          this.apiUrls.PRICES,
           `/v1/historical-prices/${coinId}`,
           {
             signal,
@@ -839,7 +834,7 @@ export class PricesApiClient extends BaseApiClient {
       ],
       queryFn: ({ signal }: QueryFunctionContext) =>
         this.fetch<V1HistoricalPricesResponse>(
-          API_URLS.PRICES,
+          this.apiUrls.PRICES,
           `/v1/chains/${chainIdDecimal}/historical-prices`,
           {
             signal,
@@ -923,7 +918,7 @@ export class PricesApiClient extends BaseApiClient {
       ],
       queryFn: ({ signal }: QueryFunctionContext) =>
         this.fetch<V1HistoricalPricesResponse>(
-          API_URLS.PRICES,
+          this.apiUrls.PRICES,
           `/v1/chains/${chainIdDecimal}/historical-prices/${tokenAddress}`,
           {
             signal,
@@ -1000,7 +995,7 @@ export class PricesApiClient extends BaseApiClient {
       queryKey: ['prices', 'v3Historical', chainId, assetType, queryOptions],
       queryFn: ({ signal }: QueryFunctionContext) =>
         this.fetch<V3HistoricalPricesResponse>(
-          API_URLS.PRICES,
+          this.apiUrls.PRICES,
           `/v3/historical-prices/${chainId}/${assetType}`,
           {
             signal,
@@ -1080,7 +1075,7 @@ export class PricesApiClient extends BaseApiClient {
       queryKey: ['prices', 'v1GraphByCoinId', coinId, currency, includeOHLC],
       queryFn: ({ signal }: QueryFunctionContext) =>
         this.fetch<V3HistoricalPricesResponse>(
-          API_URLS.PRICES,
+          this.apiUrls.PRICES,
           `/v1/historical-prices-graph/${coinId}`,
           {
             signal,
@@ -1151,7 +1146,7 @@ export class PricesApiClient extends BaseApiClient {
       ],
       queryFn: ({ signal }: QueryFunctionContext) =>
         this.fetch<V3HistoricalPricesResponse>(
-          API_URLS.PRICES,
+          this.apiUrls.PRICES,
           `/v1/chains/${chainIdDecimal}/historical-prices-graph/${tokenAddress}`,
           {
             signal,

--- a/packages/core-backend/src/api/shared-types.ts
+++ b/packages/core-backend/src/api/shared-types.ts
@@ -145,7 +145,16 @@ export type ApiPlatformClientOptions = {
   authTokenTimeout?: number;
   /** Optional custom QueryClient instance */
   queryClient?: QueryClient;
+  /**
+   * Optional overrides for the API base URLs. Any service not specified falls
+   * back to the production URL in {@link API_URLS}. Useful for pointing
+   * clients at dev/local backend environments (e.g. via client env vars).
+   */
+  apiUrls?: Partial<ApiUrls>;
 };
+
+/** Map of API service names to their base URLs. */
+export type ApiUrls = { [Service in keyof typeof API_URLS]: string };
 
 /**
  * Options for API fetch and query methods.

--- a/packages/core-backend/src/api/token/client.ts
+++ b/packages/core-backend/src/api/token/client.ts
@@ -17,12 +17,7 @@ import type {
   QueryFunctionContext,
 } from '@tanstack/query-core';
 
-import {
-  BaseApiClient,
-  API_URLS,
-  STALE_TIMES,
-  GC_TIMES,
-} from '../base-client.js';
+import { BaseApiClient, STALE_TIMES, GC_TIMES } from '../base-client.js';
 import { getQueryOptionsOverrides } from '../shared-types.js';
 import type { FetchOptions } from '../shared-types.js';
 import type {
@@ -72,7 +67,7 @@ export class TokenApiClient extends BaseApiClient {
     return {
       queryKey: ['token', 'networks'],
       queryFn: ({ signal }: QueryFunctionContext) =>
-        this.fetch<NetworkInfo[]>(API_URLS.TOKEN, '/networks', { signal }),
+        this.fetch<NetworkInfo[]>(this.apiUrls.TOKEN, '/networks', { signal }),
       ...getQueryOptionsOverrides(options),
       staleTime: options?.staleTime ?? STALE_TIMES.SUPPORTED_NETWORKS,
       gcTime: options?.gcTime ?? GC_TIMES.EXTENDED,
@@ -103,7 +98,7 @@ export class TokenApiClient extends BaseApiClient {
     return {
       queryKey: ['token', 'networkByChainId', chainId],
       queryFn: ({ signal }: QueryFunctionContext) =>
-        this.fetch<NetworkInfo>(API_URLS.TOKEN, `/networks/${chainId}`, {
+        this.fetch<NetworkInfo>(this.apiUrls.TOKEN, `/networks/${chainId}`, {
           signal,
         }),
       ...getQueryOptionsOverrides(options),
@@ -167,7 +162,7 @@ export class TokenApiClient extends BaseApiClient {
     return {
       queryKey: ['token', 'tokenList', { chainId, options: queryOptions }],
       queryFn: ({ signal }: QueryFunctionContext) =>
-        this.fetch<TokenMetadata[]>(API_URLS.TOKEN, `/tokens/${chainId}`, {
+        this.fetch<TokenMetadata[]>(this.apiUrls.TOKEN, `/tokens/${chainId}`, {
           signal,
           params: {
             includeTokenFees: queryOptions?.includeTokenFees,
@@ -271,21 +266,25 @@ export class TokenApiClient extends BaseApiClient {
       queryFn: async ({
         signal,
       }: QueryFunctionContext): Promise<TokenMetadata> => {
-        return this.fetch<TokenMetadata>(API_URLS.TOKEN, `/token/${chainId}`, {
-          signal,
-          params: {
-            address: tokenAddress,
-            includeTokenFees: queryOptions?.includeTokenFees,
-            includeAssetType: queryOptions?.includeAssetType,
-            includeAggregators: queryOptions?.includeAggregators,
-            includeERC20Permit: queryOptions?.includeERC20Permit,
-            includeOccurrences: queryOptions?.includeOccurrences,
-            includeStorage: queryOptions?.includeStorage,
-            includeIconUrl: queryOptions?.includeIconUrl,
-            includeAddress: queryOptions?.includeAddress,
-            includeName: queryOptions?.includeName,
+        return this.fetch<TokenMetadata>(
+          this.apiUrls.TOKEN,
+          `/token/${chainId}`,
+          {
+            signal,
+            params: {
+              address: tokenAddress,
+              includeTokenFees: queryOptions?.includeTokenFees,
+              includeAssetType: queryOptions?.includeAssetType,
+              includeAggregators: queryOptions?.includeAggregators,
+              includeERC20Permit: queryOptions?.includeERC20Permit,
+              includeOccurrences: queryOptions?.includeOccurrences,
+              includeStorage: queryOptions?.includeStorage,
+              includeIconUrl: queryOptions?.includeIconUrl,
+              includeAddress: queryOptions?.includeAddress,
+              includeName: queryOptions?.includeName,
+            },
           },
-        });
+        );
       },
       ...getQueryOptionsOverrides(options),
       staleTime: options?.staleTime ?? STALE_TIMES.TOKEN_METADATA,
@@ -360,7 +359,7 @@ export class TokenApiClient extends BaseApiClient {
         signal,
       }: QueryFunctionContext): Promise<V1TokenDescriptionResponse> =>
         this.fetch<V1TokenDescriptionResponse>(
-          API_URLS.TOKEN,
+          this.apiUrls.TOKEN,
           `/token/${chainId}/description`,
           {
             signal,
@@ -434,7 +433,7 @@ export class TokenApiClient extends BaseApiClient {
         { chainIds: [...chainIds].sort(), options: queryOptions },
       ],
       queryFn: ({ signal }: QueryFunctionContext) =>
-        this.fetch<TrendingToken[]>(API_URLS.TOKEN, '/v3/tokens/trending', {
+        this.fetch<TrendingToken[]>(this.apiUrls.TOKEN, '/v3/tokens/trending', {
           signal,
           params: {
             chainIds,
@@ -521,19 +520,23 @@ export class TokenApiClient extends BaseApiClient {
         { chainIds: [...chainIds].sort(), options: queryOptions },
       ],
       queryFn: ({ signal }: QueryFunctionContext) =>
-        this.fetch<TrendingToken[]>(API_URLS.TOKEN, '/v3/tokens/top-gainers', {
-          signal,
-          params: {
-            chainIds,
-            sort: queryOptions?.sort,
-            blockRegion: queryOptions?.blockRegion,
-            minLiquidity: queryOptions?.minLiquidity,
-            minVolume24hUsd: queryOptions?.minVolume24hUsd,
-            maxVolume24hUsd: queryOptions?.maxVolume24hUsd,
-            minMarketCap: queryOptions?.minMarketCap,
-            maxMarketCap: queryOptions?.maxMarketCap,
+        this.fetch<TrendingToken[]>(
+          this.apiUrls.TOKEN,
+          '/v3/tokens/top-gainers',
+          {
+            signal,
+            params: {
+              chainIds,
+              sort: queryOptions?.sort,
+              blockRegion: queryOptions?.blockRegion,
+              minLiquidity: queryOptions?.minLiquidity,
+              minVolume24hUsd: queryOptions?.minVolume24hUsd,
+              maxVolume24hUsd: queryOptions?.maxVolume24hUsd,
+              minMarketCap: queryOptions?.minMarketCap,
+              maxMarketCap: queryOptions?.maxMarketCap,
+            },
           },
-        }),
+        ),
       ...getQueryOptionsOverrides(options),
       staleTime: options?.staleTime ?? STALE_TIMES.TRENDING,
       gcTime: options?.gcTime ?? GC_TIMES.SHORT,
@@ -606,7 +609,7 @@ export class TokenApiClient extends BaseApiClient {
         { chainIds: [...chainIds].sort(), options: queryOptions },
       ],
       queryFn: ({ signal }: QueryFunctionContext) =>
-        this.fetch<TrendingToken[]>(API_URLS.TOKEN, '/v3/tokens/popular', {
+        this.fetch<TrendingToken[]>(this.apiUrls.TOKEN, '/v3/tokens/popular', {
           signal,
           params: {
             chainIds,
@@ -673,7 +676,7 @@ export class TokenApiClient extends BaseApiClient {
     return {
       queryKey: ['token', 'topAssets', chainId],
       queryFn: ({ signal }: QueryFunctionContext) =>
-        this.fetch<TopAsset[]>(API_URLS.TOKEN, `/topAssets/${chainId}`, {
+        this.fetch<TopAsset[]>(this.apiUrls.TOKEN, `/topAssets/${chainId}`, {
           signal,
         }),
       ...getQueryOptionsOverrides(options),
@@ -715,7 +718,7 @@ export class TokenApiClient extends BaseApiClient {
       queryKey: ['token', 'v1SuggestedOccurrenceFloors'],
       queryFn: ({ signal }: QueryFunctionContext) =>
         this.fetch<V1SuggestedOccurrenceFloorsResponse>(
-          API_URLS.TOKEN,
+          this.apiUrls.TOKEN,
           '/v1/suggestedOccurrenceFloors',
           { signal },
         ),

--- a/packages/core-backend/src/api/tokens/client.ts
+++ b/packages/core-backend/src/api/tokens/client.ts
@@ -11,12 +11,7 @@ import type {
   QueryFunctionContext,
 } from '@tanstack/query-core';
 
-import {
-  BaseApiClient,
-  API_URLS,
-  STALE_TIMES,
-  GC_TIMES,
-} from '../base-client.js';
+import { BaseApiClient, STALE_TIMES, GC_TIMES } from '../base-client.js';
 import { getQueryOptionsOverrides } from '../shared-types.js';
 import type { FetchOptions } from '../shared-types.js';
 import type {
@@ -61,7 +56,7 @@ export class TokensApiClient extends BaseApiClient {
       queryKey: ['tokens', 'v1SupportedNetworks'],
       queryFn: ({ signal }: QueryFunctionContext) =>
         this.fetch<V1TokenSupportedNetworksResponse>(
-          API_URLS.TOKENS,
+          this.apiUrls.TOKENS,
           '/v1/supportedNetworks',
           { signal },
         ),
@@ -98,7 +93,7 @@ export class TokensApiClient extends BaseApiClient {
       queryKey: ['tokens', 'v2SupportedNetworks'],
       queryFn: ({ signal }: QueryFunctionContext) =>
         this.fetch<V2TokenSupportedNetworksResponse>(
-          API_URLS.TOKENS,
+          this.apiUrls.TOKENS,
           '/v2/supportedNetworks',
           { signal },
         ),
@@ -152,13 +147,17 @@ export class TokensApiClient extends BaseApiClient {
         if (assetIds.length === 0) {
           return [];
         }
-        return this.fetch<V3AssetResponse[]>(API_URLS.TOKENS, '/v3/assets', {
-          signal,
-          params: {
-            assetIds,
-            ...queryOptions,
+        return this.fetch<V3AssetResponse[]>(
+          this.apiUrls.TOKENS,
+          '/v3/assets',
+          {
+            signal,
+            params: {
+              assetIds,
+              ...queryOptions,
+            },
           },
-        });
+        );
       },
       ...getQueryOptionsOverrides(fetchOptions),
       staleTime: fetchOptions?.staleTime ?? STALE_TIMES.TOKEN_METADATA,

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -137,6 +137,7 @@ export {
 export type {
   // Client options
   ApiPlatformClientOptions,
+  ApiUrls,
   FetchOptions,
   // Shared types
   PageInfo,


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where every balances/prices/token HTTP request is routed; misconfigured overrides could send wallet data to the wrong environment, though behavior is unchanged when `apiUrls` is omitted.
> 
> **Overview**
> Adds optional **`apiUrls`** on **`ApiPlatformClientOptions`** so MetaMask clients can point Accounts, Prices, Token, and Tokens API calls at dev/staging hosts (e.g. from env vars) without forking the SDK. **`BaseApiClient`** resolves **`this.apiUrls`** by merging overrides onto production **`API_URLS`**; unspecified services keep the default production base URL.
> 
> All platform HTTP clients now use **`this.apiUrls.*`** instead of the static **`API_URLS`** constant. The new **`ApiUrls`** type is exported from the package API surface, and tests assert default production URLs vs a per-service override on **`AccountsApiClient`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6228714d14f7ed78d928348c3efc16d38a1eace7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->