### PR TITLE
fix: keep the keyring cast valid in preview builds

### DIFF
--- a/packages/keyring-controller/src/KeyringController.ts
+++ b/packages/keyring-controller/src/KeyringController.ts
@@ -641,12 +641,16 @@ const hdKeyringV2Builder: KeyringV2Builder = Object.assign(
 const simpleKeyringV2Builder: KeyringV2Builder = Object.assign(
   (keyring: Keyring): KeyringV2 =>
     new SimpleKeyringV2({
-      // @ts-expect-error TODO: `Keyring` here comes from `@metamask/keyring-utils`,
-      // which still depends on `@metamask/utils@^11`, while this package now
-      // depends on the workspace copy at v12. That leaves two distinct identities
-      // for the same type, so the cast no longer overlaps. Remove this once the
-      // keyring packages depend on v12.
-      legacyKeyring: keyring as SimpleKeyring,
+      // TODO: `Keyring` here comes from `@metamask/keyring-utils`, which still
+      // depends on `@metamask/utils@^11`, while this package depends on the
+      // workspace copy at v12. That leaves two distinct identities for the same
+      // type, so a direct cast does not overlap. Whether it overlaps at all
+      // depends on how `@metamask/utils` resolves: preview builds add a
+      // `portal:` resolution that collapses both copies onto the workspace one,
+      // which would make a `@ts-expect-error` here unused. Going through
+      // `unknown` holds in both. Drop the extra hop once the keyring packages
+      // depend on v12.
+      legacyKeyring: keyring as unknown as SimpleKeyring,
     }),
   { type: KeyringTypes.simple as string },
 );


### PR DESCRIPTION
## Explanation

Preview builds have been failing since #10192 with one TS error:

```
packages/keyring-controller/src/KeyringController.ts(644,7): error TS2578: Unused '@ts-expect-error' directive.
```

`Keyring` in that builder comes from `@metamask/keyring-utils`, which still depends on `@metamask/utils@^11`, while this package depends on the workspace copy at v12. Normally that leaves two identities for the same type, so the cast does not overlap and the directive is needed.

Preview builds resolve it differently. The workflow writes a `portal:` resolution for every workspace into the root manifest, and since that applies globally it also replaces the nested v11 copy `@metamask/keyring-utils` brings along. Both copies collapse onto the workspace one, the cast overlaps again, and the directive is flagged as unused.

So it is required in a normal build and wrong in a preview build. Casting through `unknown` holds either way. The comment notes it can go once the keyring packages depend on `@metamask/utils@12`.

## References

Failing run: https://github.com/MetaMask/core/actions/runs/34633477377/job/103375769956

Related to #10192

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by [updating changelogs for packages I've changed](https://github.com/MetaMask/core/tree/main/docs/processes/updating-changelogs.md)
- [ ] I've introduced [breaking changes](https://github.com/MetaMask/core/tree/main/docs/processes/breaking-changes.md) in this PR and have prepared draft pull requests for clients and consumer packages to resolve them
