### PR TITLE
fix: added check for native assets for fetch balance after transaction confirmation

### DIFF
--- a/packages/assets-controller/CHANGELOG.md
+++ b/packages/assets-controller/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `AccountsApiDataSource` now treats Accounts API `/v2/supportedNetworks` `partialSupport` as active chains in addition to `fullSupport`, still gated by the Snaps assets migration feature flags ([#10144](https://github.com/MetaMask/core/pull/10144))
 - `AccountsApiDataSource` now reads Accounts API `/v2/supportedNetworks` as CAIP-2 `fullSupport` and `partialSupport` string arrays, matching the current API payload
 
+### Fixed
+
+- Fix post-transaction balance refreshes for default-tracked native assets on AccountActivity-active chains ([#10198](https://github.com/MetaMask/core/pull/10198))
+
 ## [16.0.0]
 
 ### Changed

--- a/packages/assets-controller/src/AssetsController.test.ts
+++ b/packages/assets-controller/src/AssetsController.test.ts
@@ -3007,6 +3007,39 @@ describe('AssetsController', () => {
       });
     });
 
+    it('force refreshes default-tracked native assets even when the chain is AccountActivity-active', async () => {
+      await withController(async ({ controller, messenger }) => {
+        const getAssetsSpy = jest
+          .spyOn(controller, 'getAssets')
+          .mockResolvedValue({});
+
+        messenger.publish('AccountActivityService:statusChanged', {
+          chainIds: ['eip155:5042'],
+          status: 'up',
+        });
+
+        await flushPromises();
+
+        messenger.publish('TransactionController:transactionConfirmed', {
+          chainId: '0x13b2',
+          txParams: { from: '0x1234567890123456789012345678901234567890' },
+        });
+
+        await flushPromises();
+
+        expect(getAssetsSpy).toHaveBeenCalledWith(
+          [expect.objectContaining({ id: MOCK_ACCOUNT_ID })],
+          {
+            chainIds: ['eip155:5042'],
+            forceUpdate: true,
+            bypassServerCache: true,
+          },
+        );
+
+        getAssetsSpy.mockRestore();
+      });
+    });
+
     it('publishes balanceChanged event when balance updates', async () => {
       await withController(async ({ controller, messenger }) => {
         const balanceChangedHandler = jest.fn();

--- a/packages/assets-controller/src/AssetsController.ts
+++ b/packages/assets-controller/src/AssetsController.ts
@@ -109,6 +109,7 @@ import {
   DEFAULT_TRACKED_ASSETS_BY_CHAIN,
   buildDefaultAssetsInfo,
   getDefaultAssetMetadata,
+  getDefaultTrackedAssetsForChain,
 } from './defaults.js';
 import { AssetsDataSourceError } from './errors.js';
 import { projectLogger, createModuleLogger } from './logger.js';
@@ -1258,12 +1259,19 @@ export class AssetsController extends BaseController<
 
     const caipChainId = `eip155:${parseInt(hexChainId, 16)}` as ChainId;
 
+    const hasDefaultTrackedNativeAsset = getDefaultTrackedAssetsForChain(
+      caipChainId,
+    ).some((assetId) => assetId.includes('/slip44:'));
+
     // AccountActivity pushes live balance updates for its active chains; a
     // force getAssets would be redundant and can race the WebSocket path.
+    // Default-tracked native assets still need the full fetch pipeline because
+    // AccountActivity can miss their post-transaction balance updates.
     if (
       this.#accountActivityDataSource
         .getActiveChainsSync()
-        .includes(caipChainId)
+        .includes(caipChainId) &&
+      !hasDefaultTrackedNativeAsset
     ) {
       return;
     }


### PR DESCRIPTION
## Explanation

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?
* Are there any changes whose purpose might not obvious to those unfamiliar with the domain?
* If your primary goal was to update one package but you found you had to update another one along the way, why did you do so?
* If you had to upgrade a dependency, why did you do so?
-->

This PR fixes post-transaction balance refreshes for default-tracked native assets on chains where `AccountActivityDataSource` is active.

Previously, `AssetsController` skipped the full post-transaction `getAssets` refresh whenever the transaction chain was covered by AccountActivity, assuming websocket balance updates would keep balances fresh.
That works for most assets, but it can miss default-tracked native assets such as Arc native USDC (`eip155:5042/slip44:5042`).
As a result, after flows like swapping `EURC -> USDC` on Arc, the USDC balance could remain stale until a full asset re-scan was triggered by reloading the app or switching accounts.

This change keeps the existing AccountActivity skip optimization, but bypasses it for chains that have default-tracked native assets.
In those cases, the controller still runs the full post-transaction refresh with `forceUpdate` and `bypassServerCache`.

### Changes

- Detect whether the transaction chain has a default-tracked native asset.
- Continue skipping redundant refreshes for regular AccountActivity-active chains.
- Force-refresh default-tracked native assets after confirmed transactions, even when AccountActivity is active.
- Add test for Arc (`eip155:5042`) confirming the refresh still runs when AccountActivity marks the chain active.

## References

<!--
Are there any issues that this pull request is tied to?
Are there other links that reviewers should consult to understand these changes better?
Are there client or consumer pull requests to adopt any breaking changes?

For example:

* Fixes #12345
* Related to #67890
-->

## Checklist

- [X] I've updated the test suite for new or updated code as appropriate
- [X] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes post-transaction balance refresh gating on AccountActivity-active chains; scope is narrow but affects visible balance correctness and reintroduces forced fetches where WebSocket coverage was assumed sufficient.
> 
> **Overview**
> Fixes **stale default-tracked native balances** (e.g. Arc USDC at `eip155:5042/slip44:5042`) after a transaction confirms when AccountActivity already owns live updates on that chain.
> 
> Previously `#refreshAssetsForTransaction` **skipped** the post-confirmation `getAssets({ forceUpdate: true, bypassServerCache: true })` whenever the chain was AccountActivity-active, to avoid racing the WebSocket path. AccountActivity can **miss** updates for those default-tracked native assets, so balances could stay wrong until another refresh.
> 
> The skip now applies only when the chain has **no** default-tracked **native** asset (`/slip44:` in `getDefaultTrackedAssetsForChain`). Otherwise the forced Accounts API fetch still runs. A regression test covers AccountActivity-up + `transactionConfirmed` on Arc (`0x13b2`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa0a609d54b8e9893ff552900905c857a693b214. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->